### PR TITLE
wrongly keystore on agents

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -908,7 +908,6 @@ InstallCommon()
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/fim/db
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/syscollector
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/syscollector/db
-  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/keystore
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/logcollector
 
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/ruleset
@@ -1283,6 +1282,7 @@ InstallServer()
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} ../framework/wrappers/generic_wrapper.sh ${INSTALLDIR}/integrations/maltiverse
 
     # Keystore
+    ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/keystore
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} wazuh-keystore ${INSTALLDIR}/bin/
 }
 


### PR DESCRIPTION
|Related issue|
|---|
| #22616 |

## Description
Fix wrongly keystore folder create on agents

## Configuration options
The manager and the agent must be built to be tested

[Build #191476 [manager-debian-amd64][bug/22616-wrongly-keystore-on-agents][trash]](https://ci.wazuh.info/job/Packages_builder/191476/)
<details><summary>Details</summary>
<p>

```shell
. . .
14:44:35  + sudo chown -R ec2-user:ec2-user /mnt/efs/packages/trash/apt/wazuh-agent_4.8.0-1_amd64.deb.sha512
14:44:35  [Pipeline] sh
14:44:35  + sudo mv /mnt/efs/packages/trash/apt/wazuh-agent_4.8.0-1_amd64.deb.sha512 /mnt/efs/packages/trash/checksums/wazuh/4.8.0
14:44:35  [Pipeline] sh
14:44:35  + aws --region us-east-1 s3 cp --quiet --acl public-read /mnt/efs/packages/trash/checksums/wazuh/4.8.0/wazuh-agent_4.8.0-1_amd64.deb.sha512 s3://packages-dev.wazuh.com/trash/checksums/wazuh/4.8.0/
14:44:37  [Pipeline] echo
14:44:37  ---------------------- Wazuh dashboard plugin invalidations ----------------------------
14:44:37  [Pipeline] echo
14:44:37  No Wazuh dashboard plugin selected, skipping invalidation
14:44:37  [Pipeline] echo
14:44:37  ----------------------------------------------------------------
14:44:37  [Pipeline] }
14:44:37  [Pipeline] // stage
14:44:37  [Pipeline] }
14:44:37  [Pipeline] // node
14:44:37  [Pipeline] End of Pipeline
14:44:37  Finished: SUCCESS
```
</p>
</details> 

[Build #191470 [agent-debian-amd64][bug/22616-wrongly-keystore-on-agents][trash]](https://ci.wazuh.info/job/Packages_builder/191470/parameters/)
<details><summary>Details</summary>
<p>

```shell
. . .
16:32:42  + sudo chown -R ec2-user:ec2-user /mnt/efs/packages/trash/apt/wazuh-manager_4.8.0-1_amd64.deb.sha512
16:32:42  [Pipeline] sh
16:32:42  + sudo mv /mnt/efs/packages/trash/apt/wazuh-manager_4.8.0-1_amd64.deb.sha512 /mnt/efs/packages/trash/checksums/wazuh/4.8.0
16:32:42  [Pipeline] sh
16:32:42  + aws --region us-east-1 s3 cp --quiet --acl public-read /mnt/efs/packages/trash/checksums/wazuh/4.8.0/wazuh-manager_4.8.0-1_amd64.deb.sha512 s3://packages-dev.wazuh.com/trash/checksums/wazuh/4.8.0/
16:32:44  [Pipeline] echo
16:32:44  ---------------------- Wazuh dashboard plugin invalidations ----------------------------
16:32:44  [Pipeline] echo
16:32:44  No Wazuh dashboard plugin selected, skipping invalidation
16:32:44  [Pipeline] echo
16:32:44  ----------------------------------------------------------------
16:32:44  [Pipeline] }
16:32:44  [Pipeline] // stage
16:32:44  [Pipeline] }
16:32:44  [Pipeline] // node
16:32:44  [Pipeline] End of Pipeline
16:32:45  Finished: SUCCESS
``` 
</p>
</details> 

## Tests
[#2198 [4.7.3, 4.6.0, 3.13.6][4.8.0]](https://ci.wazuh.info/view/Tests/job/Test_upgrade_tier/2198/)
* [#133802 [debian-bullseye(amd64)][debian-bullseye(amd64)][4.7.3->4.8.0]](https://ci.wazuh.info/job/Test_upgrade/133802/)
<details><summary>Details</summary>
<p>

![image](https://github.com/wazuh/wazuh/assets/93778492/5df113f8-1fcf-47e8-a7d1-8b6f11be9fb8)

</p>
</details> 

All other debian and ubuntu agent tests are done
<details><summary>Details</summary>
<p>

16:36:33  Starting building: [Test_upgrade #133803](https://ci.wazuh.info/job/Test_upgrade/133803/)
16:36:33  Starting building: [Test_upgrade #133804](https://ci.wazuh.info/job/Test_upgrade/133804/)
16:36:38  Starting building: [Test_upgrade #133807](https://ci.wazuh.info/job/Test_upgrade/133807/)
16:36:38  Starting building: [Test_upgrade #133808](https://ci.wazuh.info/job/Test_upgrade/133808/)
16:36:38  Starting building: [Test_upgrade #133809](https://ci.wazuh.info/job/Test_upgrade/133809/)
16:36:38  Starting building: [Test_upgrade #133806](https://ci.wazuh.info/job/Test_upgrade/133806/)
16:36:38  Starting building: [Test_upgrade #133805](https://ci.wazuh.info/job/Test_upgrade/133805/)

</p>
</details> 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [X] Package installation
- [ ] Source upgrade
- [X] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities