### PR TITLE
Add support for alternative syntaxes in PEP440 version matching

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_002.out
@@ -1,0 +1,3 @@
+[
+    "Match found, the package 'cfscrape', is vulnerable to 'CVE-2017-7235'. Current version: '1.7.0' (less than '1.8.0' or equal to ''). - Agent '' (ID: '001', Version: '')."
+]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_003.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_003.out
@@ -1,0 +1,4 @@
+[
+    "Match found, the package 'pypdf2', is vulnerable to 'CVE-2023-36464'. Current version: '2.10.5' (less than '' or equal to '3.0.1'). - Agent '' (ID: '001', Version: '')",
+    "Match found, the package 'pypdf2', is vulnerable to 'CVE-2023-36807'. Current version: '2.10.5' (less than '2.10.6' or equal to ''). - Agent '' (ID: '001', Version: '')."
+]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_004.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_004.out
@@ -1,0 +1,3 @@
+[
+    "Match found, the package 'py-evm', is vulnerable to 'CVE-2018-18920'. Current version: '0.2.0a32' (less than '0.2.0a33' or equal to ''). - Agent '' (ID: '001', Version: '')"
+]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_005.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_005.out
@@ -1,0 +1,3 @@
+[
+    "Match found, the package 'py-evm', is vulnerable to 'CVE-2018-18920'. Current version: 'v0.2.0-alpha.32' (less than '0.2.0a33' or equal to ''). - Agent '' (ID: '001', Version: '')"
+]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_006.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/expected_006.out
@@ -1,0 +1,3 @@
+[
+    "Match found, the package 'geonode', is vulnerable to 'CVE-2023-42439'. Current version: '4.1.0-1' (less than '4.1.3.post1' or equal to ''). - Agent '' (ID: '001', Version: '')"
+]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_001.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_001.json
@@ -1,0 +1,21 @@
+{
+  "agent_info": {
+    "agent_id": "001",
+    "node_name": "test_node_name"
+  },
+  "data_type": "dbsync_osinfo",
+  "data": {
+      "architecture":"x86_64",
+      "checksum":"1691178971959743855",
+      "hostname":"fd9b83c25f30",
+      "os_major":"15",
+      "os_name":"SLES",
+      "os_platform":"sles",
+      "os_version":"15-SP5",
+      "release":"5.4.0-155-generic",
+      "scan_time":"2023/08/04 19:56:11",
+      "sysname":"Linux",
+      "version":"#172-Ubuntu SMP Fri Jul 7 16:10:02 UTC 2023"
+  },
+  "operation": "INSERTED"
+}

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_002.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_002.json
@@ -1,0 +1,24 @@
+{
+  "agent_info": {
+    "agent_id": "001",
+    "node_name": "test_node_name"
+  },
+  "data_type": "dbsync_packages",
+  "data": {
+    "architecture": "amd64",
+    "checksum": "0e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+    "description": "A simple Python module to bypass Cloudflare's anti-bot page",
+    "format": "pypi",
+    "groups": "libs",
+    "item_id": "0c465b7eb5fa011a336e95614072e4c7f1a65a53",
+    "multiarch": "same",
+    "name": "cfscrape",
+    "priority": "optional",
+    "scan_time": "2023/08/04 19:56:11",
+    "size": 72,
+    "source": "cfscrape",
+    "vendor": "pypi",
+    "version": "1.7.0"
+  },
+  "operation": "INSERTED"
+}

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_003.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_003.json
@@ -1,0 +1,24 @@
+{
+  "agent_info": {
+    "agent_id": "001",
+    "node_name": "test_node_name"
+  },
+  "data_type": "dbsync_packages",
+  "data": {
+    "architecture": "amd64",
+    "checksum": "0e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+    "description": "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files",
+    "format": "pypi",
+    "groups": "libs",
+    "item_id": "2c465b7eb5fa011a336e95614072e4c7f1a65a53",
+    "multiarch": "same",
+    "name": "pypdf2",
+    "priority": "optional",
+    "scan_time": "2023/08/04 19:56:11",
+    "size": 72,
+    "source": "pypdf2",
+    "vendor": "pypi",
+    "version": "2.10.5"
+  },
+  "operation": "INSERTED"
+}

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_004.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_004.json
@@ -1,0 +1,24 @@
+{
+  "agent_info": {
+    "agent_id": "001",
+    "node_name": "test_node_name"
+  },
+  "data_type": "dbsync_packages",
+  "data": {
+    "architecture": "amd64",
+    "checksum": "5e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+    "description": "Python implementation of the Ethereum Virtual Machine",
+    "format": "pypi",
+    "groups": "libs",
+    "item_id": "5c465b7eb5fa011a336e95614072e4c7f1a65a53",
+    "multiarch": "same",
+    "name": "py-evm",
+    "priority": "optional",
+    "scan_time": "2023/08/04 19:56:11",
+    "size": 72,
+    "source": "py-evm",
+    "vendor": "pypi",
+    "version": "0.2.0a32"
+  },
+  "operation": "INSERTED"
+}

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_005.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_005.json
@@ -1,0 +1,24 @@
+{
+  "agent_info": {
+    "agent_id": "001",
+    "node_name": "test_node_name"
+  },
+  "data_type": "dbsync_packages",
+  "data": {
+    "architecture": "amd64",
+    "checksum": "5e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+    "description": "Python implementation of the Ethereum Virtual Machine",
+    "format": "pypi",
+    "groups": "libs",
+    "item_id": "5c465b7eb5fa011a336e95614072e4c7f1a65a53",
+    "multiarch": "same",
+    "name": "py-evm",
+    "priority": "optional",
+    "scan_time": "2023/08/04 19:56:11",
+    "size": 72,
+    "source": "py-evm",
+    "vendor": "pypi",
+    "version": "v0.2.0-alpha.32"
+  },
+  "operation": "INSERTED"
+}

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_006.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/006/input_006.json
@@ -1,0 +1,24 @@
+{
+  "agent_info": {
+    "agent_id": "001",
+    "node_name": "test_node_name"
+  },
+  "data_type": "dbsync_packages",
+  "data": {
+    "architecture": "amd64",
+    "checksum": "5e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
+    "description": "Application for serving and sharing geospatial data",
+    "format": "pypi",
+    "groups": "libs",
+    "item_id": "5c465b7eb5fa011a336e95614072e4c7f1a65a53",
+    "multiarch": "same",
+    "name": "geonode",
+    "priority": "optional",
+    "scan_time": "2023/08/04 19:56:11",
+    "size": 72,
+    "source": "geonode",
+    "vendor": "pypi",
+    "version": "4.1.0-1"
+  },
+  "operation": "INSERTED"
+}

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.cpp
@@ -11,6 +11,27 @@
 
 #include "versionObjectPEP440.hpp"
 
+/**
+ * @brief Regular expression pattern for parsing PEP 440 version strings.
+ *
+ * @details This regex is used to parse PEP 440 version strings. It supports the alternative syntax as well as the
+ * canonical form.
+ *
+ * Capture groups:
+ * - 1: Epoch
+ * - 2: Release version string
+ * - 3: Pre-release string: a, b, c, rc, alpha, beta, pre, preview
+ * - 4: Pre-release number
+ * - 5: Implicit post release number
+ * - 6: Post-release string: post, r, rev
+ * - 7: Post-release number
+ * - 8: Development release string: dev
+ * - 9: Development release number
+ *
+ * This regex is case-insensitive.
+ */
 std::regex VersionObjectPEP440::m_parserRegex(
-    R"(^(?:([1-9][0-9]*)!)?((?:0|[1-9][0-9]*)(?:\.(?:0|[1-9][0-9]*))*)(?:(a|b|rc)(0|[1-9][0-9]*))?(?:\.post(0|[1-9][0-9]*))?(?:\.dev(0|[1-9][0-9]*))?$)");
+    R"(^v?(?:(?:([0-9]+)!)?([0-9]+(?:\.[0-9]+)*)(?:[-_\.]?(a|b|c|rc|alpha|beta|pre|preview)[-_\.]?([0-9]+)?)?(?:(?:-([0-9]+))|(?:[-_\.]?(post|rev|r)[-_\.]?([0-9]+)?))?(?:[-_\.]?(dev)[-_\.]?([0-9]+)?)?)?$)",
+    std::regex_constants::icase);
+
 std::regex VersionObjectPEP440::m_parserVersionStrRegex(R"(\.)");

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
@@ -13,7 +13,8 @@
 #define _VERSION_OBJECT_PEP440_HPP
 
 #include "iVersionObjectInterface.hpp"
-#include <iostream>
+#include <algorithm>
+#include <cctype>
 #include <memory>
 #include <regex>
 #include <string>
@@ -119,26 +120,57 @@ public:
     static bool match(const std::string& version, PEP440& data)
     {
         std::smatch parserMatches;
-        if ((std::regex_match(version, parserMatches, m_parserRegex) == false) || (parserMatches.size() != 7))
+        if (!std::regex_match(version, parserMatches, m_parserRegex))
         {
             return false;
         }
 
+        // Epoch
         data.epoch = parserMatches.str(1).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(1)));
+
+        // Release version string
         data.versionStr = parserMatches.str(2);
 
-        data.preReleaseStr = parserMatches.str(3);
+        // Pre-release
+        data.hasPreRelease = parserMatches[3].matched;
+        if (data.hasPreRelease)
+        {
+            data.preReleaseStr = parserMatches.str(3);
+            std::transform(data.preReleaseStr.begin(), data.preReleaseStr.end(), data.preReleaseStr.begin(), ::tolower);
+            if (data.preReleaseStr == "alpha")
+            {
+                data.preReleaseStr = "a";
+            }
+            else if (data.preReleaseStr == "beta")
+            {
+                data.preReleaseStr = "b";
+            }
+            else if (data.preReleaseStr == "c" || data.preReleaseStr == "pre" || data.preReleaseStr == "preview")
+            {
+                data.preReleaseStr = "rc";
+            }
+        }
         data.preReleaseNumber =
             parserMatches.str(4).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(4)));
-        data.hasPreRelease = (!parserMatches.str(3).empty() && !parserMatches.str(4).empty());
 
-        data.postReleaseNumber =
-            parserMatches.str(5).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(5)));
-        data.hasPostRelease = !parserMatches.str(5).empty();
+        // Post release
+        data.hasPostRelease = parserMatches[6].matched || parserMatches[5].matched;
+
+        if (parserMatches[5].matched)
+        {
+            data.postReleaseNumber = static_cast<uint32_t>(std::stoul(parserMatches.str(5)));
+        }
+        else
+        {
+            data.postReleaseNumber =
+                parserMatches.str(7).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(7)));
+        }
+
+        // Development release
+        data.hasDevRelease = parserMatches[8].matched;
 
         data.devReleaseNumber =
-            parserMatches.str(6).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(6)));
-        data.hasDevRelease = !parserMatches.str(6).empty();
+            parserMatches.str(9).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(9)));
 
         return true;
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
@@ -150,27 +150,24 @@ public:
                 data.preReleaseStr = "rc";
             }
         }
-        data.preReleaseNumber =
-            parserMatches.str(4).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(4)));
+        data.preReleaseNumber = parserMatches.str(4).empty() ? 0 : std::stoul(parserMatches.str(4));
 
         // Post release
         data.hasPostRelease = parserMatches[6].matched || parserMatches[5].matched;
 
         if (parserMatches[5].matched)
         {
-            data.postReleaseNumber = static_cast<uint32_t>(std::stoul(parserMatches.str(5)));
+            data.postReleaseNumber = std::stoul(parserMatches.str(5));
         }
         else
         {
-            data.postReleaseNumber =
-                parserMatches.str(7).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(7)));
+            data.postReleaseNumber = parserMatches.str(7).empty() ? 0 : std::stoul(parserMatches.str(7));
         }
 
         // Development release
         data.hasDevRelease = parserMatches[8].matched;
 
-        data.devReleaseNumber =
-            parserMatches.str(9).empty() ? 0 : static_cast<uint32_t>(std::stoul(parserMatches.str(9)));
+        data.devReleaseNumber = parserMatches.str(9).empty() ? 0 : std::stoul(parserMatches.str(9));
 
         return true;
     }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -100,6 +100,145 @@ TEST_F(VersionMatcherTest, comparePEP440_OkEqual)
     EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
 }
 
+TEST_F(VersionMatcherTest, comparePEP440_AlternativeSyntax_OkEqual)
+{
+    VersionComparisonResult compareResult;
+
+    // Case sensitivity
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.1RC1", "1.1rc1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.3A2", "2.3a2", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.0.Dev1", "1.0.dev1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Integer normalization
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("03.004.0023", "3.4.23", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2014.05.03", "2014.5.3", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Pre-release separators
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3.a1", "1.2.3a1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3-a1", "1.2.3a1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3_a1", "1.2.3a1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3a.1", "1.2.3a1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3a-1", "1.2.3a1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3a_1", "1.2.3a1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Pre-release spelling
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3alpha1", "1.2.3a1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3beta1", "1.2.3b1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3c1", "1.2.3rc1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3pre1", "1.2.3rc1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3preview1", "1.2.3rc1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Implicit pre-release number
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3a", "1.2.3a0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3b", "1.2.3b0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3rc", "1.2.3rc0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Post release separators
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3-post1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3_post1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3post1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW(
+        (compareResult = VersionMatcher::compare("1.2.3.post.1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW(
+        (compareResult = VersionMatcher::compare("1.2.3.post-1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW(
+        (compareResult = VersionMatcher::compare("1.2.3.post_1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Post release spelling
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3.rev1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3.r1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Implicit post release number
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3.post", "1.2.3.post0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3.rev", "1.2.3.post0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3.r", "1.2.3.post0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Implicit post releases
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3-1", "1.2.3.post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Development release separators
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3-dev1", "1.2.3.dev1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3_dev1", "1.2.3.dev1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3dev1", "1.2.3.dev1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Implicit development release number
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.3.dev", "1.2.3.dev0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Preceding 'v' character
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("v1.2.3", "1.2.3", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+
+    // Combination of previous cases
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
+                         "1!2.0Beta_rev345-DEV456", "1!2.0b0.post345.dev456", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
+                         "2.0BETA2.post_dev456", "2.0b2.post0.dev456", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare(
+                         "v2.0.Preview2-r.6-dev1", "2.0rc2.post6.dev1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_EQUAL_B);
+}
+
 TEST_F(VersionMatcherTest, comparePEP440_OkLess)
 {
     VersionComparisonResult compareResult;
@@ -138,6 +277,28 @@ TEST_F(VersionMatcherTest, comparePEP440_OkLess)
     EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
 }
 
+TEST_F(VersionMatcherTest, comparePEP440_AlternativeSyntax_OkLess)
+{
+    VersionComparisonResult compareResult;
+
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.0003", "1.2.4", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0alpha2", "2.0beta2", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0beta2", "2.0preview2", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0beta", "2.0beta2", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0post0", "2.0-post.1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0post", "2.0-post1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0-DEV1", "2.0.dev2", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.dev", "2.0.dev1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_LESS_THAN_B);
+}
+
 TEST_F(VersionMatcherTest, comparePEP440_OkGreater)
 {
     VersionComparisonResult compareResult;
@@ -173,6 +334,27 @@ TEST_F(VersionMatcherTest, comparePEP440_OkGreater)
     EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_NO_THROW(
         (compareResult = VersionMatcher::compare("2.0.1.2.3", "2.0.1.2.2.0.0.0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+}
+
+TEST_F(VersionMatcherTest, comparePEP440_AlternativeSyntax_OkGreater)
+{
+    VersionComparisonResult compareResult;
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("1.2.4", "1.2.0003", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0beta2", "2.0alpha2", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0preview2", "2.0beta2", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0beta2", "2.0beta", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0-post.1", "2.0post0", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0-post1", "2.0post", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.dev2", "2.0-DEV1", VersionObjectType::PEP440)));
+    EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
+    EXPECT_NO_THROW((compareResult = VersionMatcher::compare("2.0.dev1", "2.0.dev", VersionObjectType::PEP440)));
     EXPECT_EQ(compareResult, VersionComparisonResult::A_GREATER_THAN_B);
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#22181|

## Description

This PR enhances the version matching functionality for PEP440 by reducing its restrictiveness, accepting also the alternative syntaxes documented at [Version Specifiers - Normalization](https://packaging.python.org/en/latest/specifications/version-specifiers/#normalization).

The following examples illustrate newly accepted version strings and their normalized equivalents:
`1.1RC1` ->  `1.1rc1`
`1.2.3.a1` ->  `1.2.3a1`
`1.2.3a-1` ->  `1.2.3a1`
`1.2.3alpha1` ->  `1.2.3a1`
`1.2.3c1` ->  `1.2.3rc1`
`1.2.3b` ->  `1.2.3b0`
`1.2.3_post1` ->  `1.2.3.post1`
`1.2.3.rev1` ->  `1.2.3.post1`
`1.2.3-1` ->  `1.2.3.post1`

<!--
Add a clear description of how the problem has been solved.
-->


## Tests

New unit tests added:
```
$ ./vulnerability_scanner_unit_tests --gtest_filter=VersionMatcher*PEP440_AlternativeSyntax_*
Note: Google Test filter = VersionMatcher*PEP440_AlternativeSyntax_*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from VersionMatcherTest
[ RUN      ] VersionMatcherTest.comparePEP440_AlternativeSyntax_OkEqual
[       OK ] VersionMatcherTest.comparePEP440_AlternativeSyntax_OkEqual (8 ms)
[ RUN      ] VersionMatcherTest.comparePEP440_AlternativeSyntax_OkLess
[       OK ] VersionMatcherTest.comparePEP440_AlternativeSyntax_OkLess (2 ms)
[ RUN      ] VersionMatcherTest.comparePEP440_AlternativeSyntax_OkGreater
[       OK ] VersionMatcherTest.comparePEP440_AlternativeSyntax_OkGreater (2 ms)
[----------] 3 tests from VersionMatcherTest (12 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (12 ms total)
[  PASSED  ] 3 tests.
```

Tests cases were added to the vulnerability scanner qa tests: `src/wazuh_modules/vulnerability_scanner/qa/test_data/006/`
```
DEBUG    test_efficacy_log:test_efficacy_log.py:171 Running test wazuh_modules/vulnerability_scanner/qa/test_data/006/
input_006.json
DEBUG    test_efficacy_log:test_efficacy_log.py:192 Sending flatbuffer data
DEBUG    test_efficacy_log:test_efficacy_log.py:30 Found 4 matches
DEBUG    test_efficacy_log:test_efficacy_log.py:30 Found 5 matches
DEBUG    test_efficacy_log:test_efficacy_log.py:77 Found line: wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:211 operator() : Match found, the package 'cfscrape', is vulnerable to 'CVE-2017-7235'. Current version: '1.7.0' (less than '1.8.0' or equal to ''). - Agent '' (ID: '001', Version: '').

DEBUG    test_efficacy_log:test_efficacy_log.py:77 Found line: wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:211 operator() : Match found, the package 'pypdf2', is vulnerable to 'CVE-2023-36464'. Current version: '2.10.5' (less than '' or equal to '3.0.1'). - Agent '' (ID: '001', Version: '').

DEBUG    test_efficacy_log:test_efficacy_log.py:77 Found line: wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:211 operator() : Match found, the package 'pypdf2', is vulnerable to 'CVE-2023-36807'. Current version: '2.10.5' (less than '2.10.6' or equal to ''). - Agent '' (ID: '001', Version: '').

DEBUG    test_efficacy_log:test_efficacy_log.py:77 Found line: wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:211 operator() : Match found, the package 'py-evm', is vulnerable to 'CVE-2018-18920'. Current version: '0.2.0a32' (less than '0.2.0a33' or equal to ''). - Agent '' (ID: '001', Version: '').

DEBUG    test_efficacy_log:test_efficacy_log.py:77 Found line: wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:211 operator() : Match found, the package 'py-evm', is vulnerable to 'CVE-2018-18920'. Current version: 'v0.2.0-alpha.32' (less than '0.2.0a33' or equal to ''). - Agent '' (ID: '001', Version: '').

DEBUG    test_efficacy_log:test_efficacy_log.py:77 Found line: wazuh-modulesd:vulnerability-scanner:packageScanner.hpp:211 operator() : Match found, the package 'geonode', is vulnerable to 'CVE-2023-42439'. Current version: '4.1.0-1' (less than '4.1.3.post1' or equal to ''). - Agent '' (ID: '001', Version: '').

PASSED                                                                   [100%]
```
