### PR TITLE
Fix undefined behavior when extract some elements from the rocksdb queue

### DIFF
--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -26,9 +26,9 @@ class TThreadEventDispatcher
 {
 public:
     explicit TThreadEventDispatcher(Functor functor,
-                                   const std::string& dbPath,
-                                   const uint64_t bulkSize,
-                                   const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
+                                    const std::string& dbPath,
+                                    const uint64_t bulkSize,
+                                    const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
         : m_functor {std::move(functor)}
         , m_running {true}
         , m_maxQueueSize {maxQueueSize}
@@ -36,7 +36,6 @@ public:
     {
         m_queue = std::make_unique<Utils::TSafeQueue<T, U, RocksDBQueue<T, U>>>(RocksDBQueue<T, U>(dbPath));
         m_thread = std::thread {&TThreadEventDispatcher<T, U, Functor>::dispatch, this};
-
     }
     TThreadEventDispatcher& operator=(const TThreadEventDispatcher&) = delete;
     TThreadEventDispatcher(TThreadEventDispatcher& other) = delete;
@@ -81,10 +80,12 @@ private:
             try
             {
                 std::queue<U> data = m_queue->getBulk(m_bulkSize);
+                const auto size = data.size();
+
                 if (!data.empty())
                 {
                     m_functor(data);
-                    m_queue->popBulk(m_bulkSize);
+                    m_queue->popBulk(size);
                 }
             }
             catch (const std::exception& ex)

--- a/src/shared_modules/utils/threadSafeQueue.h
+++ b/src/shared_modules/utils/threadSafeQueue.h
@@ -132,7 +132,7 @@ namespace Utils
             // extract the elements from the queue.
             if (!timeoutReached || (!m_queue.empty() && !m_canceled))
             {
-                for (auto i = 0; i < elementsQuantity && !m_queue.empty(); ++i)
+                for (auto i = 0; i < elementsQuantity && i < m_queue.size(); ++i)
                 {
                     bulkQueue.push(std::move(m_queue.at(i)));
                 }
@@ -144,7 +144,6 @@ namespace Utils
         void popBulk(const uint64_t elementsQuantity)
         {
             std::lock_guard<std::mutex> lock {m_mutex};
-
             for (auto i = 0; i < elementsQuantity && !m_queue.empty(); ++i)
             {
                 m_queue.pop();


### PR DESCRIPTION
|Related issue|
|---|
|Closes #22224|

## Description

This PR aims to fix some undefined behaviors during the rocksdb queue processing.