### PR TITLE
Update unknown fields format

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5145,6 +5145,7 @@ components:
                 format: int32
               node_name:
                 type: string
+                format: alphanumeric_symbols
         groups:
           type: array
           description: "Recount of the number of Wazuh agents group by Wazuh groups"
@@ -5167,10 +5168,10 @@ components:
                     format: alphanumeric_symbols
                   platform:
                     type: string
-                    format: alphanumeric
+                    format: alphanumeric_symbols
                   version:
                     type: string
-                    format: alphanumeric
+                    format: alphanumeric_symbols
         agent_status:
           $ref: '#/components/schemas/AgentsSummaryStatus'
         agent_version:
@@ -5184,7 +5185,7 @@ components:
                 format: int32
               version:
                 type: string
-                format: alphanumeric
+                format: alphanumeric_symbols
         last_registered_agent:
           type: array
           items:


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/22744 |

## Description

Updates the format of the fields that can be `N/A` (alphanumeric_symbols).

## Tests

<details><summary>test_overview_endpoints.tavern.yaml</summary>

```console
(venv_connexion) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest --nobuild -vv test_overview_endpoints.tavern.yaml
================================================ test session starts =================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0 -- /home/gasti/work/wazuh/venv_connexion/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.4.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'metadata': '3.1.1', 'html': '2.1.1', 'anyio': '4.3.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, metadata-3.1.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 1 item                                                                                                     

test_overview_endpoints.tavern.yaml::GET /overview/agents PASSED                                                                                           [100%]

======================================================================== warnings summary ========================================================================
../../../venv_connexion/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/gasti/work/wazuh/venv_connexion/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_overview_endpoints.tavern.yaml::GET /overview/agents
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 1 passed, 2 warnings in 116.65s (0:01:56) ============================================================
```

</details>