### PR TITLE
Delay OS scan if hotfixes information is not synced

### DIFF
--- a/src/shared_modules/utils/socketDBWrapper.hpp
+++ b/src/shared_modules/utils/socketDBWrapper.hpp
@@ -98,7 +98,15 @@ private:
                                 }
                                 else
                                 {
-                                    m_response.push_back(responseParsed);
+                                    if (responseParsed.contains("status") &&
+                                        responseParsed.at("status") == "NOT_SYNCED")
+                                    {
+                                        m_exceptionStr = "DB query not synced";
+                                    }
+                                    else
+                                    {
+                                        m_response.push_back(responseParsed);
+                                    }
                                 }
                             }
                             catch (const nlohmann::detail::exception& ex)

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
@@ -231,6 +231,8 @@ def run_process_and_monitor_log(request, run_on_end):
     if not test_folder.name == '000':
         regex = r"Event type: (.*) processed"
         found = find_regex_in_file(regex, log_file, len(expected_json_files))
+        regex = r"Discarded event: DB query not synced"
+        found = found or find_regex_in_file(regex, log_file, len(expected_json_files))
         assert found, "The scan is not finished"
 
     basetimeout = timeout
@@ -244,7 +246,7 @@ def run_process_and_monitor_log(request, run_on_end):
 
     return found_lines
 
-test_folders = sorted(Path("wazuh_modules/vulnerability_scanner/qa/test_data").glob("*"))
+test_folders = sorted(Path("wazuh_modules/vulnerability_scanner/qa/test_data").glob(os.getenv('WAZUH_VD_TEST_GLOB', '*')))
 
 @pytest.mark.parametrize("run_process_and_monitor_log", test_folders, indirect=True)
 def test_false_negatives(run_process_and_monitor_log):

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/fakeAgentData/agentHotfixesData.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/fakeAgentData/agentHotfixesData.json
@@ -57,5 +57,6 @@
       { "hotfix":"KB5034619" },
       { "hotfix":"KB5034768" },
       { "hotfix":"KB5034863" }
-  ]
+  ],
+  "1004":{"status":"NOT_SYNCED"}
 }


### PR DESCRIPTION
|Related issue|
|---|
|#22443|

## Description

This PR adds the OS events to the delayed queue when it is not possible to get the hotfixes information. 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux