### PR TITLE
Add indexer API configuration option

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -92,6 +92,9 @@ default_api_configuration = {
             "allow_higher_versions": {
                 "allow": True
             }
+        },
+        "indexer": {
+            "allow": True
         }
     }
 }

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -72,3 +72,5 @@
 #   agents:
 #     allow_higher_versions:
 #       allow: yes
+#   indexer:
+#     allow: yes

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -60,6 +60,9 @@ custom_api_configuration = {
             "allow_higher_versions": {
                 "allow": True
             }
+        },
+        "indexer": {
+            "allow": True
         }
     }
 }
@@ -141,7 +144,8 @@ def test_read_configuration(mock_open, mock_exists, read_config):
     {'remote_commands': {'wodle_command': {'enabled': 'invalid_type'}}},
     {'remote_commands': {'wodle_command': {'exceptions': [0, 1, 2]}}},
     {'remote_commands': {'wodle_command': {'invalid_subkey': 'invalid_type'}}},
-    {'agents': {'allowed_higher_versions': {'allow': []}}},
+    {'agents': {'allow_higher_versions': {'allow': True}}},
+    {'indexer': {'allow': True}},
 ])
 @patch('os.path.exists', return_value=True)
 def test_read_wrong_configuration(mock_exists, config):

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -205,10 +205,19 @@ api_config_schema = {
                             },
                         }
                     }
+                },
+                "indexer": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "allow": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
-        },
-    },
+        }
+    }
 }
 
 WAZUH_COMPONENT_CONFIGURATION_MAPPING = MappingProxyType(

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -995,6 +995,8 @@ stages:
                   agents:
                     allow_higher_versions:
                       allow: !anybool
+                  indexer:
+                    allow: !anybool
             - node_name: "worker1"
               node_api_config:
                 <<: *default_api_config

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -944,6 +944,8 @@ stages:
                   agents:
                     allow_higher_versions:
                       allow: !anybool
+                  indexer:
+                    allow: !anybool
           total_affected_items: 1
           total_failed_items: 0
           failed_items: []

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1880,8 +1880,9 @@ def test_add_dynamic_detail(detail, value, attribs, details):
 @patch('wazuh.core.utils.check_wazuh_limits_unchanged')
 @patch('wazuh.core.utils.check_remote_commands')
 @patch('wazuh.core.utils.check_agents_allow_higher_versions')
+@patch('wazuh.core.utils.check_indexer')
 @patch('wazuh.core.manager.common.WAZUH_PATH', new=test_files_path)
-def test_validate_wazuh_xml(mock_remote_commands, mock_agents_versions, mock_unchanged_limits):
+def test_validate_wazuh_xml(mock_check_indexer, mock_agents_versions, mock_remote_commands, mock_unchanged_limits):
     """Test validate_wazuh_xml method works and methods inside are called with expected parameters"""
 
     with open(os.path.join(test_files_path, 'test_rules.xml')) as f:
@@ -1893,11 +1894,13 @@ def test_validate_wazuh_xml(mock_remote_commands, mock_agents_versions, mock_unc
         utils.validate_wazuh_xml(xml_file)
     mock_remote_commands.assert_not_called()
     mock_agents_versions.assert_not_called()
+    mock_check_indexer.assert_not_called()
 
     with patch('builtins.open', m):
         utils.validate_wazuh_xml(xml_file, config_file=True)
     mock_remote_commands.assert_called_once()
     mock_agents_versions.assert_called_once()
+    mock_check_indexer.assert_called_once()
 
 
 @pytest.mark.parametrize('effect, expected_exception', [
@@ -2116,6 +2119,69 @@ def test_agents_allow_higher_versions(new_conf, agents_conf):
         else:
             with pytest.raises(exception.WazuhError, match=".* 1129 .*"):
                 utils.check_agents_allow_higher_versions(new_conf)
+
+
+@pytest.mark.parametrize("new_conf, original_conf, indexer_changed", [
+    (
+        "<ossec_config><indexer><enabled>yes</enabled></indexer></ossec_config>",
+        "<ossec_config><indexer><enabled>no</enabled></indexer></ossec_config>",
+        True,
+     ),
+    (
+        "<ossec_config><indexer><enabled>no</enabled></indexer></ossec_config>",
+        "<ossec_config><indexer><enabled>no</enabled></indexer></ossec_config>",
+        False,
+    ),
+    (
+        "<ossec_config><indexer><hosts><host>https://0.0.0.0:9200/</host></hosts></indexer></ossec_config>",
+        "<ossec_config><indexer><hosts><host>https://127.0.0.1:9200/</host></hosts></indexer></ossec_config>",
+        True,
+    ),
+    (
+        "<ossec_config><indexer><enabled>yes</enabled><ssl><key>/etc/filebeat/certs/filebeat-key.pem</key></ssl>" \
+        "</indexer></ossec_config>",
+        "<ossec_config><indexer><enabled>yes</enabled></indexer></ossec_config>",
+        True,
+    ),
+    (
+        "<ossec_config><indexer><enabled>yes</enabled><ssl><key>/etc/filebeat/certs/filebeat-key.pem</key></ssl>" \
+        "</indexer></ossec_config>",
+        "<ossec_config><indexer><enabled>yes</enabled><ssl><key>filebeat-key.pem</key></ssl></indexer></ossec_config>",
+        True,
+    ),
+    (
+        "<ossec_config><auth><disabled>no</disabled></auth></ossec_config>",
+        "<ossec_config><auth><disabled>yes</disabled></auth></ossec_config>",
+        False,
+    ),
+])
+@pytest.mark.parametrize("indexer_allowed", [
+    True,
+    False,
+])
+def test_check_indexer(new_conf, original_conf, indexer_changed, indexer_allowed):
+    """Check if the ossec.conf indexer section is protected by the API.
+
+    Parameters
+    ----------
+    new_conf : str
+        New ossec.conf to be uploaded.
+    original_conf : str
+        Original ossec.conf.
+    indexer_changed : bool
+        Whether the indexer section of the original and new configurations is equal or not.
+    indexer_allowed : bool
+        Whether it is allowed to modify the indexer API configuration section.
+    """
+    api_conf = utils.configuration.api_conf
+    api_conf['upload_configuration']['indexer']['allow'] = indexer_allowed
+
+    with patch('wazuh.core.utils.configuration.api_conf', new=api_conf):
+        if indexer_allowed:
+            utils.check_indexer(new_conf, original_conf)
+        elif indexer_changed:
+            with pytest.raises(exception.WazuhError, match=".* 1127 .*"):
+                utils.check_indexer(new_conf, original_conf)
 
 
 @pytest.mark.parametrize(

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -968,6 +968,74 @@ def check_agents_allow_higher_versions(data: str):
         check_section(auth_section, split_section='</auth>')
 
 
+def check_indexer(new_conf: str, original_conf: str):
+    """Check if modifying the indexer configuration is allowed.
+
+    Parameters
+    ----------
+    new_conf : str
+        New configuration file.
+    original_conf : str
+        Original configuration file.
+    
+    Raises
+    -------
+    WazuhError(1127)
+        Raised if the indexer section is modified in the configuration to upload.
+    """
+
+    def update_dict(section_dict: dict, section):
+        """Updates a dictionary with the values of a section recursively.
+
+        Parameters
+        ----------
+        section_dict : dict
+            Section dictionary.
+        section : Element
+            XML section to get the values from.
+        """
+        for value in section:
+            if value.text is None:
+                # The value contains more tags, iterate over them
+                update_dict(section_dict, value)
+                return
+
+            section_dict.update({value.tag: {'attrib': value.attrib, 'value': value.text.strip()}})
+
+    def xml_to_dict(conf: str) -> list:
+        """Convert XML to a list of dictionaries.
+
+        Parameters
+        ----------
+        conf : str
+            XML configuration file.
+
+        Returns
+        -------
+        matched_configurations : list
+            Dictionaries with the configuration.
+        """
+        matched_configurations = []
+
+        for str_conf in re.findall(r'<indexer>.*?</indexer>', conf, re.MULTILINE | re.DOTALL | re.IGNORECASE):
+            indexer_section = fromstring(str_conf)
+
+            for section in indexer_section.iter():
+                section_dict = {section.tag: {}}
+                update_dict(section_dict[section.tag], section)
+                matched_configurations.append(section_dict)
+
+        return matched_configurations
+
+    upload_configuration = configuration.api_conf['upload_configuration']
+
+    if not upload_configuration['indexer']['allow']:
+        new_indexer = xml_to_dict(new_conf)
+        original_indexer = xml_to_dict(original_conf)
+        if len(new_indexer) != len(original_indexer) or any(x != y for x, y in zip(new_indexer, original_indexer)):
+            raise WazuhError(1127, extra_message='indexer')
+
+
 def load_wazuh_xml(xml_path, data=None):
     if not data:
         with open(xml_path) as f:
@@ -2005,10 +2073,11 @@ def validate_wazuh_xml(content: str, config_file: bool = False):
         # Check if remote commands are allowed if it is a configuration file
         if config_file:
             check_remote_commands(final_xml)
+            check_agents_allow_higher_versions(final_xml)
             with open(common.OSSEC_CONF, 'r') as f:
                 current_xml = f.read()
+            check_indexer(final_xml, current_xml)
             check_wazuh_limits_unchanged(final_xml, current_xml)
-            check_agents_allow_higher_versions(final_xml)
         # Check xml format
         load_wazuh_xml(xml_path='', data=final_xml)
     except ExpatError:

--- a/tests/integration/test_api/test_config/test_indexer/__init__.py
+++ b/tests/integration/test_api/test_config/test_indexer/__init__.py
@@ -1,0 +1,11 @@
+"""
+Copyright (C) 2015, Wazuh Inc.
+Created by Wazuh, Inc. <info@wazuh.com>.
+This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+"""
+from pathlib import Path
+
+# Constants & base paths
+TEST_DATA_PATH = Path(Path(__file__).parent, 'data')
+TEST_CASES_FOLDER_PATH = Path(TEST_DATA_PATH, 'test_cases')
+CONFIGURATIONS_FOLDER_PATH = Path(TEST_DATA_PATH, 'configuration_templates')

--- a/tests/integration/test_api/test_config/test_indexer/data/configuration_templates/configuration_indexer.yaml
+++ b/tests/integration/test_api/test_config/test_indexer/data/configuration_templates/configuration_indexer.yaml
@@ -1,0 +1,15 @@
+- blocks:
+    upload_configuration:
+      indexer:
+        allow: ALLOWED
+  sections:
+    - section: indexer
+      elements:
+        - enabled:
+            value: yes
+    - section: remote
+      elements:
+        - connection:
+            value: secure
+        - port:
+            value: 1514

--- a/tests/integration/test_api/test_config/test_indexer/data/test_cases/cases_indexer.yaml
+++ b/tests/integration/test_api/test_config/test_indexer/data/test_cases/cases_indexer.yaml
@@ -1,0 +1,125 @@
+- name: UPLOAD_ONE_BLOCK_CONFIG_NOT_ALLOWED
+  description: Upload one block configuration with a forbidden section
+  configuration_parameters:
+    ALLOWED: no
+  metadata:
+    expected_code: 200
+    expected_error_code: 1
+    expected_indexer_enabled: yes
+    request_body: >
+      <ossec_config>
+        <remote>
+          <connection>secure</connection>
+          <port>1514</port>
+        </remote>
+        <indexer>
+          <enabled>yes</enabled>
+        </indexer>
+      </ossec_config>
+
+- name: UPLOAD_ONE_BLOCK_CONFIG_ALLOWED
+  description: Upload one block configuration without a forbidden section
+  configuration_parameters:
+    ALLOWED: yes
+  metadata:
+    expected_code: 200
+    expected_error_code: 0
+    expected_indexer_enabled: yes
+    request_body: >
+      <ossec_config>
+        <remote>
+          <connection>secure</connection>
+          <port>1514</port>
+        </remote>
+        <indexer>
+          <enabled>yes</enabled>
+        </indexer>
+      </ossec_config>
+
+- name: UPLOAD_TWO_BLOCKS_CONFIG_FIRST_BLOCK_NOT_ALLOWED
+  description: Upload two blocks configuration with a forbidden section in the first block
+  configuration_parameters:
+    ALLOWED: no
+  metadata:
+    expected_code: 200
+    expected_error_code: 1
+    expected_indexer_enabled: yes
+    request_body: >
+      <ossec_config>
+        <indexer>
+          <enabled>no</enabled>
+        </indexer>
+      </ossec_config>
+
+      <ossec_config>
+        <remote>
+          <connection>secure</connection>
+          <port>1514</port>
+        </remote>
+      </ossec_config>
+
+- name: UPLOAD_TWO_BLOCKS_CONFIG_FIRST_BLOCK_ALLOWED
+  description: Upload two blocks configuration without a forbidden section in the first block
+  configuration_parameters:
+    ALLOWED: yes
+  metadata:
+    expected_code: 200
+    expected_error_code: 0
+    expected_indexer_enabled: no
+    request_body: >
+      <ossec_config>
+        <indexer>
+          <enabled>no</enabled>
+        </indexer>
+      </ossec_config>
+
+      <ossec_config>
+        <remote>
+          <connection>secure</connection>
+          <port>1514</port>
+        </remote>
+      </ossec_config>
+
+- name: UPLOAD_TWO_BLOCKS_CONFIG_SECOND_NOT_ALLOWED
+  description: Upload two blocks configuration with a forbidden section in the second block
+  configuration_parameters:
+    ALLOWED: no
+  metadata:
+    expected_code: 200
+    expected_error_code: 1
+    expected_indexer_enabled: yes
+    request_body: >
+      <ossec_config>
+        <remote>
+          <connection>secure</connection>
+          <port>1514</port>
+        </remote>
+      </ossec_config>
+
+      <ossec_config>
+        <indexer>
+          <enabled>yes</enabled>
+        </indexer>
+      </ossec_config>
+
+- name: UPLOAD_TWO_BLOCKS_CONFIG_SECOND_BLOCK_ALLOWED
+  description: Upload two blocks configuration without a forbidden section in the second block
+  configuration_parameters:
+    ALLOWED: yes
+  metadata:
+    expected_code: 200
+    expected_error_code: 0
+    expected_indexer_enabled: yes
+    request_body: >
+      <ossec_config>
+        <remote>
+          <connection>secure</connection>
+          <port>1514</port>
+        </remote>
+      </ossec_config>
+
+      <ossec_config>
+        <indexer>
+          <enabled>yes</enabled>
+        </indexer>
+      </ossec_config>

--- a/tests/integration/test_api/test_config/test_indexer/test_indexer.py
+++ b/tests/integration/test_api/test_config/test_indexer/test_indexer.py
@@ -1,0 +1,167 @@
+"""
+copyright: Copyright (C) 2015, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: This test checks that the API works as expected when uploading configurations with forbidden sections
+
+components:
+    - api
+
+suite: config
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-apid
+    - wazuh-modulesd
+    - wazuh-analysisd
+    - wazuh-execd
+    - wazuh-db
+    - wazuh-remoted
+
+os_platform:
+    - linux
+
+os_version:
+    - Arch Linux
+    - Amazon Linux 2
+    - Amazon Linux 1
+    - CentOS 8
+    - CentOS 7
+    - Debian Buster
+    - Red Hat 8
+    - Ubuntu Focal
+    - Ubuntu Bionic
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/api/getting-started.html
+    - https://documentation.wazuh.com/current/user-manual/api/configuration.html
+
+tags:
+    - api
+"""
+import pytest
+from pathlib import Path
+import requests
+
+from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
+from wazuh_testing.constants.api import CONFIGURATION_TYPES, MANAGER_CONFIGURATION_ROUTE
+from wazuh_testing.constants.daemons import API_DAEMONS_REQUIREMENTS
+from wazuh_testing.modules.api.utils import login, get_base_url
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template, get_wazuh_conf
+
+# Marks
+pytestmark = pytest.mark.server
+
+# Variables
+# Used by add_configuration to select the target configuration file
+configuration_type = CONFIGURATION_TYPES[0]
+
+# Paths
+test_configuration_path = Path(CONFIGURATIONS_FOLDER_PATH, 'configuration_indexer.yaml')
+test_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_indexer.yaml')
+
+# Configurations
+test_configuration, test_metadata, test_cases_id = get_test_cases_data(test_cases_path)
+test_configuration = load_configuration_template(test_configuration_path, test_configuration, test_metadata)
+daemons_handler_configuration = {'daemons': API_DAEMONS_REQUIREMENTS}
+
+
+@pytest.mark.tier(level=0)
+@pytest.mark.parametrize('test_configuration,test_metadata', zip(test_configuration, test_metadata), ids=test_cases_id)
+def test_indexer(test_configuration, test_metadata, set_wazuh_configuration, add_configuration,
+                   truncate_monitored_files, daemons_handler, wait_for_api_start):
+    """
+    description: Check if the API works as expected when uploading configurations with forbidden sections.
+
+    wazuh_min_version: 4.8.0
+
+    test_phases:
+        - setup:
+            - Apply ossec.conf configuration changes according to the configuration template and use case.
+            - Append configuration to the target configuration files (defined by configuration_type)
+            - Truncate the log files
+            - Restart daemons defined in `daemons_handler_configuration` in this module
+            - Wait until the API is ready to receive requests
+        - test:
+            - Get expected code and request body
+            - Get expected configuration
+        - teardown:
+            - Remove configuration and restore backup configuration
+            - Truncate the log files
+            - Stop daemons defined in `daemons_handler_configuration` in this module
+
+    tier: 0
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration data from the test case.
+        - test_metadata:
+            type: dict
+            brief: Metadata from the test case.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Apply changes to the ossec.conf configuration.
+        - add_configuration:
+            type: fixture
+            brief: Add configuration to the Wazuh API configuration files.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - daemons_handler:
+            type: fixture
+            brief: Wrapper of a helper function to handle Wazuh daemons.
+        - wait_for_api_start:
+            type: fixture
+            brief: Monitor the API log file to detect whether it has been started or not.
+
+    input_description: The test gets the configuration from the YAML file, which contains the API configuration.
+
+    assertions:
+        - Verify that the API requests are made correctly and the ossec.conf file is updated as expected.
+
+    expected_output:
+        - r'200' ('OK' HTTP status code)
+    """
+    # Get metadata for the tests
+    expected_code = test_metadata['expected_code']
+    expected_error_code = test_metadata['expected_error_code']
+    request_body = test_metadata['request_body']
+
+    # Get url and token for the request
+    url = get_base_url()
+    authentication_headers, _ = login()
+    authentication_headers['Content-Type'] = 'application/octet-stream'
+
+    # Makes an API request for uploading the new configuration
+    response = requests.put(url + MANAGER_CONFIGURATION_ROUTE, headers=authentication_headers, verify=False, timeout=10,
+                            data=request_body)
+
+    # Parses the response
+    json_response = response.json()
+    error_code = json_response['error']
+
+    # Assert the status code
+    assert response.status_code == expected_code, f"Expected status code {expected_code}, but " \
+                                                  f"{response.status_code} was returned: {json_response}"
+    # Assert the error code is the expected one
+    assert error_code == expected_error_code, f"Expected error code {expected_error_code}, but " \
+                                              f"{error_code} was returned: {json_response}"
+    if error_code == 1:
+        internal_error_code = json_response['data']["failed_items"][0]['error']['code']
+        assert internal_error_code == 1127, f"Expected error code {1127}, but " \
+                                            f"{internal_error_code} was returned: {json_response}"
+    
+    # Asserts that the configuration has the expected values
+    wazuh_config = "".join(get_wazuh_conf())
+    enabled = 'yes'
+    if not test_metadata['expected_indexer_enabled']:
+        enabled = 'no'
+    assert f"<enabled>{enabled}</enabled>" in wazuh_config


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/22656 |

## Description

Adds the `indexer -> allow` API configuration value and the logic in charge of verifying that the indexer configuration is not updated through the API when the configuration does not permit it.

## Tests

### Not allowed, indexer section modified

<details><summary>API configuration</summary>

```yaml
upload_configuration:
  indexer:
    allow: no
```

</details>


<details><summary>PUT /manager/configuration</summary>

Body:

```xml
<ossec_config>
  ...
  <indexer>
    <enabled>yes</enabled>
  </indexer>
</ossec_config>
```

Response:

```json
{
    "data": {
        "affected_items": [],
        "total_affected_items": 0,
        "total_failed_items": 1,
        "failed_items": [
            {
                "error": {
                    "code": 1127,
                    "message": "Protected section was modified: indexer",
                    "remediation": "To solve this, either revert the changes made to this section or disable the protection in the API settings: https://documentation.wazuh.com/4.8/user-manual/api/configuration.html"
                },
                "id": [
                    "master-node"
                ]
            }
        ]
    },
    "message": "Could not update configuration in specified node",
    "error": 1
}
```

</details>

### Not allowed, indexer section not modified

<details><summary>API configuration</summary>

```yaml
upload_configuration:
  indexer:
    allow: no
```

</details>


<details><summary>PUT /manager/configuration</summary>

Body:

```xml
<ossec_config>
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>yes</logall>
    ...
</ossec_config>
```

Response:

```json
{
    "data": {
        "affected_items": [
            "master-node"
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Configuration was successfully updated in specified node",
    "error": 0
}
```

</details>

### Allowed

<details><summary>API configuration</summary>

```yaml
upload_configuration:
  indexer:
     allow: yes
```

</details>


<details><summary>PUT /manager/configuration</summary>

Body:

```xml
<ossec_config>
  ...
  <indexer>
    <enabled>no</enabled>
  </indexer>
</ossec_config>
```

Response:

```json
{
    "data": {
        "affected_items": [
            "master-node"
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Configuration was successfully updated in specified node",
    "error": 0
}
```

</details>

<details><summary>OSSEC configuration</summary>

```console
root@wazuh-master:/# cat /var/ossec/etc/ossec.conf
<ossec_config>
 ...
  <indexer>
    <enabled>no</enabled>
  </indexer>
</ossec_config>
```

</details>