### PR TITLE
Debian packages generation and debug symbols, migration

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/control
+++ b/packages/debs/SPECS/wazuh-agent/debian/control
@@ -12,3 +12,10 @@ Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
 Conflicts: ossec-hids-agent, wazuh-manager, ossec-hids, wazuh-api
 Breaks: ossec-hids-agent, wazuh-manager, ossec-hids
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-agent-dbg
+Section: debug
+Priority: optional
+Architecture: any
+Depends: wazuh-agent
+Description: Debug symbols for wazuh-agent, this package contains debug symbols for debugging wazuh-agent.

--- a/packages/debs/SPECS/wazuh-agent/debian/rules
+++ b/packages/debs/SPECS/wazuh-agent/debian/rules
@@ -156,6 +156,6 @@ override_dh_auto_clean:
 
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym
+	dh_strip --no-automatic-dbgsym --dbg-package=wazuh-agent-dbg
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure

--- a/packages/debs/SPECS/wazuh-manager/debian/control
+++ b/packages/debs/SPECS/wazuh-manager/debian/control
@@ -13,3 +13,10 @@ Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api
 Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+Package: wazuh-manager-dbg
+Section: debug
+Priority: optional
+Architecture: any
+Depends: wazuh-manager
+Description: Debug symbols for wazuh-manager, this package contains debug symbols for debugging wazuh-manager.

--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -240,6 +240,6 @@ override_dh_auto_clean:
 	$(MAKE) -C src clean
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym --exclude=dh_strip --no-automatic-dbgsym --exclude=${PKG_DIR}${INSTALLATION_DIR}/framework/python
+	dh_strip --dbg-package=wazuh-manager-dbg --no-automatic-dbgsym --exclude=dh_strip --no-automatic-dbgsym --exclude=${PKG_DIR}${INSTALLATION_DIR}/framework/python
 
 .PHONY: override_dh_install override_dh_strip override_dh_auto_clean override_dh_auto_build override_dh_auto_configure override_dh_fixperms

--- a/packages/debs/utils/helper_function.sh
+++ b/packages/debs/utils/helper_function.sh
@@ -62,21 +62,26 @@ get_checksum(){
     wazuh_version="$1"
     short_commit_hash="$2"
     base_name="wazuh-${BUILD_TARGET}_${wazuh_version}-${REVISION}"
+    symbols_base_name="wazuh-${BUILD_TARGET}-dbg_${wazuh_version}-${REVISION}"
 
     if [[ "${ARCHITECTURE_TARGET}" == "ppc64le" ]]; then
         deb_file="${base_name}_ppc64el.deb"
+        symbols_deb_file="${symbols_base_name}_ppc64el.deb"
     else
         deb_file="${base_name}_${ARCHITECTURE_TARGET}.deb"
+        symbols_deb_file="${symbols_base_name}_${ARCHITECTURE_TARGET}.deb"
     fi
 
     if [[ "${IS_STAGE}" == "no" ]]; then
         deb_file="$(sed "s/\.deb/_${short_commit_hash}&/" <<< "$deb_file")"
+        symbols_deb_file="$(sed "s/\.deb/_${short_commit_hash}&/" <<< "$symbols_deb_file")"
     fi
 
     pkg_path="${build_dir}/${BUILD_TARGET}"
     if [[ "${checksum}" == "yes" ]]; then
         cd ${pkg_path} && sha512sum wazuh-${BUILD_TARGET}*deb > /var/local/wazuh/${deb_file}.sha512
+        cd ${pkg_path} && sha512sum ${symbols_deb_file} > /var/local/checksum/${symbols_deb_file}.sha512
     fi
 
-    find ${pkg_path} -type f -name "wazuh-${BUILD_TARGET}*deb" -exec mv {} /var/local/wazuh/${deb_file} \;
+    find ${pkg_path} -type f -name "wazuh-${BUILD_TARGET}*deb" -exec mv {} /var/local/wazuh/ \;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#22382|

## Description
Migrate changes of debug symbols, made on `wazu-packages` repo
The related changes were made in https://github.com/wazuh/wazuh-packages/pull/2875

## Tests
```shell
[+] Building 4.0s (14/14) FINISHED                  
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.6s
 => => transferring dockerfile: 2.17kB                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.7s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/debian:7                                                                                                                                                   1.8s
 => [1/9] FROM docker.io/library/debian:7@sha256:2259b099d947443e44bbd1c94967c785361af8fd22df48a08a3942e2d5630849                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                             0.2s
 => => transferring context: 8.06kB                                                                                                                                                                           0.0s
 => CACHED [2/9] RUN echo "deb http://archive.debian.org/debian/ wheezy contrib main non-free" > /etc/apt/sources.list &&     echo "deb-src http://archive.debian.org/debian/ wheezy contrib main non-free"   0.0s
 => CACHED [3/9] RUN apt-get update && apt-get build-dep python3.2 -y --force-yes                                                                                                                             0.0s
 => CACHED [4/9] RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz &&     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ &&     ./contrib/download_prerequisites &&     ./configure --prefix=/us  0.0s
 => CACHED [5/9] RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz &&     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 &&     ./bootstrap --no-system-curl CXX=/usr/local/gcc-9.4.0/  0.0s
 => CACHED [6/9] ADD build.sh /usr/local/bin/build_package                                                                                                                                                    0.0s
 => CACHED [7/9] RUN chmod +x /usr/local/bin/build_package                                                                                                                                                    0.0s
 => CACHED [8/9] ADD helper_function.sh /usr/local/bin/helper_function.sh                                                                                                                                     0.0s
 => CACHED [9/9] ADD gen_permissions.sh /tmp/gen_permissions.sh                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                        0.1s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:4a5361f58433f2253aec8bcb8cbf088cab7accec19318cb6c3e0bdf4aa3555f3                                                                                                                  0.1s
 => => naming to docker.io/library/pkg_deb_agent_builder_amd64:latest                                                                                                                                         0.1s
. . .
Finished running lintian.                                                                                                                                                                                          
                                                                                                                                                                                                                   
WARNING generated by debuild:                                                                                                                                                                                      
Making debian/rules executable!                                                                                                                                                                                    
                                                                                                                                                                                                                   
+ get_checksum 4.9.0 b5cb5ac no
+ wazuh_version=4.9.0
+ short_commit_hash=b5cb5ac
+ base_name=wazuh-agent_4.9.0-0
+ symbols_base_name=wazuh-agent-dbg_4.9.0-0
+ [[ amd64 == \p\p\c\6\4\l\e ]]
+ deb_file=wazuh-agent_4.9.0-0_amd64.deb
+ symbols_deb_file=wazuh-agent-dbg_4.9.0-0_amd64.deb 
+ [[ no == \n\o ]]
++ sed 's/\.deb/_b5cb5ac&/'
+ deb_file=wazuh-agent_4.9.0-0_amd64_b5cb5ac.deb
++ sed 's/\.deb/_b5cb5ac&/'
+ symbols_deb_file=wazuh-agent-dbg_4.9.0-0_amd64_b5cb5ac.deb
+ pkg_path=/build_wazuh/agent
+ [[ no == \y\e\s ]]
+ find /build_wazuh/agent -type f -name 'wazuh-agent*deb' -exec mv '{}' /var/local/wazuh/ ';'
Package wazuh-agent_4.9.0-0_amd64.deb added to /tmp/wazuh/packages/output/.
``` 
generated files
```shell
$ ls -1 output/
wazuh-agent-dbg_4.9.0-0_amd64.deb
wazuh-agent_4.9.0-0_amd64.deb
``` 
- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X