### PR TITLE
Increased engine queue capacity

### DIFF
--- a/src/engine/source/cmds/src/start.cpp
+++ b/src/engine/source/cmds/src/start.cpp
@@ -50,6 +50,11 @@
 
 namespace
 {
+struct QueueTraits : public moodycamel::ConcurrentQueueDefaultTraits
+{
+    static constexpr size_t BLOCK_SIZE = 2048;
+    static constexpr size_t IMPLICIT_INITIAL_INDEX_SIZE = 8192;
+};
 std::shared_ptr<engineserver::EngineServer> g_engineServer {};
 
 void sigintHandler(const int signum)
@@ -295,7 +300,7 @@ void runStart(ConfHandler confManager)
         // Router
         {
             // External queues
-            using QEventType = base::queue::ConcurrentQueue<base::Event>;
+            using QEventType = base::queue::ConcurrentQueue<base::Event, QueueTraits>;
             using QTestType = base::queue::ConcurrentQueue<router::test::QueueType>;
 
             std::shared_ptr<QEventType> eventQueue {};

--- a/src/engine/source/queue/include/queue/concurrentQueue.hpp
+++ b/src/engine/source/queue/include/queue/concurrentQueue.hpp
@@ -113,12 +113,12 @@ public:
  * and the pathFloodedFile is provided.
  * @tparam T The type of the data to be stored in the queue.
  */
-template<typename T,
-         typename D = moodycamel::ConcurrentQueueDefaultTraits,
-         typename = std::enable_if_t<std::is_base_of<moodycamel::ConcurrentQueueDefaultTraits, D>::value>>
+template<typename T, typename D = moodycamel::ConcurrentQueueDefaultTraits>
 class ConcurrentQueue : public iQueue<T>
 {
 private:
+    static_assert(std::is_base_of_v<moodycamel::ConcurrentQueueDefaultTraits, D>,
+                  "The template parameter D must be a subclass of ConcurrentQueueDefaultTraits");
     struct Metrics
     {
         std::shared_ptr<metricsManager::IMetricsScope> m_metricsScope;  ///< Metrics scope for the queue
@@ -131,7 +131,7 @@ private:
         std::shared_ptr<metricsManager::iCounter<uint64_t>> m_consumendPerSecond; ///< Counter for the used queue
     };
 
-    moodycamel::BlockingConcurrentQueue<T> m_queue {}; ///< The queue itself.
+    moodycamel::BlockingConcurrentQueue<T, D> m_queue {}; ///< The queue itself.
 
     std::shared_ptr<FloodingFile> m_floodingFile; ///< The flooding file.
     std::size_t m_maxAttempts;                    ///< The maximum number of attempts to push an element to the queue.
@@ -230,7 +230,7 @@ public:
             throw std::runtime_error("The capacity of the queue must be greater than 0");
         }
 
-        m_queue = moodycamel::BlockingConcurrentQueue<T>(capacity);
+        m_queue = moodycamel::BlockingConcurrentQueue<T, D>(capacity);
 
         // Verify if the pathFloodedFile is provided
         if (!pathFloodedFile.empty())


### PR DESCRIPTION
|Related issue|
|---|
|#22708|

Defined block size and implicit initial index size traits to increase maximum queue capacity to 16 777 216.