### PR TITLE
Enhance auditd log recognition by making "node=" optional

### DIFF
--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -7,7 +7,7 @@
 -->
 
 <decoder name="auditd">
-  <prematch>^type=</prematch>
+  <prematch>^node=\S+ type=|^type=</prematch>
 </decoder>
 
 <!--

--- a/ruleset/testing/tests/auditd.ini
+++ b/ruleset/testing/tests/auditd.ini
@@ -1,12 +1,12 @@
 ;  Copyright (C) 2015, Wazuh Inc.
 ;
-;  Tests for products: 
+;  Tests for products:
 ;    Audit logs;
 ;
-;  Sample logs source: 
+;  Sample logs source:
 ;    Audit logs;
-;      Software name: passwd. 
-;      Version: n/a. 
+;      Software name: passwd.
+;      Version: n/a.
 ;      From: member.
 
 [Auditd: Daemon Start / Resume.]
@@ -182,6 +182,7 @@ decoder = auditd
 
 [Audit: Created: $(audit.file.name).]
 log 1 pass = type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes exit=3 a0=7ffedc40d83b a1=941 a2=1b6 a3=7ffedc40cce0 items=2 ppid=432 pid=3333 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=2 comm="touch" exe="/bin/touch" key="audit-wazuh-w" type=CWD msg=audit(1479982525.380:50):  cwd="/var/log/audit" type=PATH msg=audit(1479982525.380:50): item=0 name="/var/log/audit/tmp_directory1/" inode=399849 dev=ca:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT type=PATH msg=audit(1479982525.380:50): item=1 name="/var/log/audit/tmp_directory1/malware.py" inode=399852 dev=ca:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=CREATE type=PROCTITLE msg=audit(1479982525.380:50): proctitle=746F756368002F7661722F6C6F672F61756469742F746D705F6469726563746F7279312F6D616C776172652E7079
+log 1 pass = node=localhost type=SYSCALL msg=audit(1479982525.380:50): arch=c000003e syscall=2 success=yes exit=3 a0=7ffedc40d83b a1=941 a2=1b6 a3=7ffedc40cce0 items=2 ppid=432 pid=3333 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=2 comm="touch" exe="/bin/touch" key="audit-wazuh-w" type=CWD msg=audit(1479982525.380:50):  cwd="/var/log/audit" type=PATH msg=audit(1479982525.380:50): item=0 name="/var/log/audit/tmp_directory1/" inode=399849 dev=ca:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT type=PATH msg=audit(1479982525.380:50): item=1 name="/var/log/audit/tmp_directory1/malware.py" inode=399852 dev=ca:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=CREATE type=PROCTITLE msg=audit(1479982525.380:50): proctitle=746F756368002F7661722F6C6F672F61756469742F746D705F6469726563746F7279312F6D616C776172652E7079
 rule = 80790
 alert = 3
 decoder = auditd


### PR DESCRIPTION
|Related issue|
|---|
|Closes #22066|

This PR addresses a bug in our product where logs starting with "node=" were not being recognized properly. I've modified the `<prematch>` regex option to make the presence of "node=" at the beginning of the log optional. This change ensures that logs both with and without "node=" are correctly identified.

Additionally, I've updated the tests to accommodate this modification, ensuring robustness in our testing suite.

## Tests

- [X] Extend ruleset ini tests.
- [X] wazuh-logtest.

### 🟢 Unchanged

> type=PROCTITLE msg=audit(1708637434.880:672): proctitle="su"

<details><summary>Result:</summary>

```
**Phase 2: Completed decoding.
        name: 'auditd'
        audit.id: '672'
        audit.type: 'PROCTITLE'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '1'
        mail: 'False'
```

</details>

### 🟢 Fixed

> node=localhost type=PROCTITLE msg=audit(1708637434.880:672): proctitle="su"

<details><summary>Result:</summary>

```
**Phase 2: Completed decoding.
        name: 'auditd'
        audit.id: '672'
        audit.type: 'PROCTITLE'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '1'
        mail: 'False'
```

</details>