### PR TITLE
Typo(sambad) in policy chcek command ID 28561 for cis_ubuntu22-04.yml

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -1501,7 +1501,7 @@ checks:
     condition: all
     rules:
       - "c:dpkg-query -s samba -> r:package 'samba' is not installed"
-      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:no packages found matching sambad|deinstall|not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:no packages found matching samba|deinstall|not-installed"
 
   # 2.2.12 Ensure HTTP Proxy Server is not installed. (Automated)
   - id: 28562


### PR DESCRIPTION
|Related issue|
|---|
|[#28561](https://github.com/wazuh/wazuh/issues/21622) [# 22614](https://github.com/wazuh/wazuh/issues/22614)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
This PR will solve the anomaly for SCA check in Ubuntu22.04 for Control ID `28561` for the typo in the section regarding [Samba](https://github.com/wazuh/wazuh/commit/4c840d4619aedd7890cf49ebe7befd6ab631d23f#diff-5f2bfc5c68ab43291f29308cbd47c26d64f82dda1802493e65c35ae0335d0695L1504).

Typo:
   
     - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:no packages found matching sambad|deinstall|not-installed"

Correct:
   
     - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' samba -> r:no packages found matching samba|deinstall|not-installed"


### Unit testing

- [x] a) Output from `agent.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>

```
2024/04/03 16:30:16 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2024/04/03 16:30:16 sca: INFO: Security Configuration Assessment scan finished. Duration: 7 seconds.
```
