### PR TITLE
Remove deprecated fields from CVEv5 fbs

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/cve5.fbs
@@ -199,8 +199,6 @@ table Remediation {
 
 table Remediations {
     windows: [Remediation];
-    alpine: [Remediation];
-    custom: [string];
 }
 
 table ProviderMetadata {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/storeRemediationsModel_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/storeRemediationsModel_test.cpp
@@ -19,7 +19,7 @@ constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
 const std::string FLATBUFFER_SCHEMA {FLATBUFFER_SCHEMAS_DIR "/cve5.fbs"};
 const char* FB_INCLUDE_DIRECTORIES[] = {FLATBUFFER_SCHEMAS_DIR, nullptr};
 
-auto JSON_CVE5_VALID_ONE_BLOCK = R"(
+const auto JSON_CVE5_VALID_ONE_BLOCK = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -83,7 +83,7 @@ auto JSON_CVE5_VALID_ONE_BLOCK = R"(
     }
 )";
 
-auto JSON_CVE5_VALID_MULTIPLE_BLOCKS = R"(
+const auto JSON_CVE5_VALID_MULTIPLE_BLOCKS = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -162,7 +162,7 @@ auto JSON_CVE5_VALID_MULTIPLE_BLOCKS = R"(
     }
 )";
 
-auto JSON_CVE5_VALID_MULTIPLE_BLOCKS_SOME_WITH_NO_ANYOF = R"(
+const auto JSON_CVE5_VALID_MULTIPLE_BLOCKS_SOME_WITH_NO_ANYOF = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -240,71 +240,7 @@ auto JSON_CVE5_VALID_MULTIPLE_BLOCKS_SOME_WITH_NO_ANYOF = R"(
     }
 )";
 
-auto JSON_CVE5_EMPTY_WINDOWS = R"(
-    {
-        "dataType": "CVE_RECORD",
-        "dataVersion": "5.0",
-        "cveMetadata": {
-            "cveId": "CVE-1337-1234",
-            "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
-            "state": "PUBLISHED"
-        },
-        "containers": {
-            "cna": {
-                "providerMetadata": {
-                    "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
-                },
-                "problemTypes": [
-                    {
-                        "descriptions": [
-                            {
-                                "lang": "en",
-                                "description": "CWE-78 OS Command Injection"
-                            }
-                        ]
-                    }
-                ],
-                "affected": [
-                    {
-                        "vendor": "Example.org",
-                        "product": "Example Enterprise",
-                        "versions": [
-                            {
-                                "version": "1.0.0",
-                                "status": "affected",
-                                "lessThan": "1.0.6",
-                                "versionType": "semver"
-                            }
-                        ],
-                        "defaultStatus": "unaffected"
-                    }
-                ],
-                "descriptions": [
-                    {
-                        "lang": "en",
-                        "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, MacOS and XT-4500 allows remote unauthenticated attackers to escalate privileges.\n\nThis issue affects:\n  *  1.0 versions before 1.0.6\n  *  2.1 versions from 2.16 until 2.1.9."
-                    }
-                ],
-                "references": [
-                    {
-                        "url": "https://example.org/ESA-22-11-CVE-1337-1234"
-                    }
-                ],
-                "x_remediations": {
-                    "alpine": [
-                        {
-                            "anyOf":["KBT-800","KBT-1000","KBT-3000"],
-                            "products": ["Windows 10 - HastaLaVistaBaby", "Windows 11 - RiseOfTheMachines", "Windows 12 - Genisys"],
-                            "type": "update"
-                        }
-                    ]
-                }
-            }
-        }
-    }
-)";
-
-auto JSON_CVE5_EMPTY_UPDATES = R"(
+const auto JSON_CVE5_EMPTY_UPDATES = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -367,7 +303,7 @@ auto JSON_CVE5_EMPTY_UPDATES = R"(
     }
 )";
 
-auto JSON_CVE5_NO_REMEDIATIONS = R"(
+const auto JSON_CVE5_NO_REMEDIATIONS = R"(
     {
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0",
@@ -564,41 +500,6 @@ TEST_F(StoreRemediationsModelTest, UpdatesWindowsRemediationMultipleBlocksSomeWi
     EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(4)->str().c_str(), "KBT-7000");
     EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(5)->str().c_str(), "KBT-8000");
     EXPECT_STREQ(dtoVulnRemediation.data->updates()->Get(6)->str().c_str(), "KBT-9000");
-}
-
-TEST_F(StoreRemediationsModelTest, SkipsEmptyRemediations)
-{
-    // Define schema variable and parse JSON object.
-    std::string schemaStr;
-
-    // Load file with schema.
-    bool valid = flatbuffers::LoadFile(FLATBUFFER_SCHEMA.c_str(), false, &schemaStr);
-    EXPECT_TRUE(valid);
-
-    // Parse schema.
-    flatbuffers::Parser parser;
-    valid = parser.Parse(schemaStr.c_str(), FB_INCLUDE_DIRECTORIES) && parser.Parse(JSON_CVE5_EMPTY_WINDOWS);
-    EXPECT_TRUE(valid);
-
-    // Create a test Entry object with Windows remediations
-    auto jbuf = parser.builder_.GetBufferPointer();
-    flatbuffers::Verifier jverifier(jbuf, parser.builder_.GetSize());
-    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(jverifier));
-    auto entry = cve_v5::GetEntry(jbuf);
-
-    // Create a mock RocksDBWrapper object
-    std::unique_ptr<Utils::IRocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-
-    if (!rocksDBWrapper->columnExists(REMEDIATIONS_COLUMN))
-    {
-        rocksDBWrapper->createColumn(REMEDIATIONS_COLUMN);
-    }
-
-    // Asserts there's no element with the key provided.
-    EXPECT_NO_THROW(StoreRemediationsModel::updateRemediation(entry, rocksDBWrapper.get()));
-    std::string key {entry->cveMetadata()->cveId()->str()};
-    FlatbufferDataPair<RemediationInfo> dtoVulnRemediation;
-    EXPECT_EQ(false, rocksDBWrapper->get(key, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN));
 }
 
 TEST_F(StoreRemediationsModelTest, SkipsEmptyUpdates)


### PR DESCRIPTION
|Related issue|
|---|
| #22385 |

## Description
This PR removes some deprecated fields from the CVEv5 fbs
