### PR TITLE
Changed SCA checks for AlmaLinux9

### DIFF
--- a/ruleset/sca/almalinux/cis_alma_linux_9.yml
+++ b/ruleset/sca/almalinux/cis_alma_linux_9.yml
@@ -49,11 +49,11 @@ checks:
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
-    condition: all
-    rules:
-      - "c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found"
-      - "not c:lsmod -> r:squashfs"
-      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:blacklist\t*\s*squashfs'
+    condition: all 
+    rules: 
+      - "c:modprobe -n -v squashfs -> r:install /bin/false|install /bin/true|Module squashfs not found" 
+      - "not c:lsmod -> r:squashfs" 
+      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:install\t*\s*squashfs\t*\s*/bin/true' 
 
   # 1.1.1.2 Ensure mounting of udf filesystems is disabled. (Automated)
 
@@ -75,11 +75,11 @@ checks:
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
-    condition: all
-    rules:
-      - "c:modprobe -n -v udf -> r:install /bin/false|Module udf not found"
-      - "not c:lsmod -> r:udf"
-      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:blacklist\t*\s*udf'
+    condition: all 
+    rules: 
+      - "c:modprobe -n -v udf -> r:install /bin/false|install /bin/true|Module udf not found" 
+      - "not c:lsmod -> r:udf" 
+      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:install\t*\s*udf\t*\s*/bin/true' 
 
   # 1.1.2.1 Ensure /tmp is a separate partition. (Automated)
 
@@ -925,11 +925,11 @@ checks:
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_v4.0: ["1.3.1", "7.1"]
       - soc_2: ["CC5.2", "CC6.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0700/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
-      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+    condition: all 
+    rules: 
+       - 'c:stat -Lc "%n %#a %u/%U %g/%G" /boot/grub2/grub.cfg -> r:/boot/grub2/grub.cfg 0600 0/root 0/root' 
+       - 'c:stat -Lc "%n %#a %u/%U %g/%G" /boot/grub2/grubenv -> r:/boot/grub2/grubenv 0600 0/root 0/root' 
+       - 'c:stat -Lc "%n %#a %u/%U %g/%G" /boot/grub2/user.cfg -> r:/boot/grub2/user.cfg 0600 0/root 0/root|No such file or directory' 
 
   # 1.5.1 Ensure core dump storage is disabled. (Automated)
 
@@ -1329,7 +1329,6 @@ checks:
       - mitre_tactics: ["TA0007"]
     condition: all
     rules:
-      - "f:/etc/dconf/profile/gdm"
       - "f:/etc/dconf/profile/gdm -> r:user-db:user"
       - "f:/etc/dconf/profile/gdm -> r:system-db:gdm"
       - "f:/etc/dconf/profile/gdm -> r:file-db:/usr/share/gdm/greeter-dconf-defaults"
@@ -1352,7 +1351,6 @@ checks:
       - mitre_techniques: ["T1078", "T1078.001", "T1078.002", "T1078.003", "T1087", "T1087.001", "T1087.002"]
     condition: all
     rules:
-      - "f:/etc/dconf/profile/gdm"
       - "f:/etc/dconf/profile/gdm -> r:user-db:user"
       - "f:/etc/dconf/profile/gdm -> r:system-db:gdm"
       - "f:/etc/dconf/profile/gdm -> r:file-db:/usr/share/gdm/greeter-dconf-defaults"
@@ -1382,7 +1380,6 @@ checks:
       - pci_dss_v4.0: ["8.2.8"]
     condition: all
     rules:
-      - "f:/etc/dconf/profile/gdm"
       - "f:/etc/dconf/profile/gdm -> r:user-db:user"
       - "f:/etc/dconf/profile/gdm -> r:system-db:gdm"
       - 'd:/etc/dconf/db/local.d -> r:\.+ -> r:lock-delay=uint32'
@@ -1480,7 +1477,7 @@ checks:
       - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
     condition: all
     rules:
-      - 'f:/etc/crypto-policies/config -> r:^\s*LEGACY'
+      - 'f:/etc/crypto-policies/config -> !r:^\s*LEGACY'
 
   # 2.1.1 Ensure time synchronization is in use. (Automated)
   - id: 32559
@@ -3966,7 +3963,7 @@ checks:
       - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
       - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
       - soc_2: ["CC5.2", "CC7.2"]
-    condition: all
+    condition: any
     rules:
       - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
       - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
@@ -4223,8 +4220,8 @@ checks:
       - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7'
-      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare < 7'
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
+      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare < 1'
 
   # 5.6.1.3 Ensure password expiration warning days is 7 or more. (Automated)
   - id: 32674


### PR DESCRIPTION
|Related issue|
|---|
|contribution|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
SCA Rules: 32500, 32501, 32534, 32552, 32553, 32554, 32558, 32662 and 32673 all updated to better match de CIS-Benchmark for AlmaLinux 9. Each rule will be discussed with an explanation and the modification. 
<!--
Add a clear description of how the problem has been solved.
-->

**32500:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - "c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found" 
      - "not c:lsmod -> r:squashfs" 
      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:blacklist\t*\s*squashfs' 
```

Updated checks: 
```
condition: all 
    rules: 
      - "c:modprobe -n -v squashfs -> r:install /bin/false|install /bin/true|Module squashfs not found" 
      - "not c:lsmod -> r:squashfs" 
      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:install\t*\s*squashfs\t*\s*/bin/true' 
```

*Explanation:* 

Both “/bin/false” and “/bin/true” produce the same hardening results. However, “/bin/false” returns a non-zero exit code and /bin/true a zero exit code. Both of the rules in modprobe will result in disabled squashfs. 

**32501:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - "c:modprobe -n -v udf -> r:install /bin/false|Module udf not found" 
      - "not c:lsmod -> r:udf" 
      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:blacklist\t*\s*udf' 
```

*Updated checks:* 
```
condition: all 
    rules: 
      - "c:modprobe -n -v udf -> r:install /bin/false|install /bin/true|Module udf not found" 
      - "not c:lsmod -> r:udf" 
      - 'd:/etc/modprobe.d -> r:\.*.conf -> r:install\t*\s*udf\t*\s*/bin/true' 
```

*Explanation:* 

Both “/bin/false” and “/bin/true” produce the same hardening results. However, “/bin/false” returns a non-zero exit code and /bin/true a zero exit code. Both of the rules in modprobe will result in disabled udf filesystems. 

 

**32534:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - 'c:stat -L /boot/grub2/grub.cfg -> r:Access:\s*\(0700/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)' 
      - 'c:stat -L /boot/grub2/grubenv -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)' 
      - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)' 
 ```

*Updated checks:* 
```
condition: all 
    rules: 
       - 'c:stat -Lc "%n %#a %u/%U %g/%G" /boot/grub2/grub.cfg -> r:/boot/grub2/grub.cfg 0600 0/root 0/root' 
       - 'c:stat -Lc "%n %#a %u/%U %g/%G" /boot/grub2/grubenv -> r:/boot/grub2/grubenv 0600 0/root 0/root' 
       - 'c:stat -Lc "%n %#a %u/%U %g/%G" /boot/grub2/user.cfg -> r:/boot/grub2/user.cfg 0600 0/root 0/root|No such file or directory' 
``` 

Explanation: 

The rights 0600 will not match with “-r———” because it is read/write,  besides checks in CIS Benchmark don’t give output in the form of  “-r———”, because stat is used with other flags.  

Also the user.cfg is not always present, so it checks if the file exists. 

**32552:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - "f:/etc/dconf/profile/gdm" 
      - "f:/etc/dconf/profile/gdm -> r:user-db:user" 
      - "f:/etc/dconf/profile/gdm -> r:system-db:gdm" 
      - "f:/etc/dconf/profile/gdm -> r:file-db:/usr/share/gdm/greeter-dconf-defaults" 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-enable=true' 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-text=' 
```

*Updated checks:*
```
condition: all 
    rules: 
      - "f:/etc/dconf/profile/gdm -> r:user-db:user" 
      - "f:/etc/dconf/profile/gdm -> r:system-db:gdm" 
      - "f:/etc/dconf/profile/gdm -> r:file-db:/usr/share/gdm/greeter-dconf-defaults" 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-enable=true' 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-text=' 
 ```

*Explanation:* 

This would always result in a failed condition when GDM is not installed. Removing this line would cause it to return a “not applicable” as it should. 

**32553:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - "f:/etc/dconf/profile/gdm" 
      - "f:/etc/dconf/profile/gdm -> r:user-db:user" 
      - "f:/etc/dconf/profile/gdm -> r:system-db:gdm" 
      - "f:/etc/dconf/profile/gdm -> r:file-db:/usr/share/gdm/greeter-dconf-defaults" 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-enable=true' 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-text=' 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:disable-user-list=true' 
```
*Updated checks:* 
```
condition: all 
    rules: 
      - "f:/etc/dconf/profile/gdm -> r:user-db:user" 
      - "f:/etc/dconf/profile/gdm -> r:system-db:gdm" 
      - "f:/etc/dconf/profile/gdm -> r:file-db:/usr/share/gdm/greeter-dconf-defaults" 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-enable=true' 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-text=' 
      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:disable-user-list=true' 
 ```

*Explanation:* 

This would always result in a failed condition when GDM is not installed. Removing this line would cause it to return a “not applicable” as it should. 

**32554:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - "f:/etc/dconf/profile/gdm" 
      - "f:/etc/dconf/profile/gdm -> r:user-db:user" 
      - "f:/etc/dconf/profile/gdm -> r:system-db:gdm" 
      - 'd:/etc/dconf/db/local.d -> r:\.+ -> r:lock-delay=uint32' 
```
*Updated checks:* 
```
condition: all 
    rules: 
      - "f:/etc/dconf/profile/gdm -> r:user-db:user" 
      - "f:/etc/dconf/profile/gdm -> r:system-db:gdm" 
      - 'd:/etc/dconf/db/local.d -> r:\.+ -> r:lock-delay=uint32' 
```
*Explanation:* 

This would always result in a failed condition when GDM is not installed. Removing this line would cause it to return a “not applicable” as it should. 

**32558:** 

*Previous checks:*
```
condition: all 
    rules: 
      - 'f:/etc/crypto-policies/config -> r:^\s*LEGACY' 
```
Updated checks: 
```
condition: all 
    rules: 
      - 'f:/etc/crypto-policies/config -> !r:^\s*LEGACY' 
```
*Explanation:* 

Currently it checks if the LEGACY string is present in the configuration file. When enforcing CIS Benchmark Level 2, it states that the LEGACY string should NOT be present. It should be configured as DEFAULT, FUTURE or FIPS. LEGACY contains to many weak cryptographic algorithms. 

**32662:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile=' 
      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile=' 
```
*Updated checks:* 
```
condition: any 
    rules: 
      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile=' 
      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile=' 
```
*Explanation:* 

There were checks at two locations, but the CIS Benchmarks state that one of the two is sufficient. Hence, the use of "any" instead of "all." 

**32673:** 

*Previous checks:* 
```
condition: all 
    rules: 
      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 7' 
      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare < 7' 
```
*Updated checks:* 
```
condition: all 
    rules: 
      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1' 
      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare < 1' 
```
*Explanation:*

The CIS Benchmark stated that it is recommended that PASS_MIN_DAYS parameter be set to 1 or more days. However, the almalinux9 SCA checks for a value of 7. 

## OSCAP

In addition to these modified checks, we have also attempted to create a cis_alma_linux_9.yml that is compatible with the hardening tool oscap. For more information, please refer to: https://github.com/x00dd/SCA-CIS-benchmark-OSCAP. 

If there are still errors or if you have any questions, please feel free to let me know! 

