### PR TITLE
Fix unauthorized exception error handling

### DIFF
--- a/api/api/error_handler.py
+++ b/api/api/error_handler.py
@@ -9,7 +9,8 @@ import jwt
 from content_size_limit_asgi.errors import ContentSizeExceeded
 
 from api import configuration
-from api.middlewares import ip_block, ip_stats, LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT
+from api.middlewares import ip_block, ip_stats, LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, UNKNOWN_USER_STRING
+from api.alogging import custom_logging
 from api.api_exception import BlockedIPException, MaxRequestsException, ExpectFailedException
 from api.controllers.util import json_response, ERROR_CONTENT_TYPE
 from wazuh.core.utils import get_utc_now
@@ -109,6 +110,7 @@ async def unauthorized_error_handler(request: ConnexionRequest,
         problem.update({'detail': 'No authorization token provided'} \
                             if 'token_info' not in request.context \
                             else {})
+
     return json_response(data=problem, pretty=request.query_params.get('pretty', 'false') == 'true',
                          status_code=exc.status_code, content_type=ERROR_CONTENT_TYPE)
 

--- a/api/api/error_handler.py
+++ b/api/api/error_handler.py
@@ -9,8 +9,7 @@ import jwt
 from content_size_limit_asgi.errors import ContentSizeExceeded
 
 from api import configuration
-from api.middlewares import ip_block, ip_stats, LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, UNKNOWN_USER_STRING
-from api.alogging import custom_logging
+from api.middlewares import ip_block, ip_stats, LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT
 from api.api_exception import BlockedIPException, MaxRequestsException, ExpectFailedException
 from api.controllers.util import json_response, ERROR_CONTENT_TYPE
 from wazuh.core.utils import get_utc_now
@@ -110,7 +109,6 @@ async def unauthorized_error_handler(request: ConnexionRequest,
         problem.update({'detail': 'No authorization token provided'} \
                             if 'token_info' not in request.context \
                             else {})
-
     return json_response(data=problem, pretty=request.query_params.get('pretty', 'false') == 'true',
                          status_code=exc.status_code, content_type=ERROR_CONTENT_TYPE)
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/22735|

## Description

Handles `Authorization` header values decoding errors to avoid showing the stack trace and fail gracefully. 

### Tests

<details><summary>Invalid authorization attempts</summary>

```console
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Basic asd"
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Basic  "
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer  "
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer asd"
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization: BearerBearerBearer"
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer <token>"
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer ''"
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -k -X GET "https://localhost:55050/" -H "Authorization"
{"title": "Unauthorized", "detail": "No authorization token provided"}
gasti@pop-os:~/work/wazuh$ curl -u wazuh:wazuh -k -X POST "https://localhost:55050/security/user/authenticate"
{"data": {"token": "eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzEyMjUzMTMzLCJleHAiOjE3MTIyNTQwMzMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ASEZoZr99_1OdE6UbFFMGkc8WzRALfz7rJoiaiWRIq0IAc7QhPnegR4D7vZ50uPAQ1dquF6tws1HkNR-xcxXfPzgAP0ciWUXCbgmKDKNfKI1GUuwAa0Y1FdXyThCr9OBldj1QgJNsYLO3oJd937_yNPCeU57sfUHxA8nq6Ae378H-tfW"}, "error": 0}
gasti@pop-os:~/work/wazuh$ curl -u wazuh:wazuh -k -X POST "https://localhost:55050/security/user/authenticate" k -X GET "https://localhost:55050/" -H "Authorization: Bearer eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzEyMjUzMTMzLCJleHAiOjE3MTIyNTQwMzMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.ASEZoZr99_1OdE6UbFFMGkc8WzRALfz7rJoiaiWRIq0IAc7QhPnegR4D7vZ50uPAQ1dquF6tws1HkNR-xcxXfPzgAP0ciWUXCbgmKDKNfKI1GUuwAa0Y1FdXyThCr9OBldj1QgJNsYLO3oJd937_yNPCeU57sfUHxA8nq6Ae378H-tfW"
{"data": {"title": "Wazuh API REST", "api_version": "4.9.0", "revision": 40900, "license_name": "GPL 2.0", "license_url": "https://github.com/wazuh/wazuh/blob/v4.9.0/LICENSE", "hostname": "wazuh-master", "timestamp": "2024-04-04T17:52:23Z"}, "error": 0}
```

</details>


<details><summary>API logs</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
2024/04/04 17:51:10 INFO: Starting API in foreground
2024/04/04 17:51:10 INFO: Checking RBAC database integrity...
2024/04/04 17:51:10 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2024/04/04 17:51:10 INFO: RBAC database integrity check finished successfully
2024/04/04 17:51:12 INFO: Listening on 0.0.0.0:55000.
2024/04/04 17:51:12 INFO: Getting installation UID...
2024/04/04 17:51:12 INFO: Getting updates information...
2024/04/04 17:51:14 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:51:18 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:51:22 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:51:25 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:51:28 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:51:38 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:51:47 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:51:51 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:52:05 INFO: unknown_user 172.18.0.1 "GET /" with parameters {} and body {} done in 0.001s: 401
2024/04/04 17:52:13 INFO: wazuh 172.18.0.1 "POST /security/user/authenticate" with parameters {} and body {} done in 0.161s: 200
2024/04/04 17:52:23 INFO: wazuh 172.18.0.1 "GET /" with parameters {} and body {} done in 1.405s: 200
```

</details>

> Failed checks are related to the epic branch