### PR TITLE
Fix AIT content type errors

### DIFF
--- a/api/api/error_handler.py
+++ b/api/api/error_handler.py
@@ -106,7 +106,7 @@ async def unauthorized_error_handler(request: ConnexionRequest,
             attempts=configuration.api_conf['access']['max_login_attempts']
         )
     else:
-        problem.update({'detail': 'No authorization token provided'} \
+        problem.update({'detail': exc.detail} \
                             if 'token_info' not in request.context \
                             else {})
     return json_response(data=problem, pretty=request.query_params.get('pretty', 'false') == 'true',
@@ -136,30 +136,6 @@ async def http_error_handler(request: ConnexionRequest,
     }
     return json_response(data=problem, pretty=request.query_params.get('pretty', 'false') == 'true',
                          status_code=exc.status_code, content_type=ERROR_CONTENT_TYPE)
-
-
-async def jwt_error_handler(request: ConnexionRequest, _: jwt.exceptions.PyJWTError) -> ConnexionResponse:
-    """JWTException Error handler.
-    
-    Parameters
-    ----------
-    request : ConnexionRequest
-        Incomming request.
-    _ : JWTError
-        Raised exception.
-        Unnamed parameter not used.
-
-    Returns
-    -------
-    Response
-        HTTP Response returned to the client.
-    """
-    problem = {
-        "title": "Unauthorized",
-        "detail": "No authorization token provided"
-    }
-    return json_response(data=problem, pretty=request.query_params.get('pretty', 'false') == 'true',
-                         status_code=401, content_type=ERROR_CONTENT_TYPE)
 
 
 async def problem_error_handler(request: ConnexionRequest, exc: exceptions.ProblemException) -> ConnexionResponse:

--- a/api/api/error_handler.py
+++ b/api/api/error_handler.py
@@ -113,33 +113,6 @@ async def unauthorized_error_handler(request: ConnexionRequest,
                          status_code=exc.status_code, content_type=ERROR_CONTENT_TYPE)
 
 
-async def bad_request_error_handler(request: ConnexionRequest,
-                                    exc: exceptions.BadRequestProblem) -> ConnexionResponse:
-    """Bad Request Exception Error handler.
-    
-    Parameters
-    ----------
-    request : ConnexionRequest
-        Incomming request.
-    exc : BadRequestProblem
-        Raised exception.
-
-    Returns
-    -------
-    Response
-        HTTP Response returned to the client.
-    """
-
-    problem = {
-        "title": 'Bad Request',
-    }
-    if exc.detail:
-        problem['detail'] = exc.detail
-
-    return json_response(data=problem, pretty=request.query_params.get('pretty', 'false') == 'true',
-                         status_code=exc.status_code, content_type=ERROR_CONTENT_TYPE)
-
-
 async def http_error_handler(request: ConnexionRequest,
                              exc: exceptions.HTTPException) -> ConnexionResponse:
     """HTTPError Exception Error handler.

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8784,6 +8784,15 @@ paths:
                       - type: object
                         description: "The output format depends on the type of file that has been requested: rootkit
                         file, rootkit trojans or rcl"
+            application/xml:
+              schema:
+                properties:
+                  data:
+                    oneOf:
+                      - type: array
+                      - type: object
+                        description: "The output format depends on the type of file that has been requested: rootkit
+                        file, rootkit trojans or rcl"
               example:
                 data:
                   vars: None
@@ -11876,6 +11885,14 @@ paths:
           description: "Wazuh configuration"
           content:
             application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ApiResponse'
+                - type: object
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/WazuhManagerConfiguration'
+            application/xml:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/ApiResponse'

--- a/api/api/test/test_error_handler.py
+++ b/api/api/test/test_error_handler.py
@@ -199,7 +199,7 @@ async def test_expect_failed_error_handler(query_param_pretty, expected_detail):
     response = await expect_failed_error_handler(request, ExpectFailedException(detail=expected_detail) if expected_detail else None)
     
     assert response.status_code == 417
-    assert response.content_type == "application/problem+json; charset=utf-8"
+    assert response.content_type == ERROR_CONTENT_TYPE
     
     body = json.loads(response.body)
     assert body["title"] == "Expectation failed"

--- a/api/api/test/test_error_handler.py
+++ b/api/api/test/test_error_handler.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 
 from connexion.exceptions import HTTPException, ProblemException, BadRequestProblem, Unauthorized
 from api.error_handler import _cleanup_detail_field, prevent_bruteforce_attack, jwt_error_handler, \
-    http_error_handler, problem_error_handler, bad_request_error_handler, unauthorized_error_handler, \
+    http_error_handler, problem_error_handler, unauthorized_error_handler, \
     expect_failed_error_handler, ERROR_CONTENT_TYPE
 from api.middlewares import LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT
 from api.api_exception import ExpectFailedException
@@ -185,23 +185,6 @@ async def test_problem_error_handler(title, detail, ext, error_type, mock_reques
     assert response.status_code == 400
     assert response.content_type == ERROR_CONTENT_TYPE
     assert body == problem
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize('detail', [None, 'detail'])
-async def test_bad_request_error_handler(detail, mock_request):
-    """Test bad request error handler."""
-    problem = {
-        "title": 'Bad Request',
-    }
-    problem.update({'detail': detail} if detail else {})
-
-    exc = BadRequestProblem(detail=detail)
-    response = await bad_request_error_handler(mock_request, exc)
-    body = json.loads(response.body)
-    assert body == problem
-    assert response.status_code == exc.status_code
-    assert response.content_type == ERROR_CONTENT_TYPE
 
 
 @pytest.mark.asyncio

--- a/api/scripts/wazuh-apid.py
+++ b/api/scripts/wazuh-apid.py
@@ -213,7 +213,6 @@ def start(params: dict):
 
     # Add error handlers to format exceptions
     app.add_error_handler(ExpectFailedException, error_handler.expect_failed_error_handler)
-    app.add_error_handler(jwt.exceptions.PyJWTError, error_handler.jwt_error_handler)
     app.add_error_handler(Unauthorized, error_handler.unauthorized_error_handler)
     app.add_error_handler(HTTPException, error_handler.http_error_handler)
     app.add_error_handler(ProblemException, error_handler.problem_error_handler)

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -974,47 +974,6 @@ stages:
           total_failed_items: 0
 
 ---
-test_name: GET /manager/validation (KO)
-
-stages:
-
-  #### Upload corrupted rules file
-  # PUT /rules/files
-  - name: Upload corrupted
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/rules/files/new-rules_corrupted.xml"
-      method: PUT
-      data: "{corrupted_rules_file}"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-        content-type: application/octet-stream
-    response:
-      status_code: 200
-
-  # GET /manager/configuration/validation
-  - name: Request validation
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration/validation"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 1
-        data:
-          affected_items: []
-          failed_items:
-            - error:
-                code: 1908
-              id:
-                - !anystr
-          total_affected_items: 0
-          total_failed_items: 1
-
----
 test_name: GET /manager/configuration/{component}/{configuration}
 
 stages:

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -95,6 +95,3 @@ Werkzeug==3.0.1
 xmltodict==0.12.0
 yarl==1.7.0
 zipp==3.3.2
-content_size_limit_asgi
-uvicorn==0.24.0.post1
-content_size_limit_asgi==0.1.5

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -95,3 +95,6 @@ Werkzeug==3.0.1
 xmltodict==0.12.0
 yarl==1.7.0
 zipp==3.3.2
+content_size_limit_asgi
+uvicorn==0.24.0.post1
+content_size_limit_asgi==0.1.5


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/22742 |

## Description

Updates the `/manager/configuration` specification, removes the special content type used for the errors and removes a wrong test case that was trying to upload an invalid file and was rejected by the API. 

## Tests

<details><summary>test_manager_endpoints.tavern.yaml</summary>

```console
(venv_connexion) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest --nobuild -vv test_manager_endpoints.tavern.yaml
======================================================= test session starts =======================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0 -- /home/gasti/work/wazuh/venv_connexion/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.4.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'metadata': '3.1.1', 'html': '2.1.1', 'anyio': '4.3.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, metadata-3.1.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 35 items                                                                                                                

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                              [  2%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                [  5%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                     [  8%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                       [ 11%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                    [ 14%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                    [ 17%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                    [ 20%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                     [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                  [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                    [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                     [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                  [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                    [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                        [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                   [ 42%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                               [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detection] PASSED                    [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[indexer] PASSED                                    [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                       [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                       [ 57%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                               [ 60%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                        [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                        [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                     [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                       [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                [ 74%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                        [ 77%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                          [ 80%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                       [ 82%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                           [ 85%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                       [ 88%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check PASSED                                                       [ 91%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update_check disabled PASSED                            [ 94%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update check service error PASSED                       [ 97%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                             [100%]

======================================================== warnings summary =========================================================
../../../venv_connexion/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/gasti/work/wazuh/venv_connexion/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_manager_endpoints.tavern.yaml: 35 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 35 passed, 36 warnings in 341.08s (0:05:41) ===========================================
```

</details>

<details><summary>Tests after removing <code>jwt_error_handler</code></summary>

```console
# Invalid tokens
gasti@pop-os:~/work/docs$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer asda"
{"title": "Unauthorized", "detail": "Invalid token"}

gasti@pop-os:~/work/docs$ curl -k -X GET "https://localhost:55050/"
{"title": "Unauthorized", "detail": "No authorization token provided"}

gasti@pop-os:~/work/docs$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer  "
{"title": "Unauthorized", "detail": "Invalid authorization header"}

gasti@pop-os:~/work/docs$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzEzMjgwNDU0LCJleHAiOjE3MTMyODEzNTQsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9"
{"title": "Unauthorized", "detail": "Invalid token"}

# Valid token
gasti@pop-os:~/work/docs$ curl -k -X GET "https://localhost:55050/" -H "Authorization: Bearer eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzEzMjgxNzkyLCJleHAiOjE3MTMyODI2OTIsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.AZj4OFUKZOK8msA3kMOyVSOeJYFKWPUvPclRep9LKv0e4YLzKUbOFrPIYeqImDlJbH6aXZqw-57CzjE9kjNNX7_xAVy_flbIWU7e7ypBd-_TR19r78H4EGfCckBBX2PBz9jJ8COhgHXQuTRy8JNGIaZ-irD9ElSGYKlBjI9mwqwqmZnY"
{"data": {"title": "Wazuh API REST", "api_version": "4.9.0", "revision": 40900, "license_name": "GPL 2.0", "license_url": "https://github.com/wazuh/wazuh/blob/v4.9.0/LICENSE", "hostname": "wazuh-master", "timestamp": "2024-04-16T15:36:45Z"}, "error": 0}
```


</details>