### PR TITLE
Updated README of the AITs with the new parameters

### DIFF
--- a/api/test/integration/README.md
+++ b/api/test/integration/README.md
@@ -160,7 +160,7 @@ API integration tests
 
 optional arguments:
   --build-managers-only            
-                  Recreates only the managers images once the AIT test environment is built.
+                  Recreates only the managers' image once the AIT test environment is built.
   --nobuild
                   Prevents rebuilding the environment when running tests once the images are already created.
   --disable-warnings 

--- a/api/test/integration/README.md
+++ b/api/test/integration/README.md
@@ -155,6 +155,18 @@ test_agent_GET_endpoints.tavern.yaml ...........................................
 ============================== 92 passed, 98 warnings in 217.61s (0:03:37) ===============================
 ```
 
+```text
+API integration tests
+
+optional arguments:
+  --build-managers-only            
+                  Recreates only the managers images once the AIT test environment is built.
+  --nobuild
+                  Prevents rebuilding the environment when running tests once the images are already created.
+  --disable-warnings 
+                  Disables warnings during test execution.
+```
+
 We can also use the `wazuh/api/test/integration/run_tests.py` script. This script includes the possibility to collect a 
 group of tests to be passed. Script arguments:
 


### PR DESCRIPTION
|Related issue|
|---|
| #21740  |


## Description

The parameters that were added in `conftest.py` were included in the AITs `README`.
Added parameters:
- `--disable-warnings`
- `--build-managers-only` --> https://github.com/wazuh/wazuh/pull/21924
- `--nobuild` --> https://github.com/wazuh/wazuh/pull/17750

