### PR TITLE
Populate wazuh.manager.name field on each scan UT debt

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -90,9 +90,9 @@ public:
 
         try
         {
-            auto socketDBWrapper = std::make_shared<TSocketDBWrapper>(WDB_SOCKET);
-            socketDBWrapper->query(WazuhDBQueryBuilder::builder().globalSelectCommand("agent-name 000").build(),
-                                   response);
+            TSocketDBWrapper socketDBWrapper(WDB_SOCKET);
+            socketDBWrapper.query(WazuhDBQueryBuilder::builder().globalSelectCommand("agent-name 000").build(),
+                                  response);
 
             if (!response.empty())
             {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -90,9 +90,9 @@ public:
 
         try
         {
-            TSocketDBWrapper socketDBWrapper(WDB_SOCKET);
-            socketDBWrapper.query(WazuhDBQueryBuilder::builder().globalSelectCommand("agent-name 000").build(),
-                                  response);
+            auto socketDBWrapper = std::make_shared<TSocketDBWrapper>(WDB_SOCKET);
+            socketDBWrapper->query(WazuhDBQueryBuilder::builder().globalSelectCommand("agent-name 000").build(),
+                                   response);
 
             if (!response.empty())
             {

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockFactoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockFactoryOrchestrator.hpp
@@ -12,6 +12,7 @@
 #define _MOCK_FACTORYORCHESTRATOR_HPP
 
 #include "TrampolineOsDataCache.hpp"
+#include "TrampolineScanContext.hpp"
 #include "scanContext.hpp"
 #include "shared_modules/utils/mocks/chainOfResponsabilityMock.h"
 #include "gmock/gmock.h"
@@ -40,10 +41,7 @@ public:
      *
      * @note This method is intended for testing purposes and does not perform any real action.
      */
-    MOCK_METHOD(std::shared_ptr<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>,
-                create,
-                (),
-                ());
+    MOCK_METHOD(std::shared_ptr<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>, create, (), ());
 };
 
 #endif // _MOCK_FACTORYORCHESTRATOR_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockSocketDBWrapper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockSocketDBWrapper.hpp
@@ -1,0 +1,58 @@
+/*
+ * Wazuh databaseFeedManager
+ * Copyright (C) 2015, Wazuh Inc.
+ * February 23, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#ifndef _MOCK_SOCKETDBWRAPPER_HPP
+#define _MOCK_SOCKETDBWRAPPER_HPP
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "json.hpp"
+
+/**
+ * @class MockSocketDBWrapper
+ *
+ * @brief Mock class for simulating a database feed manager object.
+ *
+ * The `MockSocketDBWrapper` class is designed to simulate the behavior of a
+ * socketDBWrapper class for testing purposes. It provides mock implementations of methods and
+ * allows you to set expectations on method calls and their return values for testing.
+ *
+ * This class is used in unit tests only to verify interactions with a content
+ * register without actually performing real operations on it.
+ */
+class MockSocketDBWrapper
+{
+public:
+    /**
+     * @brief Mock Constructor
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
+    MockSocketDBWrapper() = default;
+
+    /**
+     * @brief Mock Constructor
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
+    MockSocketDBWrapper(const std::string&) {};
+
+    virtual ~MockSocketDBWrapper() = default;
+
+    /**
+     * @brief Mock method for query.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
+    MOCK_METHOD(void, query, (const std::string& query, nlohmann::json& response), ());
+};
+
+#endif // _MOCK_SOCKETDBWRAPPER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineFactoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineFactoryOrchestrator.hpp
@@ -14,6 +14,7 @@
 #include "MockDatabaseFeedManager.hpp"
 #include "MockFactoryOrchestrator.hpp"
 #include "MockIndexerConnector.hpp"
+#include "TrampolineScanContext.hpp"
 
 extern std::shared_ptr<MockFactoryOrchestrator> spFactoryOrchestratorMock;
 
@@ -46,14 +47,13 @@ public:
      * @return std::shared_ptr<ScanContext> Abstract handler.
      * @param subOrchestration Suborchestration to forward messages.
      */
-    static std::shared_ptr<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>
+    static std::shared_ptr<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>
     create(ScannerType type,
            std::shared_ptr<MockDatabaseFeedManager> databaseFeedManager,
            std::shared_ptr<MockIndexerConnector> indexerConnector,
            Utils::RocksDBWrapper& inventoryDatabase,
            std::shared_ptr<ReportDispatcher> reportDispatcher,
-           std::shared_ptr<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>> subOrchestration =
-               nullptr)
+           std::shared_ptr<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>> subOrchestration = nullptr)
     {
         return spFactoryOrchestratorMock->create();
     }

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineScanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineScanContext.hpp
@@ -1,0 +1,84 @@
+/*
+ * Wazuh Vulnerability scanner - Scan Orchestrator
+ * Copyright (C) 2015, Wazuh Inc.
+ * February 28, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _TRAMPOLINE_SCANCONTEXT_HPP
+#define _TRAMPOLINE_SCANCONTEXT_HPP
+
+#include "scanContext.hpp"
+#include <memory>
+
+extern std::shared_ptr<TScanContext<TrampolineOsDataCache>> spScanContext;
+
+/**
+ * @brief ScanContext structure.
+ *
+ * @tparam TOsDataCache os data cache type.
+ */
+struct TrampolineTScanContext final
+{
+public:
+    // LCOV_EXCL_START
+    /**
+     * @brief Class constructor.
+     *
+     */
+    TrampolineTScanContext() = default;
+    // LCOV_EXCL_STOP
+
+    /**
+     * @brief Class constructor.
+     *
+     * @param data Scan context.
+     */
+    explicit TrampolineTScanContext(std::variant<const SyscollectorDeltas::Delta*,
+                                                 const SyscollectorSynchronization::SyncMsg*,
+                                                 const nlohmann::json*> data)
+    {
+    }
+
+    // LCOV_EXCL_START
+    /**
+     * @brief Class destructor.
+     *
+     */
+    ~TrampolineTScanContext() = default;
+    // LCOV_EXCL_STOP
+
+    /**
+     * @brief Gets scan type.
+     *
+     * @return Scan type.
+     */
+    ScannerType getType() const
+    {
+        return spScanContext->getType();
+    }
+
+    /**
+     * @brief Gets manager name.
+     * @return Manager name.
+     */
+    std::string_view managerName() const
+    {
+        return spScanContext->managerName();
+    }
+
+    /**
+     * @brief Sets manager name.
+     * @param managerName Manager name.
+     */
+    void managerName(std::string_view managerName)
+    {
+        return spScanContext->managerName(managerName);
+    }
+};
+
+#endif // _TRAMPOLINE_SCANCONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineSocketDBWrapper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineSocketDBWrapper.hpp
@@ -1,0 +1,54 @@
+/*
+ * Wazuh databaseFeedManager
+ * Copyright (C) 2015, Wazuh Inc.
+ * February 27, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#ifndef _TRAMPOLINE_SOCKETDBWRAPPER_HPP
+#define _TRAMPOLINE_SOCKETDBWRAPPER_HPP
+
+#include "MockSocketDBWrapper.hpp"
+
+extern std::shared_ptr<MockSocketDBWrapper> spSocketDBWrapperMock;
+
+/**
+ * @brief This class is a wrapper of the trampoline socket DB wrapper
+ */
+class TrampolineSocketDBWrapper final
+{
+public:
+    /**
+     * @brief Constructor.
+     *
+     */
+    TrampolineSocketDBWrapper() = default;
+
+    /**
+     * @brief Constructor.
+     *
+     */
+    TrampolineSocketDBWrapper(const std::string&) {};
+
+    /**
+     * @brief Destructor.
+     *
+     */
+    virtual ~TrampolineSocketDBWrapper() = default;
+
+    /**
+     * @brief Mock method for creating an orchestrator and returns it.
+     *
+     * @param query DB query string.
+     * @param response JSON object
+     */
+    void query(const std::string& query, nlohmann::json& response)
+    {
+        spSocketDBWrapperMock->query(query, response);
+    }
+};
+
+#endif //_TRAMPOLINE_SOCKETDBWRAPPER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/detailsAugmentation_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/detailsAugmentation_test.cpp
@@ -22,6 +22,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
+#include <unistd.h>
 
 using ::testing::_;
 using ::testing::HasSubstr;
@@ -325,6 +326,14 @@ TEST_F(DetailsAugmentationTest, TestSuccessfulPackageInsertedCVSS2)
                      ? vulnerabilityDetection.at("clusterName").get_ref<const std::string&>().c_str()
                      : "");
 
+    auto managerName = scanContextOriginal->managerName();
+    constexpr auto MAX_HOSTNAME_SIZE = 256;
+    std::string realManagerName;
+    realManagerName.reserve(MAX_HOSTNAME_SIZE);
+    ::gethostname(realManagerName.data(), realManagerName.size());
+    EXPECT_STREQ(elementData.at("wazuh").at("manager").at("name").get_ref<const std::string&>().c_str(),
+                 managerName.empty() ? realManagerName.data() : managerName.data());
+
     EXPECT_EQ(scanContextResult->m_alerts.size(), 1);
     EXPECT_NE(scanContextResult->m_alerts.find(CVEID), scanContextResult->m_alerts.end());
 
@@ -592,6 +601,14 @@ TEST_F(DetailsAugmentationTest, TestSuccessfulPackageInsertedCVSS3)
                  vulnerabilityDetection.contains("clusterName")
                      ? vulnerabilityDetection.at("clusterName").get_ref<const std::string&>().c_str()
                      : "");
+
+    auto managerName = scanContextOriginal->managerName();
+    constexpr auto MAX_HOSTNAME_SIZE = 256;
+    std::string realManagerName;
+    realManagerName.reserve(MAX_HOSTNAME_SIZE);
+    ::gethostname(realManagerName.data(), realManagerName.size());
+    EXPECT_STREQ(elementData.at("wazuh").at("manager").at("name").get_ref<const std::string&>().c_str(),
+                 managerName.empty() ? realManagerName.data() : managerName.data());
 
     EXPECT_EQ(scanContextResult->m_alerts.size(), 1);
     EXPECT_NE(scanContextResult->m_alerts.find(CVEID), scanContextResult->m_alerts.end());

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -17,8 +17,11 @@
 #include "../databaseFeedManager/databaseFeedManager.hpp"
 #include "../scanOrchestrator/scanOrchestrator.hpp"
 #include "MockFactoryOrchestrator.hpp"
+#include "MockSocketDBWrapper.hpp"
 #include "TrampolineFactoryOrchestrator.hpp"
 #include "TrampolineOsDataCache.hpp"
+#include "TrampolineScanContext.hpp"
+#include "TrampolineSocketDBWrapper.hpp"
 #include "flatbuffers/flatbuffer_builder.h"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
@@ -29,6 +32,8 @@ auto constexpr TEST_REPORTS_BULK_SIZE {1};
 auto constexpr TEST_REPORTS_THREADS_NUMBER {1};
 
 using ::testing::_;
+using testing::Return;
+using ::testing::SetArgReferee;
 
 namespace NSScanOrchestratorTest
 {
@@ -179,11 +184,22 @@ namespace NSScanOrchestratorTest
             }
         )";
 
+    const auto MANAGER_NAME =
+        R"(
+            {
+                "manager": {
+                    "name": "test"
+                }
+            }
+        )"_json;
+
     const std::string TEST_PATH {"/tmp/socket"};
 } // namespace NSScanOrchestratorTest
 
 // Shared pointers definitions
 std::shared_ptr<MockFactoryOrchestrator> spFactoryOrchestratorMock;
+std::shared_ptr<MockSocketDBWrapper> spSocketDBWrapperMock;
+std::shared_ptr<TScanContext<TrampolineOsDataCache>> spScanContext;
 
 using namespace NSScanOrchestratorTest;
 
@@ -193,6 +209,8 @@ void ScanOrchestratorTest::TearDown()
 {
     spFactoryOrchestratorMock.reset();
     spOsDataCacheMock.reset();
+    spSocketDBWrapperMock.reset();
+    spScanContext.reset();
     Log::deassignLogFunction();
 }
 
@@ -217,37 +235,35 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(1);
 
     auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
 
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
 
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
@@ -255,10 +271,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
         .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
         .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -277,14 +293,20 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
                                                                  TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
+    spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>(WDB_SOCKET);
+    EXPECT_CALL(*spSocketDBWrapperMock, query(_, _)).Times(1).WillOnce(SetArgReferee<1>(MANAGER_NAME));
+
+    TScanOrchestrator<TrampolineTScanContext,
                       TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
                       MockIndexerConnector,
-                      MockDatabaseFeedManager>
+                      MockDatabaseFeedManager,
+                      TrampolineSocketDBWrapper>
         scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
+    EXPECT_STREQ(spScanContext->managerName().data(), "test");
 }
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
@@ -308,37 +330,35 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(1);
 
     auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
 
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
 
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
@@ -346,10 +366,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
         .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
         .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -368,14 +388,20 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
                                                                  TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
+    spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>(WDB_SOCKET);
+    EXPECT_CALL(*spSocketDBWrapperMock, query(_, _)).Times(1).WillOnce(SetArgReferee<1>(MANAGER_NAME));
+
+    TScanOrchestrator<TrampolineTScanContext,
                       TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
                       MockIndexerConnector,
-                      MockDatabaseFeedManager>
+                      MockDatabaseFeedManager,
+                      TrampolineSocketDBWrapper>
         scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
+    EXPECT_STREQ(spScanContext->managerName().data(), "test");
 }
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
@@ -399,37 +425,35 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
 
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
 
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
@@ -437,10 +461,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
         .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
         .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -459,14 +483,20 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
                                                                  TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
+    spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>(WDB_SOCKET);
+    EXPECT_CALL(*spSocketDBWrapperMock, query(_, _)).Times(1).WillOnce(SetArgReferee<1>(MANAGER_NAME));
+
+    TScanOrchestrator<TrampolineTScanContext,
                       TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
                       MockIndexerConnector,
-                      MockDatabaseFeedManager>
+                      MockDatabaseFeedManager,
+                      TrampolineSocketDBWrapper>
         scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
+    EXPECT_STREQ(spScanContext->managerName().data(), "test");
 }
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
@@ -490,37 +520,35 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
 
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
 
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
@@ -528,10 +556,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
         .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
         .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -550,14 +578,20 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
                                                                  TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
+    spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>(WDB_SOCKET);
+    EXPECT_CALL(*spSocketDBWrapperMock, query(_, _)).Times(1).WillOnce(SetArgReferee<1>(MANAGER_NAME));
+
+    TScanOrchestrator<TrampolineTScanContext,
                       TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
                       MockIndexerConnector,
-                      MockDatabaseFeedManager>
+                      MockDatabaseFeedManager,
+                      TrampolineSocketDBWrapper>
         scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
+    EXPECT_STREQ(spScanContext->managerName().data(), "test");
 }
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
@@ -565,37 +599,35 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
 
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
 
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
 
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
@@ -603,10 +635,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
         .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
         .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -625,14 +657,20 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
                                                                  TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
+    spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>(WDB_SOCKET);
+    EXPECT_CALL(*spSocketDBWrapperMock, query(_, _)).Times(1).WillOnce(SetArgReferee<1>(MANAGER_NAME));
+
+    TScanOrchestrator<TrampolineTScanContext,
                       TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
                       MockIndexerConnector,
-                      MockDatabaseFeedManager>
+                      MockDatabaseFeedManager,
+                      TrampolineSocketDBWrapper>
         scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorDelta));
+    EXPECT_STREQ(spScanContext->managerName().data(), "test");
 }
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
@@ -656,37 +694,35 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
 
     auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
     EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(1);
 
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
 
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
 
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
 
     spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
     EXPECT_CALL(*spFactoryOrchestratorMock, create())
@@ -694,10 +730,10 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
         .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
         .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
         .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock));
 
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
@@ -716,304 +752,18 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
                                                                  TEST_REPORTS_THREADS_NUMBER);
     std::shared_mutex mutexScanOrchestrator;
 
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
+    spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorSynchronization);
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>(WDB_SOCKET);
+    EXPECT_CALL(*spSocketDBWrapperMock, query(_, _)).Times(1).WillOnce(SetArgReferee<1>(MANAGER_NAME));
+
+    TScanOrchestrator<TrampolineTScanContext,
                       TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
                       MockIndexerConnector,
-                      MockDatabaseFeedManager>
+                      MockDatabaseFeedManager,
+                      TrampolineSocketDBWrapper>
         scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
 
     EXPECT_NO_THROW(scanOrchestrator.run(syscollectorSynchronization));
-}
-
-TEST_F(ScanOrchestratorTest, TestRunScannerTypeReScanAllAgents)
-{
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(0);
-
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(1);
-
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
-
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
-
-    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
-    EXPECT_CALL(*spFactoryOrchestratorMock, create())
-        .WillOnce(testing::Return(spOsOrchestrationMock))
-        .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
-        .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
-        .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
-
-    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
-
-    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-
-    nlohmann::json dataValue;
-    dataValue["action"] = "reboot";
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &dataValue;
-
-    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
-                                                                 TEST_REPORTS_QUEUE_PATH,
-                                                                 TEST_REPORTS_BULK_SIZE,
-                                                                 TEST_REPORTS_THREADS_NUMBER);
-    std::shared_mutex mutexScanOrchestrator;
-
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
-                      TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
-                      MockIndexerConnector,
-                      MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
-
-    EXPECT_NO_THROW(scanOrchestrator.run(data));
-}
-
-TEST_F(ScanOrchestratorTest, TestRunScannerTypeReScanSingleAgent)
-{
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(0);
-
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(1);
-
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
-
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
-
-    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
-    EXPECT_CALL(*spFactoryOrchestratorMock, create())
-        .WillOnce(testing::Return(spOsOrchestrationMock))
-        .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
-        .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
-        .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
-
-    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
-
-    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-
-    nlohmann::json dataValue = nlohmann::json::parse(
-        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"test_node_name"},  "action":"upgradeAgentDB"})");
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &dataValue;
-
-    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
-                                                                 TEST_REPORTS_QUEUE_PATH,
-                                                                 TEST_REPORTS_BULK_SIZE,
-                                                                 TEST_REPORTS_THREADS_NUMBER);
-    std::shared_mutex mutexScanOrchestrator;
-
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
-                      TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
-                      MockIndexerConnector,
-                      MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
-
-    EXPECT_NO_THROW(scanOrchestrator.run(data));
-}
-
-TEST_F(ScanOrchestratorTest, TestRunScannerTypeCleanupAgentData)
-{
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(0);
-
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(1);
-
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(0);
-
-    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
-    EXPECT_CALL(*spFactoryOrchestratorMock, create())
-        .WillOnce(testing::Return(spOsOrchestrationMock))
-        .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
-        .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
-        .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
-
-    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
-
-    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-
-    nlohmann::json dataValue;
-    dataValue["action"] = "deleteAgent";
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &dataValue;
-
-    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
-                                                                 TEST_REPORTS_QUEUE_PATH,
-                                                                 TEST_REPORTS_BULK_SIZE,
-                                                                 TEST_REPORTS_THREADS_NUMBER);
-    std::shared_mutex mutexScanOrchestrator;
-
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
-                      TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
-                      MockIndexerConnector,
-                      MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
-
-    EXPECT_NO_THROW(scanOrchestrator.run(data));
-}
-
-TEST_F(ScanOrchestratorTest, TestRunScannerTypeCleanupAllData)
-{
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(0);
-
-    auto spOsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageInsertOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spPackageDeleteOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spIntegrityClearOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spReScanAllAgentsOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanAllAgentsOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spReScanSingleAgentOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spReScanSingleAgentOrchestrationMock, handleRequest(_)).Times(0);
-
-    auto spCleanupAgentDataMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAgentDataMock, handleRequest(_)).Times(0);
-
-    auto spCleanupAllDataOrchestrationMock =
-        std::make_shared<MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>>();
-    EXPECT_CALL(*spCleanupAllDataOrchestrationMock, handleRequest(_)).Times(1);
-
-    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
-    EXPECT_CALL(*spFactoryOrchestratorMock, create())
-        .WillOnce(testing::Return(spOsOrchestrationMock))
-        .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
-        .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
-        .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
-        .WillOnce(testing::Return(spReScanAllAgentsOrchestrationMock))
-        .WillOnce(testing::Return(spReScanSingleAgentOrchestrationMock))
-        .WillOnce(testing::Return(spCleanupAgentDataMock))
-        .WillOnce(testing::Return(spCleanupAllDataOrchestrationMock));
-
-    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
-
-    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-
-    nlohmann::json dataValue;
-    dataValue["action"] = "cleanup";
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &dataValue;
-
-    auto spReportDispatcher = std::make_shared<ReportDispatcher>([](std::queue<std::string>& dataQueue) {},
-                                                                 TEST_REPORTS_QUEUE_PATH,
-                                                                 TEST_REPORTS_BULK_SIZE,
-                                                                 TEST_REPORTS_THREADS_NUMBER);
-    std::shared_mutex mutexScanOrchestrator;
-
-    TScanOrchestrator<TScanContext<TrampolineOsDataCache>,
-                      TrampolineFactoryOrchestrator,
-                      MockAbstractHandler<std::shared_ptr<TScanContext<TrampolineOsDataCache>>>,
-                      MockIndexerConnector,
-                      MockDatabaseFeedManager>
-        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
-
-    EXPECT_NO_THROW(scanOrchestrator.run(data));
+    EXPECT_STREQ(spScanContext->managerName().data(), "test");
 }


### PR DESCRIPTION
|Related issue|
|---|
|#22129|

## Description
It is intended to complete the outstanding debt of UTs related to issue #21953.
## Tests
```shell
$ ctest
Test project /workspaces/wazuh/src/build/wazuh_modules/vulnerability_scanner/tests/unit
    Start 1: vulnerability_scanner_unit_tests
1/1 Test #1: vulnerability_scanner_unit_tests ...   Passed  138.47 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) = 138.51 sec
``` 
```shell
$ ./vulnerability_scanner_unit_tests --gtest_filter=\*Details\*
Note: Google Test filter = *Details*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from DetailsAugmentationTest
[ RUN      ] DetailsAugmentationTest.TestSuccessfulPackageInsertedCVSS2
Failed to set socket options
Failed to set socket options
[       OK ] DetailsAugmentationTest.TestSuccessfulPackageInsertedCVSS2 (539 ms)
[ RUN      ] DetailsAugmentationTest.TestSuccessfulPackageInsertedCVSS3
[       OK ] DetailsAugmentationTest.TestSuccessfulPackageInsertedCVSS3 (579 ms)
[ RUN      ] DetailsAugmentationTest.TestSuccessfulPackageDeleted
[       OK ] DetailsAugmentationTest.TestSuccessfulPackageDeleted (501 ms)
[ RUN      ] DetailsAugmentationTest.TestSuccessfulIntegrityClear
[       OK ] DetailsAugmentationTest.TestSuccessfulIntegrityClear (3 ms)
[----------] 4 tests from DetailsAugmentationTest (1624 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (1624 ms total)
[  PASSED  ] 4 tests.
``` 
```shell
$ ./vulnerability_scanner_unit_tests --gtest_filter=\*ScanOrchestr\*
Note: Google Test filter = *ScanOrchestr*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from ScanOrchestratorTest
[ RUN      ] ScanOrchestratorTest.TestRunScannerTypePackageInsert
[       OK ] ScanOrchestratorTest.TestRunScannerTypePackageInsert (5367 ms)
[ RUN      ] ScanOrchestratorTest.TestRunScannerTypePackageDelete
[       OK ] ScanOrchestratorTest.TestRunScannerTypePackageDelete (5252 ms)
[ RUN      ] ScanOrchestratorTest.TestRunScannerTypeHotfixInsert
ScanOrchestrator::run::HotfixInserted
[       OK ] ScanOrchestratorTest.TestRunScannerTypeHotfixInsert (5370 ms)
[ RUN      ] ScanOrchestratorTest.TestRunScannerTypeHotfixDelete
ScanOrchestrator::run::HotfixDeleted
[       OK ] ScanOrchestratorTest.TestRunScannerTypeHotfixDelete (5380 ms)
[ RUN      ] ScanOrchestratorTest.TestRunScannerTypeOs
ScanOrchestrator::run::Os
[       OK ] ScanOrchestratorTest.TestRunScannerTypeOs (5182 ms)
[ RUN      ] ScanOrchestratorTest.TestRunScannerTypeIntegrityClear
[       OK ] ScanOrchestratorTest.TestRunScannerTypeIntegrityClear (5361 ms)
[----------] 6 tests from ScanOrchestratorTest (31916 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (31916 ms total)
[  PASSED  ] 6 tests.
``` 