### PR TITLE
Enhance RPM matcher by excluding `dist` tag from release part

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
@@ -330,8 +330,25 @@ public:
         output.version = version.substr(versionStart, versionEnd - versionStart);
         output.release = version.substr(releaseStart);
 
+        // List of known distribution tags
+        // Keep .module always in first place
+        std::vector<std::string> distTags = {
+            ".module", ".el", ".fc", ".amzn", ".centos", ".rhel", ".sles", ".alma", ".mga"};
+
+        // Search and truncate the release string at the first occurrence of any distribution tag
+        for (const auto& tag : distTags)
+        {
+            size_t tagPos = output.release.find(tag);
+            if (tagPos != std::string::npos)
+            {
+                output.release = output.release.substr(0, tagPos);
+                break; // Exit the loop after finding the first tag
+            }
+        }
+
         return true;
     }
+
     /**
      * @brief Constructor.
      *

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
@@ -330,20 +330,19 @@ public:
         output.version = version.substr(versionStart, versionEnd - versionStart);
         output.release = version.substr(releaseStart);
 
-        // List of known distribution tags
-        // Keep .module always in first place
-        std::vector<std::string> distTags = {
-            ".module", ".el", ".fc", ".amzn", ".centos", ".rhel", ".sles", ".alma", ".mga"};
-
         // Search and truncate the release string at the first occurrence of any distribution tag
-        for (const auto& tag : distTags)
+        auto it = output.release.begin();
+
+        // Iterate through the release string until a non-numeric or non-tag character is found
+        while (it != output.release.end() && (std::isdigit(*it) || *it == '.' || *it == '+' || *it == '^'))
         {
-            size_t tagPos = output.release.find(tag);
-            if (tagPos != std::string::npos)
-            {
-                output.release = output.release.substr(0, tagPos);
-                break; // Exit the loop after finding the first tag
-            }
+            ++it;
+        }
+
+        // Truncate the string at the position of the first non-numeric or non-tag character found
+        if (it != output.release.end() && it != output.release.begin()) // Check if it's not pointing to the beginning
+        {
+            output.release.erase(it - 1, output.release.end());
         }
 
         return true;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -606,8 +606,8 @@ TEST_F(VersionMatcherTest, compareRpmVer_rmpPackages)
                                       "1.0.1-10.module_el8.5.0+150+5f0dbea0.alma.ppc64le",
                                       VersionObjectType::RPM),
               VersionComparisonResult::A_EQUAL_B); // Alma
-    EXPECT_EQ(VersionMatcher::compare("2.2.20-2.el8", "2.2.20-2.el8.aarch64", VersionObjectType::RPM),
-              VersionComparisonResult::A_LESS_THAN_B); // CentOS
+    EXPECT_EQ(VersionMatcher::compare("2.2.20-2.el8.centos", "2.2.20-2.el8", VersionObjectType::RPM),
+              VersionComparisonResult::A_EQUAL_B); // CentOS
 }
 
 TEST_F(VersionMatcherTest, matchCalVer)
@@ -738,7 +738,7 @@ TEST_F(VersionMatcherTest, matchRPM)
         VersionMatcher::compare("1.57.0-1.amzn2023.0.1", "1.41.0-1.amzn2.0.4.aarch64.rpm", VersionObjectType::RPM),
         VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("5.4.4-3.amzn2023.0.2", "5.4.4-3.amzn2022", VersionObjectType::RPM),
-              VersionComparisonResult::A_GREATER_THAN_B);
+              VersionComparisonResult::A_EQUAL_B);
     EXPECT_EQ(VersionMatcher::compare("2~almost^post", "2.0.1", VersionObjectType::RPM),
               VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("0.9.1+git.20181118-bp156.3.5", "0.9.1-16.fc39", VersionObjectType::RPM),

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/versionMatcher_test.cpp
@@ -746,7 +746,7 @@ TEST_F(VersionMatcherTest, matchRPM)
     EXPECT_EQ(VersionMatcher::compare("4.5.1-bp156.4.2", "4.5.1-bp155.3.7", VersionObjectType::RPM),
               VersionComparisonResult::A_GREATER_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("11.1-2.git3118496.2.mga10", "11.1-2.git3118496.1.mga9", VersionObjectType::RPM),
-              VersionComparisonResult::A_GREATER_THAN_B);
+              VersionComparisonResult::A_EQUAL_B);
     EXPECT_EQ(VersionMatcher::compare("0.0.26-bp156.3.5", "0.0.26-9", VersionObjectType::RPM),
               VersionComparisonResult::A_LESS_THAN_B);
     EXPECT_EQ(VersionMatcher::compare("0.9.1+git.20181118-bp156.3.5", "0.9.1+git.20181118-1.3", VersionObjectType::RPM),


### PR DESCRIPTION
|Related issue|
|---|
|#21988|

## Objective
The aim of this PR is to refine the functionality of the RPM matcher. Following the identification of an issue where the inclusion of the distribution tag in the release part of RPM package versions could lead to inaccurate matching, this update seeks to improve matching accuracy by excluding the distribution tag from the release part during comparisons.

## Description
- An analysis of the RPM matcher revealed that the presence of distribution tags in the release part of package versions was causing mismatches during package comparison operations. These mismatches could potentially lead to incorrect package updates or vulnerability assessments.
- To address this issue, we have implemented changes to the RPM matcher logic, specifically by modifying the algorithm to ignore the distribution tag when creating the object compared to the release part of RPM package versions. 

## Quality Assurance

### Static Analysis

### Testing

#### Unit Testing
- Tests were designed to cover a variety of version formats and comparison scenarios, confirming the matcher's improved accuracy and reliability.

#### Integration Testing
N/A