### PR TITLE
Fix memory leak on indexer's configuration

### DIFF
--- a/src/config/indexer-config.c
+++ b/src/config/indexer-config.c
@@ -82,6 +82,7 @@ int indexer_config_subnode_read(const OS_XML *xml, XML_NODE node, cJSON *output_
        /* Unknown paths are ignored */
         if(!key_is_in_array(subnode_keypath, valid_paths)){
             mwarn(XML_INVELEM, subnode_keypath);
+            os_free(subnode_keypath);
             continue;
         }
 


### PR DESCRIPTION
|Related issue|
|---|
|#22507|

## Description

When a misconfiguration is present in the Indexer's configuration, the tag is skipped. A temporary buffer to accommodate a configuration relative path (for checking and logging) was being dynamically allocated, and released at the end of the loop. But since a misconfiguration breaks the loop to force skipping, it should be freed also in that place.


## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors