### PR TITLE
Changes to limit the memory usage in write/read operations with rocksdb.

### DIFF
--- a/src/shared_modules/utils/rocksDBQueue.hpp
+++ b/src/shared_modules/utils/rocksDBQueue.hpp
@@ -13,9 +13,9 @@
 #define _ROCKSDB_QUEUE_HPP
 
 #include "rocksdb/db.h"
+#include "rocksdb/filter_policy.h"
+#include "rocksdb/table.h"
 #include <filesystem>
-#include <functional>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -27,19 +27,32 @@ public:
     explicit RocksDBQueue(const std::string& connectorName)
     {
         // RocksDB initialization.
+        // Read cache is used to cache the data read from the disk.
+        m_readCache = rocksdb::NewLRUCache(16 * 1024 * 1024);
+        rocksdb::BlockBasedTableOptions tableOptions;
+        tableOptions.block_cache = m_readCache;
+
+        // Write buffer manager is used to manage the memory used for writing data to the disk.
+        m_writeManager = std::make_shared<rocksdb::WriteBufferManager>(64 * 1024 * 1024);
+
         rocksdb::Options options;
+        options.table_factory.reset(NewBlockBasedTableFactory(tableOptions));
         options.create_if_missing = true;
         options.keep_log_file_num = 1;
         options.info_log_level = rocksdb::InfoLogLevel::FATAL_LEVEL;
+        options.max_open_files = 64;
+        options.write_buffer_manager = m_writeManager;
+        options.num_levels = 4;
+
+        options.write_buffer_size = 32 * 1024 * 1024;
+        options.max_write_buffer_number = 2;
 
         rocksdb::DB* db;
 
         // Create directories recursively if they do not exist
         std::filesystem::create_directories(std::filesystem::path(connectorName));
 
-        rocksdb::Status status = rocksdb::DB::Open(options, connectorName, &db);
-
-        if (!status.ok())
+        if (const auto status = rocksdb::DB::Open(options, connectorName, &db); !status.ok())
         {
             throw std::runtime_error("Failed to open RocksDB database");
         }
@@ -82,9 +95,8 @@ public:
     void push(const T& data)
     {
         // RocksDB enqueue element.
-        auto status = m_db->Put(rocksdb::WriteOptions(), std::to_string(++m_last), data);
-
-        if (!status.ok())
+        ++m_last;
+        if (const auto status = m_db->Put(rocksdb::WriteOptions(), std::to_string(m_last), data); !status.ok())
         {
             throw std::runtime_error("Failed to enqueue element");
         }
@@ -149,6 +161,8 @@ public:
 
 private:
     std::unique_ptr<rocksdb::DB> m_db;
+    std::shared_ptr<rocksdb::Cache> m_readCache;
+    std::shared_ptr<rocksdb::WriteBufferManager> m_writeManager;
     uint64_t m_size;
     uint64_t m_first;
     uint64_t m_last;

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -150,9 +150,14 @@ namespace Utils
         rocksdb::ColumnFamilyOptions buildColumnFamilyOptions() const
         {
             rocksdb::ColumnFamilyOptions columnFamilyOptions;
+            // Amount of data to build up in memory (backed by an unsorted log
+            // on disk) before converting to a sorted on-disk file.
             columnFamilyOptions.write_buffer_size = 64 * 1024 * 1024;
+            // The maximum number of write buffers that are built up in memory.
             columnFamilyOptions.max_write_buffer_number = 2;
+            // The maximum number of levels of compaction to allow.
             columnFamilyOptions.num_levels = 4;
+            // The size of the LRU cache used to prevent cold reads.
             columnFamilyOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(buildTableOptions()));
 
             return columnFamilyOptions;
@@ -170,15 +175,28 @@ namespace Utils
             }
 
             rocksdb::Options options;
+            // If the total size of all live memtables of all the DBs exceeds
+            // a limit, a flush will be triggered in the next DB to which the next write
+            // is issued, as long as there is one or more column family not already
+            // flushing.
             options.write_buffer_manager = m_writeManager;
+            // If true, the database will be created if it is missing.
             options.create_if_missing = true;
+            // If true, log files will be kept around to restore the database
             options.keep_log_file_num = 1;
+            // Log level for the info log.
             options.info_log_level = rocksdb::InfoLogLevel::FATAL_LEVEL;
+            // The maximum number of files to keep open at the same time.
             options.max_open_files = 256;
+            // The maximum levels of compaction to allow.
             options.num_levels = 4;
+            // Amount of data to build up in memory (backed by an unsorted log
+            // on disk) before converting to a sorted on-disk file.
             options.write_buffer_size = 64 * 1024 * 1024;
+            // The maximum number of write buffers that are built up in memory.
             options.max_write_buffer_number = 2;
 
+            // The size of the LRU cache used to prevent cold reads.
             options.table_factory.reset(NewBlockBasedTableFactory(buildTableOptions()));
             return options;
         }

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -13,11 +13,12 @@
 #define _ROCKS_DB_WRAPPER_HPP
 
 #include "rocksDBIterator.hpp"
-#include "stringHelper.h"
 #include <algorithm>
 #include <filesystem>
 #include <memory>
 #include <rocksdb/db.h>
+#include <rocksdb/filter_policy.h>
+#include <rocksdb/table.h>
 #include <rocksdb/utilities/transaction.h>
 #include <rocksdb/utilities/transaction_db.h>
 #include <stdexcept>
@@ -27,6 +28,77 @@
 
 namespace Utils
 {
+
+    /**
+     * @brief RAII wrapper for RocksDB column family handle.
+     *
+     */
+    class ColumnFamilyRAII final
+    {
+    private:
+        std::shared_ptr<rocksdb::DB> m_db; ///< RocksDB instance.
+        std::unique_ptr<rocksdb::ColumnFamilyHandle, std::function<void(rocksdb::ColumnFamilyHandle*)>>
+            m_handle; ///< Column family handle.
+
+    public:
+        /**
+         * @brief Constructor.
+         *
+         * @param db RocksDB instance.
+         * @param rawHandle Column family handle.
+         */
+        ColumnFamilyRAII(std::shared_ptr<rocksdb::DB> db, rocksdb::ColumnFamilyHandle* rawHandle)
+            : m_db {db}
+            , m_handle(rawHandle,
+                       [db](rocksdb::ColumnFamilyHandle* handle)
+                       {
+                           if (db && handle)
+                           {
+                               auto status = db->DestroyColumnFamilyHandle(handle);
+                               if (!status.ok())
+                               {
+                                   throw std::runtime_error("Failed to free RocksDB column family: " +
+                                                            std::string {status.getState()});
+                               }
+                           }
+                       })
+        {
+        }
+
+        /**
+         * @brief Get the column family handle.
+         *
+         * @return rocksdb::ColumnFamilyHandle* Column family handle.
+         */
+        rocksdb::ColumnFamilyHandle* handle() const
+        {
+            return m_handle.get();
+        }
+
+        /**
+         * @brief Overload of the arrow operator.
+         *
+         * @return rocksdb::ColumnFamilyHandle* Column family handle.
+         */
+        rocksdb::ColumnFamilyHandle* operator->() const
+        {
+            return this->handle();
+        }
+
+        /**
+         * @brief Drops the column family.
+         *
+         * @note This method is used to delete a column family from the database.
+         */
+        void drop() const
+        {
+            if (const auto status = m_db->DropColumnFamily(m_handle.get()); !status.ok())
+            {
+                throw std::runtime_error("Error deleting data: " + status.ToString());
+            }
+        }
+    };
+
     class RocksDBTransaction;
     class IRocksDBWrapper
     {
@@ -52,20 +124,83 @@ namespace Utils
      * @brief Wrapper class for RocksDB.
      *
      */
-    class RocksDBWrapper : public IRocksDBWrapper
+    template<typename T = rocksdb::DB>
+    class TRocksDBWrapper : public IRocksDBWrapper
     {
         /**
-         * @brief Initializes the RocksDB instance.
+         * @brief Builds the table options for the RocksDB instance.
+         * @return rocksdb::BlockBasedTableOptions Table options.
          */
-        void initialize()
+        rocksdb::BlockBasedTableOptions buildTableOptions() const
         {
+            if (m_readCache == nullptr)
+            {
+                throw std::runtime_error("Read cache is not initialized");
+            }
+
+            rocksdb::BlockBasedTableOptions tableOptions;
+            tableOptions.block_cache = m_readCache;
+            return tableOptions;
+        }
+
+        /**
+         * @brief Builds the column family options for the RocksDB instance.
+         * @return rocksdb::ColumnFamilyOptions Column family options.
+         */
+        rocksdb::ColumnFamilyOptions buildColumnFamilyOptions() const
+        {
+            rocksdb::ColumnFamilyOptions columnFamilyOptions;
+            columnFamilyOptions.write_buffer_size = 64 * 1024 * 1024;
+            columnFamilyOptions.max_write_buffer_number = 2;
+            columnFamilyOptions.num_levels = 4;
+            columnFamilyOptions.table_factory.reset(rocksdb::NewBlockBasedTableFactory(buildTableOptions()));
+
+            return columnFamilyOptions;
+        }
+
+        /**
+         * @brief Builds the DB options for the RocksDB instance.
+         * @return rocksdb::Options DB options.
+         */
+        rocksdb::Options buildDBOptions() const
+        {
+            if (m_writeManager == nullptr)
+            {
+                throw std::runtime_error("Write buffer manager is not initialized");
+            }
+
             rocksdb::Options options;
+            options.write_buffer_manager = m_writeManager;
             options.create_if_missing = true;
             options.keep_log_file_num = 1;
             options.info_log_level = rocksdb::InfoLogLevel::FATAL_LEVEL;
-            options.max_open_files = 200;
+            options.max_open_files = 256;
+            options.num_levels = 4;
+            options.write_buffer_size = 64 * 1024 * 1024;
+            options.max_write_buffer_number = 2;
 
-            rocksdb::TransactionDB* dbRawPtr;
+            options.table_factory.reset(NewBlockBasedTableFactory(buildTableOptions()));
+            return options;
+        }
+
+    public:
+        /**
+         * @brief Constructor.
+         *
+         * @param dbPath Path to the RocksDB database.
+         * @param enableWal Whether to enable WAL or not.
+         */
+        explicit TRocksDBWrapper(std::string dbPath, const bool enableWal = true)
+            : m_enableWal {enableWal}
+            , m_path {std::move(dbPath)}
+        {
+            m_readCache = rocksdb::NewLRUCache(16 * 1024 * 1024);
+            m_writeManager = std::make_shared<rocksdb::WriteBufferManager>(128 * 1024 * 1024);
+
+            rocksdb::Options options = buildDBOptions();
+            rocksdb::ColumnFamilyOptions columnFamilyOptions = buildColumnFamilyOptions();
+
+            T* dbRawPtr;
             std::vector<rocksdb::ColumnFamilyDescriptor> columnsDescriptors;
             const std::filesystem::path databasePath {m_path};
 
@@ -73,13 +208,11 @@ namespace Utils
             std::filesystem::create_directories(databasePath);
 
             // Get a list of the existing columns descriptors.
-            const auto databaseFile {databasePath / "CURRENT"};
-            if (std::filesystem::exists(databaseFile))
+            if (const auto databaseFile {databasePath / "CURRENT"}; std::filesystem::exists(databaseFile))
             {
                 // Read columns names.
                 std::vector<std::string> columnsNames;
-                const auto listStatus {rocksdb::TransactionDB::ListColumnFamilies(options, m_path, &columnsNames)};
-                if (!listStatus.ok())
+                if (const auto listStatus {T::ListColumnFamilies(options, m_path, &columnsNames)}; !listStatus.ok())
                 {
                     throw std::runtime_error("Failed to list columns: " + std::string {listStatus.getState()});
                 }
@@ -87,75 +220,56 @@ namespace Utils
                 // Create a set of column descriptors. This includes the default column.
                 for (auto& columnName : columnsNames)
                 {
-                    columnsDescriptors.emplace_back(columnName, rocksdb::ColumnFamilyOptions());
+                    columnsDescriptors.emplace_back(columnName, columnFamilyOptions);
                 }
             }
             else
             {
                 // Database doesn't exist: Set just the default column descriptor.
-                columnsDescriptors.emplace_back(rocksdb::kDefaultColumnFamilyName, rocksdb::ColumnFamilyOptions());
+                columnsDescriptors.emplace_back(rocksdb::kDefaultColumnFamilyName, columnFamilyOptions);
             }
 
+            // Create a vector of column handles.
+            // This vector will be used to store the column handles created by the Open method and based on the
+            // columnsDescriptors.
+            std::vector<rocksdb::ColumnFamilyHandle*> columnHandles;
+            columnHandles.reserve(columnsDescriptors.size());
+
             // Open database with a list of columns descriptors.
-            const auto status {rocksdb::TransactionDB::Open(
-                options, rocksdb::TransactionDBOptions(), m_path, columnsDescriptors, &m_columnsHandles, &dbRawPtr)};
-            if (!status.ok())
+            // Compare if T is a rocksdb::DB or rocksdb::TransactionDB.
+            if constexpr (std::is_same_v<T, rocksdb::DB>)
             {
-                throw std::runtime_error("Failed to open RocksDB database. Reason: " + std::string {status.getState()});
+                if (const auto status {T::Open(options, m_path, columnsDescriptors, &columnHandles, &dbRawPtr)};
+                    !status.ok())
+                {
+                    throw std::runtime_error("Failed to open RocksDB database. Reason: " +
+                                             std::string {status.getState()});
+                }
+            }
+            else
+            {
+                if (const auto status {T::Open(options,
+                                               rocksdb::TransactionDBOptions(),
+                                               m_path,
+                                               columnsDescriptors,
+                                               &columnHandles,
+                                               &dbRawPtr)};
+                    !status.ok())
+                {
+                    throw std::runtime_error("Failed to open RocksDB database. Reason: " +
+                                             std::string {status.getState()});
+                }
             }
             // Assigns the raw pointer to the unique_ptr. When db goes out of scope, it will automatically delete the
             // allocated RocksDB instance.
             m_db.reset(dbRawPtr);
-        }
 
-        /**
-         * @brief Frees column family handles.
-         */
-        void destroyColumnFamilyHandles()
-        {
-            std::for_each(m_columnsHandles.begin(),
-                          m_columnsHandles.end(),
-                          [this](rocksdb::ColumnFamilyHandle* handle)
-                          {
-                              const auto status {m_db->DestroyColumnFamilyHandle(handle)};
-                              if (!status.ok())
-                              {
-                                  std::cerr
-                                      << "Failed to free RocksDB column family: " + std::string {status.getState()}
-                                      << std::endl;
-                              }
-                          });
+            // Create a RAII wrapper for each column handle.
+            for (const auto& handle : columnHandles)
+            {
+                m_columnsInstances.emplace_back(m_db, handle);
+            }
         }
-
-    public:
-        explicit RocksDBWrapper(std::string dbPath, const bool enableWal = true)
-            : m_enableWal {enableWal}
-            , m_path {std::move(dbPath)}
-        {
-            initialize();
-        }
-
-        /**
-         * @brief Reopen the database.
-         */
-        void reopen()
-        {
-            destroyColumnFamilyHandles();
-            m_db.reset();
-            initialize();
-        }
-
-        /**
-         * @brief Class destructor. Frees column family handles.
-         *
-         * @note The documentation of the lib clearly states that we should not free the default column family handler
-         * but not freeing it ends up on memory leaks and ASAN errors. OTOH, no problems seem to appear freeing it.
-         *
-         */
-        ~RocksDBWrapper() override
-        {
-            destroyColumnFamilyHandles();
-        };
 
         /**
          * @brief Put a key-value pair in the database.
@@ -175,8 +289,9 @@ namespace Utils
             rocksdb::WriteOptions writeOptions;
             writeOptions.disableWAL = !m_enableWal;
 
-            const auto status {m_db->Put(writeOptions, getColumnFamilyHandle(columnName), key, value)};
-            if (!status.ok())
+            if (const auto status {
+                    m_db->Put(writeOptions, getColumnFamilyBasedOnName(columnName).handle(), key, value)};
+                !status.ok())
             {
                 throw std::runtime_error("Error putting data: " + status.ToString());
             }
@@ -212,8 +327,9 @@ namespace Utils
                 throw std::invalid_argument("Key is empty");
             }
 
-            const auto status {m_db->Get(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName), key, &value)};
-            if (status.IsNotFound())
+            if (const auto status {
+                    m_db->Get(rocksdb::ReadOptions(), getColumnFamilyBasedOnName(columnName).handle(), key, &value)};
+                status.IsNotFound())
             {
                 return false;
             }
@@ -234,7 +350,6 @@ namespace Utils
          * @return bool True if the operation was successful.
          * @return bool False if the key was not found.
          */
-
         bool get(const std::string& key, rocksdb::PinnableSlice& value, const std::string& columnName) override
         {
             if (key.empty())
@@ -242,8 +357,9 @@ namespace Utils
                 throw std::invalid_argument("Key is empty");
             }
 
-            const auto status {m_db->Get(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName), key, &value)};
-            if (status.IsNotFound())
+            if (const auto status {
+                    m_db->Get(rocksdb::ReadOptions(), getColumnFamilyBasedOnName(columnName).handle(), key, &value)};
+                status.IsNotFound())
             {
                 return false;
             }
@@ -285,7 +401,7 @@ namespace Utils
             rocksdb::WriteOptions writeOptions;
             writeOptions.disableWAL = !m_enableWal;
 
-            const auto status {m_db->Delete(writeOptions, getColumnFamilyHandle(columnName), key)};
+            const auto status {m_db->Delete(writeOptions, getColumnFamilyBasedOnName(columnName).handle(), key)};
             if (!status.ok())
             {
                 throw std::runtime_error("Error deleting data: " + status.ToString());
@@ -314,7 +430,7 @@ namespace Utils
         std::pair<std::string, rocksdb::Slice> getLastKeyValue(const std::string& columnName = "")
         {
             std::unique_ptr<rocksdb::Iterator> it(
-                m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName)));
+                m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyBasedOnName(columnName).handle()));
 
             it->SeekToLast();
             if (it->Valid())
