### PR TITLE
Update detailsAugmentation class to comply with changes on vulnerability-states indices

### DIFF
--- a/src/shared_modules/indexer_connector/testtool/input/example.json
+++ b/src/shared_modules/indexer_connector/testtool/input/example.json
@@ -13,9 +13,6 @@
         "type": "agent_type_1",
         "version": "1.0.0"
       },
-      "ecs": {
-        "version": "1.8.0"
-      },
       "event": {
         "action": "sample_action",
         "agent_id_status": "sample_status",

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/detailsAugmentation.hpp
@@ -18,6 +18,8 @@
 #include "scanContext.hpp"
 #include "timeHelper.h"
 
+constexpr auto WAZUH_SCHEMA_VERSION = "1.0.0";
+
 /**
  * @brief TDetailsAugmentation class.
  *
@@ -29,7 +31,6 @@ class TDetailsAugmentation final : public AbstractHandler<std::shared_ptr<TScanC
 {
 private:
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
-    std::string ECS_VERSION = "8.11.0";
 
     /**
      * @brief Populate a JSON field with a value if the value is non-empty (for strings) or always (for other types).
@@ -87,9 +88,6 @@ private:
         populateField(package, "/type"_json_pointer, data->packageFormat());
         populateField(package, "/version"_json_pointer, data->packageVersion());
 
-        nlohmann::json ecs;
-        populateField(ecs, "/version"_json_pointer, ECS_VERSION);
-
         nlohmann::json agent;
         populateField(agent, "/ephemeral_id"_json_pointer, data->agentNodeName());
         populateField(agent, "/id"_json_pointer, data->agentId());
@@ -140,8 +138,6 @@ private:
                 auto ecsData = nlohmann::json::object();
                 // ECS agent fields.
                 ecsData["agent"] = agent;
-                // ECS fields.
-                ecsData["ecs"] = ecs;
                 // ECS package fields.
                 ecsData["package"] = package;
                 // ECS os fields.
@@ -162,6 +158,7 @@ private:
                 ecsData["wazuh"]["cluster"]["name"] =
                     vulnerabilityDetection.contains("clusterName") ? vulnerabilityDetection.at("clusterName") : "";
                 ecsData["wazuh"]["manager"]["name"] = data->managerName();
+                ecsData["wazuh"]["schema"]["version"] = WAZUH_SCHEMA_VERSION;
                 // ECS base fields.
                 ecsData["@timestamp"] = Utils::getCurrentISO8601();
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/detailsAugmentation_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/detailsAugmentation_test.cpp
@@ -247,8 +247,6 @@ TEST_F(DetailsAugmentationTest, TestSuccessfulPackageInsertedCVSS2)
     EXPECT_STREQ(elementData.at("agent").at("version").get_ref<const std::string&>().c_str(),
                  scanContextOriginal->agentVersion().data());
 
-    EXPECT_STREQ(elementData.at("ecs").at("version").get_ref<const std::string&>().c_str(), "8.11.0");
-
     EXPECT_STREQ(elementData.at("package").at("architecture").get_ref<const std::string&>().c_str(),
                  scanContextOriginal->packageArchitecture().data());
     EXPECT_STREQ(elementData.at("package").at("description").get_ref<const std::string&>().c_str(),
@@ -325,6 +323,8 @@ TEST_F(DetailsAugmentationTest, TestSuccessfulPackageInsertedCVSS2)
                  vulnerabilityDetection.contains("clusterName")
                      ? vulnerabilityDetection.at("clusterName").get_ref<const std::string&>().c_str()
                      : "");
+    EXPECT_STREQ(elementData.at("wazuh").at("schema").at("version").get_ref<const std::string&>().c_str(),
+                 WAZUH_SCHEMA_VERSION);
 
     auto managerName = scanContextOriginal->managerName();
     constexpr auto MAX_HOSTNAME_SIZE = 256;
@@ -523,8 +523,6 @@ TEST_F(DetailsAugmentationTest, TestSuccessfulPackageInsertedCVSS3)
     EXPECT_STREQ(elementData.at("agent").at("version").get_ref<const std::string&>().c_str(),
                  scanContextOriginal->agentVersion().data());
 
-    EXPECT_STREQ(elementData.at("ecs").at("version").get_ref<const std::string&>().c_str(), "8.11.0");
-
     EXPECT_STREQ(elementData.at("package").at("architecture").get_ref<const std::string&>().c_str(),
                  scanContextOriginal->packageArchitecture().data());
     EXPECT_STREQ(elementData.at("package").at("description").get_ref<const std::string&>().c_str(),
@@ -601,6 +599,8 @@ TEST_F(DetailsAugmentationTest, TestSuccessfulPackageInsertedCVSS3)
                  vulnerabilityDetection.contains("clusterName")
                      ? vulnerabilityDetection.at("clusterName").get_ref<const std::string&>().c_str()
                      : "");
+    EXPECT_STREQ(elementData.at("wazuh").at("schema").at("version").get_ref<const std::string&>().c_str(),
+                 WAZUH_SCHEMA_VERSION);
 
     auto managerName = scanContextOriginal->managerName();
     constexpr auto MAX_HOSTNAME_SIZE = 256;


### PR DESCRIPTION
|Related issue|
|---|
| #22402 |

## Description
This PR updates the detailsAugmentation class to comply with the new and removed vulnerability-states indice

## Tests
All my system vulnerabilities are indexed
![image](https://github.com/wazuh/wazuh/assets/34063881/c83aec11-db09-4a04-b8f3-f5cf71c5bb0f)

Index holds the right values:
```json
      {
        "_index": "wazuh-states-vulnerabilities",
        "_id": "node01_000_4cd14a9aa8a81bdc06fa81c5863cfea9aed9fb95_CVE-2024-0727",
        "_score": 1,
        "_source": {
          "@timestamp": "2024-03-07T17:13:59.600Z",
          "agent": {
            "ephemeral_id": "node01",
            "id": "000",
            "name": "Thinkpad-Sebas",
            "type": "wazuh",
            "version": "v4.8.0"
          },
          "host": {
            "os": {
              "full": "Linux Mint 21.1 (Vera)",
              "kernel": "5.15.0-94-generic",
              "name": "Linux Mint",
              "platform": "linuxmint",
              "type": "linuxmint",
              "version": "21.1"
            }
          },
          "package": {
            "name": "cryptography",
            "path": "/home/sebas/.local/lib/python3.10/site-packages/cryptography-3.3.2.dist-info/METADATA",
            "size": 0,
            "type": "pypi",
            "version": "3.3.2"
          },
          "vulnerability": {
            "category": "Packages",
            "classification": "CVSS",
            "description": "Issue summary: Processing a maliciously formatted PKCS12 file may lead OpenSSL to crash leading to a potential Denial of Service attack  Impact summary: Applications loading files in the PKCS12 format from untrusted sources might terminate abruptly.  A file in PKCS12 format can contain certificates and keys and may come from an untrusted source. The PKCS12 specification allows certain fields to be NULL, but OpenSSL does not correctly check for this case. This can lead to a NULL pointer dereference that results in OpenSSL crashing. If an application processes PKCS12 files from an untrusted source using the OpenSSL APIs then that application will be vulnerable to this issue.  OpenSSL APIs that are vulnerable to this are: PKCS12_parse(), PKCS12_unpack_p7data(), PKCS12_unpack_p7encdata(), PKCS12_unpack_authsafes() and PKCS12_newpass().  We have also fixed a similar issue in SMIME_write_PKCS7(). However since this function is related to writing data we do not consider it security significant.  The FIPS modules in 3.2, 3.1 and 3.0 are not affected by this issue.",
            "enumeration": "CVE",
            "id": "CVE-2024-0727",
            "reference": "https://github.com/openssl/openssl/commit/09df4395b5071217b76dc7d3d2e630eb8c5a79c2, https://github.com/openssl/openssl/commit/775acfdbd0c6af9ac855f34969cdab0c0c90844a, https://github.com/openssl/openssl/commit/d135eeab8a5dbf72b3da5240bab9ddb7678dbd2c, https://github.openssl.org/openssl/extended-releases/commit/03b3941d60c4bce58fab69a0c22377ab439bc0e8, https://github.openssl.org/openssl/extended-releases/commit/aebaa5883e31122b404e450732dc833dc9dee539, https://www.openssl.org/news/secadv/20240125.txt, https://security.netapp.com/advisory/ntap-20240208-0006/",
            "scanner": {
              "vendor": "Wazuh"
            },
            "score": {
              "base": 5.5,
              "version": "3.1"
            },
            "severity": "Medium"
          },
          "wazuh": {
            "cluster": {
              "name": "wazuh"
            },
            "manager": {
              "name": "Thinkpad-Sebas"
            },
            "schema": {
              "version": "1.0.0"
            }
          }
        }
      },
```

### Dashboard
The VD dashboard must be updated to remove the ecs.version field and to add the wazuh.schema.version field:
![image](https://github.com/wazuh/wazuh/assets/34063881/409e51e9-8beb-46a7-bfcb-7b72ac6a0b50)
![image](https://github.com/wazuh/wazuh/assets/34063881/e175b3a3-1157-409d-9985-50228b31e90c)
