### PR TITLE
Add WIX binaries to path in Windows workflows

### DIFF
--- a/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
+      - name: Add WiX toolkit to PATH
+        shell: bash
+        run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration-tests-execd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-win.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
+      - name: Add WiX toolkit to PATH
+        shell: bash
+        run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration-tests-github-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-github-tier-0-1-win.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
+      - name: Add WiX toolkit to PATH
+        shell: bash
+        run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration-tests-office365-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-office365-tier-0-1-win.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
+      - name: Add WiX toolkit to PATH
+        shell: bash
+        run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration-tests-sca-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-sca-tier-0-1-win.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
+      - name: Add WiX toolkit to PATH
+        shell: bash
+        run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-lin.yml
@@ -9,7 +9,7 @@ on:
         default: 'main'
   pull_request:
     paths:
-        - ".github/workflows/integration-tests-syscollector-tier-0-1.yml"
+        - ".github/workflows/integration-tests-syscollector-tier-0-1-lin.yml"
         - "src/wazuh_modules/syscollector/**"
         - "src/config/wmodules-syscollector.c"
         - "src/Makefile"

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
@@ -9,7 +9,7 @@ on:
         default: 'main'
   pull_request:
     paths:
-      - ".github/workflows/integration-tests-syscollector-tier-0-1.yml"
+      - ".github/workflows/integration-tests-syscollector-tier-0-1-win.yml"
       - "src/wazuh_modules/syscollector/**"
       - "src/config/wmodules-syscollector.c"
       - "src/Makefile"

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
+      - name: Add WiX toolkit to PATH
+        shell: bash
+        run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: actions/download-artifact@v3

--- a/.github/workflows/windows-msi-upgrade-check.yml
+++ b/.github/workflows/windows-msi-upgrade-check.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
+      - name: Add WiX toolkit to PATH
+        shell: bash
+        run: echo "${WIX}bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
           pip install -r src/win32/qa/requirements.txt


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22409|

## Description

This PR fixes the Windows workflows.

It is necessary to add the WIX path to the PATH variable since the runners aren't able to find the related binaries.
