### PR TITLE
Migrate integratord IT to core repository

### DIFF
--- a/.github/workflows/integration-tests-integratord-tier-0-1.yml
+++ b/.github/workflows/integration-tests-integratord-tier-0-1.yml
@@ -1,0 +1,85 @@
+name: Integration tests for Integratord - Tier 0 and 1
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
+  pull_request:
+    paths:
+        - ".github/workflows/integration-tests-integratord-tier-0-1.yml"
+        - "src/os_integrator/**"
+        - "src/Makefile"
+        - "tests/integration/conftest.py"
+        - "tests/integration/test_integratord/**"
+
+jobs:
+  build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: ".github/workflows/.python-version-it"
+          architecture: x64
+      # Build wazuh server for linux.
+      - name: Build wazuh server for linux
+        run: |
+          make deps -C src TARGET=server -j2
+          make -C src TARGET=server -j2
+      # Install wazuh server for linux.
+      - name: Install wazuh server for linux
+        run: |
+          echo 'USER_LANGUAGE="en"' > ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_NO_STOP="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_INSTALL_TYPE="server"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo "USER_DIR=/var/ossec" >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_EMAIL="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSCHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ROOTCHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSCOLLECTOR="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SCA="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_WHITE_LIST="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          sudo sh install.sh
+          rm ./etc/preloaded-vars.conf
+      # Download and install integration tests framework.
+      - name: Download and install integration tests framework
+        run: |
+          if [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote --heads https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
+          sudo pip install qa-integration-framework/
+          sudo rm -rf qa-integration-framework/
+      # Run integratord integration tests.
+      - name: Run integratord integration tests
+        run: |
+          cd tests/integration
+          sudo python -m pytest --tier 0 --tier 1 test_integratord/

--- a/tests/integration/test_agentd/test_agentd_multi_server/conftest.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server/conftest.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_CONNECTION_PORT
 from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
 
 
@@ -11,7 +12,7 @@ from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
 def start_remoted_simulators(test_metadata) -> None:
     # Servers paremeters
     remoted_server_address = "127.0.0.1"
-    remoted_server_ports = [1514,1516,1517]
+    remoted_server_ports = [DEFAULT_SSL_REMOTE_CONNECTION_PORT,1516,1517]
     remoted_servers = [None,None,None]
 
     # Start Remoted Simulators

--- a/tests/integration/test_agentd/test_agentd_multi_server/test_agentd_multi_server.py
+++ b/tests/integration/test_agentd/test_agentd_multi_server/test_agentd_multi_server.py
@@ -50,6 +50,7 @@ import sys
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS
+from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_CONNECTION_PORT
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG, AGENTD_TIMEOUT
 from wazuh_testing.modules.agentd.patterns import *
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
@@ -61,7 +62,7 @@ from wazuh_testing.utils.configuration import get_test_cases_data, load_configur
 from . import CONFIGS_PATH, TEST_CASES_PATH
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')
@@ -162,7 +163,7 @@ def test_agentd_multi_server(test_configuration, test_metadata, set_wazuh_config
         - keys
     '''
     remoted_server_address = "127.0.0.1"
-    remoted_server_ports = [1514,1516,1517]
+    remoted_server_ports = [DEFAULT_SSL_REMOTE_CONNECTION_PORT,1516,1517]
 
     # Configure keys
     if(test_metadata['SIMULATOR_MODES']['AUTHD'] == 'ACCEPT'):

--- a/tests/integration/test_agentd/test_agentd_parametrized_reconnections/test_agentd_parametrized_reconnections.py
+++ b/tests/integration/test_agentd/test_agentd_parametrized_reconnections/test_agentd_parametrized_reconnections.py
@@ -73,7 +73,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 from utils import wait_connect, wait_server_rollback, check_connection_try
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_connection_retries_pre_enrollment.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_connection_retries_pre_enrollment.py
@@ -61,7 +61,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 from utils import wait_keepalive
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_initial_enrollment_retries.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_initial_enrollment_retries.py
@@ -64,7 +64,7 @@ from wazuh_testing.utils import callbacks
 from . import CONFIGS_PATH, TEST_CASES_PATH
 from utils import wait_keepalive, wait_enrollment, check_module_stop
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_reconection_enrollment_no_keys.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_reconection_enrollment_no_keys.py
@@ -61,7 +61,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 from utils import wait_keepalive, wait_enrollment, wait_enrollment_try
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_reconection_enrollment_no_keys_file.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_reconection_enrollment_no_keys_file.py
@@ -61,7 +61,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 from utils import wait_keepalive, wait_enrollment_try
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_reconection_enrollment_with_keys.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection/test_agentd_reconection_enrollment_with_keys.py
@@ -61,7 +61,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 from utils import wait_keepalive, wait_enrollment_try
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_agentd/test_agentd_state/test_agentd_state.py
+++ b/tests/integration/test_agentd/test_agentd_state/test_agentd_state.py
@@ -62,7 +62,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 from utils import wait_keepalive, wait_ack, wait_state_update, wait_agent_notification
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_agentd/test_agentd_state_config/test_agentd_state_config.py
+++ b/tests/integration/test_agentd/test_agentd_state_config/test_agentd_state_config.py
@@ -65,7 +65,7 @@ from wazuh_testing.utils.services import check_if_process_is_running
 from . import CONFIGS_PATH, TEST_CASES_PATH
 
 # Marks
-pytestmark = pytest.mark.tier(level=0)
+pytestmark = [pytest.mark.agent, pytest.mark.tier(level=0)]
 
 # Configuration and cases data.
 configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')

--- a/tests/integration/test_analysisd/conftest.py
+++ b/tests/integration/test_analysisd/conftest.py
@@ -10,8 +10,6 @@ from collections import defaultdict
 
 import pytest
 
-from wazuh_testing.constants.keys.events import *
-from wazuh_testing.constants.keys.alerts import *
 from wazuh_testing.constants.paths.configurations import CUSTOM_RULES_PATH, CUSTOM_RULES_FILE, WAZUH_CONF_PATH
 from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, WAZUH_LOG_PATH
 from wazuh_testing.constants.users import WAZUH_UNIX_GROUP, WAZUH_UNIX_USER
@@ -84,11 +82,11 @@ def generate_events_syscheck(request):
         event = (json.loads(re.match(key, test_case['input']).group(2)))
 
         try:
-            value_name = '\\' + event[SYSCHECK_DATA][SYSCHECK_VALUE_NAME]
+            value_name = '\\' + event[patterns.SYSCHECK_DATA][patterns.SYSCHECK_VALUE_NAME]
         except KeyError:
             value_name = ''
 
-        events[event[SYSCHECK_DATA][SYSCHECK_PATH] + value_name].update({test_case['stage']: event})
+        events[event[patterns.SYSCHECK_DATA][patterns.SYSCHECK_PATH] + value_name].update({test_case['stage']: event})
         socket_controller.send(test_case['input'])
         time.sleep(1 / ips)
 
@@ -122,7 +120,7 @@ def read_alerts_syscheck(request):
     for alert in alert_list:
         try:
             alert_json = json.loads(alert)
-            if (alert_json[ALERTS_RULE][ALERTS_ID] in patterns.ANALYSISD_ALERTS_SYSCHECK_IDS):
+            if (alert_json[patterns.ALERTS_RULE][patterns.ALERTS_ID] in patterns.ANALYSISD_ALERTS_SYSCHECK_IDS):
                 alerts.append(alert_json)
         except json.decoder.JSONDecodeError:
             continue

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_linux_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_linux_analysisd_alerts.py
@@ -49,8 +49,6 @@ import pytest
 from pathlib import Path
 
 from wazuh_testing.constants.daemons import WAZUH_DB_DAEMON, ANALYSISD_DAEMON
-from wazuh_testing.constants.keys.alerts import *
-from wazuh_testing.constants.keys.events import *
 from wazuh_testing.constants.paths.sockets import ANALYSISD_QUEUE_SOCKET_PATH
 from wazuh_testing.modules.analysisd import patterns, utils, configuration as analysisd_config
 from wazuh_testing.modules.monitord import configuration as monitord_config
@@ -144,6 +142,6 @@ def test_validate_all_linux_alerts(test_metadata, configure_local_internal_optio
         - wdb_socket
     '''
     alert = next(read_alerts_syscheck)
-    path = alert[ALERTS_SYSCHECK][SYSCHECK_PATH]
-    mode = alert[ALERTS_SYSCHECK][ALERTS_SYSCHECK_EVENT].title()
+    path = alert[patterns.ALERTS_SYSCHECK][patterns.SYSCHECK_PATH]
+    mode = alert[patterns.ALERTS_SYSCHECK][patterns.ALERTS_SYSCHECK_EVENT].title()
     utils.validate_analysis_alert_syscheck(alert, events_dict[path][mode])

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_rare_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_rare_analysisd_alerts.py
@@ -49,8 +49,6 @@ import pytest
 from pathlib import Path
 
 from wazuh_testing.constants.daemons import WAZUH_DB_DAEMON, ANALYSISD_DAEMON
-from wazuh_testing.constants.keys.alerts import *
-from wazuh_testing.constants.keys.events import *
 from wazuh_testing.constants.paths.sockets import ANALYSISD_QUEUE_SOCKET_PATH
 from wazuh_testing.modules.analysisd import patterns, utils, configuration as analysisd_config
 from wazuh_testing.modules.monitord import configuration as monitord_config
@@ -142,6 +140,6 @@ def test_validate_all_rare_alerts(test_metadata, configure_local_internal_option
         - wdb_socket
     '''
     alert = next(read_alerts_syscheck)
-    path = alert[ALERTS_SYSCHECK][SYSCHECK_PATH]
-    mode = alert[ALERTS_SYSCHECK][ALERTS_SYSCHECK_EVENT].title()
+    path = alert[patterns.ALERTS_SYSCHECK][patterns.SYSCHECK_PATH]
+    mode = alert[patterns.ALERTS_SYSCHECK][patterns.ALERTS_SYSCHECK_EVENT].title()
     utils.validate_analysis_alert_syscheck(alert, events_dict[path][mode])

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_alerts.py
@@ -49,8 +49,6 @@ import pytest
 from pathlib import Path
 
 from wazuh_testing.constants.daemons import WAZUH_DB_DAEMON, ANALYSISD_DAEMON
-from wazuh_testing.constants.keys.alerts import *
-from wazuh_testing.constants.keys.events import *
 from wazuh_testing.constants.paths.sockets import ANALYSISD_QUEUE_SOCKET_PATH
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.analysisd import patterns, utils, configuration as analysisd_config
@@ -144,6 +142,6 @@ def test_validate_all_win32_alerts(test_metadata, configure_local_internal_optio
         - wdb_socket
     '''
     alert = next(read_alerts_syscheck)
-    path = alert[ALERTS_SYSCHECK][SYSCHECK_PATH]
-    mode = alert[ALERTS_SYSCHECK][ALERTS_SYSCHECK_EVENT].title()
+    path = alert[patterns.ALERTS_SYSCHECK][patterns.SYSCHECK_PATH]
+    mode = alert[patterns.ALERTS_SYSCHECK][patterns.ALERTS_SYSCHECK_EVENT].title()
     utils.validate_analysis_alert_syscheck(alert, events_dict[path][mode], schema=WINDOWS)

--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_validate_win32_analysisd_registry_alerts.py
@@ -49,8 +49,6 @@ import pytest
 from pathlib import Path
 
 from wazuh_testing.constants.daemons import WAZUH_DB_DAEMON, ANALYSISD_DAEMON
-from wazuh_testing.constants.keys.alerts import *
-from wazuh_testing.constants.keys.events import *
 from wazuh_testing.constants.paths.sockets import ANALYSISD_QUEUE_SOCKET_PATH
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.analysisd import patterns, utils, configuration as analysisd_config
@@ -144,11 +142,11 @@ def test_validate_all_win32_registry_alerts(test_metadata, configure_local_inter
         - wdb_socket
     '''
     alert = next(read_alerts_syscheck)
-    path = alert[ALERTS_SYSCHECK][SYSCHECK_PATH]
-    mode = alert[ALERTS_SYSCHECK][ALERTS_SYSCHECK_EVENT].title()
+    path = alert[patterns.ALERTS_SYSCHECK][patterns.SYSCHECK_PATH]
+    mode = alert[patterns.ALERTS_SYSCHECK][patterns.ALERTS_SYSCHECK_EVENT].title()
 
     try:
-        value_name = alert[ALERTS_SYSCHECK][SYSCHECK_VALUE_NAME]
+        value_name = alert[patterns.ALERTS_SYSCHECK][patterns.SYSCHECK_VALUE_NAME]
         path += '\\' + value_name
     except KeyError:
         pass

--- a/tests/integration/test_authd/test_authd_key_request_worker.py
+++ b/tests/integration/test_authd/test_authd_key_request_worker.py
@@ -49,10 +49,10 @@ tags:
 from pathlib import Path
 
 import pytest
-from wazuh_testing.modules.clusterd.utils import CLUSTER_DATA_HEADER_SIZE
 from wazuh_testing.constants.paths.sockets import MODULESD_C_INTERNAL_SOCKET_PATH, MODULESD_KREQUEST_SOCKET_PATH
 from wazuh_testing.tools.mitm import WorkerMID
 from wazuh_testing.utils.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.utils.cluster import CLUSTER_DATA_HEADER_SIZE
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH, SCRIPTS_FOLDER_PATH
 

--- a/tests/integration/test_authd/test_authd_worker.py
+++ b/tests/integration/test_authd/test_authd_worker.py
@@ -40,13 +40,13 @@ import time
 from pathlib import Path
 
 import pytest
-from wazuh_testing.modules.clusterd.utils import CLUSTER_DATA_HEADER_SIZE
 from wazuh_testing.constants.paths.logs import WAZUH_CLUSTER_LOGS_PATH
 from wazuh_testing.constants.paths.sockets import MODULESD_C_INTERNAL_SOCKET_PATH
 from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_ENROLLMENT_PORT
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, CLUSTER_DAEMON
 from wazuh_testing.tools.mitm import WorkerMID
 from wazuh_testing.utils.configuration import load_configuration_template, get_test_cases_data
+from wazuh_testing.utils.cluster import CLUSTER_DATA_HEADER_SIZE
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 

--- a/tests/integration/test_authd/test_remote_enrollment.py
+++ b/tests/integration/test_authd/test_remote_enrollment.py
@@ -48,6 +48,7 @@ import socket, time
 from pathlib import Path
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.constants.ports import DEFAULT_SSL_CLUSTER_PORT
 from wazuh_testing.utils import callbacks
 from wazuh_testing.modules.authd import PREFIX
 from wazuh_testing.tools.socket_controller import SocketController
@@ -78,7 +79,7 @@ monitored_sockets_params = [(MODULES_DAEMON, None, True), (WAZUH_DB_DAEMON, None
 
 receiver_sockets, monitored_sockets = None, None  # Set in the fixtures
 
-cluster_socket_address = ('localhost', 1516)
+cluster_socket_address = ('localhost', DEFAULT_SSL_CLUSTER_PORT)
 remote_enrollment_address = ('localhost', DEFAULT_SSL_REMOTE_ENROLLMENT_PORT)
 
 # Test daemons to restart.

--- a/tests/integration/test_execd/test_run_active_response/test_firewall_drop.py
+++ b/tests/integration/test_execd/test_run_active_response/test_firewall_drop.py
@@ -46,8 +46,7 @@ import pytest
 from pathlib import Path
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH, ACTIVE_RESPONSE_LOG_PATH
-from wazuh_testing.modules.active_response import patterns as ar_patterns
-from wazuh_testing.modules.agentd.configuration import AGENTD_WINDOWS_DEBUG
+from wazuh_testing.modules.execd.active_response import patterns as ar_patterns
 from wazuh_testing.modules.execd import patterns as execd_paterns
 from wazuh_testing.modules.execd.configuration import EXECD_DEBUG_CONFIG
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
@@ -58,7 +57,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 
 
 # Set pytest marks.
-pytestmark = [pytest.mark.agent, pytest.mark.tier(level=1)]
+pytestmark = [pytest.mark.linux, pytest.mark.tier(level=1)]
 
 # Cases metadata and its ids.
 cases_path = Path(TEST_CASES_PATH, 'cases_execd_firewall_drop.yaml')

--- a/tests/integration/test_execd/test_run_active_response/test_restart_wazuh.py
+++ b/tests/integration/test_execd/test_run_active_response/test_restart_wazuh.py
@@ -52,7 +52,7 @@ from pathlib import Path
 
 from wazuh_testing.constants.paths.logs import ACTIVE_RESPONSE_LOG_PATH, WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS
-from wazuh_testing.modules.active_response.patterns import ACTIVE_RESPONSE_RESTART_WAZUH
+from wazuh_testing.modules.execd.active_response.patterns import ACTIVE_RESPONSE_RESTART_WAZUH
 from wazuh_testing.modules.agentd.configuration import AGENTD_WINDOWS_DEBUG
 from wazuh_testing.modules.execd.configuration import EXECD_DEBUG_CONFIG
 from wazuh_testing.modules.execd.patterns import EXECD_SHUTDOWN_RECEIVED
@@ -64,7 +64,7 @@ from . import CONFIGS_PATH, TEST_CASES_PATH
 
 
 # Set pytest marks.
-pytestmark = [pytest.mark.agent, pytest.mark.win32, pytest.mark.tier(level=1)]
+pytestmark = [pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=1)]
 
 # Cases metadata and its ids.
 cases_path = Path(TEST_CASES_PATH, 'cases_execd_restart.yaml')

--- a/tests/integration/test_integratord/conftest.py
+++ b/tests/integration/test_integratord/conftest.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2022, Wazuh Inc.
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
            Created by Wazuh, Inc. <info@wazuh.com>.
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 '''

--- a/tests/integration/test_integratord/conftest.py
+++ b/tests/integration/test_integratord/conftest.py
@@ -1,0 +1,19 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+'''
+import pytest
+
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.modules.integratord.patterns import INTEGRATORD_CONNECTED
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils import callbacks
+
+
+@pytest.fixture()
+def wait_for_integratord_start(request):
+    # Wait for integratord thread to start
+    log_monitor = FileMonitor(WAZUH_LOG_PATH)
+    log_monitor.start(callback=callbacks.generate_callback(INTEGRATORD_CONNECTED))
+    assert (log_monitor.callback_result == None), f'Error invalid configuration event not detected'

--- a/tests/integration/test_integratord/test_alerts_reading/__init__.py
+++ b/tests/integration/test_integratord/test_alerts_reading/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2015-2023, Wazuh Inc.
+Copyright (C) 2015-2024, Wazuh Inc.
 Created by Wazuh, Inc. <info@wazuh.com>.
 This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """

--- a/tests/integration/test_integratord/test_alerts_reading/__init__.py
+++ b/tests/integration/test_integratord/test_alerts_reading/__init__.py
@@ -1,0 +1,12 @@
+"""
+Copyright (C) 2015-2023, Wazuh Inc.
+Created by Wazuh, Inc. <info@wazuh.com>.
+This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+"""
+from pathlib import Path
+
+
+# Constants & base paths
+TEST_DATA_PATH = Path(Path(__file__).parent, 'data')
+TEST_CASES_FOLDER_PATH = Path(TEST_DATA_PATH, 'test_cases')
+CONFIGURATIONS_FOLDER_PATH = Path(TEST_DATA_PATH, 'configuration_templates')

--- a/tests/integration/test_integratord/test_alerts_reading/data/configuration_templates/configuration_alerts_reading.yaml
+++ b/tests/integration/test_integratord/test_alerts_reading/data/configuration_templates/configuration_alerts_reading.yaml
@@ -1,0 +1,38 @@
+- sections:
+    - section: integration
+      elements:
+        - name:
+            value: slack
+        - hook_url:
+            value: 'https://slack.com'
+        - rule_id:
+            value: 5712
+        - level:
+            value: 10
+        - alert_format:
+            value: json
+
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+
+    - section: vulnerability-detection
+      elements:
+        - enabled:
+            value: 'no'
+
+    - section: indexer
+      elements:
+        - enabled:
+            value: 'no'
+
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_alerts_reading/data/test_cases/cases_integratord_change_inode_alert.yaml
+++ b/tests/integration/test_integratord/test_alerts_reading/data/test_cases/cases_integratord_change_inode_alert.yaml
@@ -1,0 +1,21 @@
+- name: cannot_read_alerts_file_inode_changed
+  description: The alerts.json file inode has changed and it cannot read alerts from it until it reloads.
+  configuration_parameters:
+  metadata:
+    alert_sample: '{"timestamp":"2022-05-11T12:29:19.905+0000","rule":{"level":10,"description":
+                   "sshd: brute force trying to get access to the system. Non existent user.","id":"5712",
+                   "mitre":{"id":["T1110"],"tactic":["Credential Access"],"technique":["Brute Force"]},"frequency":8,
+                   "firedtimes":1,"mail":false,"groups":["syslog","sshd","authentication_failures"],"gdpr":
+                   ["IV_35.7.d","IV_32.2"],"hipaa":["164.312.b"],"nist_800_53":["SI.4","AU.14","AC.7"],"pci_dss":
+                   ["11.4","10.2.4","10.2.5"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":
+                   "localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1652272159.1549653",
+                   "previous_output":"May 11 12:29:16 localhost sshd[17582]: Invalid user paco from 172.17.1.1 port
+                   56402\nMay 11 12:29:14 localhost sshd[17580]: Invalid user paco from 172.17.1.1 port 56400\nMay
+                   11 12:29:11 localhost sshd[17578]: Invalid user paco from 172.17.1.1 port 56398\nMay 11 12:29:09
+                   localhost sshd[17576]: Invalid user paco from 172.17.1.1 port 56396\nMay 11 12:29:07 localhost
+                   sshd[17574]: Invalid user paco from 172.17.1.1 port 56394\nMay 11 12:29:04 localhost sshd[17572]:
+                   Invalid user paco from 172.17.1.1 port 56392\nMay 11 12:29:00 localhost sshd[17570]: Invalid user
+                   paco from 172.17.1.1 port 56390","full_log":"May 11 12:29:18 localhost sshd[17584]: Invalid user
+                   paco from 172.17.1.1 port 56404","predecoder":{"program_name":"sshd","timestamp":"May 11 12:29:18",
+                   "hostname":"localhost"},"decoder":{"parent":"sshd","name":"sshd"},"data":{"srcip":"172.17.1.1",
+                   "srcport":"56404","srcuser":"paco"},"location":"/var/log/secure"}'

--- a/tests/integration/test_integratord/test_alerts_reading/data/test_cases/cases_integratord_read_invalid_json_alerts.yaml
+++ b/tests/integration/test_integratord/test_alerts_reading/data/test_cases/cases_integratord_read_invalid_json_alerts.yaml
@@ -1,0 +1,45 @@
+- name: read_invalid_json_alert
+  description: Read a invalid alert from alerts.json - removed rule key name - Integration fails
+  configuration_parameters:
+  metadata:
+    alert_sample: '{"timestamp":"2022-05-11T12:29:19.905+0000",:{"level":10,"description":
+                   "sshd: brute force trying to get access to the system. Non existent user.","id":"5712",
+                   "mitre":{"id":["T1110"],"tactic":["Credential Access"],"technique":["Brute Force"]},"frequency":8,
+                   "firedtimes":1,"mail":false,"groups":["syslog","sshd","authentication_failures"],"gdpr":
+                   ["IV_35.7.d","IV_32.2"],"hipaa":["164.312.b"],"nist_800_53":["SI.4","AU.14","AC.7"],"pci_dss":
+                   ["11.4","10.2.4","10.2.5"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":
+                   "localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1652272159.1549653",
+                   "previous_output":"May 11 12:29:16 localhost sshd[17582]: Invalid user paco from 172.17.1.1 port
+                   56402\nMay 11 12:29:14 localhost sshd[17580]: Invalid user paco from 172.17.1.1 port 56400\nMay
+                   11 12:29:11 localhost sshd[17578]: Invalid user paco from 172.17.1.1 port 56398\nMay 11 12:29:09
+                   localhost sshd[17576]: Invalid user paco from 172.17.1.1 port 56396\nMay 11 12:29:07 localhost
+                   sshd[17574]: Invalid user paco from 172.17.1.1 port 56394\nMay 11 12:29:04 localhost sshd[17572]:
+                   Invalid user paco from 172.17.1.1 port 56392\nMay 11 12:29:00 localhost sshd[17570]: Invalid user
+                   paco from 172.17.1.1 port 56390","full_log":"May 11 12:29:18 localhost sshd[17584]: Invalid user
+                   paco from 172.17.1.1 port 56404","predecoder":{"program_name":"sshd","timestamp":"May 11 12:29:18",
+                   "hostname":"localhost"},"decoder":{"parent":"sshd","name":"sshd"},"data":{"srcip":"172.17.1.1",
+                   "srcport":"56404","srcuser":"paco"},"location":"/var/log/secure"}'
+    alert_type: invalid
+
+- name: read_overlong_json_alert
+  description: Read a an alert that is over 64kb alert from alerts.json - Integration fails
+  configuration_parameters:
+  metadata:
+    alert_sample: '{"timestamp":"2022-05-11T12:29:19.905+0000","rule":{"level":10,"description":
+                   "sshd: brute force trying to get access to the system. Non existent user.","id":"5712",
+                   "mitre":{"id":["T1110"],"tactic":["Credential Access"],"technique":["Brute Force"]},"frequency":8,
+                   "firedtimes":1,"mail":false,"groups":["syslog","sshd","authentication_failures"],"gdpr":
+                   ["IV_35.7.d","IV_32.2"],"hipaa":["164.312.b"],"nist_800_53":["SI.4","AU.14","AC.7"],"pci_dss":
+                   ["11.4","10.2.4","10.2.5"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":
+                   "padding_input"},"manager":{"name":"localhost.localdomain"},"id":"1652272159.1549653",
+                   "previous_output":"May 11 12:29:16 localhost sshd[17582]: Invalid user paco from 172.17.1.1 port
+                   56402\nMay 11 12:29:14 localhost sshd[17580]: Invalid user paco from 172.17.1.1 port 56400\nMay
+                   11 12:29:11 localhost sshd[17578]: Invalid user paco from 172.17.1.1 port 56398\nMay 11 12:29:09
+                   localhost sshd[17576]: Invalid user paco from 172.17.1.1 port 56396\nMay 11 12:29:07 localhost
+                   sshd[17574]: Invalid user paco from 172.17.1.1 port 56394\nMay 11 12:29:04 localhost sshd[17572]:
+                   Invalid user paco from 172.17.1.1 port 56392\nMay 11 12:29:00 localhost sshd[17570]: Invalid user
+                   paco from 172.17.1.1 port 56390","full_log":"May 11 12:29:18 localhost sshd[17584]: Invalid user
+                   paco from 172.17.1.1 port 56404","predecoder":{"program_name":"sshd","timestamp":"May 11 12:29:18",
+                   "hostname":"localhost"},"decoder":{"parent":"sshd","name":"sshd"},"data":{"srcip":"172.17.1.1",
+                   "srcport":"56404","srcuser":"paco"},"location":"/var/log/secure"}'
+    alert_type: overlong

--- a/tests/integration/test_integratord/test_alerts_reading/data/test_cases/cases_integratord_read_valid_json_alerts.yaml
+++ b/tests/integration/test_integratord/test_alerts_reading/data/test_cases/cases_integratord_read_valid_json_alerts.yaml
@@ -1,0 +1,21 @@
+- name: read_valid_json_alert
+  description: Read a valid alert from alerts.json
+  configuration_parameters:
+  metadata:
+    alert_sample: '{"timestamp":"2022-05-11T12:29:19.905+0000","rule":{"level":10,"description":
+                   "sshd: brute force trying to get access to the system. Non existent user.","id":"5712",
+                   "mitre":{"id":["T1110"],"tactic":["Credential Access"],"technique":["Brute Force"]},"frequency":8,
+                   "firedtimes":1,"mail":false,"groups":["syslog","sshd","authentication_failures"],"gdpr":
+                   ["IV_35.7.d","IV_32.2"],"hipaa":["164.312.b"],"nist_800_53":["SI.4","AU.14","AC.7"],"pci_dss":
+                   ["11.4","10.2.4","10.2.5"],"tsc":["CC6.1","CC6.8","CC7.2","CC7.3"]},"agent":{"id":"000","name":
+                   "localhost.localdomain"},"manager":{"name":"localhost.localdomain"},"id":"1652272159.1549653",
+                   "previous_output":"May 11 12:29:16 localhost sshd[17582]: Invalid user paco from 172.17.1.1 port
+                   56402\nMay 11 12:29:14 localhost sshd[17580]: Invalid user paco from 172.17.1.1 port 56400\nMay
+                   11 12:29:11 localhost sshd[17578]: Invalid user paco from 172.17.1.1 port 56398\nMay 11 12:29:09
+                   localhost sshd[17576]: Invalid user paco from 172.17.1.1 port 56396\nMay 11 12:29:07 localhost
+                   sshd[17574]: Invalid user paco from 172.17.1.1 port 56394\nMay 11 12:29:04 localhost sshd[17572]:
+                   Invalid user paco from 172.17.1.1 port 56392\nMay 11 12:29:00 localhost sshd[17570]: Invalid user
+                   paco from 172.17.1.1 port 56390","full_log":"May 11 12:29:18 localhost sshd[17584]: Invalid user
+                   paco from 172.17.1.1 port 56404","predecoder":{"program_name":"sshd","timestamp":"May 11 12:29:18",
+                   "hostname":"localhost"},"decoder":{"parent":"sshd","name":"sshd"},"data":{"srcip":"172.17.1.1",
+                   "srcport":"56404","srcuser":"paco"},"location":"/var/log/secure"}'

--- a/tests/integration/test_integratord/test_alerts_reading/test_alerts_reading.py
+++ b/tests/integration/test_integratord/test_alerts_reading/test_alerts_reading.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2022, Wazuh Inc.
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
            Created by Wazuh, Inc. <info@wazuh.com>.
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 

--- a/tests/integration/test_integratord/test_alerts_reading/test_alerts_reading.py
+++ b/tests/integration/test_integratord/test_alerts_reading/test_alerts_reading.py
@@ -1,0 +1,348 @@
+'''
+copyright: Copyright (C) 2015-2022, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Integratord manages Wazuh integrations with other applications such as Yara or Slack, by feeding
+the integrated aplications with the alerts located in alerts.json file. This test module aims to validate that
+given a specific alert, the expected response is recieved, depending if it is a valid/invalid json alert, an
+overlong alert (64kb+) or what happens when it cannot read the file because it is missing.
+
+components:
+    - integratord
+
+suite: test_integratord
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-integratord
+
+os_platform:
+    - Linux
+
+os_version:
+    - Centos 8
+    - Ubuntu Focal
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/manager/manual-integration.html#slack
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-integratord.html
+
+pytest_args:
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - slack
+'''
+import pytest
+import time
+from pathlib import Path
+
+from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
+from wazuh_testing import session_parameters
+from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, WAZUH_DB_DAEMON, INTEGRATOR_DAEMON
+from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, WAZUH_LOG_PATH
+from wazuh_testing.modules.analysisd.configuration import ANALYSISD_DEBUG
+from wazuh_testing.modules.integratord.configuration import INTEGRATORD_DEBUG
+from wazuh_testing.modules.integratord.patterns import INTEGRATORD_THIRD_PARTY_RESPONSE, INTEGRATORD_INODE_CHANGED, \
+                                                       INTEGRATORD_INVALID_ALERT_READ, INTEGRATORD_OVERLONG_ALERT_READ
+from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils.callbacks import generate_callback
+from wazuh_testing.utils.commands import run_local_command_returning_output
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+from wazuh_testing.utils.file import copy, remove_file
+
+
+# Marks
+pytestmark = [pytest.mark.server]
+
+# Paths
+test_configuration_path = Path(CONFIGURATIONS_FOLDER_PATH, 'configuration_alerts_reading.yaml')
+test1_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_integratord_change_inode_alert.yaml')
+test2_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_integratord_read_valid_json_alerts.yaml')
+test3_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_integratord_read_invalid_json_alerts.yaml')
+
+# Configurations
+test1_configuration, test1_metadata, test1_cases_ids = get_test_cases_data(test1_cases_path)
+test2_configuration, test2_metadata, test2_cases_ids = get_test_cases_data(test2_cases_path)
+test3_configuration, test3_metadata, test3_cases_ids = get_test_cases_data(test3_cases_path)
+
+test1_configuration = load_configuration_template(test_configuration_path, test1_configuration, test1_metadata)
+test2_configuration = load_configuration_template(test_configuration_path, test2_configuration, test2_metadata)
+test3_configuration = load_configuration_template(test_configuration_path, test3_configuration, test3_metadata)
+
+# Variables
+TIME_TO_DETECT_FILE = 2
+TEMP_FILE_PATH = ALERTS_JSON_PATH + '.tmp'
+daemons_handler_configuration = {'daemons': [INTEGRATOR_DAEMON, WAZUH_DB_DAEMON, ANALYSISD_DAEMON]}
+local_internal_options = {INTEGRATORD_DEBUG: '2', ANALYSISD_DEBUG: '1', MONITORD_ROTATE_LOG: '0'}
+
+
+# Tests
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test1_configuration, test1_metadata), ids=test1_cases_ids)
+def test_integratord_change_json_inode(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                                       configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that wazuh-integratord detects a change in the inode of the alerts.json and continues reading
+                 alerts.
+
+    test_phases:
+        - setup:
+            - Apply ossec.conf configuration changes according to the configuration template and use case.
+            - Truncate Wazuh's logs.
+            - Configure internal options.
+            - Restart the daemons defined in `daemons_handler_configuration`.
+            - Wait for the restarted modules to start correctly.
+        - test:
+            - Wait until integratord is ready to read alerts.
+            - Insert an alert in the `alerts.json` file.
+            - Check if the alert was received by Slack.
+            - Replace the `alerts.json` file while wazuh-integratord is reading it.
+            - Wait for the inode change to be detected by wazuh-integratord.
+            - Check if wazuh-integratord detects that the file's inode has changed.
+            - Insert an alert in the `alerts.json` file.
+            - Check if the alert is processed.
+            - Check alert was received by Slack.
+        - teardown:
+            - Truncate Wazuh's logs.
+            - Restore initial configuration, both `ossec.conf` and `local_internal_options.conf`.
+
+    wazuh_min_version: 4.3.5
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module in the ossec.log
+
+    assertions:
+        - Verify the expected response with for a given alert is recieved
+
+    input_description:
+        - The `configuration_integratord_read_json_alerts.yaml` file provides the module configuration for this test.
+        - The `cases_integratord_read_json_alerts` file provides the test cases.
+
+    expected_output:
+        - r'.+wazuh-integratord.*DEBUG: jqueue_next.*Alert file inode changed.*'
+        - r'.+wazuh-integratord.*Processing alert.*'
+        - r'.+wazuh-integratord.*<Response [200]>'
+    '''
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+    command = f"echo '{test_metadata['alert_sample']}' >> {ALERTS_JSON_PATH}"
+
+    # Wait until integratord is ready to read alerts
+    time.sleep(TIME_TO_DETECT_FILE)
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+    # Check that expected log appears
+    assert wazuh_monitor.callback_result
+
+    # Change file to change inode
+    copy(ALERTS_JSON_PATH, TEMP_FILE_PATH)
+    remove_file(ALERTS_JSON_PATH)
+    copy(TEMP_FILE_PATH, ALERTS_JSON_PATH)
+
+    # Wait for Inode change to be detected
+    # The `integratord` library tries to read alerts from the file every 1 second. So, the test waits 1 second + 1
+    # until the file is reloaded.
+    time.sleep(TIME_TO_DETECT_FILE)
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_INODE_CHANGED), timeout=session_parameters.default_timeout)
+
+    # Check that expected log appears
+    assert wazuh_monitor.callback_result
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+    # Check that expected log appears
+    assert wazuh_monitor.callback_result
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test2_configuration, test2_metadata), ids=test2_cases_ids)
+def test_integratord_read_valid_alerts(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                                       configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when a given alert is inserted into alerts.json, integratord works as expected. In case
+    of a valid alert, a slack integration alert is expected in the alerts.json file.
+
+    test_phases:
+        - setup:
+            - Apply ossec.conf configuration changes according to the configuration template and use case.
+            - Truncate Wazuh's logs.
+            - Configure internal options.
+            - Restart the daemons defined in `daemons_handler_configuration`.
+            - Wait for the restarted modules to start correctly.
+        - test:
+            - Insert a valid alert in the alerts.json file.
+            - Check if the alert was received by Slack correctly (HTTP response status code: 200)
+        - teardown:
+            - Truncate Wazuh's logs.
+            - Restore initial configuration, both `ossec.conf` and `local_internal_options.conf`.
+
+    wazuh_min_version: 4.3.7
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module in the ossec.log
+
+    assertions:
+        - Verify the expected response with for a given alert is recieved
+
+    input_description:
+        - The `configuration_integratord_read_json_alerts.yaml` file provides the module configuration for this test.
+        - The `cases_integratord_read_valid_json_alerts` file provides the test cases.
+
+    expected_output:
+        - r'.+wazuh-integratord.*alert_id.*\"integration\": \"slack\".*'
+    '''
+    sample = test_metadata['alert_sample']
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+
+    run_local_command_returning_output(f"echo '{sample}' >> {ALERTS_JSON_PATH}")
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+    # Check that expected log appears
+    assert wazuh_monitor.callback_result
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test3_configuration, test3_metadata), ids=test3_cases_ids)
+def test_integratord_read_invalid_alerts(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                                         configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when a given alert is inserted into alerts.json, integratord works as expected. If the alert
+                 is invalid, broken, or overlong a message will appear in the ossec.log file.
+
+    test_phases:
+        - setup:
+            - Apply ossec.conf configuration changes according to the configuration template and use case.
+            - Truncate Wazuh's logs.
+            - Configure internal options.
+            - Restart the daemons defined in `daemons_handler_configuration`.
+            - Wait for the restarted modules to start correctly.
+        - test:
+            - Insert an invalid alert in the alerts.json file.
+            - Check if wazuh-integratord process the alert and report an error.
+        - teardown:
+            - Truncate Wazuh's logs.
+            - Restore initial configuration, both `ossec.conf` and `local_internal_options.conf`.
+
+    wazuh_min_version: 4.3.7
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Handler of Wazuh daemons.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module in the ossec.log
+
+    assertions:
+        - Verify the expected response with for a given alert is recieved
+
+    input_description:
+        - The `configuration_integratord_read_json_alerts.yaml` file provides the module configuration for this test.
+        - The `cases_integratord_read_invalid_json_alerts` file provides the test cases.
+
+    expected_output:
+        - r'.+wazuh-integratord.*WARNING: Invalid JSON alert read.*'
+        - r'.+wazuh-integratord.*WARNING: Overlong JSON alert read.*'
+
+    '''
+    sample = test_metadata['alert_sample']
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+
+    if test_metadata['alert_type'] == 'invalid':
+        callback = INTEGRATORD_INVALID_ALERT_READ
+    else:
+        callback = INTEGRATORD_OVERLONG_ALERT_READ
+        # Add 90kb of padding to alert to make it go over the allowed value of 64KB.
+        padding = "0" * 90000
+        sample = sample.replace("padding_input", "agent_" + padding)
+
+    run_local_command_returning_output(f"echo '{sample}' >> {ALERTS_JSON_PATH}")
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(callback), timeout=session_parameters.default_timeout)
+
+    # Check that expected log appears
+    assert wazuh_monitor.callback_result

--- a/tests/integration/test_integratord/test_integration_options/__init__.py
+++ b/tests/integration/test_integratord/test_integration_options/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2015-2023, Wazuh Inc.
+Copyright (C) 2015-2024, Wazuh Inc.
 Created by Wazuh, Inc. <info@wazuh.com>.
 This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """

--- a/tests/integration/test_integratord/test_integration_options/__init__.py
+++ b/tests/integration/test_integratord/test_integration_options/__init__.py
@@ -1,0 +1,12 @@
+"""
+Copyright (C) 2015-2023, Wazuh Inc.
+Created by Wazuh, Inc. <info@wazuh.com>.
+This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+"""
+from pathlib import Path
+
+
+# Constants & base paths
+TEST_DATA_PATH = Path(Path(__file__).parent, 'data')
+TEST_CASES_FOLDER_PATH = Path(TEST_DATA_PATH, 'test_cases')
+CONFIGURATIONS_FOLDER_PATH = Path(TEST_DATA_PATH, 'configuration_templates')

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_no_option_tag.yaml
@@ -1,7 +1,5 @@
 - tags:
     - all
-  apply_to_modules:
-    - test_pagerduty_no_option_tag
   sections:
     - section: integration
       elements:

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_no_option_tag.yaml
@@ -1,0 +1,35 @@
+- tags:
+    - all
+  apply_to_modules:
+    - test_pagerduty_no_option_tag
+  sections:
+    - section: integration
+      elements:
+        - name:
+            value: pagerduty
+        - api_key:
+            value: testing
+        - alert_format:
+            value: json
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_options.yaml
@@ -1,7 +1,5 @@
 - tags:
     - all
-  apply_to_modules:
-    - test_pagerduty_options
   sections:
     - section: integration
       elements:

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_pagerduty_options.yaml
@@ -1,0 +1,37 @@
+- tags:
+    - all
+  apply_to_modules:
+    - test_pagerduty_options
+  sections:
+    - section: integration
+      elements:
+        - name:
+            value: pagerduty
+        - api_key:
+            value: testing
+        - alert_format:
+            value: json
+        - options:
+            value: OPTIONS_VALUE
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_no_option_tag.yaml
@@ -1,7 +1,5 @@
 - tags:
     - all
-  apply_to_modules:
-    - test_shuffle_no_option_tag
   sections:
     - section: integration
       elements:

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_no_option_tag.yaml
@@ -1,0 +1,35 @@
+- tags:
+    - all
+  apply_to_modules:
+    - test_shuffle_no_option_tag
+  sections:
+    - section: integration
+      elements:
+        - name:
+            value: shuffle
+        - hook_url:
+            value: 'https://shuffle.com'
+        - alert_format:
+            value: json
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_options.yaml
@@ -1,0 +1,37 @@
+- tags:
+    - all
+  apply_to_modules:
+    - test_shuffle_options
+  sections:
+    - section: integration
+      elements:
+        - name:
+            value: shuffle
+        - hook_url:
+            value: 'https://shuffle.com'
+        - alert_format:
+            value: json
+        - options:
+            value: OPTIONS_VALUE
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_shuffle_options.yaml
@@ -1,7 +1,5 @@
 - tags:
     - all
-  apply_to_modules:
-    - test_shuffle_options
   sections:
     - section: integration
       elements:

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_no_option_tag.yaml
@@ -1,7 +1,5 @@
 - tags:
     - all
-  apply_to_modules:
-    - test_slack_no_option_tag
   sections:
     - section: integration
       elements:

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_no_option_tag.yaml
@@ -1,0 +1,35 @@
+- tags:
+    - all
+  apply_to_modules:
+    - test_slack_no_option_tag
+  sections:
+    - section: integration
+      elements:
+        - name:
+            value: slack
+        - hook_url:
+            value: 'https://slack.com'
+        - alert_format:
+            value: json
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_options.yaml
@@ -1,0 +1,37 @@
+- tags:
+    - all
+  apply_to_modules:
+    - test_slack_options
+  sections:
+    - section: integration
+      elements:
+        - name:
+            value: slack
+        - hook_url:
+            value: 'https://slack.com'
+        - alert_format:
+            value: json
+        - options:
+            value: OPTIONS_VALUE
+    - section: sca
+      elements:
+        - enabled:
+            value: 'no'
+    - section: rootcheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: syscheck
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: wodle
+      attributes:
+        - name: syscollector
+      elements:
+        - disabled:
+            value: 'yes'
+    - section: auth
+      elements:
+        - disabled:
+            value: 'yes'

--- a/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/configuration_templates/config_slack_options.yaml
@@ -1,7 +1,5 @@
 - tags:
     - all
-  apply_to_modules:
-    - test_slack_options
   sections:
     - section: integration
       elements:

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_pagerduty_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_pagerduty_no_option_tag.yaml
@@ -1,0 +1,5 @@
+- name: pagerduty_works_with_no_option_tag_present
+  description: When the option tag is missing, the pagerduty integration works
+  configuration_parameters:
+  metadata:
+    integration: pagerduty

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_pagerduty_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_pagerduty_options.yaml
@@ -1,0 +1,51 @@
+- name: pagerduty_option_tag_no_value
+  description: When the option has no value passed, the integration is unable to run
+  configuration_parameters:
+    OPTIONS_VALUE:
+  metadata:
+    integration: pagerduty
+    sends_message: false
+
+- name: pagerduty_option_empty_json_value
+  description: When the option is passed an empty JSON, the integration works properly with default values
+  configuration_parameters:
+    OPTIONS_VALUE: '{}'
+  metadata:
+    integration: pagerduty
+    sends_message: true
+    added_option:
+
+- name: pagerduty_option_custom_pretext
+  description: When a custom value is added to an option, the integration works and the passed value is in the message
+  configuration_parameters:
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext"}'
+  metadata:
+    integration: pagerduty
+    sends_message: true
+    added_option: '"pretext": "Custom Pretext"'
+
+- name: pagerduty_option_invalid_json
+  description: When an invalid json is passed, the integration is unable to send the message
+  configuration_parameters:
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext}'
+  metadata:
+    integration: pagerduty
+    sends_message: false
+
+- name: pagerduty_option_invalid_value
+  description: When an invalid value for an option, the message is sent to the integration endpoint
+  configuration_parameters:
+    OPTIONS_VALUE: '{"severity":"Invalid Severity"}'
+  metadata:
+    integration: pagerduty
+    sends_message: true
+    added_option: '"severity": "Invalid Severity"'
+
+- name: pagerduty_custom_option
+  description: When a non existent option is passed, the message is sent to the integration endpoint and works properly
+  configuration_parameters:
+    OPTIONS_VALUE: '{"custom_option":"custom value"}'
+  metadata:
+    integration: pagerduty
+    sends_message: true
+    added_option: '"custom_option": "custom value"'

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_shuffle_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_shuffle_no_option_tag.yaml
@@ -1,0 +1,5 @@
+- name: shuffle_works_with_no_option_tag_present
+  description: When the option tag is missing, the shuffle integration works
+  configuration_parameters:
+  metadata:
+    integration: shuffle

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_shuffle_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_shuffle_options.yaml
@@ -1,0 +1,42 @@
+- name: shuffle_option_tag_no_value
+  description: When the option has no value passed, the shuffle integration is unable to run
+  configuration_parameters:
+    OPTIONS_VALUE:
+  metadata:
+    integration: shuffle
+    sends_message: false
+
+- name: shuffle_option_empty_json_value
+  description: When the option is passed an empty JSON, the integration works properly with default values
+  configuration_parameters:
+    OPTIONS_VALUE: '{}'
+  metadata:
+    integration: shuffle
+    sends_message: true
+    added_option:
+
+- name: shuffle_option_custom_pretext
+  description: When a custom value is added to an option, the integration works and the passed value is in the message
+  configuration_parameters:
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext"}'
+  metadata:
+    integration: shuffle
+    sends_message: true
+    added_option: '"pretext": "Custom Pretext"'
+
+- name: shuffle_option_invalid_json
+  description: When an invalid json is passed, the integration is unable to send the message
+  configuration_parameters:
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext}'
+  metadata:
+    integration: shuffle
+    sends_message: false
+
+- name: shuffle_custom_option
+  description: When a non existent option is passed, the message is sent to the integration endpoint and works properly
+  configuration_parameters:
+    OPTIONS_VALUE: '{"custom_option":"custom value"}'
+  metadata:
+    integration: shuffle
+    sends_message: true
+    added_option: '"custom_option": "custom value"'

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_no_option_tag.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_no_option_tag.yaml
@@ -1,0 +1,5 @@
+- name: slack_works_with_no_option_tag_present
+  description: When the option tag is missing, the slack integration works
+  configuration_parameters:
+  metadata:
+    integration: slack

--- a/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
+++ b/tests/integration/test_integratord/test_integration_options/data/test_cases/cases_slack_options.yaml
@@ -1,0 +1,51 @@
+- name: slack_option_tag_no_value
+  description: When the option has no value passed, the slack integration is unable to run
+  configuration_parameters:
+    OPTIONS_VALUE:
+  metadata:
+    integration: slack
+    sends_message: false
+
+- name: slack_option_empty_json_value
+  description: When the option is passed an empty JSON, the integration works with default values
+  configuration_parameters:
+    OPTIONS_VALUE: '{}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option:
+
+- name: slack_option_custom_pretext
+  description: When a custom value is added to an option, the integration works and the passed value is in the message
+  configuration_parameters:
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext"}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option: '"pretext": "Custom Pretext"'
+
+- name: slack_option_invalid_json
+  description: When an invalid json is passed, the integration is unable to send the message
+  configuration_parameters:
+    OPTIONS_VALUE: '{"pretext":"Custom Pretext}'
+  metadata:
+    integration: slack
+    sends_message: false
+
+- name: slack_option_invalid_value
+  description: When an invalid value for an option, the message is sent to the integration endpoint
+  configuration_parameters:
+    OPTIONS_VALUE: '{"title_link":"invalid value - no link"}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option: '"title_link": "invalid value - no link"'
+
+- name: slack_custom_option
+  description: When a non existent option is passed, the message is sent to the integration endpoint and works properly
+  configuration_parameters:
+    OPTIONS_VALUE: '{"custom_option":"custom value"}'
+  metadata:
+    integration: slack
+    sends_message: true
+    added_option: '"custom_option": "custom value"'

--- a/tests/integration/test_integratord/test_integration_options/test_pagerduty_options.py
+++ b/tests/integration/test_integratord/test_integration_options/test_pagerduty_options.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2023, Wazuh Inc.
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
            Created by Wazuh, Inc. <info@wazuh.com>.
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 

--- a/tests/integration/test_integratord/test_integration_options/test_pagerduty_options.py
+++ b/tests/integration/test_integratord/test_integration_options/test_pagerduty_options.py
@@ -1,0 +1,295 @@
+'''
+copyright: Copyright (C) 2015-2023, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Integratord manages wazuh integrations with other applications such as Slack, Pagerduty, Shuffle, Yara or
+       Virustotal by feeding the integrated aplications with the alerts located in alerts.json file. Custom values for
+       fields can be configured to be sent using the 'options' tag. This test modules aim to test how the shuffle
+       integration works with different configurations, when the options tag is not present or when custom values are
+       passed into the tag for the shuffle integration
+
+components:
+    - integratord
+
+suite: integration_options
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-integratord
+
+os_platform:
+    - Linux
+
+os_version:
+    - Centos 8
+    - Ubuntu Focal
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/virustotal-scan/integration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-integratord.htm
+
+pytest_args:
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - PagerDuty
+'''
+import pytest
+from pathlib import Path
+
+from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
+from wazuh_testing import session_parameters
+from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, WAZUH_DB_DAEMON, INTEGRATOR_DAEMON
+from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, WAZUH_LOG_PATH
+from wazuh_testing.modules.analysisd.configuration import ANALYSISD_DEBUG
+from wazuh_testing.modules.integratord.configuration import INTEGRATORD_DEBUG
+from wazuh_testing.modules.integratord.patterns import INTEGRATORD_THIRD_PARTY_RESPONSE, INTEGRATORD_ENABLED_INTEGRATION, \
+                                                       INTEGRATORD_OPTIONS_FILE_DOES_NOT_EXISTENT, INTEGRATORD_SENDING_MESSAGE, \
+                                                       INTEGRATORD_ERROR_RUNNING_INTEGRATION
+from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils.callbacks import generate_callback
+from wazuh_testing.utils.commands import run_local_command_returning_output
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+
+
+# Marks
+pytestmark = [pytest.mark.server]
+
+# Paths
+t1_configurations_path = Path(CONFIGURATIONS_FOLDER_PATH, 'config_pagerduty_no_option_tag.yaml')
+t2_configurations_path = Path(CONFIGURATIONS_FOLDER_PATH, 'config_pagerduty_options.yaml')
+t1_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_pagerduty_no_option_tag.yaml')
+t2_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_pagerduty_options.yaml')
+
+# Configurations
+test1_configuration, test1_metadata, test1_cases_ids = get_test_cases_data(t1_cases_path)
+test2_configuration, test2_metadata, test2_cases_ids = get_test_cases_data(t2_cases_path)
+
+test1_configuration = load_configuration_template(t1_configurations_path, test1_configuration, test1_metadata)
+test2_configuration = load_configuration_template(t2_configurations_path, test2_configuration, test2_metadata)
+
+# Variables
+JSON_ALERT = '{"timestamp":"2022-05-11T12:29:19.905+0000",' \
+              '"rule":{"level":10,"description":"testing","id":"1234","groups":["test"]},' \
+              '"agent":{"id":"000","name":"localhost.localdomain"},' \
+              '"id":"1652272159.1549653",' \
+              '"location":"/test"}'
+daemons_handler_configuration = {'daemons': [INTEGRATOR_DAEMON, WAZUH_DB_DAEMON, ANALYSISD_DAEMON]}
+local_internal_options = {INTEGRATORD_DEBUG: '2', ANALYSISD_DEBUG: '1', MONITORD_ROTATE_LOG: '0'}
+
+
+# Tests
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test1_configuration, test1_metadata), ids=test1_cases_ids)
+def test_pagerduty_no_option_tag(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                                 configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when the options tag is not present for the PagerDuty integration, the integration works
+                 properly.
+
+    wazuh_min_version: 4.6.0
+
+    test_phases:
+        - setup:
+            - Set wazuh configuration and local_internal_options.
+            - Clean logs files and restart wazuh to apply the configuration.
+        - test:
+            - Check integration is enabled
+            - Check no options JSON file is created
+            - Check the message is sent to the PagerDuty server
+            - Check the response code is 200
+        - teardown:
+            - Restore configuration
+            - Stop wazuh
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module
+
+    assertions:
+        - Verify the integration is enabled
+        - Verify no options JSON file is detected
+        - Verify the integration sends message to the integrated app's server
+        - Verify the response code from the integrated app
+
+    input_description:
+        - The `config_integration_no_option_tag.yaml` file provides the module configuration for this test.
+        - The `cases_integration_no_option_tag_alerts` file provides the test cases.
+
+    expected_output:
+        - ".*(Enabling integration for: '{integration}')."
+        - ".*ERROR: Unable to run integration for ({integration}) -> integrations"
+        - '.*OS_IntegratorD.*(JSON file for options  doesn't exist)'
+        - '.*Response received.* [200].*'
+    '''
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+    command = f"echo '{JSON_ALERT}' >> {ALERTS_JSON_PATH}"
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ENABLED_INTEGRATION,
+                                                   replacement={"integration": test_metadata['integration']}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check integration is enabled
+    assert wazuh_monitor.callback_result
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_OPTIONS_FILE_DOES_NOT_EXISTENT), timeout=session_parameters.default_timeout)
+
+    # Check no options JSON file is detected
+    assert wazuh_monitor.callback_result
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_SENDING_MESSAGE,
+                                                   replacement={"integration": 'PagerDuty'}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check the message is sent to the integration's server
+    assert wazuh_monitor.callback_result
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+    # Check the response code from the integration's server
+    assert wazuh_monitor.callback_result
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test2_configuration, test2_metadata), ids=test2_cases_ids)
+def test_pagerduty_options(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                           configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when configuring the options tag with differents values, the integration works as expected.
+                 The test also checks that when it is supposed to fail, it fails.
+
+    wazuh_min_version: 4.6.0
+
+    test_phases:
+        - setup:
+            - Set wazuh configuration and local_internal_options.
+            - Clean logs files and restart wazuh to apply the configuration.
+        - test:
+            - Check integration is enabled
+            - Check the integration is unable to run when expected
+            - Check the integration sends the message and gets a response when expected
+        - teardown:
+            - Restore configuration
+            - Stop wazuh
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module
+
+    assertions:
+        - Verify the integration is enabled
+        - Verify no options JSON file is detected
+        - Verify the integration sends message to the integrated app's server
+        - Verify the response code from the integrated app
+
+
+    input_description:
+        - The `config_PagerDuty_options.yaml` file provides the module configuration for this test.
+        - The `cases_PagerDuty_options.yaml` file provides the test cases.
+
+    expected_output:
+        - ".*(Enabling integration for: '{integration}')."
+        - ".*ERROR: Unable to run integration for ({integration}) -> integrations"
+        - '.*OS_IntegratorD.*(JSON file for options  doesn't exist)'
+        - '.*Response received.* [200].*'
+
+    '''
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+    command = f"echo '{JSON_ALERT}' >> {ALERTS_JSON_PATH}"
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ENABLED_INTEGRATION,
+                                                   replacement={"integration": test_metadata['integration']}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check integration is enabled
+    assert wazuh_monitor.callback_result
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    if not test_metadata['sends_message']:
+        # Start monitor
+        wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ERROR_RUNNING_INTEGRATION,
+                                                    replacement={"integration": 'pagerduty'}),
+                                                    timeout=session_parameters.default_timeout)
+
+        # Check the message is sent to the integration's server
+        assert wazuh_monitor.callback_result
+    else:
+        # Start monitor
+        message = wazuh_monitor.start(callback=generate_callback(INTEGRATORD_SENDING_MESSAGE,
+                                                    replacement={"integration": 'PagerDuty'}),
+                                                    timeout=session_parameters.default_timeout,
+                                                    return_matched_line=True)
+
+        # Check the message is sent to the integration's server
+        assert wazuh_monitor.callback_result
+
+        # Verify that when the options JSON was not empty the sent information is in the response message.
+        if test_metadata['added_option'] is not None:
+            assert test_metadata['added_option'] in message, "The configured option is not present in the message sent"
+
+        # Start monitor
+        wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+        # Check the response code from the integration's server
+        assert wazuh_monitor.callback_result

--- a/tests/integration/test_integratord/test_integration_options/test_shuffle_options.py
+++ b/tests/integration/test_integratord/test_integration_options/test_shuffle_options.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2023, Wazuh Inc.
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
            Created by Wazuh, Inc. <info@wazuh.com>.
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 

--- a/tests/integration/test_integratord/test_integration_options/test_shuffle_options.py
+++ b/tests/integration/test_integratord/test_integration_options/test_shuffle_options.py
@@ -1,0 +1,295 @@
+'''
+copyright: Copyright (C) 2015-2023, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Integratord manages wazuh integrations with other applications such as Slack, Pagerduty, Shuffle, Yara or
+       Virustotal by feeding the integrated aplications with the alerts located in alerts.json file. Custom values for
+       fields can be configured to be sent using the 'options' tag. This test modules aim to test how the shuffle
+       integration works with different configurations, when the options tag is not present or when custom values are
+       passed into the tag for the shuffle integration
+
+components:
+    - integratord
+
+suite: integration_options
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-integratord
+
+os_platform:
+    - Linux
+
+os_version:
+    - Centos 8
+    - Ubuntu Focal
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/virustotal-scan/integration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-integratord.htm
+
+pytest_args:
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - shuffle
+'''
+import pytest
+from pathlib import Path
+
+from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
+from wazuh_testing import session_parameters
+from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, WAZUH_DB_DAEMON, INTEGRATOR_DAEMON
+from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, WAZUH_LOG_PATH
+from wazuh_testing.modules.analysisd.configuration import ANALYSISD_DEBUG
+from wazuh_testing.modules.integratord.configuration import INTEGRATORD_DEBUG
+from wazuh_testing.modules.integratord.patterns import INTEGRATORD_THIRD_PARTY_RESPONSE, INTEGRATORD_ENABLED_INTEGRATION, \
+                                                       INTEGRATORD_OPTIONS_FILE_DOES_NOT_EXISTENT, INTEGRATORD_SENDING_MESSAGE, \
+                                                       INTEGRATORD_ERROR_RUNNING_INTEGRATION
+from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils.callbacks import generate_callback
+from wazuh_testing.utils.commands import run_local_command_returning_output
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+
+
+# Marks
+pytestmark = [pytest.mark.server]
+
+# Paths
+t1_configurations_path = Path(CONFIGURATIONS_FOLDER_PATH, 'config_shuffle_no_option_tag.yaml')
+t2_configurations_path = Path(CONFIGURATIONS_FOLDER_PATH, 'config_shuffle_options.yaml')
+t1_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_shuffle_no_option_tag.yaml')
+t2_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_shuffle_options.yaml')
+
+# Configurations
+test1_configuration, test1_metadata, test1_cases_ids = get_test_cases_data(t1_cases_path)
+test2_configuration, test2_metadata, test2_cases_ids = get_test_cases_data(t2_cases_path)
+
+test1_configuration = load_configuration_template(t1_configurations_path, test1_configuration, test1_metadata)
+test2_configuration = load_configuration_template(t2_configurations_path, test2_configuration, test2_metadata)
+
+# Variables
+JSON_ALERT = '{"timestamp":"2022-05-11T12:29:19.905+0000",' \
+              '"rule":{"level":10,"description":"testing","id":"1234","groups":["test"]},' \
+              '"agent":{"id":"000","name":"localhost.localdomain"},' \
+              '"id":"1652272159.1549653",' \
+              '"location":"/test"}'
+daemons_handler_configuration = {'daemons': [INTEGRATOR_DAEMON, WAZUH_DB_DAEMON, ANALYSISD_DAEMON]}
+local_internal_options = {INTEGRATORD_DEBUG: '2', ANALYSISD_DEBUG: '1', MONITORD_ROTATE_LOG: '0'}
+
+
+# Tests
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test1_configuration, test1_metadata), ids=test1_cases_ids)
+def test_shuffle_no_option_tag(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                               configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when the options tag is not present for the Shuffle integration, the integration works
+                 properly.
+
+    wazuh_min_version: 4.6.0
+
+    test_phases:
+        - setup:
+            - Set wazuh configuration and local_internal_options.
+            - Clean logs files and restart wazuh to apply the configuration.
+        - test:
+            - Check integration is enabled
+            - Check no options JSON file is created
+            - Check the message is sent to the Shuffle server
+            - Check the response code is 200
+        - teardown:
+            - Restore configuration
+            - Stop wazuh
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module
+
+    assertions:
+        - Verify the integration is enabled
+        - Verify no options JSON file is detected
+        - Verify the integration sends message to the integrated app's server
+        - Verify the response code from the integrated app
+
+    input_description:
+        - The `config_integration_no_option_tag.yaml` file provides the module configuration for this test.
+        - The `cases_integration_no_option_tag_alerts` file provides the test cases.
+
+    expected_output:
+        - ".*(Enabling integration for: '{integration}')."
+        - ".*ERROR: Unable to run integration for ({integration}) -> integrations"
+        - '.*OS_IntegratorD.*(JSON file for options  doesn't exist)'
+        - '.*Response received.* [200].*'
+    '''
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+    command = f"echo '{JSON_ALERT}' >> {ALERTS_JSON_PATH}"
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ENABLED_INTEGRATION,
+                                                   replacement={"integration": test_metadata['integration']}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check integration is enabled
+    assert wazuh_monitor.callback_result
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_OPTIONS_FILE_DOES_NOT_EXISTENT), timeout=session_parameters.default_timeout)
+
+    # Check no options JSON file is detected
+    assert wazuh_monitor.callback_result
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_SENDING_MESSAGE,
+                                                   replacement={"integration": 'Shuffle'}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check the message is sent to the integration's server
+    assert wazuh_monitor.callback_result
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+    # Check the response code from the integration's server
+    assert wazuh_monitor.callback_result
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test2_configuration, test2_metadata), ids=test2_cases_ids)
+def test_shuffle_options(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                         configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when configuring the options tag with differents values, the integration works as expected.
+                 The test also checks that when it is supposed to fail, it fails.
+
+    wazuh_min_version: 4.6.0
+
+    test_phases:
+        - setup:
+            - Set wazuh configuration and local_internal_options.
+            - Clean logs files and restart wazuh to apply the configuration.
+        - test:
+            - Check integration is enabled
+            - Check the integration is unable to run when expected
+            - Check the integration sends the message and gets a response when expected
+        - teardown:
+            - Restore configuration
+            - Stop wazuh
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module
+
+    assertions:
+        - Verify the integration is enabled
+        - Verify no options JSON file is detected
+        - Verify the integration sends message to the integrated app's server
+        - Verify the response code from the integrated app
+
+
+    input_description:
+        - The `config_shuffle_options.yaml` file provides the module configuration for this test.
+        - The `cases_shuffle_options.yaml` file provides the test cases.
+
+    expected_output:
+        - ".*(Enabling integration for: '{integration}')."
+        - ".*ERROR: Unable to run integration for ({integration}) -> integrations"
+        - '.*OS_IntegratorD.*(JSON file for options  doesn't exist)'
+        - '.*Response received.* [200].*'
+
+    '''
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+    command = f"echo '{JSON_ALERT}' >> {ALERTS_JSON_PATH}"
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ENABLED_INTEGRATION,
+                                                   replacement={"integration": test_metadata['integration']}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check integration is enabled
+    assert wazuh_monitor.callback_result
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    if not test_metadata['sends_message']:
+        # Start monitor
+        wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ERROR_RUNNING_INTEGRATION,
+                                                    replacement={"integration": 'shuffle'}),
+                                                    timeout=session_parameters.default_timeout)
+
+        # Check the message is sent to the integration's server
+        assert wazuh_monitor.callback_result
+    else:
+        # Start monitor
+        message = wazuh_monitor.start(callback=generate_callback(INTEGRATORD_SENDING_MESSAGE,
+                                                    replacement={"integration": 'Shuffle'}),
+                                                    timeout=session_parameters.default_timeout,
+                                                    return_matched_line=True)
+
+        # Check the message is sent to the integration's server
+        assert wazuh_monitor.callback_result
+
+        # Verify that when the options JSON was not empty the sent information is in the response message.
+        if test_metadata['added_option'] is not None:
+            assert test_metadata['added_option'] in message, "The configured option is not present in the message sent"
+
+        # Start monitor
+        wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+        # Check the response code from the integration's server
+        assert wazuh_monitor.callback_result

--- a/tests/integration/test_integratord/test_integration_options/test_slack_options.py
+++ b/tests/integration/test_integratord/test_integration_options/test_slack_options.py
@@ -1,5 +1,5 @@
 '''
-copyright: Copyright (C) 2015-2023, Wazuh Inc.
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
            Created by Wazuh, Inc. <info@wazuh.com>.
            This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 

--- a/tests/integration/test_integratord/test_integration_options/test_slack_options.py
+++ b/tests/integration/test_integratord/test_integration_options/test_slack_options.py
@@ -1,0 +1,295 @@
+'''
+copyright: Copyright (C) 2015-2023, Wazuh Inc.
+           Created by Wazuh, Inc. <info@wazuh.com>.
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Integratord manages wazuh integrations with other applications such as Slack, Pagerduty, Shuffle, Yara or
+       Virustotal by feeding the integrated aplications with the alerts located in alerts.json file. Custom values for
+       fields can be configured to be sent using the 'options' tag. This test modules aim to test how the shuffle
+       integration works with different configurations, when the options tag is not present or when custom values are
+       passed into the tag for the shuffle integration
+
+components:
+    - integratord
+
+suite: integration_options
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-integratord
+
+os_platform:
+    - Linux
+
+os_version:
+    - Centos 8
+    - Ubuntu Focal
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/capabilities/virustotal-scan/integration.html
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-integratord.htm
+
+pytest_args:
+    - tier:
+        0: Only level 0 tests are performed, they check basic functionalities and are quick to perform.
+        1: Only level 1 tests are performed, they check functionalities of medium complexity.
+        2: Only level 2 tests are performed, they check advanced functionalities and are slow to perform.
+
+tags:
+    - slack
+'''
+import pytest
+from pathlib import Path
+
+from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
+from wazuh_testing import session_parameters
+from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, WAZUH_DB_DAEMON, INTEGRATOR_DAEMON
+from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH, WAZUH_LOG_PATH
+from wazuh_testing.modules.analysisd.configuration import ANALYSISD_DEBUG
+from wazuh_testing.modules.integratord.configuration import INTEGRATORD_DEBUG
+from wazuh_testing.modules.integratord.patterns import INTEGRATORD_THIRD_PARTY_RESPONSE, INTEGRATORD_ENABLED_INTEGRATION, \
+                                                       INTEGRATORD_OPTIONS_FILE_DOES_NOT_EXISTENT, INTEGRATORD_SENDING_MESSAGE, \
+                                                       INTEGRATORD_ERROR_RUNNING_INTEGRATION
+from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils.callbacks import generate_callback
+from wazuh_testing.utils.commands import run_local_command_returning_output
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+
+
+# Marks
+pytestmark = [pytest.mark.server]
+
+# Paths
+t1_configurations_path = Path(CONFIGURATIONS_FOLDER_PATH, 'config_slack_no_option_tag.yaml')
+t2_configurations_path = Path(CONFIGURATIONS_FOLDER_PATH, 'config_slack_options.yaml')
+t1_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_slack_no_option_tag.yaml')
+t2_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_slack_options.yaml')
+
+# Configurations
+test1_configuration, test1_metadata, test1_cases_ids = get_test_cases_data(t1_cases_path)
+test2_configuration, test2_metadata, test2_cases_ids = get_test_cases_data(t2_cases_path)
+
+test1_configuration = load_configuration_template(t1_configurations_path, test1_configuration, test1_metadata)
+test2_configuration = load_configuration_template(t2_configurations_path, test2_configuration, test2_metadata)
+
+# Variables
+JSON_ALERT = '{"timestamp":"2022-05-11T12:29:19.905+0000",' \
+              '"rule":{"level":10,"description":"testing","id":"1234","groups":["test"]},' \
+              '"agent":{"id":"000","name":"localhost.localdomain"},' \
+              '"id":"1652272159.1549653",' \
+              '"location":"/test"}'
+daemons_handler_configuration = {'daemons': [INTEGRATOR_DAEMON, WAZUH_DB_DAEMON, ANALYSISD_DAEMON]}
+local_internal_options = {INTEGRATORD_DEBUG: '2', ANALYSISD_DEBUG: '1', MONITORD_ROTATE_LOG: '0'}
+
+
+# Tests
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test1_configuration, test1_metadata), ids=test1_cases_ids)
+def test_slack_no_option_tag(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                             configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when the options tag is not present for the Slack integration, the integration works
+                 properly.
+
+    wazuh_min_version: 4.6.0
+
+    test_phases:
+        - setup:
+            - Set wazuh configuration and local_internal_options.
+            - Clean logs files and restart wazuh to apply the configuration.
+        - test:
+            - Check integration is enabled
+            - Check no options JSON file is created
+            - Check the message is sent to the Slack server
+            - Check the response code is 200
+        - teardown:
+            - Restore configuration
+            - Stop wazuh
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module
+
+    assertions:
+        - Verify the integration is enabled
+        - Verify no options JSON file is detected
+        - Verify the integration sends message to the integrated app's server
+        - Verify the response code from the integrated app
+
+    input_description:
+        - The `config_integration_no_option_tag.yaml` file provides the module configuration for this test.
+        - The `cases_integration_no_option_tag_alerts` file provides the test cases.
+
+    expected_output:
+        - ".*(Enabling integration for: '{integration}')."
+        - ".*ERROR: Unable to run integration for ({integration}) -> integrations"
+        - '.*OS_IntegratorD.*(JSON file for options  doesn't exist)'
+        - '.*Response received.* [200].*'
+    '''
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+    command = f"echo '{JSON_ALERT}' >> {ALERTS_JSON_PATH}"
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ENABLED_INTEGRATION,
+                                                   replacement={"integration": test_metadata['integration']}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check integration is enabled
+    assert wazuh_monitor.callback_result
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_OPTIONS_FILE_DOES_NOT_EXISTENT), timeout=session_parameters.default_timeout)
+
+    # Check no options JSON file is detected
+    assert wazuh_monitor.callback_result
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_SENDING_MESSAGE,
+                                                   replacement={"integration": 'Slack'}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check the message is sent to the integration's server
+    assert wazuh_monitor.callback_result
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+    # Check the response code from the integration's server
+    assert wazuh_monitor.callback_result
+
+
+@pytest.mark.tier(level=1)
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test2_configuration, test2_metadata), ids=test2_cases_ids)
+def test_slack_options(test_configuration, test_metadata, set_wazuh_configuration, truncate_monitored_files,
+                       configure_local_internal_options, daemons_handler, wait_for_integratord_start):
+    '''
+    description: Check that when configuring the options tag with differents values, the integration works as expected.
+                 The test also checks that when it is supposed to fail, it fails.
+
+    wazuh_min_version: 4.6.0
+
+    test_phases:
+        - setup:
+            - Set wazuh configuration and local_internal_options.
+            - Clean logs files and restart wazuh to apply the configuration.
+        - test:
+            - Check integration is enabled
+            - Check the integration is unable to run when expected
+            - Check the integration sends the message and gets a response when expected
+        - teardown:
+            - Restore configuration
+            - Stop wazuh
+
+    tier: 1
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration loaded from `configuration_template`.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Set wazuh configuration.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the local internal options file.
+        - daemons_handler:
+            type: fixture
+            brief: Restart wazuh daemon before starting a test.
+        - wait_for_integratord_start:
+            type: fixture
+            brief: Detect the start of the Integratord module
+
+    assertions:
+        - Verify the integration is enabled
+        - Verify no options JSON file is detected
+        - Verify the integration sends message to the integrated app's server
+        - Verify the response code from the integrated app
+
+
+    input_description:
+        - The `config_slack_options.yaml` file provides the module configuration for this test.
+        - The `cases_slack_options.yaml` file provides the test cases.
+
+    expected_output:
+        - ".*(Enabling integration for: '{integration}')."
+        - ".*ERROR: Unable to run integration for ({integration}) -> integrations"
+        - '.*OS_IntegratorD.*(JSON file for options  doesn't exist)'
+        - '.*Response received.* [200].*'
+
+    '''
+    wazuh_monitor = FileMonitor(WAZUH_LOG_PATH)
+    command = f"echo '{JSON_ALERT}' >> {ALERTS_JSON_PATH}"
+
+    # Start monitor
+    wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ENABLED_INTEGRATION,
+                                                   replacement={"integration": test_metadata['integration']}),
+                                                   timeout=session_parameters.default_timeout)
+
+    # Check integration is enabled
+    assert wazuh_monitor.callback_result
+
+    # Insert a new alert
+    run_local_command_returning_output(command)
+
+    if not test_metadata['sends_message']:
+        # Start monitor
+        wazuh_monitor.start(callback=generate_callback(INTEGRATORD_ERROR_RUNNING_INTEGRATION,
+                                                    replacement={"integration": 'slack'}),
+                                                    timeout=session_parameters.default_timeout)
+
+        # Check the message is sent to the integration's server
+        assert wazuh_monitor.callback_result
+    else:
+        # Start monitor
+        message = wazuh_monitor.start(callback=generate_callback(INTEGRATORD_SENDING_MESSAGE,
+                                                    replacement={"integration": 'Slack'}),
+                                                    timeout=session_parameters.default_timeout,
+                                                    return_matched_line=True)
+
+        # Check the message is sent to the integration's server
+        assert wazuh_monitor.callback_result
+
+        # Verify that when the options JSON was not empty the sent information is in the response message.
+        if test_metadata['added_option'] is not None:
+            assert test_metadata['added_option'] in message, "The configured option is not present in the message sent"
+
+        # Start monitor
+        wazuh_monitor.start(callback=generate_callback(INTEGRATORD_THIRD_PARTY_RESPONSE), timeout=session_parameters.default_timeout)
+
+        # Check the response code from the integration's server
+        assert wazuh_monitor.callback_result

--- a/tests/integration/test_remoted/test_multi_groups/conftest.py
+++ b/tests/integration/test_remoted/test_multi_groups/conftest.py
@@ -11,7 +11,7 @@ from wazuh_testing.tools.simulators import agent_simulator
 from wazuh_testing.utils.agent_groups import create_group, delete_group, add_agent_to_group
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def prepare_environment(request, simulate_agents):
     """Configure a custom environment for testing."""
     agent = simulate_agents[0]

--- a/tests/integration/test_sca/conftest.py
+++ b/tests/integration/test_sca/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from wazuh_testing.constants.paths.ruleset import CIS_RULESET_PATH
 from wazuh_testing.utils.file import copy, remove_file, copy_files_in_folder, delete_path_recursively
 from wazuh_testing.tools.monitors import file_monitor
-from wazuh_testing.modules.sca import patterns
+from wazuh_testing.modules.modulesd.sca import patterns
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.paths import TEMP_FILE_PATH
 from wazuh_testing.utils import callbacks

--- a/tests/integration/test_sca/test_basic.py
+++ b/tests/integration/test_sca/test_basic.py
@@ -45,7 +45,7 @@ from pathlib import Path
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils import callbacks, configuration
 from wazuh_testing.tools.monitors import file_monitor
-from wazuh_testing.modules.sca import patterns
+from wazuh_testing.modules.modulesd.sca import patterns
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.agentd.configuration import AGENTD_WINDOWS_DEBUG
 from wazuh_testing.constants.platforms import WINDOWS

--- a/tests/integration/test_sca/test_scan_results.py
+++ b/tests/integration/test_sca/test_scan_results.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils import callbacks, configuration
 from wazuh_testing.tools.monitors import file_monitor
-from wazuh_testing.modules.sca import patterns
+from wazuh_testing.modules.modulesd.sca import patterns
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.agentd.configuration import AGENTD_WINDOWS_DEBUG
 from wazuh_testing.constants.platforms import WINDOWS

--- a/tests/integration/test_sca/test_validate_remediation.py
+++ b/tests/integration/test_sca/test_validate_remediation.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils import callbacks, configuration
 from wazuh_testing.tools.monitors import file_monitor
-from wazuh_testing.modules.sca import patterns
+from wazuh_testing.modules.modulesd.sca import patterns
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.agentd.configuration import AGENTD_WINDOWS_DEBUG
 from wazuh_testing.constants.platforms import WINDOWS

--- a/tests/integration/test_syscollector/test_syscollector_configuration.py
+++ b/tests/integration/test_syscollector/test_syscollector_configuration.py
@@ -50,15 +50,14 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.utils import services
 from wazuh_testing.tools.monitors import file_monitor
-from wazuh_testing.utils import callbacks, configuration, file
-from wazuh_testing.modules.syscollector import patterns
+from wazuh_testing.utils import callbacks, configuration
+from wazuh_testing.modules.modulesd.syscollector import patterns
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 
 
 # Marks
-pytestmark = [pytest.mark.tier(level=0), pytest.mark.server, pytest.mark.agent,
-              pytest.mark.linux, pytest.mark.darwin, pytest.mark.win32]
+pytestmark = [pytest.mark.tier(level=0), pytest.mark.linux, pytest.mark.win32]
 
 # Variables
 local_internal_options = {MODULESD_DEBUG: '2'}

--- a/tests/integration/test_vulnerability_detector/conftest.py
+++ b/tests/integration/test_vulnerability_detector/conftest.py
@@ -9,11 +9,11 @@ from wazuh_testing.utils.db_queries import cve_db
 from wazuh_testing.utils.services import control_service
 from wazuh_testing import FEEDS_PATH
 from wazuh_testing.constants.paths.databases import CPE_HELPER_PATH
-from wazuh_testing.modules.vulnerability_detector import CUSTOM_CPE_HELPER
+from wazuh_testing.modules.modulesd.vulnerability_detector import CUSTOM_CPE_HELPER
 from wazuh_testing.utils.file import read_json_file, copy, write_json_file
-from wazuh_testing.modules.vulnerability_detector.utils import (insert_vulnerable_packages,
-                                                                insert_vulnerabilities_agent_inventory,
-                                                                insert_suse_system_package, VULNERABLE_PACKAGES)
+from wazuh_testing.utils.mocking import (insert_vulnerable_packages,
+                                         insert_vulnerabilities_agent_inventory,
+                                         insert_suse_system_package, VULNERABLE_PACKAGES)
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.time import get_current_timestamp
 

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/conftest.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.file import read_json_file, copy, write_json_file, read_file, write_file
-from wazuh_testing.modules.vulnerability_detector import CUSTOM_CPE_HELPER_TEMPLATE
+from wazuh_testing.modules.modulesd.vulnerability_detector import CUSTOM_CPE_HELPER_TEMPLATE
 from wazuh_testing.constants.paths.databases import CPE_HELPER_PATH
 from wazuh_testing import FEEDS_PATH
 

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_empty_fields.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_empty_fields.py
@@ -53,10 +53,10 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.configuration import (load_configuration_template, get_test_cases_data,
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES_EMPTY_VENDOR
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES_EMPTY_VENDOR
 from test_vulnerability_detector.utils import check_cve_affects_package_alert
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_nvd_json_feed_path

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_empty_vendor_version.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_empty_vendor_version.py
@@ -53,10 +53,10 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.configuration import (load_configuration_template, get_test_cases_data,
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES_EMPTY_VENDOR_VERSION
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES_EMPTY_VENDOR_VERSION
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_nvd_json_feed_path
 

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_missing_field.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_missing_field.py
@@ -53,12 +53,12 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.configuration import (load_configuration_template, get_test_cases_data,
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from test_vulnerability_detector.utils import check_baseline_scan_start
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_nvd_json_feed_path
 

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_tags.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_tags.py
@@ -54,11 +54,11 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.configuration import (load_configuration_template, get_test_cases_data,
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH
 

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_values.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_values.py
@@ -54,11 +54,11 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.configuration import (load_configuration_template, get_test_cases_data,
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/__init__.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/__init__.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from pathlib import Path
 from wazuh_testing import FEEDS_PATH
-from wazuh_testing.modules.vulnerability_detector import CUSTOM_NVD_FEED, CUSTOM_CPE_HELPER, CUSTOM_MSU_JSON_FEED
+from wazuh_testing.modules.modulesd.vulnerability_detector import CUSTOM_NVD_FEED, CUSTOM_CPE_HELPER, CUSTOM_MSU_JSON_FEED
 
 
 # Constants & base paths

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_cpe_indexing.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_cpe_indexing.py
@@ -55,11 +55,11 @@ from wazuh_testing.utils.configuration import (load_configuration_template, get_
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector import CUSTOM_NVD_FEED, CUSTOM_CPE_HELPER, CUSTOM_MSU_JSON_FEED
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.modules.modulesd.vulnerability_detector import CUSTOM_NVD_FEED, CUSTOM_CPE_HELPER, CUSTOM_MSU_JSON_FEED
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_nvd_json_feed_path,
                custom_msu_feed_path)
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
@@ -66,7 +66,7 @@ from wazuh_testing.utils.configuration import (load_configuration_template, get_
 from wazuh_testing.modules import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH
 
 

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py
@@ -60,7 +60,7 @@ from wazuh_testing.utils.file import read_yaml
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries.cve_db import get_rows_number
 from wazuh_testing.utils.configuration import get_test_cases_data
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_msu_inventory.py
@@ -67,7 +67,7 @@ from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries.cve_db import get_rows_from_table
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_enabled.py
@@ -56,7 +56,7 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_interval.py
@@ -53,7 +53,7 @@ from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_min_full_scan_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_min_full_scan_interval.py
@@ -58,7 +58,7 @@ from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries import agent_db, cve_db
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from test_vulnerability_detector import utils as evm

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_retry_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_retry_interval.py
@@ -65,7 +65,7 @@ from wazuh_testing.utils import mocking
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path, custom_rhel_json_feed_path,

--- a/tests/integration/test_vulnerability_detector/test_general_settings/test_run_on_start.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/test_run_on_start.py
@@ -53,7 +53,7 @@ from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_nvd_json_feed_path

--- a/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_enabled.py
@@ -66,7 +66,7 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH

--- a/tests/integration/test_vulnerability_detector/test_providers/test_missing_os.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_missing_os.py
@@ -67,7 +67,7 @@ from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries import cve_db
 from wazuh_testing.utils.services import control_service
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.modules.modulesd.patterns import CONFIGURATION_ERROR

--- a/tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py
@@ -59,7 +59,7 @@ from wazuh_testing.utils.db_queries import cve_db
 from wazuh_testing.utils.services import control_service
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path, custom_rhel_json_feed_path,

--- a/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/test_update_interval.py
@@ -62,7 +62,7 @@ from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.time import time_to_seconds
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py
@@ -64,10 +64,10 @@ from wazuh_testing.utils.file import read_json_file, copy, write_json_file
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as ev
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_nvd_json_feed_path, custom_cpe_helper_path
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py
@@ -54,15 +54,15 @@ tags:
 import pytest
 from pathlib import Path
 
+from .utils import update_feed_path_configurations
 from wazuh_testing import FEEDS_PATH
 from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, MODULES_DAEMON, SYSCHECK_DAEMON
 from wazuh_testing.utils.file import read_yaml
-from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
-                                               update_feed_path_configurations)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.utils.configuration import get_test_cases_data
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as ev
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py
@@ -54,15 +54,15 @@ tags:
 import pytest
 from pathlib import Path
 
+from .utils import update_feed_path_configurations
 from wazuh_testing import FEEDS_PATH
 from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, MODULES_DAEMON, SYSCHECK_DAEMON
 from wazuh_testing.utils.file import read_yaml
-from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
-                                               update_feed_path_configurations)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.utils.configuration import get_test_cases_data
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as ev
 from . import TEST_CASES_PATH, CONFIGURATIONS_PATH
 

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py
@@ -62,10 +62,10 @@ from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as ev
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path,
                custom_rhel_json_feed_path, custom_nvd_json_feed_path)

--- a/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py
@@ -58,6 +58,7 @@ tags:
 import pytest
 from pathlib import Path
 
+from .utils import update_feed_path_configurations
 from wazuh_testing import FEEDS_PATH
 from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, MODULES_DAEMON, SYSCHECK_DAEMON
 from wazuh_testing.utils.file import read_yaml
@@ -66,8 +67,8 @@ from wazuh_testing.utils.db_queries import agent_db, cve_db
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.utils.callbacks import generate_callback
-from wazuh_testing.utils.configuration import (get_test_cases_data, update_feed_path_configurations)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.utils.configuration import get_test_cases_data
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from test_vulnerability_detector import utils as evm

--- a/tests/integration/test_vulnerability_detector/test_scan_results/utils.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/utils.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2015-2023, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+import os
+import json
+
+from copy import deepcopy
+
+
+def update_feed_path_configurations(configurations, metadata, feeds_path):
+    """Replace feed path tags in the configuration template, using the metadata information.
+
+    Args:
+        configurations (list(dict)): List of configuration templates.
+        metadata (list(dict)): List of configuration templates metadata.
+        feeds_path (str): Absolute path where the feeds are located.
+
+    Returns:
+        list(dict): List of configurations with the feeds path updated.
+    """
+    new_configurations = deepcopy(configurations)
+
+    for index, _ in enumerate(configurations):
+        if 'json_feed' in metadata[index] and metadata[index]['json_feed'] is not None:
+            new_configurations[index] = json.loads(json.dumps(new_configurations[index]).
+                                                   replace(metadata[index]['json_feed_tag'],
+                                                   os.path.join(feeds_path, metadata[index]['provider_name'],
+                                                                metadata[index]['json_feed'])))
+
+        if 'oval_feed' in metadata[index] and metadata[index]['oval_feed'] is not None:
+            new_configurations[index] = json.loads(json.dumps(new_configurations[index]).
+                                                   replace(metadata[index]['oval_feed_tag'],
+                                                   os.path.join(feeds_path, metadata[index]['provider_name'],
+                                                                metadata[index]['oval_feed'])))
+
+        if 'nvd_feed_tag' in metadata[index] and 'nvd_feed' in metadata[index]:
+            new_configurations[index] = json.loads(json.dumps(new_configurations[index]).
+                                                   replace(metadata[index]['nvd_feed_tag'],
+                                                   os.path.join(feeds_path, 'nvd', metadata[index]['nvd_feed'])))
+
+    return new_configurations

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py
@@ -49,10 +49,10 @@ from pathlib import Path
 from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, MODULES_DAEMON, SYSCHECK_DAEMON
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as evm
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path,
                custom_rhel_json_feed_path, custom_nvd_json_feed_path)

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_full_scan_type.py
@@ -49,14 +49,14 @@ from pathlib import Path
 from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, MODULES_DAEMON, SYSCHECK_DAEMON
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.utils.db_queries import agent_db, cve_db
 from wazuh_testing.utils.file import truncate_file
 from wazuh_testing.utils.time import get_current_timestamp
 from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as evm
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path,
                custom_rhel_json_feed_path, custom_nvd_json_feed_path)

--- a/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/test_partial_scan_type.py
@@ -49,14 +49,14 @@ from pathlib import Path
 from wazuh_testing.constants.daemons import ANALYSISD_DAEMON, MODULES_DAEMON, SYSCHECK_DAEMON
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.utils.db_queries import agent_db, cve_db
 from wazuh_testing.utils.file import truncate_file
 from wazuh_testing.utils.time import get_current_timestamp
 from wazuh_testing.constants.paths.logs import ALERTS_JSON_PATH
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as evm
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path, custom_rhel_json_feed_path,
                custom_nvd_json_feed_path)

--- a/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_baseline_scan.py
+++ b/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_baseline_scan.py
@@ -49,10 +49,10 @@ from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as evm
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path, custom_rhel_json_feed_path, custom_nvd_json_feed_path)
 

--- a/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_full_scan.py
+++ b/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_full_scan.py
@@ -49,10 +49,10 @@ from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as evm
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path, custom_rhel_json_feed_path, custom_nvd_json_feed_path)
 

--- a/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_partial_scan.py
+++ b/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_partial_scan.py
@@ -49,10 +49,10 @@ from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries import agent_db
 from wazuh_testing.utils.configuration import (get_test_cases_data, load_configuration_template,
                                                update_configuration_template)
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
-from wazuh_testing.modules.vulnerability_detector.utils import VULNERABLE_PACKAGES
+from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES
 from test_vulnerability_detector import utils as evm
 from . import (TEST_CASES_PATH, CONFIGURATIONS_PATH, custom_rhel_oval_feed_path, custom_rhel_json_feed_path,
                custom_nvd_json_feed_path)

--- a/tests/integration/test_vulnerability_detector/utils.py
+++ b/tests/integration/test_vulnerability_detector/utils.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH, ALERTS_JSON_PATH
-from wazuh_testing.modules.vulnerability_detector import patterns as cb
+from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.callbacks import generate_callback
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/19084|

## Description

This PR includes the `integratord` ITs from the old `wazuh-qa` repository.

Tests have been migrated following the new standards.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade