### PR TITLE
Fix openfiles during content process

### DIFF
--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -63,6 +63,7 @@ namespace Utils
             options.create_if_missing = true;
             options.keep_log_file_num = 1;
             options.info_log_level = rocksdb::InfoLogLevel::FATAL_LEVEL;
+            options.max_open_files = 200;
 
             rocksdb::TransactionDB* dbRawPtr;
             std::vector<rocksdb::ColumnFamilyDescriptor> columnsDescriptors;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -227,10 +227,10 @@ public:
                     // Acquiring exclusive access to write new data
                     std::lock_guard<std::shared_mutex> lock(m_mutex);
 
-                    if (step++ % 100 == 0)
+                    if (step++ % 1000 == 0)
                     {
                         logDebug2(WM_VULNSCAN_LOGTAG, "Processing line: %d", step);
-                        // Flush the database every 100 lines, we don't need to reopen the database, because all of the
+                        // Flush the database every 1000 lines, we don't need to reopen the database, because all of the
                         // elements are inserted.
                         m_feedDatabase->flush();
                     }


### PR DESCRIPTION
# Description
|Closes #22279|

This pr aims to solve an inhiterance problems during the content parsing using rocksdb.

During the processing of the file (moving the cve5 to the vd model), a high fd is experimented with because of the continuous calls to the flush method.

