### PR TITLE
Update deprecated warning message for obsolete VD configuration

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -195,7 +195,11 @@ static int read_main_elements(const OS_XML *xml, int modules,
         } else if (strcmp(node[i]->element, osvulndetector) == 0) {
 #if !defined(WIN32) && !defined(CLIENT)
             if ((modules & CWMODULE)) {
-                mwarn("%s configuration is deprecated. Use %s instead.", osvulndetector, osvulndetection);
+                mwarn(
+                    "The '%s' configuration is now obsolete and will not function. Please update your settings to use "
+                    "the new '%s' block for continued vulnerability management. See https://documentation.wazuh.com",
+                    osvulndetector,
+                    osvulndetection);
                 if (Read_Vulnerability_Detection(xml, chld_node, d1, true) < 0) {
                     goto fail;
                 }


### PR DESCRIPTION
|Related issues|
|---|
| https://github.com/wazuh/wazuh-documentation/issues/7076 |
| #22366  |

## Description
This PR updates a warning message logged when the VD configuration was not updated from the old vulnerability-detector to the new vulnerability-detection.

## Configuration options
```
  <vulnerability-detector>
    <enabled>yes</enabled>
    <index-status>yes</index-status>
    <feed-update-interval>60m</feed-update-interval>
  </vulnerability-detector>
```

## Logs/Alerts example
```
2024/03/05 14:13:56 wazuh-modulesd[52550] config.c:198 at read_main_elements(): WARNING: The 'vulnerability-detector' configuration is now obsolete and will not function. Please update your settings to use the new 'vulnerability-detection' block for continued vulnerability management. See https://documentation.wazuh.com
2024/03/05 14:14:01 wazuh-modulesd[52915] config.c:198 at read_main_elements(): WARNING: The 'vulnerability-detector' configuration is now obsolete and will not function. Please update your settings to use the new 'vulnerability-detection' block for continued vulnerability management. See https://documentation.wazuh.com
```

## Tests
Performed an upgrade via sources with the old VD configuration present and check the logs