### PR TITLE
feat: SQLite synchronization mode validate

### DIFF
--- a/tests/integration/test_wazuh_db/test_databases/data/test_cases/cases_agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/test_databases/data/test_cases/cases_agent_messages.yaml
@@ -803,7 +803,15 @@
       output: 'ok []'
       stage: "agent sync_info set synced"
     - input: 'agent 003 package get'
-      output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
-              'due {"name":"test_rpm_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}',
-              'ok {"status":"SUCCESS"}']
+      output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","format":"deb","item_id":"1"}', 'due {"name":"test_rpm_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","format":"rpm","item_id":"1"}', 'ok {"status":"SUCCESS"}']
       stage: "agent sys_programs getting not all packages"
+
+- name: Synchronization value
+  description: Check agent db synchronization value
+  configuration_parameters:
+  metadata:
+    test_case:
+    - input: agent 003 sql PRAGMA synchronous
+      output: ok [{"synchronous":2}]
+      stage: agent sync type
+      use_regex: "no"

--- a/tests/integration/test_wazuh_db/test_databases/data/test_cases/cases_global_messages.yaml
+++ b/tests/integration/test_wazuh_db/test_databases/data/test_cases/cases_global_messages.yaml
@@ -354,3 +354,13 @@
       output: ok [{"id":0,*,"last_keepalive":253402300799,"group_sync_status":"synced","sync_status":"synced","connection_status":"active","disconnection_time":0,"group_config_status":"synced","status_code":0}]
       stage: global manager get-agent-info success post update without IP
       use_regex: "yes"
+
+- name: Synchronization value
+  description: Check global db synchronization value
+  configuration_parameters:
+  metadata:
+    test_case:
+    - input: global sql PRAGMA synchronous
+      output: ok [{"synchronous":2}]
+      stage: global sync type
+      use_regex: "no"

--- a/tests/integration/test_wazuh_db/test_databases/data/test_cases/cases_tasks_messages.yaml
+++ b/tests/integration/test_wazuh_db/test_databases/data/test_cases/cases_tasks_messages.yaml
@@ -1,0 +1,9 @@
+- name: Synchronization value
+  description: Check tasks db synchronization value
+  configuration_parameters:
+  metadata:
+    test_case:
+    - input: task sql PRAGMA synchronous
+      output: ok [{"synchronous":2}]
+      stage: tasks db sync type
+      use_regex: "no"

--- a/tests/integration/test_wazuh_db/test_databases/test_agent_database_version.py
+++ b/tests/integration/test_wazuh_db/test_databases/test_agent_database_version.py
@@ -62,7 +62,7 @@ from wazuh_testing.tools.simulators import agent_simulator as ag
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
 # Variables
-expected_database_version = '13'
+expected_database_version = '14'
 
 # Test daemons to restart.
 daemons_handler_configuration = {'all_daemons': True}


### PR DESCRIPTION
|Related issue|
|---|
|#22864|

## Description

The synchronization mode in which the global db is at the moment of being opened must be validated.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
- [X] QA templates contemplate the added capabilities