### PR TITLE
Change API response with `Expect`

### DIFF
--- a/api/api/test/test_error_handler.py
+++ b/api/api/test/test_error_handler.py
@@ -9,11 +9,12 @@ from copy import copy
 import pytest
 
 from freezegun import freeze_time
+from content_size_limit_asgi.errors import ContentSizeExceeded
 
 from connexion.exceptions import HTTPException, ProblemException, BadRequestProblem, Unauthorized
 from api.error_handler import _cleanup_detail_field, prevent_bruteforce_attack, jwt_error_handler, \
     http_error_handler, problem_error_handler, bad_request_error_handler, unauthorized_error_handler, \
-    ERROR_CONTENT_TYPE
+    handle_expect_header, ERROR_CONTENT_TYPE
 from api.middlewares import LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT
 
 
@@ -184,6 +185,21 @@ async def test_problem_error_handler(title, detail, ext, error_type, mock_reques
     assert response.status_code == 400
     assert response.content_type == ERROR_CONTENT_TYPE
     assert body == problem
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('expect_header, exc, expected_status_code, expected_response', [
+    ('100-continue', None, 200, '"100-continue"'),
+    ('expect_value', ContentSizeExceeded(), 417, {"title": "error : 417", "detail": "Expectation Failed."}),
+])
+async def test_handle_expect_header(expect_header, exc, expected_status_code, expected_response, mock_request):
+    """Test handle_expect_header function."""
+    mock_request.headers = {'Expect': expect_header}
+    response = await handle_expect_header(mock_request, exc)
+    assert response.status_code == expected_status_code
+    if isinstance(expected_response, str):
+        assert response.body == expected_response
+    else:
+        assert json.loads(response.body) == expected_response
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
|Related issue|
|---|
| #21935  |



## Description

The API responses were modified when they contain the `Expect` header.

The corresponding test was added for the new function

Without Expect header:
```console
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/?pretty=true" -H "Authorization: Bearer $TOKEN"   
{
   "title": "Unauthorized",
   "detail": "No authorization token provided"
}
```
With Expect 100-continue:
```console
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/?pretty=true" -H "Authorization: Bearer $TOKEN" -H "Expect: 100-continue"
"100-continue"
```

With Different Expect:
```console
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/?pretty=true" -H "Authorization: Bearer test_token" -H "Expect: Test_header"
{
   "title": "error : 417",
   "detail": "Expectation Failed."
}
```

## Tests

```console
(unittest-env) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest api/api/test/test_error_handler.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0
rootdir: /home/wazuh/Git/wazuh/api/api
configfile: pytest.ini
plugins: anyio-4.3.0, aiohttp-1.0.4, trio-0.8.0, html-2.1.1, metadata-3.1.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 31 items                                                                                                                                                                                                

api/api/test/test_error_handler.py ...............................                                                                                                                                          [100%]

========================================================================================= 31 passed, 9 warnings in 0.63s ==========================================================================================
```

