### PR TITLE
Modify /agents/stats/distinct endpoint field unknown default value to N/A

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9272,7 +9272,7 @@ paths:
                         version: "20.04.2 LTS"
                       count: 2
                     - os:
-                        version: "unknown"
+                        version: "N/A"
                       count: 1
                   total_affected_items: 3
                   total_failed_items: 0

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -4421,7 +4421,7 @@ stages:
                 platform: !anystr
             - count: !anyint
               os:
-                platform: unknown
+                platform: N/A
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
@@ -4451,7 +4451,7 @@ stages:
             - count: !anyint
               status: never_connected
               os:
-                name: unknown
+                name: N/A
 
           failed_items: []
           total_affected_items: !anyint

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -388,7 +388,7 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
         self.remove_extra_fields = True
 
     def _format_data_into_dictionary(self) -> str:
-        """Add <field>: 'unknown' when filter field is not within the response. Compute 'status' field, format id with
+        """Add <field>: 'N/A' when filter field is not within the response. Compute 'status' field, format id with
         zero padding and remove non-user-requested fields. Also remove, extra fields (internal key and registration IP).
 
         Returns
@@ -399,7 +399,7 @@ class WazuhDBQueryGroupByAgents(WazuhDBQueryGroupBy, WazuhDBQueryAgents):
         for result in self._data:
             for field in self.filter_fields['fields']:
                 if field not in result.keys():
-                    result[field] = 'unknown'
+                    result[field] = 'N/A'
 
         fields_to_nest, non_nested = get_fields_to_nest(self.fields.keys(), ['os'], '.')
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -346,17 +346,17 @@ def test_WazuhDBQueryGroupByAgents_format_data_into_dictionary(mock_socket_conn)
                          {'count': 1, 'name': 'wazuh-agent1'}]
 
     result = query_group._format_data_into_dictionary()
-    assert all(x['os']['name'] == 'unknown' for x in result['items'])
+    assert all(x['os']['name'] == 'N/A' for x in result['items'])
 
 
 @pytest.mark.parametrize('filter_fields, expected_response', [
     (['os.codename'], [{'os': {'codename': 'Bionic Beaver'}, 'count': 3}, {'os': {'codename': 'Xenial'}, 'count': 1},
-                       {'os': {'codename': 'unknown'}, 'count': 2}, {'os': {'codename': 'XP'}, 'count': 3}]),
+                       {'os': {'codename': 'N/A'}, 'count': 2}, {'os': {'codename': 'XP'}, 'count': 3}]),
     (['node_name'], [{'count': 7, 'node_name': 'node01'}, {'count': 2, 'node_name': 'unknown'}]),
     (['status', 'os.version'], [{'os': {'version': '18.04.1 LTS'}, 'count': 2, 'status': 'active'},
                                 {'os': {'version': '16.04.1 LTS'}, 'count': 1, 'status': 'active'},
-                                {'os': {'version': 'unknown'}, 'count': 1, 'status': 'never_connected'},
-                                {'os': {'version': 'unknown'}, 'count': 1, 'status': 'pending'},
+                                {'os': {'version': 'N/A'}, 'count': 1, 'status': 'never_connected'},
+                                {'os': {'version': 'N/A'}, 'count': 1, 'status': 'pending'},
                                 {'os': {'version': '18.04.1 LTS'}, 'count': 1, 'status': 'disconnected'},
                                 {'os': {'version': '5.2'}, 'count': 2, 'status': 'active'},
                                 {'os': {'version': '7.2'}, 'count': 1, 'status': 'active'}])

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -58,19 +58,19 @@ def send_msg_to_wdb(msg, raw=False):
 @pytest.mark.parametrize('fields, expected_items', [
     (
             ['os.platform'],
-            [{'os': {'platform': 'ubuntu'}, 'count': 4}, {'os': {'platform': 'unknown'}, 'count': 2}]
+            [{'os': {'platform': 'ubuntu'}, 'count': 4}, {'os': {'platform': 'N/A'}, 'count': 2}]
     ),
     (
             ['version'],
             [{'version': 'Wazuh v3.9.0', 'count': 1}, {'version': 'Wazuh v3.8.2', 'count': 2},
-             {'version': 'Wazuh v3.6.2', 'count': 1}, {'version': 'unknown', 'count': 2}]
+             {'version': 'Wazuh v3.6.2', 'count': 1}, {'version': 'N/A', 'count': 2}]
     ),
     (
             ['os.platform', 'os.major'],
             [{'count': 1, 'os': {'major': '20', 'platform': 'ubuntu'}},
              {'count': 1, 'os': {'major': '18', 'platform': 'ubuntu'}},
              {'count': 2, 'os': {'major': '16', 'platform': 'ubuntu'}},
-             {'count': 2, 'os': {'major': 'unknown', 'platform': 'unknown'}}]
+             {'count': 2, 'os': {'major': 'N/A', 'platform': 'N/A'}}]
     ),
     (
             ['node_name'],
@@ -82,7 +82,7 @@ def send_msg_to_wdb(msg, raw=False):
              {'count': 1, 'os': {'name': 'Ubuntu', 'platform': 'ubuntu', 'version': '18.08.1 LTS'}},
              {'count': 1, 'os': {'name': 'Ubuntu', 'platform': 'ubuntu', 'version': '16.06.1 LTS'}},
              {'count': 1, 'os': {'name': 'Ubuntu', 'platform': 'ubuntu', 'version': '16.04.1 LTS'}},
-             {'count': 2, 'os': {'name': 'unknown', 'platform': 'unknown', 'version': 'unknown'}}]
+             {'count': 2, 'os': {'name': 'N/A', 'platform': 'N/A', 'version': 'N/A'}}]
     ),
 ])
 @patch('wazuh.core.common.CLIENT_KEYS', new=os.path.join(test_agent_path, 'client.keys'))


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22368 |

## Description

Modifies the response of the `GET /agents/stats/distinct endpoint` endpoint, specifically the `<field>` value to `N/A` (Not Available) when the field is not within the response from the `agent` database.

## Tests

<details><summary>Framework Unit tests</summary>

```console
$ pytest framework/
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: metadata-3.0.0, cov-3.0.0, aiohttp-1.0.4, trio-0.7.0, tavern-1.23.5, asyncio-0.18.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 2211 items                                                                                                                                            

framework/scripts/tests/test_agent_groups.py ..............                                                                                               [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                             [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                    [  1%]
framework/scripts/tests/test_rbac_control.py .........                                                                                                    [  1%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                    [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                      [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                     [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                        [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                    [  7%]
framework/wazuh/core/cluster/tests/test_common.py ....................................................................................                    [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                    [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                          [ 12%]
framework/wazuh/core/cluster/tests/test_master.py ...............................................                                                         [ 14%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                           [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ................                                                                                         [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                      [ 18%]
framework/wazuh/core/tests/test_active_response.py ....................                                                                                   [ 19%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................ [ 24%]
.....................................                                                                                                                     [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                        [ 27%]
framework/wazuh/core/tests/test_common.py .........                                                                                                       [ 28%]
framework/wazuh/core/tests/test_configuration.py .........................................................................................                [ 32%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                               [ 33%]
framework/wazuh/core/tests/test_exception.py ..........                                                                                                   [ 33%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                    [ 33%]
framework/wazuh/core/tests/test_logtest.py ...                                                                                                            [ 33%]
framework/wazuh/core/tests/test_manager.py ...............................                                                                                [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                    [ 35%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                   [ 36%]
framework/wazuh/core/tests/test_results.py ........................................                                                                       [ 37%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                [ 38%]
framework/wazuh/core/tests/test_rule.py .......................                                                                                           [ 39%]
framework/wazuh/core/tests/test_sca.py .............................                                                                                      [ 40%]
framework/wazuh/core/tests/test_security.py .............                                                                                                 [ 41%]
framework/wazuh/core/tests/test_stats.py ........................................                                                                         [ 43%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                       [ 43%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                       [ 43%]
framework/wazuh/core/tests/test_task.py ........                                                                                                          [ 43%]
framework/wazuh/core/tests/test_utils.py ................................................................................................................ [ 49%]
......................................................................................................................................................... [ 55%]
...............                                                                                                                                           [ 56%]
framework/wazuh/core/tests/test_wazuh_queue.py .......................                                                                                    [ 57%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                      [ 58%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                    [ 59%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                  [ 60%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                        [ 60%]
framework/wazuh/rbac/tests/test_decorators.py ........................................................................................................... [ 65%]
..                                                                                                                                                        [ 65%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                          [ 68%]
framework/wazuh/rbac/tests/test_orm.py ..............................................................                                                     [ 70%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                               [ 71%]
framework/wazuh/tests/test_active_response.py ............                                                                                                [ 71%]
framework/wazuh/tests/test_agent.py ..................................................................................................................... [ 77%]
............                                                                                                                                              [ 77%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                              [ 80%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                    [ 81%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                          [ 82%]
framework/wazuh/tests/test_decoder.py ..........................................................                                                          [ 84%]
framework/wazuh/tests/test_event.py ....                                                                                                                  [ 84%]
framework/wazuh/tests/test_logtest.py ......                                                                                                              [ 85%]
framework/wazuh/tests/test_manager.py ....................................                                                                                [ 86%]
framework/wazuh/tests/test_mitre.py .......                                                                                                               [ 87%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                [ 89%]
framework/wazuh/tests/test_rule.py ..........................................................................                                             [ 92%]
framework/wazuh/tests/test_sca.py ...........                                                                                                             [ 93%]
framework/wazuh/tests/test_security.py .......................................................................                                            [ 96%]
framework/wazuh/tests/test_stats.py ...............                                                                                                       [ 97%]
framework/wazuh/tests/test_syscheck.py .........................                                                                                          [ 98%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                   [ 98%]
framework/wazuh/tests/test_task.py ............................                                                                                           [100%]

=============================================================== 2211 passed in 254.03s (0:04:14) ================================================================
```

</details>

<details><summary>Endpoint response</summary>

```json
{
  "data": {
    "affected_items": [
      {
        "os": {
          "arch": "x86_64",
          "build": "N/A",
          "codename": "Focal Fossa",
          "major": "20",
          "minor": "04",
          "name": "Ubuntu",
          "platform": "ubuntu",
          "uname": "Linux |f326e69c57aa |5.15.0-97-generic |#107~20.04.1-Ubuntu SMP Fri Feb 9 14:20:11 UTC 2024 |x86_64",
          "version": "20.04.6 LTS"
        },
        "group_config_status": "synced",
        "disconnection_time": "1970-01-01T00:00:00+00:00",
        "lastKeepAlive": "9999-12-31T23:59:59+00:00",
        "dateAdd": "2024-03-07T16:09:52+00:00",
        "id": "000",
        "registerIP": "127.0.0.1",
        "status": "active",
        "count": 1,
        "ip": "127.0.0.1",
        "version": "Wazuh v4.9.0",
        "status_code": 0,
        "node_name": "master_1",
        "name": "f326e69c57aa",
        "manager": "f326e69c57aa",
        "configSum": "N/A",
        "group": [
          "N/A"
        ],
        "mergedSum": "N/A",
        "internal_key": "N/A"
      },
      {
        "os": {
          "arch": "x86_64",
          "build": "N/A",
          "codename": "Focal Fossa",
          "major": "20",
          "minor": "04",
          "name": "Ubuntu",
          "platform": "ubuntu",
          "uname": "Linux |d4d306e58630 |5.15.0-97-generic |#107~20.04.1-Ubuntu SMP Fri Feb 9 14:20:11 UTC 2024 |x86_64",
          "version": "20.04.6 LTS"
        },
        "group_config_status": "synced",
        "disconnection_time": "1970-01-01T00:00:00+00:00",
        "lastKeepAlive": "2024-03-07T16:26:21+00:00",
        "dateAdd": "2024-03-07T16:10:17+00:00",
        "id": "001",
        "mergedSum": "4a8724b20dee0124ff9656783c490c4e",
        "registerIP": "any",
        "internal_key": "KEY",
        "status": "active",
        "count": 1,
        "ip": "172.21.0.5",
        "version": "Wazuh v4.9.0",
        "status_code": 0,
        "node_name": "e92090a7a90b",
        "name": "d4d306e58630",
        "manager": "e92090a7a90b",
        "configSum": "ab73af41699f13fdd81903b5f23d8d00",
        "group": [
          "default"
        ]
      },
      {
        "os": {
          "arch": "N/A",
          "build": "N/A",
          "codename": "N/A",
          "major": "N/A",
          "minor": "N/A",
          "name": "N/A",
          "platform": "N/A",
          "uname": "N/A",
          "version": "N/A"
        },
        "group_config_status": "not synced",
        "disconnection_time": "1970-01-01T00:00:00+00:00",
        "dateAdd": "2024-03-07T16:10:44+00:00",
        "id": "002",
        "registerIP": "1.2.3.4",
        "internal_key": "KEY",
        "status": "never_connected",
        "count": 1,
        "ip": "1.2.3.4",
        "status_code": 0,
        "node_name": "unknown",
        "name": "TEST",
        "lastKeepAlive": "N/A",
        "manager": "N/A",
        "configSum": "N/A",
        "group": [
          "N/A"
        ],
        "mergedSum": "N/A",
        "version": "N/A"
      }
    ],
    "total_affected_items": 3,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>