### PR TITLE
Content Manager - Improve downloaded hash file update mechanism

### DIFF
--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -70,7 +70,7 @@ public:
      *
      * @return True if the execution was made, false otherwise.
      */
-    bool runActionExclusively(const ActionOrchestrator::UpdateData& updateData = ActionOrchestrator::UpdateData())
+    bool runActionExclusively(const ActionOrchestrator::UpdateData& updateData)
     {
         auto expectedValue {false};
         if (m_actionInProgress.compare_exchange_strong(expectedValue, true))
@@ -116,7 +116,7 @@ public:
     void runActionScheduled()
     {
         logDebug2(WM_CONTENTUPDATER, "Starting scheduled action for '%s'", m_topicName.c_str());
-        if (!runActionExclusively())
+        if (!runActionExclusively(ActionOrchestrator::UpdateData::createContentUpdateData(-1)))
         {
             logDebug2(WM_CONTENTUPDATER, "Action in progress for '%s', scheduled request ignored", m_topicName.c_str());
         }
@@ -172,7 +172,7 @@ public:
      *
      * @param updateData Update orchestration data.
      */
-    void runActionOnDemand(const ActionOrchestrator::UpdateData& updateData = ActionOrchestrator::UpdateData())
+    void runActionOnDemand(const ActionOrchestrator::UpdateData& updateData)
     {
         logDebug2(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
         if (!runActionExclusively(updateData))

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -80,12 +80,13 @@ public:
      */
     bool runActionExclusively(const ActionID id,
                               const int offset = -1,
+                              const std::string& fileHash = "",
                               const ActionOrchestrator::UpdateType type = ActionOrchestrator::UpdateType::CONTENT)
     {
         auto expectedValue {false};
         if (m_actionInProgress.compare_exchange_strong(expectedValue, true))
         {
-            runAction(id, offset, type);
+            runAction(id, offset, fileHash, type);
         }
         return !expectedValue;
     }
@@ -155,8 +156,8 @@ public:
     void registerActionOnDemand()
     {
         OnDemandManager::instance().addEndpoint(m_topicName,
-                                                [this](int offset, const ActionOrchestrator::UpdateType type)
-                                                { this->runActionOnDemand(offset, type); });
+                                                [this](int offset, const std::string& fileHash, const ActionOrchestrator::UpdateType type)
+                                                { this->runActionOnDemand(offset, fileHash, type); });
     }
 
     /**
@@ -184,10 +185,11 @@ public:
      * @param type Type of update to perform.
      */
     void runActionOnDemand(const int offset = -1,
+                        const std::string& fileHash = "",
                            const ActionOrchestrator::UpdateType type = ActionOrchestrator::UpdateType::CONTENT)
     {
         logDebug2(WM_CONTENTUPDATER, "Starting on-demand action for '%s'", m_topicName.c_str());
-        if (!runActionExclusively(ActionID::ON_DEMAND, offset, type))
+        if (!runActionExclusively(ActionID::ON_DEMAND, offset, fileHash, type))
         {
             logDebug2(WM_CONTENTUPDATER, "Action in progress for '%s', on-demand request ignored", m_topicName.c_str());
         }
@@ -219,13 +221,14 @@ private:
 
     void runAction(const ActionID id,
                    const int offset = -1,
+                   const std::string& fileHash = "",
                    const ActionOrchestrator::UpdateType type = ActionOrchestrator::UpdateType::CONTENT)
     {
         logDebug2(WM_CONTENTUPDATER, "Action for '%s' started", m_topicName.c_str());
 
         try
         {
-            m_orchestration->run(offset, type);
+            m_orchestration->run(offset, fileHash, type);
         }
         catch (const std::exception& e)
         {

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -73,8 +73,7 @@ public:
      * @brief Action execution with exclusivity: The action is only executed if there isn't another action in progress.
      *
      * @param id Action ID.
-     * @param offset Manually set current offset to process.
-     * @param type Type of update to perform.
+     * @param updateData Update orchestration data.
      *
      * @return True if the execution was made, false otherwise.
      */
@@ -179,8 +178,7 @@ public:
     /**
      * @brief Runs ondemand action. Wrapper of runActionExclusively().
      *
-     * @param offset Manually set current offset to process. Default -1
-     * @param type Type of update to perform.
+     * @param updateData Update orchestration data.
      */
     void runActionOnDemand(const ActionOrchestrator::UpdateData& updateData = ActionOrchestrator::UpdateData())
     {
@@ -215,8 +213,7 @@ private:
     std::shared_ptr<ConditionSync> m_stopActionCondition;
     std::unique_ptr<ActionOrchestrator> m_orchestration;
 
-    void runAction(const ActionID id,
-                   const ActionOrchestrator::UpdateData& updateData)
+    void runAction(const ActionID id, const ActionOrchestrator::UpdateData& updateData)
     {
         logDebug2(WM_CONTENTUPDATER, "Action for '%s' started", m_topicName.c_str());
 

--- a/src/shared_modules/content_manager/src/action.hpp
+++ b/src/shared_modules/content_manager/src/action.hpp
@@ -14,8 +14,8 @@
 
 #include "actionOrchestrator.hpp"
 #include "conditionSync.hpp"
+#include "iRouterProvider.hpp"
 #include "onDemandManager.hpp"
-#include "routerProvider.hpp"
 #include "updaterContext.hpp"
 #include <atomic>
 #include <chrono>
@@ -44,7 +44,7 @@ public:
      * @param topicName Topic name.
      * @param parameters ActionOrchestrator parameters.
      */
-    explicit Action(const std::shared_ptr<RouterProvider> channel, std::string topicName, nlohmann::json parameters)
+    explicit Action(const std::shared_ptr<IRouterProvider> channel, std::string topicName, nlohmann::json parameters)
         : m_channel {channel}
         , m_actionInProgress {false}
         , m_cv {}
@@ -201,7 +201,7 @@ public:
     }
 
 private:
-    std::shared_ptr<RouterProvider> m_channel;
+    std::shared_ptr<IRouterProvider> m_channel;
     std::thread m_schedulerThread;
     std::atomic<bool> m_schedulerRunning = false;
     std::atomic<bool> m_actionInProgress;

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -171,6 +171,12 @@ private:
         FactoryOffsetUpdater::create(m_spBaseContext->configData)->handleRequest(std::move(spUpdaterContext));
     }
 
+    /**
+     * @brief Performs a file hash update in the database with the specified hash.
+     *
+     * @param spUpdaterContext Updater context.
+     * @param fileHash Hash value to be used in the update.
+     */
     void runFileHashUpdate(std::shared_ptr<UpdaterContext> spUpdaterContext, const std::string& fileHash) const
     {
         logDebug2(WM_CONTENTUPDATER, "Running '%s' file hash update", m_spBaseContext->topicName.c_str());

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -118,7 +118,11 @@ public:
 
                 case UpdateType::CONTENT: runContentUpdate(std::move(spUpdaterContext), updateData.offset == 0); break;
 
-                default: break;
+                // LCOV_EXCL_START
+                default:
+                    logDebug1(WM_CONTENTUPDATER, "Invalid update type, the orchestration will be skipped");
+                    break;
+                    // LCOV_EXCL_STOP
             }
         }
         catch (const std::exception& e)

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -40,6 +40,15 @@ public:
         FILE_HASH
     };
 
+    struct UpdateData
+    {
+        UpdateType type;
+        int offset;
+        std::string fileHash;
+
+        UpdateData() : type(UpdateType::CONTENT), offset(-1), fileHash("") {};
+    };
+
     /**
      * @brief Creates a new instance of ActionOrchestrator.
      *
@@ -84,7 +93,7 @@ public:
      * offset will be reset to zero. If \p type is OFFSET, this value will be used to perform the offset update.
      * @param type Type of update the orchestrator should perform.
      */
-    void run(const int offset = -1, const std::string& fileHash = "", const UpdateType type = UpdateType::CONTENT) const
+    void run(const UpdateData& updateData = UpdateData()) const
     {
         // Create a updater context
         auto spUpdaterContext {std::make_shared<UpdaterContext>()};
@@ -92,18 +101,18 @@ public:
 
         try
         {
-            switch (type)
+            switch (updateData.type)
             {
             case UpdateType::OFFSET:
-                runOffsetUpdate(std::move(spUpdaterContext), offset);
+                runOffsetUpdate(std::move(spUpdaterContext), updateData.offset);
                 break;
             
             case UpdateType::FILE_HASH:
-                runFileHashUpdate(std::move(spUpdaterContext), fileHash);
+                runFileHashUpdate(std::move(spUpdaterContext), updateData.fileHash);
                 break;
             
             case UpdateType::CONTENT:
-                runContentUpdate(std::move(spUpdaterContext), offset == 0);
+                runContentUpdate(std::move(spUpdaterContext), updateData.offset == 0);
                 break;
             
             default:

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -43,11 +43,17 @@ public:
     /**
      * @brief Struct containing the necessary members to execute the orchestrations.
      *
+     * @details When 'type' is CONTENT, the orchestrator will perform a content update. If 'offset' is
+     * zero, the offset value will be reset. Otherwise, its value will be read from the RocksDB database.
+     * @details When 'type' is OFFSET, the orchestrator will write the 'offset' value in the RocksDB database. This
+     * value should be nonnegative.
+     * @details When 'type' is FILE_HASH, the orchestrator will write the 'fileHash' value in the RocksDB database. This
+     * value shouldn't be empty.
      */
     struct UpdateData
     {
-        UpdateType type = UpdateType::CONTENT; ///< Orchestration update type.
-        int offset = -1;                       ///< Offset value used in the update.
+        UpdateType type {UpdateType::CONTENT}; ///< Orchestration update type.
+        int offset {1};                        ///< Offset value used in the update.
         std::string fileHash;                  ///< Hash value used in the update.
 
         /**
@@ -98,9 +104,6 @@ public:
      * @brief Run the content updater orchestration.
      *
      * @param updateData Update orchestration data.
-     *
-     * @note If the \p updateData offset equals zero and the \p updateData type is CONTENT, the current offset will be
-     * reset to zero. If \p updateData type is OFFSET, this value will be used to perform the offset update.
      */
     void run(const UpdateData& updateData = UpdateData()) const
     {

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -40,13 +40,24 @@ public:
         FILE_HASH
     };
 
+    /**
+     * @brief Struct containing the necessary members to execute the orchestrations.
+     *
+     */
     struct UpdateData
     {
-        UpdateType type;
-        int offset;
-        std::string fileHash;
+        UpdateType type;      ///< Orchestration update type.
+        int offset;           ///< Offset value used in the update.
+        std::string fileHash; ///< Hash value used in the update.
 
-        UpdateData() : type(UpdateType::CONTENT), offset(-1), fileHash("") {};
+        /**
+         * @brief Struct constructor. Initialize the struct with default values.
+         *
+         */
+        UpdateData()
+            : type(UpdateType::CONTENT)
+            , offset(-1)
+            , fileHash(std::string()) {};
     };
 
     /**
@@ -89,9 +100,10 @@ public:
     /**
      * @brief Run the content updater orchestration.
      *
-     * @param offset Offset value from the on-demand request. If equals zero and \p type is CONTENT, the current
-     * offset will be reset to zero. If \p type is OFFSET, this value will be used to perform the offset update.
-     * @param type Type of update the orchestrator should perform.
+     * @param updateData Update orchestration data.
+     *
+     * @note If the \p updateData offset equals zero and the \p updateData type is CONTENT, the current offset will be
+     * reset to zero. If \p updateData type is OFFSET, this value will be used to perform the offset update.
      */
     void run(const UpdateData& updateData = UpdateData()) const
     {
@@ -103,20 +115,13 @@ public:
         {
             switch (updateData.type)
             {
-            case UpdateType::OFFSET:
-                runOffsetUpdate(std::move(spUpdaterContext), updateData.offset);
-                break;
-            
-            case UpdateType::FILE_HASH:
-                runFileHashUpdate(std::move(spUpdaterContext), updateData.fileHash);
-                break;
-            
-            case UpdateType::CONTENT:
-                runContentUpdate(std::move(spUpdaterContext), updateData.offset == 0);
-                break;
-            
-            default:
-                break;
+                case UpdateType::OFFSET: runOffsetUpdate(std::move(spUpdaterContext), updateData.offset); break;
+
+                case UpdateType::FILE_HASH: runFileHashUpdate(std::move(spUpdaterContext), updateData.fileHash); break;
+
+                case UpdateType::CONTENT: runContentUpdate(std::move(spUpdaterContext), updateData.offset == 0); break;
+
+                default: break;
             }
         }
         catch (const std::exception& e)
@@ -178,9 +183,7 @@ private:
         if (spUpdaterContext->spUpdaterBaseContext->spRocksDB)
         {
             spUpdaterContext->spUpdaterBaseContext->spRocksDB->put(
-                Utils::getCompactTimestamp(std::time(nullptr)),
-                fileHash,
-                Components::Columns::DOWNLOADED_FILE_HASH);
+                Utils::getCompactTimestamp(std::time(nullptr)), fileHash, Components::Columns::DOWNLOADED_FILE_HASH);
         }
 
         spUpdaterContext->spUpdaterBaseContext->downloadedFileHash = fileHash;

--- a/src/shared_modules/content_manager/src/actionOrchestrator.hpp
+++ b/src/shared_modules/content_manager/src/actionOrchestrator.hpp
@@ -46,18 +46,15 @@ public:
      */
     struct UpdateData
     {
-        UpdateType type;      ///< Orchestration update type.
-        int offset;           ///< Offset value used in the update.
-        std::string fileHash; ///< Hash value used in the update.
+        UpdateType type = UpdateType::CONTENT; ///< Orchestration update type.
+        int offset = -1;                       ///< Offset value used in the update.
+        std::string fileHash;                  ///< Hash value used in the update.
 
         /**
-         * @brief Struct constructor. Initialize the struct with default values.
+         * @brief Struct empty constructor.
          *
          */
-        UpdateData()
-            : type(UpdateType::CONTENT)
-            , offset(-1)
-            , fileHash(std::string()) {};
+        UpdateData() {};
     };
 
     /**

--- a/src/shared_modules/content_manager/src/components/fileDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/fileDownloader.hpp
@@ -82,11 +82,9 @@ private:
             return;
         }
 
-        // Store new hash.
-        context.spUpdaterBaseContext->downloadedFileHash = std::move(downloadFileHash);
-
         // Download finished: Update context paths.
         context.data.at("paths").push_back(outputFilePath);
+        context.data["fileHash"] = std::move(downloadFileHash);
     }
 
 public:

--- a/src/shared_modules/content_manager/src/components/fileDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/fileDownloader.hpp
@@ -84,7 +84,7 @@ private:
 
         // Download finished: Update context paths.
         context.data.at("paths").push_back(outputFilePath);
-        context.data["fileHash"] = std::move(downloadFileHash);
+        context.data["fileMetadata"]["hash"] = std::move(downloadFileHash);
     }
 
 public:

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -151,7 +151,7 @@ private:
         {
             // Download finished: Insert path into context.
             context.data.at("paths").push_back(outputFilePath.string());
-            context.data["fileHash"] = std::move(inputFileHash);
+            context.data["fileMetadata"]["hash"] = std::move(inputFileHash);
             return;
         }
 

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -149,11 +149,9 @@ private:
         auto inputFileHash {Utils::asciiToHex(Utils::hashFile(outputFilePath))};
         if (context.spUpdaterBaseContext->downloadedFileHash != inputFileHash)
         {
-            // Store new hash.
-            context.spUpdaterBaseContext->downloadedFileHash = std::move(inputFileHash);
-
             // Download finished: Insert path into context.
             context.data.at("paths").push_back(outputFilePath.string());
+            context.data["fileHash"] = std::move(inputFileHash);
             return;
         }
 

--- a/src/shared_modules/content_manager/src/onDemandManager.cpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.cpp
@@ -51,9 +51,7 @@ void OnDemandManager::startServer()
                                  const auto& it {m_endpoints.find(req.matches[1].str())};
                                  if (it != m_endpoints.end())
                                  {
-                                     auto updateData {ActionOrchestrator::UpdateData()};
-                                     updateData.offset = offset;
-                                     it->second(updateData);
+                                     it->second(ActionOrchestrator::UpdateData::createContentUpdateData(offset));
                                      res.status = 200;
                                  }
                                  else
@@ -88,10 +86,7 @@ void OnDemandManager::startServer()
 
                                  if (const auto& it {m_endpoints.find(topicName)}; it != m_endpoints.end())
                                  {
-                                     auto updateData {ActionOrchestrator::UpdateData()};
-                                     updateData.offset = offset;
-                                     updateData.type = ActionOrchestrator::UpdateType::OFFSET;
-                                     it->second(updateData);
+                                     it->second(ActionOrchestrator::UpdateData::createOffsetUpdateData(offset));
                                      res.status = 200;
                                      res.body = "Offset update processed successfully";
                                  }
@@ -127,10 +122,7 @@ void OnDemandManager::startServer()
 
                                  if (const auto& it {m_endpoints.find(topicName)}; it != m_endpoints.end())
                                  {
-                                     auto updateData {ActionOrchestrator::UpdateData()};
-                                     updateData.type = ActionOrchestrator::UpdateType::FILE_HASH;
-                                     updateData.fileHash = fileHash;
-                                     it->second(updateData);
+                                     it->second(ActionOrchestrator::UpdateData::createHashUpdateData(fileHash));
                                      res.status = 200;
                                      res.body = "File hash update processed successfully";
                                  }

--- a/src/shared_modules/content_manager/src/onDemandManager.cpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.cpp
@@ -51,7 +51,7 @@ void OnDemandManager::startServer()
                                  const auto& it {m_endpoints.find(req.matches[1].str())};
                                  if (it != m_endpoints.end())
                                  {
-                                     it->second(offset, ActionOrchestrator::UpdateType::CONTENT);
+                                     it->second(offset, "", ActionOrchestrator::UpdateType::CONTENT);
                                      res.status = 200;
                                  }
                                  else
@@ -66,7 +66,7 @@ void OnDemandManager::startServer()
                              }
                          });
 
-            // Capture PUT requests. These requests are used to update the offset from the database.
+            // Capture offset PUT requests. These requests are used to update the offset from the database.
             m_server.Put("/offset",
                          [&](const httplib::Request& req, httplib::Response& res)
                          {
@@ -86,7 +86,7 @@ void OnDemandManager::startServer()
 
                                  if (const auto& it {m_endpoints.find(topicName)}; it != m_endpoints.end())
                                  {
-                                     it->second(offset, ActionOrchestrator::UpdateType::OFFSET);
+                                     it->second(offset, "", ActionOrchestrator::UpdateType::OFFSET);
                                      res.status = 200;
                                      res.body = "Offset update processed successfully";
                                  }
@@ -102,6 +102,43 @@ void OnDemandManager::startServer()
                                  res.body = e.what();
                              }
                          });
+
+            // Capture hash PUT requests. These requests are used to update the file hash from the database.
+            m_server.Put("/hash",
+                         [&](const httplib::Request& req, httplib::Response& res)
+                         {
+                             std::shared_lock<std::shared_mutex> lock {m_mutex};
+
+                             try
+                             {
+                                 const auto requestData = nlohmann::json::parse(req.body);
+                                 const auto& fileHash {requestData.at("fileHash").get_ref<const std::string&>()};
+                                 const auto& topicName {requestData.at("topicName").get_ref<const std::string&>()};
+
+                                 if (fileHash.empty())
+                                 {
+                                     throw std::invalid_argument {"Invalid hash value: The hash is empty"};
+                                 }
+
+                                 if (const auto& it {m_endpoints.find(topicName)}; it != m_endpoints.end())
+                                 {
+                                     it->second(-1, fileHash, ActionOrchestrator::UpdateType::FILE_HASH);
+                                     res.status = 200;
+                                     res.body = "File hash update processed successfully";
+                                 }
+                                 else
+                                 {
+                                     res.status = 404;
+                                     res.body = "Topic '" + topicName + "' not found";
+                                 }
+                             }
+                             catch (const std::exception& e)
+                             {
+                                 res.status = 400;
+                                 res.body = e.what();
+                             }
+                         });
+
             m_server.set_address_family(AF_UNIX);
 
             std::filesystem::remove(ONDEMAND_SOCK);
@@ -133,7 +170,7 @@ void OnDemandManager::stopServer()
 }
 
 void OnDemandManager::addEndpoint(const std::string& endpoint,
-                                  std::function<void(int, ActionOrchestrator::UpdateType)> func)
+                                  std::function<void(int, std::string, ActionOrchestrator::UpdateType)> func)
 {
     std::unique_lock<std::shared_mutex> lock {m_mutex};
     // Check if the endpoint already exists

--- a/src/shared_modules/content_manager/src/onDemandManager.cpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.cpp
@@ -51,7 +51,9 @@ void OnDemandManager::startServer()
                                  const auto& it {m_endpoints.find(req.matches[1].str())};
                                  if (it != m_endpoints.end())
                                  {
-                                     it->second(offset, "", ActionOrchestrator::UpdateType::CONTENT);
+                                     auto updateData {ActionOrchestrator::UpdateData()};
+                                     updateData.offset = offset;
+                                     it->second(updateData);
                                      res.status = 200;
                                  }
                                  else
@@ -86,7 +88,10 @@ void OnDemandManager::startServer()
 
                                  if (const auto& it {m_endpoints.find(topicName)}; it != m_endpoints.end())
                                  {
-                                     it->second(offset, "", ActionOrchestrator::UpdateType::OFFSET);
+                                     auto updateData {ActionOrchestrator::UpdateData()};
+                                     updateData.offset = offset;
+                                     updateData.type = ActionOrchestrator::UpdateType::OFFSET;
+                                     it->second(updateData);
                                      res.status = 200;
                                      res.body = "Offset update processed successfully";
                                  }
@@ -122,7 +127,10 @@ void OnDemandManager::startServer()
 
                                  if (const auto& it {m_endpoints.find(topicName)}; it != m_endpoints.end())
                                  {
-                                     it->second(-1, fileHash, ActionOrchestrator::UpdateType::FILE_HASH);
+                                     auto updateData {ActionOrchestrator::UpdateData()};
+                                     updateData.type = ActionOrchestrator::UpdateType::FILE_HASH;
+                                     updateData.fileHash = fileHash;
+                                     it->second(updateData);
                                      res.status = 200;
                                      res.body = "File hash update processed successfully";
                                  }
@@ -170,7 +178,7 @@ void OnDemandManager::stopServer()
 }
 
 void OnDemandManager::addEndpoint(const std::string& endpoint,
-                                  std::function<void(int, std::string, ActionOrchestrator::UpdateType)> func)
+                                  std::function<void(ActionOrchestrator::UpdateData)> func)
 {
     std::unique_lock<std::shared_mutex> lock {m_mutex};
     // Check if the endpoint already exists

--- a/src/shared_modules/content_manager/src/onDemandManager.cpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.cpp
@@ -117,7 +117,7 @@ void OnDemandManager::startServer()
                              try
                              {
                                  const auto requestData = nlohmann::json::parse(req.body);
-                                 const auto& fileHash {requestData.at("fileHash").get_ref<const std::string&>()};
+                                 const auto& fileHash {requestData.at("hash").get_ref<const std::string&>()};
                                  const auto& topicName {requestData.at("topicName").get_ref<const std::string&>()};
 
                                  if (fileHash.empty())

--- a/src/shared_modules/content_manager/src/onDemandManager.cpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.cpp
@@ -177,8 +177,7 @@ void OnDemandManager::stopServer()
     logDebug1(WM_CONTENTUPDATER, "Server stopped");
 }
 
-void OnDemandManager::addEndpoint(const std::string& endpoint,
-                                  std::function<void(ActionOrchestrator::UpdateData)> func)
+void OnDemandManager::addEndpoint(const std::string& endpoint, std::function<void(ActionOrchestrator::UpdateData)> func)
 {
     std::unique_lock<std::shared_mutex> lock {m_mutex};
     // Check if the endpoint already exists

--- a/src/shared_modules/content_manager/src/onDemandManager.hpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.hpp
@@ -32,7 +32,7 @@ class OnDemandManager final : public Singleton<OnDemandManager>
 {
 private:
     httplib::Server m_server {};
-    std::map<std::string, std::function<void(int, ActionOrchestrator::UpdateType)>> m_endpoints {};
+    std::map<std::string, std::function<void(int, std::string, ActionOrchestrator::UpdateType)>> m_endpoints {};
     std::shared_mutex m_mutex {};
     std::thread m_serverThread {};
     std::atomic<bool> m_runningTrigger {true};
@@ -46,7 +46,7 @@ public:
      * @param endpoint Endpoint to add
      * @param func Function to call when the endpoint is called
      */
-    void addEndpoint(const std::string& endpoint, std::function<void(int, ActionOrchestrator::UpdateType)> func);
+    void addEndpoint(const std::string& endpoint, std::function<void(int, std::string, ActionOrchestrator::UpdateType)> func);
 
     /**
      * @brief Remove an endpoint and stop the server if there are no more endpoints

--- a/src/shared_modules/content_manager/src/onDemandManager.hpp
+++ b/src/shared_modules/content_manager/src/onDemandManager.hpp
@@ -32,7 +32,7 @@ class OnDemandManager final : public Singleton<OnDemandManager>
 {
 private:
     httplib::Server m_server {};
-    std::map<std::string, std::function<void(int, std::string, ActionOrchestrator::UpdateType)>> m_endpoints {};
+    std::map<std::string, std::function<void(ActionOrchestrator::UpdateData)>> m_endpoints {};
     std::shared_mutex m_mutex {};
     std::thread m_serverThread {};
     std::atomic<bool> m_runningTrigger {true};
@@ -46,7 +46,7 @@ public:
      * @param endpoint Endpoint to add
      * @param func Function to call when the endpoint is called
      */
-    void addEndpoint(const std::string& endpoint, std::function<void(int, std::string, ActionOrchestrator::UpdateType)> func);
+    void addEndpoint(const std::string& endpoint, std::function<void(ActionOrchestrator::UpdateData)> func);
 
     /**
      * @brief Remove an endpoint and stop the server if there are no more endpoints

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -300,8 +300,12 @@ TEST_F(ActionOrchestratorTest, RunWithFullContentDownload)
     auto actionOrchestrator {
         std::make_shared<ActionOrchestrator>(routerProvider, m_parameters, m_spStopActionCondition)};
 
+    constexpr auto OFFSET {0};
+    auto updateData {ActionOrchestrator::UpdateData()};
+    updateData.offset = OFFSET;
+
     // Trigger orchestration with an offset of zero.
-    ASSERT_NO_THROW(actionOrchestrator->run(0));
+    ASSERT_NO_THROW(actionOrchestrator->run(updateData));
 
     const auto& outputFolder {m_parameters.at("configData").at("outputFolder").get_ref<const std::string&>()};
 
@@ -323,11 +327,14 @@ TEST_F(ActionOrchestratorTest, RunWithFullContentDownload)
 TEST_F(ActionOrchestratorTest, RunOffsetUpdate)
 {
     constexpr auto OFFSET {1234};
+    auto updateData {ActionOrchestrator::UpdateData()};
+    updateData.type = ActionOrchestrator::UpdateType::OFFSET;
+    updateData.offset = OFFSET;
 
     {
         // Trigger orchestrator in a reduced scope to avoid conflicts with the RocksDB connection below.
         ASSERT_NO_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition)
-                            .run(OFFSET, "", ActionOrchestrator::UpdateType::OFFSET));
+                            .run(updateData));
     }
 
     const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
@@ -343,8 +350,11 @@ TEST_F(ActionOrchestratorTest, RunOffsetUpdate)
 TEST_F(ActionOrchestratorTest, RunOffsetUpdateInvalidOffsetThrows)
 {
     constexpr auto OFFSET {-100};
+    auto updateData {ActionOrchestrator::UpdateData()};
+    updateData.type = ActionOrchestrator::UpdateType::OFFSET;
+    updateData.offset = OFFSET;
 
     EXPECT_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition)
-                     .run(OFFSET, "", ActionOrchestrator::UpdateType::OFFSET),
+                     .run(updateData),
                  std::invalid_argument);
 }

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -357,3 +357,36 @@ TEST_F(ActionOrchestratorTest, RunOffsetUpdateInvalidOffsetThrows)
     EXPECT_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition).run(updateData),
                  std::invalid_argument);
 }
+
+/**
+ * @brief Tests the file hash update process execution.
+ *
+ */
+TEST_F(ActionOrchestratorTest, RunFileHashUpdate)
+{
+    constexpr auto HASH_VALUE {"hash"};
+
+    auto updateData {ActionOrchestrator::UpdateData()};
+    updateData.type = ActionOrchestrator::UpdateType::FILE_HASH;
+    updateData.fileHash = HASH_VALUE;
+
+    ASSERT_NO_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition).run(updateData));
+
+    const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
+    const auto fullDatabasePath {DATABASE_PATH / ("updater_" + topicName + "_metadata")};
+    auto wrapper {Utils::RocksDBWrapper(fullDatabasePath)};
+    EXPECT_EQ(wrapper.getLastKeyValue(Components::Columns::DOWNLOADED_FILE_HASH).second.ToString(), HASH_VALUE);
+}
+
+/**
+ * @brief Tests the file hash update process execution with an empty hash. An exception is expected.
+ *
+ */
+TEST_F(ActionOrchestratorTest, RunFileHashUpdateInvalidHashThrows)
+{
+    auto updateData {ActionOrchestrator::UpdateData()};
+    updateData.type = ActionOrchestrator::UpdateType::FILE_HASH;
+
+    EXPECT_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition).run(updateData),
+                 std::invalid_argument);
+}

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -333,8 +333,8 @@ TEST_F(ActionOrchestratorTest, RunOffsetUpdate)
 
     {
         // Trigger orchestrator in a reduced scope to avoid conflicts with the RocksDB connection below.
-        ASSERT_NO_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition)
-                            .run(updateData));
+        ASSERT_NO_THROW(
+            ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition).run(updateData));
     }
 
     const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
@@ -354,7 +354,6 @@ TEST_F(ActionOrchestratorTest, RunOffsetUpdateInvalidOffsetThrows)
     updateData.type = ActionOrchestrator::UpdateType::OFFSET;
     updateData.offset = OFFSET;
 
-    EXPECT_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition)
-                     .run(updateData),
+    EXPECT_THROW(ActionOrchestrator(m_spMockRouterProvider, m_parameters, m_spStopActionCondition).run(updateData),
                  std::invalid_argument);
 }

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -338,7 +338,10 @@ TEST_F(ActionTest, RunActionOnDemandOffsetUpdate)
     action.registerActionOnDemand();
 
     constexpr auto OFFSET {1000};
-    ASSERT_NO_THROW(action.runActionOnDemand(OFFSET, "", ActionOrchestrator::UpdateType::OFFSET));
+    auto updateData {ActionOrchestrator::UpdateData()};
+    updateData.type = ActionOrchestrator::UpdateType::OFFSET;
+    updateData.offset = OFFSET;
+    ASSERT_NO_THROW(action.runActionOnDemand(updateData));
 
     action.unregisterActionOnDemand();
     action.clearEndpoints();

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -382,7 +382,7 @@ TEST_F(ActionTest, HashOnDemandUpdate)
     std::string putUrl {"http://localhost/hash"};
     auto fileHash {Utils::asciiToHex(Utils::hashFile(INPUT_FILES_DIR / SAMPLE_TXT_FILENAME))};
     nlohmann::json putData;
-    putData["fileHash"] = std::move(fileHash);
+    putData["hash"] = std::move(fileHash);
     putData["topicName"] = topicName;
     UNIXSocketRequest::instance().put(
         HttpUnixSocketURL(ONDEMAND_SOCK, std::move(putUrl)), std::move(putData), [](auto) {});

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -338,7 +338,7 @@ TEST_F(ActionTest, RunActionOnDemandOffsetUpdate)
     action.registerActionOnDemand();
 
     constexpr auto OFFSET {1000};
-    ASSERT_NO_THROW(action.runActionOnDemand(OFFSET, ActionOrchestrator::UpdateType::OFFSET));
+    ASSERT_NO_THROW(action.runActionOnDemand(OFFSET, "", ActionOrchestrator::UpdateType::OFFSET));
 
     action.unregisterActionOnDemand();
     action.clearEndpoints();

--- a/src/shared_modules/content_manager/tests/component/action_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.hpp
@@ -30,6 +30,7 @@ protected:
     ~ActionTest() override = default;
 
     nlohmann::json m_parameters; ///< Parameters used to create the Action
+    const std::filesystem::path m_outputFolder {std::filesystem::temp_directory_path() / "ActionTest"}; ///< Output test folder.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
 
@@ -53,12 +54,12 @@ protected:
                     "versionedContent": "false",
                     "deleteDownloadedContent": false,
                     "url": "http://localhost:4444/raw/consumers",
-                    "outputFolder": "/tmp/action-tests",
-                    "contentFileName": "sample.json",
-                    "databasePath": "/tmp/action-tests/rocksdb"
+                    "contentFileName": "sample.json"
                 }
             }
         )"_json;
+        m_parameters["configData"]["outputFolder"] = m_outputFolder;
+        m_parameters["configData"]["databasePath"] = m_outputFolder;
 
         // Init router provider.
         const auto& topicName {m_parameters.at("topicName").get_ref<const std::string&>()};
@@ -77,11 +78,10 @@ protected:
     void TearDown() override
     {
         // Removes the directory if it exists
-        const auto outputFolder = m_parameters.at("configData").at("outputFolder").get_ref<const std::string&>();
-        if (std::filesystem::exists(outputFolder))
+        if (std::filesystem::exists(m_outputFolder))
         {
             // Delete the output folder.
-            std::filesystem::remove_all(outputFolder);
+            std::filesystem::remove_all(m_outputFolder);
         }
 
         // Stop router provider.

--- a/src/shared_modules/content_manager/tests/component/action_test.hpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.hpp
@@ -30,7 +30,8 @@ protected:
     ~ActionTest() override = default;
 
     nlohmann::json m_parameters; ///< Parameters used to create the Action
-    const std::filesystem::path m_outputFolder {std::filesystem::temp_directory_path() / "ActionTest"}; ///< Output test folder.
+    const std::filesystem::path m_outputFolder {std::filesystem::temp_directory_path() /
+                                                "ActionTest"}; ///< Output test folder.
 
     inline static std::unique_ptr<FakeServer> m_spFakeServer; ///< Pointer to FakeServer class
 

--- a/src/shared_modules/content_manager/tests/component/input_files/sample.txt
+++ b/src/shared_modules/content_manager/tests/component/input_files/sample.txt
@@ -1,0 +1,1 @@
+Test file.

--- a/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
@@ -22,7 +22,9 @@
 const auto OK_STATUS = R"({"stage":"FileDownloader","status":"ok"})"_json;
 const auto FAIL_STATUS = R"({"stage":"FileDownloader","status":"fail"})"_json;
 const auto CONTENT_FILENAME_RAW = "raw";
+const auto FILEHASH_RAW = "228458095a9502070fc113d99504226a6ff90a9a";
 const auto CONTENT_FILENAME_XZ = "xz";
+const auto FILEHASH_XZ = "89fe2d7ad5369373c4b96f8eeedd11d27ed3bc79";
 const std::string BASE_URL = "localhost:4444/";
 
 constexpr auto DEFAULT_TYPE {"raw"}; ///< Default content type.
@@ -110,6 +112,7 @@ TEST_F(FileDownloaderTest, DownloadRawFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
+    expectedData["fileHash"] = FILEHASH_RAW;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/raw'.
     m_spUpdaterBaseContext->configData["compressionType"] = "raw";
@@ -141,6 +144,7 @@ TEST_F(FileDownloaderTest, DownloadCompressedFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
+    expectedData["fileHash"] = FILEHASH_XZ;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";
@@ -157,8 +161,7 @@ TEST_F(FileDownloaderTest, DownloadCompressedFile)
 }
 
 /**
- * @brief Tests two downloads in a row of the same file. The second download should not add the filepath to the data
- * paths.
+ * @brief Tests two downloads in a row of the same file.
  *
  */
 TEST_F(FileDownloaderTest, DownloadSameFileTwice)
@@ -173,6 +176,7 @@ TEST_F(FileDownloaderTest, DownloadSameFileTwice)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
+    expectedData["fileHash"] = FILEHASH_XZ;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";
@@ -187,68 +191,9 @@ TEST_F(FileDownloaderTest, DownloadSameFileTwice)
     m_spUpdaterContext.reset(new UpdaterContext());
     m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
 
-    // No paths are expected.
-    expectedData.at("paths").clear();
-
     // Run downloader. Second download. Same file as before.
     EXPECT_NO_THROW(FileDownloader().handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
-}
-
-/**
- * @brief Tests two downloads in a row of the same file. The second download should not add the filepath to the data
- * paths. After that, a third different file is downloaded.
- *
- */
-TEST_F(FileDownloaderTest, DownloadSameFileTwiceAndThenADifferentOne)
-{
-    // Given that the file is compressed, the download should be made into de 'downloadsFolder'.
-    const auto compressedExpectedFilepath {m_spUpdaterBaseContext->downloadsFolder / CONTENT_FILENAME_XZ};
-
-    // Set up expected data.
-    nlohmann::json expectedData;
-    expectedData["paths"].push_back(compressedExpectedFilepath.string());
-    expectedData["stageStatus"] = nlohmann::json::array();
-    expectedData["stageStatus"].push_back(OK_STATUS);
-    expectedData["type"] = DEFAULT_TYPE;
-    expectedData["offset"] = 0;
-
-    // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
-    m_spUpdaterBaseContext->configData["compressionType"] = "xz";
-    m_spUpdaterBaseContext->configData["url"] = BASE_URL + CONTENT_FILENAME_XZ;
-
-    // Run downloader. First download.
-    EXPECT_NO_THROW(FileDownloader().handleRequest(m_spUpdaterContext));
-    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
-    EXPECT_TRUE(std::filesystem::exists(compressedExpectedFilepath));
-
-    // Reset context.
-    m_spUpdaterContext.reset(new UpdaterContext());
-    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-
-    // No paths are expected.
-    expectedData.at("paths").clear();
-
-    // Run downloader. Second download. Same file as before.
-    EXPECT_NO_THROW(FileDownloader().handleRequest(m_spUpdaterContext));
-    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
-
-    // Reset context.
-    m_spUpdaterContext.reset(new UpdaterContext());
-    m_spUpdaterContext->spUpdaterBaseContext = m_spUpdaterBaseContext;
-
-    // Set expected paths. Given that the file is raw, the download should be made into de 'contentsFolder'.
-    const auto rawExpectedFilepath {m_spUpdaterBaseContext->contentsFolder / CONTENT_FILENAME_RAW};
-    expectedData["paths"].push_back(rawExpectedFilepath.string());
-
-    // Set config data. This will make the downloader to download from 'localhost:4444/raw'.
-    m_spUpdaterBaseContext->configData["compressionType"] = "raw";
-    m_spUpdaterBaseContext->configData["url"] = BASE_URL + CONTENT_FILENAME_RAW;
-
-    // Run downloader. Third download. Different file.
-    EXPECT_NO_THROW(FileDownloader().handleRequest(m_spUpdaterContext));
-    EXPECT_EQ(m_spUpdaterContext->data, expectedData);
-    EXPECT_TRUE(std::filesystem::exists(rawExpectedFilepath));
 }
 
 /**

--- a/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/fileDownloader_test.cpp
@@ -112,7 +112,7 @@ TEST_F(FileDownloaderTest, DownloadRawFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_RAW;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_RAW;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/raw'.
     m_spUpdaterBaseContext->configData["compressionType"] = "raw";
@@ -144,7 +144,7 @@ TEST_F(FileDownloaderTest, DownloadCompressedFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_XZ;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_XZ;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";
@@ -176,7 +176,7 @@ TEST_F(FileDownloaderTest, DownloadSameFileTwice)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_XZ;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_XZ;
 
     // Set config data. This will make the downloader to download from 'localhost:4444/xz'.
     m_spUpdaterBaseContext->configData["compressionType"] = "xz";

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.cpp
@@ -59,7 +59,7 @@ TEST_F(OfflineDownloaderTest, RawFileDownload)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = m_inputFileHashRaw;
+    expectedData["fileMetadata"]["hash"] = m_inputFileHashRaw;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -82,7 +82,7 @@ TEST_F(OfflineDownloaderTest, CompressedFileDownload)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = m_inputFileHashCompressed;
+    expectedData["fileMetadata"]["hash"] = m_inputFileHashCompressed;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -126,7 +126,7 @@ TEST_F(OfflineDownloaderTest, DownloadSameFileTwice)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = m_inputFileHashRaw;
+    expectedData["fileMetadata"]["hash"] = m_inputFileHashRaw;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -178,7 +178,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadRawFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_RAW;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_RAW;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -202,7 +202,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadCompressedFile)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_XZ;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_XZ;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -266,7 +266,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadRawFileOverride)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_RAW;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_RAW;
 
     // Create dummy file in the expected output path.
     std::ofstream testFileStream {expectedOutputFile};
@@ -315,7 +315,7 @@ TEST_F(OfflineDownloaderTest, HttpDownloadFileTwice)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_RAW;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_RAW;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);
@@ -347,7 +347,7 @@ TEST_F(OfflineDownloaderTest, HttpAndLocalDownloadFileTwice)
     expectedData["stageStatus"].push_back(OK_STATUS);
     expectedData["type"] = DEFAULT_TYPE;
     expectedData["offset"] = 0;
-    expectedData["fileHash"] = FILEHASH_RAW;
+    expectedData["fileMetadata"]["hash"] = FILEHASH_RAW;
 
     ASSERT_NO_THROW(OfflineDownloader(HTTPRequest::instance()).handleRequest(m_spUpdaterContext));
     EXPECT_EQ(m_spUpdaterContext->data, expectedData);

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -31,13 +31,13 @@ protected:
     OfflineDownloaderTest() = default;
     ~OfflineDownloaderTest() override = default;
 
-    const std::filesystem::path m_tempPath {std::filesystem::temp_directory_path()}; ///< Temporary path.
-    const std::filesystem::path m_inputFilePathRaw {m_tempPath / "testFile.txt"};    ///< Raw input test path.
-    const std::string m_inputFileHashRaw {"da21ecfc2146bfeb7c2d4020eda94afc6878266d"};
+    const std::filesystem::path m_tempPath {std::filesystem::temp_directory_path()};   ///< Temporary path.
+    const std::filesystem::path m_inputFilePathRaw {m_tempPath / "testFile.txt"};      ///< Raw input test path.
+    const std::string m_inputFileHashRaw {"da21ecfc2146bfeb7c2d4020eda94afc6878266d"}; ///< Raw file hash.
     const std::filesystem::path m_inputFilePathCompressed {m_tempPath /
                                                            "testFile.txt.gz"}; ///< Compressed input test path.
-    const std::string m_inputFileHashCompressed {"b2e0c197e5bc308fb868b31292c5e75145d8735b"};
-    const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"}; ///< Output test folder.
+    const std::string m_inputFileHashCompressed {"b2e0c197e5bc308fb868b31292c5e75145d8735b"}; ///< Compressed file hash.
+    const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"};     ///< Output test folder.
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;         ///< UpdaterContext used on tests.
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on tests.
 

--- a/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
+++ b/src/shared_modules/content_manager/tests/unit/offlineDownloader_test.hpp
@@ -33,8 +33,10 @@ protected:
 
     const std::filesystem::path m_tempPath {std::filesystem::temp_directory_path()}; ///< Temporary path.
     const std::filesystem::path m_inputFilePathRaw {m_tempPath / "testFile.txt"};    ///< Raw input test path.
+    const std::string m_inputFileHashRaw {"da21ecfc2146bfeb7c2d4020eda94afc6878266d"};
     const std::filesystem::path m_inputFilePathCompressed {m_tempPath /
                                                            "testFile.txt.gz"}; ///< Compressed input test path.
+    const std::string m_inputFileHashCompressed {"b2e0c197e5bc308fb868b31292c5e75145d8735b"};
     const std::filesystem::path m_outputFolder {m_tempPath / "offline-downloader-tests"}; ///< Output test folder.
     std::shared_ptr<UpdaterContext> m_spUpdaterContext;         ///< UpdaterContext used on tests.
     std::shared_ptr<UpdaterBaseContext> m_spUpdaterBaseContext; ///< UpdaterBaseContext used on tests.

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -702,7 +702,7 @@ private:
      * @param topicName Topic name.
      * @param fileHash Value of the hash to be used in the update.
      */
-    void contentManagerUpdateHash(const std::string& topicName, const std::string& fileHash)
+    void contentManagerUpdateHash(const std::string& topicName, const std::string& fileHash) const
     {
         constexpr auto URL {"http://localhost/hash"};
         nlohmann::json data;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -227,6 +227,13 @@ public:
 
                 // Update the offset.
                 contentManagerUpdateOffset(topicName, parsedMessage.at("offset"));
+
+                if (parsedMessage.contains("/fileMetadata/hash"_json_pointer))
+                {
+                    // Update last parsed file hash.
+                    contentManagerUpdateHash(topicName,
+                                             parsedMessage.at("fileMetadata").at("hash").get_ref<const std::string&>());
+                }
             }
         }
         else
@@ -685,6 +692,31 @@ private:
                 // Not used
             },
             [](const std::string& msg, const long) { throw std::runtime_error("Error updating offset: " + msg); });
+        // LCOV_EXCL_STOP
+    }
+
+    /**
+     * @brief Makes the Content Manager to update the last parsed file hash value so that redundant processing is
+     * avoided.
+     *
+     * @param topicName Topic name.
+     * @param fileHash Value of the hash to be used in the update.
+     */
+    void contentManagerUpdateHash(const std::string& topicName, const std::string& fileHash)
+    {
+        constexpr auto URL {"http://localhost/hash"};
+        nlohmann::json data;
+        data["hash"] = fileHash;
+        data["topicName"] = topicName;
+
+        // Exclude from coverage because need to be tested in integration tests.
+        // LCOV_EXCL_START
+        TUNIXSocketRequest::instance().put(
+            HttpUnixSocketURL(ONDEMAND_SOCK, URL),
+            std::move(data),
+            [](const std::string& msg) {},
+            [](const std::string& msg, const long responseCode)
+            { throw std::runtime_error("Error updating file hash: " + msg); });
         // LCOV_EXCL_STOP
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -1669,3 +1669,48 @@ TEST_F(DatabaseFeedManagerVendorMapTest, TestGetCnaNameByContains)
     cnaName = m_spDatabaseFeedManager->getCnaNameByContains("invalid");
     EXPECT_EQ(cnaName, "");
 }
+
+TEST_F(DatabaseFeedManagerMessageProcessorTest, FileProcessingOffsetAndHashUpdate)
+{
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+
+    const auto expectedOffsetPutData = R"(
+        {
+            "topicName": "topicName",
+            "offset": 0
+        }
+    )"_json;
+
+    const auto expectedHashPutData = R"(
+        {
+            "topicName": "topicName",
+            "hash": "hash_value"
+        }
+    )"_json;
+
+    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, expectedOffsetPutData, _, _)).Times(1);
+    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, expectedHashPutData, _, _)).Times(1);
+
+    auto spIndexerConnectorTramp {std::make_shared<TrampolineIndexerConnector>()};
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              RouterSubscriber,
+                                              MockUnixSocketRequest>>(spIndexerConnectorTramp, shouldStop, mutex)};
+    std::string messageStr {R"(
+        {
+            "type": "raw",
+            "offset": 0,
+            "paths": [ "file4.json"],
+            "fileMetadata": {
+                "hash": "hash_value"
+            }
+        }
+    )"};
+    std::vector<char> message {std::vector<char>(messageStr.begin(), messageStr.end())};
+    auto testLambda {[](const nlohmann::json& obj, Utils::IRocksDBWrapper* dbWrapper) {
+    }};
+    EXPECT_NO_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testLambda));
+}


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22526 |

## Description

This PR improves how the Content Manager stores the last downloaded file hash, used to avoid redundant processing of files.

Change log:
- Modify file downloaders to not write the file hash in the context.
- Modify file action orchestrator to not write the file hash in the database on every execution.
- Create endpoint in the ondemand content manager to update the file hash on demand.
- Improve how the orchestration config is passed from the ondemand manager to the action orchestrator.
- Add/Adapt testing
- Modify the scanner to trigger the hash update.

## Results

#### Scanner testtool execution (happy path)

Config file:
```json
{
  "vulnerability-detection": {
      "enabled": "yes",
      "index-status": "yes",
      "cti-url": "file:///home/reduced_snapshot.zip",
      "offline-url": "file:///home/reduced_snapshot.zip",
      "managerNodeName": "wazuh-manager",
      "managerDisabledScan": 1
  },
  "indexer": {
      "enabled": "yes",
      "hosts": [
          "https://0.0.0.0:9200"
      ],
      "username": "admin",
      "password": "admin",
      "ssl": {
          "certificate_authorities": [
              "/home/dwordcito/Development/wazuh/src/root-ca.pem"
          ],
          "certificate": "/home/dwordcito/Development/wazuh/src/node-1.pem",
          "key": "/home/dwordcito/Development/wazuh/src/node-1-key.pem"
        }
  }
}
```
> Note: `reduced_snapshot.zip` is a zip file containing a snapshot with only 3500 lines.

Execution and output:
<details><summary>Output</summary>

```bash
# LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.6 ./vd_scanner_testtool -c config.json -t /home/wazuh-dev-22526-content-manager-improve-hash-update-mechanism/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json -d
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
indexer-connector:indexerConnector.cpp:93 IndexerConnector : No username and password found in the keystore, using default values.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 2 seconds. Maximum wait time: 60 seconds.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 4 seconds. Maximum wait time: 60 seconds.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 8 seconds. Maximum wait time: 60 seconds.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 16 seconds. Maximum wait time: 60 seconds.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 32 seconds. Maximum wait time: 60 seconds.
Failed to set socket options
Failed to set socket options
wazuh-modulesd:content-updater:actionOrchestrator.hpp:79 ActionOrchestrator : Creating 'vulnerability_feed_manager' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:202 handleRequest : ExecutionContext - Starting process
wazuh-modulesd:content-updater:executionContext.hpp:184 createOutputFolder : Creating output folders at 'queue/vd_updater/tmp'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create : FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:46 create : Creating 'offline' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create : Creating 'zip' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create : Creating 'false' version updater
wazuh-modulesd:content-updater:factoryCleaner.hpp:41 create : Content cleaner created
wazuh-modulesd:content-updater:actionOrchestrator.hpp:89 ActionOrchestrator : Content updater orchestration created
wazuh-modulesd:content-updater:action.hpp:126 runActionScheduled : Starting scheduled action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:207 runContentUpdate : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:181 handleRequest : OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:66 copyFile : Copying file from 'file:///home/reduced_snapshot.zip' into 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip'
wazuh-modulesd:content-updater:zipDecompressor.hpp:74 handleRequest : ZipDecompressor - Starting process
wazuh-modulesd:content-updater:zipDecompressor.hpp:49 decompress : Decompressing 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip' into 'queue/vd_updater/tmp/contents'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:61 handleRequest : PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish : Data to be published: '{"fileMetadata":{"hash":"8ae3941827f4e893e09c80b93b0d28ad18ed3011"},"offset":0,"paths":["queue/vd_updater/tmp/contents/reduced_snapshot.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:45 publish : Data published
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest : CleanUpContent - Starting process
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:337 operator() : Processing message
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
Error modifying FD from interface.
wazuh-modulesd:vulnerability-scanner:scanOrchestrator.hpp:117 TScanOrchestrator : Timeout waiting for DB response, Using the hostname by fallback.
wazuh-modulesd:vulnerability-scanner:vulnerabilityScannerFacade.cpp:594 start : Vulnerability scanner module started
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': No available server. Retrying in 60 seconds. Maximum wait time: 60 seconds.
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:210 processMessage : Processing file: queue/vd_updater/tmp/contents/reduced_snapshot.json
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 1
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 1001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 2001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 3001
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:163 runOffsetUpdate : Running 'vulnerability_feed_manager' offset update
wazuh-modulesd:content-updater:factoryOffsetUpdater.hpp:41 create : FactoryOffsetUpdater - Starting process
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:70 handleRequest : UpdateCtiApiOffset - Starting process
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:42 update : Updating offset with value: 0
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:183 runFileHashUpdate : Running 'vulnerability_feed_manager' file hash update
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:365 operator() : Error processing message: Vendor map can not be found in DB.
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:207 runContentUpdate : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:181 handleRequest : OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:66 copyFile : Copying file from 'file:///home/reduced_snapshot.zip' into 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip'
wazuh-modulesd:content-updater:offlineDownloader.hpp:158 download : File 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip' didn't change from last download so it won't be published
wazuh-modulesd:content-updater:zipDecompressor.hpp:74 handleRequest : ZipDecompressor - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:61 handleRequest : PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:49 publish : No data to publish
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest : CleanUpContent - Starting process
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
```
</details>

Key logs:
- First CM execution (snapshot content published)
```
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish : Data to be published: '{"fileMetadata":{"hash":"8ae3941827f4e893e09c80b93b0d28ad18ed3011"},"offset":0,"paths":["queue/vd_updater/tmp/contents/reduced_snapshot.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
```
- VD processing:
```
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:210 processMessage : Processing file: queue/vd_updater/tmp/contents/reduced_snapshot.json
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 1
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 1001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 2001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 3001
```
- VD updating offset and hash:
```
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:163 runOffsetUpdate : Running 'vulnerability_feed_manager' offset update
wazuh-modulesd:content-updater:factoryOffsetUpdater.hpp:41 create : FactoryOffsetUpdater - Starting process
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:70 handleRequest : UpdateCtiApiOffset - Starting process
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:42 update : Updating offset with value: 0
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:183 runFileHashUpdate : Running 'vulnerability_feed_manager' file hash update
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
```
- Second CM execution (content is not published)
```
wazuh-modulesd:content-updater:offlineDownloader.hpp:158 download : File 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip' didn't change from last download so it won't be published
```

#### Scanner testtool execution (error recovery)

A forced exception was inserted in the database feed manager when a line is to be processed (just once, in the second try, the content is processed without errors). On this way, we can see how the scanner recovers from this error and the content manager re-sends the content file.

Config: The same as above.

Execution and output:
<details><summary>Output</summary>

