### PR TITLE
Fix extract and strip macOS symbols

### DIFF
--- a/packages/macos/package_files/build.sh
+++ b/packages/macos/package_files/build.sh
@@ -13,6 +13,7 @@ SOURCES_PATH=$2
 BUILD_JOBS=$3
 DEBUG=$4
 INSTALLATION_SCRIPTS_DIR=${DESTINATION_PATH}/packages_files/agent_installation_scripts
+SEARCH_DIR=${SOURCES_PATH}/src
 
 function configure() {
     echo USER_LANGUAGE="en" > ${CONFIG}


### PR DESCRIPTION
|Related issue|
|---|
|#9913|

## Description

This PR fixes the error that is occurring in the generation of macOS packages:

<details>
<summary>Error</summary>

```
clang: error: unable to execute command: Segmentation fault: 11
clang: error: clang frontend command failed due to signal (use -v to see invocation)
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: x86_64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
clang: note: diagnostic msg:
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/sysInfoCommonBSD-241c71.cpp
clang: note: diagnostic msg: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/sysInfoCommonBSD-241c71.sh
clang: note: diagnostic msg: Crash backtrace is located in
clang: note: diagnostic msg: /Users/ec2-user/Library/Logs/DiagnosticReports/clang_<YYYY-MM-DD-HHMMSS>_<hostname>.crash
clang: note: diagnostic msg: (choose the .crash file that corresponds to your crash)
clang: note: diagnostic msg:

********************
make[4]: *** [CMakeFiles/sysinfo.dir/src/sysInfoCommonBSD.cpp.o] Error 1
make[3]: *** [CMakeFiles/sysinfo.dir/all] Error 2
make[2]: *** [all] Error 2
make[1]: *** [build_sysinfo] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 80%] Building CXX object testtool/CMakeFiles/dbsync_test_tool.dir/main.cpp.o
[ 90%] Linking CXX executable ../bin/dbsync_example
[ 90%] Built target dbsync_example
[100%] Linking CXX executable ../bin/dbsync_test_tool
[100%] Built target dbsync_test_tool
cd shared_modules/rsync/ && mkdir -p build && cd build && cmake     .. && /Library/Developer/CommandLineTools/usr/bin/make
-- The C compiler identification is AppleClang 15.0.0.15000100
-- The CXX compiler identification is AppleClang 15.0.0.15000100
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/ec2-user/prueba_leo/compilacion/wazuh/packages/macos/repository/wazuh/src/shared_modules/rsync/build
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsyncImplementation.cpp.o
[ 25%] Building CXX object CMakeFiles/rsync.dir/src/rsync.cpp.o
[ 37%] Linking CXX shared library lib/librsync.dylib
[ 37%] Built target rsync
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/main.cpp.o
[ 62%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/agentEmulator.cpp.o
[ 75%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/oneTimeSync.cpp.o
[ 87%] Building CXX object testtool/CMakeFiles/rsync_test_tool.dir/managerEmulator.cpp.o
[100%] Linking CXX executable ../bin/rsync_test_tool
[100%] Built target rsync_test_tool
make: *** [agent] Error 2
+ sign_binaries
+ '[' '!' -z '' ']'
+ packagesbuild /Users/ec2-user/prueba_leo/compilacion/wazuh/packages/macos/repository/wazuh/packages/macos/package_files/wazuh-agent-intel64.pkgproj --build-folder /Users/ec2-user/prueba_leo/compilacion/wazuh/packages/macos/output/
==============================================================================
ERROR:

Description:

Unable to read attributes of item at path "/Library/Ossec"
Step:

Project > Distribution > Package 'agent' > Payload > Assemble

==============================================================================
Build Failed
+ echo 'ERROR: something went wrong while building the package.'
ERROR: something went wrong while building the package.
+ clean_and_exit 1
+ exit_code=1
+ '[' -z enhancement/9913-generate-debug-symbols-epic ']'
+ /Users/ec2-user/prueba_leo/compilacion/wazuh/packages/macos/uninstall.sh
sudo: /Library/Ossec/bin/wazuh-control: command not found
rm: /Library/Ossec*: No such file or directory
Unload failed: 5: Input/output error
Try running `launchctl bootout` as root for richer errors.
delete: Invalid Path
<dscl_cmd> DS Error: -14009 (eDSUnknownNodeName)
delete: Invalid Path
<dscl_cmd> DS Error: -14009 (eDSUnknownNodeName)
No receipt for 'com.wazuh.pkg.wazuh-agent' found at '/'.
No receipt for 'com.wazuh.pkg.wazuh-agent-etc' found at '/'.

Wazuh agent correctly removed from the system.

+ exit 1
```
</details>

This error is due to mistakenly removing the declaration of the `SEARCH_DIR `variable that is used to store the list of executable files to which the debug symbols will be separated and removed. 

<details>
<summary>Script execution after fix</summary>

```
sudo ./generate_wazuh_packages.sh -b fix/21734-add-debug-symbols-macos


Build Successful (1 second)
+ echo 'The wazuh agent package for macOS has been successfully built.'
The wazuh agent package for macOS has been successfully built.
++ echo 'wazuh-agent_4.9.0-1_intel64_-C
/Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/repository/wazuh
--short'
++ tr '\n' ' '
++ cut -d ' ' -f 1
+ symbols_pkg_name=wazuh-agent_4.9.0-1_intel64_-C
+ symbols_pkg_name=wazuh-agent_4.9.0-1_intel64_-C_debug_symbols
+ cp -R /Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/repository/wazuh/src/symbols /Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/
+ zip -r /Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/wazuh-agent_4.9.0-1_intel64_-C_debug_symbols.zip /Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/librsync.dylib.yml (deflated 88%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Resources/DWARF/librsync.dylib (deflated 80%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/librsync.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/Relocations/x86_64/kaspersky.yml (deflated 21%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Resources/DWARF/kaspersky (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/kaspersky.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/Relocations/x86_64/host-deny.yml (deflated 21%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Resources/DWARF/host-deny (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/host-deny.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/Relocations/x86_64/firewalld-drop.yml (deflated 22%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Resources/DWARF/firewalld-drop (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/firewalld-drop.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/Relocations/x86_64/libwazuhshared.dylib.yml (deflated 84%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Resources/DWARF/libwazuhshared.dylib (deflated 65%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhshared.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/Relocations/x86_64/libsysinfo.dylib.yml (deflated 87%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Resources/DWARF/libsysinfo.dylib (deflated 76%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsysinfo.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/Relocations/x86_64/agent-auth.yml (deflated 85%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Resources/DWARF/agent-auth (deflated 64%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/agent-auth.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/Relocations/x86_64/wazuh-logcollector.yml (deflated 86%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Resources/DWARF/wazuh-logcollector (deflated 65%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-logcollector.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/Relocations/x86_64/libwazuhext.dylib.yml (deflated 85%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Resources/DWARF/libwazuhext.dylib (deflated 73%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libwazuhext.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/Relocations/x86_64/default-firewall-drop.yml (deflated 23%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Resources/DWARF/default-firewall-drop (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/default-firewall-drop.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/Relocations/x86_64/ipfw.yml (deflated 21%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Resources/DWARF/ipfw (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ipfw.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/Relocations/x86_64/route-null.yml (deflated 22%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Resources/DWARF/route-null (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/route-null.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/Relocations/x86_64/libsyscollector.dylib.yml (deflated 88%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Resources/DWARF/libsyscollector.dylib (deflated 78%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libsyscollector.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/Relocations/x86_64/restart-wazuh.yml (deflated 24%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Resources/DWARF/restart-wazuh (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/restart-wazuh.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/Relocations/x86_64/wazuh-slack.yml (deflated 23%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Resources/DWARF/wazuh-slack (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-slack.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/Relocations/x86_64/pf.yml (deflated 21%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Resources/DWARF/pf (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/pf.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/Relocations/x86_64/libdbsync.dylib.yml (deflated 89%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Resources/DWARF/libdbsync.dylib (deflated 80%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libdbsync.dylib.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/Relocations/x86_64/manage_agents.yml (deflated 85%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Resources/DWARF/manage_agents (deflated 64%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/manage_agents.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/Relocations/x86_64/disable-account.yml (deflated 22%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Resources/DWARF/disable-account (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/disable-account.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/Relocations/x86_64/wazuh-execd.yml (deflated 86%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Resources/DWARF/wazuh-execd (deflated 65%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-execd.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/Relocations/x86_64/wazuh-modulesd.yml (deflated 86%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Resources/DWARF/wazuh-modulesd (deflated 65%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-modulesd.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/Relocations/x86_64/wazuh-agentd.yml (deflated 86%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Resources/DWARF/wazuh-agentd (deflated 65%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/wazuh-agentd.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/Relocations/x86_64/ip-customblock.yml (deflated 22%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Resources/DWARF/ip-customblock (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/ip-customblock.dSYM/Contents/Info.plist (deflated 52%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/Relocations/x86_64/npf.yml (deflated 21%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Resources/DWARF/npf (deflated 91%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/npf.dSYM/Contents/Info.plist (deflated 53%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/Relocations/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/Relocations/x86_64/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/Relocations/x86_64/libfimdb.dylib.yml (deflated 88%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Resources/DWARF/libfimdb.dylib (deflated 78%)
  adding: Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols/libfimdb.dylib.dSYM/Contents/Info.plist (deflated 52%)
+ rm -rf /Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/output/symbols
+ sign_pkg
+ '[' '!' -z '' ']'
+ [[ no == \y\e\s ]]
+ clean_and_exit 0
+ exit_code=0
+ rm -rf /Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/repository
+ '[' -z fix/21734-add-debug-symbols-macos ']'
+ /Users/ec2-user/leo/nueva_rama/wazuh/packages/macos/uninstall.sh
wazuh-modulesd not running...
wazuh-logcollector not running...
wazuh-syscheckd not running...
wazuh-agentd not running...
wazuh-execd not running...
Wazuh v4.9.0 Stopped
Unload failed: 5: Input/output error
Try running `launchctl bootout` as root for richer errors.
No receipt for 'com.wazuh.pkg.wazuh-agent' found at '/'.
No receipt for 'com.wazuh.pkg.wazuh-agent-etc' found at '/'.

Wazuh agent correctly removed from the system.

+ exit 0


macos % ls output 
wazuh-agent_4.9.0-1_intel64_-C.pkg               wazuh-agent_4.9.0-1_intel64_-C_debug_symbols.zip
```

</details>

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors