### PR TITLE
Modify `conftest.py` to launch tags 

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -150,9 +150,7 @@ def down_env():
     """Stop and remove all Docker containers."""
     os.chdir(env_path)
     with open(docker_log_path, mode='a') as f_docker:
-        current_process = subprocess.Popen(["docker", "compose",
-                                            "down", "--remove-orphans", "-t0" ],
-                                           stdout=f_docker,
+        current_process = subprocess.Popen(["docker", "compose", "down", "-t0" ], stdout=f_docker,
                                            stderr=subprocess.STDOUT, universal_newlines=True)
         current_process.wait()
     os.chdir(current_path)

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -111,8 +111,14 @@ def build_and_up(env_mode: str, interval: int = 10, interval_build_env: int = 10
         'max_retries': 3,
         'retries': 0
     }
-    # Get current branch
-    current_branch = '/'.join(open('../../../../.git/HEAD', 'r').readline().split('/')[2:])
+   # Get current branch or tag
+    with open('../../../../.git/HEAD', 'r') as f:
+        ref = f.readline().strip()
+    if ref.startswith("ref:"):
+        current_branch = ref.split("refs/heads/")[1]
+    else:
+        current_branch = ref.split("/")[-1]
+        
     os.makedirs(test_logs_path, exist_ok=True)
     with open(docker_log_path, mode='w') as f_docker:
         while values_build_env['retries'] < values_build_env['max_retries']:


### PR DESCRIPTION
|Related issue|
|---|
| #16480 |

## Description

This PR closes https://github.com/wazuh/wazuh/issues/16480, the option to launch AITs with tags was added to `conftest.py`, and its functionality was tested