### PR TITLE
Fix manager and agent SPECS to allow no stage nomenclature without overwrite _rpmfilename

### DIFF
--- a/packages/build.sh
+++ b/packages/build.sh
@@ -114,7 +114,7 @@ set_debug $debug $sources_dir
 # Installing build dependencies
 cd $sources_dir
 build_deps $legacy
-build_package $package_name $debug "$short_commit_hash"
+build_package $package_name $debug "$short_commit_hash" "$wazuh_version"
 
 # Post-processing
 get_checksum $wazuh_version $short_commit_hash $src

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -5,9 +5,15 @@
   %define __strip /bin/true
 %endif
 
+%if %{_isstage} == no
+  %define _rpmfilename %%{NAME}_%%{VERSION}-%%{RELEASE}_%%{ARCH}_%{_hashcommit}.rpm
+%else
+  %define _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm
+%endif
+
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-agent
-Version:     4.9.0
+Version:     %{_version}
 Release:     %{_release}
 License:     GPL
 Group:       System Environment/Daemons

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -5,9 +5,15 @@
   %define __strip /bin/true
 %endif
 
+%if %{_isstage} == no
+  %define _rpmfilename %%{NAME}_%%{VERSION}-%%{RELEASE}_%%{ARCH}_%{_hashcommit}.rpm
+%else
+  %define _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm
+%endif
+
 Summary:     Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
 Name:        wazuh-manager
-Version:     4.9.0
+Version:     %{_version}
 Release:     %{_release}
 License:     GPL
 Group:       System Environment/Daemons

--- a/packages/rpms/utils/helper_function.sh
+++ b/packages/rpms/utils/helper_function.sh
@@ -20,8 +20,6 @@ setup_build(){
     package_name="$4"
 
     rpm_build_dir=${build_dir}/rpmbuild
-    file_name="$package_name-${REVISION}"
-    src_file="${file_name}.src.rpm"
 
     mkdir -p ${rpm_build_dir}/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
@@ -58,6 +56,7 @@ build_package(){
     package_name="$1"
     debug="$2"
     short_commit_hash="$3"
+    wazuh_version="$4"
 
     if [ "${ARCHITECTURE_TARGET}" = "i386" ] || [ "${ARCHITECTURE_TARGET}" = "armhf" ]; then
         linux="linux32"
@@ -76,18 +75,10 @@ build_package(){
         return 1
     fi
 
-    if [[ "${IS_STAGE}" == "yes" ]]; then
-        rpm_file="${file_name}.${ARCH}.rpm"
-    else
-        # Replace "-" with "_" between BUILD_TARGET and Version
-        base_name="$(sed 's/-/_/2' <<< "$file_name")"
-        rpm_file="${base_name}_${ARCH}_${short_commit_hash}.rpm"
-    fi
-
     $linux $rpmbuild --define "_sysconfdir /etc" --define "_topdir ${rpm_build_dir}" \
-        --define "_threads ${JOBS}" --define "_release ${REVISION}" \
+        --define "_threads ${JOBS}" --define "_release ${REVISION}" --define "_isstage ${IS_STAGE}" \
         --define "_localstatedir ${INSTALLATION_PATH}" --define "_debugenabled ${debug}" \
-        --define "_rpmfilename ${rpm_file}" \
+        --define "_version ${wazuh_version}" --define "_hashcommit ${short_commit_hash}" \
         --target $ARCH -ba ${rpm_build_dir}/SPECS/${package_name}.spec
     return 0
 }
@@ -95,15 +86,15 @@ build_package(){
 get_checksum(){
     src="$3"
     if [[ "${checksum}" == "yes" ]]; then
-        cd "${rpm_build_dir}/RPMS" && sha512sum ${rpm_file} > /var/local/wazuh/${rpm_file}.sha512
+        cd "${rpm_build_dir}/RPMS" && sha512sum *.rpm > /var/local/wazuh/*.rpm.sha512
         if [[ "${src}" == "yes" ]]; then
-            cd "${rpm_build_dir}/SRPMS" && sha512sum ${src_file} > /var/local/wazuh/${src_file}.sha512
+            cd "${rpm_build_dir}/SRPMS" && sha512sum *.src.rpm > /var/local/wazuh/*.src.rpm.sha512
         fi
     fi
 
     if [[ "${src}" == "yes" ]]; then
-        mv ${rpm_build_dir}/SRPMS/${src_file} /var/local/wazuh
+        mv ${rpm_build_dir}/SRPMS/*.src.rpm /var/local/wazuh
     else
-        mv ${rpm_build_dir}/RPMS/${rpm_file} /var/local/wazuh
+        mv ${rpm_build_dir}/RPMS/*.rpm /var/local/wazuh
     fi
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22080|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we introduce some fixes to avoid overwriting the _rpmfilename macro, since we need to use the NAME variable of the specs for packages with debug symbols.
We have also included the parameterization of the package version value inside the SPECS.

### Testing logs
```
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-agent-4.9.0-test1.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-agent-4.9.0-test1.x86_64.rpm
Executing(%clean): /bin/sh -e /usr/local/var/tmp/rpm-tmp.pT9sAh
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-agent-4.9.0
+ rm -fr /build_wazuh/rpmbuild/BUILDROOT/wazuh-agent-4.9.0-test1.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
+ return 0
+ get_checksum 4.9.0 a165ffc no
+ src=no
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ mv /build_wazuh/rpmbuild/RPMS/wazuh-agent-4.9.0-test1.x86_64.rpm /var/local/wazuh
++ tail -n 1
++ ls -Art /tmp
+ echo 'Package wazuh-agent-4.9.0-test1.x86_64.rpm added to /tmp.'
Package wazuh-agent-4.9.0-test1.x86_64.rpm added to /tmp.
+ return 0
+ return 0
+ clean 0
+ exit_code=0
+ find /home/vagrant/wazuh/packages/rpms/amd64/agent '(' -name '*.sh' -o -name '*.tar.gz' -o -name 'wazuh-*' ')' '!' -name docker_builder.sh -exec rm -rf '{}' +
+ exit 0
```