### PR TITLE
Fix groups query limit

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -607,7 +607,7 @@ def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None
 
         rbac_filters = get_rbac_filters(system_resources=system_groups, permitted_resources=group_list)
 
-        with WazuhDBQueryGroup(**rbac_filters, limit=limit, offset=offset) as group_query:
+        with WazuhDBQueryGroup(**rbac_filters, limit=None) as group_query:
             query_data = group_query.run()
 
             for group in query_data['items']:
@@ -627,15 +627,12 @@ def get_agent_groups(group_list: list = None, offset: int = 0, limit: int = None
 
                 affected_groups.append(group)
 
-        data = process_array(affected_groups, allowed_sort_fields=GROUP_FIELDS,
+        data = process_array(affected_groups, offset=offset, limit=limit, allowed_sort_fields=GROUP_FIELDS,
                             sort_by=sort_by, sort_ascending=sort_ascending, search_text=search_text,
                             complementary_search=complementary_search, q=q, allowed_select_fields=GROUP_FIELDS,
                             select=select, distinct=distinct, required_fields=GROUP_REQUIRED_FIELDS)
         result.affected_items = data['items']
-        total_items = query_data['totalItems']
-        if q is not None or search_text is not None:
-            total_items = data['totalItems']
-        result.total_affected_items = total_items
+        result.total_affected_items = data['totalItems']
 
     return result
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21912 |

## Description

Rollbacks the changes made in https://github.com/wazuh/wazuh/pull/21181 and sets the `limit` parameter to `None` in `WazuhDBQueryGroup` to avoid returning the first 500 items only.

## Tests

Environment: 505 groups

<details><summary>Get all groups</summary>

`GET /groups`

```json
{
   "data": {
      "affected_items": [
         {
            "name": "06jrCMJP0H3gD",
            "count": 0,
            "mergedSum": "ac210c408631f07975dafa720f831b6f",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
         {
            "name": "08Y7LrR5GcJtu",
            "count": 0,
            "mergedSum": "b748c296132abe7f830666424ec5d49d",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00"
         },
		...
	],
      "total_affected_items": 506,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected groups information was returned",
   "error": 0
}
```

</details>

<details><summary>Offset 500</summary>

`GET /groups?offset=500`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "zOzeO6I1QCDyJ",
                "count": 0,
                "mergedSum": "15b4c7ab3dd9db1d22c2bb9c237d58be",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zR7T8HzB6yUPv",
                "count": 0,
                "mergedSum": "b445afdfa00fb2f7203fb080abd0546b",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "ZTPBSWz7A19PQ",
                "count": 0,
                "mergedSum": "afa474e4d74c42f724b52c6e33f083f0",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "ZV6PwPWjU1do4",
                "count": 0,
                "mergedSum": "8999005392632cf81386d15fe38576f8",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zWIAcY5SjX5YQ",
                "count": 0,
                "mergedSum": "1438215b6eb006190f3c324fa63072d3",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "Zz2ZGQdpoQTGl",
                "count": 0,
                "mergedSum": "095870027d96d7b4c15c68c5afbd6e1c",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 506,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>


<details><summary>Limit 3</summary>

`GET /groups?limit=3`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "06jrCMJP0H3gD",
                "count": 0,
                "mergedSum": "ac210c408631f07975dafa720f831b6f",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "08Y7LrR5GcJtu",
                "count": 0,
                "mergedSum": "b748c296132abe7f830666424ec5d49d",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "0BCrJk3hLJ3GX",
                "count": 0,
                "mergedSum": "e31a3ee5111cf903eac4b8b86ec2c21a",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 506,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>


<details><summary>Offset 500, limit 10</summary>

`GET /groups?offset=500&limit=10`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "zOzeO6I1QCDyJ",
                "count": 0,
                "mergedSum": "15b4c7ab3dd9db1d22c2bb9c237d58be",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zR7T8HzB6yUPv",
                "count": 0,
                "mergedSum": "b445afdfa00fb2f7203fb080abd0546b",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "ZTPBSWz7A19PQ",
                "count": 0,
                "mergedSum": "afa474e4d74c42f724b52c6e33f083f0",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "ZV6PwPWjU1do4",
                "count": 0,
                "mergedSum": "8999005392632cf81386d15fe38576f8",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "zWIAcY5SjX5YQ",
                "count": 0,
                "mergedSum": "1438215b6eb006190f3c324fa63072d3",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
                "name": "Zz2ZGQdpoQTGl",
                "count": 0,
                "mergedSum": "095870027d96d7b4c15c68c5afbd6e1c",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 506,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details>

<details><summary>Search by the last item name</summary>

`GET /groups?search=Zz2ZGQdpoQTGl`

```json
{
    "data": {
        "affected_items": [
            {
                "name": "Zz2ZGQdpoQTGl",
                "count": 0,
                "mergedSum": "095870027d96d7b4c15c68c5afbd6e1c",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups information was returned",
    "error": 0
}
```

</details> 