### PR TITLE
Add publication and detection timestamp fields to VD events

### DIFF
--- a/src/shared_modules/indexer_connector/testtool/input/example.json
+++ b/src/shared_modules/indexer_connector/testtool/input/example.json
@@ -2,7 +2,6 @@
     "id": "worker1_000_pkghash_CVE-2022-1234",
     "operation": "INSERT",
     "data":{
-      "@timestamp": "2023-09-18T12:00:00Z",
       "agent": {
         "build": {
           "original": "sample_build_1"
@@ -62,6 +61,8 @@
       },
       "tags": ["sample", "tag1"],
       "vulnerability": {
+        "detected_at": "2023-09-18T12:00:00Z",
+        "published_at": "2023-01-18T12:00:00Z",
         "category": "sample_category",
         "classification": "sample_classification",
         "description": "Sample vulnerability description",

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -166,34 +166,39 @@ public:
             if (returnData.data)
             {
                 auto ecsData = nlohmann::json::object();
+
                 // ECS agent fields.
                 ecsData["agent"] = agent;
+
                 // ECS package fields.
                 if (data->affectedComponentType() == AffectedComponentType::Package)
                 {
                     ecsData["package"] = package;
                 }
+
                 // ECS os fields.
                 ecsData["host"]["os"] = os;
+
                 // ECS vulnerability fields.
                 ecsData["vulnerability"]["category"] = "Packages";
                 ecsData["vulnerability"]["classification"] = returnData.data->classification()->str();
                 ecsData["vulnerability"]["description"] = returnData.data->description()->str();
+                ecsData["vulnerability"]["detected_at"] = Utils::getCurrentISO8601();
                 ecsData["vulnerability"]["enumeration"] = "CVE";
                 ecsData["vulnerability"]["id"] = cve;
+                ecsData["vulnerability"]["published_at"] = returnData.data->datePublished()->str();
                 ecsData["vulnerability"]["reference"] = returnData.data->reference()->str();
                 ecsData["vulnerability"]["scanner"]["vendor"] = "Wazuh";
                 ecsData["vulnerability"]["score"]["base"] = Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
                 ecsData["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
                 ecsData["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
+
                 // ECS wazuh fields.
                 auto vulnerabilityDetection = PolicyManager::instance().getVulnerabilityDetection();
                 ecsData["wazuh"]["cluster"]["name"] =
                     vulnerabilityDetection.contains("clusterName") ? vulnerabilityDetection.at("clusterName") : "";
                 ecsData["wazuh"]["manager"]["name"] = data->managerName();
                 ecsData["wazuh"]["schema"]["version"] = WAZUH_SCHEMA_VERSION;
-                // ECS base fields.
-                ecsData["@timestamp"] = Utils::getCurrentISO8601();
 
                 json["data"] = std::move(ecsData);
             }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -22,6 +22,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
+#include "timeHelper.h"
 #include <unistd.h>
 
 using ::testing::_;
@@ -329,6 +330,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
                      : "");
     EXPECT_STREQ(elementData.at("wazuh").at("schema").at("version").get_ref<const std::string&>().c_str(),
                  WAZUH_SCHEMA_VERSION);
+    EXPECT_STREQ(elementData.at("vulnerability").at("published_at").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
+    EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
+                Utils::getCurrentISO8601());
 
     auto managerName = scanContext->managerName();
     constexpr auto MAX_HOSTNAME_SIZE = 256;
@@ -514,6 +519,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
                      : "");
     EXPECT_STREQ(elementData.at("wazuh").at("schema").at("version").get_ref<const std::string&>().c_str(),
                  WAZUH_SCHEMA_VERSION);
+    EXPECT_STREQ(elementData.at("vulnerability").at("published_at").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
+    EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
+                Utils::getCurrentISO8601());
 
     auto managerName = scanContext->managerName();
     constexpr auto MAX_HOSTNAME_SIZE = 256;
@@ -764,6 +773,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
                  vulnerabilityDetection.contains("clusterName")
                      ? vulnerabilityDetection.at("clusterName").get_ref<const std::string&>().c_str()
                      : "");
+    EXPECT_STREQ(elementData.at("vulnerability").at("published_at").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
+    EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
+                Utils::getCurrentISO8601());
 
     auto managerName = scanContext->managerName();
     constexpr auto MAX_HOSTNAME_SIZE = 256;


### PR DESCRIPTION
|Related issue|
|---|
| #22649 |

## Description
This PR adds two fields to the vulnerability events from VD:
- `detected_at` -> When the vulnerability was detected on the system
- `published_at` -> When the vulnerability was published (obtained from content)

## Tests
I've cherry-picked both of these commits:
- https://github.com/wazuh/wazuh/pull/22611/commits

Installed the manager and generated the indices:
![image](https://github.com/wazuh/wazuh/assets/34063881/94752e24-99bd-4cee-81a2-1035e542e3bb)


## Note
The format of the timestamp obtained from the content is different than the one obtained from `Utils::getCurrentISO8601()`. Is this behaviour expected?