### PR TITLE
RPM packages generation and debug symbols, migration

### DIFF
--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -1,9 +1,4 @@
-%if %{_debugenabled} == yes
-  %global _enable_debug_package 0
-  %global debug_package %{nil}
-  %global __os_install_post %{nil}
-  %define __strip /bin/true
-%endif
+%define _debugenabled yes
 
 %if %{_isstage} == no
   %define _rpmfilename %%{NAME}_%%{VERSION}-%%{RELEASE}_%%{ARCH}_%{_hashcommit}.rpm
@@ -40,6 +35,13 @@ ExclusiveOS: linux
 Wazuh helps you to gain security visibility into your infrastructure by monitoring
 hosts at an operating system and application level. It provides the following capabilities:
 log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+
+# Build debuginfo package
+%debug_package
+%package wazuh-agent-debuginfo
+Summary: Debug information for package %{name}.
+%description wazuh-agent-debuginfo
+This package provides debug information for package %{name}.
 
 %prep
 %setup -q
@@ -197,6 +199,8 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 # Add installation scripts
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/src/
+
+%{_rpmconfigdir}/find-debuginfo.sh
 
 exit 0
 

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -1,9 +1,4 @@
-%if %{_debugenabled} == yes
-  %global _enable_debug_package 0
-  %global debug_package %{nil}
-  %global __os_install_post %{nil}
-  %define __strip /bin/true
-%endif
+%define _debugenabled yes
 
 %if %{_isstage} == no
   %define _rpmfilename %%{NAME}_%%{VERSION}-%%{RELEASE}_%%{ARCH}_%{_hashcommit}.rpm
@@ -44,6 +39,13 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 # Don't generate build_id links to prevent conflicts with other
 # packages.
 %global _build_id_links none
+
+# Build debuginfo package
+%debug_package
+%package wazuh-manager-debuginfo
+Summary: Debug information for package %{name}.
+%description wazuh-manager-debuginfo
+This package provides debug information for package %{name}.
 
 %prep
 %setup -q
@@ -194,6 +196,8 @@ install -m 0640 src/init/*.sh ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/
 # Add installation scripts
 cp src/VERSION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
 cp src/REVISION ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/manager_installation_scripts/src/
+
+%{_rpmconfigdir}/find-debuginfo.sh
 
 exit 0
 


### PR DESCRIPTION
|Related issue|
|---|
|#22382|

## Description
Migrate changes of debug symbols, made on `wazu-packages` repo
The related changes were made in https://github.com/wazuh/wazuh-packages/issues/2866

## Tests

- To run the generation of rpm agent packages use the command: `sudo ./generate_package.sh -b enhancement/22382-rpm-debug-symbols -t agent --system rpm` in the directory `/wazuh/packages`

```shell
Provides: wazuh-agent-debuginfo = 4.9.0-0 wazuh-agent-debuginfo(x86-64) = 4.9.0-0
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/local/lib/rpm/check-files /build_wazuh/rpmbuild/BUILDROOT/wazuh-agent-4.9.0-0.x86_64
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-agent-4.9.0-0.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-agent_4.9.0-0_x86_64_1d5a38b.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-agent-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm
Executing(%clean): /bin/sh -e /usr/local/var/tmp/rpm-tmp.DCQqQR
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-agent-4.9.0
+ rm -fr /build_wazuh/rpmbuild/BUILDROOT/wazuh-agent-4.9.0-0.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
+ return 0
+ get_checksum 4.9.0 1d5a38b no
+ src=no
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ mv /build_wazuh/rpmbuild/RPMS/wazuh-agent-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm /build_wazuh/rpmbuild/RPMS/wazuh-agent_4.9.0-0_x86_64_1d5a38b.rpm /var/local/wazuh
++ tail -n 1
++ ls -Art /home/leo/Desktop/debug_symbols/prueba_Jose/wazuh/packages/output/
+ echo 'Package wazuh-agent-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm added to /home/leo/Desktop/debug_symbols/prueba_Jose/wazuh/packages/output/.'
Package wazuh-agent-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm added to /home/leo/Desktop/debug_symbols/prueba_Jose/wazuh/packages/output/.
+ return 0
+ return 0
+ clean 0
+ exit_code=0
+ find /home/leo/Desktop/debug_symbols/prueba_Jose/wazuh/packages/rpms/amd64/agent '(' -name '*.sh' -o -name '*.tar.gz' -o -name 'wazuh-*' ')' '!' -name docker_builder.sh -exec rm -rf '{}' +
+ exit 0
``` 
generated files
```shell
ls output/
wazuh-agent_4.9.0-0_x86_64_1d5a38b.rpm  wazuh-agent-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm 
``` 
- To run the generation of rpm managerpackages use the command: `sudo ./generate_package.sh -b enhancement/22382-rpm-debug-symbols -t manager --system rpm` in the directory `/wazuh/packages`

```shell
Provides: wazuh-manager = 4.9.0-0 wazuh-manager(x86-64) = 4.9.0-0
Requires(interp): /bin/sh /bin/sh /bin/sh /bin/sh /bin/sh /bin/sh
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires(pre): /bin/sh /usr/sbin/groupadd /usr/sbin/useradd
Requires(post): /bin/sh
Requires(preun): /bin/sh
Requires(postun): /bin/sh /usr/sbin/groupdel /usr/sbin/userdel
Requires(posttrans): /bin/sh
Conflicts: ossec-hids ossec-hids-agent wazuh-agent wazuh-local
Obsoletes: wazuh-api < 4.0.0
Processing files: wazuh-manager-debuginfo-4.9.0-0.x86_64
Provides: wazuh-manager-debuginfo = 4.9.0-0 wazuh-manager-debuginfo(x86-64) = 4.9.0-0
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/local/lib/rpm/check-files /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-4.9.0-0.x86_64
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-manager-4.9.0-0.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-manager-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-manager_4.9.0-0_x86_64_1d5a38b.rpm
Executing(%clean): /bin/sh -e /usr/local/var/tmp/rpm-tmp.eaPCHO
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-manager-4.9.0
+ rm -fr /build_wazuh/rpmbuild/BUILDROOT/wazuh-manager-4.9.0-0.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
+ return 0
+ get_checksum 4.9.0 1d5a38b no
+ src=no
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ mv /build_wazuh/rpmbuild/RPMS/wazuh-manager-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm /build_wazuh/rpmbuild/RPMS/wazuh-manager_4.9.0-0_x86_64_1d5a38b.rpm /var/local/wazuh
++ ls -Art /home/vagrant/wazuh/packages/output/
++ tail -n 1
+ echo 'Package wazuh-manager_4.9.0-0_x86_64_1d5a38b.rpm added to /home/vagrant/wazuh/packages/output/.'
Package wazuh-manager_4.9.0-0_x86_64_1d5a38b.rpm added to /home/vagrant/wazuh/packages/output/.
+ return 0
+ return 0
+ clean 0
+ exit_code=0
+ find /home/vagrant/wazuh/packages/rpms/amd64/manager '(' -name '*.sh' -o -name '*.tar.gz' -o -name 'wazuh-*' ')' '!' -name docker_builder.sh -exec rm -rf '{}' +
+ exit 0
``` 
generated files
```shell
ls output/
wazuh-manager-debuginfo_4.9.0-0_x86_64_1d5a38b.rpm  wazuh-manager_4.9.0-0_x86_64_1d5a38b.rpm
``` 

- Compilation without warnings in every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X