### PR TITLE
Enable wazuh-modulesd debugging in AIT

### DIFF
--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable debug mode for the modulesd daemon
+echo 'wazuh_modules.debug=2' >> /var/ossec/etc/local_internal_options.conf
+
 # Apply API configuration
 cp -rf /tmp_volume/config/* /var/ossec/ && chown -R wazuh:wazuh /var/ossec/api
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1578,313 +1578,6 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /cluster/{node_id}/logs
-
-marks:
-  - cluster
-  - parametrize:
-      key: node_id
-      vals:
-        - master-node
-        - worker1
-        - worker2
-
-stages:
-
-  - name: Read logs {node_id}
-    request: &get_cluster_logs
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> limit=3 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 3
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - &cluster_log
-              description: !anystr
-              level: !anystr
-              tag: !anystr
-              timestamp: !anystr
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> limit=4 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 4
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-            - <<: *cluster_log
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> limit=2, sort=tag {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 2
-        sort: tag
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "tag"
-      status_code: 200
-
-  - name: Read logs with filters -> limit=1, sort=-level {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 1
-        sort: -level
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "level"
-            reverse: true
-      status_code: 200
-
-  - name: Read logs with filters -> offset=2, limit=3 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 3
-        offset: 2
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> offset=5, limit=2 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 2
-        offset: 5
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> tag=wazuh-analysisd, limit=1 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        tag: wazuh-analysisd
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> tag=wazuh-syscheckd, limit=2 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        tag: wazuh-syscheckd
-        limit: 2
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-              tag: wazuh-syscheckd
-            - <<: *cluster_log
-              tag: wazuh-syscheckd
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> tag=wazuh-unknown-daemon {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        tag: wazuh-unknown-daemon
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: []
-          failed_items: []
-          total_affected_items: 0
-          total_failed_items: 0
-
-  - name: Read logs with filters -> level=info, limit=1 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        level: info
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-              level: info
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters by query (tag=wazuh-syscheckd, level=info) {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        q: tag=wazuh-syscheckd;level=info
-    response:
-      status_code: 200
-      verify_response_with:
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "tag"
-            expected_values: "wazuh-syscheckd"
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "level"
-            expected_values: "info"
-
-  - name: Read logs using valid select
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        select: 'timestamp,tag'
-    response:
-      verify_response_with:
-        # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items
-        extra_kwargs:
-          select_key: 'timestamp,tag'
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Try to read logs using invalid select
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        select: 'noexists'
-    response:
-      status_code: 400
-      json: &invalid_select
-        error: 1724
-
-  - name: Get distinct cluster node logs
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        distinct: true
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tavern_utils:test_distinct_key
-
----
-test_name: GET /cluster/{node_id}/logs/summary
-
-marks:
-  - cluster
-  - parametrize:
-      key: node_id
-      vals:
-        - worker1
-        - worker2
-
-stages:
-
-  - name: Read logs summary {node_id}
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-        message: !anystr
-
----
 test_name: GET /cluster/{node_id}/daemons/stats
 
 marks:
@@ -2275,6 +1968,313 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
+
+---
+test_name: GET /cluster/{node_id}/logs
+
+marks:
+  - cluster
+  - parametrize:
+      key: node_id
+      vals:
+        - master-node
+        - worker1
+        - worker2
+
+stages:
+
+  - name: Read logs {node_id}
+    request: &get_cluster_logs
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> limit=3 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 3
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - &cluster_log
+              description: !anystr
+              level: !anystr
+              tag: !anystr
+              timestamp: !anystr
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> limit=4 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 4
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+            - <<: *cluster_log
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> limit=2, sort=tag {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 2
+        sort: tag
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "tag"
+      status_code: 200
+
+  - name: Read logs with filters -> limit=1, sort=-level {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 1
+        sort: -level
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "level"
+            reverse: true
+      status_code: 200
+
+  - name: Read logs with filters -> offset=2, limit=3 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 3
+        offset: 2
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> offset=5, limit=2 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 2
+        offset: 5
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> tag=wazuh-analysisd, limit=1 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        tag: wazuh-analysisd
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> tag=wazuh-modulesd, limit=2 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        tag: wazuh-modulesd
+        limit: 2
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+              tag: wazuh-modulesd
+            - <<: *cluster_log
+              tag: wazuh-modulesd
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> tag=wazuh-unknown-daemon {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        tag: wazuh-unknown-daemon
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Read logs with filters -> level=info, limit=1 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        level: info
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+              level: info
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters by query (tag=sca, level=info) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        q: tag=sca;level=info
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "tag"
+            expected_values: "sca"
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "level"
+            expected_values: "info"
+
+  - name: Read logs using valid select
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        select: 'timestamp,tag'
+    response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'timestamp,tag'
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Try to read logs using invalid select
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        select: 'noexists'
+    response:
+      status_code: 400
+      json: &invalid_select
+        error: 1724
+
+  - name: Get distinct cluster node logs
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
+---
+test_name: GET /cluster/{node_id}/logs/summary
+
+marks:
+  - cluster
+  - parametrize:
+      key: node_id
+      vals:
+        - worker1
+        - worker2
+
+stages:
+
+  - name: Read logs summary {node_id}
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr
 
 ---
 test_name: PUT /cluster/restart

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -582,303 +582,6 @@ stages:
             total_failed_items: 0
 
 ---
-test_name: GET /manager/logs
-
-stages:
-
-  # GET /manager/logs
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items: !anything
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> limit=4
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 4
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - &manager_log
-                description: !anystr
-                level: !anystr
-                tag: !anystr
-                timestamp: !anystr
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> limit=2, sort=-level
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: -level
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "level"
-            reverse: true
-      status_code: 200
-
-  # GET /manager/logs
-  - name: Filters -> offset=3, limit=3
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 3
-        offset: 3
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> offset=3, level=info, limit=4
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 4
-        offset: 3
-        level: info
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> tag=wazuh-analysisd, limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        tag: wazuh-analysisd
-        limit: 1
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> tag=wazuh-syscheckd, limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        tag: wazuh-syscheckd
-        limit: 1
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  - name: Filters by query (tag=wazuh-syscheckd, level=info)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: tag=wazuh-syscheckd;level=info
-    response:
-      status_code: 200
-      verify_response_with:
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "tag"
-            expected_values: "wazuh-syscheckd"
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "level"
-            expected_values: "info"
-
-  - name: Filters by query (timestamp<2021-07-01)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: timestamp<2021-07-01
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: []
-          failed_items: []
-          total_affected_items: 0
-          total_failed_items: 0
-
-  - name: Filter by non-existent tag
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        tag: wazuh-unknown-daemon
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: []
-          failed_items: []
-          total_affected_items: 0
-          total_failed_items: 0
-
-  - name: Read logs using valid select
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        select: 'timestamp,tag'
-    response:
-      verify_response_with:
-        # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items
-        extra_kwargs:
-          select_key: 'timestamp,tag'
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Try to read logs using invalid select
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        select: 'noexists'
-    response:
-      status_code: 400
-      json: &invalid_select
-        error: 1724
-
-  - name: Get distinct manager logs
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        distinct: true
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tavern_utils:test_distinct_key
-
----
-test_name: GET /manager/logs/summary
-
-stages:
-
-  # GET /manager/logs/summary
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
----
 test_name: GET /manager/api/config
 
 stages:
@@ -1799,6 +1502,303 @@ stages:
       status_code: 500
       json:
         error: 2100
+
+---
+test_name: GET /manager/logs
+
+stages:
+
+  # GET /manager/logs
+  - name: Request
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items: !anything
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> limit=4
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 4
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - &manager_log
+                description: !anystr
+                level: !anystr
+                tag: !anystr
+                timestamp: !anystr
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> limit=2, sort=-level
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2
+        sort: -level
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "level"
+            reverse: true
+      status_code: 200
+
+  # GET /manager/logs
+  - name: Filters -> offset=3, limit=3
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 3
+        offset: 3
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> offset=3, level=debug, limit=4
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 4
+        offset: 3
+        level: debug
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> tag=wazuh-modulesd, limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        tag: wazuh-modulesd
+        limit: 1
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> tag=wazuh-analysisd, limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        tag: wazuh-analysisd
+        limit: 1
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  - name: Filters by query (tag=wazuh-modulesd, level=debug)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        q: tag=wazuh-modulesd;level=debug
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "tag"
+            expected_values: "wazuh-modulesd"
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "level"
+            expected_values: "debug"
+
+  - name: Filters by query (timestamp<2021-07-01)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        q: timestamp<2021-07-01
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Filter by non-existent tag
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        tag: wazuh-unknown-daemon
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Read logs using valid select
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: 'timestamp,tag'
+    response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'timestamp,tag'
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Try to read logs using invalid select
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: 'noexists'
+    response:
+      status_code: 400
+      json: &invalid_select
+        error: 1724
+
+  - name: Get distinct manager logs
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
+---
+test_name: GET /manager/logs/summary
+
+stages:
+
+  # GET /manager/logs/summary
+  - name: Request
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
 
 ---
 test_name: PUT /manager/restart


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/22842 |

## Description

Sets `wazuh-modulesd.debug=2` in the local internal options configuration of the cluster nodes in the API integration tests environment.

## Logs/Alerts example

<details><summary>ossec.log</summary>

```console
root@wazuh-master:/# cat /var/ossec/logs/ossec.log | grep wazuh-modulesd | head -n 20
2024/04/09 13:12:54 wazuh-modulesd[69] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/04/09 13:12:54 wazuh-modulesd[69] main.c:77 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/04/09 13:12:54 wazuh-modulesd[69] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2024/04/09 13:12:54 wazuh-modulesd[69] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2024/04/09 13:12:54 wazuh-modulesd:router[69] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2024/04/09 13:12:54 wazuh-modulesd:content_manager[69] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2024/04/09 13:13:04 wazuh-modulesd[628] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/04/09 13:13:04 wazuh-modulesd[628] main.c:77 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/04/09 13:13:04 wazuh-modulesd[628] wmodules-osquery-monitor.c:78 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2024/04/09 13:13:04 wazuh-modulesd[628] wmodules-osquery-monitor.c:84 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2024/04/09 13:13:04 wazuh-modulesd:router[628] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2024/04/09 13:13:04 wazuh-modulesd:content_manager[628] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2024/04/09 13:13:04 wazuh-modulesd[628] main.c:87 at main(): INFO: Started (pid: 630).
2024/04/09 13:13:04 wazuh-modulesd[628] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2024/04/09 13:13:04 wazuh-modulesd[628] main.c:95 at main(): DEBUG: Created new thread for the 'agent-upgrade' module.
2024/04/09 13:13:04 wazuh-modulesd[628] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2024/04/09 13:13:04 wazuh-modulesd:agent-upgrade[628] wm_agent_upgrade_manager.c:69 at wm_agent_upgrade_start_manager_module(): INFO: (8153): Module Agent Upgrade started.
2024/04/09 13:13:04 wazuh-modulesd[628] main.c:95 at main(): DEBUG: Created new thread for the 'task-manager' module.
2024/04/09 13:13:04 wazuh-modulesd[628] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2024/04/09 13:13:04 wazuh-modulesd[628] main.c:95 at main(): DEBUG: Created new thread for the 'cis-cat' module.
```

</details>

## Tests

<details><summary>test_manager_endpoints.tavern.yaml</summary>

```console
(venv10) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest --nobuild -vv test_manager_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 36 items                                                                                                                                              

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                            [  2%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                              [  5%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                   [  8%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                     [ 11%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                  [ 13%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                  [ 16%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                  [ 19%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                   [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                  [ 27%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                   [ 30%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                [ 33%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                  [ 36%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                      [ 38%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                 [ 41%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                             [ 44%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detection] PASSED                                                  [ 47%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[indexer] PASSED                                                                  [ 50%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                     [ 52%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                     [ 55%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                             [ 58%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                      [ 61%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                      [ 63%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                   [ 66%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                     [ 69%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                        [ 72%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                     [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                   [ 77%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                         [ 80%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                     [ 83%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check PASSED                                                                                     [ 86%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update_check disabled PASSED                                                          [ 89%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update check service error PASSED                                                     [ 92%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                              [ 94%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                      [ 97%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                           [100%]

======================================================================= warnings summary ========================================================================
../../../../../.local/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/gasti/.local/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_manager_endpoints.tavern.yaml: 36 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 36 passed, 37 warnings in 338.25s (0:05:38) ==========================================================
```

</details>

<details><summary>test_cluster_endpoints.tavern.yaml</summary>

```console
(venv10) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest --nobuild -vv test_cluster_endpoints.tavern.yaml
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.0.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'aiohttp': '1.0.4', 'metadata': '3.0.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, html-2.1.1, aiohttp-1.0.4, metadata-3.0.0
asyncio: mode=auto
collected 49 items                                                                                                                                              

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                      [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                       [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                                           [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                        [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                             [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                    [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                    [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                  [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                             [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                            [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                           [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                          [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                        [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                               [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                       [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                           [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                           [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                                                              [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                                                  [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                                                  [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                      [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                          [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                          [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                  [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                            [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                               [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                   [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                   [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                              [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                  [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                  [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                               [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                   [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                   [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                     [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                         [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                         [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                       [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                           [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                           [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                   [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                   [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                           [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                           [100%]

======================================================================= warnings summary ========================================================================
../../../../../.local/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/gasti/.local/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_cluster_endpoints.tavern.yaml: 49 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 49 passed, 50 warnings in 563.12s (0:09:23) ==========================================================
```

</details>