### PR TITLE
Handle version matcher invalid match

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -273,11 +273,11 @@ public:
             catch (const std::exception& e)
             {
                 // Log the warning and continue with the next vulnerability.
-                logWarn(WM_VULNSCAN_LOGTAG,
-                        "Failed to scan package: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'",
-                        packageName.c_str(),
-                        cnaName.c_str(),
-                        e.what());
+                logDebug1(WM_VULNSCAN_LOGTAG,
+                          "Failed to scan package: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'",
+                          packageName.c_str(),
+                          cnaName.c_str(),
+                          e.what());
 
                 return false;
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -65,7 +65,8 @@ public:
                 for (const auto& platform : *callbackData.platforms())
                 {
                     const std::string platformValue {platform->str()};
-                    // if the platform is a CPE, we need to parse it and check if the product is the same as the os cpe.
+                    // if the platform is a CPE, we need to parse it and check if the product is the same as the os
+                    // cpe.
                     if (ScannerHelper::isCPE(platformValue))
                     {
                         const auto cpe {ScannerHelper::parseCPE(platformValue)};
@@ -130,10 +131,13 @@ public:
                           versionStringLessThan.c_str(),
                           versionStringLessThanOrEqual.c_str());
 
+                // No version range specified, check if the installed version is equal to the required version.
                 if (versionStringLessThan.empty() && versionStringLessThanOrEqual.empty())
                 {
-                    if (VersionMatcher::compare(packageVersion, versionString, objectType) == 0)
+                    if (VersionMatcher::compare(packageVersion, versionString, objectType) ==
+                        VersionComparisonResult::A_EQUAL_B)
                     {
+                        // Version match found, the package status is defined by the vulnerability status.
                         if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                         {
                             logDebug1(WM_VULNSCAN_LOGTAG,
@@ -153,22 +157,44 @@ public:
 
                             return true;
                         }
-                        else
-                        {
-                            return false;
-                        }
+
+                        return false;
                     }
                 }
                 else
                 {
-                    if ((versionString.compare("0") == 0 ||
-                         VersionMatcher::compare(packageVersion, versionString, objectType) >= 0))
+                    // Version range specified
+
+                    // Check if the installed version satisfies the lower bound of the version range.
+                    auto matchResult = VersionMatcher::compare(packageVersion, versionStringLessThan, objectType);
+                    const auto lowerBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B ||
+                                                 matchResult == VersionComparisonResult::A_EQUAL_B ||
+                                                 versionString.compare("0") == 0;
+
+                    if (lowerBoundMatch)
                     {
-                        if (((!versionStringLessThan.empty() && versionStringLessThan.compare("*") != 0 &&
-                              VersionMatcher::compare(packageVersion, versionStringLessThan, objectType) < 0) ||
-                             (!versionStringLessThanOrEqual.empty() &&
-                              VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual, objectType) <= 0)))
+                        // Check if the installed version satisfies the upper bound of the version range.
+                        auto upperBoundMatch = false;
+                        if (!versionStringLessThan.empty() && versionStringLessThan.compare("*") != 0)
                         {
+                            matchResult = VersionMatcher::compare(packageVersion, versionStringLessThan, objectType);
+                            upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B;
+                        }
+                        else if (!versionStringLessThanOrEqual.empty())
+                        {
+                            matchResult =
+                                VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual, objectType);
+                            upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B ||
+                                              matchResult == VersionComparisonResult::A_EQUAL_B;
+                        }
+                        else
+                        {
+                            upperBoundMatch = false;
+                        }
+
+                        if (upperBoundMatch)
+                        {
+                            // Version match found, the package status is defined by the vulnerability status.
                             if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                             {
                                 logDebug1(WM_VULNSCAN_LOGTAG,
@@ -212,8 +238,9 @@ public:
                     }
                 }
             }
-            const auto defaultStatus {callbackData.defaultStatus()};
-            if (defaultStatus == NSVulnerabilityScanner::Status::Status_affected)
+
+            // No match found, the default status defines the package status.
+            if (callbackData.defaultStatus() == NSVulnerabilityScanner::Status::Status_affected)
             {
                 logDebug1(WM_VULNSCAN_LOGTAG,
                           "Match found for Package: %s for vulnerability: %s due to default status.",
@@ -226,10 +253,14 @@ public:
 
                 return true;
             }
-            else
-            {
-                return false;
-            }
+
+            logDebug2(
+                WM_VULNSCAN_LOGTAG,
+                "No match due to default status for Package: %s, Version: %s while scanning for Vulnerability: %s",
+                packageName.c_str(),
+                data->packageVersion().data(),
+                callbackData.cveId()->str().c_str());
+            return false;
         };
 
         auto cnaName {m_databaseFeedManager->getCnaNameByFormat(data->packageFormat().data())};

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -58,209 +58,229 @@ public:
         auto vulnerabilityScan =
             [&](const std::string& cnaName, const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
-            // if the platforms are not empty, we need to check if the platform is in the list.
-            if (callbackData.platforms())
+            try
             {
-                bool matchPlatform {false};
-                for (const auto& platform : *callbackData.platforms())
+                // if the platforms are not empty, we need to check if the platform is in the list.
+                if (callbackData.platforms())
                 {
-                    const std::string platformValue {platform->str()};
-                    // if the platform is a CPE, we need to parse it and check if the product is the same as the os
-                    // cpe.
-                    if (ScannerHelper::isCPE(platformValue))
+                    bool matchPlatform {false};
+                    for (const auto& platform : *callbackData.platforms())
                     {
-                        const auto cpe {ScannerHelper::parseCPE(platformValue)};
-                        if (cpe.part.compare("o") == 0)
+                        const std::string platformValue {platform->str()};
+                        // if the platform is a CPE, we need to parse it and check if the product is the same as the os
+                        // cpe.
+                        if (ScannerHelper::isCPE(platformValue))
                         {
-                            if (ScannerHelper::compareCPE(cpe, ScannerHelper::parseCPE(data->osCPEName().data())))
+                            const auto cpe {ScannerHelper::parseCPE(platformValue)};
+                            if (cpe.part.compare("o") == 0)
                             {
-                                logDebug2(WM_VULNSCAN_LOGTAG,
-                                          "The platform is in the list based on CPE comparison for "
-                                          "Package: %s, Version: %s, CVE: %s, Content platform CPE: %s OS CPE: %s",
-                                          packageName.c_str(),
-                                          data->packageVersion().data(),
-                                          callbackData.cveId()->str().c_str(),
-                                          platformValue.c_str(),
-                                          data->osCPEName().data());
+                                if (ScannerHelper::compareCPE(cpe, ScannerHelper::parseCPE(data->osCPEName().data())))
+                                {
+                                    logDebug2(WM_VULNSCAN_LOGTAG,
+                                              "The platform is in the list based on CPE comparison for "
+                                              "Package: %s, Version: %s, CVE: %s, Content platform CPE: %s OS CPE: %s",
+                                              packageName.c_str(),
+                                              data->packageVersion().data(),
+                                              callbackData.cveId()->str().c_str(),
+                                              platformValue.c_str(),
+                                              data->osCPEName().data());
+                                    matchPlatform = true;
+                                    break;
+                                }
+                            }
+                        }
+                        // If the platform is not a CPE, it is a string, at the moment, we only support the os code
+                        // name. This is used mainly for debian and ubuntu platforms.
+                        else
+                        {
+                            if (platformValue.compare(data->osCodeName()) == 0)
+                            {
                                 matchPlatform = true;
                                 break;
                             }
                         }
                     }
-                    // If the platform is not a CPE, it is a string, at the moment, we only support the os code name.
-                    // This is used mainly for debian and ubuntu platforms.
-                    else
+
+                    if (!matchPlatform)
                     {
-                        if (platformValue.compare(data->osCodeName()) == 0)
-                        {
-                            matchPlatform = true;
-                            break;
-                        }
-                    }
-                }
-
-                if (!matchPlatform)
-                {
-                    return false;
-                }
-            }
-
-            VersionObjectType objectType = VersionObjectType::Unspecified;
-            const auto it = m_mapVendors.find(data->packageFormat());
-            if (it != m_mapVendors.end())
-            {
-                objectType = it->second;
-            }
-
-            for (const auto& version : *callbackData.versions())
-            {
-                const std::string packageVersion {data->packageVersion()};
-                std::string versionString {version->version() ? version->version()->str() : ""};
-                std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : ""};
-                std::string versionStringLessThanOrEqual {version->lessThanOrEqual() ? version->lessThanOrEqual()->str()
-                                                                                     : ""};
-
-                logDebug2(WM_VULNSCAN_LOGTAG,
-                          "Scanning package - '%s' (Installed Version: %s, Security Vulnerability: %s). Identified "
-                          "vulnerability: "
-                          "Version: %s. Required Version Threshold: %s. Required Version Threshold (or Equal): %s.",
-                          packageName.c_str(),
-                          packageVersion.c_str(),
-                          callbackData.cveId()->str().c_str(),
-                          versionString.c_str(),
-                          versionStringLessThan.c_str(),
-                          versionStringLessThanOrEqual.c_str());
-
-                // No version range specified, check if the installed version is equal to the required version.
-                if (versionStringLessThan.empty() && versionStringLessThanOrEqual.empty())
-                {
-                    if (VersionMatcher::compare(packageVersion, versionString, objectType) ==
-                        VersionComparisonResult::A_EQUAL_B)
-                    {
-                        // Version match found, the package status is defined by the vulnerability status.
-                        if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
-                        {
-                            logDebug1(WM_VULNSCAN_LOGTAG,
-                                      "Match found, the package '%s', is vulnerable to '%s'. Current version: '%s' is "
-                                      "equal to '%s'. - Agent '%s' (ID: '%s', Version: '%s').",
-                                      packageName.c_str(),
-                                      callbackData.cveId()->str().c_str(),
-                                      packageVersion.c_str(),
-                                      versionString.c_str(),
-                                      data->agentName().data(),
-                                      data->agentId().data(),
-                                      data->agentVersion().data());
-
-                            data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
-                            data->m_alerts[callbackData.cveId()->str()]["vulnerability"]["package"]["condition"] =
-                                "Package equal to " + versionString;
-
-                            return true;
-                        }
-
                         return false;
                     }
                 }
-                else
+
+                VersionObjectType objectType = VersionObjectType::Unspecified;
+                const auto it = m_mapVendors.find(data->packageFormat());
+                if (it != m_mapVendors.end())
                 {
-                    // Version range specified
+                    objectType = it->second;
+                }
 
-                    // Check if the installed version satisfies the lower bound of the version range.
-                    auto matchResult = VersionMatcher::compare(packageVersion, versionString, objectType);
-                    const auto lowerBoundMatch = matchResult == VersionComparisonResult::A_GREATER_THAN_B ||
-                                                 matchResult == VersionComparisonResult::A_EQUAL_B ||
-                                                 versionString.compare("0") == 0;
+                for (const auto& version : *callbackData.versions())
+                {
+                    const std::string packageVersion {data->packageVersion()};
+                    std::string versionString {version->version() ? version->version()->str() : ""};
+                    std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : ""};
+                    std::string versionStringLessThanOrEqual {
+                        version->lessThanOrEqual() ? version->lessThanOrEqual()->str() : ""};
 
-                    if (lowerBoundMatch)
+                    logDebug2(WM_VULNSCAN_LOGTAG,
+                              "Scanning package - '%s' (Installed Version: %s, Security Vulnerability: %s). Identified "
+                              "vulnerability: "
+                              "Version: %s. Required Version Threshold: %s. Required Version Threshold (or Equal): %s.",
+                              packageName.c_str(),
+                              packageVersion.c_str(),
+                              callbackData.cveId()->str().c_str(),
+                              versionString.c_str(),
+                              versionStringLessThan.c_str(),
+                              versionStringLessThanOrEqual.c_str());
+
+                    // No version range specified, check if the installed version is equal to the required version.
+                    if (versionStringLessThan.empty() && versionStringLessThanOrEqual.empty())
                     {
-                        // Check if the installed version satisfies the upper bound of the version range.
-                        auto upperBoundMatch = false;
-                        if (!versionStringLessThan.empty() && versionStringLessThan.compare("*") != 0)
-                        {
-                            matchResult = VersionMatcher::compare(packageVersion, versionStringLessThan, objectType);
-                            upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B;
-                        }
-                        else if (!versionStringLessThanOrEqual.empty())
-                        {
-                            matchResult =
-                                VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual, objectType);
-                            upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B ||
-                                              matchResult == VersionComparisonResult::A_EQUAL_B;
-                        }
-                        else
-                        {
-                            upperBoundMatch = false;
-                        }
-
-                        if (upperBoundMatch)
+                        if (VersionMatcher::compare(packageVersion, versionString, objectType) ==
+                            VersionComparisonResult::A_EQUAL_B)
                         {
                             // Version match found, the package status is defined by the vulnerability status.
                             if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                             {
-                                logDebug1(WM_VULNSCAN_LOGTAG,
-                                          "Match found, the package '%s', is vulnerable to '%s'. Current version: "
-                                          "'%s' ("
-                                          "less than '%s' or equal to '%s'). - Agent '%s' (ID: '%s', Version: '%s').",
-                                          packageName.c_str(),
-                                          callbackData.cveId()->str().c_str(),
-                                          packageVersion.c_str(),
-                                          versionStringLessThan.c_str(),
-                                          versionStringLessThanOrEqual.c_str(),
-                                          data->agentName().data(),
-                                          data->agentId().data(),
-                                          data->agentVersion().data());
+                                logDebug1(
+                                    WM_VULNSCAN_LOGTAG,
+                                    "Match found, the package '%s', is vulnerable to '%s'. Current version: '%s' is "
+                                    "equal to '%s'. - Agent '%s' (ID: '%s', Version: '%s').",
+                                    packageName.c_str(),
+                                    callbackData.cveId()->str().c_str(),
+                                    packageVersion.c_str(),
+                                    versionString.c_str(),
+                                    data->agentName().data(),
+                                    data->agentId().data(),
+                                    data->agentVersion().data());
 
                                 data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
                                 data->m_alerts[callbackData.cveId()->str()]["vulnerability"]["package"]["condition"] =
-                                    versionStringLessThan.empty()
-                                        ? "Package less than or equal to " + versionStringLessThanOrEqual
-                                        : "Package less than " + versionStringLessThan;
+                                    "Package equal to " + versionString;
 
                                 return true;
                             }
+
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        // Version range specified
+
+                        // Check if the installed version satisfies the lower bound of the version range.
+                        auto matchResult = VersionMatcher::compare(packageVersion, versionString, objectType);
+                        const auto lowerBoundMatch = matchResult == VersionComparisonResult::A_GREATER_THAN_B ||
+                                                     matchResult == VersionComparisonResult::A_EQUAL_B ||
+                                                     versionString.compare("0") == 0;
+
+                        if (lowerBoundMatch)
+                        {
+                            // Check if the installed version satisfies the upper bound of the version range.
+                            auto upperBoundMatch = false;
+                            if (!versionStringLessThan.empty() && versionStringLessThan.compare("*") != 0)
+                            {
+                                matchResult =
+                                    VersionMatcher::compare(packageVersion, versionStringLessThan, objectType);
+                                upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B;
+                            }
+                            else if (!versionStringLessThanOrEqual.empty())
+                            {
+                                matchResult =
+                                    VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual, objectType);
+                                upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B ||
+                                                  matchResult == VersionComparisonResult::A_EQUAL_B;
+                            }
                             else
                             {
-                                logDebug2(WM_VULNSCAN_LOGTAG,
-                                          "No match due to default status for Package: %s, Version: %s while scanning "
-                                          "for Vulnerability: %s, "
-                                          "Installed Version: %s, Required Version Threshold: %s, Required Version "
-                                          "Threshold (or Equal): %s",
-                                          packageName.c_str(),
-                                          packageVersion.c_str(),
-                                          callbackData.cveId()->str().c_str(),
-                                          versionString.c_str(),
-                                          versionStringLessThan.c_str(),
-                                          versionStringLessThanOrEqual.c_str());
+                                upperBoundMatch = false;
+                            }
 
-                                return false;
+                            if (upperBoundMatch)
+                            {
+                                // Version match found, the package status is defined by the vulnerability status.
+                                if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
+                                {
+                                    logDebug1(
+                                        WM_VULNSCAN_LOGTAG,
+                                        "Match found, the package '%s', is vulnerable to '%s'. Current version: "
+                                        "'%s' ("
+                                        "less than '%s' or equal to '%s'). - Agent '%s' (ID: '%s', Version: '%s').",
+                                        packageName.c_str(),
+                                        callbackData.cveId()->str().c_str(),
+                                        packageVersion.c_str(),
+                                        versionStringLessThan.c_str(),
+                                        versionStringLessThanOrEqual.c_str(),
+                                        data->agentName().data(),
+                                        data->agentId().data(),
+                                        data->agentVersion().data());
+
+                                    data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
+                                    data->m_alerts[callbackData.cveId()->str()]["vulnerability"]["package"]
+                                                  ["condition"] =
+                                        versionStringLessThan.empty()
+                                            ? "Package less than or equal to " + versionStringLessThanOrEqual
+                                            : "Package less than " + versionStringLessThan;
+
+                                    return true;
+                                }
+                                else
+                                {
+                                    logDebug2(
+                                        WM_VULNSCAN_LOGTAG,
+                                        "No match due to default status for Package: %s, Version: %s while scanning "
+                                        "for Vulnerability: %s, "
+                                        "Installed Version: %s, Required Version Threshold: %s, Required Version "
+                                        "Threshold (or Equal): %s",
+                                        packageName.c_str(),
+                                        packageVersion.c_str(),
+                                        callbackData.cveId()->str().c_str(),
+                                        versionString.c_str(),
+                                        versionStringLessThan.c_str(),
+                                        versionStringLessThanOrEqual.c_str());
+
+                                    return false;
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            // No match found, the default status defines the package status.
-            if (callbackData.defaultStatus() == NSVulnerabilityScanner::Status::Status_affected)
+                // No match found, the default status defines the package status.
+                if (callbackData.defaultStatus() == NSVulnerabilityScanner::Status::Status_affected)
+                {
+                    logDebug1(WM_VULNSCAN_LOGTAG,
+                              "Match found for Package: %s for vulnerability: %s due to default status.",
+                              packageName.c_str(),
+                              callbackData.cveId()->str().c_str());
+
+                    data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
+                    data->m_alerts[callbackData.cveId()->str()]["vulnerability"]["package"]["condition"] =
+                        "Package default status";
+
+                    return true;
+                }
+
+                logDebug2(
+                    WM_VULNSCAN_LOGTAG,
+                    "No match due to default status for Package: %s, Version: %s while scanning for Vulnerability: %s",
+                    packageName.c_str(),
+                    data->packageVersion().data(),
+                    callbackData.cveId()->str().c_str());
+
+                return false;
+            }
+            catch (const std::exception& e)
             {
-                logDebug1(WM_VULNSCAN_LOGTAG,
-                          "Match found for Package: %s for vulnerability: %s due to default status.",
-                          packageName.c_str(),
-                          callbackData.cveId()->str().c_str());
+                // Log the warning and continue with the next vulnerability.
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "Failed to scan package: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'",
+                        packageName.c_str(),
+                        cnaName.c_str(),
+                        e.what());
 
-                data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
-                data->m_alerts[callbackData.cveId()->str()]["vulnerability"]["package"]["condition"] =
-                    "Package default status";
-
-                return true;
+                return false;
             }
-
-            logDebug2(
-                WM_VULNSCAN_LOGTAG,
-                "No match due to default status for Package: %s, Version: %s while scanning for Vulnerability: %s",
-                packageName.c_str(),
-                data->packageVersion().data(),
-                callbackData.cveId()->str().c_str());
-            return false;
         };
 
         auto cnaName {m_databaseFeedManager->getCnaNameByFormat(data->packageFormat().data())};

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -169,10 +169,17 @@ public:
                         // Version range specified
 
                         // Check if the installed version satisfies the lower bound of the version range.
-                        auto matchResult = VersionMatcher::compare(packageVersion, versionString, objectType);
-                        const auto lowerBoundMatch = matchResult == VersionComparisonResult::A_GREATER_THAN_B ||
-                                                     matchResult == VersionComparisonResult::A_EQUAL_B ||
-                                                     versionString.compare("0") == 0;
+                        auto lowerBoundMatch = false;
+                        if (versionString.compare("0") == 0)
+                        {
+                            lowerBoundMatch = true;
+                        }
+                        else
+                        {
+                            const auto matchResult = VersionMatcher::compare(packageVersion, versionString, objectType);
+                            lowerBoundMatch = matchResult == VersionComparisonResult::A_GREATER_THAN_B ||
+                                              matchResult == VersionComparisonResult::A_EQUAL_B;
+                        }
 
                         if (lowerBoundMatch)
                         {
@@ -180,13 +187,13 @@ public:
                             auto upperBoundMatch = false;
                             if (!versionStringLessThan.empty() && versionStringLessThan.compare("*") != 0)
                             {
-                                matchResult =
+                                const auto matchResult =
                                     VersionMatcher::compare(packageVersion, versionStringLessThan, objectType);
                                 upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B;
                             }
                             else if (!versionStringLessThanOrEqual.empty())
                             {
-                                matchResult =
+                                const auto matchResult =
                                     VersionMatcher::compare(packageVersion, versionStringLessThanOrEqual, objectType);
                                 upperBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B ||
                                                   matchResult == VersionComparisonResult::A_EQUAL_B;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -166,8 +166,8 @@ public:
                     // Version range specified
 
                     // Check if the installed version satisfies the lower bound of the version range.
-                    auto matchResult = VersionMatcher::compare(packageVersion, versionStringLessThan, objectType);
-                    const auto lowerBoundMatch = matchResult == VersionComparisonResult::A_LESS_THAN_B ||
+                    auto matchResult = VersionMatcher::compare(packageVersion, versionString, objectType);
+                    const auto lowerBoundMatch = matchResult == VersionComparisonResult::A_GREATER_THAN_B ||
                                                  matchResult == VersionComparisonResult::A_EQUAL_B ||
                                                  versionString.compare("0") == 0;
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/iVersionObjectInterface.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/iVersionObjectInterface.hpp
@@ -23,10 +23,6 @@ enum class VersionObjectType : int
     RPM = 6,
 };
 
-auto constexpr LEFT_IS_NEWER = 1;
-auto constexpr RIGHT_IS_NEWER = -1;
-auto constexpr LEFT_EQ_RIGHT = 0;
-
 /**
  * @brief IVersionObject class.
  *

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -25,7 +25,12 @@
 #include <stdexcept>
 #include <string>
 
-constexpr auto INVALID_VERSION_OBJECT_TYPE = 0x7FFFFFFF;
+enum class VersionComparisonResult : int
+{
+    A_LESS_THAN_B,
+    A_EQUAL_B,
+    A_GREATER_THAN_B
+};
 
 /**
  * @brief VersionMatcher class.
@@ -184,11 +189,11 @@ public:
      * @param versionA string version item A to compare
      * @param versionB string version item B to compare
      * @param type VersionObjectType of the version strings A and B to compare.
-     * @return int
+     * @return VersionComparisonResult result of the comparison.
      */
-    static int compare(const std::string& versionA,
-                       const std::string& versionB,
-                       VersionObjectType type = VersionObjectType::Unspecified)
+    static VersionComparisonResult compare(const std::string& versionA,
+                                           const std::string& versionB,
+                                           VersionObjectType type = VersionObjectType::Unspecified)
     {
         auto pVersionObjectA = createVersionObject(versionA, type);
         auto pVersionObjectB = createVersionObject(versionB, type);
@@ -198,18 +203,19 @@ public:
 
             if (*pVersionObjectA == *pVersionObjectB)
             {
-                return 0;
+                return VersionComparisonResult::A_EQUAL_B;
             }
             else if (*pVersionObjectA < *pVersionObjectB)
             {
-                return -1;
+                return VersionComparisonResult::A_LESS_THAN_B;
             }
             else
             {
-                return 1;
+                return VersionComparisonResult::A_GREATER_THAN_B;
             }
         }
-        return INVALID_VERSION_OBJECT_TYPE;
+
+        throw std::invalid_argument("Invalid version type");
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -215,7 +215,7 @@ public:
             }
         }
 
-        throw std::invalid_argument("Invalid version type");
+        throw std::invalid_argument("Unable to compare versions (" + versionA + " vs " + versionB + ").");
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectDpkg.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectDpkg.hpp
@@ -211,6 +211,7 @@ public:
             output.epoch = 0;
         }
         output.version = std::string(string, end - string);
+
         auto hyphen = const_cast<char*>(std::strchr(output.version.c_str(), '-'));
         if (hyphen != nullptr)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
@@ -20,6 +20,10 @@
 #include <regex>
 #include <string>
 
+static auto constexpr RIGHT_IS_NEWER = -1;
+static auto constexpr LEFT_EQ_RIGHT = 0;
+static auto constexpr LEFT_IS_NEWER = 1;
+
 /**
  * @brief Rpm data struct.
  *
@@ -383,6 +387,7 @@ public:
         {
             throw std::runtime_error {"Error casting VersionObject type"};
         }
+
         return compareRpmVersion(pB->m_epoch, pB->m_version, pB->m_release) == RIGHT_IS_NEWER;
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -19,426 +19,413 @@ void VersionMatcherTest::TearDown() {};
 
 TEST_F(VersionMatcherTest, compareCalVer_OkEqual)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.11.02.1", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("23.11.02.1", "23.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.02", "2023.11.02", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11", "2023.11", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023", "2023", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareCalVer_OkLess)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.11.02.0", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("23.11.02.0", "23.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.01", "2023.11.02", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.10", "2023.11", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2022", "2023", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareCalVer_OkGreater)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.11.02.2", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("23.11.02.2", "23.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.03", "2023.11.02", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.12", "2023.11", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2024", "2023", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareCalVer_ErrorInvalidVersion)
 {
-    int compareResult;
-    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
-    EXPECT_NO_THROW(
-        (compareResult = VersionMatcher::compare("2023.13.02.1", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
-    EXPECT_NO_THROW(
-        (compareResult = VersionMatcher::compare("2023.12.32.1", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
+    EXPECT_THROW(VersionMatcher::compare("A.B.C", "2023.11.02.1", VersionObjectType::CalVer), std::invalid_argument);
+    EXPECT_THROW(VersionMatcher::compare("2023.13.02.1", "2023.11.02.1", VersionObjectType::CalVer),
+                 std::invalid_argument);
+    EXPECT_THROW(VersionMatcher::compare("2023.12.32.1", "2023.11.02.1", VersionObjectType::CalVer),
+                 std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_OkEqual)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev456", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev456", "2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345", "2.0b2.post345", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0", "2.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.3.0.0.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3.0.0.0", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_OkLess)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev455", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev455", "1!2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev455", "2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345", "2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post344", "2.0b2.post345", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0b2.post344", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b1", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0a2", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0a2", "2.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0", "2.1", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.1.2.2", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.2", "2.0.1.2.3.0.0.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.2.0.0.0", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_OkGreater)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev457", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev455", "2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev456", "2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345.dev455", "2.0b2.post345", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345", "2.0b2.post344", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2.post344", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0b1", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0a2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0", "2.0a2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.1", "2.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3.0.0.0", "2.0.1.2.2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.2.0.0.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_ErrorInvalidVersion)
 {
-    int compareResult;
-    EXPECT_NO_THROW(
-        (compareResult = VersionMatcher::compare("A.B.C", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
+    EXPECT_THROW(VersionMatcher::compare("A.B.C", "1!2.0b2.post345.dev456", VersionObjectType::PEP440),
+                 std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_OkEqual)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-2", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_OkLess)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.1", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.1", "2.1", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-1", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-1", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_OkGreater)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.3", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.2", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-3", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-3", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_ErrorInvalidVersion)
 {
-    int compareResult;
-    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
+    EXPECT_THROW(VersionMatcher::compare("A.B.C", "1.2", VersionObjectType::MajorMinor), std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_OkEqual)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta+001", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta+001", "1.2.3-beta", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3+001", "1.2.3+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3+001", "1.2.3", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_OkLess)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "2.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "1.3.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "1.2.3-beta", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-alfa+001", "1.2.3+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-alfa+001", "1.2.3-beta", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.2+001", "1.2.3+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.2+001", "1.2.3", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_OkGreater)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.4-beta+001", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.3.2-beta+001", "1.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.2.2-beta+001", "1.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta", "1.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta", "1.2.3-alfa+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3+001", "1.2.2+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3", "1.2.2+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_ErrorInvalidVersion)
 {
-    int compareResult;
-    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
+    EXPECT_THROW(VersionMatcher::compare("A.B.C", "1.2.3-beta+001", VersionObjectType::SemVer), std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkCalVer)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.02.1", "2023.11.02.1")));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkPEP440)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1!2.0b2.post345.dev456", "1!2.0b2.post345.dev456")));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkMajorMinor)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2", "1.2")));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkSemVer)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3-beta+001", "1.2.3-beta+001")));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_ErrorInvalidFormat)
 {
-    int compareResult;
-    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "2023.11.02.1")));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
+    EXPECT_THROW(VersionMatcher::compare("A.B.C", "2023.11.02.1"), std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_ErrorDifferentFormats)
 {
-    EXPECT_EQ(VersionMatcher::compare("2023.11.02.1", "1!2.0b2.post345.dev456"), VERSION_COMPARE_RESULT::INVALID);
+    EXPECT_THROW(VersionMatcher::compare("2023.11.02.1", "1!2.0b2.post345.dev456"), std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, compareUnexistingVersionObjectType)
 {
-    int compareResult;
-    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "A.B.C", static_cast<VersionObjectType>(1000))));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
+    EXPECT_THROW(VersionMatcher::compare("A.B.C", "A.B.C", static_cast<VersionObjectType>(1000)),
+                 std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_OkEqual)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1:5.15.8-2ubuntu2.0", "1:5.15.8-2ubuntu2.0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("5.15.8-2", "5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2:5.15.8-2", "2:5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("5.15.16-0+deb10u1", "5.15.16-0+deb10u1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("7.3.0+dfsg-1", "7.3.0+dfsg-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_OkLess)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1:4.15.8-2ubuntu2.0", "1:5.15.8-2ubuntu2.0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("5.15.8-1", "5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1:5.15.8-2", "2:5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("5.14.16-0+deb10u1", "5.15.16-0+deb10u1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("7.2.0+dfsg-1", "7.3.0+dfsg-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_OkGreater)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1:6.15.8-2ubuntu2.0", "1:5.15.8-2ubuntu2.0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("5.15.8-3", "5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("3:5.15.8-2", "2:5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("5.16.16-0+deb10u1", "5.15.16-0+deb10u1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("7.3.1+dfsg-1", "7.3.0+dfsg-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_ErrorInvalidVersion)
 {
-    EXPECT_NO_THROW(VersionMatcher::compare("A.B.C", "2023.11.02-1", VersionObjectType::DPKG));
-    EXPECT_NO_THROW(VersionMatcher::compare("0.9.8?", "0.9.8?", VersionObjectType::DPKG));
-    EXPECT_NO_THROW(
-        VersionMatcher::compare("2.9.4+dfsg1-3.1, 2.9.5", "2.9.4+dfsg1-3.1, 2.9.5", VersionObjectType::DPKG));
+    EXPECT_THROW(VersionMatcher::compare("A.B.C", "2023.11.02-1", VersionObjectType::DPKG), std::invalid_argument);
+    EXPECT_THROW(VersionMatcher::compare("0.9.8?", "0.9.8?", VersionObjectType::DPKG), std::invalid_argument);
+    EXPECT_THROW(VersionMatcher::compare("2.9.4+dfsg1-3.1, 2.9.5", "2.9.4+dfsg1-3.1, 2.9.5", VersionObjectType::DPKG),
+                 std::invalid_argument);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_dpkgLib)
 {
-    int compareResult;
+    VersionComparisonResult compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:1.1-1", "0:1.1-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:1.1-0", "0:2.1-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:2.1-0", "0:1.1-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:1.0-0", "0:1.0-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:0.0-0", "0:0.0-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
 TEST_F(VersionMatcherTest, compareRpmVer_rmpPackages)
 {
     EXPECT_EQ(VersionMatcher::compare(
                   "4.2.5_02_3.0.101_0.46-0.7.9.i586", "4.2.5_02_3.0.101_0.46-0.7.9.i586", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT); // Suse
+              VersionComparisonResult::A_EQUAL_B); // Suse
     EXPECT_EQ(VersionMatcher::compare("4.1.0-18.el7_1.3.x86_64", "4.1.0-18.el7_1.3.x86_64", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT); // Redhat
+              VersionComparisonResult::A_EQUAL_B); // Redhat
     EXPECT_EQ(VersionMatcher::compare("1.0.1-10.module_el8.5.0+150+5f0dbea0.alma.ppc64le",
                                       "1.0.1-10.module_el8.5.0+150+5f0dbea0.alma.ppc64le",
                                       VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT); // Alma
+              VersionComparisonResult::A_EQUAL_B); // Alma
     EXPECT_EQ(VersionMatcher::compare("2.2.20-2.el8", "2.2.20-2.el8.aarch64", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER); // CentOS
+              VersionComparisonResult::A_LESS_THAN_B); // CentOS
 }
 
 TEST_F(VersionMatcherTest, matchCalVer)
@@ -519,65 +506,75 @@ TEST_F(VersionMatcherTest, matchRPM)
     EXPECT_TRUE(VersionMatcher::match("A.B.C", VersionObjectType::RPM));
 
     EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
-    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+              VersionComparisonResult::A_EQUAL_B);
+    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM),
+              VersionComparisonResult::A_EQUAL_B);
     EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+              VersionComparisonResult::A_EQUAL_B);
     EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+              VersionComparisonResult::A_EQUAL_B);
     EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+              VersionComparisonResult::A_EQUAL_B);
     EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+              VersionComparisonResult::A_EQUAL_B);
     EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+              VersionComparisonResult::A_EQUAL_B);
 
     EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "2:4.8.0-2.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "6-4.amzn2023.0.5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "6-4.amzn2023.0.5", VersionObjectType::RPM),
+              VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.15-5.amzn2023.0.3", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.6-12.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-2.amzn2023.0.3", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-2.amzn2023", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.22-26.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_LESS_THAN_B);
 
     EXPECT_EQ(VersionMatcher::compare("2:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("6-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("6-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM),
+              VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("3.15-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("1:2.0.5-13.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("3.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("2:9.1.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("2.21-29.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
 
     EXPECT_EQ(VersionMatcher::compare("1.15.1-6.amzn2023.0.3", "gpgme-1.4.3-5.15", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(
         VersionMatcher::compare("1.57.0-1.amzn2023.0.1", "1.41.0-1.amzn2.0.4.aarch64.rpm", VersionObjectType::RPM),
-        VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+        VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("5.4.4-3.amzn2023.0.2", "5.4.4-3.amzn2022", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("2~almost^post", "2.0.1", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("2~almost^post", "2.0.1", VersionObjectType::RPM),
+              VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("0.9.1+git.20181118-bp156.3.5", "0.9.1-16.fc39", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("4.5.1-bp156.4.2", "4.5.1-bp155.3.7", VersionObjectType::RPM), VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("4.5.1-bp156.4.2", "4.5.1-bp155.3.7", VersionObjectType::RPM),
+              VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("11.1-2.git3118496.2.mga10", "11.1-2.git3118496.1.mga9", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("0.0.26-bp156.3.5", "0.0.26-9", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("0.0.26-bp156.3.5", "0.0.26-9", VersionObjectType::RPM),
+              VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("0.9.1+git.20181118-bp156.3.5", "0.9.1+git.20181118-1.3", VersionObjectType::RPM),
-              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("0.2-bp156.4.5", "0.2-3.2", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("2.15.6-1.mga10", "2.15.6-1.1", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("0.5.2-5.el4.at", "0.5.2-5.0.el5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("2:3.28.1-3.el8", "3:2.3.15-24.el8", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+              VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("0.2-bp156.4.5", "0.2-3.2", VersionObjectType::RPM),
+              VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("2.15.6-1.mga10", "2.15.6-1.1", VersionObjectType::RPM),
+              VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("0.5.2-5.el4.at", "0.5.2-5.0.el5", VersionObjectType::RPM),
+              VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_EQ(VersionMatcher::compare("2:3.28.1-3.el8", "3:2.3.15-24.el8", VersionObjectType::RPM),
+              VersionComparisonResult::A_LESS_THAN_B);
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -22,15 +22,15 @@ TEST_F(VersionMatcherTest, compareCalVer_OkEqual)
     int compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.11.02.1", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("23.11.02.1", "23.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.02", "2023.11.02", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11", "2023.11", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023", "2023", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareCalVer_OkLess)
@@ -38,15 +38,15 @@ TEST_F(VersionMatcherTest, compareCalVer_OkLess)
     int compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.11.02.0", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("23.11.02.0", "23.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.01", "2023.11.02", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.10", "2023.11", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2022", "2023", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareCalVer_OkGreater)
@@ -54,28 +54,28 @@ TEST_F(VersionMatcherTest, compareCalVer_OkGreater)
     int compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.11.02.2", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("23.11.02.2", "23.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.03", "2023.11.02", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.12", "2023.11", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2024", "2023", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareCalVer_ErrorInvalidVersion)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.13.02.1", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2023.12.32.1", "2023.11.02.1", VersionObjectType::CalVer)));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_OkEqual)
@@ -83,25 +83,25 @@ TEST_F(VersionMatcherTest, comparePEP440_OkEqual)
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev456", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev456", "2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345", "2.0b2.post345", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0", "2.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.3.0.0.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3.0.0.0", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_OkLess)
@@ -109,37 +109,37 @@ TEST_F(VersionMatcherTest, comparePEP440_OkLess)
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev455", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev455", "1!2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev455", "2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345", "2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post344", "2.0b2.post345", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0b2.post344", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b1", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0a2", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0a2", "2.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0", "2.1", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.1.2.2", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.2", "2.0.1.2.3.0.0.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.2.0.0.0", "2.0.1.2.3", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_OkGreater)
@@ -147,37 +147,37 @@ TEST_F(VersionMatcherTest, comparePEP440_OkGreater)
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev457", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1!2.0b2.post345.dev455", "2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "2.0b2.post345.dev456", "2.0b2.post345.dev455", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345.dev455", "2.0b2.post345", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0b2.post345", "2.0b2.post344", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2.post344", "2.0b2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0b1", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0b2", "2.0a2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0", "2.0a2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.1", "2.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3.0.0.0", "2.0.1.2.2", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.2.0.0.0", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, comparePEP440_ErrorInvalidVersion)
@@ -185,51 +185,51 @@ TEST_F(VersionMatcherTest, comparePEP440_ErrorInvalidVersion)
     int compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("A.B.C", "1!2.0b2.post345.dev456", VersionObjectType::PEP440)));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_OkEqual)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-2", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_OkLess)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.1", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.1", "2.1", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-1", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-1", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_OkGreater)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.3", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.2", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-3", "1-2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1-3", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareMajorMinor_ErrorInvalidVersion)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "1.2", VersionObjectType::MajorMinor)));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_OkEqual)
@@ -237,14 +237,14 @@ TEST_F(VersionMatcherTest, compareSemVer_OkEqual)
     int compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta+001", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta+001", "1.2.3-beta", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3+001", "1.2.3+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3+001", "1.2.3", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_OkLess)
@@ -252,26 +252,26 @@ TEST_F(VersionMatcherTest, compareSemVer_OkLess)
     int compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "2.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "1.3.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.2-beta+001", "1.2.3-beta", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-alfa+001", "1.2.3+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-alfa+001", "1.2.3-beta", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.2+001", "1.2.3+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.2+001", "1.2.3", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_OkGreater)
@@ -279,77 +279,77 @@ TEST_F(VersionMatcherTest, compareSemVer_OkGreater)
     int compareResult;
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.4-beta+001", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.3.2-beta+001", "1.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.2.2-beta+001", "1.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta", "1.2.2-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("1.2.3-beta", "1.2.3-alfa+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3+001", "1.2.2+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3", "1.2.2+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareSemVer_ErrorInvalidVersion)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "1.2.3-beta+001", VersionObjectType::SemVer)));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkCalVer)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2023.11.02.1", "2023.11.02.1")));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkPEP440)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1!2.0b2.post345.dev456", "1!2.0b2.post345.dev456")));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkMajorMinor)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2", "1.2")));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_OkSemVer)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3-beta+001", "1.2.3-beta+001")));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_ErrorInvalidFormat)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "2023.11.02.1")));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
 }
 
 TEST_F(VersionMatcherTest, compareUnspecified_ErrorDifferentFormats)
 {
-    EXPECT_EQ(VersionMatcher::compare("2023.11.02.1", "1!2.0b2.post345.dev456"), INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(VersionMatcher::compare("2023.11.02.1", "1!2.0b2.post345.dev456"), VERSION_COMPARE_RESULT::INVALID);
 }
 
 TEST_F(VersionMatcherTest, compareUnexistingVersionObjectType)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("A.B.C", "A.B.C", static_cast<VersionObjectType>(1000))));
-    EXPECT_EQ(compareResult, INVALID_VERSION_OBJECT_TYPE);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::INVALID);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_OkEqual)
@@ -357,16 +357,16 @@ TEST_F(VersionMatcherTest, compareDpkgVer_OkEqual)
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1:5.15.8-2ubuntu2.0", "1:5.15.8-2ubuntu2.0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("5.15.8-2", "5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2:5.15.8-2", "2:5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("5.15.16-0+deb10u1", "5.15.16-0+deb10u1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("7.3.0+dfsg-1", "7.3.0+dfsg-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_OkLess)
@@ -374,16 +374,16 @@ TEST_F(VersionMatcherTest, compareDpkgVer_OkLess)
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1:4.15.8-2ubuntu2.0", "1:5.15.8-2ubuntu2.0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("5.15.8-1", "5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1:5.15.8-2", "2:5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("5.14.16-0+deb10u1", "5.15.16-0+deb10u1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("7.2.0+dfsg-1", "7.3.0+dfsg-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_OkGreater)
@@ -391,16 +391,16 @@ TEST_F(VersionMatcherTest, compareDpkgVer_OkGreater)
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
                          "1:6.15.8-2ubuntu2.0", "1:5.15.8-2ubuntu2.0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("5.15.8-3", "5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("3:5.15.8-2", "2:5.15.8-2", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("5.16.16-0+deb10u1", "5.15.16-0+deb10u1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("7.3.1+dfsg-1", "7.3.0+dfsg-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
 }
 
 TEST_F(VersionMatcherTest, compareDpkgVer_ErrorInvalidVersion)
@@ -415,30 +415,30 @@ TEST_F(VersionMatcherTest, compareDpkgVer_dpkgLib)
 {
     int compareResult;
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:1.1-1", "0:1.1-1", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:1.1-0", "0:2.1-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, RIGHT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:2.1-0", "0:1.1-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_IS_NEWER);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:1.0-0", "0:1.0-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_NO_THROW((compareResult = VersionMatcher::compare("0:0.0-0", "0:0.0-0", VersionObjectType::DPKG)));
-    EXPECT_EQ(compareResult, LEFT_EQ_RIGHT);
+    EXPECT_EQ(compareResult, VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 }
 
 TEST_F(VersionMatcherTest, compareRpmVer_rmpPackages)
 {
     EXPECT_EQ(VersionMatcher::compare(
                   "4.2.5_02_3.0.101_0.46-0.7.9.i586", "4.2.5_02_3.0.101_0.46-0.7.9.i586", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT); // Suse
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT); // Suse
     EXPECT_EQ(VersionMatcher::compare("4.1.0-18.el7_1.3.x86_64", "4.1.0-18.el7_1.3.x86_64", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT); // Redhat
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT); // Redhat
     EXPECT_EQ(VersionMatcher::compare("1.0.1-10.module_el8.5.0+150+5f0dbea0.alma.ppc64le",
                                       "1.0.1-10.module_el8.5.0+150+5f0dbea0.alma.ppc64le",
                                       VersionObjectType::RPM),
-              LEFT_EQ_RIGHT); // Alma
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT); // Alma
     EXPECT_EQ(VersionMatcher::compare("2.2.20-2.el8", "2.2.20-2.el8.aarch64", VersionObjectType::RPM),
-              RIGHT_IS_NEWER); // CentOS
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER); // CentOS
 }
 
 TEST_F(VersionMatcherTest, matchCalVer)
@@ -519,65 +519,65 @@ TEST_F(VersionMatcherTest, matchRPM)
     EXPECT_TRUE(VersionMatcher::match("A.B.C", VersionObjectType::RPM));
 
     EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT);
-    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM), LEFT_EQ_RIGHT);
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
+    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT);
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT);
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT);
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT);
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
     EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::RPM),
-              LEFT_EQ_RIGHT);
+              VERSION_COMPARE_RESULT::LEFT_EQ_RIGHT);
 
     EXPECT_EQ(VersionMatcher::compare("1:4.8.0-2.amzn2023.0.2", "2:4.8.0-2.amzn2023.0.2", VersionObjectType::RPM),
-              RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "6-4.amzn2023.0.5", VersionObjectType::RPM), RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("5-4.amzn2023.0.5", "6-4.amzn2023.0.5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("3.14-5.amzn2023.0.3", "3.15-5.amzn2023.0.3", VersionObjectType::RPM),
-              RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("1:2.0.5-12.amzn2023.0.2", "1:2.0.6-12.amzn2023.0.2", VersionObjectType::RPM),
-              RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("2.37.4-1.amzn2023.0.3", "2.37.4-2.amzn2023.0.3", VersionObjectType::RPM),
-              RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("2:9.0.2120-1.amzn2023", "2:9.0.2120-2.amzn2023", VersionObjectType::RPM),
-              RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("2.21-26.amzn2023.0.2", "2.22-26.amzn2023.0.2", VersionObjectType::RPM),
-              RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
 
     EXPECT_EQ(VersionMatcher::compare("2:4.8.0-2.amzn2023.0.2", "1:4.8.0-2.amzn2023.0.2", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("6-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM), LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("6-4.amzn2023.0.5", "5-4.amzn2023.0.5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("3.15-5.amzn2023.0.3", "3.14-5.amzn2023.0.3", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("1:2.0.5-13.amzn2023.0.2", "1:2.0.5-12.amzn2023.0.2", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("3.37.4-1.amzn2023.0.3", "2.37.4-1.amzn2023.0.3", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("2:9.1.2120-1.amzn2023", "2:9.0.2120-1.amzn2023", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("2.21-29.amzn2023.0.2", "2.21-26.amzn2023.0.2", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
 
     EXPECT_EQ(VersionMatcher::compare("1.15.1-6.amzn2023.0.3", "gpgme-1.4.3-5.15", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(
         VersionMatcher::compare("1.57.0-1.amzn2023.0.1", "1.41.0-1.amzn2.0.4.aarch64.rpm", VersionObjectType::RPM),
-        LEFT_IS_NEWER);
+        VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("5.4.4-3.amzn2023.0.2", "5.4.4-3.amzn2022", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("2~almost^post", "2.0.1", VersionObjectType::RPM), RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("2~almost^post", "2.0.1", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("0.9.1+git.20181118-bp156.3.5", "0.9.1-16.fc39", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("4.5.1-bp156.4.2", "4.5.1-bp155.3.7", VersionObjectType::RPM), LEFT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("4.5.1-bp156.4.2", "4.5.1-bp155.3.7", VersionObjectType::RPM), VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("11.1-2.git3118496.2.mga10", "11.1-2.git3118496.1.mga9", VersionObjectType::RPM),
-              LEFT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("0.0.26-bp156.3.5", "0.0.26-9", VersionObjectType::RPM), RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::LEFT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("0.0.26-bp156.3.5", "0.0.26-9", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
     EXPECT_EQ(VersionMatcher::compare("0.9.1+git.20181118-bp156.3.5", "0.9.1+git.20181118-1.3", VersionObjectType::RPM),
-              RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("0.2-bp156.4.5", "0.2-3.2", VersionObjectType::RPM), RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("2.15.6-1.mga10", "2.15.6-1.1", VersionObjectType::RPM), RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("0.5.2-5.el4.at", "0.5.2-5.0.el5", VersionObjectType::RPM), RIGHT_IS_NEWER);
-    EXPECT_EQ(VersionMatcher::compare("2:3.28.1-3.el8", "3:2.3.15-24.el8", VersionObjectType::RPM), RIGHT_IS_NEWER);
+              VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("0.2-bp156.4.5", "0.2-3.2", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("2.15.6-1.mga10", "2.15.6-1.1", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("0.5.2-5.el4.at", "0.5.2-5.0.el5", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
+    EXPECT_EQ(VersionMatcher::compare("2:3.28.1-3.el8", "3:2.3.15-24.el8", VersionObjectType::RPM), VERSION_COMPARE_RESULT::RIGHT_IS_NEWER);
 }


### PR DESCRIPTION
## Description
This PR adds a handling logic for the scenarios where the `compare` method of the versionComparer fails to determine the exact value of the match. Now this compare method throws an exception on this scenario

These scenarios are:
- One or both versions are not compatible with the `VersionObjectType`
  - `versionA` is rpm and the `VersionObjectType::RPM`
- The comparators are not of the same type
  - `VersionObjectType` is `Unspecified`. `versionA` and `versionB` are different types of versioning schemas
  
### Changelog

- Added enum class for the different version compare scenarios
- Updated UTs to reflect changes
- Small refactor 