### PR TITLE
Fix offset update condition

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -161,13 +161,15 @@ public:
                     jsonPointer);
                 // LCOV_EXCL_STOP
 
-                // If the module is stopped, we do not commit the transaction and update the offset,
-                // so that the next time the module is started, it will start from the last offset committed.
+                // Update the offset in the database after processing the file.
+                // If the module is stopped, we update the offset in the last processed element.
+                // So that the next time the module is started, it will start from the last processed element.
+                contentManagerUpdateOffset(topicName, currentOffset);
+
                 if (m_shouldStop.load())
                 {
                     break;
                 }
-                contentManagerUpdateOffset(topicName, currentOffset);
             }
         }
         else if (parsedMessage.at("type") == "raw")


### PR DESCRIPTION
|Related issue|
|---|
|Closes #22835|

## Description
This pr aims to fix a problem during the feed update when the modulesd process is updated.
We need to update the offset before close the process to recover from the last point updated.
