### PR TITLE
16014 update channel for windows terminal services gateway rules

### DIFF
--- a/ruleset/rules/0620-win-generic_rules.xml
+++ b/ruleset/rules/0620-win-generic_rules.xml
@@ -51,7 +51,7 @@
 
   <rule id="64104" level="0">
     <if_sid>60009,60010,60011,60012</if_sid>
-    <field name="win.system.channel">^Microsoft-Windows-TerminalServices$</field>
+    <field name="win.system.channel">^Microsoft-Windows-TerminalServices-Gateway/Operational$</field>
     <description>Group of Windows rules for Terminal Services</description>
     <options>no_full_log</options>
   </rule>

--- a/ruleset/testing/tests/win-generic_rules.ini
+++ b/ruleset/testing/tests/win-generic_rules.ini
@@ -1,0 +1,5 @@
+[TS Gateway login success]
+log 1 pass = {"win":{"system":{"providerName":"Microsoft-Windows-TerminalServices-Gateway","providerGuid":"{4D5AE6A1-C7B8-3E6D-B840-4D8029342E1B}","eventID":"200","version":"0","level":"4","task":"2","opcode":"30","keywords":"0x4020000001000000","systemTime":"2023-01-25T20:56:39.141308000Z","eventRecordID":"84771","processID":"4672","threadID":"1996","channel":"Microsoft-Windows-TerminalServices-Gateway/Operational","computer":"server.domain.com","severityValue":"INFORMATION","message":"The user \"DOM\\user\", on client computer \"172.16.63.71\", met connection authorization policy requirements and was therefore authorized to access the RD Gateway server. The authentication method used was: \"NTLM\" and connection protocol used: \"HTTP\"."},"eventInfo":{"username":"DOM\\user","ipAddress":"172.16.93.71","authType":"NTLM","connectionProtocol":"HTTP","errorCode":"0"}}}
+rule = 64105
+alert = 3
+decoder = json


### PR DESCRIPTION
|Related issue|
|---|
|Closes #16014 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Rule ID 64104 lists the channel name for Microsoft Windows TerminalServices Gateway events incorrectly as Microsoft-Windows-TerminalServices, the correct channel should be Microsoft-Windows-TerminalServices-Gateway/Operational.
This PR aims to fix this issue


## Logs/Alerts example

{"win":{"system":{"providerName":"Microsoft-Windows-TerminalServices-Gateway","providerGuid":"{4D5AE6A1-C7B8-3E6D-B840-4D8029342E1B}","eventID":"200","version":"0","level":"4","task":"2","opcode":"30","keywords":"0x4020000001000000","systemTime":"2023-01-25T20:56:39.141308000Z","eventRecordID":"84771","processID":"4672","threadID":"1996","channel":"Microsoft-Windows-TerminalServices-Gateway/Operational","computer":"server.domain.com","severityValue":"INFORMATION","message":"\"The user \"DOM\\user\", on client computer \"172.16.63.71\", met connection authorization policy requirements and was therefore authorized to access the RD Gateway server. The authentication method used was: \"NTLM\" and connection protocol used: \"HTTP\".\""},"eventInfo":{"username":"DOM\\user","ipAddress":"172.16.93.71","authType":"NTLM","connectionProtocol":"HTTP","errorCode":"0"}}}

## Tests


<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [x] Added unit testing files ".ini"
  - [x] runtests.py executed without errors

## Ruleset test results

|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   1417   |   4420   |  32.06%  |
| Decoders |   125    |   170    |  73.53%  |


|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/proftpd.ini      |    7     |    0     |   ✅    |
|./tests/exim.ini         |    7     |    0     |   ✅    |
|./tests/squid_rules.ini  |    2     |    0     |   ✅    |
|./tests/sysmon_eid_3.ini |    10    |    0     |   ✅    |
|./tests/amazon_sec_lake.ini|    20    |    0     |   ✅    |
|./tests/checkpoint_smart1.ini|    18    |    0     |   ✅    |
|./tests/iptables.ini     |    9     |    0     |   ✅    |
|./tests/sysmon_eid_10.ini|    4     |    0     |   ✅    |
|./tests/SonicWall.ini    |    11    |    0     |   ✅    |
|./tests/panda_paps.ini   |    8     |    0     |   ✅    |
|./tests/fortiauth.ini    |    4     |    0     |   ✅    |
|./tests/openldap.ini     |    9     |    0     |   ✅    |
|./tests/f5_big_ip.ini    |    48    |    0     |   ✅    |
|./tests/sophos.ini       |    8     |    0     |   ✅    |
|./tests/opensmtpd.ini    |    7     |    0     |   ✅    |
|./tests/netscreen.ini    |    4     |    0     |   ✅    |
|./tests/rsh.ini          |    2     |    0     |   ✅    |
|./tests/arbor.ini        |    2     |    0     |   ✅    |
|./tests/web_rules.ini    |    10    |    0     |   ✅    |
|./tests/exchange.ini     |    2     |    0     |   ✅    |
|./tests/vuln_detector.ini|    2     |    0     |   ✅    |
|./tests/win-generic_rules.ini|    1     |    0     |   ✅    |
|./tests/sysmon_eid_7.ini |    6     |    0     |   ✅    |
|./tests/macos.ini        |    11    |    0     |   ✅    |
|./tests/samba.ini        |    4     |    0     |   ✅    |
|./tests/apparmor.ini     |    5     |    0     |   ✅    |
|./tests/test_osmatch_regex.ini|    6     |    0     |   ✅    |
|./tests/test_features.ini|    7     |    0     |   ✅    |
|./tests/pam.ini          |    5     |    0     |   ✅    |
|./tests/apache.ini       |    12    |    0     |   ✅    |
|./tests/fireeye.ini      |    3     |    0     |   ✅    |
|./tests/sysmon.ini       |    25    |    0     |   ✅    |
|./tests/dovecot.ini      |    15    |    0     |   ✅    |
|./tests/web_appsec.ini   |    31    |    0     |   ✅    |
|./tests/nextcloud.ini    |    8     |    0     |   ✅    |
|./tests/kernel_usb.ini   |    6     |    0     |   ✅    |
|./tests/paloalto.ini     |    16    |    0     |   ✅    |
|./tests/sysmon_eid_13.ini|    9     |    0     |   ✅    |
|./tests/ossec.ini        |    5     |    0     |   ✅    |
|./tests/test_osregex_regex.ini|    28    |    0     |   ✅    |
|./tests/cisco_ftd.ini    |    42    |    0     |   ✅    |
|./tests/sysmon_eid_1.ini |    63    |    0     |   ✅    |
|./tests/github.ini       |   324    |    0     |   ✅    |
|./tests/test_pcre2_regex.ini|    33    |    0     |   ✅    |
|./tests/named.ini        |    5     |    0     |   ✅    |
|./tests/powershell.ini   |    32    |    0     |   ✅    |
|./tests/openvpn_ldap.ini |    2     |    0     |   ✅    |
|./tests/sysmon_eid_8.ini |    4     |    0     |   ✅    |
|./tests/cloudflare-waf.ini|    13    |    0     |   ✅    |
|./tests/huawei_usg.ini   |    3     |    0     |   ✅    |
|./tests/eset.ini         |    8     |    0     |   ✅    |
|./tests/test_expr_negation.ini|    56    |    0     |   ✅    |
|./tests/gcp.ini          |    31    |    0     |   ✅    |
|./tests/cpanel.ini       |    7     |    0     |   ✅    |
|./tests/pfsense.ini      |    2     |    0     |   ✅    |
|./tests/cisco_asa.ini    |    88    |    0     |   ✅    |
|./tests/systemd.ini      |    2     |    0     |   ✅    |
|./tests/nginx.ini        |    12    |    0     |   ✅    |
|./tests/sysmon_eid_11.ini|    28    |    0     |   ✅    |
|./tests/cisco_ios.ini    |    17    |    0     |   ✅    |
|./tests/pix.ini          |    22    |    0     |   ✅    |
|./tests/php.ini          |    2     |    0     |   ✅    |
|./tests/office365.ini    |   128    |    0     |   ✅    |
|./tests/fortigate.ini    |    45    |    0     |   ✅    |
|./tests/fortimail.ini    |    6     |    0     |   ✅    |
|./tests/audit_scp.ini    |    8     |    0     |   ✅    |
|./tests/win_application.ini|    0     |    0     |   ✅    |
|./tests/fortiddos.ini    |    3     |    0     |   ✅    |
|./tests/cimserver.ini    |    2     |    0     |   ✅    |
|./tests/freepbx.ini      |    6     |    0     |   ✅    |
|./tests/overwrite.ini    |    10    |    0     |   ✅    |
|./tests/sshd.ini         |    49    |    0     |   ✅    |
|./tests/win_event_channel.ini|    8     |    0     |   ✅    |
|./tests/gitlab.ini       |    27    |    0     |   ✅    |
|./tests/windows_baseline_intrusion_detection.ini|    29    |    0     |   ✅    |
|./tests/glpi.ini         |    3     |    0     |   ✅    |
|./tests/api.ini          |    21    |    0     |   ✅    |
|./tests/dropbear.ini     |    3     |    0     |   ✅    |
|./tests/win_security.ini |    9     |    0     |   ✅    |
|./tests/firewalld.ini    |    2     |    0     |   ✅    |
|./tests/mailscanner.ini  |    1     |    0     |   ✅    |
|./tests/owlh.ini         |    4     |    0     |   ✅    |
|./tests/sysmon_eid_20.ini|    2     |    0     |   ✅    |
|./tests/auditd.ini       |    31    |    0     |   ✅    |
|./tests/mcafee_epo.ini   |    1     |    0     |   ✅    |
|./tests/doas.ini         |    4     |    0     |   ✅    |
|./tests/junos.ini        |    3     |    0     |   ✅    |
|./tests/sudo.ini         |    8     |    0     |   ✅    |
|./tests/syslog.ini       |    6     |    0     |   ✅    |
|./tests/sophos_fw.ini    |    10    |    0     |   ✅    |
|./tests/vsftpd.ini       |    4     |    0     |   ✅    |
|./tests/postfix.ini      |    2     |    0     |   ✅    |
|./tests/modsecurity.ini  |    6     |    0     |   ✅    |
|./tests/su.ini           |    5     |    0     |   ✅    |
|./tests/unbound.ini      |    0     |    0     |   ✅    |
|./tests/aws_s3_access.ini|    10    |    0     |   ✅    |
|./tests/test_static_filters.ini|    28    |    0     |   ✅    |
|./tests/oscap.ini        |    32    |    0     |   ✅    |
