### PR TITLE
Extract and strip macOS symbols

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -170,7 +170,6 @@ function build_package() {
         echo "The wazuh agent package for macOS has been successfully built."
         symbols_pkg_name=$(echo "${pkg_name}" | tr '\n' ' ' | cut -d ' ' -f 1)
         symbols_pkg_name="${symbols_pkg_name}_debug_symbols"
-        echo "Parte deseada: ${symbols_pkg_name}"
         cp -R "${SOURCES_DIRECTORY}/wazuh/src/symbols"  "${DESTINATION}"
         zip -r "${DESTINATION}${symbols_pkg_name}.zip" "${DESTINATION}symbols"
         rm -rf "${DESTINATION}symbols"

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -168,9 +168,12 @@ function build_package() {
     # create package
     if packagesbuild ${AGENT_PKG_FILE} --build-folder ${DESTINATION} ; then
         echo "The wazuh agent package for macOS has been successfully built."
-        cp -R "${SOURCES_DIRECTORY}/wazuh/src/symbols" "${DESTINATION}"
-        zip -r "${DESTINATION}/symbols.zip" "${DESTINATION}/symbols"
-        rm -rf "${DESTINATION}/symbols"
+        symbols_pkg_name=$(echo "${pkg_name}" | tr '\n' ' ' | cut -d ' ' -f 1)
+        symbols_pkg_name="${symbols_pkg_name}_debug_symbols"
+        echo "Parte deseada: ${symbols_pkg_name}"
+        cp -R "${SOURCES_DIRECTORY}/wazuh/src/symbols"  "${DESTINATION}"
+        zip -r "${DESTINATION}${symbols_pkg_name}.zip" "${DESTINATION}symbols"
+        rm -rf "${DESTINATION}symbols"
         sign_pkg
         if [[ "${CHECKSUM}" == "yes" ]]; then
             mkdir -p ${CHECKSUMDIR}

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -168,6 +168,9 @@ function build_package() {
     # create package
     if packagesbuild ${AGENT_PKG_FILE} --build-folder ${DESTINATION} ; then
         echo "The wazuh agent package for macOS has been successfully built."
+        cp -R "${SOURCES_DIRECTORY}/wazuh/src/symbols" "${DESTINATION}"
+        zip -r "${DESTINATION}/symbols.zip" "${DESTINATION}/symbols"
+        rm -rf "${DESTINATION}/symbols"
         sign_pkg
         if [[ "${CHECKSUM}" == "yes" ]]; then
             mkdir -p ${CHECKSUMDIR}

--- a/packages/macos/package_files/build.sh
+++ b/packages/macos/package_files/build.sh
@@ -42,6 +42,14 @@ function build() {
     make -j $BUILD_JOBS -C ${SOURCES_PATH}/src DYLD_FORCE_FLAT_NAMESPACE=1 DEBUG=$DEBUG TARGET=agent build
     fi
 
+    EXECUTABLE_FILES=$(find "${SEARCH_DIR}" -maxdepth 1 -type f ! -name "*.py" -exec file {} + | grep 'executable' | cut -d: -f1)
+    EXECUTABLE_FILES+=" $(find "${SEARCH_DIR}" -type f ! -name "*.py" ! -path "${SEARCH_DIR}/external/*" ! -path "${SEARCH_DIR}/symbols/*" -name "*.dylib" -print 2>/dev/null)"
+
+    for var in $EXECUTABLE_FILES; do
+    filename=$(basename "$var")
+    dsymutil -o "${SEARCH_DIR}/symbols/${filename}.dSYM" "$var" 2>/dev/null && strip -S "$var"
+    done
+
     echo "Running install script"
     ${SOURCES_PATH}/install.sh
 


### PR DESCRIPTION
Related issue|
|---|
|[#21734](https://github.com/wazuh/wazuh/issues/21734)|

## Description

This PR modifies the `wazuh/packages/macos/generate_wazuh_packages.sh` and `wazuh/packages/macos/package_files/build.sh` files to (by default) extract and remove from all executables the debug symbols that were generated in the compilation, leaving these symbols in the directory that is set as output for the `.pkg` file and for the debug symbols (by default the `output/` folder is set).

<details>
<summary>Script execution</summary>

```
sudo ./generate_wazuh_packages.sh -b 21734-add-debug-symbols-macos


+ find /Library/Ossec/ruleset/sca/ -type f -exec rm -f '{}' ';'
+ mkdir -p /Library/Ossec/packages_files/agent_installation_scripts/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/gen_ossec.sh /Library/Ossec/packages_files/agent_installation_scripts/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/add_localfiles.sh /Library/Ossec/packages_files/agent_installation_scripts/
+ mkdir -p /Library/Ossec/packages_files/agent_installation_scripts/src/init
+ mkdir -p /Library/Ossec/packages_files/agent_installation_scripts/etc/templates/config/generic /Library/Ossec/packages_files/agent_installation_scripts/etc/templates/config/darwin
+ cp -r /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/generic /Library/Ossec/packages_files/agent_installation_scripts/etc/templates/config
+ cp -r /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin /Library/Ossec/packages_files/agent_installation_scripts/etc/templates/config
+ find /Users/ec2-user/wazuh/packages/macos/repository/wazuh/src/init/ -name '*.sh' -type f -exec install -m 0640 '{}' /Library/Ossec/packages_files/agent_installation_scripts/src/init ';'
+ mkdir -p /Library/Ossec/packages_files/agent_installation_scripts/sca/generic
+ mkdir -p /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/15 /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/16 /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/17 /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/18 /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/20 /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/21 /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/22 /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/23
+ cp -r /Users/ec2-user/wazuh/packages/macos/repository/wazuh/ruleset/sca/darwin /Library/Ossec/packages_files/agent_installation_scripts/sca
+ cp -r /Users/ec2-user/wazuh/packages/macos/repository/wazuh/ruleset/sca/generic /Library/Ossec/packages_files/agent_installation_scripts/sca
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/generic/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/generic/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/15/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/15/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/16/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/16/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/17/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/17/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/18/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/18/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/19/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/19/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/20/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/20/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/21/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/21/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/22/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/22/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/etc/templates/config/darwin/23/sca.files /Library/Ossec/packages_files/agent_installation_scripts/sca/darwin/23/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/src/VERSION /Library/Ossec/packages_files/agent_installation_scripts/src/
+ cp /Users/ec2-user/wazuh/packages/macos/repository/wazuh/src/REVISION /Library/Ossec/packages_files/agent_installation_scripts/src/
+ sign_binaries
+ '[' '!' -z '' ']'
+ packagesbuild /Users/ec2-user/wazuh/packages/macos/repository/wazuh/packages/macos/package_files/wazuh-agent-intel64.pkgproj --build-folder /Users/ec2-user/wazuh/packages/macos/output/
Build Successful (2 seconds)
+ echo 'The wazuh agent package for macOS has been successfully built.'
The wazuh agent package for macOS has been successfully built.
--short'
++ tr '\n' ' '
++ cut -d ' ' -f 1
+ cp -R /Users/ec2-user/wazuh/packages/macos/repository/wazuh/src/symbols /Users/ec2-user/wazuh/packages/macos/output/
+ zip -r /Users/ec2-user/wazuh/packages/macos/output/wazuh-agent_4.9.0-1_intel64_-C_debug_symbols.zip /Users/ec2-user/wazuh/packages/macos/output/symbols
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/librsync.dylib.yml (deflated 24%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/DWARF/librsync.dylib (deflated 89%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/Relocations/x86_64/kaspersky.yml (deflated 20%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/DWARF/kaspersky (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/Relocations/x86_64/host-deny.yml (deflated 20%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/DWARF/host-deny (deflated 91%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/Relocations/x86_64/firewalld-drop.yml (deflated 21%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/DWARF/firewalld-drop (deflated 91%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/Relocations/x86_64/libwazuhshared.dylib.yml (deflated 22%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/DWARF/libwazuhshared.dylib (deflated 76%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/Relocations/x86_64/libsysinfo.dylib.yml (deflated 24%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/DWARF/libsysinfo.dylib (deflated 86%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/Relocations/x86_64/agent-auth.yml (deflated 21%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/DWARF/agent-auth (deflated 73%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/Relocations/x86_64/wazuh-logcollector.yml (deflated 86%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/DWARF/wazuh-logcollector (deflated 65%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/Relocations/x86_64/libwazuhext.dylib.yml (deflated 22%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/DWARF/libwazuhext.dylib (deflated 75%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/Relocations/x86_64/default-firewall-drop.yml (deflated 21%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/DWARF/default-firewall-drop (deflated 91%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/Relocations/x86_64/ipfw.yml (deflated 19%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/DWARF/ipfw (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/Relocations/x86_64/route-null.yml (deflated 21%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/DWARF/route-null (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/Relocations/x86_64/libsyscollector.dylib.yml (deflated 28%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/DWARF/libsyscollector.dylib (deflated 88%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/Relocations/x86_64/restart-wazuh.yml (deflated 22%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/DWARF/restart-wazuh (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/Relocations/x86_64/wazuh-slack.yml (deflated 22%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/DWARF/wazuh-slack (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/Relocations/x86_64/pf.yml (deflated 19%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/DWARF/pf (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/libdbsync.dylib.yml (deflated 25%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/DWARF/libdbsync.dylib (deflated 89%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/Resources/Relocations/x86_64/firewall-drop.yml (deflated 20%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/Resources/DWARF/firewall-drop (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/firewall-drop.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/Relocations/x86_64/manage_agents.yml (deflated 21%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/DWARF/manage_agents (deflated 72%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/Relocations/x86_64/disable-account.yml (deflated 21%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/DWARF/disable-account (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/Relocations/x86_64/wazuh-execd.yml (deflated 86%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/DWARF/wazuh-execd (deflated 65%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/Relocations/x86_64/wazuh-modulesd.yml (deflated 22%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/DWARF/wazuh-modulesd (deflated 69%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/Relocations/x86_64/wazuh-agentd.yml (deflated 22%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/DWARF/wazuh-agentd (deflated 69%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/Relocations/x86_64/ip-customblock.yml (deflated 21%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/DWARF/ip-customblock (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/Relocations/x86_64/npf.yml (deflated 20%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/DWARF/npf (deflated 90%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/Relocations/x86_64/libfimdb.dylib.yml (deflated 22%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/DWARF/libfimdb.dylib (deflated 87%)
  adding: Users/ec2-user/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Info.plist (deflated 52%)
+ rm -rf /Users/ec2-user/wazuh/packages/macos/output/symbols
+ sign_pkg
+ '[' '!' -z '' ']'
+ [[ no == \y\e\s ]]
+ clean_and_exit 0
+ exit_code=0
+ '[' -z 21734-add-debug-symbols-macos ']'
+ /Users/ec2-user/wazuh/packages/macos/uninstall.sh
wazuh-modulesd not running...
wazuh-logcollector not running...
wazuh-syscheckd not running...
wazuh-agentd not running...
wazuh-execd not running...
Wazuh v4.9.0 Stopped
Unload failed: 5: Input/output error
Try running `launchctl bootout` as root for richer errors.
No receipt for 'com.wazuh.pkg.wazuh-agent' found at '/'.
No receipt for 'com.wazuh.pkg.wazuh-agent-etc' found at '/'.

Wazuh agent correctly removed from the system.

+ exit 0


macos % ls output 
wazuh-agent_4.9.0-1_intel64_-C.pkg               wazuh-agent_4.9.0-1_intel64_-C_debug_symbols.zip

```

</details>

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors