### PR TITLE
Apply minor changes in manager and filebeat packages workflows

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -1,4 +1,4 @@
-name: Build Wazuh Manager Packages - DEB|RPM - amd64|x86_64
+run-name: Build Wazuh Manager Package - ${{ inputs.system }} - ${{ inputs.architecture }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -1,4 +1,4 @@
-run-name: Build Wazuh Manager Package - ${{ inputs.system }} - ${{ inputs.architecture }}
+run-name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }} ${{ inputs.is_stage && '- is stage' || '' }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.debug && '- debug' || '' }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -3,12 +3,17 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: 'Revision used to naming Filebeat package wazuh-filebeat-X.X.tar.gz'
-        required: true
+        description: | 
+          Revision used to naming Filebeat package wazuh-filebeat-X.X.tar.gz.
+          Default 0.0.
+        required: false
+        default: "0.0"
+        type: string
+
   workflow_call:
     inputs:
       revision:
-        required: true
+        required: false
         default: "0.0"
         type: string
     

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -1,11 +1,17 @@
-name: Packages - Build filebeat package
+name: Packages - Build Filebeat Package
 on:
   workflow_dispatch:
     inputs:
       revision:
         description: 'Revision used to naming Filebeat package wazuh-filebeat-X.X.tar.gz'
         required: true
-
+  workflow_call:
+    inputs:
+      revision:
+        required: true
+        default: "0.0"
+        type: string
+    
 jobs:
   Filebeat-module-generation:
     runs-on: ubuntu-latest
@@ -22,7 +28,7 @@ jobs:
 
       - name: Set package name
         run: |
-          echo "FILEBEAT_TAR_NAME=wazuh-filebeat-${{ github.event.inputs.revision }}.tar.gz" >> $GITHUB_ENV
+          echo "FILEBEAT_TAR_NAME=wazuh-filebeat-${{ inputs.revision }}.tar.gz" >> $GITHUB_ENV
 
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/22955 & https://github.com/wazuh/wazuh/issues/22957|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR adds:
- `workflow_call` tag in the `.github/workflows/packages-filebeat.yml` file, letting this workflow be called from another one.
- Dynamic workflow name for the `.github/workflows/packages-build-manager.yml` workflow calls, using `run-name` instead of `name` to set the job execution name. [Reference](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name).
<!--
Add a clear description of how the problem has been solved.
-->

## Test
The Job name changes in every execution depending on the arguments. For example, for `.deb` and `amd64` the job name is set as follows:
![image](https://github.com/wazuh/wazuh/assets/119335479/988ab304-c93f-4bf3-bca1-55706df5d5fd)

Manager package
- performed execution with `debug` and `checksum`: https://github.com/wazuh/wazuh/actions/runs/8739953751
- performed execution without `debug` and `checksum`: https://github.com/wazuh/wazuh/actions/runs/8740058785

Filebeat package performed execution: https://github.com/wazuh/wazuh/actions/runs/8737877001