### PR TITLE
Remove uvicorn server header from response

### DIFF
--- a/api/api/signals.py
+++ b/api/api/signals.py
@@ -52,11 +52,6 @@ def cancel_signal_handler(func: Callable) -> Callable:
     return wrapper
 
 
-async def modify_response_headers(request, response):
-    # Delete 'Server' entry
-    response.headers.pop('Server', None)
-
-
 @cancel_signal_handler
 async def check_installation_uid() -> None:
     """Check if the installation UID exists, populate it if not and inject it into the global cti context."""


### PR DESCRIPTION
|Related issue|
|---|
| #22329 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR closes #22329. Removes the `server: uvicorn` header from response.

## Logs/Alerts example

### Before the change

```bash
curl -i --silent -u wazuh:wazuh -k -X GET "https://localhost:55050/security/user/authenticate?raw=true"
HTTP/1.1 200 OK
date: Tue, 05 Mar 2024 19:58:24 GMT
server: uvicorn
content-type: text/plain
deprecated: true
link: <https://documentation.wazuh.com/4.9.0/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user>; rel="Deprecated"
content-length: 398
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

### After the change

```bash
curl -i --silent -u wazuh:wazuh -k -X GET "https://localhost:55050/security/user/authenticate?raw=true"
HTTP/1.1 200 OK
date: Tue, 05 Mar 2024 19:49:56 GMT
content-type: text/plain
deprecated: true
link: <https://documentation.wazuh.com/4.9.0/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user>; rel="Deprecated"
content-length: 398
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```