### PR TITLE
Fix upload package whit debug symbols to S3

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -170,7 +170,7 @@ function build_package() {
         echo "The wazuh agent package for macOS has been successfully built."
         symbols_pkg_name=$(echo "${pkg_name}" | tr '\n' ' ' | cut -d ' ' -f 1)
         symbols_pkg_name="${symbols_pkg_name}_debug_symbols"
-        cp -R "${SOURCES_DIRECTORY}/wazuh/src/symbols"  "${DESTINATION}"
+        cp -R "${WAZUH_PATH}/src/symbols"  "${DESTINATION}"
         zip -r "${DESTINATION}${symbols_pkg_name}.zip" "${DESTINATION}symbols"
         rm -rf "${DESTINATION}symbols"
         sign_pkg


### PR DESCRIPTION
|Related issue|
|---|
|#22946|

## Description

This PR changes the directory being pointed to in order to extract the debug symbols generated in the compilation, since only one condition of the following if was being taken into account:

```
    if [ -n "$BRANCH_TAG" ]; then.
        SOURCES_DIRECTORY="${{CURRENT_PATH}/repository"
        WAZUH_PATH="${{SOURCES_DIRECTORY}/wazuh"
        git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}"
        short_commit_hash="$(git rev-parse -C "${WAZUH_PATH}" --short HEAD)"
    else
        WAZUH_PATH="${CURRENT_PATH}/../..."
        short_commit_hash="$(git rev-parse --short HEAD)"
    fi
``` 


The `SOURCES_DIRECTORY` variable was being pointed to, but the idea is to point to the `WAZUH_PATH` variable.

After making the change and running the Build macOS Wazuh Agent Packages, in the `Upload package and checksum to S3 `section I get:

```
Run for file in output/*agent*; do
Completed 256.0 KiB/6.2 MiB (288.8 KiB/s) with 1 file(s) remaining
Completed 512.0 KiB/6.2 MiB (447.9 KiB/s) with 1 file(s) remaining
Completed 768.0 KiB/6.2 MiB (587.5 KiB/s) with 1 file(s) remaining
Completed 1.0 MiB/6.2 MiB (707.0 KiB/s) with 1 file(s) remaining  
Completed 1.2 MiB/6.2 MiB (828.5 KiB/s) with 1 file(s) remaining  
Completed 1.5 MiB/6.2 MiB (921.5 KiB/s) with 1 file(s) remaining  
Completed 1.8 MiB/6.2 MiB (1.0 MiB/s) with 1 file(s) remaining    
Completed 2.0 MiB/6.2 MiB (1.1 MiB/s) with 1 file(s) remaining    
Completed 2.2 MiB/6.2 MiB (1.2 MiB/s) with 1 file(s) remaining    
Completed 2.5 MiB/6.2 MiB (1.3 MiB/s) with 1 file(s) remaining    
Completed 2.8 MiB/6.2 MiB (1.3 MiB/s) with 1 file(s) remaining    
Completed 3.0 MiB/6.2 MiB (1.4 MiB/s) with 1 file(s) remaining    
Completed 3.2 MiB/6.2 MiB (1.5 MiB/s) with 1 file(s) remaining    
Completed 3.5 MiB/6.2 MiB (1.6 MiB/s) with 1 file(s) remaining    
Completed 3.8 MiB/6.2 MiB (1.6 MiB/s) with 1 file(s) remaining    
Completed 4.0 MiB/6.2 MiB (1.7 MiB/s) with 1 file(s) remaining    
Completed 4.2 MiB/6.2 MiB (1.7 MiB/s) with 1 file(s) remaining    
Completed 4.5 MiB/6.2 MiB (1.8 MiB/s) with 1 file(s) remaining    
Completed 4.8 MiB/6.2 MiB (1.9 MiB/s) with 1 file(s) remaining    
Completed 5.0 MiB/6.2 MiB (1.9 MiB/s) with 1 file(s) remaining    
Completed 5.2 MiB/6.2 MiB (2.0 MiB/s) with 1 file(s) remaining    
Completed 5.5 MiB/6.2 MiB (2.0 MiB/s) with 1 file(s) remaining    
Completed 5.8 MiB/6.2 MiB (2.1 MiB/s) with 1 file(s) remaining    
Completed 6.0 MiB/6.2 MiB (2.2 MiB/s) with 1 file(s) remaining    
Completed 6.2 MiB/6.2 MiB (2.1 MiB/s) with 1 file(s) remaining    
upload: output/wazuh-agent_4.9.0-test_intel64_d87b2cc.pkg to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-agent_4.9.0-test_intel64_d87b2cc.pkg
Completed 256.0 KiB/9.3 MiB (296.7 KiB/s) with 1 file(s) remaining
Completed 512.0 KiB/9.3 MiB (508.3 KiB/s) with 1 file(s) remaining
Completed 768.0 KiB/9.3 MiB (701.4 KiB/s) with 1 file(s) remaining
Completed 1.0 MiB/9.3 MiB (819.6 KiB/s) with 1 file(s) remaining  
Completed 1.2 MiB/9.3 MiB (1017.4 KiB/s) with 1 file(s) remaining 
Completed 1.5 MiB/9.3 MiB (1.1 MiB/s) with 1 file(s) remaining    
Completed 1.8 MiB/9.3 MiB (1.2 MiB/s) with 1 file(s) remaining    
Completed 2.0 MiB/9.3 MiB (1.3 MiB/s) with 1 file(s) remaining    
Completed 2.2 MiB/9.3 MiB (1.4 MiB/s) with 1 file(s) remaining    
Completed 2.3 MiB/9.3 MiB (1.4 MiB/s) with 1 file(s) remaining    
Completed 2.5 MiB/9.3 MiB (1.5 MiB/s) with 1 file(s) remaining    
Completed 2.8 MiB/9.3 MiB (1.6 MiB/s) with 1 file(s) remaining    
Completed 3.0 MiB/9.3 MiB (1.6 MiB/s) with 1 file(s) remaining    
Completed 3.3 MiB/9.3 MiB (1.7 MiB/s) with 1 file(s) remaining    
Completed 3.5 MiB/9.3 MiB (1.7 MiB/s) with 1 file(s) remaining    
Completed 3.8 MiB/9.3 MiB (1.8 MiB/s) with 1 file(s) remaining    
Completed 4.0 MiB/9.3 MiB (1.8 MiB/s) with 1 file(s) remaining    
Completed 4.3 MiB/9.3 MiB (1.9 MiB/s) with 1 file(s) remaining    
Completed 4.5 MiB/9.3 MiB (1.9 MiB/s) with 1 file(s) remaining    
Completed 4.8 MiB/9.3 MiB (2.0 MiB/s) with 1 file(s) remaining    
Completed 5.0 MiB/9.3 MiB (2.1 MiB/s) with 1 file(s) remaining    
Completed 5.3 MiB/9.3 MiB (2.1 MiB/s) with 1 file(s) remaining    
Completed 5.5 MiB/9.3 MiB (2.2 MiB/s) with 1 file(s) remaining    
Completed 5.8 MiB/9.3 MiB (2.2 MiB/s) with 1 file(s) remaining    
Completed 6.0 MiB/9.3 MiB (2.3 MiB/s) with 1 file(s) remaining    
Completed 6.3 MiB/9.3 MiB (2.3 MiB/s) with 1 file(s) remaining    
Completed 6.5 MiB/9.3 MiB (2.3 MiB/s) with 1 file(s) remaining    
Completed 6.8 MiB/9.3 MiB (2.4 MiB/s) with 1 file(s) remaining    
Completed 7.0 MiB/9.3 MiB (2.4 MiB/s) with 1 file(s) remaining    
Completed 7.3 MiB/9.3 MiB (2.5 MiB/s) with 1 file(s) remaining    
Completed 7.5 MiB/9.3 MiB (2.5 MiB/s) with 1 file(s) remaining    
Completed 7.8 MiB/9.3 MiB (2.6 MiB/s) with 1 file(s) remaining    
Completed 8.0 MiB/9.3 MiB (2.6 MiB/s) with 1 file(s) remaining    
Completed 8.3 MiB/9.3 MiB (2.7 MiB/s) with 1 file(s) remaining    
Completed 8.5 MiB/9.3 MiB (2.7 MiB/s) with 1 file(s) remaining    
Completed 8.8 MiB/9.3 MiB (2.7 MiB/s) with 1 file(s) remaining    
Completed 9.0 MiB/9.3 MiB (2.8 MiB/s) with 1 file(s) remaining    
Completed 9.3 MiB/9.3 MiB (2.8 MiB/s) with 1 file(s) remaining    
upload: output/wazuh-agent_4.9.0-test_intel64_d87b2cc_debug_symbols.zip to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-agent_4.9.0-test_intel64_d87b2cc_debug_symbols.zip
``` 
This is the link to the actions execution: https://github.com/wazuh/wazuh/actions/runs/8713337109/job/23901527614

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [x] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors
