### PR TITLE
Fix scan build error, use const char* in variadic function

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/queryAllPackages.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/queryAllPackages.hpp
@@ -169,7 +169,7 @@ public:
                 {
                     logWarn(WM_VULNSCAN_LOGTAG,
                             "Empty response for agent '%s' in Wazuh-DB 'sys_programs' query",
-                            agentIdStr);
+                            agentIdStr.c_str());
                     continue;
                 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #22055 |

## Description

This PR aims to fix an error while executing the scan-build check.

Curiously, the checks of the PR that introduced this change are completely green.

https://github.com/wazuh/wazuh/actions/runs/7995876290/job/21837175488?pr=21446