### PR TITLE
added ignore_sregex pointer to null

### DIFF
--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -77,6 +77,7 @@ int rootcheck_init(int test_config)
     rootcheck.basedir = NULL;
     rootcheck.unixaudit = NULL;
     rootcheck.ignore = NULL;
+    rootcheck.ignore_sregex = NULL;
     rootcheck.rootkit_files = NULL;
     rootcheck.rootkit_trojans = NULL;
     rootcheck.winaudit = NULL;


### PR DESCRIPTION
|Related issue|
|---|
|[1704](https://github.com/wazuh/external-devel-requests/issues/1704)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR solve the issue [1704](https://github.com/wazuh/external-devel-requests/issues/1704), the solution was add initialize default values to ignore_sregex.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
  - [x] AIX
- [x] Source installation
- [x] Package installation
