### PR TITLE
Fix integrity check file error on master disconnection

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1487,8 +1487,12 @@ class SyncFiles(SyncTask):
                     self.logger.debug(f"Increasing sync size limit to {self.server.current_zip_limit / (1024**2):.2f}"
                                       f" MB.")
 
-            # Remove local file.
-            os.unlink(compressed_data)
+            try:
+                # Remove local file.
+                os.unlink(compressed_data)
+            except FileNotFoundError:
+                self.logger.error(f"File {compressed_data} could not be removed/not found. "
+                                  f"May be due to a lost connection.")
 
 
 class SyncWazuhdb(SyncTask):


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22516 |


## Description

Fixes an error that kept an instance of the `Integrity check` worker's task trying to request permission after a lost connection with the master.

## Error logs example

```log
2024/03/18 16:42:19 INFO: [Worker 7196062a79c9] [Integrity check] Starting.
2024/03/18 16:42:19 DEBUG: [Worker 7196062a79c9] [Integrity check] Compressing 'files_metadata.json' of 34 files.
2024/03/18 16:42:19 DEBUG: [Worker 7196062a79c9] [Integrity check] Sending zip file.
2024/03/18 16:42:19 DEBUG: [Worker 7196062a79c9] [Integrity check] Zip file sent.
2024/03/18 16:42:19 INFO: [Worker 7196062a79c9] [Integrity check] Finished in 0.029s. Sync not required.
2024/03/18 16:42:27 ERROR: [Worker 7196062a79c9] [Integrity check] File /var/ossec/queue/cluster/7196062a79c9/7196062a79c9-1710790939.801322-c6e5f418c4c4428984a2fac63441cb13.zip could not be removed/not found. May be due to a lost connection.
2024/03/18 16:42:37 ERROR: [Local Server] [Main] Could not connect to master. Trying again in 10 seconds.
2024/03/18 16:42:47 ERROR: [Local Server] [Main] Could not connect to master. Trying again in 10 seconds.
2024/03/18 16:42:57 ERROR: [Local Server] [Main] Could not connect to master. Trying again in 10 seconds.
2024/03/18 16:43:07 ERROR: [Local Server] [Main] Could not connect to master. Trying again in 10 seconds.
2024/03/18 16:43:26 DEBUG: [Worker 7196062a79c9] [Integrity check] Permission to synchronize granted.
2024/03/18 16:43:26 INFO: [Worker 7196062a79c9] [Integrity check] Starting.
2024/03/18 16:43:26 DEBUG: [Worker 7196062a79c9] [Integrity check] Compressing 'files_metadata.json' of 34 files.
2024/03/18 16:43:26 DEBUG: [Worker 7196062a79c9] [Integrity check] Sending zip file.
2024/03/18 16:43:26 DEBUG: [Worker 7196062a79c9] [Integrity check] Zip file sent.
2024/03/18 16:43:26 INFO: [Worker 7196062a79c9] [Integrity check] Finished in 0.045s. Sync not required.
```

## Framework Unit Tests
<details>

```console
$ pytest framework/
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: metadata-3.0.0, cov-3.0.0, aiohttp-1.0.4, trio-0.7.0, tavern-1.23.5, asyncio-0.18.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 2199 items                                                                                                                                            

framework/scripts/tests/test_agent_groups.py ..............                                                                                               [  0%]
framework/scripts/tests/test_agent_upgrade.py ...............                                                                                             [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                    [  1%]
framework/scripts/tests/test_rbac_control.py .........                                                                                                    [  2%]
framework/scripts/tests/test_wazuh_clusterd.py .......                                                                                                    [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                      [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                     [  4%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                        [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                    [  7%]
framework/wazuh/core/cluster/tests/test_common.py ....................................................................................                    [ 10%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                 [ 11%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                    [ 11%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                          [ 12%]
framework/wazuh/core/cluster/tests/test_master.py ................................................                                                        [ 15%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                           [ 16%]
framework/wazuh/core/cluster/tests/test_utils.py ................                                                                                         [ 17%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                      [ 18%]
framework/wazuh/core/tests/test_active_response.py ....................                                                                                   [ 19%]
framework/wazuh/core/tests/test_agent.py ................................................................................................................ [ 24%]
.....................................                                                                                                                     [ 26%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                        [ 28%]
framework/wazuh/core/tests/test_common.py .........                                                                                                       [ 28%]
framework/wazuh/core/tests/test_configuration.py ........................................................................................                 [ 32%]
framework/wazuh/core/tests/test_database.py .............                                                                                                 [ 33%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                               [ 33%]
framework/wazuh/core/tests/test_exception.py ..........                                                                                                   [ 34%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                    [ 34%]
framework/wazuh/core/tests/test_logtest.py ..                                                                                                             [ 34%]
framework/wazuh/core/tests/test_manager.py ...............................                                                                                [ 35%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                    [ 36%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                   [ 36%]
framework/wazuh/core/tests/test_results.py ........................................                                                                       [ 38%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                [ 39%]
framework/wazuh/core/tests/test_rule.py .......................                                                                                           [ 40%]
framework/wazuh/core/tests/test_sca.py .............................                                                                                      [ 41%]
framework/wazuh/core/tests/test_security.py .............                                                                                                 [ 42%]
framework/wazuh/core/tests/test_stats.py .................                                                                                                [ 42%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                       [ 43%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                       [ 43%]
framework/wazuh/core/tests/test_task.py ........                                                                                                          [ 43%]
framework/wazuh/core/tests/test_utils.py ................................................................................................................ [ 48%]
......................................................................................................................................................... [ 55%]
..............                                                                                                                                            [ 56%]
framework/wazuh/core/tests/test_wazuh_queue.py .......................                                                                                    [ 57%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                      [ 58%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                    [ 59%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                  [ 60%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                        [ 60%]
framework/wazuh/rbac/tests/test_decorators.py ........................................................................................................... [ 65%]
..                                                                                                                                                        [ 65%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                          [ 67%]
framework/wazuh/rbac/tests/test_orm.py ..............................................................                                                     [ 70%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                               [ 71%]
framework/wazuh/tests/test_active_response.py ............                                                                                                [ 71%]
framework/wazuh/tests/test_agent.py ..................................................................................................................... [ 77%]
.....                                                                                                                                                     [ 77%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                              [ 79%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                    [ 81%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                          [ 81%]
framework/wazuh/tests/test_decoder.py ..........................................................                                                          [ 84%]
framework/wazuh/tests/test_event.py ....                                                                                                                  [ 84%]
framework/wazuh/tests/test_group.py .......                                                                                                               [ 84%]
framework/wazuh/tests/test_logtest.py ......                                                                                                              [ 85%]
framework/wazuh/tests/test_manager.py ....................................                                                                                [ 86%]
framework/wazuh/tests/test_mitre.py .......                                                                                                               [ 86%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                [ 89%]
framework/wazuh/tests/test_rule.py ..........................................................................                                             [ 92%]
framework/wazuh/tests/test_sca.py ...........                                                                                                             [ 93%]
framework/wazuh/tests/test_security.py .......................................................................                                            [ 96%]
framework/wazuh/tests/test_stats.py ...............                                                                                                       [ 97%]
framework/wazuh/tests/test_syscheck.py .........................                                                                                          [ 98%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                   [ 98%]
framework/wazuh/tests/test_task.py ............................                                                                                           [100%]

=============================================================== 2199 passed in 336.01s (0:05:36) ================================================================
```

</details>