```bash
# LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.6 ./vd_scanner_testtool -c config.json -t /home/wazuh-dev-22526-content-manager-improve-hash-update-mechanism/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json -d
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
Failed to set socket options
indexer-connector:indexerConnector.cpp:93 IndexerConnector : No username and password found in the keystore, using default values.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 2 seconds. Maximum wait time: 60 seconds.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 4 seconds. Maximum wait time: 60 seconds.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 8 seconds. Maximum wait time: 60 seconds.
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 16 seconds. Maximum wait time: 60 seconds.
Failed to set socket options
Failed to set socket options
wazuh-modulesd:content-updater:actionOrchestrator.hpp:79 ActionOrchestrator : Creating 'vulnerability_feed_manager' Content Updater orchestration
wazuh-modulesd:content-updater:executionContext.hpp:202 handleRequest : ExecutionContext - Starting process
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Failed to initialize template for index 'wazuh-states-vulnerabilities'. Error: Couldn't connect to server. Retrying in 32 seconds. Maximum wait time: 60 seconds.
wazuh-modulesd:content-updater:executionContext.hpp:184 createOutputFolder : Creating output folders at 'queue/vd_updater/tmp'
wazuh-modulesd:content-updater:factoryContentUpdater.hpp:44 create : FactoryContentUpdater - Starting process
wazuh-modulesd:content-updater:factoryDownloader.hpp:46 create : Creating 'offline' downloader
wazuh-modulesd:content-updater:factoryDecompressor.hpp:73 create : Creating 'zip' decompressor
wazuh-modulesd:content-updater:factoryVersionUpdater.hpp:41 create : Creating 'false' version updater
wazuh-modulesd:content-updater:factoryCleaner.hpp:41 create : Content cleaner created
wazuh-modulesd:content-updater:actionOrchestrator.hpp:89 ActionOrchestrator : Content updater orchestration created
wazuh-modulesd:content-updater:action.hpp:126 runActionScheduled : Starting scheduled action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:207 runContentUpdate : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:181 handleRequest : OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:66 copyFile : Copying file from 'file:///home/reduced_snapshot.zip' into 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip'
wazuh-modulesd:content-updater:zipDecompressor.hpp:74 handleRequest : ZipDecompressor - Starting process
wazuh-modulesd:content-updater:zipDecompressor.hpp:49 decompress : Decompressing 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip' into 'queue/vd_updater/tmp/contents'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:61 handleRequest : PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish : Data to be published: '{"fileMetadata":{"hash":"8ae3941827f4e893e09c80b93b0d28ad18ed3011"},"offset":0,"paths":["queue/vd_updater/tmp/contents/reduced_snapshot.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:45 publish : Data published
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest : CleanUpContent - Starting process
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:345 operator() : Processing message
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
Error modifying FD from interface.
wazuh-modulesd:vulnerability-scanner:scanOrchestrator.hpp:117 TScanOrchestrator : Timeout waiting for DB response, Using the hostname by fallback.
wazuh-modulesd:vulnerability-scanner:vulnerabilityScannerFacade.cpp:594 start : Vulnerability scanner module started
indexer-connector:indexerConnector.cpp:204 operator() : Error initializing IndexerConnector for index 'wazuh-states-vulnerabilities': No available server. Retrying in 60 seconds. Maximum wait time: 60 seconds.
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:212 processMessage : Processing file: queue/vd_updater/tmp/contents/reduced_snapshot.json
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 1
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:373 operator() : Error processing message: Forced exception while processing line!
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:207 runContentUpdate : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:181 handleRequest : OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:66 copyFile : Copying file from 'file:///home/reduced_snapshot.zip' into 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip'
wazuh-modulesd:content-updater:zipDecompressor.hpp:74 handleRequest : ZipDecompressor - Starting process
wazuh-modulesd:content-updater:zipDecompressor.hpp:49 decompress : Decompressing 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip' into 'queue/vd_updater/tmp/contents'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:61 handleRequest : PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish : Data to be published: '{"fileMetadata":{"hash":"8ae3941827f4e893e09c80b93b0d28ad18ed3011"},"offset":0,"paths":["queue/vd_updater/tmp/contents/reduced_snapshot.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:45 publish : Data published
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest : CleanUpContent - Starting process
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished

wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:345 operator() : Processing message
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:212 processMessage : Processing file: queue/vd_updater/tmp/contents/reduced_snapshot.json
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 1
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 1001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 2001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 3001
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:163 runOffsetUpdate : Running 'vulnerability_feed_manager' offset update
wazuh-modulesd:content-updater:factoryOffsetUpdater.hpp:41 create : FactoryOffsetUpdater - Starting process
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:70 handleRequest : UpdateCtiApiOffset - Starting process
wazuh-modulesd:content-updater:updateCtiApiOffset.hpp:42 update : Updating offset with value: 0
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:183 runFileHashUpdate : Running 'vulnerability_feed_manager' file hash update
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:373 operator() : Error processing message: Vendor map can not be found in DB.
wazuh-modulesd:content-updater:action.hpp:185 runActionOnDemand : Starting on-demand action for 'vulnerability_feed_manager'
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:207 runContentUpdate : Running 'vulnerability_feed_manager' content update
wazuh-modulesd:content-updater:offlineDownloader.hpp:181 handleRequest : OfflineDownloader - Starting process
wazuh-modulesd:content-updater:offlineDownloader.hpp:66 copyFile : Copying file from 'file:///home/reduced_snapshot.zip' into 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip'
wazuh-modulesd:content-updater:offlineDownloader.hpp:158 download : File 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip' didn't change from last download so it won't be published
wazuh-modulesd:content-updater:zipDecompressor.hpp:74 handleRequest : ZipDecompressor - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:61 handleRequest : PubSubPublisher - Starting process
wazuh-modulesd:content-updater:pubSubPublisher.hpp:49 publish : No data to publish
wazuh-modulesd:content-updater:skipStep.hpp:48 handleRequest : SkipStep - Starting process
wazuh-modulesd:content-updater:cleanUpContent.hpp:63 handleRequest : CleanUpContent - Starting process
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished

wazuh-modulesd:content-updater:onDemandManager.cpp:177 stopServer : Server stopped
wazuh-modulesd:content-updater:action.hpp:146 stopActionScheduler : Scheduler stopped for 'vulnerability_feed_manager'
Error removing FD from interface.
```
</details>

Key logs:
- CM publishes for the first time
```
wazuh-modulesd:content-updater:pubSubPublisher.hpp:42 publish : Data to be published: '{"fileMetadata":{"hash":"8ae3941827f4e893e09c80b93b0d28ad18ed3011"},"offset":0,"paths":["queue/vd_updater/tmp/contents/reduced_snapshot.json"],"stageStatus":[{"stage":"OfflineDownloader","status":"ok"},{"stage":"ZipDecompressor","status":"ok"}],"type":"raw"}'
wazuh-modulesd:content-updater:pubSubPublisher.hpp:45 publish : Data published
```
- Scanner starts content processing and a forced exception is thrown
```
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:210 processMessage : Processing file: queue/vd_updater/tmp/contents/reduced_snapshot.json
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:232 processMessage : Processing line: 1
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:367 operator() : Error processing message: Forced exception while processing line!
```
- The CM re-sends the content
- The Scanner process the full content without errors
```
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:345 operator() : Processing message
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:212 processMessage : Processing file: queue/vd_updater/tmp/contents/reduced_snapshot.json
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 1
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 1001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 2001
wazuh-modulesd:vulnerability-scanner:databaseFeedManager.hpp:234 processMessage : Processing line: 3001
```
- Scanner triggers hash update
```
wazuh-modulesd:content-updater:action.hpp:218 runAction : Action for 'vulnerability_feed_manager' started
wazuh-modulesd:content-updater:actionOrchestrator.hpp:183 runFileHashUpdate : Running 'vulnerability_feed_manager' file hash update
wazuh-modulesd:content-updater:action.hpp:229 runAction : Action for 'vulnerability_feed_manager' finished
```
- CM realizes the file was already processed so is no longer published
```
wazuh-modulesd:content-updater:offlineDownloader.hpp:158 download : File 'queue/vd_updater/tmp/downloads/reduced_snapshot.zip' didn't change from last download so it won't be published
```