### PR TITLE
Remove wodles Python 3.7 support

### DIFF
--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -13,8 +13,6 @@ from typing import List
 
 try:
     import pyarrow.parquet as pq
-    if sys.version_info < (3, 8):
-        import pyarrow_hotfix  # noqa: F401
 except ImportError:
     print('ERROR: pyarrow module is required.')
     sys.exit(10)


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh-documentation/issues/6238 |


## Description

Removes the `pyarrow_hotfix` dependency used in Python 3.7 to fix the `CVE-2023-47248` vulnerability.