### PR TITLE
Add new preloaded var to disable `update_check`

### DIFF
--- a/etc/preloaded-vars.conf
+++ b/etc/preloaded-vars.conf
@@ -135,10 +135,11 @@ USER_ENABLE_SECURITY_CONFIGURATION_ASSESSMENT="y"
 # USER_EMAIL_SMTP defines the SMTP server to send the e-mails.
 #USER_EMAIL_SMTP="test.ossec.net"
 
-
 # USER_ENABLE_SYSLOG enables or disables remote syslog.
 #USER_ENABLE_SYSLOG="y"
 
+# USER_ENABLE_UPDATE_CHECK enables or disables the update checker.
+#USER_ENABLE_UPDATE_CHECK="y"
 
 # USER_WHITE_LIST is a list of IPs or networks
 # that are going to be set to never be blocked.
@@ -152,10 +153,6 @@ USER_ENABLE_SECURITY_CONFIGURATION_ASSESSMENT="y"
 # building the CPython interpeter. This can take a while.
 # More info at: https://github.com/python/cpython#profile-guided-optimization
 #OPTIMIZE_CPYTHON="y"
-
-# INSTALL_API_DAEMON install wazuh-api service
-# This option must be set to 'no' when generating packages. By default the wazuh-api service is installed.
-#INSTALL_API_DAEMON="y"
 
 # DOWNLOAD_CONTENT download the latest vulnerability detection content from the Wazuh repository
 # This option must be set to 'yes' when generating packages.

--- a/install.sh
+++ b/install.sh
@@ -241,6 +241,16 @@ UseSSLCert()
     fi
 }
 
+UseUpdateCheck()
+{
+    # Update_check config predefined (is overwritten by the preload-vars file)
+    if [ "X${USER_ENABLE_UPDATE_CHECK}" = "Xn" ]; then
+        UPDATE_CHECK="no"
+     else
+        UPDATE_CHECK="yes"
+     fi
+}
+
 ##########
 # EnableAuthd()
 ##########
@@ -543,6 +553,7 @@ ConfigureServer()
         EnableAuthd "3.7"
         ConfigureBoot "3.8"
         SetupLogs "3.9"
+        UseUpdateCheck
         WriteManager
     else
         ConfigureBoot "3.6"

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -449,13 +449,19 @@ WriteManager()
     echo "<ossec_config>" >> $NEWCONFIG
 
     if [ "$EMAILNOTIFY" = "yes"   ]; then
-        sed -e "s|<email_notification>no</email_notification>|<email_notification>yes</email_notification>|g; \
+        GLOBAL_CONTENT=$(sed -e "s|<email_notification>no</email_notification>|<email_notification>yes</email_notification>|g; \
         s|<smtp_server>smtp.example.wazuh.com</smtp_server>|<smtp_server>${SMTP}</smtp_server>|g; \
         s|<email_from>wazuh@example.wazuh.com</email_from>|<email_from>wazuh@${HOST}</email_from>|g; \
-        s|<email_to>recipient@example.wazuh.com</email_to>|<email_to>${EMAIL}</email_to>|g;" "${GLOBAL_TEMPLATE}" >> $NEWCONFIG
+        s|<email_to>recipient@example.wazuh.com</email_to>|<email_to>${EMAIL}</email_to>|g;" "${GLOBAL_TEMPLATE}")
     else
-        cat ${GLOBAL_TEMPLATE} >> $NEWCONFIG
+        GLOBAL_CONTENT=$(cat ${GLOBAL_TEMPLATE})
     fi
+
+    if [ "$UPDATE_CHECK" = "no" ]; then
+        GLOBAL_CONTENT=$(echo "$GLOBAL_CONTENT" | sed "s|<update_check>yes</update_check>|<update_check>no</update_check>|g")
+    fi
+
+    echo "$GLOBAL_CONTENT" >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 
     # Alerts level


### PR DESCRIPTION
|Related issue|
|---|
|#22706|

## Description

This PR adds a new preloaded-var: `USER_ENABLE_UPDATE_CHECK`. When set to `n`, the update check will be disabled before starting wazuh.

## Configuration options

> `wazuh/etc/preloaded-vars.conf`
```
# USER_ENABLE_UPDATE_CHECK enables or disables the update checker.
#USER_ENABLE_UPDATE_CHECK="y"
```

## Logs/Alerts example

### 1. Preloaded var not included
Using this `preloaded-vars.conf` file where the new USER_ENABLE_UPDATE_CHECK is not included:
```
# cat /wazuh/etc/preloaded-vars.conf 
USER_LANGUAGE="en"
USER_NO_STOP="y"
USER_INSTALL_TYPE="server"
USER_DIR="/var/ossec"
USER_ENABLE_EMAIL="n"
USER_ENABLE_SYSCHECK="y"
USER_ENABLE_ROOTCHECK="y"
USER_ENABLE_OPENSCAP="y"
USER_WHITE_LIST="n"
USER_ENABLE_SYSLOG="y"
USER_ENABLE_AUTHD="y"
USER_AUTO_START="n"
```

This is the [installation log](https://github.com/wazuh/wazuh/files/14849144/install_updatecheck_not_included.log). The `ossec.conf` took the expected default value for the `update_check` option, which is `yes`:
```XML
# head -n30 /var/ossec/etc/ossec.conf 
<!--
  Wazuh - Manager - Default configuration for ubuntu 22.04
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
    <update_check>yes</update_check>
  </global>

  <alerts>
    <log_alert_level>3</log_alert_level>
    <email_alert_level>12</email_alert_level>
  </alerts>

  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
  <logging>
```

### 2. New preloaded var disabled
Using this `preloaded-vars.conf` file where `USER_ENABLE_UPDATE_CHECK="n"`:
```
# cat /wazuh/etc/preloaded-vars.conf
USER_LANGUAGE="en"
USER_NO_STOP="y"
USER_INSTALL_TYPE="server"
USER_DIR="/var/ossec"
USER_ENABLE_EMAIL="n"
USER_ENABLE_SYSCHECK="y"
USER_ENABLE_ROOTCHECK="y"
USER_ENABLE_OPENSCAP="y"
USER_WHITE_LIST="n"
USER_ENABLE_SYSLOG="y"
USER_ENABLE_AUTHD="y"
USER_AUTO_START="n"
USER_ENABLE_UPDATE_CHECK="n"
```

This is the [installation log](https://github.com/wazuh/wazuh/files/14849192/install_updatecheck_disabled.log). The `update_check` option is disabled in the `ossec.conf`:
```XML
# head -n25 /var/ossec/etc/ossec.conf 
<!--
  Wazuh - Manager - Default configuration for ubuntu 22.04
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
    <update_check>no</update_check>
  </global>

  <alerts>
    <log_alert_level>3</log_alert_level>
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] ~Windows~ (only affects the server)
  - [x] ~MAC OS X~ (only affects the server)
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities (it works when the option is not included)

<!-- Depending on the affected OS -->
- ~Memory tests for Linux~ (only affects the installation shell script)
