### PR TITLE
Migrated Virustotal API from v2 to v3

### DIFF
--- a/integrations/tests/test_virustotal.py
+++ b/integrations/tests/test_virustotal.py
@@ -99,14 +99,14 @@ sys_args_template = [
 ]
 
 vt_response_data = {
-        'attributes': {
-            'last_analysis_stats': {
-                'malicious': 2
-            },
-            'sha1': 'valid_sha1_value',
-            'last_analysis_date': 'valid_date_value'
-        }
+    'attributes': {
+        'last_analysis_stats': {
+            'malicious': 2
+        },
+        'sha1': 'valid_sha1_value',
+        'last_analysis_date': 'valid_date_value'
     }
+}
 
 def test_main_bad_arguments_exit():
     """Test that main function exits when wrong number of arguments are passed."""
@@ -276,7 +276,6 @@ def test_request_virustotal_info_md5_after_check_fail_8():
 def test_request_virustotal_info_md5_after_check_ok():
     """Test that the md5_after field from alerts are valid md5 hash."""
     with patch('virustotal.query_api', return_value=vt_response_data), \
-         patch('virustotal.in_database', return_value=False), \
          patch('virustotal.debug'):
 
         response = virustotal.request_virustotal_info(alert_template_md5[8], apikey_virustotal)
@@ -309,9 +308,7 @@ def test_request_info_from_api_timeout_and_retries_expired():
 def test_request_info_from_api_timeout_and_retries_not_expired():
     """Test that the query_api function fails with retries when an Timeout exception happens (retries not expired)."""
     virustotal.retries = 2