@@ -333,7 +449,7 @@ namespace Utils
         RocksDBIterator seek(std::string_view key, const std::string& columnName = "") override // NOLINT
         {
             return {std::shared_ptr<rocksdb::Iterator>(
-                        m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyHandle(columnName))),
+                        m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyBasedOnName(columnName).handle())),
                     key};
         }
 
@@ -343,9 +459,10 @@ namespace Utils
          */
         RocksDBIterator begin(const std::string& columnName = "")
         {
-            RocksDBIterator rocksDBIterator(std::shared_ptr<rocksdb::Iterator>(m_db->NewIterator(
-                                                rocksdb::ReadOptions(), getColumnFamilyHandle(columnName))),
-                                            "");
+            RocksDBIterator rocksDBIterator(
+                std::shared_ptr<rocksdb::Iterator>(
+                    m_db->NewIterator(rocksdb::ReadOptions(), getColumnFamilyBasedOnName(columnName).handle())),
+                "");
             rocksDBIterator.begin();
             return rocksDBIterator;
         }
@@ -354,7 +471,7 @@ namespace Utils
          * @brief Get an iterator to the end of the database.
          * @return const RocksDBIterator Iterator to the end of the database.
          */
-        const RocksDBIterator& end()
+        const RocksDBIterator& end() const
         {
             static const RocksDBIterator END_ITERATOR;
             return END_ITERATOR;
@@ -375,18 +492,13 @@ namespace Utils
          */
         void compactDatabaseUsingBzip2()
         {
-            auto status = m_db->SetOptions({{"compression", "kBZip2Compression"}});
-            if (!status.ok())
+            if (const auto status = m_db->SetOptions({{"compression", "kBZip2Compression"}}); !status.ok())
             {
                 throw std::runtime_error("Failed to set 'kBZip2Compression' option");
             }
 
-            // Create compact range options with kForceOptimized settings
-            rocksdb::CompactRangeOptions compactOptions;
-            compactOptions.bottommost_level_compaction = rocksdb::BottommostLevelCompaction::kForceOptimized;
-
             // Perform compaction for the entire key range
-            m_db->CompactRange(compactOptions, nullptr, nullptr);
+            m_db->CompactRange(rocksdb::CompactRangeOptions(), nullptr, nullptr);
         }
 
         /**
@@ -404,6 +516,7 @@ namespace Utils
         {
             // Create compact range options with default settings
             rocksdb::CompactRangeOptions compactOptions;
+            compactOptions.bottommost_level_compaction = rocksdb::BottommostLevelCompaction::kForceOptimized;
 
             // Perform compaction for the entire key range
             m_db->CompactRange(compactOptions, nullptr, nullptr);
@@ -413,7 +526,7 @@ namespace Utils
          * @brief Initialize transaction.
          * @return RocksDBTransaction Transaction object.
          */
-        std::unique_ptr<RocksDBTransaction> createTransaction()
+        std::unique_ptr<IRocksDBWrapper> createTransaction()
         {
             return std::make_unique<RocksDBTransaction>(this);
         }
@@ -438,13 +551,13 @@ namespace Utils
             }
 
             rocksdb::ColumnFamilyHandle* pColumnFamily;
-            rocksdb::ColumnFamilyOptions columnFamilyOptions;
-            const auto status {m_db->CreateColumnFamily(columnFamilyOptions, columnName, &pColumnFamily)};
-            if (!status.ok())
+
+            if (const auto status {m_db->CreateColumnFamily(buildColumnFamilyOptions(), columnName, &pColumnFamily)};
+                !status.ok())
             {
                 throw std::runtime_error {"Couldn't create column family: " + std::string {status.getState()}};
             }
-            m_columnsHandles.push_back(pColumnFamily);
+            m_columnsInstances.emplace_back(m_db, pColumnFamily);
         }
 
         /**
@@ -461,13 +574,10 @@ namespace Utils
                 throw std::invalid_argument {"Column name is empty"};
             }
 
-            const auto columnMatch {[&columnName](const rocksdb::ColumnFamilyHandle* handle)
-                                    {
-                                        return columnName == handle->GetName();
-                                    }};
-
-            return std::find_if(m_columnsHandles.begin(), m_columnsHandles.end(), columnMatch) !=
-                   m_columnsHandles.end();
+            return std::find_if(m_columnsInstances.begin(),
+                                m_columnsInstances.end(),
+                                [&columnName](const ColumnFamilyRAII& handle)
+                                { return columnName == handle->GetName(); }) != m_columnsInstances.end();
         }
 
         /**
@@ -479,8 +589,8 @@ namespace Utils
         {
             std::vector<std::string> columnsNames;
             rocksdb::Options options;
-            const auto listStatus {rocksdb::TransactionDB::ListColumnFamilies(options, m_path, &columnsNames)};
-            if (!listStatus.ok())
+            if (const auto listStatus {rocksdb::TransactionDB::ListColumnFamilies(options, m_path, &columnsNames)};
+                !listStatus.ok())
             {
                 throw std::runtime_error("Failed to list columns: " + std::string {listStatus.getState()});
             }
@@ -492,40 +602,28 @@ namespace Utils
          */
         void deleteAll() override
         {
-            auto it = m_columnsHandles.begin();
             std::vector<std::string> columnsNames;
+            auto it = m_columnsInstances.begin();
 
-            while (it != m_columnsHandles.end())
+            while (it != m_columnsInstances.end())
             {
                 if ((*it)->GetName() != rocksdb::kDefaultColumnFamilyName)
                 {
-                    auto status = m_db->DropColumnFamily(*it);
-                    if (!status.ok())
-                    {
-                        throw std::runtime_error("Error deleting data: " + status.ToString());
-                    }
+                    it->drop();
                     columnsNames.push_back((*it)->GetName());
-
-                    status = m_db->DestroyColumnFamilyHandle(*it);
-                    if (!status.ok())
-                    {
-                        std::cerr << "Failed to free RocksDB column family: " + std::string {status.getState()}
-                                  << std::endl;
-                    }
-
-                    it = m_columnsHandles.erase(it);
+                    it = m_columnsInstances.erase(it);
                 }
                 else
                 {
                     rocksdb::WriteBatch batch;
-                    std::unique_ptr<rocksdb::Iterator> itDefault(m_db->NewIterator(rocksdb::ReadOptions(), *it));
+                    std::unique_ptr<rocksdb::Iterator> itDefault(
+                        m_db->NewIterator(rocksdb::ReadOptions(), it->handle()));
                     for (itDefault->SeekToFirst(); itDefault->Valid(); itDefault->Next())
                     {
-                        batch.Delete(*it, itDefault->key());
+                        batch.Delete(it->handle(), itDefault->key());
                     }
 
-                    auto status = m_db->Write(rocksdb::WriteOptions(), &batch);
-                    if (!status.ok())
+                    if (const auto status = m_db->Write(rocksdb::WriteOptions(), &batch); !status.ok())
                     {
                         throw std::runtime_error("Error deleting data: " + status.ToString());
                     }
@@ -547,37 +645,30 @@ namespace Utils
         void deleteAll(const std::string& columnName)
         {
             // Delete all data from the specified column
-            const auto columnHandle = getColumnFamilyHandle(columnName);
+            const auto& columnHandle = getColumnFamilyBasedOnName(columnName);
             if (columnHandle->GetName() != rocksdb::kDefaultColumnFamilyName)
             {
-                auto status = m_db->DropColumnFamily(columnHandle);
-                if (!status.ok())
-                {
-                    throw std::runtime_error("Error deleting data: " + status.ToString());
-                }
+                const auto it =
+                    std::find_if(m_columnsInstances.begin(),
+                                 m_columnsInstances.end(),
+                                 [&columnName](const auto& handle) { return columnName == handle->GetName(); });
 
-                status = m_db->DestroyColumnFamilyHandle(columnHandle);
-                if (!status.ok())
-                {
-                    std::cerr << "Failed to free RocksDB column family: " + std::string {status.getState()}
-                              << std::endl;
-                }
-
-                m_columnsHandles.erase(std::remove(m_columnsHandles.begin(), m_columnsHandles.end(), columnHandle),
-                                       m_columnsHandles.end());
+                it->drop();
+                m_columnsInstances.erase(it);
                 createColumn(columnName);
             }
             else
             {
                 rocksdb::WriteBatch batch;
-                std::unique_ptr<rocksdb::Iterator> itDefault(m_db->NewIterator(rocksdb::ReadOptions(), columnHandle));
+                std::unique_ptr<rocksdb::Iterator> itDefault(
+                    m_db->NewIterator(rocksdb::ReadOptions(), columnHandle.handle()));
+
                 for (itDefault->SeekToFirst(); itDefault->Valid(); itDefault->Next())
                 {
-                    batch.Delete(columnHandle, itDefault->key());
+                    batch.Delete(columnHandle.handle(), itDefault->key());
                 }
 
-                auto status = m_db->Write(rocksdb::WriteOptions(), &batch);
-                if (!status.ok())
+                if (auto status = m_db->Write(rocksdb::WriteOptions(), &batch); !status.ok())
                 {
                     throw std::runtime_error("Error deleting data: " + status.ToString());
                 }
@@ -598,7 +689,7 @@ namespace Utils
         void deleteAll(const std::function<void(std::string&, std::string&)>& callback)
         {
             // Delete data from all family columns
-            for (const auto& columnHandle : m_columnsHandles)
+            for (const auto& columnHandle : m_columnsInstances)
             {
                 // Create an iterator for the current column family
                 std::unique_ptr<rocksdb::Iterator> it(m_db->NewIterator(rocksdb::ReadOptions(), columnHandle));
@@ -636,10 +727,10 @@ namespace Utils
         void deleteAll(const std::function<void(std::string&, std::string&)>& callback, const std::string& columnName)
         {
             // Get the column family handle
-            const auto columnHandle = getColumnFamilyHandle(columnName);
+            const auto& columnHandle = getColumnFamilyBasedOnName(columnName);
 
             // Create an iterator for the current column family
-            std::unique_ptr<rocksdb::Iterator> it(m_db->NewIterator(rocksdb::ReadOptions(), columnHandle));
+            std::unique_ptr<rocksdb::Iterator> it(m_db->NewIterator(rocksdb::ReadOptions(), columnHandle.handle()));
 
             for (it->SeekToFirst(); it->Valid(); it->Next())
             {
@@ -648,7 +739,7 @@ namespace Utils
 
                 callback(keyStr, valueStr);
 
-                auto status = m_db->Delete(rocksdb::WriteOptions(), columnHandle, it->key());
+                auto status = m_db->Delete(rocksdb::WriteOptions(), columnHandle.handle(), it->key());
 
                 if (!status.ok())
                 {
@@ -662,18 +753,22 @@ namespace Utils
          */
         void flush() override
         {
-            const auto status {m_db->Flush(rocksdb::FlushOptions(), m_columnsHandles)};
-            if (!status.ok())
+            for (const auto& columnFamily : m_columnsInstances)
             {
-                throw std::runtime_error {"Failed to flush transaction: " + std::string {status.getState()}};
+                if (const auto status {m_db->Flush(rocksdb::FlushOptions(), columnFamily.handle())}; !status.ok())
+                {
+                    throw std::runtime_error {"Failed to flush transaction: " + std::string {status.getState()}};
+                }
             }
         }
 
     private:
-        std::unique_ptr<rocksdb::TransactionDB> m_db;               ///< RocksDB instance.
-        std::vector<rocksdb::ColumnFamilyHandle*> m_columnsHandles; ///< List of column family handles.
-        const bool m_enableWal;                                     ///< Whether to enable WAL or not.
-        const std::string m_path;                                   ///< Location of the DB.
+        std::shared_ptr<T> m_db;                                     ///< RocksDB instance.
+        std::vector<ColumnFamilyRAII> m_columnsInstances;            ///< List of column family.
+        const bool m_enableWal;                                      ///< Whether to enable WAL or not.
+        const std::string m_path;                                    ///< Location of the DB.
+        std::shared_ptr<rocksdb::Cache> m_readCache;                 ///< Cache for read operations.
+        std::shared_ptr<rocksdb::WriteBufferManager> m_writeManager; ///< Write buffer manager.
 
         /**
          * @brief Returns the column family handle identified by its name.
@@ -681,26 +776,44 @@ namespace Utils
          * @param columnName Name of the column family. If empty, the default handle is returned.
          * @return rocksdb::ColumnFamilyHandle* Column family handle pointer.
          */
-        rocksdb::ColumnFamilyHandle* getColumnFamilyHandle(const std::string& columnName)
+        ColumnFamilyRAII& getColumnFamilyBasedOnName(const std::string& columnName)
         {
+            auto columnNameFind {columnName};
             if (columnName.empty())
             {
-                return m_db->DefaultColumnFamily();
+                columnNameFind = rocksdb::kDefaultColumnFamilyName;
             }
 
-            const auto columnMatch {[&columnName](const rocksdb::ColumnFamilyHandle* handle)
-                                    {
-                                        return columnName == handle->GetName();
-                                    }};
-
-            if (const auto it {std::find_if(m_columnsHandles.begin(), m_columnsHandles.end(), columnMatch)};
-                it != m_columnsHandles.end())
+            if (const auto it {std::find_if(m_columnsInstances.begin(),
+                                            m_columnsInstances.end(),
+                                            [&columnNameFind](const ColumnFamilyRAII& handle)
+                                            { return columnNameFind == handle.handle()->GetName(); })};
+                it != m_columnsInstances.end())
             {
                 return *it;
             }
 
             throw std::runtime_error {"Couldn't find column family: '" + columnName + "'"};
         }
+
+        auto createTransaction(const rocksdb::WriteOptions& writeOptions)
+        {
+            if constexpr (std::is_same_v<T, rocksdb::DB>)
+            {
+                throw std::runtime_error {"Transactions are only supported for rocksdb::TransactionDB"};
+                return nullptr;
+            }
+            else
+            {
+                auto txn = m_db->BeginTransaction(writeOptions);
+                if (!txn)
+                {
+                    throw std::runtime_error {"Failed to begin transaction"};
+                }
+                return txn;
+            }
+        }
+
         friend class RocksDBTransaction;
     };
 
@@ -716,7 +829,7 @@ namespace Utils
          *
          * @param db RocksDB instance.
          */
-        explicit RocksDBTransaction(RocksDBWrapper* dbWrapper)
+        explicit RocksDBTransaction(TRocksDBWrapper<>* dbWrapper)
             : m_dbWrapper {dbWrapper}
         {
             if (!m_dbWrapper)
@@ -727,23 +840,15 @@ namespace Utils
             rocksdb::WriteOptions writeOptions;
             writeOptions.disableWAL = true;
 
-            m_txn = std::unique_ptr<rocksdb::Transaction>(m_dbWrapper->m_db->BeginTransaction(writeOptions));
-            if (!m_txn)
-            {
-                throw std::runtime_error {"Failed to begin transaction"};
-            }
-        }
-
-        /**
-         * @brief Destructor.
-         * @note If the transaction has not been committed, it will be aborted.
-         */
-        ~RocksDBTransaction() override
-        {
-            if (!m_committed)
-            {
-                m_txn->Rollback();
-            }
+            m_txn = std::unique_ptr<rocksdb::Transaction, std::function<void(rocksdb::Transaction*)>>(
+                m_dbWrapper->createTransaction(writeOptions),
+                [this](rocksdb::Transaction* txn)
+                {
+                    if (txn && !m_committed)
+                    {
+                        txn->Rollback();
+                    }
+                });
         }
 
         /**
@@ -756,7 +861,7 @@ namespace Utils
          */
         void put(const std::string& key, const rocksdb::Slice& value, const std::string& columnName) override
         {
-            const auto status {m_txn->Put(m_dbWrapper->getColumnFamilyHandle(columnName), key, value)};
+            const auto status {m_txn->Put(m_dbWrapper->getColumnFamilyBasedOnName(columnName).handle(), key, value)};
             if (!status.ok())
             {
                 throw std::runtime_error {"Failed to put key: " + std::string {status.getState()}};
@@ -783,7 +888,7 @@ namespace Utils
          */
         void delete_(const std::string& key, const std::string& columnName) override
         {
-            const auto status {m_txn->Delete(m_dbWrapper->getColumnFamilyHandle(columnName), key)};
+            const auto status {m_txn->Delete(m_dbWrapper->getColumnFamilyBasedOnName(columnName).handle(), key)};
             if (!status.ok())
             {
                 throw std::runtime_error {"Failed to delete key: " + std::string {status.getState()}};
@@ -819,9 +924,9 @@ namespace Utils
                 throw std::invalid_argument("Key is empty");
             }
 
-            const auto status {
-                m_txn->Get(rocksdb::ReadOptions(), m_dbWrapper->getColumnFamilyHandle(columnName), key, &value)};
-            if (status.IsNotFound())
+            if (const auto status = m_txn->Get(
+                    rocksdb::ReadOptions(), m_dbWrapper->getColumnFamilyBasedOnName(columnName).handle(), key, &value);
+                status.IsNotFound())
             {
                 return false;
             }
@@ -852,18 +957,12 @@ namespace Utils
          */
         void commit() override
         {
-            const auto status {m_txn->Commit()};
-            if (!status.ok())
+            if (const auto status {m_txn->Commit()}; !status.ok())
             {
                 throw std::runtime_error {"Failed to commit transaction: " + std::string {status.getState()}};
             }
 
-            const auto statusFlush {m_dbWrapper->m_db->Flush(rocksdb::FlushOptions(), m_dbWrapper->m_columnsHandles)};
-            if (!statusFlush.ok())
-            {
-                throw std::runtime_error {"Failed to flush transaction: " + std::string {statusFlush.getState()}};
-            }
-
+            m_dbWrapper->flush();
             m_committed = true;
         }
 
@@ -924,17 +1023,19 @@ namespace Utils
         /**
          * @brief Flushes the transaction.
          */
-        void flush() override
+        [[noreturn]] void flush() override
         {
             // This is only permited for atomic operations.
             throw std::runtime_error("Not implemented");
         }
 
     private:
-        RocksDBWrapper* m_dbWrapper;                 ///< RocksDB instance.
-        std::unique_ptr<rocksdb::Transaction> m_txn; ///< RocksDB transaction.
-        bool m_committed {false};                    ///< Whether the transaction has been committed or not.
+        TRocksDBWrapper<>* m_dbWrapper; ///< RocksDB instance.
+        std::unique_ptr<rocksdb::Transaction, std::function<void(rocksdb::Transaction*)>>
+            m_txn;                ///< RocksDB transaction.
+        bool m_committed {false}; ///< Whether the transaction has been committed or not.
     };
+    using RocksDBWrapper = TRocksDBWrapper<>;
 } // namespace Utils
 
 #endif // _ROCKS_DB_WRAPPER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp
@@ -32,6 +32,7 @@ constexpr auto TRANSLATIONS_COLUMN {"translations"};
 constexpr auto DESCRIPTIONS_COLUMN {"descriptions"};
 constexpr auto VENDOR_MAP_COLUMN {"vendor_map"};
 constexpr auto OS_CPE_RULES_COLUMN {"oscpe_rules"};
+constexpr auto CNA_MAPPING_COLUMN {"cna_mapping"};
 constexpr auto LOCALFILE_MQ {"1"};
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -253,8 +253,7 @@ public:
         }
         catch (const std::exception& ex)
         {
-            // If the database does not exist, we need to create it, but first we need to remove the directory,
-            // because probably it is corrupted.
+            // Create the database if it doesn't exist. We must remove any existing directory, as it may be corrupted.
             if (!m_feedDatabase)
             {
                 std::filesystem::remove_all(DATABASE_PATH);
@@ -304,7 +303,7 @@ public:
                     const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
                     TUNIXSocketRequest::instance().get(
                         HttpUnixSocketURL(ONDEMAND_SOCK, url),
-                        [](const std::string&)
+                        []([[maybe_unused]] const std::string&)
                         {
                             // Not used
                         },
@@ -609,7 +608,7 @@ private:
         TUNIXSocketRequest::instance().put(
             HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
             data,
-            [](const std::string&)
+            []([[maybe_unused]] const std::string&)
             {
                 // Not used
             },

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -651,6 +651,13 @@ private:
             throw std::runtime_error("Error getting OS CPE rules content from rocksdb.");
         }
         GlobalData::instance().osCpeMaps(nlohmann::json::parse(queryResult.ToString()));
+
+        // Load CNA mappings
+        if (!m_feedDatabase->get("CNA-MAPPING-GLOBAL", queryResult, CNA_MAPPING_COLUMN))
+        {
+            throw std::runtime_error("Error getting CNA Mapping content from rocksdb.");
+        }
+        GlobalData::instance().osCpeMaps(nlohmann::json::parse(queryResult.ToString()));
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -650,7 +650,7 @@ private:
         {
             throw std::runtime_error("Error getting CNA Mapping content from rocksdb.");
         }
-        GlobalData::instance().osCpeMaps(nlohmann::json::parse(queryResult.ToString()));
+        GlobalData::instance().cnaMappings(nlohmann::json::parse(queryResult.ToString()));
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -41,7 +41,7 @@
 
 using namespace NSVulnerabilityScanner;
 constexpr auto DATABASE_PATH {"queue/vd/feed"};
-constexpr auto OFFSET_TRANSACTION_SIZE {200};
+constexpr auto OFFSET_TRANSACTION_SIZE {1000};
 
 /**
  * @brief A struct for storing a pair of FlatBuffers data.
@@ -251,7 +251,7 @@ public:
                 reloadGlobalMaps();
             }
         }
-        catch (const std::exception&)
+        catch (const std::exception& ex)
         {
             // If the database does not exist, we need to create it, but first we need to remove the directory,
             // because probably it is corrupted.
@@ -261,16 +261,10 @@ public:
                 m_feedDatabase = std::make_unique<TRocksDBWrapper>(DATABASE_PATH, false);
             }
 
-            // Tell to the content manager to download the last snapshot and process it.
-            const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
-            TUNIXSocketRequest::instance().get(
-                HttpUnixSocketURL(ONDEMAND_SOCK, url),
-                [](const std::string&)
-                {
-                    // Not used
-                },
-                [](const std::string& msg, const long responseCode)
-                { logError(WM_VULNSCAN_LOGTAG, "%s: %ld", msg.c_str(), responseCode); });
+            // Remove the updater directory to force the download of the complete feed.
+            std::filesystem::remove_all(UPDATER_PATH);
+
+            logError(WM_VULNSCAN_LOGTAG, "Error opening the database: %s, trying to re-download the feed.", ex.what());
         }
 
         // Subscription to vulnerability detector content update events.
@@ -296,16 +290,16 @@ public:
                 };
                 try
                 {
-                    logInfo(WM_VULNSCAN_LOGTAG, "Processing message");
+                    logInfo(WM_VULNSCAN_LOGTAG, "Initiating update feed process");
                     processMessage(message, topicName, orchestrationLambda);
-                    logInfo(WM_VULNSCAN_LOGTAG, "Message processed");
 
                     // Verify vendor-map and oscpe-map values and update the maps in memory
                     reloadGlobalMaps();
+                    logInfo(WM_VULNSCAN_LOGTAG, "Feed update process completed");
                 }
                 catch (const std::exception& e)
                 {
-                    logError(WM_VULNSCAN_LOGTAG, "Error processing message: %s", e.what());
+                    logError(WM_VULNSCAN_LOGTAG, "Error updating feed: %s, trying to re-download the feed.", e.what());
 
                     const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
                     TUNIXSocketRequest::instance().get(

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -13,13 +13,10 @@
 #define _DATABASE_FEED_MANAGER_HPP
 
 #include "../policyManager/policyManager.hpp"
-#include "../scanOrchestrator/scanContext.hpp"
-#include "HTTPRequest.hpp"
 #include "UNIXSocketRequest.hpp"
 #include "cacheLRU.hpp"
 #include "contentManager.hpp"
 #include "contentRegister.hpp"
-#include "defer.hpp"
 #include "eventDecoder.hpp"
 #include "feedIndexer.hpp"
 #include "globalData.hpp"
@@ -31,8 +28,6 @@
 #include "routerSubscriber.hpp"
 #include "scanDispatcher.hpp"
 #include "storeModel.hpp"
-#include "updateCVECandidates.hpp"
-#include "updateCVEDescription.hpp"
 #include "vulnerabilityCandidate_generated.h"
 #include "vulnerabilityDescription_generated.h"
 #include "vulnerabilityRemediations_generated.h"
@@ -113,17 +108,14 @@ public:
         {
             throw std::runtime_error("Invalid message");
         }
-
+        // Lock the mutex to protect the access to the internal databases.
+        std::scoped_lock<std::shared_mutex> lock(m_mutex);
         if (parsedMessage.at("type") == "offsets")
         {
             auto jsonPointer {"/data"_json_pointer};
             for (const auto& path : parsedMessage.at("paths"))
             {
-                std::lock_guard<std::shared_mutex> lock(m_mutex);
-
-                auto feedTransaction = m_feedDatabase->createTransaction();
                 auto currentOffset = 0LL;
-                auto committedInLastIteration = true;
                 logInfo(WM_VULNSCAN_LOGTAG, "Processing file: %s", path.get_ref<const std::string&>().c_str());
 
                 // Parse the file and execute the chain/orchestration for each valid resource.
@@ -132,34 +124,14 @@ public:
                 // LCOV_EXCL_START
                 JsonArray::parse(
                     path,
-                    [&](nlohmann::json&& item, const size_t itemId)
+                    [&](nlohmann::json&& item, const size_t)
                     {
-                        committedInLastIteration = false;
-                        orchestration(item, feedTransaction.get());
+                        orchestration(item, m_feedDatabase.get());
 
                         // Extract the offset from the last element.
                         currentOffset = item.at("offset");
 
                         // Commit the transaction for every 200 elements.
-                        if (itemId % OFFSET_TRANSACTION_SIZE == 0)
-                        {
-                            // Commit the transaction.
-                            feedTransaction->commit();
-
-                            // Update the offset in the content manager.
-                            contentManagerUpdateOffset(topicName, currentOffset);
-
-                            // Close transaction before reopen the DB to avoid unexpected behavior when the DB is
-                            // closed.
-                            feedTransaction.reset();
-
-                            // Reinitialize the database to avoid high memory consumption, this is because after update
-                            // some key during this process the database will consume more memory.
-                            m_feedDatabase->reopen();
-
-                            feedTransaction = m_feedDatabase->createTransaction();
-                            committedInLastIteration = true;
-                        }
                         return !m_shouldStop.load();
                     },
                     jsonPointer);
@@ -171,28 +143,8 @@ public:
                 {
                     break;
                 }
-                else
-                {
-                    if (!committedInLastIteration)
-                    {
-                        // Commit the transaction for the remaining elements.
-                        feedTransaction->commit();
-
-                        // If some data was processed, update the offset.
-                        contentManagerUpdateOffset(topicName, currentOffset);
-                    }
-
-                    // Close transaction before reopen the DB to avoid unexpected behavior when the DB is closed.
-                    feedTransaction.reset();
-
-                    // Reinitialize the database to avoid high memory consumption, this is because after update some
-                    // key during this process the database will consume more memory.
-                    m_feedDatabase->reopen();
-                }
+                contentManagerUpdateOffset(topicName, currentOffset);
             }
-
-            // Verify vendor-map and oscpe-map values and update the maps in memory
-            reloadGlobalMaps();
         }
         else if (parsedMessage.at("type") == "raw")
         {
@@ -224,15 +176,10 @@ public:
                     {
                         break;
                     }
-                    // Acquiring exclusive access to write new data
-                    std::lock_guard<std::shared_mutex> lock(m_mutex);
 
                     if (step++ % 1000 == 0)
                     {
                         logDebug2(WM_VULNSCAN_LOGTAG, "Processing line: %d", step);
-                        // Flush the database every 1000 lines, we don't need to reopen the database, because all of the
-                        // elements are inserted.
-                        m_feedDatabase->flush();
                     }
 
                     nlohmann::json parsedLine = nlohmann::json::parse(line, nullptr, false);
@@ -257,9 +204,6 @@ public:
                 // Update the offset.
                 contentManagerUpdateOffset(topicName, parsedMessage.at("offset"));
             }
-
-            // Verify vendor-map and oscpe-map values and update the maps in memory
-            reloadGlobalMaps();
         }
         else
         {
@@ -277,7 +221,6 @@ public:
      * @param reloadGlobalMapsStartup If true, the vendor and os cpe maps will be reloaded at startup.
      * @param initContentUpdater If true, the content updater will be initialized.
      */
-    // TODO: Remove LCOV flags once the implementation of the 'Indexer Connector' module is completed
     // LCOV_EXCL_START
     explicit TDatabaseFeedManager(std::shared_ptr<TIndexerConnector> indexerConnector,
                                   const std::atomic<bool>& shouldStop,
@@ -293,15 +236,41 @@ public:
         const auto updaterPolicy = TPolicyManager::instance().getUpdaterConfiguration();
         const std::string topicName = updaterPolicy.at("topicName");
 
-        m_feedDatabase = std::make_unique<TRocksDBWrapper>(DATABASE_PATH, false);
-
         m_translationsCache =
             std::make_unique<LRUCache<std::string, std::string>>(TPolicyManager::instance().getTranslationLRUSize());
 
-        // This initializes the vendor and os cpe maps and should be called before any scan or message processing.
-        if (reloadGlobalMapsStartup)
+        try
         {
-            reloadGlobalMaps();
+            m_feedDatabase = std::make_unique<TRocksDBWrapper>(DATABASE_PATH, false);
+
+            // This initializes the vendor and os cpe maps and should be called before any scan or message processing.
+            if (reloadGlobalMapsStartup)
+            {
+                // Try to load global maps from the database, if it fails we throw an exception to force the download of
+                // the complete feed.
+                reloadGlobalMaps();
+            }
+        }
+        catch (const std::exception&)
+        {
+            // If the database does not exist, we need to create it, but first we need to remove the directory,
+            // because probably it is corrupted.
+            if (!m_feedDatabase)
+            {
+                std::filesystem::remove_all(DATABASE_PATH);
+                m_feedDatabase = std::make_unique<TRocksDBWrapper>(DATABASE_PATH, false);
+            }
+
+            // Tell to the content manager to download the last snapshot and process it.
+            const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
+            TUNIXSocketRequest::instance().get(
+                HttpUnixSocketURL(ONDEMAND_SOCK, url),
+                [](const std::string&)
+                {
+                    // Not used
+                },
+                [](const std::string& msg, const long responseCode)
+                { logError(WM_VULNSCAN_LOGTAG, "%s: %ld", msg.c_str(), responseCode); });
         }
 
         // Subscription to vulnerability detector content update events.
@@ -331,27 +300,8 @@ public:
                     processMessage(message, topicName, orchestrationLambda);
                     logInfo(WM_VULNSCAN_LOGTAG, "Message processed");
 
-                    // TODO: If the databases are compressed, they weigh 2GB,
-                    //  but when generating the DEB and RPM package, the package
-                    //  goes from 165MB to 465MB.
-                    //  If the databases are not compressed, they weigh 4.5GB,
-                    //  but when generating the DEB and RPM package,
-                    //  the package goes from 165MB to 270MB and 350MB respectively.
-                    //  Find another compression algorithm.
-                    //
-                    // Compact the database
-                    // logInfo(WM_VULNSCAN_LOGTAG, "Compacting CVE5 database");
-                    // m_cvesDatabase->compactDatabaseUsingBzip2();
-                    // logInfo(WM_VULNSCAN_LOGTAG, "CVE5 database compacted successfully");
-                    // logInfo(WM_VULNSCAN_LOGTAG, "Compacting description, remediation, translation
-                    // and feed databases"); m_descriptionsDatabase->compactDatabase();
-                    // m_remediationsDatabase->compactDatabase();
-                    // m_feedDatabase->compactDatabase();
-                    // for (const auto& [key, db] : m_feedsDatabases)
-                    // {
-                    //     db->compactDatabase();
-                    // }
-                    // logInfo(WM_VULNSCAN_LOGTAG, "Databases compacted successfully");
+                    // Verify vendor-map and oscpe-map values and update the maps in memory
+                    reloadGlobalMaps();
                 }
                 catch (const std::exception& e)
                 {
@@ -360,7 +310,10 @@ public:
                     const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
                     TUNIXSocketRequest::instance().get(
                         HttpUnixSocketURL(ONDEMAND_SOCK, url),
-                        [](const std::string& msg) { std::cout << msg << std::endl; },
+                        [](const std::string&)
+                        {
+                            // Not used
+                        },
                         [](const std::string& msg, const long responseCode)
                         { logError(WM_VULNSCAN_LOGTAG, "%s: %ld", msg.c_str(), responseCode); });
                 }
@@ -390,17 +343,15 @@ public:
      */
     void getVulnerabilityRemediation(const std::string& cveId, FlatbufferDataPair<RemediationInfo>& dtoVulnRemediation)
     {
-        auto result = m_feedDatabase->get(cveId, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN);
-
         // If the remediation information is not found in the database, we return because there is no remediation.
-        if (!result)
+        if (auto result = m_feedDatabase->get(cveId, dtoVulnRemediation.slice, REMEDIATIONS_COLUMN); !result)
         {
             return;
         }
 
-        flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(dtoVulnRemediation.slice.data()),
-                                       dtoVulnRemediation.slice.size());
-        if (!VerifyRemediationInfoBuffer(verifier))
+        if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(dtoVulnRemediation.slice.data()),
+                                           dtoVulnRemediation.slice.size());
+            !VerifyRemediationInfoBuffer(verifier))
         {
             throw std::runtime_error("Error: Invalid FlatBuffers data in RocksDB.");
         }
@@ -428,22 +379,21 @@ public:
     getWazuhPackageTranslation(const std::string& packageName,
                                const std::function<void(const NSVulnerabilityScanner::TranslationEntry&)>& callback)
     {
-        auto resultCache = m_translationsCache->getValue(packageName);
-
         // If the translation is in the cache, use it to look up the translation in the database.
-        if (resultCache.has_value())
+        if (auto resultCache = m_translationsCache->getValue(packageName); resultCache.has_value())
         {
             FlatbufferDataPair<TranslationEntry> dtoVulnTranslation;
 
-            auto resultQuery = m_feedDatabase->get(resultCache.value(), dtoVulnTranslation.slice, TRANSLATIONS_COLUMN);
-            if (!resultQuery)
+            if (auto resultQuery =
+                    m_feedDatabase->get(resultCache.value(), dtoVulnTranslation.slice, TRANSLATIONS_COLUMN);
+                !resultQuery)
             {
                 throw std::runtime_error("Value for key " + resultCache.value() + " does not exist in database.");
             }
 
-            flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(dtoVulnTranslation.slice.data()),
-                                           dtoVulnTranslation.slice.size());
-            if (!VerifyTranslationEntryBuffer(verifier))
+            if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(dtoVulnTranslation.slice.data()),
+                                               dtoVulnTranslation.slice.size());
+                !VerifyTranslationEntryBuffer(verifier))
             {
                 throw std::runtime_error("Error: Invalid FlatBuffers data in RocksDB.");
             }
@@ -458,8 +408,8 @@ public:
         // a match.
         for (const auto& [key, value] : m_feedDatabase->begin(TRANSLATIONS_COLUMN))
         {
-            flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
-            if (!VerifyTranslationEntryBuffer(verifier))
+            if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+                !VerifyTranslationEntryBuffer(verifier))
             {
                 throw std::runtime_error("Error: Invalid FlatBuffers data in RocksDB.");
             }
@@ -500,8 +450,8 @@ public:
 
         for (const auto& [key, value] : m_feedDatabase->seek(packageNameWithSeparator, cnaName))
         {
-            flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
-            if (!NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifier))
+            if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+                !NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifier))
             {
                 throw std::runtime_error(
                     "Error getting ScanVulnerabilityCandidateArray object from rocksdb. FlatBuffers verifier failed");
@@ -566,9 +516,9 @@ public:
                 std::string(cveId));
         }
 
-        flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
-                                       resultContainer.slice.size());
-        if (NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+        if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                           resultContainer.slice.size());
+            NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
         {
             throw std::runtime_error(
                 "Error getting VulnerabilityDescription object from rocksdb. FlatBuffers verifier failed");
@@ -583,11 +533,9 @@ public:
      * @param format Package format.
      * @return CNA/ADP name. Empty string otherwise.
      */
-    std::string getCnaNameByFormat(std::string_view format)
+    std::string getCnaNameByFormat(std::string_view format) const
     {
-        const auto& vendorMap = GlobalData::instance().vendorMaps();
-
-        if (vendorMap.contains("format"))
+        if (const auto& vendorMap = GlobalData::instance().vendorMaps(); vendorMap.contains("format"))
         {
             for (const auto& item : vendorMap.at("format"))
             {
@@ -606,11 +554,9 @@ public:
      * @param vendor Package vendor.
      * @return CNA/ADP name. Empty string otherwise.
      */
-    std::string getCnaNameByContains(std::string_view vendor)
+    std::string getCnaNameByContains(std::string_view vendor) const
     {
-        const auto& vendorMap = GlobalData::instance().vendorMaps();
-
-        if (vendorMap.contains("contains"))
+        if (const auto& vendorMap = GlobalData::instance().vendorMaps(); vendorMap.contains("contains"))
         {
             for (const auto& item : vendorMap.at("contains"))
             {
@@ -629,10 +575,9 @@ public:
      * @param vendor Package vendor.
      * @return CNA/ADP name. Empty string otherwise.
      */
-    std::string getCnaNameByPrefix(std::string_view vendor)
+    std::string getCnaNameByPrefix(std::string_view vendor) const
     {
-        const auto& vendorMap = GlobalData::instance().vendorMaps();
-        if (vendorMap.contains("prefix"))
+        if (const auto& vendorMap = GlobalData::instance().vendorMaps(); vendorMap.contains("prefix"))
         {
             for (const auto& item : vendorMap.at("prefix"))
             {
@@ -659,7 +604,7 @@ private:
     std::unique_ptr<TRouterSubscriber> m_contentUpdateSubscription;
     const std::atomic<bool>& m_shouldStop;
 
-    void contentManagerUpdateOffset(const std::string& topicName, const long long currentOffset)
+    void contentManagerUpdateOffset(const std::string& topicName, const long long currentOffset) const
     {
         nlohmann::json data;
         data["offset"] = currentOffset;
@@ -670,9 +615,11 @@ private:
         TUNIXSocketRequest::instance().put(
             HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
             data,
-            [](const std::string& msg) {},
-            [](const std::string& msg, const long responseCode)
-            { throw std::runtime_error("Error updating offset: " + msg); });
+            [](const std::string&)
+            {
+                // Not used
+            },
+            [](const std::string& msg, const long) { throw std::runtime_error("Error updating offset: " + msg); });
         // LCOV_EXCL_STOP
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventContext.hpp
@@ -27,7 +27,8 @@ enum class ResourceType
     CVE,
     TRANSLATION,
     VENDOR_MAP,
-    OSCPE_RULES
+    OSCPE_RULES,
+    CNA_MAPPING
 };
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -26,12 +26,14 @@
 const static std::map<ResourceType, const char*> SCHEMA = {{ResourceType::CVE, cve5_SCHEMA},
                                                            {ResourceType::TRANSLATION, packageTranslation_SCHEMA},
                                                            {ResourceType::VENDOR_MAP, nullptr},
-                                                           {ResourceType::OSCPE_RULES, nullptr}};
+                                                           {ResourceType::OSCPE_RULES, nullptr},
+                                                           {ResourceType::CNA_MAPPING, nullptr}};
 
 const static std::map<ResourceType, const char*> COLUMNS = {{ResourceType::CVE, "cve5"},
                                                             {ResourceType::TRANSLATION, "translation"},
                                                             {ResourceType::VENDOR_MAP, "vendor_map"},
-                                                            {ResourceType::OSCPE_RULES, "oscpe_rules"}};
+                                                            {ResourceType::OSCPE_RULES, "oscpe_rules"},
+                                                            {ResourceType::CNA_MAPPING, "cna_mapping"}};
 
 /**
  * @brief EventDecoder class.
@@ -45,7 +47,7 @@ private:
      *
      * @param data Event context.
      */
-    void processEvent(std::shared_ptr<EventContext> data)
+    void processEvent(std::shared_ptr<EventContext> data) const
     {
         if (data->resource.contains("resource"))
         {
@@ -65,6 +67,10 @@ private:
             {
                 data->resourceType = ResourceType::OSCPE_RULES;
             }
+            else if (Utils::startsWith(data->resource.at("resource"), "CNA-MAPPING-GLOBAL"))
+            {
+                data->resourceType = ResourceType::CNA_MAPPING;
+            }
             else
             {
                 logError(WM_VULNSCAN_LOGTAG,
@@ -76,11 +82,11 @@ private:
             auto schema = SCHEMA.at(data->resourceType);
             auto column = COLUMNS.at(data->resourceType);
 
-            for (auto& element : COLUMNS)
+            for (const auto& [resourceType, columnFamilyName] : COLUMNS)
             {
-                if (!data->feedDatabase->columnExists(element.second))
+                if (!data->feedDatabase->columnExists(columnFamilyName))
                 {
-                    data->feedDatabase->createColumn(element.second);
+                    data->feedDatabase->createColumn(columnFamilyName);
                 }
             }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/globalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/globalData.hpp
@@ -25,6 +25,7 @@ class GlobalData final : public Singleton<GlobalData>
     mutable std::shared_mutex m_mutex;
     nlohmann::json m_vendorMaps;
     nlohmann::json m_osCpeMaps;
+    nlohmann::json m_cnaMappings;
     std::string m_managerName;
 
 public:
@@ -34,7 +35,7 @@ public:
      */
     void vendorMaps(const nlohmann::json& vendor)
     {
-        std::unique_lock<std::shared_mutex> lock(m_mutex);
+        std::unique_lock lock(m_mutex);
         m_vendorMaps = vendor;
     }
 
@@ -44,7 +45,7 @@ public:
      */
     void osCpeMaps(const nlohmann::json& osCpe)
     {
-        std::unique_lock<std::shared_mutex> lock(m_mutex);
+        std::unique_lock lock(m_mutex);
         m_osCpeMaps = osCpe;
     }
 
@@ -52,9 +53,19 @@ public:
      * @brief Set manager name.
      * @param managerName Manager name.
      */
-    void managerName(const std::string& managerName)
+    void managerName(std::string_view managerName)
     {
         m_managerName = managerName;
+    }
+
+    /**
+     * @brief Set CNA mappings.
+     * @param cnaMappings CNA mappings.
+     */
+    void cnaMappings(const nlohmann::json& cnaMappings)
+    {
+        std::unique_lock lock(m_mutex);
+        m_cnaMappings = cnaMappings;
     }
 
     /**
@@ -63,7 +74,7 @@ public:
      */
     nlohmann::json vendorMaps() const
     {
-        std::shared_lock<std::shared_mutex> lock(m_mutex);
+        std::shared_lock lock(m_mutex);
         return m_vendorMaps;
     }
 
@@ -73,8 +84,18 @@ public:
      */
     nlohmann::json osCpeMaps() const
     {
-        std::shared_lock<std::shared_mutex> lock(m_mutex);
+        std::shared_lock lock(m_mutex);
         return m_osCpeMaps;
+    }
+
+    /**
+     * @brief Get CNA mappings.
+     * @return CNA mappings.
+     */
+    nlohmann::json cnaMappings() const
+    {
+        std::shared_lock lock(m_mutex);
+        return m_cnaMappings;
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
@@ -47,7 +47,6 @@ public:
             if ("update" == type)
             {
                 // We clean the candidates DBs to keep the data synced
-                UpdateCVECandidates::removeVulnerabilityCandidate(cve5Entry, data->feedDatabase);
                 if ("PUBLISHED" == state)
                 {
                     StoreRemediationsModel::updateRemediation(cve5Entry, data->feedDatabase);
@@ -58,6 +57,7 @@ public:
                 {
                     StoreRemediationsModel::removeRemediation(cve5Entry, data->feedDatabase);
                     UpdateCVEDescription::removeVulnerabilityDescription(cve5Entry, data->feedDatabase);
+                    UpdateCVECandidates::removeVulnerabilityCandidate(cve5Entry, data->feedDatabase);
                 }
                 else
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -23,7 +23,7 @@ const std::unordered_map<std::string, NSVulnerabilityScanner::Status> VERSION_ST
     {"affected", NSVulnerabilityScanner::Status::Status_affected},
     {"unknown", NSVulnerabilityScanner::Status::Status_unknown}};
 
-auto constexpr CVE_PACKAGE_COLUMN_NAME {"cve_package"};
+auto constexpr CVE_PACKAGE_COLUMN_NAME_PREFIX {"cve_package"};
 
 /**
  * @brief UpdateCVECandidates class.
@@ -47,6 +47,11 @@ public:
         }
 
         const auto cveId {cve5Flatbuffer->cveMetadata()->cveId()};
+
+        if (!cveId)
+        {
+            throw std::runtime_error("Empty cveId.");
+        }
 
         auto candidateLambda = [&](const flatbuffers::Vector<::flatbuffers::Offset<cve_v5::Affected>>* affectedVector,
                                    const std::string& shortName)
@@ -82,7 +87,7 @@ public:
                 {
                     for (const auto& versionElement : *affected->versions())
                     {
-                        NSVulnerabilityScanner::Status status;
+                        NSVulnerabilityScanner::Status status = NSVulnerabilityScanner::Status::Status_unknown;
 
                         if (versionElement->status() &&
                             VERSION_STATUS_MAP.find(versionElement->status()->str()) != VERSION_STATUS_MAP.end())
@@ -130,6 +135,33 @@ public:
                 candidatesArraysMap.at(productName).first.push_back(candidate);
             }
 
+            const auto CVE_PACKAGE_COLUMN_NAME =
+                std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX).append("_").append(shortName);
+
+            // Get all candidates stored in the database.
+            // If some of the candidates are already store, and is removed in the new feed, we need to remove it from
+            // the database.
+            const auto cveIdKey = cveId->str().append("_");
+            std::vector<std::pair<std::string, std::string>> previousCandidates;
+
+            for (const auto& [cvePackage, packageCve] : feedDatabase->seek(cveIdKey, CVE_PACKAGE_COLUMN_NAME))
+            {
+                previousCandidates.emplace_back(packageCve.ToString(), cvePackage);
+            }
+
+            for (const auto& [packageCve, cvePackage] : previousCandidates)
+            {
+                // Remove _CVE-XXXX-XXXX from the key.
+                auto packageCandidate = packageCve;
+                Utils::replaceFirst(packageCandidate, std::string("_" + cveId->str()), "");
+
+                if (candidatesArraysMap.find(packageCandidate) == candidatesArraysMap.end())
+                {
+                    feedDatabase->delete_(packageCve, shortName);
+                    feedDatabase->delete_(cvePackage, CVE_PACKAGE_COLUMN_NAME);
+                }
+            }
+
             for (auto& [key, value] : candidatesArraysMap)
             {
                 const auto finalArray =
@@ -143,8 +175,14 @@ public:
                 const auto finalKey = key + "_" + cveId->str();
                 const auto reverseKey = cveId->str() + "_" + key;
 
-                feedDatabase->put(finalKey, slice, shortName);
-                feedDatabase->put(reverseKey, finalKey, CVE_PACKAGE_COLUMN_NAME);
+                if (rocksdb::PinnableSlice currentValueCandidate;
+                    !feedDatabase->get(finalKey, currentValueCandidate, shortName) ||
+                    currentValueCandidate.size() != slice.size() ||
+                    std::memcmp(currentValueCandidate.data(), slice.data(), slice.size()) != 0)
+                {
+                    feedDatabase->put(finalKey, slice, shortName);
+                    feedDatabase->put(reverseKey, finalKey, CVE_PACKAGE_COLUMN_NAME);
+                }
             }
         };
 
@@ -152,20 +190,23 @@ public:
         {
             for (const auto& adp : *cve5Flatbuffer->containers()->adp())
             {
-                if (!adp->providerMetadata() || !adp->providerMetadata()->shortName() || !adp->affected())
+                if (!adp->providerMetadata() || !adp->providerMetadata()->x_subShortName() || !adp->affected())
                 {
                     std::cerr << "Empty providerMetadata, shortName or affected.\n";
                     continue;
                 }
 
-                auto shortName = adp->providerMetadata()->shortName()->str();
+                const auto shortName = adp->providerMetadata()->x_subShortName()->str();
 
                 if (!feedDatabase->columnExists(shortName))
                 {
                     feedDatabase->createColumn(shortName);
                 }
 
-                if (!feedDatabase->columnExists(CVE_PACKAGE_COLUMN_NAME))
+                // Create column to maintain the relationship between the cve and the package.
+                if (const auto CVE_PACKAGE_COLUMN_NAME =
+                        std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX).append("_").append(shortName);
+                    !feedDatabase->columnExists(CVE_PACKAGE_COLUMN_NAME))
                 {
                     feedDatabase->createColumn(CVE_PACKAGE_COLUMN_NAME);
                 }
@@ -196,7 +237,10 @@ public:
                 feedDatabase->createColumn(shortName);
             }
 
-            if (!feedDatabase->columnExists(CVE_PACKAGE_COLUMN_NAME))
+            // Create column to maintain the relationship between the cve and the package.
+            if (const auto CVE_PACKAGE_COLUMN_NAME =
+                    std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX).append("_").append(shortName);
+                !feedDatabase->columnExists(CVE_PACKAGE_COLUMN_NAME))
             {
                 feedDatabase->createColumn(CVE_PACKAGE_COLUMN_NAME);
             }
@@ -218,23 +262,31 @@ public:
             return;
         }
 
-        if (!feedDatabase->columnExists(CVE_PACKAGE_COLUMN_NAME))
-        {
-            return;
-        }
-
         std::string cveId {cve5Flatbuffer->cveMetadata()->cveId()->str()};
         cveId.append("_");
 
-        auto cnaNames = feedDatabase->getAllColumns();
+        const auto cnaNames = feedDatabase->getAllColumns();
 
-        for (const auto& [cvePackage, packageCve] : feedDatabase->seek(cveId, CVE_PACKAGE_COLUMN_NAME))
+        for (const auto& cnaName : cnaNames)
         {
-            for (const auto& cnaName : cnaNames)
+            const auto CVE_PACKAGE_COLUMN_NAME =
+                std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX).append("_").append(cnaName);
+
+            if (feedDatabase->columnExists(CVE_PACKAGE_COLUMN_NAME))
             {
-                feedDatabase->delete_(packageCve.ToString(), cnaName);
+                // Delete elements inner iteration is unsafe.
+                std::vector<std::string> cvePackagesToDelete;
+                for (const auto& [cvePackage, packageCve] : feedDatabase->seek(cveId, CVE_PACKAGE_COLUMN_NAME))
+                {
+                    feedDatabase->delete_(packageCve.ToString(), cnaName);
+                    cvePackagesToDelete.push_back(cvePackage);
+                }
+
+                for (const auto& cvePackage : cvePackagesToDelete)
+                {
+                    feedDatabase->delete_(cvePackage, CVE_PACKAGE_COLUMN_NAME);
+                }
             }
-            feedDatabase->delete_(cvePackage, CVE_PACKAGE_COLUMN_NAME);
         }
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -29,6 +29,7 @@ constexpr auto UNKNOWN_VALUE {" "};
 constexpr auto STATES_VD_INDEX_NAME {"wazuh-states-vulnerabilities"};
 constexpr auto DEFAULT_TRANSLATION_LRU_SIZE {2048};
 constexpr auto DEFAULT_OSDATA_LRU_SIZE {1000};
+const static std::string UPDATER_PATH {"queue/vd_updater"};
 
 enum class DisableManagerScanStatus : uint32_t
 {
@@ -145,8 +146,8 @@ private:
                 newPolicy["updater"]["configData"]["compressionType"] = "raw";
                 newPolicy["updater"]["configData"]["versionedContent"] = "false";
                 newPolicy["updater"]["configData"]["deleteDownloadedContent"] = true;
-                newPolicy["updater"]["configData"]["outputFolder"] = "queue/vd_updater/tmp";
-                newPolicy["updater"]["configData"]["databasePath"] = "queue/vd_updater/rocksdb";
+                newPolicy["updater"]["configData"]["outputFolder"] = UPDATER_PATH + "/tmp";
+                newPolicy["updater"]["configData"]["databasePath"] = UPDATER_PATH + "/rocksdb";
                 newPolicy["updater"]["configData"]["url"] = newPolicy.at("vulnerability-detection").at("offline-url");
                 newPolicy["updater"]["configData"]["offset"] = 0;
             }
@@ -156,9 +157,9 @@ private:
                 newPolicy["updater"]["configData"]["compressionType"] = "raw";
                 newPolicy["updater"]["configData"]["versionedContent"] = "false";
                 newPolicy["updater"]["configData"]["deleteDownloadedContent"] = true;
-                newPolicy["updater"]["configData"]["outputFolder"] = "queue/vd_updater/tmp";
+                newPolicy["updater"]["configData"]["outputFolder"] = UPDATER_PATH + "/tmp";
                 newPolicy["updater"]["configData"]["contentFileName"] = "api_file.json";
-                newPolicy["updater"]["configData"]["databasePath"] = "queue/vd_updater/rocksdb";
+                newPolicy["updater"]["configData"]["databasePath"] = UPDATER_PATH + "/rocksdb";
                 newPolicy["updater"]["configData"]["url"] = newPolicy.at("vulnerability-detection").at("cti-url");
                 newPolicy["updater"]["configData"]["offset"] = 0;
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -29,7 +29,9 @@ auto constexpr DEFAULT_CNA {"nvd"};
  * format can be deb, rpm, pypi, npm, pacman, snap, pkg, apk, win, macports. The vulnerability scan is performed using
  * the database feed manager.
  */
-template<typename TDatabaseFeedManager = DatabaseFeedManager, typename TScanContext = ScanContext>
+template<typename TDatabaseFeedManager = DatabaseFeedManager,
+         typename TScanContext = ScanContext,
+         typename TGlobalData = GlobalData>
 class TPackageScanner final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 private:
@@ -76,7 +78,7 @@ private:
             }
         }
 
-        const auto mapping = GlobalData::instance().cnaMappings();
+        const auto mapping = TGlobalData::instance().cnaMappings();
 
         const auto& cnaMapping = mapping.at("cnaMapping");
         const auto platformEquivalence = [&](const std::string& platform)
@@ -88,7 +90,7 @@ private:
             }
             else
             {
-                return it->get_ref<const std::string&>();
+                return it->template get_ref<const std::string&>();
             }
         };
 
@@ -107,7 +109,7 @@ private:
                 }
                 else
                 {
-                    return itMajorVersion->get_ref<const std::string&>();
+                    return itMajorVersion->template get_ref<const std::string&>();
                 }
             }
         };

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -17,7 +17,6 @@
 #include "scanContext.hpp"
 #include "scannerHelper.hpp"
 #include "versionMatcher/versionMatcher.hpp"
-#include <iostream>
 #include <variant>
 
 auto constexpr DEFAULT_CNA {"nvd"};
@@ -53,6 +52,80 @@ private:
         {"apk", VersionMatcherStrategy::APK},
         {"win", VersionMatcherStrategy::Windows},
         {"macports", VersionMatcherStrategy::MacOS}};
+
+    /**
+     * @brief Define what CNA will be used to read the data.
+     *
+     * @param ctx Scan context.
+     * @return std::string CNA name.
+     */
+    std::string getCNA(std::shared_ptr<TScanContext> ctx)
+    {
+        auto cnaName {m_databaseFeedManager->getCnaNameByFormat(ctx->packageFormat().data())};
+
+        if (cnaName.empty())
+        {
+            cnaName = m_databaseFeedManager->getCnaNameByPrefix(ctx->packageVendor().data());
+            if (cnaName.empty())
+            {
+                cnaName = m_databaseFeedManager->getCnaNameByContains(ctx->packageVendor().data());
+                if (cnaName.empty())
+                {
+                    return DEFAULT_CNA;
+                }
+            }
+        }
+
+        const auto mapping = GlobalData::instance().cnaMappings();
+
+        const auto& cnaMapping = mapping.at("cnaMapping");
+        const auto platformEquivalence = [&](const std::string& platform)
+        {
+            const auto& platformMapping = mapping.at("platformEquivalence");
+            if (const auto it = platformMapping.find(platform); it == platformMapping.end())
+            {
+                return platform;
+            }
+            else
+            {
+                return it->get_ref<const std::string&>();
+            }
+        };
+
+        const auto majorVersionEquivalence = [&](const std::string& platform, const std::string& majorVersion)
+        {
+            const auto& majorVersionMapping = mapping.at("majorVersionEquivalence");
+            if (const auto itPlatform = majorVersionMapping.find(platform); itPlatform == majorVersionMapping.end())
+            {
+                return majorVersion;
+            }
+            else
+            {
+                if (const auto itMajorVersion = itPlatform->find(majorVersion); itMajorVersion == itPlatform->end())
+                {
+                    return majorVersion;
+                }
+                else
+                {
+                    return itMajorVersion->get_ref<const std::string&>();
+                }
+            }
+        };
+
+        if (const auto it = cnaMapping.find(cnaName); it == cnaMapping.end())
+        {
+            return cnaName;
+        }
+        else
+        {
+            std::string base = it->template get<std::string>();
+            Utils::replaceAll(base, "$(PLATFORM)", platformEquivalence(ctx->osPlatform().data()));
+            Utils::replaceAll(base,
+                              "$(MAJOR_VERSION)",
+                              majorVersionEquivalence(ctx->osPlatform().data(), ctx->osMajorVersion().data()));
+            return base;
+        }
+    }
 
 public:
     // LCOV_EXCL_START
@@ -317,20 +390,7 @@ public:
             }
         };
 
-        auto cnaName {m_databaseFeedManager->getCnaNameByFormat(data->packageFormat().data())};
-
-        if (cnaName.empty())
-        {
-            cnaName = m_databaseFeedManager->getCnaNameByPrefix(data->packageVendor().data());
-            if (cnaName.empty())
-            {
-                cnaName = m_databaseFeedManager->getCnaNameByContains(data->packageVendor().data());
-                if (cnaName.empty())
-                {
-                    cnaName = DEFAULT_CNA;
-                }
-            }
-        }
+        const auto CNAValue = getCNA(data);
 
         logDebug1(WM_VULNSCAN_LOGTAG,
                   "Initiating a vulnerability scan for package '%s' (%s) (%s) with CVE Numbering Authorities (CNA) "
@@ -339,21 +399,21 @@ public:
                   packageName.c_str(),
                   data->packageFormat().data(),
                   data->packageVendor().data(),
-                  cnaName.c_str(),
+                  CNAValue.c_str(),
                   data->agentName().data(),
                   data->agentId().data(),
                   data->agentVersion().data());
 
         try
         {
-            m_databaseFeedManager->getVulnerabilitiesCandidates(cnaName, packageName, vulnerabilityScan);
+            m_databaseFeedManager->getVulnerabilitiesCandidates(CNAValue, packageName, vulnerabilityScan);
         }
         catch (const std::exception& e)
         {
             logWarn(WM_VULNSCAN_LOGTAG,
                     "Failed to scan package: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'",
                     packageName.c_str(),
-                    cnaName.c_str(),
+                    CNAValue.c_str(),
                     e.what());
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scannerHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scannerHelper.hpp
@@ -13,7 +13,6 @@
 #define _SCANNER_HELPER_HPP
 
 #include "stringHelper.h"
-#include <iostream>
 #include <string>
 
 /**
@@ -165,92 +164,66 @@ public:
         }
 
         // Compare the CPEs
-        if (minorSize >= CPEFIELDS::part)
+        if (minorSize >= CPEFIELDS::part && cpe1.part != "*" && cpe2.part != "*" && cpe1.part != cpe2.part)
         {
-            if (cpe1.part != "*" && cpe2.part != "*" && cpe1.part != cpe2.part)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::vendor)
+        if (minorSize >= CPEFIELDS::vendor && cpe1.vendor != "*" && cpe2.vendor != "*" && cpe1.vendor != cpe2.vendor)
         {
-            if (cpe1.vendor != "*" && cpe2.vendor != "*" && cpe1.vendor != cpe2.vendor)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::product)
+        if (minorSize >= CPEFIELDS::product && cpe1.product != "*" && cpe2.product != "*" &&
+            cpe1.product != cpe2.product)
         {
-            if (cpe1.product != "*" && cpe2.product != "*" && cpe1.product != cpe2.product)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::version)
+        if (minorSize >= CPEFIELDS::version && cpe1.version != "*" && cpe2.version != "*" &&
+            cpe1.version != cpe2.version)
         {
-            if (cpe1.version != "*" && cpe2.version != "*" && cpe1.version != cpe2.version)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::update)
+        if (minorSize >= CPEFIELDS::update && cpe1.update != "*" && cpe2.update != "*" && cpe1.update != cpe2.update)
         {
-            if (cpe1.update != "*" && cpe2.update != "*" && cpe1.update != cpe2.update)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::edition)
+        if (minorSize >= CPEFIELDS::edition && cpe1.edition != "*" && cpe2.edition != "*" &&
+            cpe1.edition != cpe2.edition)
         {
-            if (cpe1.edition != "*" && cpe2.edition != "*" && cpe1.edition != cpe2.edition)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::language)
+        if (minorSize >= CPEFIELDS::language && cpe1.language != "*" && cpe2.language != "*" &&
+            cpe1.language != cpe2.language)
         {
-            if (cpe1.language != "*" && cpe2.language != "*" && cpe1.language != cpe2.language)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::swEdition)
+        if (minorSize >= CPEFIELDS::swEdition && cpe1.swEdition != "*" && cpe2.swEdition != "*" &&
+            cpe1.swEdition != cpe2.swEdition)
         {
-            if (cpe1.swEdition != "*" && cpe2.swEdition != "*" && cpe1.swEdition != cpe2.swEdition)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::targetSw)
+        if (minorSize >= CPEFIELDS::targetSw && cpe1.targetSw != "*" && cpe2.targetSw != "*" &&
+            cpe1.targetSw != cpe2.targetSw)
         {
-            if (cpe1.targetSw != "*" && cpe2.targetSw != "*" && cpe1.targetSw != cpe2.targetSw)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::targetHw)
+        if (minorSize >= CPEFIELDS::targetHw && cpe1.targetHw != "*" && cpe2.targetHw != "*" &&
+            cpe1.targetHw != cpe2.targetHw)
         {
-            if (cpe1.targetHw != "*" && cpe2.targetHw != "*" && cpe1.targetHw != cpe2.targetHw)
-            {
-                return false;
-            }
+            return false;
         }
 
-        if (minorSize >= CPEFIELDS::other)
+        if (minorSize >= CPEFIELDS::other && cpe1.other != "*" && cpe2.other != "*" && cpe1.other != cpe2.other)
         {
-            if (cpe1.other != "*" && cpe2.other != "*" && cpe1.other != cpe2.other)
-            {
-                return false;
-            }
+            return false;
         }
 
         return true;

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockGlobalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockGlobalData.hpp
@@ -43,6 +43,11 @@ public:
 
     /**
      * @brief Mock method
+     */
+    MOCK_METHOD(void, cnaMappings, (const nlohmann::json& cna));
+
+    /**
+     * @brief Mock method
      *
      * @return nlohmann::json
      */
@@ -54,6 +59,13 @@ public:
      * @return nlohmann::json
      */
     MOCK_METHOD(nlohmann::json, osCpeMaps, (), (const));
+
+    /**
+     * @brief Mock method
+     *
+     * @return nlohmann::json
+     */
+    MOCK_METHOD(nlohmann::json, cnaMappings, (), (const));
 };
 
 #endif // _MOCK_GLOBAL_DATA_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineGlobalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineGlobalData.hpp
@@ -67,6 +67,26 @@ public:
     {
         return spGlobalDataMock->osCpeMaps();
     }
+
+    /**
+     * @brief Trampoline to method cnaMappings.
+     *
+     * @param cna
+     */
+    void cnaMappings(const nlohmann::json& cna)
+    {
+        spGlobalDataMock->cnaMappings(cna);
+    }
+
+    /**
+     * @brief Trampoline to method cnaMappings.
+     *
+     * @return nlohmann::json
+     */
+    nlohmann::json cnaMappings() const
+    {
+        return spGlobalDataMock->cnaMappings();
+    }
 };
 
 #endif // _TRAMPOLINE_GLOBAL_DATA_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -12,12 +12,10 @@
 #include "databaseFeedManager_test.h"
 #include "MockContentRegister.hpp"
 #include "MockIndexerConnector.hpp"
-#include "MockOsDataCache.hpp"
 #include "MockPolicyManager.hpp"
 #include "MockRouterSubscriber.hpp"
 #include "MockUnixSocketRequest.hpp"
 #include "flatbuffers/flatbuffer_builder.h"
-#include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "routerModule.hpp"
 #include "routerProvider.hpp"
@@ -1670,69 +1668,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, DISABLED_TestProcessingStop)
     EXPECT_LT(counter, totalElements);
 }
 
-TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithNoVendorMap)
-{
-    // Remove vendor-map entry
-    {
-        auto spRocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-        spRocksDBWrapper->delete_("FEED-GLOBAL", VENDOR_MAP_COLUMN);
-    }
-
-    std::string stdMessage = R"({"type":"offsets","offset":1234,"paths":["file3.json"]})";
-    std::vector<char> message = std::vector<char>(stdMessage.begin(), stdMessage.end());
-
-    auto testingLambda1 = [](const nlohmann::json& obj, Utils::IRocksDBWrapper* dbWrapper) {
-    };
-    std::atomic<bool> shouldStop {false};
-    std::shared_mutex mutex;
-
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _))
-        .Times(1)
-        .WillOnce(::testing::InvokeArgument<2>(std::string {"ok"}));
-
-    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
-    auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
-                                                                      TrampolinePolicyManager,
-                                                                      TrampolineContentRegister,
-                                                                      RouterSubscriber,
-                                                                      MockUnixSocketRequest>>(
-        spIndexerConnectorTramp, shouldStop, mutex, true, false)};
-
-    EXPECT_ANY_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1));
-}
-
-TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithInvalidVendorMap)
-{
-    // Invalid vendor-map entry
-    {
-        auto spRocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-        spRocksDBWrapper->put("FEED-GLOBAL", "invalid", VENDOR_MAP_COLUMN);
-    }
-
-    std::string stdMessage = R"({"type":"offsets","offset":1234,"paths":["file3.json"]})";
-    std::vector<char> message = std::vector<char>(stdMessage.begin(), stdMessage.end());
-
-    auto testingLambda1 = [](const nlohmann::json& obj, Utils::IRocksDBWrapper* dbWrapper) {
-    };
-    std::atomic<bool> shouldStop {false};
-    std::shared_mutex mutex;
-
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _))
-        .Times(1)
-        .WillOnce(::testing::InvokeArgument<2>(std::string {"ok"}));
-
-    auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
-    auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
-                                                                      TrampolinePolicyManager,
-                                                                      TrampolineContentRegister,
-                                                                      RouterSubscriber,
-                                                                      MockUnixSocketRequest>>(
-        spIndexerConnectorTramp, shouldStop, mutex, true, false)};
-
-    EXPECT_ANY_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1));
-}
-
-TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithNoVendorMap)
+TEST_F(DatabaseFeedManagerMessageProcessorTest, TestNoVendorMap)
 {
     // Delete vendor-map entry
     {
@@ -1740,17 +1676,10 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithNoVendorMap)
         spRocksDBWrapper->delete_("FEED-GLOBAL", VENDOR_MAP_COLUMN);
     }
 
-    std::string stdMessage = R"({"type":"raw","offset":1234,"paths":["file4.json"]})";
-    std::vector<char> message = std::vector<char>(stdMessage.begin(), stdMessage.end());
-
-    auto testingLambda1 = [](const nlohmann::json& obj, Utils::IRocksDBWrapper* dbWrapper) {
-    };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _)).Times(1);
+    EXPECT_CALL(MockUnixSocketRequest::instance(), get(_, _, _)).Times(1);
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
     auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
@@ -1758,12 +1687,10 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithNoVendorMap)
                                                                       TrampolineContentRegister,
                                                                       RouterSubscriber,
                                                                       MockUnixSocketRequest>>(
-        spIndexerConnectorTramp, shouldStop, mutex, true, false)};
-
-    EXPECT_ANY_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1));
+        spIndexerConnectorTramp, shouldStop, mutex, true, true)};
 }
 
-TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithInvalidVendorMap)
+TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidVendorMap)
 {
     // Insert invalid vendor-map entry
     {
@@ -1771,17 +1698,10 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithInvalidVendorMap)
         spRocksDBWrapper->put("FEED-GLOBAL", "invalid", VENDOR_MAP_COLUMN);
     }
 
-    std::string stdMessage = R"({"type":"raw","offset":1234,"paths":["file4.json"]})";
-    std::vector<char> message = std::vector<char>(stdMessage.begin(), stdMessage.end());
-
-    auto testingLambda1 = [](const nlohmann::json& obj, Utils::IRocksDBWrapper* dbWrapper) {
-    };
-    auto testingLambda2 = []() {
-    };
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _)).Times(1);
+    EXPECT_CALL(MockUnixSocketRequest::instance(), get(_, _, _)).Times(1);
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
     auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
@@ -1789,9 +1709,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithInvalidVendorMap)
                                                                       TrampolineContentRegister,
                                                                       RouterSubscriber,
                                                                       MockUnixSocketRequest>>(
-        spIndexerConnectorTramp, shouldStop, mutex, true, false)};
-
-    EXPECT_ANY_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testingLambda1));
+        spIndexerConnectorTramp, shouldStop, mutex, true, true)};
 }
 
 /* Vendor maps tests */

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -100,6 +100,25 @@ const std::string VULNERABILITY_CANDIDATE_EXAMPLE = R"(
 const std::string CNA_NAME {"cnaName"};
 const std::string PACKAGE_NAME {"libmagic-mgc"};
 const std::string CORRUPTED_PACKAGE_NAME {"libcorrupted"};
+const nlohmann::json CNA_MAPPINGS = "\
+    { \
+      \"cnaMapping\": { \
+        \"alas\": \"alas_$(MAJOR_VERSION)\", \
+        \"alma\": \"alma_$(MAJOR_VERSION)\", \
+        \"redhat\": \"redhat_$(MAJOR_VERSION)\", \
+        \"suse\": \"$(PLATFORM)_$(MAJOR_VERSION)\" \
+      }, \
+      \"majorVersionEquivalence\": { \
+        \"amzn\": { \
+          \"2018\": \"1\" \
+        } \
+      }, \
+      \"platformEquivalence\": { \
+        \"sled\": \"suse_desktop\", \
+        \"sles\": \"suse_server\" \
+      } \
+    } \
+    "_json;
 
 // External shared pointers definitions
 std::shared_ptr<MockIndexerConnector> spIndexerConnectorMock;
@@ -160,6 +179,13 @@ void DatabaseFeedManagerTest::SetUp()
     auto osCpeRules = R"({})";
 
     rocksDBWrapper.put("OSCPE-GLOBAL", osCpeRules, OS_CPE_RULES_COLUMN);
+
+    // Mock cna mapping
+    if (!rocksDBWrapper.columnExists(CNA_MAPPING_COLUMN))
+    {
+        rocksDBWrapper.createColumn(CNA_MAPPING_COLUMN);
+    }
+    rocksDBWrapper.put("CNA-MAPPING-GLOBAL", CNA_MAPPINGS.dump(), CNA_MAPPING_COLUMN);
 };
 
 void DatabaseFeedManagerTest::TearDown()
@@ -1132,6 +1158,14 @@ void DatabaseFeedManagerMessageProcessorTest::SetUp()
     auto osCpeRules = R"({})";
 
     spRocksDBWrapper->put("OSCPE-GLOBAL", osCpeRules, OS_CPE_RULES_COLUMN);
+
+    // Mock cna mapping
+    if (!spRocksDBWrapper->columnExists(CNA_MAPPING_COLUMN))
+    {
+        spRocksDBWrapper->createColumn(CNA_MAPPING_COLUMN);
+    }
+    spRocksDBWrapper->put("CNA-MAPPING-GLOBAL", CNA_MAPPINGS.dump(), CNA_MAPPING_COLUMN);
+
     spRocksDBWrapper.reset();
 };
 
@@ -1596,8 +1630,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithDataSuccess)
             throw std::runtime_error {"Error"};
         }
     };
-    auto testingLambda2 = []() {
-    };
+
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -26,8 +26,8 @@
 using ::testing::_;
 using ::testing::Return;
 
-constexpr auto COMMON_DATABASE_DIR {"queue/vd"}; //<<Used for all databases
-
+constexpr auto COMMON_DATABASE_DIR {"queue/vd"};        //<<Used for all databases
+constexpr auto COMMON_UPDATER_DIR {"queue/vd_updater"}; //<<Used for all updaters
 constexpr auto CVEID_TEST_OK {"cveid_test_ok"};
 constexpr auto CVEID_TEST_NOT_FOUND {"cveid_test_not_found"};
 constexpr auto CVEID_TEST_CORRUPTED {"cveid_test_corrupted"};
@@ -1712,8 +1712,8 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestNoVendorMap)
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), get(_, _, _)).Times(1);
-
+    // Create dummy folder for UPDATER_PATH
+    std::filesystem::create_directories(COMMON_UPDATER_DIR);
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
     auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
                                                                       TrampolinePolicyManager,
@@ -1721,6 +1721,8 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestNoVendorMap)
                                                                       RouterSubscriber,
                                                                       MockUnixSocketRequest>>(
         spIndexerConnectorTramp, shouldStop, mutex, true, true)};
+    // Check if file exists.
+    EXPECT_FALSE(std::filesystem::exists(COMMON_UPDATER_DIR));
 }
 
 TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidVendorMap)
@@ -1734,7 +1736,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidVendorMap)
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), get(_, _, _)).Times(1);
+    std::filesystem::create_directories(COMMON_UPDATER_DIR);
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
     auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
@@ -1743,6 +1745,8 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestInvalidVendorMap)
                                                                       RouterSubscriber,
                                                                       MockUnixSocketRequest>>(
         spIndexerConnectorTramp, shouldStop, mutex, true, true)};
+    // Check if file exists.
+    EXPECT_FALSE(std::filesystem::exists(COMMON_UPDATER_DIR));
 }
 
 /* Vendor maps tests */

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -100,25 +100,25 @@ const std::string VULNERABILITY_CANDIDATE_EXAMPLE = R"(
 const std::string CNA_NAME {"cnaName"};
 const std::string PACKAGE_NAME {"libmagic-mgc"};
 const std::string CORRUPTED_PACKAGE_NAME {"libcorrupted"};
-const nlohmann::json CNA_MAPPINGS = "\
-    { \
-      \"cnaMapping\": { \
-        \"alas\": \"alas_$(MAJOR_VERSION)\", \
-        \"alma\": \"alma_$(MAJOR_VERSION)\", \
-        \"redhat\": \"redhat_$(MAJOR_VERSION)\", \
-        \"suse\": \"$(PLATFORM)_$(MAJOR_VERSION)\" \
-      }, \
-      \"majorVersionEquivalence\": { \
-        \"amzn\": { \
-          \"2018\": \"1\" \
-        } \
-      }, \
-      \"platformEquivalence\": { \
-        \"sled\": \"suse_desktop\", \
-        \"sles\": \"suse_server\" \
-      } \
-    } \
-    "_json;
+const nlohmann::json CNA_MAPPINGS = R"***(
+{
+  "cnaMapping": {
+    "alas": "alas_$(MAJOR_VERSION)",
+    "alma": "alma_$(MAJOR_VERSION)",
+    "redhat": "redhat_$(MAJOR_VERSION)",
+    "suse": "$(PLATFORM)_$(MAJOR_VERSION)"
+  },
+  "majorVersionEquivalence": {
+    "amzn": {
+      "2018": "1"
+    }
+  },
+  "platformEquivalence": {
+    "sled": "suse_desktop",
+    "sles": "suse_server"
+  }
+}
+)***"_json;
 
 // External shared pointers definitions
 std::shared_ptr<MockIndexerConnector> spIndexerConnectorMock;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -246,25 +246,25 @@ namespace NSPackageScannerTest
 
     const std::string CVEID {"CVE-2024-1234"};
 
-    const nlohmann::json CNA_MAPPINGS = "\
-    { \
-      \"cnaMapping\": { \
-        \"alas\": \"alas_$(MAJOR_VERSION)\", \
-        \"alma\": \"alma_$(MAJOR_VERSION)\", \
-        \"redhat\": \"redhat_$(MAJOR_VERSION)\", \
-        \"suse\": \"$(PLATFORM)_$(MAJOR_VERSION)\" \
-      }, \
-      \"majorVersionEquivalence\": { \
-        \"amzn\": { \
-          \"2018\": \"1\" \
-        } \
-      }, \
-      \"platformEquivalence\": { \
-        \"sled\": \"suse_desktop\", \
-        \"sles\": \"suse_server\" \
-      } \
-    } \
-    "_json;
+    const nlohmann::json CNA_MAPPINGS = R"***(
+    {
+      "cnaMapping": {
+        "alas": "alas_$(MAJOR_VERSION)",
+        "alma": "alma_$(MAJOR_VERSION)",
+        "redhat": "redhat_$(MAJOR_VERSION)",
+        "suse": "$(PLATFORM)_$(MAJOR_VERSION)"
+      },
+      "majorVersionEquivalence": {
+        "amzn": {
+          "2018": "1"
+        }
+      },
+      "platformEquivalence": {
+        "sled": "suse_desktop",
+        "sles": "suse_server"
+      }
+    }
+    )***"_json;
 
 } // namespace NSPackageScannerTest
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -1028,3 +1028,297 @@ TEST_F(PackageScannerTest, TestPackageGetVulnerabilitiesCandidatesGeneratesExcep
 
     EXPECT_TRUE(scanContextResult == nullptr);
 }
+
+TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlma8)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "8",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "alma",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaNameByFormat(_)).WillOnce(testing::Return("alma"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates("alma_8", _, _));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
+        spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
+}
+
+TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas1)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "2018",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "amzn",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaNameByFormat(_)).WillOnce(testing::Return("alas"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates("alas_1", _, _));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
+        spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
+}
+
+TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "2",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "amzn",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaNameByFormat(_)).WillOnce(testing::Return("alas"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates("alas_2", _, _));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
+        spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
+}
+
+TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2022)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "2022",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "amzn",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaNameByFormat(_)).WillOnce(testing::Return("alas"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates("alas_2022", _, _));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
+        spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
+}
+
+TEST_F(PackageScannerTest, TestPackageAffectedEqualToRedHat7)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "7",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "redhat",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaNameByFormat(_)).WillOnce(testing::Return("redhat"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates("redhat_7", _, _));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
+        spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
+}
+
+TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLED)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "15",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "sled",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaNameByFormat(_)).WillOnce(testing::Return("suse"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates("suse_desktop_15", _, _));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
+        spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
+}
+
+TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLES)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "15",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "sles",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getCnaNameByFormat(_)).WillOnce(testing::Return("suse"));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilitiesCandidates("suse_server_15", _, _));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
+        spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -17,9 +17,9 @@
 #include "../databaseFeedManager/databaseFeedManager.hpp"
 #include "../scanOrchestrator/scanOrchestrator.hpp"
 #include "MockDatabaseFeedManager.hpp"
+#include "TrampolineGlobalData.hpp"
 #include "TrampolineOsDataCache.hpp"
 #include "flatbuffers/flatbuffer_builder.h"
-#include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
 
@@ -245,6 +245,27 @@ namespace NSPackageScannerTest
     const std::string CANDIDATES_FLATBUFFER_SCHEMA_PATH {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityCandidate.fbs"};
 
     const std::string CVEID {"CVE-2024-1234"};
+
+    const nlohmann::json CNA_MAPPINGS = "\
+    { \
+      \"cnaMapping\": { \
+        \"alas\": \"alas_$(MAJOR_VERSION)\", \
+        \"alma\": \"alma_$(MAJOR_VERSION)\", \
+        \"redhat\": \"redhat_$(MAJOR_VERSION)\", \
+        \"suse\": \"$(PLATFORM)_$(MAJOR_VERSION)\" \
+      }, \
+      \"majorVersionEquivalence\": { \
+        \"amzn\": { \
+          \"2018\": \"1\" \
+        } \
+      }, \
+      \"platformEquivalence\": { \
+        \"sled\": \"suse_desktop\", \
+        \"sles\": \"suse_server\" \
+      } \
+    } \
+    "_json;
+
 } // namespace NSPackageScannerTest
 
 using namespace NSPackageScannerTest;
@@ -325,7 +346,10 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualTo)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -413,7 +437,10 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedEqualTo)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -491,7 +518,10 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThan)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -579,7 +609,10 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanOrEqual)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -667,7 +700,10 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanWithVersionNotZero)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -755,7 +791,10 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedLessThan)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -833,7 +872,10 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusAffected)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -920,7 +962,10 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusUnaffected)
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;
@@ -972,7 +1017,10 @@ TEST_F(PackageScannerTest, TestPackageGetVulnerabilitiesCandidatesGeneratesExcep
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContextOriginal = std::make_shared<TScanContext<TrampolineOsDataCache>>(syscollectorDelta);
 
-    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>> packageScanner(
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+
+    TPackageScanner<MockDatabaseFeedManager, TScanContext<TrampolineOsDataCache>, TrampolineGlobalData> packageScanner(
         spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache>> scanContextResult;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVECandidates_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVECandidates_test.cpp
@@ -10,12 +10,10 @@
  */
 
 #include "updateCVECandidates_test.hpp"
-#include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "flatbuffers/verifier.h"
 #include "rocksDBWrapper.hpp"
 #include "updateCVECandidates.hpp"
-#include <unordered_map>
 
 namespace NSUpdateCVECandidatesTest
 {
@@ -75,7 +73,8 @@ namespace NSUpdateCVECandidatesTest
                         ],
                         "providerMetadata": {
                             "orgId": "00000000-0000-4000-A000-000000000000",
-                            "shortName" : "canonical"
+                            "shortName" : "canonical",
+                            "x_subShortName": "canonical"
                         },
                         "references": [
                             {
@@ -106,7 +105,8 @@ namespace NSUpdateCVECandidatesTest
                         ],
                         "providerMetadata": {
                             "orgId": "79363d38-fa19-49d1-9214-5f28da3f3ac5",
-                            "shortName" : "debian"
+                            "shortName" : "debian",
+                            "x_subShortName": "debian"
                         },
                         "references": [
                             {
@@ -181,7 +181,8 @@ namespace NSUpdateCVECandidatesTest
                     ],
                     "providerMetadata": {
                         "orgId": "00000000-0000-4000-A000-000000000001",
-                        "shortName": "nvd"
+                        "shortName": "nvd",
+                        "x_subShortName": "nvd"
                     },
                     "references": [
                         {
@@ -260,7 +261,8 @@ namespace NSUpdateCVECandidatesTest
                 ],
                 "providerMetadata": {
                     "orgId": "00000000-0000-4000-A000-000000000000",
-                    "shortName" : "canonical"
+                    "shortName" : "canonical",
+                    "x_subShortName": "canonical"
                 },
                 "references": [
                     {
@@ -303,7 +305,8 @@ namespace NSUpdateCVECandidatesTest
                 ],
                 "providerMetadata": {
                     "orgId": "79363d38-fa19-49d1-9214-5f28da3f3ac5",
-                    "shortName" : "debian"
+                    "shortName" : "debian",
+                    "x_subShortName": "debian"
                 },
                 "references": [
                     {
@@ -378,7 +381,8 @@ namespace NSUpdateCVECandidatesTest
             ],
             "providerMetadata": {
                 "orgId": "00000000-0000-4000-A000-000000000001",
-                "shortName": "nvd"
+                "shortName": "nvd",
+                "x_subShortName": "nvd"
             }
         }
     },
@@ -1216,7 +1220,7 @@ TEST_F(UpdateCVECandidatesTest, UpdateCVECandidateSuccess)
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
+    uint8_t const* buf = parser.builder_.GetBufferPointer();
     size_t flatbufferSize = parser.builder_.GetSize();
 
     // Verify flatbuffer.
@@ -1324,7 +1328,7 @@ TEST_F(UpdateCVECandidatesTest, RemoveCandidates)
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
+    uint8_t const* buf = parser.builder_.GetBufferPointer();
     size_t flatbufferSize = parser.builder_.GetSize();
 
     // Verify flatbuffer.
@@ -1343,11 +1347,19 @@ TEST_F(UpdateCVECandidatesTest, RemoveCandidates)
     EXPECT_TRUE(m_feedDatabase->get("bash_CVE-2020-0002", slice, "canonical"));
     EXPECT_TRUE(m_feedDatabase->get("kernel_CVE-2020-0002", slice, "canonical"));
 
-    EXPECT_TRUE(m_feedDatabase->get("CVE-2020-0002_bash", slice, CVE_PACKAGE_COLUMN_NAME));
+    EXPECT_TRUE(
+        m_feedDatabase->get("CVE-2020-0002_bash", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_debian"));
     EXPECT_EQ(slice.ToString(), "bash_CVE-2020-0002");
-    EXPECT_TRUE(m_feedDatabase->get("CVE-2020-0002_firefox", slice, CVE_PACKAGE_COLUMN_NAME));
+    EXPECT_TRUE(
+        m_feedDatabase->get("CVE-2020-0002_firefox", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_debian"));
     EXPECT_EQ(slice.ToString(), "firefox_CVE-2020-0002");
-    EXPECT_TRUE(m_feedDatabase->get("CVE-2020-0002_kernel", slice, CVE_PACKAGE_COLUMN_NAME));
+    EXPECT_TRUE(m_feedDatabase->get("CVE-2020-0002_bash", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_nvd"));
+    EXPECT_EQ(slice.ToString(), "bash_CVE-2020-0002");
+    EXPECT_TRUE(
+        m_feedDatabase->get("CVE-2020-0002_bash", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_canonical"));
+    EXPECT_EQ(slice.ToString(), "bash_CVE-2020-0002");
+    EXPECT_TRUE(
+        m_feedDatabase->get("CVE-2020-0002_kernel", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_canonical"));
     EXPECT_EQ(slice.ToString(), "kernel_CVE-2020-0002");
 
     // Remove candidates
@@ -1360,9 +1372,16 @@ TEST_F(UpdateCVECandidatesTest, RemoveCandidates)
     EXPECT_FALSE(m_feedDatabase->get("bash_CVE-2020-0002", slice, "canonical"));
     EXPECT_FALSE(m_feedDatabase->get("kernel_CVE-2020-0002", slice, "canonical"));
 
-    EXPECT_FALSE(m_feedDatabase->get("CVE-2020-0002_bash", slice, CVE_PACKAGE_COLUMN_NAME));
-    EXPECT_FALSE(m_feedDatabase->get("CVE-2020-0002_firefox", slice, CVE_PACKAGE_COLUMN_NAME));
-    EXPECT_FALSE(m_feedDatabase->get("CVE-2020-0002_kernel", slice, CVE_PACKAGE_COLUMN_NAME));
+    EXPECT_FALSE(
+        m_feedDatabase->get("CVE-2020-0002_bash", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_debian"));
+    EXPECT_FALSE(
+        m_feedDatabase->get("CVE-2020-0002_firefox", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_debian"));
+    EXPECT_FALSE(
+        m_feedDatabase->get("CVE-2020-0002_bash", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_nvd"));
+    EXPECT_FALSE(
+        m_feedDatabase->get("CVE-2020-0002_bash", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_canonical"));
+    EXPECT_FALSE(
+        m_feedDatabase->get("CVE-2020-0002_kernel", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_canonical"));
 }
 
 TEST_F(UpdateCVECandidatesTest, RemoveCandidatesSeparator)
@@ -1379,7 +1398,7 @@ TEST_F(UpdateCVECandidatesTest, RemoveCandidatesSeparator)
     ASSERT_EQ(valid, true);
 
     // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
+    uint8_t const* buf = parser.builder_.GetBufferPointer();
     size_t flatbufferSize = parser.builder_.GetSize();
 
     // Verify flatbuffer.
@@ -1415,8 +1434,10 @@ TEST_F(UpdateCVECandidatesTest, RemoveCandidatesSeparator)
 
     // Verify data
     EXPECT_FALSE(m_feedDatabase->get("windows_10_CVE-2020-1352", slice, "nvd"));
-    EXPECT_FALSE(m_feedDatabase->get("CVE-2020-1352_windows_10", slice, CVE_PACKAGE_COLUMN_NAME));
+    EXPECT_FALSE(
+        m_feedDatabase->get("CVE-2020-1352_windows_10", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_nvd"));
 
     EXPECT_TRUE(m_feedDatabase->get("openusd_CVE-2020-13520", slice, "nvd"));
-    EXPECT_TRUE(m_feedDatabase->get("CVE-2020-13520_openusd", slice, CVE_PACKAGE_COLUMN_NAME));
+    EXPECT_TRUE(
+        m_feedDatabase->get("CVE-2020-13520_openusd", slice, std::string(CVE_PACKAGE_COLUMN_NAME_PREFIX) + "_nvd"));
 }


### PR DESCRIPTION
|Related issue|
|---|
|#22581|
|#22529|
|#22528|

## Description

- Move from TransactionsDB to rocksdb:db, because the high memory usage implicated on the rocksdb::TransactionsDB, we suffer the same problem that -> https://github.com/facebook/rocksdb/issues/4333
- Set memory limits for read and write memtables.
- Handle the #22529 issue triggering the full content download and process if we cannot load the vendor map (if we stop the update process in the middle of the execution.)
- Establish zero and five constructor rules for the rocksdbwrapper class.
- Create a new RAII class to manage column family handles.


## Considerations
- This PR breaks support of alas, centos, rh, amazon linux until the issue  https://github.com/wazuh/wazuh/issues/22689 is resolved


## Test
### Update offsets from 257xxx to 429xxx

Before changes:
Memory:
![image](https://github.com/wazuh/wazuh/assets/14300208/dc89e6eb-5db9-4a89-a4a3-2fb935e66fee)

Temporary allocations:
![image](https://github.com/wazuh/wazuh/assets/14300208/3c7148fe-e5db-416b-a4cf-51700f70f5fb)

Summary:
![image](https://github.com/wazuh/wazuh/assets/14300208/41790742-abdd-4b58-8a40-ff0a7b63bff4)

Disk usage -> 
![image](https://github.com/wazuh/wazuh/assets/14300208/c112bb53-d30a-41fe-b326-f0add6f10339)

Take 1:53 hours to update all the data.

After changes:


After changes:
Memory usage:
![image](https://github.com/wazuh/wazuh/assets/14300208/2f733193-a2d2-4506-86e2-0704d03bbb8d)

Temporary allocations:
![image](https://github.com/wazuh/wazuh/assets/14300208/fea8b450-4ac6-42cd-9b9c-0b6b0cc2a7be)

Summary:
![image](https://github.com/wazuh/wazuh/assets/14300208/4785fc42-26ae-43d1-acba-ef2716f8b6a9)


Disk usage
![image](https://github.com/wazuh/wazuh/assets/14300208/f198e45a-7e96-42d6-8490-192c13ef7aec)

Take 18 minutes.
