### PR TITLE
Add flatbuffer parser to rocksdb testtool

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
@@ -72,7 +72,22 @@ int main(const int argc, const char** argv)
             {
                 rocksDB.createColumn(columnFamily);
             }
-            rocksDB.put(requestedKey, value, columnFamily);
+
+            if (!fbs.empty())
+            {
+                if (!parser.Parse(value.c_str()))
+                {
+                    throw std::runtime_error("Unable to parse value.");
+                }
+                rocksdb::Slice flatbufferResource(reinterpret_cast<const char*>(parser.builder_.GetBufferPointer()),
+                                                  parser.builder_.GetSize());
+                rocksDB.put(requestedKey, flatbufferResource, columnFamily);
+            }
+            else
+            {
+                rocksDB.put(requestedKey, value, columnFamily);
+            }
+
             std::cout << "Value inserted." << std::endl;
         }
         else if (!requestedKey.empty())


### PR DESCRIPTION
|Related issue|
|---|
| #22940 |

## Description
This PR adds the possibility to insert flatbuffer data into rocksDB databases using the testtool

## Tests
Inserted value into translations table (uses a specific flatbuffer schema):
```
sudo ./rocks_db_query_testtool -d /var/ossec/queue/vd/feed/ -c "translation" -f /home/sebas/Documents/work/development/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/packageTranslation.fbs -k TID-0049 -v '{"target":"windows","source":{"vendor":"","product":"^Snip & Sketch$","version":""},"translation":[{"vendor":"microsoft","product":"snip_\\&_sketch","version":""}],"action":["replace_vendor","replace_product"]}'
Value inserted.
```

Read value with flatbuffer
```
sudo ./rocks_db_query_testtool -d /var/ossec/queue/vd/feed/ -c "translation" -f /home/sebas/Documents/work/development/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/packageTranslation.fbs -k TID-0049
TID-0049 ==> {
  "action": [
    "replace_vendor",
    "replace_product"
  ],
  "source": {
    "vendor": "",
    "product": "^Snip & Sketch$",
    "version": ""
  },
  "target": "windows",
  "translation": [
    {
      "vendor": "microsoft",
      "product": "snip_\\&_sketch",
      "version": ""
    }
  ]
}
```

Read value without flatbuffer:
```
sudo ./rocks_db_query_testtool -d /var/ossec/queue/vd/feed/ -c "translation" -k TID-0049
TID-0049 ==> 


            `�
              ����(snip_\&_sketch       microsoft


(^Snip & Sketch$windows
```