-    with patch('virustotal.query_api', side_effect=[Timeout(), Timeout(), alert_output]), patch(
-        'virustotal.in_database', return_value=False
-    ), patch('virustotal.debug') as debug:
+    with patch('virustotal.query_api', side_effect=[Timeout(), Timeout(), alert_output]), patch('virustotal.debug') as debug:
         response = virustotal.request_info_from_api(alert_template_md5[8], {'virustotal': {}}, apikey_virustotal)
         debug.assert_has_calls(
             [

--- a/integrations/tests/test_virustotal.py
+++ b/integrations/tests/test_virustotal.py
@@ -98,6 +98,15 @@ sys_args_template = [
     '>/dev/null 2>&1',
 ]
 
+vt_response_data = {
+        'attributes': {
+            'last_analysis_stats': {
+                'malicious': 2
+            },
+            'sha1': 'valid_sha1_value',
+            'last_analysis_date': 'valid_date_value'
+        }
+    }
 
 def test_main_bad_arguments_exit():
     """Test that main function exits when wrong number of arguments are passed."""
@@ -266,9 +275,16 @@ def test_request_virustotal_info_md5_after_check_fail_8():
 
 def test_request_virustotal_info_md5_after_check_ok():
     """Test that the md5_after field from alerts are valid md5 hash."""
-    with patch('virustotal.query_api'), patch('virustotal.in_database', return_value=False), patch('virustotal.debug'):
+    with patch('virustotal.query_api', return_value=vt_response_data), \
+         patch('virustotal.in_database', return_value=False), \
+         patch('virustotal.debug'):
+
         response = virustotal.request_virustotal_info(alert_template_md5[8], apikey_virustotal)
-        assert response == alert_output
+
+        assert response['virustotal']['found'] == 1
+        assert response['virustotal']['malicious'] == 1
+        assert response['virustotal']['permalink'] == 'https://www.virustotal.com/gui/file/5d41402abc4b2a76b9719d911017c592/detection'
+        assert response['virustotal']['positives'] == 2
 
 
 def test_request_info_from_api_exception():

--- a/integrations/virustotal.py
+++ b/integrations/virustotal.py
@@ -253,13 +253,6 @@ def request_virustotal_info(alert: any, apikey: str):
     return alert_output
 
 
-def in_database(data, hash):
-    result = data['response_code']
-    if result == 0:
-        return False
-    return True
-
-
 def query_api(hash: str, apikey: str) -> any:
     """Send a request to VT API and fetch information to build message
 
@@ -287,7 +280,7 @@ def query_api(hash: str, apikey: str) -> any:
 
     debug('# Querying VirusTotal API')
     response = requests.get(
-        f'https://www.virustotal.com/api/v3/files/{hash}', headers=headers, timeout=timeout    
+        f'https://www.virustotal.com/api/v3/files/{hash}', headers=headers, timeout=timeout
     )
 
     if response.status_code == 200:

--- a/integrations/virustotal.py
+++ b/integrations/virustotal.py
@@ -211,8 +211,10 @@ def request_virustotal_info(alert: any, apikey: str):
         return None
 
     # If the md5_after field is not a md5 hash checksum. Exit
-    md5_checksum = alert['syscheck']['md5_after']
-    if not re.match(r'\b([a-f\d]{32}|[A-F\d]{32})\b', md5_checksum):
+    if not (
+        isinstance(alert['syscheck']['md5_after'], str) is True
+        and len(re.findall(r'\b([a-f\d]{32}|[A-F\d]{32})\b', alert['syscheck']['md5_after'])) == 1
+    ):
         debug('# md5_after field in the alert is not a md5 hash checksum')
         return None
 
@@ -224,12 +226,12 @@ def request_virustotal_info(alert: any, apikey: str):
     alert_output['virustotal']['source'] = {
         'alert_id': alert['id'],
         'file': alert['syscheck']['path'],
-        'md5': md5_checksum,
+        'md5': alert['syscheck']['md5_after'],
         'sha1': alert['syscheck']['sha1_after'],
     }
 
     # Check if VirusTotal has any info about the hash
-    if in_database(vt_response_data, md5_checksum):
+    if in_database(vt_response_data, hash):
         alert_output['virustotal']['found'] = 1
 
     # Info about the file found in VirusTotal

--- a/integrations/virustotal.py
+++ b/integrations/virustotal.py
@@ -2,7 +2,7 @@
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
-# License (version 3) as published by the FSF - Free Software
+# License (version 2) as published by the FSF - Free Software
 # Foundation.
 
 

--- a/ruleset/rules/0490-virustotal_rules.xml
+++ b/ruleset/rules/0490-virustotal_rules.xml
@@ -18,14 +18,14 @@
 
     <rule id="87101" level="3">
         <if_sid>87100</if_sid>
-        <field name="virustotal.error">204</field>
+        <field name="virustotal.error">409</field>
         <description>VirusTotal: Error: Public API request rate limit reached</description>
         <options>no_full_log</options>
     </rule>
 
     <rule id="87102" level="3">
         <if_sid>87100</if_sid>
-        <field name="virustotal.error">403</field>
+        <field name="virustotal.error">401</field>
         <description>VirusTotal: Error: Check credentials</description>
         <group>gdpr_IV_35.7.d,gdpr_IV_32.2,</group>
         <options>no_full_log</options>


### PR DESCRIPTION
|Related issue|
|---|
| #22573  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The VirusTotal API was migrated from `v2` to `v3` following the provided documentation, its functionality was verified [here](https://github.com/wazuh/wazuh/issues/22573#issuecomment-2010296130), and the corresponding tests were launched

## Tests

```console
(unittest-env) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest integrations/tests/test_virustotal.py 
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0
rootdir: /home/wazuh/Git/wazuh/integrations
configfile: pytest.ini
plugins: anyio-4.3.0, aiohttp-1.0.4, trio-0.8.0, html-2.1.1, metadata-3.1.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 22 items                                                                                                                                                                                         

integrations/tests/test_virustotal.py ......................                                                                                                                                         [100%]

============================================================================================ 22 passed in 0.10s ============================================================================================
```

All integrations tests:
```console
(unittest-env) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest integrations/tests/
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0
rootdir: /home/wazuh/Git/wazuh/integrations
configfile: pytest.ini
plugins: anyio-4.3.0, aiohttp-1.0.4, trio-0.8.0, html-2.1.1, metadata-3.1.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 122 items                                                                                                                                                                                        

integrations/tests/test_maltiverse.py ..............................................................                                                                                                 [ 50%]
integrations/tests/test_pagerduty.py ..........                                                                                                                                                      [ 59%]
integrations/tests/test_shuffle.py ..................                                                                                                                                                [ 73%]
integrations/tests/test_slack.py ..........                                                                                                                                                          [ 81%]
integrations/tests/test_virustotal.py ......................                                                                                                                                         [100%]

=========================================================================================== 122 passed in 2.46s ============================================================================================
```