### PR TITLE
Improve the way Wazuh DB cleans open databases

### DIFF
--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -434,7 +434,6 @@ void * run_gc(__attribute__((unused)) void * args) {
         }
 
         wdb_close_old();
-        wdb_pool_clean();
 
         sleep(1);
     }

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -326,7 +326,6 @@ STATIC int wdb_execute_single_int_select_query(wdb_t * wdb, const char *query, i
 STATIC int wdb_get_last_vacuum_data(wdb_t* wdb, int *last_vacuum_time, int *last_vacuum_value);
 
 wdb_config wconfig;
-_Atomic(int) wdb_open_count;
 
 // Opens global database and stores it in DB pool. It returns a locked database or NULL
 wdb_t * wdb_open_global() {
@@ -362,7 +361,6 @@ wdb_t * wdb_open_global() {
             }
         }
 
-        wdb_open_count++;
         wdb_enable_foreign_keys(wdb->db);
     }
 
@@ -388,7 +386,6 @@ wdb_t * wdb_open_mitre() {
         return NULL;
     }
 
-    wdb_open_count++;
     return wdb;
 }
 
@@ -433,7 +430,6 @@ wdb_t * wdb_open_agent2(int agent_id) {
         }
     }
 
-    wdb_open_count++;
     return wdb;
 }
 
@@ -467,7 +463,6 @@ wdb_t * wdb_open_tasks() {
         }
     }
 
-    wdb_open_count++;
     return wdb;
 }
 
@@ -1111,8 +1106,9 @@ int wdb_update_last_vacuum_data(wdb_t* wdb, const char *last_vacuum_time, const 
 
 void wdb_close_old() {
     char ** keys = wdb_pool_keys();
+    int closed = 0;
 
-    for (int i = 0; keys[i] && wdb_open_count > wconfig.open_db_limit; i++) {
+    for (int i = 0; keys[i] && wdb_pool_size - closed > wconfig.open_db_limit; i++) {
         wdb_t * node = wdb_pool_get(keys[i]);
 
         if (node == NULL) {
@@ -1122,11 +1118,14 @@ void wdb_close_old() {
         if (node->db != NULL && node->refcount == 1 && strcmp(node->id, WDB_GLOB_NAME) != 0) {
             mdebug2("Closing database for agent %s", node->id);
             wdb_close(node, true);
+            closed++;
         }
 
         wdb_pool_leave(node);
 
     }
+
+    wdb_pool_clean();
 
     free_strarray(keys);
 }
@@ -1374,7 +1373,6 @@ int wdb_close(wdb_t * wdb, bool commit) {
 
     if (result == SQLITE_OK) {
         wdb->db = NULL;
-        wdb_open_count--;
         return OS_SUCCESS;
     } else {
         merror("DB(%s) wdb_close(): %s", wdb->id, sqlite3_errmsg(wdb->db));

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1108,7 +1108,7 @@ void wdb_close_old() {
     char ** keys = wdb_pool_keys();
     int closed = 0;
 
-    for (int i = 0; keys[i] && wdb_pool_size - closed > wconfig.open_db_limit; i++) {
+    for (int i = 0; keys[i] && (int)wdb_pool_size() - closed > wconfig.open_db_limit; i++) {
         wdb_t * node = wdb_pool_get(keys[i]);
 
         if (node == NULL) {

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -440,7 +440,6 @@ extern char *schema_global_upgrade_v4_sql;
 extern char *schema_global_upgrade_v5_sql;
 
 extern wdb_config wconfig;
-extern _Atomic(int) wdb_pool_size;
 
 typedef struct os_data {
     char *os_name;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -440,7 +440,7 @@ extern char *schema_global_upgrade_v4_sql;
 extern char *schema_global_upgrade_v5_sql;
 
 extern wdb_config wconfig;
-extern _Atomic(int) wdb_open_count;
+extern _Atomic(int) wdb_pool_size;
 
 typedef struct os_data {
     char *os_name;

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -19,7 +19,6 @@
 #endif
 
 STATIC wdb_pool_t wdb_pool;
-_Atomic(int) wdb_pool_size;
 
 // Initialize global pool.
 
@@ -56,7 +55,7 @@ wdb_t * wdb_pool_get_or_create(const char * name) {
     if (node == NULL) {
         node = wdb_init(name);
         rbtree_insert(wdb_pool.nodes, name, node);
-        wdb_pool_size++;
+        wdb_pool.size++;
     }
 
     node->refcount++;
@@ -105,10 +104,16 @@ void wdb_pool_clean() {
         if (node->refcount == 0 && node->db == NULL) {
             wdb_destroy(node);
             rbtree_delete(wdb_pool.nodes, keys[i]);
-            wdb_pool_size--;
+            wdb_pool.size--;
         }
     }
 
     free_strarray(keys);
     w_mutex_unlock(&wdb_pool.mutex);
+}
+
+// Get the current pool size.
+
+unsigned wdb_pool_size() {
+    return wdb_pool.size;
 }

--- a/src/wazuh_db/wdb_pool.c
+++ b/src/wazuh_db/wdb_pool.c
@@ -19,6 +19,7 @@
 #endif
 
 STATIC wdb_pool_t wdb_pool;
+_Atomic(int) wdb_pool_size;
 
 // Initialize global pool.
 
@@ -55,6 +56,7 @@ wdb_t * wdb_pool_get_or_create(const char * name) {
     if (node == NULL) {
         node = wdb_init(name);
         rbtree_insert(wdb_pool.nodes, name, node);
+        wdb_pool_size++;
     }
 
     node->refcount++;
@@ -103,6 +105,7 @@ void wdb_pool_clean() {
         if (node->refcount == 0 && node->db == NULL) {
             wdb_destroy(node);
             rbtree_delete(wdb_pool.nodes, keys[i]);
+            wdb_pool_size--;
         }
     }
 

--- a/src/wazuh_db/wdb_pool.h
+++ b/src/wazuh_db/wdb_pool.h
@@ -16,6 +16,7 @@
 typedef struct {
     rb_tree * nodes;
     pthread_mutex_t mutex;
+    _Atomic(unsigned) size;
 } wdb_pool_t;
 
 /**
@@ -67,3 +68,13 @@ char ** wdb_pool_keys();
  * Scans the pool and destroys all nodes associated to closed databases.
  */
 void wdb_pool_clean();
+
+/**
+ * @brief Get the current pool size.
+ *
+ * This function returns how many nodes are currently in the pool, no matter if
+ * the databases are open or closed.
+ *
+ * @return Number of nodes in the pool.
+ */
+unsigned wdb_pool_size();


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22130|


## Description

It was discovered that the `wdb_pool_size` variable could contain an invalid value, which could cause an excessive number of file descriptors to be opened and the `wazuh-db` daemon to use excessive memory due to an incorrect filter in the database cleaning. This was because the `wdb_close` function (where `wdb_pool_size` was decremented) is not always called with a valid database pointer, which could lead to decrementing the number of `wdb_pool_size` when it was not necessary.

This PR replaces the `wdb_open_count` variable with `wdb_pool_size`. This new variable corresponds to the number of nodes that are stored in `wdb_pool` where all open objects are stored, whether the database is already open or not.

This new variable is used as a filter in the `wdb_close_old` function instead of `wdb_pool_size`. Now, every time a new node is created/deleted, this new variable is modified, so it will always correspond to the current number of databases stored in memory.


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade