### PR TITLE
Fix agent PUT AIT groups file upload error code

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -287,7 +287,7 @@ stages:
     response:
       status_code: 400
       json:
-        error: 1112
+        error: 1912
 
     # PUT /groups/group1/configuration
   - name: Try to update configuration using an invalid configuration file


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/22743 |

## Description

Updates the expected error code to `1912`, which is the one thrown when there's an `AttributeError` in the request body [validation](https://github.com/wazuh/wazuh/blob/560e637606f52c93e5207ab48e20345421c175b1/api/api/controllers/agent_controller.py#L1286).

## Tests

<details><summary>test_agent_PUT_endpoints.tavern.yaml</summary>

```console
(venv_connexion) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest --nobuild -vv test_agent_PUT_endpoints.tavern.yaml
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0 -- /home/gasti/work/wazuh/venv_connexion/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.4.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'metadata': '3.1.1', 'html': '2.1.1', 'anyio': '4.3.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, metadata-3.1.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 10 items                                                             

test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group PASSED                                                            [ 10%]
test_agent_PUT_endpoints.tavern.yaml::PUT /groups/{group_id}/configuration PASSED                                         [ 20%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/group/{group_id}/restart PASSED                                         [ 30%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/reconnect PASSED                                                        [ 40%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/restart PASSED                                                          [ 50%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/group/{group_id} PASSED                                      [ 60%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/restart PASSED                                               [ 70%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/node/{node_id}/restart PASSED                                           [ 80%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade PASSED                                                          [ 90%]
test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom PASSED                                        [100%]

======================================================= warnings summary ========================================================
../../../venv_connexion/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/gasti/work/wazuh/venv_connexion/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_agent_PUT_endpoints.tavern.yaml: 10 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== 10 passed, 11 warnings in 638.08s (0:10:38) ==========================================
```

</details>

> Failed checks are not related to the changes introduced in this pull request.