### PR TITLE
Update CVEv5 score fields type

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -16,7 +16,7 @@ table CVSS_V3_1 {
     exploitCodeMaturity: string;
     remediationLevel: string;
     reportConfidence: string;
-    temporalScore: string;
+    temporalScore: float;
     temporalSeverity: string;
     confidentialityRequirement: string;
     integrityRequirement: string;
@@ -29,7 +29,7 @@ table CVSS_V3_1 {
     modifiedConfidentialityImpact: string;
     modifiedIntegrityImpact: string;
     modifiedAvailabilityImpact: string;
-    environmentalScore: string;
+    environmentalScore: float;
     environmentalSeverity: string;
 }
 
@@ -49,7 +49,7 @@ table CVSS_V3_0 {
     exploitCodeMaturity: string;
     remediationLevel: string;
     reportConfidence: string;
-    temporalScore: string;
+    temporalScore: float;
     temporalSeverity: string;
     confidentialityRequirement: string;
     integrityRequirement: string;
@@ -62,7 +62,7 @@ table CVSS_V3_0 {
     modifiedConfidentialityImpact: string;
     modifiedIntegrityImpact: string;
     modifiedAvailabilityImpact: string;
-    environmentalScore: string;
+    environmentalScore: float;
     environmentalSeverity: string;
 }
 
@@ -79,13 +79,13 @@ table CVSS_V2_0 {
     exploitability: string;
     remediationLevel: string;
     reportConfidence: string;
-    temporalScore: string;
+    temporalScore: float;
     collateralDamagePotential: string;
     targetDistribution: string;
     confidentialityRequirement: string;
     integrityRequirement: string;
     availabilityRequirement: string;
-    environmentalScore: string;
+    environmentalScore: float;
 }
 
 table StringifiedObject {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -52,7 +52,10 @@ auto constexpr CREATED_RESOURCE {R"(
                                     "attackComplexity": "LOW",
                                     "availabilityImpact": "NONE",
                                     "privilegesRequired": "LOW",
-                                    "confidentialityImpact": "NONE"
+                                    "confidentialityImpact": "NONE",
+                                    "environmentalScore": 0,
+                                    "temporalScore": 0
+
                                 }
                             }
                         ],
@@ -124,7 +127,10 @@ auto constexpr CREATED_RESOURCE {R"(
                                 "confidentialityImpact": "NONE",
                                 "integrityImpact": "NONE",
                                 "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-                                "version": "2.0"
+                                "version": "2.0",
+                                "environmentalScore": 0,
+                                "temporalScore": 0
+
                             },
                             "format": "CVSS"
                         }
@@ -218,7 +224,9 @@ auto constexpr UPDATED_DATA {R"(
                                 "attackComplexity": "LOW",
                                 "availabilityImpact": "NONE",
                                 "privilegesRequired": "LOW",
-                                "confidentialityImpact": "NONE"
+                                "confidentialityImpact": "NONE",
+                                "environmentalScore": 0,
+                                "temporalScore": 0
                             }
                         }
                     ],
@@ -291,7 +299,10 @@ auto constexpr UPDATED_DATA {R"(
                             "confidentialityImpact": "NONE",
                             "integrityImpact": "NONE",
                             "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-                            "version": "2.0"
+                            "version": "2.0",
+                            "environmentalScore": 0,
+                            "temporalScore": 0
+
                         },
                         "format": "CVSS"
                     }


### PR DESCRIPTION
|Related issue|
|---|
|#22150|

## Description
This PR fixed the type of the CVEv5 flatbuffer schema score fields. Some of the score fields were of the typed string when they all should have been float

## Test

Installed manager and parsed the content
<details>
  <summary>Logs</summary>
  
```
2024/02/26 21:35:23 wazuh-modulesd:vulnerability-scanner: INFO: Processing file: queue/vd_updater/tmp/contents/vd_1.0.0_vd_4.8.0_288974_1708901345.json
2024/02/26 21:36:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:36:21 rootcheck: INFO: Ending rootcheck scan.
2024/02/26 21:37:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:38:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:38:45 wazuh-logcollector: WARNING: Target 'agent' message queue is full (1024). Log lines may be lost.
2024/02/26 21:39:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:40:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:41:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:42:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:43:13 indexer-connector: WARNING: Error initializing IndexerConnector: No available server, we will try again after 60 seconds.
2024/02/26 21:43:23 wazuh-modulesd:vulnerability-scanner: ERROR: Invalid resource type: OSCPE-GLOBAL
2024/02/26 21:43:29 wazuh-modulesd:content-updater: INFO: Starting on-demand action for 'vulnerability_feed_manager'
2024/02/26 21:43:29 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' started
2024/02/26 21:43:29 wazuh-modulesd:content-updater: INFO: Action for 'vulnerability_feed_manager' finished
2024/02/26 21:43:29 wazuh-modulesd:vulnerability-scanner: INFO: Message processed
```
</details>


>[!IMPORTANT]
> To test this I've added the `source` field to the `Reference` section and the `baseSeverity` field to the `CVSSv2` section of the CVEv5 schema
>
> [Known issue](https://github.com/wazuh/intelligence-data/pull/58).