### PR TITLE
Implement Support for Multiple Journal Configuration Blocks in ossec.conf

### DIFF
--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -520,8 +520,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             }
             OSList_InsertData(logf[pl].regex_restrict, NULL, expression_restrict);
         } else if (strcasecmp(node[i]->element, xml_localfile_filter) == 0) {
-            if (init_w_journal_log_config_t(&(logf[pl].journal_log)))
-            {
+            if (init_w_journal_log_config_t(&(logf[pl].journal_log))) {
                 os_calloc(2, sizeof(w_journal_filter_t *), logf[pl].journal_log->filters);
             }
             // Use always the same filter for all the conditions (First filter)
@@ -810,7 +809,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
         }
     }
 
-
     return (0);
 }
 
@@ -876,7 +874,6 @@ void w_clean_logreader(logreader * logf) {
         Free_Logreader(logf);
         memset(logf, 0, sizeof(logreader));
     }
-
 }
 
 void Free_Logreader(logreader * logf) {
@@ -895,7 +892,6 @@ void Free_Logreader(logreader * logf) {
         os_free(logf->query);
         os_free(logf->exclude);
         os_free(logf->query_level);
-        os_free(logf->age_str);
 
         if (logf->regex_ignore) {
             OSList_Destroy(logf->regex_ignore);
@@ -1061,15 +1057,12 @@ const char * multiline_attr_match_str(w_multiline_match_type_t match_type) {
     return match_str[match_type];
 }
 
-void w_multiline_log_config_free(w_multiline_config_t** config)
-{
-    if (config == NULL || *config == NULL)
-    {
+void w_multiline_log_config_free(w_multiline_config_t ** config) {
+    if (config == NULL || *config == NULL) {
         return;
     }
 
-    if ((*config)->ctxt)
-    {
+    if ((*config)->ctxt) {
         os_free((*config)->ctxt->buffer);
         os_free((*config)->ctxt);
     }
@@ -1077,19 +1070,17 @@ void w_multiline_log_config_free(w_multiline_config_t** config)
     os_free((*config));
 }
 
-void w_macos_log_config_free(w_macos_log_config_t** macos_log) {
+void w_macos_log_config_free(w_macos_log_config_t ** macos_log) {
 
     if (macos_log == NULL || *macos_log == NULL) {
         return;
     }
 
     w_free_expression_t(&((*macos_log)->log_start_regex));
-    if ((*macos_log)->processes.stream.wfd != NULL)
-    {
+    if ((*macos_log)->processes.stream.wfd != NULL) {
         wpclose((*macos_log)->processes.stream.wfd);
     }
-    if ((*macos_log)->processes.show.wfd != NULL)
-    {
+    if ((*macos_log)->processes.show.wfd != NULL) {
         wpclose((*macos_log)->processes.show.wfd);
     }
     os_free((*macos_log)->current_settings);
@@ -1130,7 +1121,6 @@ STATIC int w_logcollector_get_macos_log_type(const char * content) {
         }
 
         os_free(type_arr);
-
     }
 
     return retval;
@@ -1152,21 +1142,17 @@ w_exp_type_t w_check_regex_type(xml_node * node, const char * element) {
     return EXP_TYPE_PCRE2;
 }
 
-bool init_w_journal_log_config_t(w_journal_log_config_t** config)
-{
-    if (config == NULL || *config != NULL)
-    {
+bool init_w_journal_log_config_t(w_journal_log_config_t ** config) {
+    if (config == NULL || *config != NULL) {
         return false;
     }
-    
+
     os_calloc(1, sizeof(w_journal_log_config_t), *config);
-    return true;    
+    return true;
 }
 
-void w_journal_log_config_free(w_journal_log_config_t** config)
-{
-    if (config == NULL || *config == NULL)
-    {
+void w_journal_log_config_free(w_journal_log_config_t ** config) {
+    if (config == NULL || *config == NULL) {
         return;
     }
 
@@ -1174,43 +1160,34 @@ void w_journal_log_config_free(w_journal_log_config_t** config)
     os_free(*config);
 }
 
-bool journald_add_condition_to_filter(xml_node* node, w_journal_filter_t** filter)
-{
-    if (node == NULL || filter == NULL)
-    {
+bool journald_add_condition_to_filter(xml_node * node, w_journal_filter_t ** filter) {
+    if (node == NULL || filter == NULL) {
         return false;
     }
 
-    const char* field = w_get_attr_val_by_name(node, "field");
-    char* expression = node->content;
+    const char * field = w_get_attr_val_by_name(node, "field");
+    char * expression = node->content;
     bool ignore_if_missing = false;
 
-    if (field == NULL || *field == '\0')
-    {
+    if (field == NULL || *field == '\0') {
         mwarn("The field for the journal filter cannot be empty");
         return false;
     }
-    if (expression == NULL || *expression == '\0')
-    {
+    if (expression == NULL || *expression == '\0') {
         mwarn("The expression for the journal filter cannot be empty");
         return false;
     }
 
-    const char* ignore_if_missing_str = w_get_attr_val_by_name(node, "ignore_if_missing");
-    if (ignore_if_missing_str != NULL)
-    {
-        if (strcasecmp(ignore_if_missing_str, "yes") == 0)
-        {
+    const char * ignore_if_missing_str = w_get_attr_val_by_name(node, "ignore_if_missing");
+    if (ignore_if_missing_str != NULL) {
+        if (strcasecmp(ignore_if_missing_str, "yes") == 0) {
             ignore_if_missing = true;
-        }
-        else if (strcasecmp(ignore_if_missing_str, "no") != 0)
-        {
+        } else if (strcasecmp(ignore_if_missing_str, "no") != 0) {
             mwarn(LOGCOLLECTOR_INV_VALUE_DEFAULT, ignore_if_missing_str, "ignore_if_missing", "journal");
         }
     }
 
-    if (w_journal_filter_add_condition(filter, field, expression, ignore_if_missing) != 0)
-    {
+    if (w_journal_filter_add_condition(filter, field, expression, ignore_if_missing) != 0) {
         mwarn("Error compiling the PCRE2 expression for the journal filter");
         return false;
     }
@@ -1224,10 +1201,8 @@ bool journald_add_condition_to_filter(xml_node* node, w_journal_filter_t** filte
  * The unit pointer is invalid after the call.
  * @param unit Journal filter unit
  */
-static void free_unit_filter(_w_journal_filter_unit_t* unit)
-{
-    if (unit == NULL)
-    {
+static void free_unit_filter(_w_journal_filter_unit_t * unit) {
+    if (unit == NULL) {
         return;
     }
 
@@ -1245,20 +1220,17 @@ static void free_unit_filter(_w_journal_filter_unit_t* unit)
  * @param ignore_if_missing Ignore if the field is missing
  * @return The filter unit or NULL if an error occurred (compiling the expression)
  */
-static _w_journal_filter_unit_t* create_unit_filter(const char* field, char* expression, bool ignore_if_missing)
-{
-    if (field == NULL || expression == NULL)
-    {
+static _w_journal_filter_unit_t * create_unit_filter(const char * field, char * expression, bool ignore_if_missing) {
+    if (field == NULL || expression == NULL) {
         return NULL;
     }
 
-    _w_journal_filter_unit_t* unit;
+    _w_journal_filter_unit_t * unit;
     os_calloc(1, sizeof(_w_journal_filter_unit_t), unit);
 
     w_calloc_expression_t(&(unit->exp), EXP_TYPE_PCRE2);
 
-    if (!w_expression_compile(unit->exp, expression, 0))
-    {
+    if (!w_expression_compile(unit->exp, expression, 0)) {
         free_unit_filter(unit);
         return NULL;
     }
@@ -1269,17 +1241,13 @@ static _w_journal_filter_unit_t* create_unit_filter(const char* field, char* exp
     return unit;
 }
 
-void w_journal_filter_free(w_journal_filter_t* ptr_filter)
-{
-    if (ptr_filter == NULL)
-    {
+void w_journal_filter_free(w_journal_filter_t * ptr_filter) {
+    if (ptr_filter == NULL) {
         return;
     }
 
-    if (ptr_filter->units != NULL)
-    {
-        for (size_t i = 0; ptr_filter->units[i] != NULL; i++)
-        {
+    if (ptr_filter->units != NULL) {
+        for (size_t i = 0; ptr_filter->units[i] != NULL; i++) {
             free_unit_filter(ptr_filter->units[i]);
         }
 
@@ -1289,32 +1257,26 @@ void w_journal_filter_free(w_journal_filter_t* ptr_filter)
     os_free(ptr_filter);
 }
 
-int w_journal_filter_add_condition(w_journal_filter_t** ptr_filter,
-                                   const char* field,
-                                   char* expression,
-                                   bool ignore_if_missing)
-{
-    if (field == NULL || expression == NULL || ptr_filter == NULL)
-    {
+int w_journal_filter_add_condition(w_journal_filter_t ** ptr_filter, const char * field, char * expression,
+                                   bool ignore_if_missing) {
+    if (field == NULL || expression == NULL || ptr_filter == NULL) {
         return -1;
     }
 
     // Crete the unit filter
-    _w_journal_filter_unit_t* unit = create_unit_filter(field, expression, ignore_if_missing);
-    if (unit == NULL)
-    {
+    _w_journal_filter_unit_t * unit = create_unit_filter(field, expression, ignore_if_missing);
+    if (unit == NULL) {
         return -1;
     }
 
     // If the filter does not exist, create it
-    if (*ptr_filter == NULL)
-    {
+    if (*ptr_filter == NULL) {
         os_calloc(1, sizeof(w_journal_filter_t), *ptr_filter);
     }
-    w_journal_filter_t* filter = *ptr_filter;
+    w_journal_filter_t * filter = *ptr_filter;
 
     // Allocate memory for the new unit
-    os_realloc(filter->units, (filter->units_size + 2) * sizeof(_w_journal_filter_unit_t*), filter->units);
+    os_realloc(filter->units, (filter->units_size + 2) * sizeof(_w_journal_filter_unit_t *), filter->units);
 
     // Add the new unit
     filter->units[filter->units_size] = unit;
@@ -1324,28 +1286,24 @@ int w_journal_filter_add_condition(w_journal_filter_t** ptr_filter,
     return 0;
 }
 
-bool w_journal_add_filter_to_list(w_journal_filters_list_t* list, w_journal_filter_t* filter)
-{
-    if (list == NULL || filter == NULL)
-    {
+bool w_journal_add_filter_to_list(w_journal_filters_list_t * list, w_journal_filter_t * filter) {
+    if (list == NULL || filter == NULL) {
         return false;
     }
 
     // Allocate memory for the new filter
-    if (*list == NULL)
-    {
-        os_calloc(1, sizeof(w_journal_filter_t*), *list);
+    if (*list == NULL) {
+        os_calloc(1, sizeof(w_journal_filter_t *), *list);
     }
 
     // Determine the size of the list
     size_t size = 0;
-    while ((*list)[size] != NULL)
-    {
+    while ((*list)[size] != NULL) {
         size++;
     }
 
     // Allocate memory for the new filter
-    os_realloc(*list, (size + 2) * sizeof(w_journal_filter_t*), *list);
+    os_realloc(*list, (size + 2) * sizeof(w_journal_filter_t *), *list);
 
     // Add the new filter
     (*list)[size] = filter;
@@ -1354,29 +1312,24 @@ bool w_journal_add_filter_to_list(w_journal_filters_list_t* list, w_journal_filt
     return true;
 }
 
-void w_journal_free_filters_list(w_journal_filters_list_t list)
-{
-    if (list == NULL)
-    {
+void w_journal_free_filters_list(w_journal_filters_list_t list) {
+    if (list == NULL) {
         return;
     }
 
-    for (size_t i = 0; list[i] != NULL; i++)
-    {
+    for (size_t i = 0; list[i] != NULL; i++) {
         w_journal_filter_free(list[i]);
     }
 
     os_free(list);
 }
 
-bool w_logreader_journald_merge(logreader ** logf_ptr, size_t src_index)
-{
+bool w_logreader_journald_merge(logreader ** logf_ptr, size_t src_index) {
     if (logf_ptr == NULL || *logf_ptr == NULL || src_index == 0) {
         return false;
     }
-    
 
-    logreader* logr = *logf_ptr;
+    logreader * logr = *logf_ptr;
 
     /* Check if src_index is in range and if it is a journald log reader */
     size_t i = 0;
@@ -1388,7 +1341,7 @@ bool w_logreader_journald_merge(logreader ** logf_ptr, size_t src_index)
     if (logr[i].journal_log == NULL) {
         return false;
     }
-    
+
     /* Search the first journald log reader, destination */
     bool dst_found = false;
     size_t dst_index = 0;
@@ -1399,19 +1352,21 @@ bool w_logreader_journald_merge(logreader ** logf_ptr, size_t src_index)
         }
     }
 
-    if (!dst_found)
-    {
+    if (!dst_found) {
         return false;
     }
-     
+
     /* Merge the filters */
-    bool src_has_filters = logr[src_index].journal_log->filters != NULL && logr[src_index].journal_log->filters[0] != NULL;
-    bool dst_has_filters = logr[dst_index].journal_log->filters != NULL && logr[dst_index].journal_log->filters[0] != NULL;
-    
+    bool src_has_filters = logr[src_index].journal_log->filters != NULL
+                           && logr[src_index].journal_log->filters[0] != NULL;
+    bool dst_has_filters = logr[dst_index].journal_log->filters != NULL
+                           && logr[dst_index].journal_log->filters[0] != NULL;
+
     // Disable filter is already disabled or if any don't have filters
     if (!src_has_filters || !dst_has_filters) {
         logr[dst_index].journal_log->disable_filters = true;
-        mwarn("The filters of the journald log will be disabled in the merge, because one of the configuration does not have filters.");
+        mwarn("The filters of the journald log will be disabled in the merge,"
+              "because one of the configuration does not have filters.");
     }
 
     // Move the filters from the src_index to the dst_index

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -14,6 +14,7 @@
 #define EVENTLOG     "eventlog"
 #define EVENTCHANNEL "eventchannel"
 #define MACOS        "macos"
+#define JOURNALD_LOG                  "journald"
 #define MULTI_LINE_REGEX              "multi-line-regex"
 #define MULTI_LINE_REGEX_TIMEOUT      5
 #define MULTI_LINE_REGEX_MAX_TIMEOUT  120
@@ -180,6 +181,11 @@ typedef struct w_journal_filter_t
 
 typedef w_journal_filter_t** w_journal_filters_list_t;
 
+typedef struct w_journal_log_config_t
+{
+    w_journal_filters_list_t filters; // List of filters
+} w_journal_log_config_t;
+
 /* Logreader config */
 typedef struct _logreader {
     off_t size;
@@ -200,8 +206,9 @@ typedef struct _logreader {
     char *ffile;
     char *file;
     char *logformat;
-    w_multiline_config_t * multiline; ///< Multiline regex config & state
-    w_macos_log_config_t * macos_log;   ///< macOS log config & state
+    w_multiline_config_t* multiline;     ///< Multiline regex config & state
+    w_macos_log_config_t* macos_log;     ///< macOS log config & state
+    w_journal_log_config_t* journal_log; ///< Journal log config & state
     long linecount;
     char *djb_program_name;
     char * channel_str;
@@ -299,6 +306,25 @@ const char * multiline_attr_replace_str(w_multiline_replace_type_t replace_type)
  */
 const char * multiline_attr_match_str(w_multiline_match_type_t match_type);
 
+
+/**
+ * @brief Init the journal configuration
+ * 
+ * @param config Journal log configuration
+ * @return bool true if the configuration was initialized, false otherwise
+ */
+bool init_w_journal_log_config_t(w_journal_log_config_t** config);
+
+/**
+ * @brief Add the filter conditions to the filter
+ * 
+ * <filter field="name" ignore_if_missing="yes">expression</filter>
+ * @param node XML node to parse
+ * @param filter Journal log filter
+ * @return bool true if the filter was added, false otherwise
+ */
+bool journald_add_condition_to_filter(xml_node *node, w_journal_filter_t** filter);
+
 /**
  * @brief Free the filter and all its resources
  *
@@ -316,7 +342,7 @@ void w_journal_filter_free(w_journal_filter_t* filter);
  * @param ignore_if_missing Ignore if the field is missing
  * @return int 0 on success or non-zero on error
  */
-int w_journal_filter_add_condition(w_journal_filter_t** filter, char* field, char* expression, bool ignore_if_missing);
+int w_journal_filter_add_condition(w_journal_filter_t** filter, const char* field, char* expression, bool ignore_if_missing);
 
 /**
  * @brief Add a filter to the filters list

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -272,8 +272,30 @@ void Free_Localfile(logreader_config * config);
 /* Frees a localfile  */
 void Free_Logreader(logreader * logf);
 
+/**
+ * @brief Clean a logreader
+ *
+ * Removes all the resources of a logreader, freeing the memory and setting all members to NULL.
+ * @param logf logreader to clean
+ */
+void w_clean_logreader(logreader * logf);
+
 /* Removes a specific localfile of an array */
 int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *globf);
+
+/**
+ * @brief Free the macos log config and all its resources
+ * 
+ * @param macos_log Macos log config
+ */
+void w_macos_log_config_free(w_macos_log_config_t** config);
+
+/**
+ * @brief Free the multiline log config and all its resources
+ * 
+ * @param multiline Multiline log config
+ */
+void w_multiline_log_config_free(w_multiline_config_t** config);
 
 /**
  * @brief Get match attribute for multiline regex
@@ -324,6 +346,14 @@ const char * multiline_attr_match_str(w_multiline_match_type_t match_type);
  * @return bool true if the configuration was initialized, false otherwise
  */
 bool init_w_journal_log_config_t(w_journal_log_config_t** config);
+
+/**
+ * @brief Free the journal configuration and all its resources
+ * 
+ * *config will be set to NULL after the call.
+ * @param config Journal log configuration
+ */
+void w_journal_log_config_free(w_journal_log_config_t** config);
 
 /**
  * @brief Add the filter conditions to the filter

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -20,7 +20,7 @@
 #define MULTI_LINE_REGEX_MAX_TIMEOUT  120
 #define DATE_MODIFIED   1
 #define DEFAULT_EVENTCHANNEL_REC_TIME 5
-#define DIFF_DEFAULT_SIZE 10 * 1024 * 1024
+#define DIFF_DEFAULT_SIZE (10 * 1024 * 1024)
 #define DEFAULT_FREQUENCY_SECS  360
 #define DIFF_MAX_SIZE (2 * 1024 * 1024 * 1024LL)
 
@@ -181,9 +181,19 @@ typedef struct w_journal_filter_t
 
 typedef w_journal_filter_t** w_journal_filters_list_t;
 
+/**
+ * @brief Represents the configuration of the journal log
+ * 
+ * Whens a configuration doesn't have a filter, all log entries are read.
+ * Whens merging the configuration of two journal log readers, the filters of the second 
+ * log reader are added to the first one.
+ * If any of the log readers don't have a filter, then the filter are disabled,
+ * all log entries are read. 
+ */
 typedef struct w_journal_log_config_t
 {
     w_journal_filters_list_t filters; // List of filters
+    bool disable_filters;              // Disable filters
 } w_journal_log_config_t;
 
 /* Logreader config */
@@ -260,7 +270,7 @@ typedef struct _logreader_config {
 void Free_Localfile(logreader_config * config);
 
 /* Frees a localfile  */
-void Free_Logreader(logreader * config);
+void Free_Logreader(logreader * logf);
 
 /* Removes a specific localfile of an array */
 int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *globf);
@@ -361,5 +371,19 @@ bool w_journal_add_filter_to_list(w_journal_filters_list_t* list, w_journal_filt
  * The list pointer is invalid after the call.
  */
 void w_journal_free_filters_list(w_journal_filters_list_t list);
+
+/**
+ * @brief Merge configuration of two journald log readers, if possible
+ * 
+ * Search in the log readers the first journald log reader and add the filters of the second log reader to the first one.
+ * @param logf Array of log readers
+ * @param src_index Index of the current log reader (Must be a journald log reader)
+ * @return true if the merge was successful, false otherwise
+ * @return false if the src_index log reader is not a journald log reader
+ * @return false if dont find a other journald log reader to merge
+ * @return false if src_index index is out of range
+ * @note the second log reader will be removed from the array
+ */
+bool w_logreader_journald_merge(logreader ** logf_ptr, size_t src_index);
 
 #endif /* CLOGREADER_H */

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -163,23 +163,21 @@ typedef struct {
 /**
  * @brief Represents a filter unit, the minimal condition of a filter
  */
-typedef struct _w_journal_filter_unit_t
-{
-    char* field;           // Field to try match
-    w_expression_t* exp;   // Expression to match against the field (PCRE2)
+typedef struct _w_journal_filter_unit_t {
+    char * field;           // Field to try match
+    w_expression_t * exp;   // Expression to match against the field (PCRE2)
     bool ignore_if_missing; // Ignore if the field is missing (TODO: Use BOOL)
 } _w_journal_filter_unit_t;
 
 /**
  * @brief Represents a filter, a set of filter units, all of which must match
  */
-typedef struct w_journal_filter_t
-{
-    _w_journal_filter_unit_t** units; // Array of unit filter TODO Change to list
-    size_t units_size;                // Number of units
+typedef struct w_journal_filter_t {
+    _w_journal_filter_unit_t ** units; // Array of unit filter TODO Change to list
+    size_t units_size;                 // Number of units
 } w_journal_filter_t;
 
-typedef w_journal_filter_t** w_journal_filters_list_t;
+typedef w_journal_filter_t ** w_journal_filters_list_t;
 
 /**
  * @brief Represents the configuration of the journal log
@@ -285,17 +283,17 @@ int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *gl
 
 /**
  * @brief Free the macos log config and all its resources
- * 
+ *
  * @param macos_log Macos log config
  */
-void w_macos_log_config_free(w_macos_log_config_t** config);
+void w_macos_log_config_free(w_macos_log_config_t ** config);
 
 /**
  * @brief Free the multiline log config and all its resources
- * 
+ *
  * @param multiline Multiline log config
  */
-void w_multiline_log_config_free(w_multiline_config_t** config);
+void w_multiline_log_config_free(w_multiline_config_t ** config);
 
 /**
  * @brief Get match attribute for multiline regex
@@ -338,39 +336,38 @@ const char * multiline_attr_replace_str(w_multiline_replace_type_t replace_type)
  */
 const char * multiline_attr_match_str(w_multiline_match_type_t match_type);
 
-
 /**
  * @brief Init the journal configuration
- * 
+ *
  * @param config Journal log configuration
  * @return bool true if the configuration was initialized, false otherwise
  */
-bool init_w_journal_log_config_t(w_journal_log_config_t** config);
+bool init_w_journal_log_config_t(w_journal_log_config_t ** config);
 
 /**
  * @brief Free the journal configuration and all its resources
- * 
+ *
  * *config will be set to NULL after the call.
  * @param config Journal log configuration
  */
-void w_journal_log_config_free(w_journal_log_config_t** config);
+void w_journal_log_config_free(w_journal_log_config_t ** config);
 
 /**
  * @brief Add the filter conditions to the filter
- * 
+ *
  * <filter field="name" ignore_if_missing="yes">expression</filter>
  * @param node XML node to parse
  * @param filter Journal log filter
  * @return bool true if the filter was added, false otherwise
  */
-bool journald_add_condition_to_filter(xml_node *node, w_journal_filter_t** filter);
+bool journald_add_condition_to_filter(xml_node * node, w_journal_filter_t ** filter);
 
 /**
  * @brief Free the filter and all its resources
  *
  * The filter pointer is invalid after the call.
  */
-void w_journal_filter_free(w_journal_filter_t* filter);
+void w_journal_filter_free(w_journal_filter_t * filter);
 
 /**
  * @brief Add a condition to the filter, creating the filter if it does not exist
@@ -382,18 +379,21 @@ void w_journal_filter_free(w_journal_filter_t* filter);
  * @param ignore_if_missing Ignore if the field is missing
  * @return int 0 on success or non-zero on error
  */
-int w_journal_filter_add_condition(w_journal_filter_t** filter, const char* field, char* expression, bool ignore_if_missing);
+int w_journal_filter_add_condition(w_journal_filter_t ** filter,
+                                   const char * field,
+                                   char * expression,
+                                   bool ignore_if_missing);
 
 /**
  * @brief Add a filter to the filters list
- * 
+ *
  * If the list is NULL, it will be created.
  * The filter will be added to the list and reallocated if necessary.
  * @param list Filters list
  * @param filter Filter to add
  * @return return false if filter is NULL or list is NULL
  */
-bool w_journal_add_filter_to_list(w_journal_filters_list_t* list, w_journal_filter_t* filter);
+bool w_journal_add_filter_to_list(w_journal_filters_list_t * list, w_journal_filter_t * filter);
 
 /**
  * @brief Free the filter list and all its resources
@@ -404,8 +404,9 @@ void w_journal_free_filters_list(w_journal_filters_list_t list);
 
 /**
  * @brief Merge configuration of two journald log readers, if possible
- * 
- * Search in the log readers the first journald log reader and add the filters of the second log reader to the first one.
+ *
+ * Search in the log readers the first journald log reader and add the filters of the second log reader to the first
+ * one.
  * @param logf Array of log readers
  * @param src_index Index of the current log reader (Must be a journald log reader)
  * @return true if the merge was successful, false otherwise

--- a/src/headers/os_ip.h
+++ b/src/headers/os_ip.h
@@ -2,14 +2,10 @@
 #define SHARED_OS_IP_H
 
 #define w_free_os_ip(x)                                                                                                \
-    if (x)                                                                                                             \
-    {                                                                                                                  \
-        if (x->is_ipv6)                                                                                                \
-        {                                                                                                              \
+    if (x) {                                                                                                           \
+        if (x->is_ipv6) {                                                                                              \
             os_free(x->ipv6)                                                                                           \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
+        } else {                                                                                                       \
             os_free(x->ipv4)                                                                                           \
         };                                                                                                             \
         os_free(x->ip);                                                                                                \
@@ -17,27 +13,23 @@
     }
 
 /* IPv4 structure */
-typedef struct _os_ipv4
-{
+typedef struct _os_ipv4 {
     unsigned int ip_address;
     unsigned int netmask;
 } os_ipv4;
 
 /* IPv6 structure */
-typedef struct _os_ipv6
-{
+typedef struct _os_ipv6 {
     uint8_t ip_address[16];
     uint8_t netmask[16];
 } os_ipv6;
 
 /* IP structure */
-typedef struct _os_ip
-{
-    char* ip;
-    union
-    {
-        os_ipv4* ipv4;
-        os_ipv6* ipv6;
+typedef struct _os_ip {
+    char * ip;
+    union {
+        os_ipv4 * ipv4;
+        os_ipv6 * ipv6;
     };
     bool is_ipv6;
 } os_ip;

--- a/src/logcollector/journal_log.c
+++ b/src/logcollector/journal_log.c
@@ -14,25 +14,25 @@
 #include "debug_op.h"
 
 static const int W_SD_JOURNAL_LOCAL_ONLY = 1 << 0;
-static const char* W_LIB_SYSTEMD = "libsystemd.so.0";
+static const char * W_LIB_SYSTEMD = "libsystemd.so.0";
 
 // Function added on version 187 of systemd
-typedef int (*w_journal_open)(sd_journal** ret, int flags);            ///< sd_journal_open
-typedef void (*w_journal_close)(sd_journal* j);                        ///< sd_journal_close
-typedef int (*w_journal_previous)(sd_journal* j);                      ///< sd_journal_previous
-typedef int (*w_journal_next)(sd_journal* j);                          ///< sd_journal_next
-typedef int (*w_journal_seek_tail)(sd_journal* j);                     ///< sd_journal_seek_tail
-typedef int (*w_journal_seek_timestamp)(sd_journal* j, uint64_t usec); ///< sd_journal_seek_realtime_usec
-typedef int (*w_journal_get_cutoff_timestamp)(sd_journal* j,
-                                              uint64_t* from,
-                                              uint64_t* to);          ///< sd_journal_get_cutoff_realtime_usec
-typedef int (*w_journal_get_timestamp)(sd_journal* j, uint64_t* ret); ///< sd_journal_get_realtime_usec
-typedef int (*w_journal_get_data)(sd_journal* j,
-                                  const char* field,
-                                  const void** data,
-                                  size_t* l);                                         ///< sd_journal_get_data
-typedef void (*w_journal_restart_data)(sd_journal* j);                                ///< sd_journal_restart_data
-typedef int (*w_journal_enumerate_date)(sd_journal* j, const void** data, size_t* l); ///< sd_journal_enumerate_data
+typedef int (*w_journal_open)(sd_journal ** ret, int flags);            ///< sd_journal_open
+typedef void (*w_journal_close)(sd_journal * j);                        ///< sd_journal_close
+typedef int (*w_journal_previous)(sd_journal * j);                      ///< sd_journal_previous
+typedef int (*w_journal_next)(sd_journal * j);                          ///< sd_journal_next
+typedef int (*w_journal_seek_tail)(sd_journal * j);                     ///< sd_journal_seek_tail
+typedef int (*w_journal_seek_timestamp)(sd_journal * j, uint64_t usec); ///< sd_journal_seek_realtime_usec
+typedef int (*w_journal_get_cutoff_timestamp)(sd_journal * j,
+                                              uint64_t * from,
+                                              uint64_t * to);           ///< sd_journal_get_cutoff_realtime_usec
+typedef int (*w_journal_get_timestamp)(sd_journal * j, uint64_t * ret); ///< sd_journal_get_realtime_usec
+typedef int (*w_journal_get_data)(sd_journal * j,
+                                  const char * field,
+                                  const void ** data,
+                                  size_t * l);                                           ///< sd_journal_get_data
+typedef void (*w_journal_restart_data)(sd_journal * j);                                  ///< sd_journal_restart_data
+typedef int (*w_journal_enumerate_date)(sd_journal * j, const void ** data, size_t * l); ///< sd_journal_enumerate_data
 
 /**
  * @brief Journal log library
@@ -40,8 +40,7 @@ typedef int (*w_journal_enumerate_date)(sd_journal* j, const void** data, size_t
  * This structure is used to store the functions of the journal log library.
  * The functions are used to interact with the journal log.
  */
-struct w_journal_lib_t
-{
+struct w_journal_lib_t {
     // Open and close functions
     w_journal_open open;   ///< Open the journal log
     w_journal_close close; ///< Close the journal log
@@ -57,7 +56,7 @@ struct w_journal_lib_t
     w_journal_get_data get_data;             ///< Get the data of the specified field in the current entry
     w_journal_restart_data restart_data;     ///< Restart the enumeration of the available data
     w_journal_enumerate_date enumerate_date; ///< Enumerate the available data in the current entry
-    void* handle;                            ///< Handle of the library
+    void * handle;                           ///< Handle of the library
 };
 
 /**********************************************************
@@ -69,11 +68,10 @@ struct w_journal_lib_t
  *
  * @return int64_t
  */
-static inline uint64_t w_get_epoch_time()
-{
+static inline uint64_t w_get_epoch_time() {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    return (uint64_t)tv.tv_sec * 1000000 + tv.tv_usec;
+    return (uint64_t) tv.tv_sec * 1000000 + tv.tv_usec;
 }
 
 /**
@@ -83,16 +81,14 @@ static inline uint64_t w_get_epoch_time()
  * @param timestamp The epoch time
  * @return char* The human-readable string or NULL on error
  */
-static inline char* w_timestamp_to_string(uint64_t timestamp)
-{
+static inline char * w_timestamp_to_string(uint64_t timestamp) {
     struct tm tm;
     time_t time = timestamp / 1000000;
-    if (gmtime_r(&time, &tm) == NULL)
-    {
+    if (gmtime_r(&time, &tm) == NULL) {
         return NULL;
     }
 
-    char* str;
+    char * str;
     os_calloc(sizeof("Mar 01 12:39:34") + 1, sizeof(char), str);
     strftime(str, sizeof("Mar 01 12:39:34"), "%b %d %T", &tm);
     return str;
@@ -110,24 +106,20 @@ static inline char* w_timestamp_to_string(uint64_t timestamp)
  * @param library_name The name of the library to search for.
  * @return The path of the library if found, or NULL if not found or an error occurred.
  */
-char* find_library_path(const char* library_name)
-{
-    FILE* maps_file = fopen("/proc/self/maps", "r");
-    if (maps_file == NULL)
-    {
+char * find_library_path(const char * library_name) {
+    FILE * maps_file = fopen("/proc/self/maps", "r");
+    if (maps_file == NULL) {
         return NULL;
     }
 
-    char* line = NULL;
+    char * line = NULL;
     size_t len = 0;
-    char* path = NULL;
+    char * path = NULL;
 
-    while (getline(&line, &len, maps_file) != -1)
-    {
-        if (strstr(line, library_name) != NULL)
-        {
-            char* path_start = strchr(line, '/');
-            char* path_end = strchr(path_start, '\n');
+    while (getline(&line, &len, maps_file) != -1) {
+        if (strstr(line, library_name) != NULL) {
+            char * path_start = strchr(line, '/');
+            char * path_end = strchr(path_start, '\n');
             *path_end = '\0';
             path = strndup(path_start, path_end - path_start);
             break;
@@ -148,11 +140,9 @@ char* find_library_path(const char* library_name)
  * @param library_path The path to the file to be checked.
  * @return true if the file is owned by the root user, false otherwise.
  */
-bool is_owned_by_root(const char* library_path)
-{
+bool is_owned_by_root(const char * library_path) {
     struct stat file_stat;
-    if (stat(library_path, &file_stat) != 0)
-    {
+    if (stat(library_path, &file_stat) != 0) {
         return false;
     }
 
@@ -161,17 +151,15 @@ bool is_owned_by_root(const char* library_path)
 
 /**
  * @brief Load and validate a function from a library.
- * 
+ *
  * @param handle Library handle
  * @param name Function name
  * @param func Function pointer
  * @return true if the function was loaded and validated successfully, false otherwise.
  */
-static inline bool load_and_validate_function(void* handle, const char* name, void** func)
-{
+static inline bool load_and_validate_function(void * handle, const char * name, void ** func) {
     *func = dlsym(handle, name);
-    if (*func == NULL)
-    {
+    if (*func == NULL) {
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_LIB_FAIL_LOAD, name, dlerror());
         return false;
     }
@@ -184,25 +172,22 @@ static inline bool load_and_validate_function(void* handle, const char* name, vo
  * The caller is responsible for freeing the returned library.
  * @return w_journal_lib_t* The library or NULL on error
  */
-static inline w_journal_lib_t* w_journal_lib_init()
-{
-    w_journal_lib_t* lib = NULL;
+static inline w_journal_lib_t * w_journal_lib_init() {
+    w_journal_lib_t * lib = NULL;
     os_calloc(1, sizeof(w_journal_lib_t), lib);
 
     // Load the library
     lib->handle = dlopen(W_LIB_SYSTEMD, RTLD_LAZY);
-    if (lib->handle == NULL)
-    {
-        char* err = dlerror();
+    if (lib->handle == NULL) {
+        char * err = dlerror();
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_LIB_FAIL_LOAD, W_LIB_SYSTEMD, err == NULL ? "Unknown error" : err);
         os_free(lib);
         return NULL;
     }
 
     // Verify the ownership of the library
-    char* library_path = find_library_path(W_LIB_SYSTEMD);
-    if (library_path == NULL || !is_owned_by_root(library_path))
-    {
+    char * library_path = find_library_path(W_LIB_SYSTEMD);
+    if (library_path == NULL || !is_owned_by_root(library_path)) {
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_LIB_FAIL_OWN, W_LIB_SYSTEMD);
         os_free(library_path);
         dlclose(lib->handle);
@@ -212,21 +197,21 @@ static inline w_journal_lib_t* w_journal_lib_init()
     os_free(library_path);
 
     // Load and verify the functions
-    bool ok = load_and_validate_function(lib->handle, "sd_journal_open", (void**)&lib->open)
-              && load_and_validate_function(lib->handle, "sd_journal_close", (void**)&lib->close)
-              && load_and_validate_function(lib->handle, "sd_journal_previous", (void**)&lib->previous)
-              && load_and_validate_function(lib->handle, "sd_journal_next", (void**)&lib->next)
-              && load_and_validate_function(lib->handle, "sd_journal_seek_tail", (void**)&lib->seek_tail)
-              && load_and_validate_function(lib->handle, "sd_journal_seek_realtime_usec", (void**)&lib->seek_timestamp)
-              && load_and_validate_function(lib->handle, "sd_journal_get_realtime_usec", (void**)&lib->get_timestamp)
-              && load_and_validate_function(lib->handle, "sd_journal_get_data", (void**)&lib->get_data)
-              && load_and_validate_function(lib->handle, "sd_journal_restart_data", (void**)&lib->restart_data)
-              && load_and_validate_function(lib->handle, "sd_journal_enumerate_data", (void**)&lib->enumerate_date)
-              && load_and_validate_function(
-                  lib->handle, "sd_journal_get_cutoff_realtime_usec", (void**)&lib->get_cutoff_timestamp);
+    bool ok =
+        load_and_validate_function(lib->handle, "sd_journal_open", (void **) &lib->open)
+        && load_and_validate_function(lib->handle, "sd_journal_close", (void **) &lib->close)
+        && load_and_validate_function(lib->handle, "sd_journal_previous", (void **) &lib->previous)
+        && load_and_validate_function(lib->handle, "sd_journal_next", (void **) &lib->next)
+        && load_and_validate_function(lib->handle, "sd_journal_seek_tail", (void **) &lib->seek_tail)
+        && load_and_validate_function(lib->handle, "sd_journal_seek_realtime_usec", (void **) &lib->seek_timestamp)
+        && load_and_validate_function(lib->handle, "sd_journal_get_realtime_usec", (void **) &lib->get_timestamp)
+        && load_and_validate_function(lib->handle, "sd_journal_get_data", (void **) &lib->get_data)
+        && load_and_validate_function(lib->handle, "sd_journal_restart_data", (void **) &lib->restart_data)
+        && load_and_validate_function(lib->handle, "sd_journal_enumerate_data", (void **) &lib->enumerate_date)
+        && load_and_validate_function(
+            lib->handle, "sd_journal_get_cutoff_realtime_usec", (void **) &lib->get_cutoff_timestamp);
 
-    if (!ok)
-    {
+    if (!ok) {
         dlclose(lib->handle);
         os_free(lib);
         return NULL;
@@ -239,36 +224,30 @@ static inline w_journal_lib_t* w_journal_lib_init()
  *                    Context related
  ***********************************************************/
 
-int w_journal_context_create(w_journal_context_t** ctx)
-{
+int w_journal_context_create(w_journal_context_t ** ctx) {
     int ret = -1; // Return error by default
 
-    if (ctx == NULL)
-    {
+    if (ctx == NULL) {
         return ret;
     }
     os_calloc(1, sizeof(w_journal_context_t), (*ctx));
 
     (*ctx)->lib = w_journal_lib_init();
-    if ((*ctx)->lib == NULL)
-    {
+    if ((*ctx)->lib == NULL) {
         os_free(*ctx);
         return ret;
     }
 
     ret = (*ctx)->lib->open(&((*ctx)->journal), W_SD_JOURNAL_LOCAL_ONLY);
-    if (ret < 0)
-    {
+    if (ret < 0) {
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_FAIL_OPEN, strerror(-ret));
         os_free(*ctx);
     }
     return ret;
 }
 
-void w_journal_context_free(w_journal_context_t* ctx)
-{
-    if (ctx == NULL)
-    {
+void w_journal_context_free(w_journal_context_t * ctx) {
+    if (ctx == NULL) {
         return;
     }
 
@@ -278,48 +257,39 @@ void w_journal_context_free(w_journal_context_t* ctx)
     os_free(ctx);
 }
 
-void w_journal_context_update_timestamp(w_journal_context_t* ctx)
-{
+void w_journal_context_update_timestamp(w_journal_context_t * ctx) {
     static bool failed_logged = false;
-    if (ctx == NULL)
-    {
+    if (ctx == NULL) {
         return;
     }
 
     int err = ctx->lib->get_timestamp(ctx->journal, &(ctx->timestamp));
-    if (err < 0)
-    {
+    if (err < 0) {
         ctx->timestamp = w_get_epoch_time();
-        if (!failed_logged)
-        {
+        if (!failed_logged) {
             failed_logged = true;
             mwarn(LOGCOLLECTOR_JOURNAL_LOG_FAIL_READ_TS, strerror(-err));
         }
     }
 }
 
-int w_journal_context_seek_most_recent(w_journal_context_t* ctx)
-{
+int w_journal_context_seek_most_recent(w_journal_context_t * ctx) {
     int err = ctx->lib->seek_tail(ctx->journal);
-    if (err < 0)
-    {
+    if (err < 0) {
         return err;
     }
 
     err = ctx->lib->previous(ctx->journal);
     // if change cursor, update timestamp
-    if (err > 0)
-    {
+    if (err > 0) {
         w_journal_context_update_timestamp(ctx);
     }
     return err;
 }
 
-int w_journal_context_seek_timestamp(w_journal_context_t* ctx, uint64_t timestamp)
-{
+int w_journal_context_seek_timestamp(w_journal_context_t * ctx, uint64_t timestamp) {
     // If the timestamp is in the future or invalid, seek the most recent entry
-    if (timestamp == 0 || timestamp > w_get_epoch_time())
-    {
+    if (timestamp == 0 || timestamp > w_get_epoch_time()) {
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_FUTURE_TS, timestamp);
         return ctx->lib->seek_tail(ctx->journal);
     }
@@ -328,19 +298,15 @@ int w_journal_context_seek_timestamp(w_journal_context_t* ctx, uint64_t timestam
     uint64_t oldest;
     int err = w_journal_context_get_oldest_timestamp(ctx, &oldest);
 
-    if (err < 0)
-    {
+    if (err < 0) {
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_FAIL_READ_OLD_TS, strerror(-err));
-    }
-    else if (timestamp < oldest)
-    {
+    } else if (timestamp < oldest) {
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_CHANGE_TS, timestamp);
         timestamp = oldest;
     }
 
     err = ctx->lib->seek_timestamp(ctx->journal, timestamp);
-    if (err < 0)
-    {
+    if (err < 0) {
         return err;
     }
 
@@ -352,34 +318,27 @@ int w_journal_context_seek_timestamp(w_journal_context_t* ctx, uint64_t timestam
     return err;
 }
 
-int w_journal_context_next_newest(w_journal_context_t* ctx)
-{
+int w_journal_context_next_newest(w_journal_context_t * ctx) {
     int ret = ctx->lib->next(ctx->journal);
 
     // if change cursor, update timestamp
-    if (ret > 0)
-    {
+    if (ret > 0) {
         w_journal_context_update_timestamp(ctx);
     }
 
     return ret;
 }
 
-int w_journal_context_next_newest_filtered(w_journal_context_t* ctx, w_journal_filters_list_t filters)
-{
+int w_journal_context_next_newest_filtered(w_journal_context_t * ctx, w_journal_filters_list_t filters) {
 
-    if (filters == NULL)
-    {
+    if (filters == NULL) {
         return w_journal_context_next_newest(ctx);
     }
 
     int ret = 0;
-    while ((ret = w_journal_context_next_newest(ctx)) > 0)
-    {
-        for (size_t i = 0; filters[i] != NULL; i++)
-        {
-            if (w_journal_filter_apply(ctx, filters[i]) > 0)
-            {
+    while ((ret = w_journal_context_next_newest(ctx)) > 0) {
+        for (size_t i = 0; filters[i] != NULL; i++) {
+            if (w_journal_filter_apply(ctx, filters[i]) > 0) {
                 return 1;
             }
         }
@@ -389,8 +348,7 @@ int w_journal_context_next_newest_filtered(w_journal_context_t* ctx, w_journal_f
 }
 
 // Check return value on value un error
-int w_journal_context_get_oldest_timestamp(w_journal_context_t* ctx, uint64_t* timestamp)
-{
+int w_journal_context_get_oldest_timestamp(w_journal_context_t * ctx, uint64_t * timestamp) {
     return ctx->lib->get_cutoff_timestamp(ctx->journal, timestamp, NULL);
 }
 
@@ -404,29 +362,26 @@ int w_journal_context_get_oldest_timestamp(w_journal_context_t* ctx, uint64_t* t
  * @param ctx Journal log context
  * @return cJSON* JSON object with the available data or NULL on error
  */
-static inline cJSON* entry_as_json(w_journal_context_t* ctx)
-{
-    cJSON* dump = cJSON_CreateObject();
+static inline cJSON * entry_as_json(w_journal_context_t * ctx) {
+    cJSON * dump = cJSON_CreateObject();
     int isEmpty = 1; // Flag to check if the entry is empty
 
     // Iterate through the available data
-    const void* data;
+    const void * data;
     size_t length;
     ctx->lib->restart_data(ctx->journal);
-    while (ctx->lib->enumerate_date(ctx->journal, &data, &length) > 0)
-    {
+    while (ctx->lib->enumerate_date(ctx->journal, &data, &length) > 0) {
         // Value is a string "key=value" without null-terminator
-        const char* equal_sign = memchr(data, '=', length);
-        if (!equal_sign)
-        {
+        const char * equal_sign = memchr(data, '=', length);
+        if (!equal_sign) {
             continue;
         }
 
-        size_t key_len = equal_sign - (const char*)data;
+        size_t key_len = equal_sign - (const char *) data;
         size_t value_len = length - key_len - 1;
 
-        char* key = strndup(data, key_len);
-        char* value = strndup(equal_sign + 1, value_len);
+        char * key = strndup(data, key_len);
+        char * value = strndup(equal_sign + 1, value_len);
 
         // Add the key and value to the JSON object
         cJSON_AddStringToObject(dump, key, value);
@@ -437,8 +392,7 @@ static inline cJSON* entry_as_json(w_journal_context_t* ctx)
     }
 
     // Error or no data
-    if (isEmpty)
-    {
+    if (isEmpty) {
         cJSON_Delete(dump);
         return NULL;
     }
@@ -453,26 +407,23 @@ static inline cJSON* entry_as_json(w_journal_context_t* ctx)
  * @param value
  * @return int
  */
-static inline char* get_field_ptr(w_journal_context_t* ctx, const char* field)
-{
-    const void* data;
+static inline char * get_field_ptr(w_journal_context_t * ctx, const char * field) {
+    const void * data;
     size_t length;
 
     int err = ctx->lib->get_data(ctx->journal, field, &data, &length);
-    if (err < 0)
-    {
+    if (err < 0) {
         return NULL;
     }
 
     // Assume that the value is a string "key=value"
-    const char* equal_sign = memchr(data, '=', length);
-    if (!equal_sign)
-    {
+    const char * equal_sign = memchr(data, '=', length);
+    if (!equal_sign) {
         return NULL; // Invalid value
     }
 
     // Copy the value
-    size_t key_len = equal_sign - (const char*)data;
+    size_t key_len = equal_sign - (const char *) data;
     size_t value_len = length - key_len - 1;
 
     return strndup(equal_sign + 1, value_len);
@@ -492,10 +443,12 @@ static inline char* get_field_ptr(w_journal_context_t* ctx, const char* field)
  * @return char*
  * @warning The arguments must be valid strings (except pid)
  */
-static inline char* create_plain_syslog(
-    const char* timestamp, const char* hostname, const char* syslog_identifier, const char* pid, const char* message)
-{
-    static const char* syslog_format = "%s %s %s%s%s%s: %s";
+static inline char * create_plain_syslog(const char * timestamp,
+                                         const char * hostname,
+                                         const char * syslog_identifier,
+                                         const char * pid,
+                                         const char * message) {
+    static const char * syslog_format = "%s %s %s%s%s%s: %s";
 
     size_t size = snprintf(NULL,
                            0,
@@ -509,7 +462,7 @@ static inline char* create_plain_syslog(
                            message)
                   + 1;
 
-    char* syslog_msg;
+    char * syslog_msg;
     os_calloc(size, sizeof(char), syslog_msg);
     snprintf(syslog_msg,
              size,
@@ -531,20 +484,17 @@ static inline char* create_plain_syslog(
  * @param type
  * @return w_journal_entry_t*
  */
-static inline char* entry_as_syslog(w_journal_context_t* ctx)
-{
-    char* hostname = get_field_ptr(ctx, "_HOSTNAME");
-    char* syslog_identifier = get_field_ptr(ctx, "SYSLOG_IDENTIFIER");
-    char* message = get_field_ptr(ctx, "MESSAGE");
-    char* pid = get_field_ptr(ctx, "SYSLOG_PID");
-    if (pid == NULL)
-    {
+static inline char * entry_as_syslog(w_journal_context_t * ctx) {
+    char * hostname = get_field_ptr(ctx, "_HOSTNAME");
+    char * syslog_identifier = get_field_ptr(ctx, "SYSLOG_IDENTIFIER");
+    char * message = get_field_ptr(ctx, "MESSAGE");
+    char * pid = get_field_ptr(ctx, "SYSLOG_PID");
+    if (pid == NULL) {
         pid = get_field_ptr(ctx, "_PID");
     }
-    char* timestamp = w_timestamp_to_string(ctx->timestamp);
+    char * timestamp = w_timestamp_to_string(ctx->timestamp);
 
-    if (!hostname || !syslog_identifier || !message || !timestamp)
-    {
+    if (!hostname || !syslog_identifier || !message || !timestamp) {
         mdebug2(LOGCOLLECTOR_JOURNAL_LOG_NOT_SYSLOG, ctx->timestamp);
         os_free(hostname);
         os_free(syslog_identifier);
@@ -554,7 +504,7 @@ static inline char* entry_as_syslog(w_journal_context_t* ctx)
         return NULL;
     }
 
-    char* syslog_msg = create_plain_syslog(timestamp, hostname, syslog_identifier, pid, message);
+    char * syslog_msg = create_plain_syslog(timestamp, hostname, syslog_identifier, pid, message);
 
     // Free the memory
     os_free(hostname);
@@ -566,74 +516,73 @@ static inline char* entry_as_syslog(w_journal_context_t* ctx)
     return syslog_msg;
 }
 
-w_journal_entry_t* w_journal_entry_dump(w_journal_context_t* ctx, w_journal_entry_dump_type_t type)
-{
-    if (ctx == NULL || ctx->journal == NULL)
-    {
+w_journal_entry_t * w_journal_entry_dump(w_journal_context_t * ctx, w_journal_entry_dump_type_t type) {
+    if (ctx == NULL || ctx->journal == NULL) {
         return NULL;
     }
 
-    w_journal_entry_t* entry = calloc(1, sizeof(w_journal_entry_t));
+    w_journal_entry_t * entry = calloc(1, sizeof(w_journal_entry_t));
     entry->type = W_JOURNAL_ENTRY_DUMP_TYPE_INVALID;
     entry->timestamp = ctx->timestamp;
 
     // Create the dump
-    switch (type)
-    {
-        case W_JOURNAL_ENTRY_DUMP_TYPE_JSON:
-            entry->data.json = entry_as_json(ctx);
-            if (entry->data.json != NULL)
-            {
-                entry->type = W_JOURNAL_ENTRY_DUMP_TYPE_JSON;
-            }
-            break;
-        case W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG:
-            entry->data.syslog = entry_as_syslog(ctx);
-            if (entry->data.syslog != NULL)
-            {
-                entry->type = W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG;
-            }
-            break;
-        default: break;
+    switch (type) {
+    case W_JOURNAL_ENTRY_DUMP_TYPE_JSON:
+        entry->data.json = entry_as_json(ctx);
+        if (entry->data.json != NULL) {
+            entry->type = W_JOURNAL_ENTRY_DUMP_TYPE_JSON;
+        }
+        break;
+    case W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG:
+        entry->data.syslog = entry_as_syslog(ctx);
+        if (entry->data.syslog != NULL) {
+            entry->type = W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG;
+        }
+        break;
+    default:
+        break;
     }
 
-    if (entry->type == W_JOURNAL_ENTRY_DUMP_TYPE_INVALID)
-    {
+    if (entry->type == W_JOURNAL_ENTRY_DUMP_TYPE_INVALID) {
         os_free(entry);
         return NULL;
     }
     return entry;
 }
 
-void w_journal_entry_free(w_journal_entry_t* entry)
-{
-    if (entry == NULL)
-    {
+void w_journal_entry_free(w_journal_entry_t * entry) {
+    if (entry == NULL) {
         return;
     }
 
-    switch (entry->type)
-    {
-        case W_JOURNAL_ENTRY_DUMP_TYPE_JSON: cJSON_Delete(entry->data.json); break;
-        case W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG: os_free(entry->data.syslog); break;
-        default: break;
+    switch (entry->type) {
+    case W_JOURNAL_ENTRY_DUMP_TYPE_JSON:
+        cJSON_Delete(entry->data.json);
+        break;
+    case W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG:
+        os_free(entry->data.syslog);
+        break;
+    default:
+        break;
     }
     os_free(entry);
 }
 
-char* w_journal_entry_to_string(w_journal_entry_t* entry)
-{
-    if (entry == NULL)
-    {
+char * w_journal_entry_to_string(w_journal_entry_t * entry) {
+    if (entry == NULL) {
         return NULL;
     }
 
-    char* str = NULL;
-    switch (entry->type)
-    {
-        case W_JOURNAL_ENTRY_DUMP_TYPE_JSON: str = cJSON_PrintUnformatted(entry->data.json); break;
-        case W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG: str = strdup(entry->data.syslog); break;
-        default: break;
+    char * str = NULL;
+    switch (entry->type) {
+    case W_JOURNAL_ENTRY_DUMP_TYPE_JSON:
+        str = cJSON_PrintUnformatted(entry->data.json);
+        break;
+    case W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG:
+        str = strdup(entry->data.syslog);
+        break;
+    default:
+        break;
     }
     return str;
 }
@@ -649,30 +598,23 @@ char* w_journal_entry_to_string(w_journal_entry_t* entry)
  * @param filter Journal log filter
  * @return int 1 if the entry matches the filter, 0 if it does not match, -1 on error
  */
-int w_journal_filter_apply(w_journal_context_t* ctx, w_journal_filter_t* filter)
-{
-    if (ctx == NULL || filter == NULL)
-    {
+int w_journal_filter_apply(w_journal_context_t * ctx, w_journal_filter_t * filter) {
+    if (ctx == NULL || filter == NULL) {
         return -1;
     }
 
-    for (size_t i = 0; i < filter->units_size; i++)
-    {
-        _w_journal_filter_unit_t* unit = filter->units[i];
+    for (size_t i = 0; i < filter->units_size; i++) {
+        _w_journal_filter_unit_t * unit = filter->units[i];
 
         // Get the data
-        const char* data;
+        const char * data;
         size_t length;
 
-        int err = ctx->lib->get_data(ctx->journal, unit->field, (const void**)&data, &length);
-        if (err < 0)
-        {
-            if (unit->ignore_if_missing)
-            {
+        int err = ctx->lib->get_data(ctx->journal, unit->field, (const void **) &data, &length);
+        if (err < 0) {
+            if (unit->ignore_if_missing) {
                 continue;
-            }
-            else
-            {
+            } else {
                 mdebug2(LOGCOLLECTOR_JOURNAL_LOG_FIELD_ERROR, unit->field, ctx->timestamp, strerror(-err));
                 return err;
             }
@@ -680,19 +622,17 @@ int w_journal_filter_apply(w_journal_context_t* ctx, w_journal_filter_t* filter)
 
         // Extract the value (data: key=value)
         size_t keyPart_len = strnlen(unit->field, length) + 1;
-        if (keyPart_len > length)
-        {
+        if (keyPart_len > length) {
             return -1; // invalid value
         }
         size_t value_len = length - keyPart_len;
-        char* value_str = strndup(data + keyPart_len, value_len);
-        const char* end_match;
+        char * value_str = strndup(data + keyPart_len, value_len);
+        const char * end_match;
 
         bool match = w_expression_match(unit->exp, value_str, &end_match, NULL);
 
         os_free(value_str);
-        if (!match)
-        {
+        if (!match) {
             return 0; // No match
         }
     }

--- a/src/logcollector/journal_log.h
+++ b/src/logcollector/journal_log.h
@@ -37,11 +37,10 @@ typedef struct w_journal_lib_t w_journal_lib_t; ///< Journal library functions
 /**
  * @brief Journal log context
  */
-typedef struct
-{
-    w_journal_lib_t* lib; ///< Journal functions
-    sd_journal* journal;  ///< Journal context
-    uint64_t timestamp;   ///< Last timestamp processed (__REALTIME_TIMESTAMP)
+typedef struct {
+    w_journal_lib_t * lib; ///< Journal functions
+    sd_journal * journal;  ///< Journal context
+    uint64_t timestamp;    ///< Last timestamp processed (__REALTIME_TIMESTAMP)
 } w_journal_context_t;
 
 /**
@@ -52,7 +51,7 @@ typedef struct
  * @return int 0 on success or -1 on error
  * @note The context should be created and used by a single thread only.
  */
-int w_journal_context_create(w_journal_context_t** ctx);
+int w_journal_context_create(w_journal_context_t ** ctx);
 
 /**
  * @brief Free the journal log context and all its resources
@@ -60,7 +59,7 @@ int w_journal_context_create(w_journal_context_t** ctx);
  * The context pointer is invalid after the call.
  * @param ctx Journal log context
  */
-void w_journal_context_free(w_journal_context_t* ctx);
+void w_journal_context_free(w_journal_context_t * ctx);
 
 /**
  * @brief Try update the timestamp in the journal log context with the timestamp of the current entry
@@ -68,7 +67,7 @@ void w_journal_context_free(w_journal_context_t* ctx);
  * If failed to get the timestamp, the timestamp updated with the current time.
  * @param ctx Journal log context
  */
-void w_journal_context_update_timestamp(w_journal_context_t* ctx);
+void w_journal_context_update_timestamp(w_journal_context_t * ctx);
 
 /**
  * @brief Move the cursor to the most recent entry
@@ -78,7 +77,7 @@ void w_journal_context_update_timestamp(w_journal_context_t* ctx);
  * @note This function is not thread-safe.
  *
  */
-int w_journal_context_seek_most_recent(w_journal_context_t* ctx);
+int w_journal_context_seek_most_recent(w_journal_context_t * ctx);
 
 /**
  * @brief Move the cursor to the entry with the specified timestamp or the next newer entry available.
@@ -89,7 +88,7 @@ int w_journal_context_seek_most_recent(w_journal_context_t* ctx);
  * @param timestamp The timestamp to seek
  * @return int 0 on success or a negative errno-style error code.
  */
-int w_journal_context_seek_timestamp(w_journal_context_t* ctx, uint64_t timestamp);
+int w_journal_context_seek_timestamp(w_journal_context_t * ctx, uint64_t timestamp);
 
 /**
  * @brief Move the cursor to the next newest entry
@@ -98,11 +97,11 @@ int w_journal_context_seek_timestamp(w_journal_context_t* ctx, uint64_t timestam
  * @return int 0 no more entries or a negative errno-style error code.
  * @note This function is not thread-safe.
  */
-int w_journal_context_next_newest(w_journal_context_t* ctx);
+int w_journal_context_next_newest(w_journal_context_t * ctx);
 
 /**
  * @brief Move the cursor to the next newest entry that matches the filters
- * 
+ *
  * If filters is NULL, the function will return the next newest entry.
  * If filters is not NULL, the function will return the next newest entry that matches the filters.
  * If no entry matches the filters, the function will return 0, but the cursor will be moved to the next newest entry.
@@ -110,7 +109,7 @@ int w_journal_context_next_newest(w_journal_context_t* ctx);
  * @param filters The filters to match
  * @return int 0 no more entries or a negative errno-style error code.
  */
-int w_journal_context_next_newest_filtered(w_journal_context_t* ctx, w_journal_filters_list_t filters);
+int w_journal_context_next_newest_filtered(w_journal_context_t * ctx, w_journal_filters_list_t filters);
 
 /**
  * @brief Get the oldest accessible timestamp in the journal (__REALTIME_TIMESTAMP)
@@ -120,7 +119,7 @@ int w_journal_context_next_newest_filtered(w_journal_context_t* ctx, w_journal_f
  * @return int 0 on success or a negative errno-style error code.
  * @note This function is not thread-safe.
  */
-int w_journal_context_get_oldest_timestamp(w_journal_context_t* ctx, uint64_t* timestamp);
+int w_journal_context_get_oldest_timestamp(w_journal_context_t * ctx, uint64_t * timestamp);
 
 /**********************************************************
  *                   Entry related
@@ -128,8 +127,7 @@ int w_journal_context_get_oldest_timestamp(w_journal_context_t* ctx, uint64_t* t
 /**
  * @brief Determine the types of dump of a journal log entry
  */
-typedef enum
-{
+typedef enum {
     W_JOURNAL_ENTRY_DUMP_TYPE_INVALID = -1, ///< Invalid dump type
     W_JOURNAL_ENTRY_DUMP_TYPE_JSON,         ///< JSON dump
     W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG,       ///< Syslog dump
@@ -138,13 +136,11 @@ typedef enum
 /**
  * @brief Represents a dump of a journal log entry
  */
-typedef struct
-{
+typedef struct {
     w_journal_entry_dump_type_t type; ///< Dump type
-    union
-    {
-        cJSON* json;    ///< JSON dump
-        char* syslog;   ///< Syslog dump
+    union {
+        cJSON * json;   ///< JSON dump
+        char * syslog;  ///< Syslog dump
     } data;             ///< Dump data
     uint64_t timestamp; ///< Indexing timestamp (__REALTIME_TIMESTAMP)
 } w_journal_entry_t;
@@ -158,7 +154,7 @@ typedef struct
  * @return w_journal_entry_t* The current entry or NULL on error
  * @note This function is not thread-safe.
  */
-w_journal_entry_t* w_journal_entry_dump(w_journal_context_t* ctx, w_journal_entry_dump_type_t type);
+w_journal_entry_t * w_journal_entry_dump(w_journal_context_t * ctx, w_journal_entry_dump_type_t type);
 
 /**
  * @brief Free the entry and all its resources,
@@ -166,7 +162,7 @@ w_journal_entry_t* w_journal_entry_dump(w_journal_context_t* ctx, w_journal_entr
  * The entry pointer is invalid after the call.
  * @param entry Journal log entry
  */
-void w_journal_entry_free(w_journal_entry_t* entry);
+void w_journal_entry_free(w_journal_entry_t * entry);
 
 /**
  * @brief Dump the current entry to a string representation
@@ -175,7 +171,7 @@ void w_journal_entry_free(w_journal_entry_t* entry);
  * @param entry Journal log entry
  * @return char*  The string representation of the entry or NULL on error
  */
-char* w_journal_entry_to_string(w_journal_entry_t* entry);
+char * w_journal_entry_to_string(w_journal_entry_t * entry);
 
 /**********************************************************
  *                   Filter related
@@ -189,6 +185,6 @@ char* w_journal_entry_to_string(w_journal_entry_t* entry);
  * @param filter Journal log filter
  * @return int positive number of entries matched, 0 if no entries matched, or a negative errno-style error code.
  */
-int w_journal_filter_apply(w_journal_context_t* ctx, w_journal_filter_t* filter);
+int w_journal_filter_apply(w_journal_context_t * ctx, w_journal_filter_t * filter);
 
 #endif // w_journal_H

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -2345,7 +2345,7 @@ static void check_text_only() {
                 #endif
                 int result = 0;
                 if (j < 0) {
-                    result = Remove_Localfile(&logff, i, 0, 1, NULL);
+                    result = Remove_Localfile(&logff, i, 0, 1, NULL); // Remove localfile w/o globs?
                 } else {
                     result = Remove_Localfile(&(globs[j].gfiles), i, 1, 0, &globs[j]);
                 }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -398,7 +398,7 @@ void LogCollectorStart()
             minfo(LOGCOLLECTOR_ONLY_MACOS);
 #endif
             os_free(current->file);
-            os_free(current->command);
+            current->command = NULL;
             os_free(current->fp);
         }
 
@@ -2345,7 +2345,7 @@ static void check_text_only() {
                 #endif
                 int result = 0;
                 if (j < 0) {
-                    result = Remove_Localfile(&logff, i, 0, 1, NULL); // Remove localfile w/o globs?
+                    result = Remove_Localfile(&logff, i, 0, 1, NULL);
                 } else {
                     result = Remove_Localfile(&(globs[j].gfiles), i, 1, 0, &globs[j]);
                 }


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22411 |
## Implement Support for Multiple Journal Configuration Blocks in ossec.conf

### Purpose
This Pull Request introduces the capability for Wazuh's Logcollector to parse and apply settings from multiple `<localfile>` blocks specific to `journald` logs within the `ossec.conf` file. This enhancement aims at providing greater flexibility and precision in log collection by allowing for detailed configuration, including support for complex filtering criteria based on PCRE2 regular expressions.

### Changes Made
- **Configuration Parsing Enhancements**: Updated the Logcollector configuration parser to recognize and correctly process multiple `journald`-specific `<localfile>` blocks.
- **Filtering Logic Implementation**: Developed the logic to handle `<filter>` tags within these blocks, enabling log filtering based on field values and regular expressions. The `ignore_missing` attribute has been incorporated to control filter behavior when specified fields are absent.
- **Logical Operation Handling**: Ensured that filters within a block apply with AND logic, while multiple blocks relate to each other with OR logic, according to the issue requirements.

### Addressing the Issue
This PR addresses the requirements outlined in the issue for Stage 2B: Support Multiple Journal Configuration Blocks in `ossec.conf`. It ensures that Wazuh's Logcollector can now handle more complex and nuanced log collection configurations, specifically tailored to `journald` logs.

### Testing Considerations
- Conducted comprehensive testing to ensure that Logcollector correctly loads and applies settings from multiple `journald`-specific configuration blocks.
- Verified the functionality and accuracy of the new filtering logic, including the handling of the `ignore_missing` attribute.
- Tested logical operations within and between blocks to confirm they meet the specified criteria.

### How to Test
Instructions on how to test the new features are included, detailing the steps to configure multiple `journald` log sources and how to set up various filters to control log collection.

### Conclusion
This PR significantly enhances the flexibility and effectiveness of log collection in Wazuh by supporting multiple `journald`-specific configuration blocks in `ossec.conf`. It opens up new possibilities for precise log monitoring and collection tailored to users' specific needs.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors