### PR TITLE
Improve package scanner version matching

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -46,6 +46,7 @@ private:
         {"pacman", VersionMatcherStrategy::Pacman},
         {"snap", VersionMatcherStrategy::Snap},
         {"pkg", VersionMatcherStrategy::PKG},
+        {"apk", VersionMatcherStrategy::APK},
         {"win", VersionMatcherStrategy::Windows},
         {"macports", VersionMatcherStrategy::MacOS}};
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -45,8 +45,8 @@ private:
         {"npm", VersionObjectType::SemVer},
         {"pacman", VersionMatcherStrategy::Pacman},
         {"snap", VersionMatcherStrategy::Snap},
+        {"pkg", VersionMatcherStrategy::PKG},
         {"win", VersionMatcherStrategy::Windows},
-        {"pkg", VersionMatcherStrategy::MacOS},
         {"macports", VersionMatcherStrategy::MacOS}};
 
 public:

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -31,16 +31,23 @@ class TPackageScanner final : public AbstractHandler<std::shared_ptr<TScanContex
 {
 private:
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
+
+    /**
+     * @brief Package format to VersionObjectType / VersionMatcherStrategy map.
+     *
+     * @note The map is used to determine the version object type or the version matcher strategy based on the package
+     * name.
+     */
     std::unordered_map<std::string_view, std::variant<VersionObjectType, VersionMatcherStrategy>> m_packageMap {
         {"deb", VersionObjectType::DPKG},
         {"rpm", VersionObjectType::RPM},
         {"pypi", VersionObjectType::PEP440},
         {"npm", VersionObjectType::SemVer},
-        {"win", VersionMatcherStrategy::windows},
-        {"pacman", VersionMatcherStrategy::pacman},
-        {"snap", VersionMatcherStrategy::snap},
-        {"pkg", VersionMatcherStrategy::macOS},
-        {"macports", VersionMatcherStrategy::macOS}};
+        {"pacman", VersionMatcherStrategy::Pacman},
+        {"snap", VersionMatcherStrategy::Snap},
+        {"win", VersionMatcherStrategy::Windows},
+        {"pkg", VersionMatcherStrategy::MacOS},
+        {"macports", VersionMatcherStrategy::MacOS}};
 
 public:
     // LCOV_EXCL_START
@@ -116,15 +123,11 @@ public:
                     }
                 }
 
-                std::variant<VersionObjectType, VersionMatcherStrategy> type;
-                const auto it = m_packageMap.find(data->packageFormat());
-                if (it != m_packageMap.end())
+                std::variant<VersionObjectType, VersionMatcherStrategy> objectType =
+                    VersionMatcherStrategy::Unspecified;
+                if (const auto it = m_packageMap.find(data->packageFormat()); it != m_packageMap.end())
                 {
                     objectType = it->second;
-                }
-                else
-                {
-                    objectType = VersionMatcherStrategy::Unspecified;
                 }
 
                 for (const auto& version : *callbackData.versions())

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -18,6 +18,7 @@
 #include "scannerHelper.hpp"
 #include "versionMatcher/versionMatcher.hpp"
 #include <iostream>
+#include <variant>
 
 auto constexpr DEFAULT_CNA {"nvd"};
 
@@ -30,15 +31,16 @@ class TPackageScanner final : public AbstractHandler<std::shared_ptr<TScanContex
 {
 private:
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
-    std::unordered_map<std::string_view, VersionObjectType> m_packageMap {{"deb", VersionObjectType::DPKG},
-                                                                          {"rpm", VersionObjectType::RPM},
-                                                                          {"pypi", VersionObjectType::PEP440},
-                                                                          {"npm", VersionObjectType::SemVer},
-                                                                          {"win", VersionObjectType::Unspecified}
-                                                                          {"pacman", VersionObjectType::Unspecified},
-                                                                          {"snap", VersionObjectType::Unspecified},
-                                                                          {"pkg", VersionObjectType::Unspecified},
-                                                                          {"macports", VersionObjectType::Unspecified}};
+    std::unordered_map<std::string_view, std::variant<VersionObjectType, VersionMatcherStrategy>> m_packageMap {
+        {"deb", VersionObjectType::DPKG},
+        {"rpm", VersionObjectType::RPM},
+        {"pypi", VersionObjectType::PEP440},
+        {"npm", VersionObjectType::SemVer},
+        {"win", VersionMatcherStrategy::windows},
+        {"pacman", VersionMatcherStrategy::pacman},
+        {"snap", VersionMatcherStrategy::snap},
+        {"pkg", VersionMatcherStrategy::macOS},
+        {"macports", VersionMatcherStrategy::macOS}};
 
 public:
     // LCOV_EXCL_START
@@ -114,11 +116,15 @@ public:
                     }
                 }
 
-                VersionObjectType objectType = VersionObjectType::Unspecified;
+                std::variant<VersionObjectType, VersionMatcherStrategy> type;
                 const auto it = m_packageMap.find(data->packageFormat());
                 if (it != m_packageMap.end())
                 {
                     objectType = it->second;
+                }
+                else
+                {
+                    objectType = VersionMatcherStrategy::Unspecified;
                 }
 
                 for (const auto& version : *callbackData.versions())

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -30,8 +30,15 @@ class TPackageScanner final : public AbstractHandler<std::shared_ptr<TScanContex
 {
 private:
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
-    std::unordered_map<std::string_view, VersionObjectType> m_mapVendors {{"deb", VersionObjectType::DPKG},
-                                                                          {"rpm", VersionObjectType::RPM}};
+    std::unordered_map<std::string_view, VersionObjectType> m_packageMap {{"deb", VersionObjectType::DPKG},
+                                                                          {"rpm", VersionObjectType::RPM},
+                                                                          {"pypi", VersionObjectType::PEP440},
+                                                                          {"npm", VersionObjectType::SemVer},
+                                                                          {"win", VersionObjectType::Unspecified}
+                                                                          {"pacman", VersionObjectType::Unspecified},
+                                                                          {"snap", VersionObjectType::Unspecified},
+                                                                          {"pkg", VersionObjectType::Unspecified},
+                                                                          {"macports", VersionObjectType::Unspecified}};
 
 public:
     // LCOV_EXCL_START
@@ -108,8 +115,8 @@ public:
                 }
 
                 VersionObjectType objectType = VersionObjectType::Unspecified;
-                const auto it = m_mapVendors.find(data->packageFormat());
-                if (it != m_mapVendors.end())
+                const auto it = m_packageMap.find(data->packageFormat());
+                if (it != m_packageMap.end())
                 {
                     objectType = it->second;
                 }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -36,7 +36,7 @@ private:
      * @brief Package format to VersionObjectType / VersionMatcherStrategy map.
      *
      * @note The map is used to determine the version object type or the version matcher strategy based on the package
-     * name.
+     * format.
      */
     std::unordered_map<std::string_view, std::variant<VersionObjectType, VersionMatcherStrategy>> m_packageMap {
         {"deb", VersionObjectType::DPKG},

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/iVersionObjectInterface.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/iVersionObjectInterface.hpp
@@ -14,13 +14,12 @@
 
 enum class VersionObjectType : int
 {
-    Unspecified = 0,
-    CalVer = 1,
-    PEP440 = 2,
-    MajorMinor = 3,
-    SemVer = 4,
-    DPKG = 5,
-    RPM = 6,
+    CalVer = 0,
+    PEP440 = 1,
+    MajorMinor = 2,
+    SemVer = 3,
+    DPKG = 4,
+    RPM = 5
 };
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -40,7 +40,8 @@ enum class VersionMatcherStrategy : int
     MacOS = 2,
     Pacman = 3,
     Snap = 4,
-    PKG = 5
+    PKG = 5,
+    APK = 6
 };
 
 using PackageMap = std::unordered_map<std::string_view, std::variant<VersionObjectType, VersionMatcherStrategy>>;
@@ -80,6 +81,8 @@ private:
                 // TODO: Define the snap strategy
             case VersionMatcherStrategy::PKG:
                 // TODO: Define the PKG strategy
+            case VersionMatcherStrategy::APK:
+                // TODO: Define the APK strategy
             case VersionMatcherStrategy::Unspecified:
                 if (matcher = createVersionObject(version, VersionObjectType::CalVer); matcher)
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -24,12 +24,22 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <variant>
 
 enum class VersionComparisonResult : int
 {
     A_LESS_THAN_B,
     A_EQUAL_B,
     A_GREATER_THAN_B
+};
+
+enum class VersionMatcherStrategy : int
+{
+    Unspecified = 0,
+    Windows = 1,
+    MacOS = 2,
+    pacman = 3,
+    snap = 4
 };
 
 /**
@@ -39,14 +49,57 @@ enum class VersionComparisonResult : int
 class VersionMatcher final
 {
 private:
-    /**
-     * @brief Creates a version object using the string and type specified.
-     *
-     * @param version string version item to create object from
-     * @param type version object type to create from enum VersionObjectType
-     * @return std::shared_ptr<IVersionObject>
-     */
-    static std::shared_ptr<IVersionObject> createVersionObject(const std::string& version, VersionObjectType type)
+    static std::shared_ptr<IVersionObject> createVersionObjectFromStrategy(const VersionMatcherStrategy strategy)
+    {
+        switch (strategy)
+        {
+            case VersionMatcherStrategy::Windows:
+                // TODO: Define the Windows strategy
+            case VersionMatcherStrategy::MacOS:
+                // TODO: Define the MacOS strategy
+            case VersionMatcherStrategy::pacman:
+                // TODO: Define the pacman strategy
+            case VersionMatcherStrategy::snap:
+                // TODO: Define the snap strategy
+            case VersionMatcherStrategy::Unspecified:
+                if (VersionObjectCalVer::match(version, calVer))
+                {
+                    return std::make_shared<VersionObjectCalVer>(calVer);
+                }
+                else if (VersionObjectPEP440::match(version, pep440))
+                {
+                    return std::make_shared<VersionObjectPEP440>(pep440);
+                }
+                else if (VersionObjectMajorMinor::match(version, majorMinor))
+                {
+                    return std::make_shared<VersionObjectMajorMinor>(majorMinor);
+                }
+                else if (VersionObjectRpm::match(version, rpmVer))
+                {
+                    return std::make_shared<VersionObjectRpm>(rpmVer);
+                }
+                else if (VersionObjectDpkg::match(version, dpkgVer))
+                {
+                    return std::make_shared<VersionObjectDpkg>(dpkgVer);
+                }
+                else if (VersionObjectSemVer::match(version, semVer))
+                {
+                    return std::make_shared<VersionObjectSemVer>(semVer);
+                }
+                else
+                {
+                    logDebug2(WM_VULNSCAN_LOGTAG,
+                              "Error creating VersionObject (Unspecified). Unrecognized type. Version string: %s",
+                              version.c_str());
+
+                    return nullptr;
+                }
+                break;
+            default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid strategy."); return nullptr;
+        }
+    }
+
+    static std::shared_ptr<IVersionObject> createVersionObjectFromType(const VersionObjectType type)
     {
         CalVer calVer {};
         PEP440 pep440 {};
@@ -54,6 +107,7 @@ private:
         SemVer semVer {};
         Dpkg dpkgVer {};
         Rpm rpmVer {};
+
         switch (type)
         {
             case VersionObjectType::CalVer:
@@ -145,40 +199,37 @@ private:
                 }
                 break;
             case VersionObjectType::Unspecified:
-                if (VersionObjectCalVer::match(version, calVer))
-                {
-                    return std::make_shared<VersionObjectCalVer>(calVer);
-                }
-                else if (VersionObjectPEP440::match(version, pep440))
-                {
-                    return std::make_shared<VersionObjectPEP440>(pep440);
-                }
-                else if (VersionObjectMajorMinor::match(version, majorMinor))
-                {
-                    return std::make_shared<VersionObjectMajorMinor>(majorMinor);
-                }
-                else if (VersionObjectRpm::match(version, rpmVer))
-                {
-                    return std::make_shared<VersionObjectRpm>(rpmVer);
-                }
-                else if (VersionObjectDpkg::match(version, dpkgVer))
-                {
-                    return std::make_shared<VersionObjectDpkg>(dpkgVer);
-                }
-                else if (VersionObjectSemVer::match(version, semVer))
-                {
-                    return std::make_shared<VersionObjectSemVer>(semVer);
-                }
-                else
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (Unspecified). Unrecognized type. Version string: %s",
-                              version.c_str());
-
-                    return nullptr;
-                }
-                break;
+                logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Unspecified.");
+                return nullptr;
             default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid type."); return nullptr;
+        }
+    }
+
+    /**
+     * @brief Creates a version object using the string and type specified.
+     *
+     * @param version string version item to create object from
+     * @param type Representing the version object or matcher strategy.
+     *
+     * @return std::shared_ptr<IVersionObject>
+     */
+    static std::shared_ptr<IVersionObject>
+    createVersionObject(const std::string& version, std::variant<VersionObjectType, VersionMatcherStrategy> type)
+    {
+        if (std::holds_alternative<VersionObjectType>(type))
+        {
+            return createVersionObjectFromType(std::get<VersionObjectType>(type));
+        }
+        else if (std::holds_alternative<VersionMatcherStrategy>(type))
+        {
+            return createVersionObjectFromStrategy(std::get<VersionMatcherStrategy>(type));
+        }
+        else
+        {
+            // LCOV_EXCL_START
+            logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid type.");
+            return nullptr;
+            // LCOV_EXCL_STOP
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -39,7 +39,8 @@ enum class VersionMatcherStrategy : int
     Windows = 1,
     MacOS = 2,
     Pacman = 3,
-    Snap = 4
+    Snap = 4,
+    PKG = 5
 };
 
 using PackageMap = std::unordered_map<std::string_view, std::variant<VersionObjectType, VersionMatcherStrategy>>;
@@ -77,6 +78,8 @@ private:
                 // TODO: Define the pacman strategy
             case VersionMatcherStrategy::Snap:
                 // TODO: Define the snap strategy
+            case VersionMatcherStrategy::PKG:
+                // TODO: Define the PKG strategy
             case VersionMatcherStrategy::Unspecified:
                 if (matcher = createVersionObject(version, VersionObjectType::CalVer); matcher)
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionMatcher.hpp
@@ -38,9 +38,11 @@ enum class VersionMatcherStrategy : int
     Unspecified = 0,
     Windows = 1,
     MacOS = 2,
-    pacman = 3,
-    snap = 4
+    Pacman = 3,
+    Snap = 4
 };
+
+using PackageMap = std::unordered_map<std::string_view, std::variant<VersionObjectType, VersionMatcherStrategy>>;
 
 /**
  * @brief VersionMatcher class.
@@ -49,57 +51,83 @@ enum class VersionMatcherStrategy : int
 class VersionMatcher final
 {
 private:
-    static std::shared_ptr<IVersionObject> createVersionObjectFromStrategy(const VersionMatcherStrategy strategy)
+    /**
+     * @brief Creates the corresponding version object using a strategy (VersionMatcherStrategy).
+     *
+     * @note A strategy is a set of rules to match a version string to a version object. For example, the default
+     * strategy is to try to match the version string to a CalVer object, if it doesn't match, then it tries to match it
+     * to a PEP440 object, and so on. If the version string doesn't match any of the specified types, it will return a
+     * nullptr.
+     *
+     *
+     * @param version string version item to create object from
+     * @param strategy VersionMatcherStrategy to use.
+     * @return std::shared_ptr<IVersionObject>
+     */
+    static std::shared_ptr<IVersionObject> createVersionObject(const std::string& version,
+                                                               const VersionMatcherStrategy& strategy)
     {
+        std::shared_ptr<IVersionObject> matcher;
+
         switch (strategy)
         {
             case VersionMatcherStrategy::Windows:
-                // TODO: Define the Windows strategy
-            case VersionMatcherStrategy::MacOS:
-                // TODO: Define the MacOS strategy
-            case VersionMatcherStrategy::pacman:
+            case VersionMatcherStrategy::MacOS: return createVersionObject(version, VersionObjectType::DPKG); break;
+            case VersionMatcherStrategy::Pacman:
                 // TODO: Define the pacman strategy
-            case VersionMatcherStrategy::snap:
+            case VersionMatcherStrategy::Snap:
                 // TODO: Define the snap strategy
             case VersionMatcherStrategy::Unspecified:
-                if (VersionObjectCalVer::match(version, calVer))
+                if (matcher = createVersionObject(version, VersionObjectType::CalVer); matcher)
                 {
-                    return std::make_shared<VersionObjectCalVer>(calVer);
+                    return matcher;
                 }
-                else if (VersionObjectPEP440::match(version, pep440))
+                else if (matcher = createVersionObject(version, VersionObjectType::PEP440); matcher)
                 {
-                    return std::make_shared<VersionObjectPEP440>(pep440);
+                    return matcher;
                 }
-                else if (VersionObjectMajorMinor::match(version, majorMinor))
+                else if (matcher = createVersionObject(version, VersionObjectType::MajorMinor); matcher)
                 {
-                    return std::make_shared<VersionObjectMajorMinor>(majorMinor);
+                    return matcher;
                 }
-                else if (VersionObjectRpm::match(version, rpmVer))
+                else if (matcher = createVersionObject(version, VersionObjectType::SemVer); matcher)
                 {
-                    return std::make_shared<VersionObjectRpm>(rpmVer);
+                    return matcher;
                 }
-                else if (VersionObjectDpkg::match(version, dpkgVer))
+                else if (matcher = createVersionObject(version, VersionObjectType::DPKG); matcher)
                 {
-                    return std::make_shared<VersionObjectDpkg>(dpkgVer);
+                    return matcher;
                 }
-                else if (VersionObjectSemVer::match(version, semVer))
+                else if (matcher = createVersionObject(version, VersionObjectType::RPM); matcher)
                 {
-                    return std::make_shared<VersionObjectSemVer>(semVer);
+                    return matcher;
                 }
                 else
                 {
                     logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (Unspecified). Unrecognized type. Version string: %s",
+                              "Error creating VersionObject (Unspecified). Version string doesn't match "
+                              "any of the specified types. Version string: %s",
                               version.c_str());
-
-                    return nullptr;
                 }
                 break;
-            default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid strategy."); return nullptr;
+            default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid strategy."); break;
         }
-    }
 
-    static std::shared_ptr<IVersionObject> createVersionObjectFromType(const VersionObjectType type)
+        return nullptr;
+    } // LCOV_EXCL_LINE
+
+    /**
+     * @brief Creates a VersionObject from a specific VersionObjectType.
+     *
+     * @param version string version item to create object from
+     * @param type VersionObjectType to use (CalVer, PEP440, MajorMinor, SemVer, DPKG, RPM, etc).
+     *
+     * @note If the version string doesn't match the specified type it will return nullptr.
+     *
+     * @return std::shared_ptr<IVersionObject>
+     */
+    static std::shared_ptr<IVersionObject> createVersionObject(const std::string& version,
+                                                               const VersionObjectType& type)
     {
         CalVer calVer {};
         PEP440 pep440 {};
@@ -115,15 +143,10 @@ private:
                 {
                     return std::make_shared<VersionObjectCalVer>(calVer);
                 }
-                else
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (CalVer). Version string doesn't match the specified type. "
-                              "Version string: %s",
-                              version.c_str());
-
-                    return nullptr;
-                }
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (CalVer). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
                 break;
 
             case VersionObjectType::PEP440:
@@ -131,29 +154,21 @@ private:
                 {
                     return std::make_shared<VersionObjectPEP440>(pep440);
                 }
-                else
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (PEP440). Version string doesn't match the specified type. "
-                              "Version string: %s",
-                              version.c_str());
-                    return nullptr;
-                }
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (PEP440). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
                 break;
+
             case VersionObjectType::MajorMinor:
                 if (VersionObjectMajorMinor::match(version, majorMinor))
                 {
                     return std::make_shared<VersionObjectMajorMinor>(majorMinor);
                 }
-                else
-                {
-                    logDebug2(
-                        WM_VULNSCAN_LOGTAG,
-                        "Error creating VersionObject (MajorMinor). Version string doesn't match the specified type. "
-                        "Version string: %s",
-                        version.c_str());
-                    return nullptr;
-                }
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (MajorMinor). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
                 break;
 
             case VersionObjectType::SemVer:
@@ -161,55 +176,44 @@ private:
                 {
                     return std::make_shared<VersionObjectSemVer>(semVer);
                 }
-                else
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (SemVer). Version string doesn't match the specified type. "
-                              "Version string: %s",
-                              version.c_str());
-                    return nullptr;
-                }
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (SemVer). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
                 break;
+
             case VersionObjectType::DPKG:
                 if (VersionObjectDpkg::match(version, dpkgVer))
                 {
                     return std::make_shared<VersionObjectDpkg>(dpkgVer);
                 }
-                else
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (DPKG). Version string doesn't match the specified type. "
-                              "Version string: %s",
-                              version.c_str());
-                    return nullptr;
-                }
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (DPKG). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
                 break;
+
             case VersionObjectType::RPM:
                 if (VersionObjectRpm::match(version, rpmVer))
                 {
                     return std::make_shared<VersionObjectRpm>(rpmVer);
                 }
-                else
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Error creating VersionObject (RPM). Version string doesn't match the specified type. "
-                              "Version string: %s",
-                              version.c_str());
-                    return nullptr;
-                }
+                logDebug2(WM_VULNSCAN_LOGTAG,
+                          "Error creating VersionObject (RPM). Version string doesn't match the specified type. "
+                          "Version string: %s",
+                          version.c_str());
                 break;
-            case VersionObjectType::Unspecified:
-                logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Unspecified.");
-                return nullptr;
-            default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid type."); return nullptr;
+
+            default: logDebug2(WM_VULNSCAN_LOGTAG, "Error creating VersionObject: Invalid type."); break;
         }
-    }
+        return nullptr;
+    } // LCOV_EXCL_LINE
 
     /**
      * @brief Creates a version object using the string and type specified.
      *
      * @param version string version item to create object from
-     * @param type Representing the version object or matcher strategy.
+     * @param type Version object or matcher strategy.
      *
      * @return std::shared_ptr<IVersionObject>
      */
@@ -218,11 +222,11 @@ private:
     {
         if (std::holds_alternative<VersionObjectType>(type))
         {
-            return createVersionObjectFromType(std::get<VersionObjectType>(type));
+            return createVersionObject(version, std::get<VersionObjectType>(type));
         }
         else if (std::holds_alternative<VersionMatcherStrategy>(type))
         {
-            return createVersionObjectFromStrategy(std::get<VersionMatcherStrategy>(type));
+            return createVersionObject(version, std::get<VersionMatcherStrategy>(type));
         }
         else
         {
@@ -239,12 +243,13 @@ public:
      *
      * @param versionA string version item A to compare
      * @param versionB string version item B to compare
-     * @param type VersionObjectType of the version strings A and B to compare.
+     * @param type Version object or matcher strategy to compare A and B.
      * @return VersionComparisonResult result of the comparison.
      */
-    static VersionComparisonResult compare(const std::string& versionA,
-                                           const std::string& versionB,
-                                           VersionObjectType type = VersionObjectType::Unspecified)
+    static VersionComparisonResult
+    compare(const std::string& versionA,
+            const std::string& versionB,
+            std::variant<VersionObjectType, VersionMatcherStrategy> type = VersionMatcherStrategy::Unspecified)
     {
         auto pVersionObjectA = createVersionObject(versionA, type);
         auto pVersionObjectB = createVersionObject(versionB, type);
@@ -275,11 +280,11 @@ public:
      * @details An unspecified version type is not allowed.
      *
      * @param version Version to validate.
-     * @param type Version type.
+     * @param type Version object or matcher strategy.
      * @return true If the version is valid.
      * @return false If the version is not valid.
      */
-    static bool match(const std::string& version, VersionObjectType type)
+    static bool match(const std::string& version, std::variant<VersionObjectType, VersionMatcherStrategy> type)
     {
         return (nullptr != createVersionObject(version, type));
     }


### PR DESCRIPTION
|Related issue|
|---|
| #21943 |


## Description
This PR adds the baseline for the improved logic for the package scanner version matching algorithms.

Changelog:
- Expanded package scanner version matcher map to cover all supported package formats:
  - Pypi -> PEP440
  - npm -> semVer
- Added new matching strategies for packages
 - MacOS -> DPKG
 - Windows -> DPKG
 - Pacman, Snap, PKG -> Try all version matchers

## Tests
Compared new results against 4.8.0:

### Diffs
New vulnerabilities are detected:

Package | version | CVEid
-- | -- | --
pip | 22.0.2 | CVE-2023-5752
setuptools | 59.6.0 | CVE-2022-40897
setuptools | 56.0.0 | CVE-2022-40897
setuptools | 56.0.0 | CVE-2022-40897
Pygments | 2.11.2 | CVE-2022-40896







<details>
<summary><b>Pygments</b></summary>

### 4.8.0
- Unaffected (CVE-2015-8557, CVE-2021-20270, CVE-2021-27291,  CVE-2022-40896)
```
2024/03/06 09:28:37 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.16.1 while scanning for Vulnerability: CVE-2015-8557
2024/03/06 09:28:37 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.16.1 while scanning for Vulnerability: CVE-2021-20270
2024/03/06 09:28:37 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.16.1 while scanning for Vulnerability: CVE-2021-27291
2024/03/06 09:28:37 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.16.1 while scanning for Vulnerability: CVE-2022-40896

```

### New branch
- Unaffected (CVE-2015-8557, CVE-2021-20270, CVE-2021-27291,  CVE-2022-40896)
```
2024/03/05 23:39:44 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.11.2 while scanning for Vulnerability: CVE-2015-8557
2024/03/05 23:39:44 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.11.2 while scanning for Vulnerability: CVE-2021-20270
2024/03/05 23:39:44 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.11.2 while scanning for Vulnerability: CVE-2021-27291
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pygments, Version: 2.16.1 while scanning for Vulnerability: CVE-2022-40896
``` 

- Affected
```
2024/03/05 23:39:44 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:227 at operator()(): DEBUG: Match found, the package 'pygments', is vulnerable to 'CVE-2022-40896'. Current version: '2.11.2' (less than '2.15.0' or equal to ''). - Agent 'Thinkpad-Sebas' (ID: '000', Version: 'Wazuh v4.8.0').
```

In this scenario, the changes allowed the detection of another version of pygments, this seems related to:
- https://github.com/wazuh/wazuh/issues/22355

</details>

<details>
<summary><b>pip</b></summary>

### 4.8.0
- Unaffected (CVE-2013-1629, CVE-2013-1888, CVE-2013-5123, CVE-2014-8991)
```
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2013-1629
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2013-1888
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2013-5123
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:271 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2014-8991
```

- Failed to scan package (CVE-2019-20916, CVE-2021-3572, CVE-2023-5752)
```
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:125 at operator()(): DEBUG: Scanning package - 'pip' (Installed Version: 22.0.2, Security Vulnerability: CVE-2019-20916). Identified vulnerability: Version: 0. Required Version Threshold: 19.2. Required Version Threshold (or Equal): .
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:283 at operator()(): DEBUG: Failed to scan package: 'pip', CVE Numbering Authorities (CNA): 'pypi', Error: 'Unable to compare versions (22.0.2 vs 19.2).'
--
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:125 at operator()(): DEBUG: Scanning package - 'pip' (Installed Version: 22.0.2, Security Vulnerability: CVE-2021-3572). Identified vulnerability: Version: 0. Required Version Threshold: 21.1. Required Version Threshold (or Equal): .
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:283 at operator()(): DEBUG: Failed to scan package: 'pip', CVE Numbering Authorities (CNA): 'pypi', Error: 'Unable to compare versions (22.0.2 vs 21.1).'
--
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:125 at operator()(): DEBUG: Scanning package - 'pip' (Installed Version: 22.0.2, Security Vulnerability: CVE-2023-5752). Identified vulnerability: Version: 0. Required Version Threshold: 23.3. Required Version Threshold (or Equal): .
2024/03/06 09:28:12 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:283 at operator()(): DEBUG: Failed to scan package: 'pip', CVE Numbering Authorities (CNA): 'pypi', Error: 'Unable to compare versions (22.0.2 vs 23.3).'
```

### New branch

- Unaffected (CVE-2013-1629, CVE-2013-1888, CVE-2013-5123, CVE-2014-8991, CVE-2019-20916, CVE-2021-3572)
```
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2013-1629
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2013-1888
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2013-5123
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2014-8991
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2019-20916
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:287 at operator()(): DEBUG: No match due to default status for Package: pip, Version: 22.0.2 while scanning for Vulnerability: CVE-2021-3572
```

- Affected (CVE-2023-5752)
```
2024/03/05 23:39:45 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:227 at operator()(): DEBUG: Match found, the package 'pip', is vulnerable to 'CVE-2023-5752'. Current version: '22.0.2' (less than '23.3' or equal to ''). - Agent 'Thinkpad-Sebas' (ID: '000', Version: 'Wazuh v4.8.0')
```

The two packages that failed are now correctly identified as not affected:

- CVE-2019-20916
```json
{
    "defaultStatus": "unaffected",
    "product": "pip",
    "vendor": "pypi",
    "versions":
    [
        {
            "lessThan": "19.2",
            "status": "affected",
            "version": "0",
            "versionType": "custom"
        }
    ]
}
```

- CVE-2021-3572
```json
{
    "defaultStatus": "unaffected",
    "product": "pip",
    "vendor": "pypi",
    "versions":
    [
        {
            "lessThan": "19.2",
            "status": "affected",
            "version": "0",
            "versionType": "custom"
        }
    ]
}
```


The remaining one is correctly identified as affected:

- CVE-2023-5752
```json
{
    "product": "pip",
    "vendor": "pypi",
    "versions": [
        {
            "lessThan": "23.3",
            "status": "affected",
            "version": "0",
            "versionType": "custom"
        }
    ]
}
```

</details>

<details>
<summary><b>Setuptools</b></summary>

### 4.8.0
- Failed to scan package (CVE-2022-40897, CVE-2022-40897, CVE-2022-40897):
```
2024/03/06 09:27:56 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:125 at operator()(): DEBUG: Scanning package - 'setuptools' (Installed Version: 56.0.0, Security Vulnerability: CVE-2022-40897). Identified vulnerability: Version: 0. Required Version Threshold: 65.5.1. Required Version Threshold (or Equal): .
2024/03/06 09:27:56 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:283 at operator()(): DEBUG: Failed to scan package: 'setuptools', CVE Numbering Authorities (CNA): 'pypi', Error: 'Unable to compare versions (56.0.0 vs 65.5.1).'
--
2024/03/06 09:28:54 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:125 at operator()(): DEBUG: Scanning package - 'setuptools' (Installed Version: 56.0.0, Security Vulnerability: CVE-2022-40897). Identified vulnerability: Version: 0. Required Version Threshold: 65.5.1. Required Version Threshold (or Equal): .
2024/03/06 09:28:54 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:283 at operator()(): DEBUG: Failed to scan package: 'setuptools', CVE Numbering Authorities (CNA): 'pypi', Error: 'Unable to compare versions (56.0.0 vs 65.5.1).'
--
2024/03/06 09:31:48 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:125 at operator()(): DEBUG: Scanning package - 'setuptools' (Installed Version: 59.6.0, Security Vulnerability: CVE-2022-40897). Identified vulnerability: Version: 0. Required Version Threshold: 65.5.1. Required Version Threshold (or Equal): .
2024/03/06 09:31:48 wazuh-modulesd:vulnerability-scanner[58809] packageScanner.hpp:283 at operator()(): DEBUG: Failed to scan package: 'setuptools', CVE Numbering Authorities (CNA): 'pypi', Error: 'Unable to compare versions (59.6.0 vs 65.5.1).'
```

### New branch
- Affected
```
2024/03/05 23:39:46 wazuh-modulesd:vulnerability-scanner[394838] packageScanner.hpp:227 at operator()(): DEBUG: Match found, the package 'setuptools', is vulnerable to 'CVE-2022-40897'. Current version: '59.6.0' (less than '65.5.1' or equal to ''). - Agent 'Thinkpad-Sebas' (ID: '000', Version: 'Wazuh v4.8.0').
```

The package that failed is now correctly detected as affected:

- CVE-2022-40897
```json
{
    "defaultStatus": "unaffected",
    "product": "setuptools",
    "vendor": "python",
    "versions":
    [
        {
            "lessThan": "65.5.1",
            "status": "affected",
            "version": "0",
            "versionType": "custom"
        }
    ]
}
```

</details>