### PR TITLE
Added UNIX socket path boundary check

### DIFF
--- a/src/shared_modules/utils/socketWrapper.hpp
+++ b/src/shared_modules/utils/socketWrapper.hpp
@@ -84,7 +84,7 @@ public:
         m_unixAddr.sun_family = AF_UNIX;
         if (path.size() >= sizeof(m_unixAddr.sun_path))
         {
-            throw std::runtime_error {"Error setting socket path too long"};
+            throw std::runtime_error {"Error setting socket path (too long)"};
         }
 
         std::copy(path.begin(), path.end(), m_unixAddr.sun_path);

--- a/src/shared_modules/utils/socketWrapper.hpp
+++ b/src/shared_modules/utils/socketWrapper.hpp
@@ -82,7 +82,14 @@ public:
     UnixAddress& address(const std::string& path)
     {
         m_unixAddr.sun_family = AF_UNIX;
+        if (path.size() >= sizeof(m_unixAddr.sun_path))
+        {
+            throw std::runtime_error {"Error setting socket path too long"};
+        }
+
         std::copy(path.begin(), path.end(), m_unixAddr.sun_path);
+        m_unixAddr.sun_path[path.size()] = '\0';
+
         return *this;
     }
 };

--- a/src/shared_modules/utils/tests/socketWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/socketWrapper_test.cpp
@@ -47,6 +47,13 @@ TEST_F(SocketWrapperTest, SocketWrapperTestInstance)
     Socket<OSWrapper> socketWrapper;
 }
 
+TEST_F(SocketWrapperTest, UnixAddressPathToLong)
+{
+    constexpr auto MAX_SUN_PATH = 108;
+    std::string path(MAX_SUN_PATH + 10, 'a');
+    EXPECT_THROW(UnixAddress::builder().address(path).build(), std::runtime_error);
+}
+
 TEST_F(SocketWrapperTest, ConnectSuccess)
 {
     Socket<OSWrapper> socketWrapper;
@@ -248,7 +255,8 @@ TEST_F(SocketWrapperTest, DISABLED_ReadPartialBody)
                             [&data, &header](int, void* buffer, size_t, int)
                             {
                                 std::copy(header.begin(), header.end(), (char*)buffer);
-                                std::copy(data.begin(), data.begin() + data.size() / 2, (char*)buffer + HEADER_FIELD_SIZE);
+                                std::copy(
+                                    data.begin(), data.begin() + data.size() / 2, (char*)buffer + HEADER_FIELD_SIZE);
                             }),
                         Return(packetSize)))
         .WillOnce(DoAll(Invoke(


### PR DESCRIPTION
|Related issue|
|---|
|#22570|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds a check for socket path length, the test is a dummy check that does not prove any functionality. The tested function should use the data context and then update the test case. 
