### PR TITLE
Implement `journald` Log Collection in Logcollector and Expose Configuration via API

### DIFF
--- a/etc/templates/config/generic/localfile-logs/syslog-logs.template
+++ b/etc/templates/config/generic/localfile-logs/syslog-logs.template
@@ -1,7 +1,7 @@
-syslog:/var/log/messages
+journald:/var/log/messages
 syslog:/var/log/authlog
 journald:/var/log/auth.log
-syslog:/var/log/secure
+journald:/var/log/secure
 syslog:/var/log/secure.log
 syslog:/var/log/system.log
 journald:/var/log/syslog
@@ -23,7 +23,7 @@ journald:/var/log/mail.info
 journald:/var/log/mail.notice
 journald:/var/log/mail.err
 journald:/var/log/mail.log
-syslog:/var/log/maillog
+journald:/var/log/maillog
 syslog:/usr/local/squid/var/logs/access.log
 syslog:/var/log/squid/access.log
 syslog:/var/log/horde.log

--- a/etc/templates/config/generic/localfile-logs/syslog-logs.template
+++ b/etc/templates/config/generic/localfile-logs/syslog-logs.template
@@ -1,10 +1,10 @@
 syslog:/var/log/messages
 syslog:/var/log/authlog
-syslog:/var/log/auth.log
+journald:/var/log/auth.log
 syslog:/var/log/secure
 syslog:/var/log/secure.log
 syslog:/var/log/system.log
-syslog:/var/log/syslog
+journald:/var/log/syslog
 syslog:/var/log/ipfilter.log
 syslog:/var/adm/ipsec.log
 syslog:/var/adm/syslog
@@ -19,8 +19,10 @@ syslog:/var/log/proftpd.log
 syslog:/var/log/vsftpd.log
 syslog:/var/log/radius.log
 syslog:/var/log/radius/radius.log
-syslog:/var/log/mail.info
-syslog:/var/log/mail.notice
+journald:/var/log/mail.info
+journald:/var/log/mail.notice
+journald:/var/log/mail.err
+journald:/var/log/mail.log
 syslog:/var/log/maillog
 syslog:/usr/local/squid/var/logs/access.log
 syslog:/var/log/squid/access.log
@@ -29,4 +31,4 @@ syslog:/var/log/asl.log
 syslog:/var/log/dpkg.log
 syslog:/var/log/vmware/hostd.log
 syslog:/var/log/proftpd/proftpd.log
-syslog:/var/log/kern.log
+journald:/var/log/kern.log

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -1188,7 +1188,7 @@ bool journald_add_condition_to_filter(xml_node * node, w_journal_filter_t ** fil
     }
 
     if (w_journal_filter_add_condition(filter, field, expression, ignore_if_missing) != 0) {
-        mwarn("Error compiling the PCRE2 expression for the journal filter");
+        mwarn("Error compiling the PCRE2 expression '%s' for field '%s' in journal filter", expression, field);
         return false;
     }
 

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -368,7 +368,7 @@ bool journald_add_condition_to_filter(xml_node * node, w_journal_filter_t ** fil
  * The filter pointer is invalid after the call.
  */
 void w_journal_filter_free(w_journal_filter_t * filter);
-
+ 
 /**
  * @brief Add a condition to the filter, creating the filter if it does not exist
  *
@@ -394,6 +394,15 @@ int w_journal_filter_add_condition(w_journal_filter_t ** filter,
  * @return return false if filter is NULL or list is NULL
  */
 bool w_journal_add_filter_to_list(w_journal_filters_list_t * list, w_journal_filter_t * filter);
+
+
+/**
+ * @brief Get the filter as a JSON Array
+ * 
+ * @param filter_lst Filters list
+ * @return cJSON* JSON Array with the filters
+ */
+cJSON * w_journal_filter_list_as_json(w_journal_filters_list_t filter_lst);
 
 /**
  * @brief Free the filter list and all its resources

--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -196,6 +196,15 @@ void _getLocalfilesListJSON(logreader *list, cJSON *array, int gl) {
             cJSON_AddNumberToObject(multiline, "timeout", list[i].multiline->timeout);
             cJSON_AddItemToObject(file, "multiline_regex", multiline);
         }
+        if (list[i].journal_log != NULL && list[i].journal_log->filters != NULL) {
+
+            cJSON * filters = w_journal_filter_list_as_json(list[i].journal_log->filters);
+            if (filters != NULL) {
+                cJSON_AddItemToObject(file, "filters", filters);
+            }
+
+            cJSON_AddBoolToObject(file, "filters_disabled", list[i].journal_log->disable_filters);
+        }
         if (list[i].regex_ignore != NULL) {
             OSListNode *node_it;
             w_expression_t *exp_it;

--- a/src/logcollector/journal_log.c
+++ b/src/logcollector/journal_log.c
@@ -13,8 +13,8 @@
 
 #include "debug_op.h"
 
-static const int W_SD_JOURNAL_LOCAL_ONLY = 1 << 0;
-static const char * W_LIB_SYSTEMD = "libsystemd.so.0";
+static const int W_SD_JOURNAL_LOCAL_ONLY = 1 << 0;     ///< Open the journal log for the local machine
+static const char * W_LIB_SYSTEMD = "libsystemd.so.0"; ///< Name of the systemd library
 
 // Function added on version 187 of systemd
 typedef int (*w_journal_open)(sd_journal ** ret, int flags);            ///< sd_journal_open

--- a/src/logcollector/journal_log.c
+++ b/src/logcollector/journal_log.c
@@ -101,16 +101,14 @@ static inline char * w_timestamp_to_string(uint64_t timestamp) {
  * @param timestamp The epoch time
  * @return char* The human-readable string or NULL on error
  */
-static inline char* w_timestamp_to_journalctl_since(uint64_t timestamp)
-{
+static inline char * w_timestamp_to_journalctl_since(uint64_t timestamp) {
     struct tm tm;
     time_t time = timestamp / 1000000;
-    if (gmtime_r(&time, &tm) == NULL)
-    {
+    if (gmtime_r(&time, &tm) == NULL) {
         return NULL;
     }
 
-    char* str;
+    char * str;
     os_calloc(sizeof("2024-03-14 14:08:52") + 1, sizeof(char), str);
     strftime(str, sizeof("2024-03-14 14:08:52"), "%Y-%m-%d %T", &tm);
     return str;
@@ -313,7 +311,7 @@ int w_journal_context_seek_timestamp(w_journal_context_t * ctx, uint64_t timesta
     // If the timestamp is in the future or invalid, seek the most recent entry
     if (timestamp == 0 || timestamp > w_get_epoch_time()) {
         mwarn(LOGCOLLECTOR_JOURNAL_LOG_FUTURE_TS, timestamp);
-        return ctx->lib->seek_tail(ctx->journal);
+        return w_journal_context_seek_most_recent(ctx);
     }
 
     // Check if the timestamp is older than the oldest available

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -408,11 +408,11 @@ void LogCollectorStart()
             if (atexit(w_journald_release_ctx)) {
                 merror(ATEXIT_ERROR);
             }
-            // TODO REVIEW READ/INIT/TARGET/TIMESTAMP
-            // for (int tg_idx = 0; current->target[tg_idx]; tg_idx++) {
-            //    mdebug1("Socket target for '%s' -> %s", JOURNALD_LOG, current->target[tg_idx]);
-            //    w_logcollector_state_add_target(JOURNALD_LOG, current->target[tg_idx]);
-            //}
+            
+            for (int tg_idx = 0; current->target[tg_idx]; tg_idx++) {
+                mdebug1("Socket target for '%s' -> %s", JOURNALD_LOG, current->target[tg_idx]);
+                w_logcollector_state_add_target(JOURNALD_LOG, current->target[tg_idx]);
+            }
 #else
             minfo("Journald log format is only available on Linux.");
             w_journal_log_config_free(&(current->journal_log));

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -405,10 +405,8 @@ void LogCollectorStart()
         else if (strcmp(current->logformat, JOURNALD_LOG) == 0) {
 #ifdef __linux__
             current->read = read_journald;
-            if (atexit(w_journald_release_ctx)) {
-                merror(ATEXIT_ERROR);
-            }
-            
+            w_journald_set_ofe(current->future);
+
             for (int tg_idx = 0; current->target[tg_idx]; tg_idx++) {
                 mdebug1("Socket target for '%s' -> %s", JOURNALD_LOG, current->target[tg_idx]);
                 w_logcollector_state_add_target(JOURNALD_LOG, current->target[tg_idx]);
@@ -2722,6 +2720,10 @@ STATIC void w_load_files_status(cJSON * global_json) {
 
 #endif
 
+#ifdef __linux__
+    w_journald_set_status_from_JSON(global_json);
+#endif
+
 }
 
 STATIC char * w_save_files_status_to_cJSON() {
@@ -2771,6 +2773,16 @@ STATIC char * w_save_files_status_to_cJSON() {
         cJSON_AddItemToObject(global_json, OS_LOGCOLLECTOR_JSON_MACOS, macos_status);
     }
 
+#endif
+
+#ifdef __linux__
+    cJSON * journald_status = w_journald_get_status_as_JSON();
+    if (journald_status != NULL) {
+        if (global_json == NULL) {
+            global_json = cJSON_CreateObject();
+        }
+        cJSON_AddItemToObject(global_json, JOURNALD_LOG, journald_status);
+    }
 #endif
 
     if (global_json != NULL) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -402,6 +402,26 @@ void LogCollectorStart()
             os_free(current->fp);
         }
 
+        else if (strcmp(current->logformat, JOURNALD_LOG) == 0) {
+#ifdef __linux__
+            current->read = read_journald;
+            if (atexit(w_journald_release_ctx)) {
+                merror(ATEXIT_ERROR);
+            }
+            // TODO REVIEW READ/INIT/TARGET/TIMESTAMP
+            // for (int tg_idx = 0; current->target[tg_idx]; tg_idx++) {
+            //    mdebug1("Socket target for '%s' -> %s", JOURNALD_LOG, current->target[tg_idx]);
+            //    w_logcollector_state_add_target(JOURNALD_LOG, current->target[tg_idx]);
+            //}
+#else
+            minfo("Journald log format is only available on Linux.");
+            w_journal_log_config_free(&(current->journal_log));
+#endif
+            os_free(current->file);
+            current->command = NULL;
+            os_free(current->fp);
+        }
+
         else if (j < 0) {
             set_read(current, i, j);
             if (current->file) {
@@ -2011,6 +2031,7 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
     int int_error = 0;
     struct timeval fp_timeout;
     struct stat tmp_stat;
+    unsigned long thread_id = (unsigned long) pthread_self();
 #else
     BY_HANDLE_FILE_INFORMATION lpFileInformation;
     memset(&lpFileInformation, 0, sizeof(BY_HANDLE_FILE_INFORMATION));
@@ -2074,6 +2095,16 @@ void * w_input_thread(__attribute__((unused)) void * t_id){
                     /* Read the macOS `log` process output */
                     else if (current->macos_log != NULL && current->macos_log->state != LOG_NOT_RUNNING) {
                         current->read(current, &r, 0);
+                    }
+#endif
+#ifdef __linux__
+                    /* Read the journald logs */
+                    else if (current->journal_log != NULL) {
+                        if (w_journald_can_read(thread_id)) {
+                            current->read(current, &r, 0);
+                        } else {
+                            mdebug2("Skipping is not the owner of the journal log");
+                        }
                     }
 #endif
                     w_mutex_unlock(&current->mutex);

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -128,7 +128,36 @@ void *read_multiline_regex(logreader *lf, int *rc, int drop_it);
  * @return NULL
  */
 void *read_macos(logreader *lf, int *rc, int drop_it);
+#endif
 
+#ifdef __linux__
+/**
+ * @brief Read journald logs
+ *
+ * @param lf status and configuration of the log file
+ * @param rc output parameter, returns zero
+ * @param drop_it if drop_it is different from 0, the logs will be read and discarded
+ * @return NULL
+ */
+void *read_journald(logreader *lf, int *rc, int drop_it);
+
+/**
+ * @brief Check if journald can be read for a specific id
+ * 
+ * If the journal is not opened, the the function try to open it, returning false if it fails and true if it succeeds.
+ * The function sets the id as the owner of the journal.
+ * If the journal is opened, the function checks if the id is the owner of the journal,
+ * returning true if it is, and false if it is not.
+ * @param id the id to be checked
+ * @return true if the id is the owner of the journal, false otherwise
+ * @note This function is not thread-safe.
+ */
+bool w_journald_can_read(unsigned long id); 
+
+/**
+ * @brief Mark the journal to be closed by the owner in the next iteration
+ */
+void w_journald_release_ctx();
 #endif
 
 /* Read DJB multilog format */

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -155,9 +155,25 @@ void *read_journald(logreader *lf, int *rc, int drop_it);
 bool w_journald_can_read(unsigned long id); 
 
 /**
- * @brief Mark the journal to be closed by the owner in the next iteration
+ * @brief Set the only future events flag to the journal log context
+ * @param ofe True if only future events should be read, false otherwise
  */
-void w_journald_release_ctx();
+void w_journald_set_ofe(bool ofe);
+
+/**
+ * @brief Set the status of the journal log from a JSON object (timestamp to start reading)
+ * 
+ * @param global_json JSON object containing the journal log status
+ */
+void w_journald_set_status_from_JSON(cJSON * global_json);
+
+/**
+ * @brief Get the status of the journal log as a JSON object
+ * 
+ * @return JSON object containing the journal log status
+ */
+cJSON * w_journald_get_status_as_JSON();
+
 #endif
 
 /* Read DJB multilog format */

--- a/src/logcollector/read_journald.c
+++ b/src/logcollector/read_journald.c
@@ -90,6 +90,8 @@ bool w_journald_can_read(unsigned long owner_id) {
             return false;
         }
 
+        minfo("Monitoring the journal");
+
     } else if (gs_journald_global.owner_id != owner_id) {
         return false;
     }

--- a/src/logcollector/read_journald.c
+++ b/src/logcollector/read_journald.c
@@ -54,7 +54,7 @@ typedef struct {
 
 STATIC w_journald_ofe_t gs_journald_ofe = {
     .exist_journal = false,
-    .only_future_events = false,
+    .only_future_events = true,
     .last_read_timestamp = 0,
     .mutex = PTHREAD_MUTEX_INITIALIZER,
 }; ///< Only future events configuration and status
@@ -70,7 +70,7 @@ bool w_journald_can_read(unsigned long owner_id) {
         gs_journald_global.owner_id = owner_id;
  
         if (gs_journald_global.journal_ctx == NULL && w_journal_context_create(&gs_journald_global.journal_ctx) != 0) {
-            pthread_mutex_unlock(&gs_journald_ofe.mutex);
+            mwarn("Failed to connect to the journal, disabling journal log");
             gs_journald_global.is_disabled = true;
             return false;
         }

--- a/src/logcollector/read_journald.c
+++ b/src/logcollector/read_journald.c
@@ -9,8 +9,6 @@
 
 #ifdef __linux__
 
-#include <stdatomic.h>
-
 #include "shared.h"
 #include "logcollector.h"
 #include "journal_log.h"
@@ -24,41 +22,75 @@
 #define INLINE inline
 #endif
 
-STATIC unsigned long gs_owner_id = 0;               ///< Owner ID of the journal log
-STATIC bool gs_is_disabled = false;                 ///< Flag to disable the journal log, error on initialization
-STATIC w_journal_context_t * gs_journal_ctx = NULL; ///< Journal log context
-STATIC atomic_int gs_close_journal = 0;             ///< Flag to close the journal log
+/* Constants */
+#define OFE_TIMESTAMP "timestamp"
 
-void w_journald_release_ctx() { atomic_store(&gs_close_journal, 1); }
+/**
+ * @brief Configuration and status of the journal log
+ * @note not thread safe, only accessible from Inputs threads
+ */
+typedef struct {
+    unsigned long owner_id;            ///< Owner ID of the journal log
+    bool is_disabled;                  ///< Flag to disable the journal log, error on initialization
+    w_journal_context_t * journal_ctx; ///< Journal log context
+} w_journald_global_t;                 ///< Current configuration and status of the journal log
+
+STATIC w_journald_global_t gs_journald_global = {
+    .owner_id = 0,
+    .is_disabled = false,
+    .journal_ctx = NULL,
+}; ///< Current configuration and status of the journal log
+
+/**
+ * @brief Only future events configuration and status
+ * @note Only accessible from Input Owner Thread and Deamon Thread (main thread)
+ */
+typedef struct {
+    bool exist_journal;           ///< Flag to indicate if the journal log exists
+    bool only_future_events;      ///< Flag to indicate if only future events are read
+    uint64_t last_read_timestamp; ///< Last read timestamp from the journal log
+    pthread_mutex_t mutex;        ///< Mutex to protect the timestamp, only resource shared with the Input Owner Thread
+} w_journald_ofe_t;
+
+STATIC w_journald_ofe_t gs_journald_ofe = {
+    .exist_journal = false,
+    .only_future_events = false,
+    .last_read_timestamp = 0,
+    .mutex = PTHREAD_MUTEX_INITIALIZER,
+}; ///< Only future events configuration and status
 
 bool w_journald_can_read(unsigned long owner_id) {
 
-    if (gs_is_disabled) {
+    if (gs_journald_global.is_disabled) {
         return false;
     }
 
-    if (gs_owner_id == 0) {
-        gs_owner_id = owner_id;
-        if (gs_journal_ctx == NULL && w_journal_context_create(&gs_journal_ctx) != 0) {
-            gs_is_disabled = true;
+    if (gs_journald_global.owner_id == 0) {
+
+        gs_journald_global.owner_id = owner_id;
+ 
+        if (gs_journald_global.journal_ctx == NULL && w_journal_context_create(&gs_journald_global.journal_ctx) != 0) {
+            pthread_mutex_unlock(&gs_journald_ofe.mutex);
+            gs_journald_global.is_disabled = true;
             return false;
         }
 
-        // move to the end of the journal
-        int ret = w_journal_context_seek_most_recent(gs_journal_ctx);
+        // Set the pointer to the journal log
+        pthread_mutex_lock(&gs_journald_ofe.mutex);
+        uint64_t lr_ts = gs_journald_ofe.last_read_timestamp;
+        pthread_mutex_unlock(&gs_journald_ofe.mutex);
+
+        int ret = gs_journald_ofe.only_future_events
+                      ? w_journal_context_seek_most_recent(gs_journald_global.journal_ctx)
+                      : w_journal_context_seek_timestamp(gs_journald_global.journal_ctx, lr_ts);
+
         if (ret < 0) {
             mwarn("Failed to move to the end of the journal, disabling journal log: %s", strerror(-ret));
-            gs_is_disabled = true;
+            gs_journald_global.is_disabled = true;
             return false;
         }
 
-    } else if (gs_owner_id != owner_id) {
-        return false;
-    }
-
-    if (atomic_load(&gs_close_journal) == 1) {
-        w_journal_context_free(gs_journal_ctx);
-        gs_is_disabled = true;
+    } else if (gs_journald_global.owner_id != owner_id) {
         return false;
     }
 
@@ -75,10 +107,10 @@ void * read_journald(logreader * lf, int * rc, __attribute__((unused)) int drop_
 
     while ((maximum_lines == 0 || count_logs < maximum_lines) && can_read()) {
         // Get the next entry
-        int result_get_next = w_journal_context_next_newest_filtered(gs_journal_ctx, filters);
+        int result_get_next = w_journal_context_next_newest_filtered(gs_journald_global.journal_ctx, filters);
         if (result_get_next < 0) {
             merror("Failed to get next entry, disabling journal log: %s", strerror(-result_get_next));
-            gs_is_disabled = true;
+            gs_journald_global.is_disabled = true;
             break;
         } else if (result_get_next == 0) {
             mdebug2("No new entries in the journal");
@@ -86,7 +118,8 @@ void * read_journald(logreader * lf, int * rc, __attribute__((unused)) int drop_
         }
 
         // Get the message
-        w_journal_entry_t * entry = w_journal_entry_dump(gs_journal_ctx, W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG);
+        w_journal_entry_t * entry =
+            w_journal_entry_dump(gs_journald_global.journal_ctx, W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG);
         char * entry_str = w_journal_entry_to_string(entry);
         w_journal_entry_free(entry);
 
@@ -114,7 +147,66 @@ void * read_journald(logreader * lf, int * rc, __attribute__((unused)) int drop_
         count_logs++;
     }
 
+    // Update timestamp
+    pthread_mutex_lock(&gs_journald_ofe.mutex);
+    gs_journald_ofe.last_read_timestamp = gs_journald_global.journal_ctx->timestamp;
+    pthread_mutex_unlock(&gs_journald_ofe.mutex);
+
     return NULL;
+}
+
+/** ONLY FUTURE EVENTS configuration */
+
+void w_journald_set_ofe(bool ofe) {
+    gs_journald_ofe.only_future_events = ofe;
+    gs_journald_ofe.exist_journal = true;
+}
+
+cJSON * w_journald_get_status_as_JSON() {
+
+    // Maybe journal log is not initialized yet
+    if (!gs_journald_ofe.exist_journal) {
+        return NULL;
+    }
+
+    pthread_mutex_lock(&gs_journald_ofe.mutex);
+    uint64_t timestamp = gs_journald_ofe.last_read_timestamp;
+    pthread_mutex_unlock(&gs_journald_ofe.mutex);
+
+    // Convert the timestamp uint64_t to a string
+    char timestamp_str[OS_SIZE_256] = {0};
+    snprintf(timestamp_str, OS_SIZE_256 - 1, "%" PRIu64, timestamp);
+    cJSON * journald_log = cJSON_CreateObject();
+    cJSON_AddStringToObject(journald_log, OFE_TIMESTAMP, timestamp_str);
+
+    return journald_log;
+}
+
+void w_journald_set_status_from_JSON(cJSON * global_json) {
+
+    if (global_json == NULL) {
+        return;
+    }
+
+    cJSON * jurnald_log = cJSON_GetObjectItem(global_json, JOURNALD_LOG);
+    char * timestamp = cJSON_GetStringValue(cJSON_GetObjectItem(jurnald_log, OFE_TIMESTAMP));
+
+    if (timestamp == NULL) {
+        return;
+    }
+
+    // Convert the timestamp to a uint64_t
+    uint64_t timestamp_uint = strtoull(timestamp, NULL, 10);
+    if (timestamp_uint == 0 || timestamp_uint == ULLONG_MAX) {
+        return;
+    }
+
+    // Set the timestamp
+    pthread_mutex_lock(&gs_journald_ofe.mutex);
+    gs_journald_ofe.last_read_timestamp = timestamp_uint;
+    pthread_mutex_unlock(&gs_journald_ofe.mutex);
+
+    mdebug2("Set last read timestamp from journald: %" PRIu64, timestamp_uint);
 }
 
 #endif

--- a/src/logcollector/read_journald.c
+++ b/src/logcollector/read_journald.c
@@ -1,0 +1,120 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifdef __linux__
+
+#include <stdatomic.h>
+
+#include "shared.h"
+#include "logcollector.h"
+#include "journal_log.h"
+
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#define INLINE
+#else
+#define STATIC static
+#define INLINE inline
+#endif
+
+STATIC unsigned long gs_owner_id = 0;               ///< Owner ID of the journal log
+STATIC bool gs_is_disabled = false;                 ///< Flag to disable the journal log, error on initialization
+STATIC w_journal_context_t * gs_journal_ctx = NULL; ///< Journal log context
+STATIC atomic_int gs_close_journal = 0;             ///< Flag to close the journal log
+
+void w_journald_release_ctx() { atomic_store(&gs_close_journal, 1); }
+
+bool w_journald_can_read(unsigned long owner_id) {
+
+    if (gs_is_disabled) {
+        return false;
+    }
+
+    if (gs_owner_id == 0) {
+        gs_owner_id = owner_id;
+        if (gs_journal_ctx == NULL && w_journal_context_create(&gs_journal_ctx) != 0) {
+            gs_is_disabled = true;
+            return false;
+        }
+
+        // move to the end of the journal
+        int ret = w_journal_context_seek_most_recent(gs_journal_ctx);
+        if (ret < 0) {
+            mwarn("Failed to move to the end of the journal, disabling journal log: %s", strerror(-ret));
+            gs_is_disabled = true;
+            return false;
+        }
+
+    } else if (gs_owner_id != owner_id) {
+        return false;
+    }
+
+    if (atomic_load(&gs_close_journal) == 1) {
+        w_journal_context_free(gs_journal_ctx);
+        gs_is_disabled = true;
+        return false;
+    }
+
+    return true;
+}
+
+void * read_journald(logreader * lf, int * rc, __attribute__((unused)) int drop_it) {
+    const unsigned long MAX_LINE_LEN = OS_MAXSTR - OS_LOG_HEADER;
+    char read_buffer[OS_MAXSTR + 1];
+    read_buffer[OS_MAXSTR] = '\0';
+    int count_logs = 0;
+    *rc = 0;
+    w_journal_filters_list_t filters = lf->journal_log->disable_filters ? NULL : lf->journal_log->filters;
+
+    while ((maximum_lines == 0 || count_logs < maximum_lines) && can_read()) {
+        // Get the next entry
+        int result_get_next = w_journal_context_next_newest_filtered(gs_journal_ctx, filters);
+        if (result_get_next < 0) {
+            merror("Failed to get next entry, disabling journal log: %s", strerror(-result_get_next));
+            gs_is_disabled = true;
+            break;
+        } else if (result_get_next == 0) {
+            mdebug2("No new entries in the journal");
+            break;
+        }
+
+        // Get the message
+        w_journal_entry_t * entry = w_journal_entry_dump(gs_journal_ctx, W_JOURNAL_ENTRY_DUMP_TYPE_SYSLOG);
+        char * entry_str = w_journal_entry_to_string(entry);
+        w_journal_entry_free(entry);
+
+        if (entry_str == NULL) {
+            merror("Failed to get the message from the journal");
+            break;
+        }
+
+        // Copy the message to the buffer
+        unsigned long entry_str_len = strlen(entry_str);
+        if (entry_str_len > MAX_LINE_LEN) {
+            mdebug1("Message size > maximum allowed, The message will be truncated");
+            entry_str_len = MAX_LINE_LEN;
+        }
+        strncpy(read_buffer, entry_str, entry_str_len);
+        read_buffer[entry_str_len] = '\0';
+        os_free(entry_str);
+
+        if (isDebug()) {
+            mdebug2("Reading from journal: %s", read_buffer);
+        }
+
+        // Send the message to the manager
+        w_msg_hash_queues_push(read_buffer, JOURNALD_LOG, entry_str_len + 1, lf->log_target, LOCALFILE_MQ);
+        count_logs++;
+    }
+
+    return NULL;
+}
+
+#endif


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22499 |
 

## Implement `journald` Log Collection in Logcollector and Expose Configuration via API

### Purpose
This PR introduces comprehensive support for collecting `journald` logs through Wazuh's Logcollector, utilizing the library developed in issue #22322. It aims to enhance Wazuh's log collection capabilities by integrating with `journald`, a core component of systemd, thus providing a more robust and flexible log monitoring solution. Additionally, this PR updates the Wazuh API to expose `journald` log collection configurations, enabling users to verify their log collection settings.

### Key Features
- **System `journald` Detection**: Automatically detects the presence of `journald` on the system, with fallback mechanisms for systems without `journald`.
- **`journald` Library Integration**: Utilizes the previously developed library for efficient log collection directly from `journald`.
- **`only-future-event=no` Support**: Ensures all logs, including historical logs, are collected when the `only-future-event` configuration is set to `no`.
- **API Configuration Exposure**: Enhances the Wazuh API to provide detailed information about the `journald` log collection configuration.

### Changes
- Implemented a detection mechanism to check for `journald` availability on the system.
- Integrated the `journald` log collection library into Logcollector's operational workflow.
- Supported the `only-future-event=no` feature for comprehensive log collection.
- Updated the Wazuh API to return `journald` log collection configuration details.

### Testing
- Conducted tests to ensure correct detection of `journald` on various systems.
- Performed integration tests to verify the stability and efficiency of the `journald` log collection.
- Validated the functionality of `only-future-event=no` through scenario-based testing.
- Tested API enhancements to ensure accurate and useful configuration details are provided.

### Documentation
- Updated the Wazuh documentation to include information on the new `journald` log collection capabilities.
- Provided detailed API documentation, including new endpoints or modifications, with examples and usage guidelines.

### Future Work
Future improvements could focus on optimizing log collection performance, expanding filtering capabilities, and enhancing API responses based on user feedback.

### Notes
This PR represents a significant enhancement to Wazuh's log collection framework, offering deeper integration with modern Linux systems using `systemd` and `journald`. It lays the groundwork for more advanced monitoring and analysis capabilities within Wazuh.

**Related Issue:** Stage 2C: Implement Functionality for `journald` Log Collection and Expose Configuration through API

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors