### PR TITLE
Fix special character handling in Custom Logs Buckets

### DIFF
--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -10,6 +10,7 @@ import sys
 
 from os import path
 from typing import List
+from urllib.parse import unquote
 
 try:
     import pyarrow.parquet as pq
@@ -201,7 +202,7 @@ class AWSSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler):
             An SQS message received from the queue.
         """
 
-        log_path = message_body['log_path']
+        log_path = unquote(message_body['log_path'])
         bucket_path = message_body['bucket_path']
 
         msg = {


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22220 |

## Description

Fixes an error raised when the name of the fetched S3 object containing special characters was not properly decoded, generating a `NoSuchKey` error that broke the module.

## Manual Test
```console
# /var/ossec/wodles/aws/aws-s3 --subscriber buckets --queue SQS-QUEUE-NAME --aws_profile dev --debug 3
DEBUG: +++ Debug mode on - Level: 3
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: The SQS queue is: https://queue.amazonaws.com/123456789123/SQS-QUEUE-NAME
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: Retrieving messages from: SQS-QUEUE-NAME
DEBUG: The raw message is: ...
DEBUG: The message is: {'Records': [{'eventVersion': '2.1', 'eventSource': 'aws:s3', 'awsRegion': 'REGION', 'eventTime': '2024-03-20T19:03:09.169Z', 'eventName': 'ObjectCreated:Put', 'userIdentity': {'principalId': 'AWS:REDACTED'}, 'requestParameters': {'sourceIPAddress': '0.0.0.0'}, 'responseElements': {'x-amz-request-id': 'QDJ5J958GNJQG8R5', 'x-amz-id-2': 'jZNmZhlKxVNkyFLqAvAyjwetZEZCvIPpoqoZlR8nUeQfx9lrSCyAQw2GW51I4lpkM2DGITbxxvcPbqiyvmgUwdaGTMdkQBNA'}, 's3': {'s3SchemaVersion': '1.0', 'configurationId': 'Log collection', 'bucket': {'name': 'BUCKET-NAME', 'ownerIdentity': {'principalId': 'PRINCIPAL-ID'}, 'arn': 'arn:aws:s3:::BUCKET-NAME'}, 'object': {'key': '2024-02-26T00%3A00%3A01.json', 'size': 42, 'eTag': '0ce9768e6b5e494a4bd56ef09ff87d8d', 'sequencer': '0065FB32ED1EEE8938'}}}]}
DEBUG: {"integration": "aws", "aws": {"log_info": {"log_file": "2024-02-26T00:00:01.json", "s3bucket": "BUCKET-NAME"}, "example": "2024-02-26T00:00:01 test log", "source": "custom"}}
DEBUG: Message deleted from queue: SQS-QUEUE-NAME
DEBUG: Retrieving messages from: SQS-QUEUE-NAME
DEBUG: The raw message is: ...
DEBUG: The message is: {'Records': [{'eventVersion': '2.1', 'eventSource': 'aws:s3', 'awsRegion': 'REGION', 'eventTime': '2024-03-20T19:03:19.605Z', 'eventName': 'ObjectCreated:Put', 'userIdentity': {'principalId': 'AWS:REDACTED'}, 'requestParameters': {'sourceIPAddress': '0.0.0.0'}, 'responseElements': {'x-amz-request-id': '76CGY2HRE76M4WSH', 'x-amz-id-2': 'ihoUAXUm9HR7jIi0kkVLcrMzN/wF5vSmsHSFjQ2YNkTXe88hZPpIdGHY+wQzI/NO8bSuu6dh8hYEZ9VAdMVMeliMqi0XmRdg'}, 's3': {'s3SchemaVersion': '1.0', 'configurationId': 'Log collection', 'bucket': {'name': 'BUCKET-NAME', 'ownerIdentity': {'principalId': 'PRINCIPAL-ID'}, 'arn': 'arn:aws:s3:::BUCKET-NAME'}, 'object': {'key': '2024-02-26T00%3A00%2501.json', 'size': 42, 'eTag': '0ce9768e6b5e494a4bd56ef09ff87d8d', 'sequencer': '0065FB32F78EA5E54F'}}}]}
DEBUG: {"integration": "aws", "aws": {"log_info": {"log_file": "2024-02-26T00:00%01.json", "s3bucket": "BUCKET-NAME"}, "example": "2024-02-26T00:00:01 test log", "source": "custom"}}
DEBUG: Message deleted from queue: SQS-QUEUE-NAME
DEBUG: Retrieving messages from: SQS-QUEUE-NAME
```

## Integration Tests

```console
root@c0fae6dde79f:/wazuh-qa# /var/ossec/bin/wazuh-control info   
WAZUH_VERSION="v4.8.2"
WAZUH_REVISION="40820"
WAZUH_TYPE="server"
root@c0fae6dde79f:/wazuh-qa# pytest -vv tests/integration/test_aws/test_custom_bucket.py
===================================================================== test session starts ======================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-5.15.0-101-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.1.2', 'pluggy': '1.4.0'}, 'Plugins': {'html': '3.1.1', 'metadata': '3.1.1', 'testinfra': '5.0.0'}}
rootdir: /wazuh-qa/tests/integration, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.1.1, testinfra-5.0.0
collected 2 items                                                                                                                                              

tests/integration/test_aws/test_custom_bucket.py::test_custom_bucket_defaults[custom_bucket_defaults] PASSED                                             [ 50%]
tests/integration/test_aws/test_custom_bucket.py::test_custom_bucket_logs[bucket_with_logs] PASSED                                                       [100%]

====================================================================== 2 passed in 33.77s ======================================================================
```