### PR TITLE
Changed cache API option warning logic.

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -289,7 +289,6 @@ def read_yaml_config(config_file: str = CONFIG_FILE_PATH, default_conf: dict = N
                         conf[k] = True
                     elif conf[k].lower() == 'no':
                         conf[k] = False
-    logger = logging.getLogger('wazuh-api')
 
     if default_conf is None:
         default_conf = default_api_configuration
@@ -313,6 +312,7 @@ def read_yaml_config(config_file: str = CONFIG_FILE_PATH, default_conf: dict = N
 
         # Check if cache is enabled
         if configuration.get('cache', {}).get('enabled', {}):
+            logger = logging.getLogger('wazuh-api')
             logger.warning(CACHE_DEPRECATED_MESSAGE.format(release="4.8.0"))
 
         schema = security_config_schema if config_file == SECURITY_CONFIG_PATH else api_config_schema

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -15,8 +15,6 @@ from wazuh.core.wlogging import TimeBasedFileRotatingHandler, SizeBasedFileRotat
 from wazuh.core import pyDaemonModule
 
 SSL_DEPRECATED_MESSAGE = 'The `{ssl_protocol}` SSL protocol is deprecated.'
-CACHE_DEPRECATED_MESSAGE = 'The `cache` API configuration option was deprecated in {release} and will be removed ' \
-                           'in the next minor release.'
 
 API_MAIN_PROCESS = 'wazuh-apid'
 API_LOCAL_REQUEST_PROCESS = 'wazuh-apid_exec'
@@ -108,7 +106,6 @@ def start():
 
     # Enable cache plugin
     if api_conf['cache']['enabled']:
-        logger.warning(CACHE_DEPRECATED_MESSAGE.format(release="4.8.0"))
         setup_cache(app.app)
 
     # Add application signals


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22567|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Changed the logic of the warning related to the `cache` API option. Now the warning only appears when the option is added to the configuration by the user-