### PR TITLE
Modify outdated agents select parameter

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -1545,7 +1545,7 @@ async def get_agent_no_group(request, pretty: bool = False, wait_for_complete: b
 
 async def get_agent_outdated(request, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                              limit: int = DATABASE_LIMIT, sort: str = None, search: str = None,
-                             q: str = None) -> web.Response:
+                             select: str = None, q: str = None) -> web.Response:
     """Get outdated agents.
 
     Parameters
@@ -1564,6 +1564,8 @@ async def get_agent_outdated(request, pretty: bool = False, wait_for_complete: b
         ascending or descending order.
     search : str
         Look for elements with the specified string.
+    select : str
+        Select which fields to return (separated by comma).
     q : str
         Query to filter results by. For example "q&#x3D;&amp;quot;status&#x3D;active&amp;quot;".
 
@@ -1576,6 +1578,7 @@ async def get_agent_outdated(request, pretty: bool = False, wait_for_complete: b
                 'limit': limit,
                 'sort': parse_api_param(sort, 'sort'),
                 'search': parse_api_param(search, 'search'),
+                'select': select,
                 'q': q}
 
     dapi = DistributedAPI(f=agent.get_outdated_agents,

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -1076,6 +1076,7 @@ async def test_get_agent_outdated(mock_exc, mock_dapi, mock_remove, mock_dfunc, 
                 'limit': DATABASE_LIMIT,
                 'sort': None,
                 'search': None,
+                'select': None,
                 'q': None
                 }
     mock_dapi.assert_called_once_with(f=agent.get_outdated_agents,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -900,19 +900,6 @@ components:
                 $ref: '#/components/schemas/GroupID'
         - $ref: '#/components/schemas/AllItemsResponse'
 
-    AllItemsResponseAgentsSimple:
-      allOf:
-        - $ref: '#/components/schemas/AllItemsResponse'
-        - type: object
-          required:
-            - affected_items
-          properties:
-            affected_items:
-              type: array
-              description: "Items that successfully applied the API call action"
-              items:
-                $ref: '#/components/schemas/AgentSimple'
-
     AllItemsResponseAgentsSynced:
       allOf:
         - $ref: '#/components/schemas/AllItemsResponse'
@@ -1370,9 +1357,17 @@ components:
         - command
 
     ## Agents models
-    ExtraAgentFields:
+    Agent:
       type: object
       properties:
+        version:
+          type: string
+          description: "Wazuh version the agent has installed"
+        id:
+          $ref: '#/components/schemas/AgentID'
+        name:
+          type: string
+          description: "Agent name used at registration process"
         status:
           $ref: '#/components/schemas/AgentStatus'
         configSum:
@@ -1433,11 +1428,6 @@ components:
           minimum: 0
           maximum: 5
 
-    Agent:
-      allOf:
-      - $ref: '#/components/schemas/AgentSimple'
-      - $ref: '#/components/schemas/ExtraAgentFields'
-
     AgentGroup:
       type: object
       properties:
@@ -1476,18 +1466,6 @@ components:
         key:
           type: string
           format: base64
-
-    AgentSimple:
-      type: object
-      properties:
-        version:
-          type: string
-          description: "Wazuh version the agent has installed"
-        id:
-          $ref: '#/components/schemas/AgentID'
-        name:
-          type: string
-          description: "Agent name used at registration process"
 
     AgentStatus:
       type: string
@@ -1534,8 +1512,7 @@ components:
 
     AgentDistinct:
       allOf:
-        - $ref: '#/components/schemas/AgentSimple'
-        - $ref: '#/components/schemas/ExtraAgentFields'
+        - $ref: '#/components/schemas/Agent'
         - type: object
           properties:
             count:
@@ -9085,6 +9062,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/select'
         - $ref: '#/components/parameters/query'
       responses:
         '200':
@@ -9097,16 +9075,60 @@ paths:
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/AllItemsResponseAgentsSimple'
+                        $ref: '#/components/schemas/AllItemsResponseAgents'
               example:
                 data:
                   affected_items:
-                    - version: Wazuh v3.0.0
-                      id: "003"
-                      name: main_database
-                    - version: Wazuh v3.0.0
-                      id: "004"
-                      name: dmz002
+                    - os:
+                        arch: x86_64
+                        codename: Focal Fossa
+                        major: '20'
+                        minor: '04'
+                        name: Ubuntu
+                        platform: ubuntu
+                        uname: Linux |ac7cb188d538 |5.8.0-45-generic |#51~20.04.1-Ubuntu SMP Tue Feb
+                          23 13:46:31 UTC 2021 |x86_64
+                        version: 20.04.2 LTS
+                      lastKeepAlive: '2024-02-26T12:40:40Z'
+                      id: '001'
+                      dateAdd: 2024-02-26T12:40:08Z
+                      configSum: ab73af41699f13fdd81903b5f23d8d00
+                      manager: wazuh-worker2
+                      group: [default]
+                      registerIP: Any
+                      ip: 172.25.0.6
+                      name: ac7cb188d538
+                      status: active
+                      mergedSum: 9a016508cea1e997ab8569f5cfab30f5
+                      version: Wazuh v3.0.0
+                      node_name: worker2
+                      group_config_status: "synced"
+                      status_code: 0
+                    - os:
+                        arch: x86_64
+                        codename: Focal Fossa
+                        major: '20'
+                        minor: '04'
+                        name: Ubuntu
+                        platform: ubuntu
+                        uname: Linux |ac7cb188d538 |5.8.0-45-generic |#51~20.04.1-Ubuntu SMP Tue Feb
+                          23 13:46:31 UTC 2021 |x86_64
+                        version: 20.04.2 LTS
+                      lastKeepAlive: '2024-02-26T12:40:40Z'
+                      id: '002'
+                      dateAdd: 2024-02-26T12:40:10Z
+                      configSum: ab73af41699f13fdd81903b5f23d8d00
+                      manager: wazuh-worker2
+                      group: [default]
+                      registerIP: Any
+                      ip: 172.25.0.11
+                      name: 91642a418627
+                      status: active
+                      mergedSum: 9a016508cea1e997ab8569f5cfab30f5
+                      version: Wazuh v3.0.0
+                      node_name: worker2
+                      group_config_status: "synced"
+                      status_code: 0
                   total_affected_items: 2
                   total_failed_items: 0
                   failed_items: []

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -4234,6 +4234,56 @@ stages:
             reverse: true
       status_code: 200
 
+  - name: Get the outdated agents fields
+    request:
+      verify: False
+      <<: *agents_outdated_request
+      params:
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            -
+              id: '005'
+              status: active
+              name: wazuh-agent5
+              version: 'Wazuh v3.13.2'
+              node_name: master-node
+              status_code: 0
+              group:
+                - default
+                - group1
+                - group2
+              registerIP: any
+              configSum: 6ca315e21ec25eab4bcb2a29218c6ae8
+              mergedSum: 0b4cbf98821ce6e4059269ac8969a8e6
+              dateAdd: '1970-01-01T00:00:00+00:00'
+              group_config_status: synced
+          failed_items: []
+          total_affected_items: 6
+          total_failed_items: 0
+
+  - name: Select
+    request:
+      verify: False
+      <<: *agents_outdated_request
+      params:
+        limit: 1
+        select: name
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - name: wazuh-agent5
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
   - name: Pagination
     request:
       verify: False
@@ -4249,7 +4299,7 @@ stages:
         data:
           affected_items:
             - id: '009'
-          failed_items: [ ]
+          failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
 

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -4250,7 +4250,6 @@ stages:
               status: active
               name: wazuh-agent5
               version: 'Wazuh v3.13.2'
-              node_name: master-node
               status_code: 0
               group:
                 - default

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -4246,8 +4246,7 @@ stages:
         error: 0
         data:
           affected_items:
-            -
-              id: '005'
+            - id: '005'
               status: active
               name: wazuh-agent5
               version: 'Wazuh v3.13.2'

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1077,7 +1077,6 @@ def get_outdated_agents(agent_list: list = None, offset: int = 0, limit: int = c
         manager = Agent(id='000')
         manager.load_info_from_db()
 
-        select = ['version', 'id', 'name'] if select is None else select
         rbac_filters = get_rbac_filters(system_resources=get_agents_info(), permitted_resources=agent_list)
 
         with WazuhDBQueryAgents(offset=offset, limit=limit, sort=sort, search=search, select=select,

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1042,7 +1042,7 @@ def remove_agents_from_group(agent_list: list = None, group_list: list = None) -
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
 def get_outdated_agents(agent_list: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: dict = None,
-                        search: str = None, select: dict = None, q: str = None) -> AffectedItemsWazuhResult:
+                        search: dict = None, select: str = None, q: str = None) -> AffectedItemsWazuhResult:
     """Gets the outdated agents.
 
     Parameters

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1042,7 +1042,7 @@ def remove_agents_from_group(agent_list: list = None, group_list: list = None) -
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
 def get_outdated_agents(agent_list: list = None, offset: int = 0, limit: int = common.DATABASE_LIMIT, sort: dict = None,
-                        search: dict = None, select: dict = None, q: str = None) -> AffectedItemsWazuhResult:
+                        search: str = None, select: dict = None, q: str = None) -> AffectedItemsWazuhResult:
     """Gets the outdated agents.
 
     Parameters
@@ -1057,8 +1057,8 @@ def get_outdated_agents(agent_list: list = None, offset: int = 0, limit: int = c
         Sorts the items. Format: {"fields":["field1","field2"],"order":"asc|desc"}.
     search : dict
         Looks for items with the specified string. Format: {"fields": ["field1","field2"]}.
-    select : dict
-        Select fields to return. Format: {"fields":["field1","field2"]}.
+    select : str
+        Select which fields to return (separated by comma).
     q : str
         Query to filter results by. For example q&#x3D;&amp;quot;status&#x3D;active&amp;quot;
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1015,43 +1015,27 @@ def test_agent_remove_agents_from_group_exceptions(group_mock, agents_info_mock,
         assert error == expected_error
 
 
-@pytest.mark.parametrize('agent_list, outdated_agents', [
-    (short_agent_list, ['001', '002', '005'])
-])
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_get_outdated_agents(socket_mock, send_mock, agent_list, outdated_agents):
+def test_agent_get_outdated_agents(socket_mock, send_mock):
     """Test get_oudated_agents function from agent module.
 
     Parameters
     ----------
-    agent_list : List of str
-        List of agent ID's to check
     outdated_agents : List of str
         List of agent ID's we expect to be outdated.
     """
-    expected_results = list()
-    for agentID in ['001', '002', '005']:
-        agent = Agent(agentID)
-        agent.load_info_from_db()
-        expected_results.append({'version': agent.version, 'id': agentID, 'name': agent.name})
+    outdated_agents = ['001', '002', '005']
     result = get_outdated_agents(agent_list=short_agent_list)
     # Check typing
-    assert isinstance(result, AffectedItemsWazuhResult), 'The returned object is not an "AffectedItemsWazuhResult".'
-    assert isinstance(result.affected_items, list), \
-        f'"affected_items" should be a list object but was "{type(result.affected_items)}" instead.'
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert isinstance(result.affected_items, list)
     # Check affected items
-    assert result.total_affected_items == len(expected_results), \
-        f'"total_affected_items" ({result.total_affected_items}) does not match with the number of expected ' \
-        f'results ({len(expected_results)})'
-    assert [item for item in result.affected_items if item not in expected_results] == list(), \
-        f'The "affected_items" received does not match.\n' \
-        f' - The "affected_items" received is "{result.affected_items}"\n' \
-        f' - The "affected_items" expected was "{expected_results}"\n' \
-        f' - The difference is "{[item for item in result.affected_items if not item in expected_results]}"\n'
+    assert result.total_affected_items == len(outdated_agents)
+    for item in result.affected_items:
+        assert item['id'] in outdated_agents
     # Check failed items
-    assert result.total_failed_items == 0, \
-        f'"failed_items" should be "0" but is "{result.total_failed_items}"'
+    assert result.total_failed_items == 0
 
 
 @pytest.mark.parametrize('agent_set, expected_errors_and_items, result_from_socket, filters, raise_error', [


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/22357 |

## Description

Removes the hard-coded fields selected in the `GET /agents/outdated` endpoint and adds the `select` parameter to its specification.

## Tests

<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

```console
(venv10) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest --nobuild -vv test_agent_GET_endpoints.tavern.yaml
================================================================ test session starts =================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 95 items                                                                                                                                   

test_agent_GET_endpoints.tavern.yaml::GET /agents PASSED                                                                                       [  1%]
test_agent_GET_endpoints.tavern.yaml::GET /agents with single agent id PASSED                                                                  [  2%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} PASSED                                         [  3%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/config/{component}/{configuration} (only cluster configuration) PASSED            [  4%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/group/is_sync PASSED                                                              [  5%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/key PASSED                                                                        [  6%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/daemons/stats PASSED                                                              [  7%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/{agent_id}/stats/{component} PASSED                                                          [  8%]
test_agent_GET_endpoints.tavern.yaml::GET /groups XFAIL                                                                                        [  9%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[md5] PASSED                                                                      [ 10%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha1] PASSED                                                                     [ 11%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha224] PASSED                                                                   [ 12%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha256] PASSED                                                                   [ 13%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha384] PASSED                                                                   [ 14%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha512] PASSED                                                                   [ 15%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2b] PASSED                                                                  [ 16%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[blake2s] PASSED                                                                  [ 17%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_224] PASSED                                                                 [ 18%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_256] PASSED                                                                 [ 20%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_384] PASSED                                                                 [ 21%]
test_agent_GET_endpoints.tavern.yaml::GET /groups filter hash[sha3_512] PASSED                                                                 [ 22%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents PASSED                                                                     [ 23%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[configSum] PASSED                                            [ 24%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[dateAdd] PASSED                                              [ 25%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[group] PASSED                                                [ 26%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[id] PASSED                                                   [ 27%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[ip] PASSED                                                   [ 28%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[lastKeepAlive] PASSED                                        [ 29%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[manager] PASSED                                              [ 30%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[mergedSum] PASSED                                            [ 31%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[name] PASSED                                                 [ 32%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[node_name] PASSED                                            [ 33%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.arch] PASSED                                              [ 34%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.build] PASSED                                             [ 35%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.codename] PASSED                                          [ 36%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.major] PASSED                                             [ 37%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.minor] PASSED                                             [ 38%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.name] PASSED                                              [ 40%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.platform] PASSED                                          [ 41%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.uname] PASSED                                             [ 42%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[os.version] PASSED                                           [ 43%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[registerIP] PASSED                                           [ 44%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status] PASSED                                               [ 45%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[version] PASSED                                              [ 46%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/agents {sort,select}[status_code] PASSED                                          [ 47%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/configuration PASSED                                                              [ 48%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files PASSED                                                                      [ 49%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[md5] PASSED                                                     [ 50%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha1] PASSED                                                    [ 51%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha224] PASSED                                                  [ 52%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha256] PASSED                                                  [ 53%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha384] PASSED                                                  [ 54%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha512] PASSED                                                  [ 55%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2b] PASSED                                                 [ 56%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[blake2s] PASSED                                                 [ 57%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_224] PASSED                                                [ 58%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_256] PASSED                                                [ 60%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_384] PASSED                                                [ 61%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files filter hash[sha3_512] PASSED                                                [ 62%]
test_agent_GET_endpoints.tavern.yaml::GET /groups/{group_id}/files/{filename} PASSED                                                           [ 63%]
test_agent_GET_endpoints.tavern.yaml::GET /agents?name=agent_name PASSED                                                                       [ 64%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group PASSED                                                                              [ 65%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[dateAdd] PASSED                                                       [ 66%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[id] PASSED                                                            [ 67%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[ip] PASSED                                                            [ 68%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[name] PASSED                                                          [ 69%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[node_name] PASSED                                                     [ 70%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[registerIP] PASSED                                                    [ 71%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status] PASSED                                                        [ 72%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/no_group {sort,select}[status_code] PASSED                                                   [ 73%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/outdated PASSED                                                                              [ 74%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct PASSED                                                                        [ 75%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[dateAdd] PASSED                                                      [ 76%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[id] PASSED                                                           [ 77%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[ip] PASSED                                                           [ 78%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[lastKeepAlive] PASSED                                                [ 80%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[manager] PASSED                                                      [ 81%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[name] PASSED                                                         [ 82%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[node_name] PASSED                                                    [ 83%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.arch] PASSED                                                      [ 84%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.build] PASSED                                                     [ 85%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.codename] PASSED                                                  [ 86%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.major] PASSED                                                     [ 87%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.minor] PASSED                                                     [ 88%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.name] PASSED                                                      [ 89%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.platform] PASSED                                                  [ 90%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.uname] PASSED                                                     [ 91%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[os.version] PASSED                                                   [ 92%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[registerIP] PASSED                                                   [ 93%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status] PASSED                                                       [ 94%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[version] PASSED                                                      [ 95%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/stats/distinct {fields}[status_code] PASSED                                                  [ 96%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/status PASSED                                                                        [ 97%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/summary/os PASSED                                                                            [ 98%]
test_agent_GET_endpoints.tavern.yaml::GET /agents/upgrade_result PASSED                                                                        [100%]

================================================================== warnings summary ==================================================================
../../../../../.local/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/gasti/.local/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_agent_GET_endpoints.tavern.yaml: 95 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 94 passed, 1 xfailed, 96 warnings in 73.25s (0:01:13) ================================================
```

</details>
