### PR TITLE
Extract debug info from executables.

### DIFF
--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -79,8 +79,42 @@ function BuildWazuhMsi(){
     }
 }
 
+function ExtractDebugSymbols(){
+	
+	#all executables in current folder
+	$exeFiles = Get-ChildItem -Filter "*.exe"
+	$exeFiles += Get-ChildItem -Filter "*.dll" 
+
+	#all executables in parent folder
+	cd .. #Get-ChildItem does not take "..\" so we have to do it manually
+	$exeFiles += Get-ChildItem -Filter "*.dll"
+	
+	#plus a few more individual libraries
+	$exeFiles +=  Get-ChildItem -Filter "data_provider\build\bin\sysinfo.dll"
+	$exeFiles +=  Get-ChildItem -Filter "shared_modules\dbsync\build\bin\dbsync.dll"
+	$exeFiles +=  Get-ChildItem -Filter "shared_modules\rsync\build\bin\rsync.dll"
+	$exeFiles +=  Get-ChildItem -Filter "wazuh_modules\syscollector\build\bin\syscollector.dll"
+	$exeFiles +=  Get-ChildItem -Filter "syscheckd\build\bin\libfimdb.dll"
+	cd "win32"
+	
+	#now loop
+	foreach ($file in $exeFiles)
+	{
+		Write-Host "Extracting dbg symbols from" $file.FullName
+		$args = $file.FullName #source (exe/dll with debug symbols)
+		$args += " "
+		$args += $file.FullName  #destination (same as source - exe/dll is stripped of debug symbols)
+		$args += " "
+		$args += $file.BaseName
+		$args += ".pdb"
+
+		Start-Process -FilePath "cv2pdb.exe" -ArgumentList $args -Wait -WindowStyle Hidden
+	}
+}
+
 ############################
 # MAIN
 ############################
 
+ExtractDebugSymbols
 BuildWazuhMsi

--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -110,6 +110,13 @@ function ExtractDebugSymbols(){
 
 		Start-Process -FilePath "cv2pdb.exe" -ArgumentList $args -Wait -WindowStyle Hidden
 	}
+
+    #compress every pdb file in current folder
+	$pdbFiles = Get-ChildItem -Filter ".\*.pdb"
+	Write-Host "Compressing debug symbols to debug-symbols.zip"
+	Compress-Archive -Path $pdbFiles -Force -DestinationPath ".\debug-symbols.zip"
+
+	Remove-Item -Path "*.pdb"
 }
 
 ############################


### PR DESCRIPTION
## Related issue
Implement debug symbol generation during the build process for Windows. #https://github.com/wazuh/wazuh/issues/21733

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Modified generate_wazuh_msi.ps1 to scan for executable files and dlls and extract debug info from them using cv2pdb.
Compressed resulting pdbs into zip file.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
- Follow [Wazuh package generation guide](https://documentation.wazuh.com/current/development/packaging/generate-windows-package.html) until  you have obtained the zip with the compiled agent and copied it along with generate_wazuh_msi.ps1 script to the Windows host. 
- Make sure you have Visual Studio 2022 Community with the following components:
 
![image](https://github.com/wazuh/wazuh/assets/100874572/8638d874-c4d6-42c9-9e9c-1e3d256f5afc)

- Make sure you have a copy of cv2pdb.exe and add the folder in the PATH environment variable.
- Make sure you change the security policy to run Powershell scritps. To do this, open Powershell as Administrator and enter the command "Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Bypass -Force"
- Run the script in the Windows host.
- If you don't have Wix installed you will get an error indicating that candle.exe and light.exe are missing but by then the process of extracting the debug information from the executables should be completed. Check for debug-symbols.zip to be present in the folder where you ran the script (wazuh\wazuh-4.7.3\src\win32)
- Script output should look like this:
![image](https://github.com/wazuh/wazuh/assets/100874572/12c2ee8d-f7a5-4cc2-8afe-c12050742565)

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors