### PR TITLE
Fix bug in worker-master connection when transport is closed

### DIFF
--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -169,7 +169,10 @@ class AbstractClient(common.Handler):
             Result of the hello request.
         """
         try:
-            future_result.result()
+            result = future_result.result()
+            if isinstance(future_result.result()[0], Exception):
+                raise result[0]
+
             self.logger.info("Successfully connected to master.")
             self.connected = True
         except Exception as e:        

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -975,7 +975,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
             pending_task.task.cancel()
 
         # Clean cluster files from previous executions.
-        cluster.clean_up(node_name=self.name)
+        self.name and cluster.clean_up(node_name=self.name)
 
 
 class Master(server.AbstractServer):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22146 |

## Description

This PR fixes two different problems, although more or less related.

### Worker-master connection
Before 4.8.0, when a worker tries to connect and the master responds with an error (for example, because the chosen name is already being used by another worker), the worker would close its transport and retry the operation 10 seconds later.

After the changes applied in [in this commit](https://github.com/wazuh/wazuh/commit/f9c87478f756b682a98c7963e05391d306c4200d) of 4.8.0, a bug was included whereby, even if the master responded with an error, the worker maintained its connection, causing errors due to lack of initialization of many variables in the master, as explained in https://github.com/wazuh/wazuh/issues/22146#issuecomment-1977154103.

The master has a [mechanism](https://github.com/wazuh/wazuh/blob/098511a487d26a962f8d72dae0647a09d017f3e6/framework/wazuh/core/cluster/server.py#L484-L502) by which, after 120 seconds without receiving the `echo-c` command from a worker, it closes the corresponding transport and removes it from the list of workers:
```
2024/03/05 11:35:00 DEBUG: [Master] [Keep alive] Calculating.
2024/03/05 11:35:00 ERROR: [Master] [Keep alive] No keep alives have been received from worker1 in the last minute. Disconnecting
2024/03/05 11:35:00 DEBUG: [Master] [Keep alive] Calculated.
2024/03/05 11:35:00 DEBUG: [Master] [Main] Disconnected worker1.
2024/03/05 11:35:00 INFO: [Master] [Main] Cancelling pending tasks.
2024/03/05 11:35:00 DEBUG: [Master] [Main] Removing '/var/ossec/queue/cluster/worker1'.
2024/03/05 11:35:00 DEBUG: [Master] [Main] Removed '/var/ossec/queue/cluster/worker1'.
2024/03/05 11:35:00 DEBUG: [Master] [Local agent-groups] Obtained 1 chunks of data in 0.005s.
2024/03/05 11:35:00 INFO: [Master] [Local agent-groups] Finished in 0.006s.
2024/03/05 11:35:03 DEBUG: [Worker] [Main] Command received: b'syn_a_w_m_p'
2024/03/05 11:35:03 DEBUG: [Worker] [Main] Command received: b'new_str'
```

However, for this mechanism to be useful, the worker must try to connect again afterward. The problem is that it was already connected (incorrectly, since the master responded with an error), so the worker did not retry connecting and the errors remained forever:
```
2024/03/05 11:34:58 DEBUG: [Worker worker1] [Integrity check] Zip file sent.
2024/03/05 11:35:03 DEBUG: [Local Server] [Keep alive] Calculating.
2024/03/05 11:35:03 DEBUG: [Local Server] [Keep alive] Calculated.
2024/03/05 11:35:03 DEBUG: [Worker worker1] [Agent-info sync] Permission to synchronize granted.
2024/03/05 11:35:03 INFO: [Worker worker1] [Agent-info sync] Starting.
2024/03/05 11:35:03 DEBUG: [Worker worker1] [Agent-info sync] Obtained 1 chunks of data in 0.001s.
2024/03/05 11:35:03 DEBUG: [Worker worker1] [Agent-info sync] Sending chunks.
```

### Cluster files deletion
Another bug discovered after fixing the one above is that, if the worker tries to connect and the master responds with an error, the worker is disconnected and its files are deleted on both the master and the worker. So far it's fine, the problem is that not only the files of the worker with problems were being deleted, but all of them.

This is because when the error occurs in the [hello](https://github.com/wazuh/wazuh/blob/098511a487d26a962f8d72dae0647a09d017f3e6/framework/wazuh/core/cluster/master.py#L355-L406) command (setting name, version, etc.), the name was not set. By default, [clean_up(node_name="")](https://github.com/wazuh/wazuh/blob/098511a487d26a962f8d72dae0647a09d017f3e6/framework/wazuh/core/cluster/cluster.py#L563-L605), when no name is set, removes cluster folders from all workers, leading to errors like these (`worker1` failed to connect, but it provokes errors in `worker2`):
```
2024/03/05 11:23:12 ERROR: [Worker] [Main] Internal error processing request 'b'hello'': Error 3028 - Worker node ID already exists: worker1
2024/03/05 11:23:12 ERROR: [Worker] [Main] Error during handshake with incoming connection.
2024/03/05 11:23:12 INFO: [Worker] [Main] Cancelling pending tasks.
2024/03/05 11:23:12 DEBUG: [Worker] [Main] Removing '/var/ossec/queue/cluster/'.
2024/03/05 11:23:12 DEBUG: [Worker] [Main] Removed '/var/ossec/queue/cluster/'.
2024/03/05 11:23:13 DEBUG: [Worker worker2] [Main] Command received: b'syn_i_w_m_p'
2024/03/05 11:23:13 DEBUG: [Worker worker2] [Main] Command received: b'syn_i_w_m'
2024/03/05 11:23:13 INFO: [Worker worker2] [Integrity check] Starting.
2024/03/05 11:23:13 DEBUG: [Worker worker2] [Main] Command received: b'new_file'
2024/03/05 11:23:13 ERROR: [Worker worker2] [Main] Unhandled error processing request 'b'new_file'': [Errno 2] No such file or directory: '/var/ossec/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 818, in dispatch
    command, payload = self.process_request(command, payload)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/master.py", line 295, in process_request
    return super().process_request(command, data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/server.py", line 106, in process_request
    return super().process_request(command, data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 855, in process_request
    return self.receive_file(data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 953, in receive_file
    self.in_file[data] = {'fd': open(common.WAZUH_PATH + data.decode(), 'wb'), 'checksum': hashlib.sha256()}
FileNotFoundError: [Errno 2] No such file or directory: '/var/ossec/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
2024/03/05 11:23:13 DEBUG: [Worker worker2] [Main] Command received: b'file_upd'
2024/03/05 11:23:13 ERROR: [Worker worker2] [Main] Unhandled error processing request 'b'file_upd'': b'/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 818, in dispatch
    command, payload = self.process_request(command, payload)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/master.py", line 295, in process_request
    return super().process_request(command, data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/server.py", line 106, in process_request
    return super().process_request(command, data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 859, in process_request
    return self.update_file(data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 972, in update_file
    self.in_file[name]['fd'].write(file_content)
KeyError: b'/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
2024/03/05 11:23:13 DEBUG: [Worker worker2] [Main] Command received: b'file_end'
2024/03/05 11:23:13 ERROR: [Worker worker2] [Main] Unhandled error processing request 'b'file_end'': b'/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 818, in dispatch
    command, payload = self.process_request(command, payload)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/master.py", line 295, in process_request
    return super().process_request(command, data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/server.py", line 106, in process_request
    return super().process_request(command, data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 865, in process_request
    return self.end_file(data)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 992, in end_file
    self.in_file[name]['fd'].close()
KeyError: b'/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
2024/03/05 11:23:13 DEBUG: [Worker worker2] [Main] Command received: b'syn_i_w_m_e'
2024/03/05 11:23:13 DEBUG: [Worker worker2] [Integrity check] Received file from worker: '/var/ossec/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
2024/03/05 11:23:13 ERROR: [Worker worker2] [Integrity check] [Errno 2] No such file or directory: '/var/ossec/queue/cluster/worker2/worker2-1709637793.461597-49766befac074430ac2f86286d18f90c.zip'
2024/03/05 11:23:13 INFO: [Master] [Local integrity] Starting.
2024/03/05 11:23:13 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 34 files.
```

## Tests
```
$ PYTHONPATH=/home/selu/Git/wazuh/api:/home/selu/Git/wazuh/framework python3 -m pytest framework/wazuh/core/cluster
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/selu/Git/wazuh/framework
configfile: pytest.ini
plugins: metadata-3.0.0, asyncio-0.18.1, testinfra-5.0.0, anyio-4.2.0, aiohttp-1.0.4, trio-0.7.0, tavern-1.23.5, html-2.1.1
asyncio: mode=auto
collected 338 items                                                                                                                                                                                          

framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                  [  9%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                     [ 14%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                                 [ 24%]
framework/wazuh/core/cluster/tests/test_common.py ....................................................................................                                                                 [ 49%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                              [ 51%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                                                                 [ 55%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                       [ 62%]
framework/wazuh/core/cluster/tests/test_master.py ................................................                                                                                                     [ 76%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                                        [ 85%]
framework/wazuh/core/cluster/tests/test_utils.py ................                                                                                                                                      [ 89%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                                                                   [100%]

============================================================================================== warnings summary ==============================================================================================
../../.local/lib/python3.10/site-packages/connexion/json_schema.py:16
../../.local/lib/python3.10/site-packages/connexion/json_schema.py:16
  /home/selu/.local/lib/python3.10/site-packages/connexion/json_schema.py:16: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import Draft4Validator, RefResolver

../../.local/lib/python3.10/site-packages/connexion/json_schema.py:17
  /home/selu/.local/lib/python3.10/site-packages/connexion/json_schema.py:17: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema.exceptions import RefResolutionError, ValidationError  # noqa

../../.local/lib/python3.10/site-packages/connexion/validators/form_data.py:4
../../.local/lib/python3.10/site-packages/connexion/validators/form_data.py:4
  /home/selu/.local/lib/python3.10/site-packages/connexion/validators/form_data.py:4: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import ValidationError, draft4_format_checker

../../.local/lib/python3.10/site-packages/connexion/validators/json.py:6
../../.local/lib/python3.10/site-packages/connexion/validators/json.py:6
  /home/selu/.local/lib/python3.10/site-packages/connexion/validators/json.py:6: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import Draft4Validator, ValidationError, draft4_format_checker

api/api/validator.py:11
api/api/validator.py:11
  /home/selu/Git/wazuh/api/api/validator.py:11: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import draft4_format_checker

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================== 338 passed, 9 warnings in 4.63s =======================================================================================
```