### PR TITLE
Migrate and adapt macos wazuh agent packages subsystem

### DIFF
--- a/.github/workflows/packages-build-macos-agent.yml
+++ b/.github/workflows/packages-build-macos-agent.yml
@@ -1,4 +1,4 @@
-name: Build Macos Wazuh Agent Packages - intel64|arm64
+name: Build macOS Wazuh Agent Packages - intel64|arm64
 on:
   workflow_dispatch:
     inputs:
@@ -24,19 +24,16 @@ on:
           False if package name should have developer format.
           Default is 'false'.
         required: false
-        default: false
       debug:
         type: boolean
         description: |
           Activate debug mode in the compilation.
           Default is 'false'.
         required: false
-        default: false
       checksum:
         type: boolean
         description: Generate checksum on the same directory than the package.
         required: false
-        default: false
 
   workflow_call:
     inputs:
@@ -57,9 +54,9 @@ on:
         required: false
 
 jobs:
-  Build-agent-linux-packages:
+  build-agent-macos-packages:
     runs-on: macos-latest
-    name: Build MacOS wazuh-agent on ${{ inputs.architecture }}
+    name: Build macOS wazuh-agent on ${{ inputs.architecture }}
 
     steps:
       - name: Cancel previous runs
@@ -75,21 +72,22 @@ jobs:
         working-directory: packages/macos/
         run: |
           nproc=$(sysctl -n hw.ncpu)
-          FLAGS="-j $nproc -r $REVISION "
+          FLAGS="-j $nproc -r ${{ inputs.revision }} "
           if [ "${{ inputs.is_stage }}" == "true" ]; then FLAGS+="--is_stage "; fi
           if [ "${{ inputs.checksum }}" == "true" ]; then FLAGS+="--checksum "; fi
           if [ "${{ inputs.debug}}" == "true" ]; then FLAGS+="--debug "; fi
+          bash generate_wazuh_packages.sh -i
+          echo "generate_wazuh_packages.sh -a ${{ inputs.architecture }} $FLAGS"
           sudo bash generate_wazuh_packages.sh -a ${{ inputs.architecture }} $FLAGS
 
       - name: Test install Wazuh agent
         working-directory: packages/macos/output
         run: |
-          sudo echo "WAZUH_MANAGER='1.1.1.1'" > /tmp/wazuh_envs && sudo installer -pkg *agent*pkg -target /
-          sudo /Library/Ossec/bin/wazuh-control start
-          if [ $(sudo /Library/Ossec/bin/wazuh-control status | grep 'is running...' | wc -l) -gt "0" ];
-            then echo "Installation successfully."
+          sudo echo "WAZUH_MANAGER='1.1.1.1'" > /tmp/wazuh_envs && sudo installer -pkg *agent*pkg -target / | sudo tee ./installer.log
+          if grep -q "The install was successful" "./installer.log"; then
+            echo "Installation successfully."
           else
-            echo "The installation could not be completed successfully. The package will not be uploaded.";
+            echo "The installation could not be completed. The package will not be uploaded.";
             exit 1;
           fi
 

--- a/.github/workflows/packages-build-macos-agent.yml
+++ b/.github/workflows/packages-build-macos-agent.yml
@@ -4,31 +4,39 @@ on:
     inputs:
       architecture:
         type: choice
-        description: Package architecture [intel64, arm64]
-        required: true
-        default: intel64
+        description: Package architecture [intel64, arm64].
         options:
           - intel64
           - arm64
+        required: true
+        default: 'intel64'
       revision:
         description: |
           Package revision (name and metadata).
+          Default is '0'.
         required: false
-        type: string
         default: "0"
       is_stage:
         type: boolean
-        description: Set development/production nomenclature
+        description: |
+          Should set development/production nomenclature
+          True if package name should have production format.
+          False if package name should have developer format.
+          Default is 'false'.
         required: false
+        default: false
       debug:
         type: boolean
         description: |
-          Build the binaries with debug symbols. By default: false
+          Activate debug mode in the compilation.
+          Default is 'false'.
         required: false
+        default: false
       checksum:
         type: boolean
-        description: Generate package checksum
+        description: Generate checksum on the same directory than the package.
         required: false
+        default: false
 
   workflow_call:
     inputs:
@@ -51,7 +59,7 @@ on:
 jobs:
   Build-agent-linux-packages:
     runs-on: macos-latest
-    name: Build Mac OS wazuh-agent on ${{ inputs.architecture }}
+    name: Build MacOS wazuh-agent on ${{ inputs.architecture }}
 
     steps:
       - name: Cancel previous runs
@@ -63,24 +71,20 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Build wazuh-agent on ${{ inputs.architecture }}
+      - name: Compile Wazuh agent and generate package
         working-directory: packages/macos/
         run: |
-          REVISION=${{ inputs.revision }}
           nproc=$(sysctl -n hw.ncpu)
-          FLAGS="-j $nproc "
-          if [ -z "$REVISION" ]; then FLAGS+="-r 0 "; else FLAGS+="-r $REVISION "; fi
+          FLAGS="-j $nproc -r $REVISION "
           if [ "${{ inputs.is_stage }}" == "true" ]; then FLAGS+="--is_stage "; fi
-          if [ "${{ inputs.checksum }}" == "true" ] && [ ${{ inputs.is_stage}} == "true" ]; then FLAGS+="--checksum "; fi
+          if [ "${{ inputs.checksum }}" == "true" ]; then FLAGS+="--checksum "; fi
           if [ "${{ inputs.debug}}" == "true" ]; then FLAGS+="--debug "; fi
-          echo $FLAGS
-          bash generate_wazuh_packages.sh -i
           sudo bash generate_wazuh_packages.sh -a ${{ inputs.architecture }} $FLAGS
 
-      - name: Test install built manager
+      - name: Test install Wazuh agent
         working-directory: packages/macos/output
         run: |
-          sudo echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg *agent*pkg -target /
+          sudo echo "WAZUH_MANAGER='1.1.1.1'" > /tmp/wazuh_envs && sudo installer -pkg *agent*pkg -target /
           sudo /Library/Ossec/bin/wazuh-control start
           if [ $(sudo /Library/Ossec/bin/wazuh-control status | grep 'is running...' | wc -l) -gt "0" ];
             then echo "Installation successfully."
@@ -96,7 +100,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
           aws-region: us-east-1
 
-      - name: Upload package to S3
+      - name: Upload package and checksum to S3
         working-directory: packages/macos/
         run: |
           for file in output/*agent*; do

--- a/.github/workflows/packages-build-macos-agent.yml
+++ b/.github/workflows/packages-build-macos-agent.yml
@@ -80,8 +80,15 @@ jobs:
       - name: Test install built manager
         working-directory: packages/macos/output
         run: |
-            sudo installer -pkg *agent*pkg -target /
-        
+          sudo echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg *agent*pkg -target /
+          sudo /Library/Ossec/bin/wazuh-control start
+          if [ $(sudo /Library/Ossec/bin/wazuh-control status | grep 'is running...' | wc -l) -gt "0" ];
+            then echo "Installation successfully."
+          else
+            echo "The installation could not be completed successfully. The package will not be uploaded.";
+            exit 1;
+          fi
+
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/packages-build-macos-agent.yml
+++ b/.github/workflows/packages-build-macos-agent.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   Build-agent-linux-packages:
     runs-on: macos-latest
-    name: Build wazuh-agent on ${{ inputs.architecture }}
+    name: Build Mac OS wazuh-agent on ${{ inputs.architecture }}
 
     steps:
       - name: Cancel previous runs
@@ -77,6 +77,11 @@ jobs:
           bash generate_wazuh_packages.sh -i
           sudo bash generate_wazuh_packages.sh -a ${{ inputs.architecture }} $FLAGS
 
+      - name: Test install built manager
+        working-directory: packages/macos/output
+        run: |
+            sudo installer -pkg *agent*pkg -target /
+        
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/packages-build-macos-agent.yml
+++ b/.github/workflows/packages-build-macos-agent.yml
@@ -1,0 +1,92 @@
+name: Build Macos Wazuh Agent Packages - intel64|arm64
+on:
+  workflow_dispatch:
+    inputs:
+      architecture:
+        type: choice
+        description: Package architecture [intel64, arm64]
+        required: true
+        default: intel64
+        options:
+          - intel64
+          - arm64
+      revision:
+        description: |
+          Package revision (name and metadata).
+        required: false
+        type: string
+        default: "0"
+      is_stage:
+        type: boolean
+        description: Set development/production nomenclature
+        required: false
+      debug:
+        type: boolean
+        description: |
+          Build the binaries with debug symbols. By default: false
+        required: false
+      checksum:
+        type: boolean
+        description: Generate package checksum
+        required: false
+
+  workflow_call:
+    inputs:
+      architecture:
+        type: string
+        required: true
+      revision:
+        type: string
+        required: false
+      is_stage:
+        type: boolean
+        required: false
+      debug:
+        type: boolean
+        required: false
+      checksum:
+        type: boolean
+        required: false
+
+jobs:
+  Build-agent-linux-packages:
+    runs-on: macos-latest
+    name: Build wazuh-agent on ${{ inputs.architecture }}
+
+    steps:
+      - name: Cancel previous runs
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: 'true'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_after_successful_duplicate: 'false'
+
+      - uses: actions/checkout@v4
+
+      - name: Build wazuh-agent on ${{ inputs.architecture }}
+        working-directory: packages/macos/
+        run: |
+          REVISION=${{ inputs.revision }}
+          nproc=$(sysctl -n hw.ncpu)
+          FLAGS="-j $nproc "
+          if [ -z "$REVISION" ]; then FLAGS+="-r 0 "; else FLAGS+="-r $REVISION "; fi
+          if [ "${{ inputs.is_stage }}" == "true" ]; then FLAGS+="--is_stage "; fi
+          if [ "${{ inputs.checksum }}" == "true" ] && [ ${{ inputs.is_stage}} == "true" ]; then FLAGS+="--checksum "; fi
+          if [ "${{ inputs.debug}}" == "true" ]; then FLAGS+="--debug "; fi
+          echo $FLAGS
+          bash generate_wazuh_packages.sh -i
+          sudo bash generate_wazuh_packages.sh -a ${{ inputs.architecture }} $FLAGS
+
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload package to S3
+        working-directory: packages/macos/
+        run: |
+          for file in output/*agent*; do
+            aws s3 cp $file s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          done

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -15,7 +15,7 @@ WAZUH_SOURCE_REPOSITORY="https://github.com/wazuh/wazuh"
 INSTALLATION_PATH="/Library/Ossec"    # Installation path
 VERSION=""                            # Default VERSION (branch/tag)
 REVISION="1"                          # Package revision.
-BRANCH_TAG=""                   # Branch that will be downloaded to build package.
+BRANCH_TAG=""                         # Branch that will be downloaded to build package.
 DESTINATION="${CURRENT_PATH}/output/" # Where package will be stored.
 JOBS="2"                              # Compilation jobs.
 VERBOSE="no"                          # Enables the full log by using `set -exf`.
@@ -129,8 +129,7 @@ function build_package() {
         SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
         WAZUH_PATH="${SOURCES_DIRECTORY}/wazuh"
         git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}"
-        short_commit_hash="$(curl -s https://api.github.com/repos/wazuh/wazuh/commits/${WAZUH_BRANCH} \
-                | grep '"sha"' | head -n 1| cut -d '"' -f 4 | cut -c 1-11)"
+        short_commit_hash="$(git rev-parse -C "${WAZUH_PATH}" --short HEAD)"
     else
         WAZUH_PATH="${CURRENT_PATH}/../.."
         short_commit_hash="$(git rev-parse --short HEAD)"

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -107,6 +107,7 @@ function sign_pkg() {
 function get_pkgproj_specs() {
 
     VERSION="$1"
+    pkg_final_name="$2"
 
     pkg_file="${WAZUH_PACKAGES_PATH}/specs/wazuh-agent-${ARCH}.pkgproj"
 
@@ -115,7 +116,7 @@ function get_pkgproj_specs() {
         exit 1
     else
         echo "Modifiying ${pkg_file} to match revision."
-        sed -i -e "s:${VERSION}-.*<:${VERSION}-${REVISION}.${ARCH}<:g" "${pkg_file}"
+        sed -i -e "s:>.*${VERSION}-.*<:>${pkg_final_name}<:g" "${pkg_file}"
         cp "${pkg_file}" "${AGENT_PKG_FILE}"
     fi
 
@@ -133,12 +134,12 @@ function build_package() {
 
     # Define output package name
     if [ $IS_STAGE == "no" ]; then
-        pkg_name="wazuh-agent_${VERSION}-${REVISION}_${ARCH}_${short_commit_hash}.pkg"
+        pkg_name="wazuh-agent_${VERSION}-${REVISION}_${ARCH}_${short_commit_hash}"
     else
-        pkg_name="wazuh-agent_${VERSION}-${REVISION}.${ARCH}.pkg"
+        pkg_name="wazuh-agent-${VERSION}-${REVISION}.${ARCH}"
     fi
 
-    get_pkgproj_specs $VERSION
+    get_pkgproj_specs $VERSION $pkg_name
 
 
     if [ -d "${INSTALLATION_PATH}" ]; then

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -190,7 +190,6 @@ function help() {
     echo "    -b, --branch <branch>         [Optional] Select Git branch [${BRANCH}]."
     echo "    -s, --store-path <path>       [Optional] Set the destination absolute path of package."
     echo "    -j, --jobs <number>           [Optional] Number of parallel jobs when compiling."
-    echo "    -j, --jobs <number>           [Optional] Number of parallel jobs when compiling."
     echo "    -r, --revision <rev>          [Optional] Package revision that append to version e.g. x.x.x-rev"
     echo "    -d, --debug                   [Optional] Build the binaries with debug symbols. By default: no."    
     echo "    -c, --checksum <path>         [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package)."

--- a/packages/macos/package_files/build.sh
+++ b/packages/macos/package_files/build.sh
@@ -11,6 +11,7 @@ set -exf
 DESTINATION_PATH=$1
 SOURCES_PATH=$2
 BUILD_JOBS=$3
+DEBUG_ENABLED=$4
 INSTALLATION_SCRIPTS_DIR=${DESTINATION_PATH}/packages_files/agent_installation_scripts
 
 function configure() {
@@ -38,7 +39,7 @@ function build() {
     make -C ${SOURCES_PATH}/src deps TARGET=agent
 
     echo "Generating Wazuh executables"
-    make -j$JOBS -C ${SOURCES_PATH}/src DYLD_FORCE_FLAT_NAMESPACE=1 TARGET=agent build
+    make -j $BUILD_JOBS -C ${SOURCES_PATH}/src DYLD_FORCE_FLAT_NAMESPACE=1 DEBUG=$DEBUG_ENABLED TARGET=agent build
     fi
 
     echo "Running install script"

--- a/packages/macos/package_files/build.sh
+++ b/packages/macos/package_files/build.sh
@@ -11,7 +11,7 @@ set -exf
 DESTINATION_PATH=$1
 SOURCES_PATH=$2
 BUILD_JOBS=$3
-DEBUG_ENABLED=$4
+DEBUG=$4
 INSTALLATION_SCRIPTS_DIR=${DESTINATION_PATH}/packages_files/agent_installation_scripts
 
 function configure() {
@@ -39,7 +39,7 @@ function build() {
     make -C ${SOURCES_PATH}/src deps TARGET=agent
 
     echo "Generating Wazuh executables"
-    make -j $BUILD_JOBS -C ${SOURCES_PATH}/src DYLD_FORCE_FLAT_NAMESPACE=1 DEBUG=$DEBUG_ENABLED TARGET=agent build
+    make -j $BUILD_JOBS -C ${SOURCES_PATH}/src DYLD_FORCE_FLAT_NAMESPACE=1 DEBUG=$DEBUG TARGET=agent build
     fi
 
     echo "Running install script"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22080|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
As the main task of this PR is to move all required components from the wazuh-package repository to be able to generate RPM, DEB, ZIP, and PKG packages for the agent, the following steps were taken:

- Moved the wazuh-agent specs from the wazuh-packages repository to the wazuh repository.
- Improved the generate_wazuh_package.sh script.
- Added workflow for Macos package generation. 
- Used the sources `branch` to specify that the specs and source code will be taken from the downloaded branch.
- 
- Update the package name to adhere to [this naming convention](https://github.com/wazuh/wazuh/issues/21755#:~:text=As%20subsystem%20owners%2C%20teams%20must%20follow%20this%20naming%20convention%20for%20development%20package%20names%3A%20%3CSubsystemName%3E_%3CVersionNumber%3E%2D%3CRevision%3E_%7B%3COSName%3E%2D%3COSVersion%3E_%7D%3CArchitecture%3E_%3CGitReference%3E.%3CPackageType%3E.) for development package names:
```
 <SubsystemName>_<VersionNumber>-<Revision>_{<OSName>-<OSVersion>_}<Architecture>_<GitReference>.<PackageType>.
```


<!--
Add a clear description of how the problem has been solved.
-->

## Generate package
To generate a DEB/RPM package for wazuh-agent:

```
git clone --branch 22080-migrate-and-adapt-macos-wazuh-agent-subsystem-1
https://github.com/wazuh/wazuh.git
cd wazuh/packages/macos

./generate_wazuh_package.sh -s /tmp  -a [arch] -r [revision]  
```

<!--
Paste here related logs and alerts
-->

## Tests
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
