### PR TITLE
Remove HAProxy wrapper API

### DIFF
--- a/framework/wazuh/core/cluster/hap_helper/data/configuration.yaml
+++ b/framework/wazuh/core/cluster/hap_helper/data/configuration.yaml
@@ -23,11 +23,13 @@ proxy:
     # Wazuh Proxy API address
     address: wazuh-proxy
     # Wazuh Proxy API port
-    port: 7777
+    port: 5555
     # Wazuh Proxy API username
-    user: wazuh
+    user: haproxy
     # Wazuh Proxy API password
-    password: wazuh
+    password: haproxy
+    # Protocol to use 'http' or 'https'. By default http
+    protocol: http
   # Defined Proxy backend (frontend will append '_front' to it)
   backend: wazuh_cluster
 

--- a/framework/wazuh/core/cluster/hap_helper/hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/hap_helper.py
@@ -89,7 +89,14 @@ class HAPHelper:
         bool
             True if the node can be deleted, else False.
         """
-        node_downtime = (await self.proxy.get_wazuh_server_stats(server_name=node_name))['lastchg']
+        node_stats = await self.proxy.get_wazuh_server_stats(server_name=node_name)
+
+        node_status = node_stats['status']
+        node_downtime = node_stats['lastchg']
+
+        if node_status == ProxyServerState.UP.value.upper():
+            return False
+
         self.logger.debug2(f"Server '{node_name}' has been disconnected for {node_downtime}s")
 
         if node_downtime < self.remove_disconnected_node_after * 60:

--- a/framework/wazuh/core/cluster/hap_helper/hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/hap_helper.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from asyncio import sleep
 from math import ceil, floor
 
@@ -217,7 +216,7 @@ class HAPHelper:
                 raise WazuhHAPHelperError(3041)
 
             self.logger.debug('Waiting for new servers to go UP')
-            time.sleep(1)
+            await sleep(1)
             backend_stats_iteration += 1
             wazuh_backend_stats = (await self.proxy.get_wazuh_backend_stats()).keys()
 
@@ -414,11 +413,14 @@ class HAPHelper:
         self.logger.info('Setting a value for `hard-stop-after` configuration.')
         agents_distribution = await self.wazuh_dapi.get_agents_node_distribution()
         agents_id = [item['id'] for agents in agents_distribution.values() for item in agents]
+        current_cluster = await self.wazuh_dapi.get_cluster_nodes()
 
         await self.proxy.set_hard_stop_after_value(
             active_agents=len(agents_id),
             chunk_size=self.agent_reconnection_chunk_size,
             agent_reconnection_time=self.agent_reconnection_time,
+            n_managers=len(current_cluster.keys()),
+            server_admin_state_delay=self.SERVER_ADMIN_STATE_DELAY,
         )
 
         if reconnect_agents and len(agents_id) > 0:

--- a/framework/wazuh/core/cluster/hap_helper/hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/hap_helper.py
@@ -387,12 +387,12 @@ class HAPHelper:
                 await sleep(self.sleep_time)
 
     async def set_hard_stop_after(self):
-        """Check if HAProxy has the hard-stop-after configuration. If is not it will be set."""
+        """Check if HAProxy has the hard-stop-after configuration. If not, it will be set."""
 
         cluster_items = get_cluster_items()
         connection_retry = cluster_items['intervals']['worker']['connection_retry'] + 2
 
-        self.logger.debug(f'Waiting for workers connections {connection_retry}s...')
+        self.logger.debug(f'Waiting {connection_retry}s for workers connections...')
         await sleep(connection_retry)
 
         self.logger.info('Setting a value for `hard-stop-after` configuration.')

--- a/framework/wazuh/core/cluster/hap_helper/hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/hap_helper.py
@@ -394,7 +394,7 @@ class HAPHelper:
                 await sleep(self.sleep_time)
 
     async def set_hard_stop_after(self):
-        """Check if HAProxy has the hard-stop-after configuration. If not, it will be set."""
+        """Calculate and set hard-stop-after configuration in HAProxy."""
 
         cluster_items = get_cluster_items()
         connection_retry = cluster_items['intervals']['worker']['connection_retry'] + 2

--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -13,7 +13,7 @@ PROXY_API_RESPONSE: TypeAlias = JSON_TYPE | None
 HTTP_PROTOCOL = Literal['http', 'https']
 
 
-def _convert_to_seconds(milliseconds: int) -> float:
+def _convert_to_seconds(milliseconds: int) -> int:
     """Convert the given milliseconds to seconds.
 
     Parameters
@@ -26,7 +26,7 @@ def _convert_to_seconds(milliseconds: int) -> float:
     float
         The amount of seconds.
     """
-    return milliseconds / 1000
+    return int(milliseconds / 1000)
 
 
 def _convert_to_milliseconds(seconds: int) -> int:
@@ -42,7 +42,7 @@ def _convert_to_milliseconds(seconds: int) -> int:
     int
         The amount of milliseconds.
     """
-    return seconds * 1000
+    return int(seconds * 1000)
 
 
 class ProxyAPIMethod(Enum):
@@ -563,12 +563,13 @@ class Proxy:
         number_of_chunks = active_agents / chunk_size if active_agents > chunk_size else 1
         hard_stop_after = number_of_chunks * agent_reconnection_time
 
-        configuration = await self.api.get_global_configuration()
-        configuration['hard_stop_after'] = _convert_to_milliseconds(hard_stop_after)
+        if self.hard_stop_after is None or self.hard_stop_after != hard_stop_after:
+            configuration = await self.api.get_global_configuration()
+            configuration['hard_stop_after'] = _convert_to_milliseconds(hard_stop_after)
 
-        await self.api.update_global_configuration(new_configuration=configuration)
-        self.hard_stop_after = hard_stop_after
-        self.logger.info(f'Set `hard-stop-after` with {hard_stop_after} seconds.')
+            await self.api.update_global_configuration(new_configuration=configuration)
+            self.hard_stop_after = hard_stop_after
+            self.logger.info(f'Set `hard-stop-after` with {hard_stop_after} seconds.')
 
     async def get_current_pid(self) -> int:
         """Get the current HAProxy PID.

--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -532,7 +532,7 @@ class Proxy:
             raise WazuhHAPHelperError(3048)
 
     async def get_hard_stop_after_value(self) -> Optional[str]:
-        """Get the `hard-stop-after` value from the global configurations.
+        """Get the `hard-stop-after` value from the global configuration.
 
         Returns
         -------
@@ -542,7 +542,7 @@ class Proxy:
         return (await self.api.get_global_configuration()).get('hard_stop_after', None)
 
     async def set_hard_stop_after_value(self, active_agents: int, chunk_size: int, agent_reconnection_time: int):
-        """Calculate a dinamic value for `hard-stop-after` and set it.
+        """Calculate a dynamic value for `hard-stop-after` and set it.
 
         Parameters
         ----------
@@ -561,7 +561,7 @@ class Proxy:
 
         await self.api.update_global_configuration(new_configuration=configuration)
         self.hard_stop_after = hard_stop_after
-        self.logger.info(f'Setted `hard-stop-after` with {hard_stop_after} seconds.')
+        self.logger.info(f'Set `hard-stop-after` with {hard_stop_after} seconds.')
 
     async def get_current_pid(self) -> int:
         """Get the current HAProxy PID.

--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -548,7 +548,14 @@ class Proxy:
         """
         return (await self.api.get_global_configuration()).get('hard_stop_after', None)
 
-    async def set_hard_stop_after_value(self, active_agents: int, chunk_size: int, agent_reconnection_time: int):
+    async def set_hard_stop_after_value(
+        self,
+        active_agents: int,
+        chunk_size: int,
+        agent_reconnection_time: int,
+        n_managers: int,
+        server_admin_state_delay: int,
+    ):
         """Calculate a dynamic value for `hard-stop-after` and set it.
 
         Parameters
@@ -559,9 +566,15 @@ class Proxy:
             Max number of agents to be reconnected at once.
         agent_reconnection_time : int
             Seconds to sleep after an agent chunk reconnection.
+        n_manager : int
+            Number of managers in the cluster.
+        server_admin_state_delay : int
+            Delay of server administration.
         """
-        number_of_chunks = active_agents / chunk_size if active_agents > chunk_size else 1
-        hard_stop_after = number_of_chunks * agent_reconnection_time
+
+        hard_stop_after = (active_agents / (n_managers * chunk_size)) * n_managers * agent_reconnection_time + (
+            n_managers * server_admin_state_delay * 2
+        )
 
         if self.hard_stop_after is None or self.hard_stop_after != hard_stop_after:
             configuration = await self.api.get_global_configuration()


### PR DESCRIPTION
|Related issue|
|---|
| #20936 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #20936. Removes the wrapper use of the wrapper and goes directly to the HAProxy API. Also, adds a handler for the `hard-stop-after` configuration. 

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

```bash
2024/03/15 18:28:52 INFO: [HAPHelper] [Main] Proxy was initialized
2024/03/15 18:28:52 DEBUG2: [HAPHelper] [Proxy] Obtained proxy backends
2024/03/15 18:28:52 DEBUG2: [HAPHelper] [Proxy] Obtained proxy frontends
2024/03/15 18:28:52 INFO: [HAPHelper] [Main] Setting a value for `hard-stop-after` configuration.
2024/03/15 18:28:52 DEBUG: [HAPHelper] [D API] Receiving parameters {'select': ['node_name', 'version'], 'sort': {'fields': ['version', 'id'], 'order': 'desc'}, 'filters': {'status': 'active'}, 'q': 'id!=000', 'limit': 100000}
2024/03/15 18:28:52 DEBUG: [HAPHelper] [D API] Starting to execute request locally
2024/03/15 18:28:52 DEBUG: [HAPHelper] [D API] Finished executing request locally
2024/03/15 18:28:52 DEBUG: [HAPHelper] [D API] Time calculating request result: 0.015s
2024/03/15 18:28:52 DEBUG: [HAPHelper] [Main] Waiting for workers connections 12s...
2024/03/15 18:28:52 INFO: [HAPHelper] [Proxy] Setted `hard-stop-after` with 5 seconds.
2024/03/15 18:29:04 INFO: [HAPHelper] [Main] Reconnecting 13 agents.
2024/03/15 18:29:04 DEBUG: [HAPHelper] [Main] Reconnecting agents
2024/03/15 18:29:04 DEBUG: [HAPHelper] [Main] Agent reconnection chunk size is set to 120. Total iterations: 1
2024/03/15 18:29:04 DEBUG: [HAPHelper] [D API] Receiving parameters {'agent_list': ['013', '011', '009', '008', '012', '007', '006', '003', '010', '005', '004', '002', '001']}
2024/03/15 18:29:04 DEBUG: [HAPHelper] [D API] Receiving parameters {'agent_list': ['001', '002', '004', '005', '010']}
2024/03/15 18:29:04 DEBUG: [HAPHelper] [D API] Starting to execute request locally
2024/03/15 18:29:04 DEBUG: [HAPHelper] [D API] Finished executing request locally
2024/03/15 18:29:04 DEBUG: [HAPHelper] [D API] Time calculating request result: 0.013s
2024/03/15 18:29:04 DEBUG: [HAPHelper] [Main] Delay between agent reconnections. Sleeping 5s...
2024/03/15 18:29:09 INFO: [HAPHelper] [Main] Starting HAProxy Helper
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained proxy servers
2024/03/15 18:29:09 DEBUG: [HAPHelper] [D API] Receiving parameters {}
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained proxy servers
2024/03/15 18:29:09 INFO: [HAPHelper] [Main] Load balancer backend is up to date
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained server 'master-node' stats
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained server 'worker1' stats
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained server 'worker2' stats
2024/03/15 18:29:09 DEBUG: [HAPHelper] [Main] Checking for agent balance. Current connections distribution: {'master-node': 4, 'worker1': 4, 'worker2': 4}
2024/03/15 18:29:09 DEBUG: [HAPHelper] [Main] Current balance is under tolerance
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained server 'master-node' stats
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained server 'worker1' stats
2024/03/15 18:29:09 DEBUG2: [HAPHelper] [Proxy] Obtained server 'worker2' stats
2024/03/15 18:29:09 DEBUG: [HAPHelper] [Main] Current backend stats: {'master-node': 4, 'worker1': 4, 'worker2': 4}
2024/03/15 18:29:09 INFO: [HAPHelper] [Main] Load balancer backend is balanced
2024/03/15 18:29:09 DEBUG: [HAPHelper] [Main] Sleeping 60s...
```