### PR TITLE
Updated `regex_cdb ` of CDB lists

### DIFF
--- a/framework/wazuh/core/cdb_list.py
+++ b/framework/wazuh/core/cdb_list.py
@@ -227,7 +227,7 @@ def validate_cdb_list(content: str):
     WazuhError(1112)
         Empty CDB list.
     """
-    regex_cdb = re.compile(r'(?:^"([\w\-:]+?)"|^[^:"\s]+):(?:"([\w\-:]*?)"$|[^:\"]*$)')
+    regex_cdb = re.compile(r'(?:^("|\')([\w\- :]+?)("|\')|^[^:"\s]+):(?:("|\')([\w\- :]*?)("|\')$|[^:\"]*$)')
 
     if len(content) == 0:
         raise WazuhError(1112)

--- a/framework/wazuh/core/cdb_list.py
+++ b/framework/wazuh/core/cdb_list.py
@@ -227,7 +227,7 @@ def validate_cdb_list(content: str):
     WazuhError(1112)
         Empty CDB list.
     """
-    regex_cdb = re.compile(r'(?:^("|\')([\w\- :]+?)("|\')|^[^:"\s]+):(?:("|\')([\w\- :]*?)("|\')$|[^:\"]*$)')
+    regex_cdb = re.compile(r'(?:^"([\w\-: ]+?)"|^[^:"\s]+):(?:"([\w\-: ]*?)"$|[^:\"]*$)')
 
     if len(content) == 0:
         raise WazuhError(1112)


### PR DESCRIPTION
|Related issue|
|---|
| #22028  |


## Description

This PR closes https://github.com/wazuh/wazuh/issues/22028 , the CDB list validation regular expression has been updated to support empty spaces in keys or values between single or double quotes.


## Tests

```console
PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/wazuh/core/tests/test_cdb_list.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.3.0, aiohttp-1.0.4, trio-0.8.0, html-2.1.1, metadata-3.1.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 38 items                                                                                                                                                                                                

framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                          [100%]

================================================================================================ warnings summary =================================================================================================
api/api/validator.py:11
api/api/validator.py:11
  /home/wazuh/Git/wazuh/api/api/validator.py:11: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import draft4_format_checker

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================= 38 passed, 2 warnings in 0.22s ==========================================================================================
```