### PR TITLE
avoid test install test of symbols packages

### DIFF
--- a/.github/workflows/packages-build-linux-agent.yml
+++ b/.github/workflows/packages-build-linux-agent.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Test install built package
         run: |
-          package_name=$(find /tmp -maxdepth 1 -type f -name "*agent*.${{ inputs.system }}" -exec basename {} 2>/dev/null \;)
+          package_name=$(find /tmp -maxdepth 1 -type f -name "*agent*.${{ inputs.system }}" -exec basename {} 2>/dev/null \; | grep -v "^wazuh-agent-dbg")
           if [ -z "$package_name" ]; then echo "No package found matching the pattern!"; exit 1; fi
           sudo docker run -v $GITHUB_WORKSPACE/.github/actions/test-install-components/:/tests -v /tmp/:/packages --entrypoint '/tests/install_component.sh' $CONTAINER_NAME:${{ env.TAG }} $package_name agent
           # Check if wazuh-agent was installed. The /tmp/status.log file was generated in the previous step.


### PR DESCRIPTION
|Related issue|
|---|
|#22944|
## Description
Fix giuthub's `workflow` due new symbols packages added.

## Configuration options
Follow steps described in [Worflow](https://github.com/wazuh/wazuh/tree/enhancement/9913-generate-debug-symbols-epic/packages#workflow) section of readme file to create any necesary image and test these changes.

test.json
```json
{
    "ref":"22944-upload-symbols",
    "inputs":
    {
        "docker_image_tag":"developer",
        "architecture":"amd64",
        "system":"deb",
        "revision":"test",
        "is_stage":"false",
        "legacy":"false",
        "checksum":"false"
    }
}
``` 
## Tests
extracted output of the [job](https://github.com/wazuh/wazuh/actions/runs/8725775749/job/23939559327) used for testing
```shell
Run for file in /tmp/*agent*; do
  for file in /tmp/*agent*; do
    aws s3 cp $file s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
  done
  shell: /usr/bin/bash -e {0}
  env:
    ARCH: amd64
    TAG: 22944-upload-symbols
    CONTAINER_NAME: pkg_deb_agent_builder_amd64
    AWS_DEFAULT_REGION: us-east-[1](https://github.com/wazuh/wazuh/actions/runs/8725775749/job/23939559327#step:10:1)
    AWS_REGION: us-east-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
  
Completed [2](https://github.com/wazuh/wazuh/actions/runs/8725775749/job/23939559327#step:10:2)56.0 KiB/19.2 MiB (357.5 KiB/s) with 1 file(s) remaining
Completed 512.0 KiB/19.2 MiB (651.7 KiB/s) with 1 file(s) remaining
Completed 768.0 KiB/19.2 MiB (898.8 KiB/s) with 1 file(s) remaining
.
.
.
Completed 18.7 MiB/19.2 MiB (12.4 MiB/s) with 1 file(s) remaining  
Completed 18.9 MiB/19.2 MiB (12.6 MiB/s) with 1 file(s) remaining  
Completed 19.2 MiB/19.2 MiB (12.8 MiB/s) with 1 file(s) remaining  
upload: ../../../../../tmp/wazuh-agent-dbg_4.9.0-test_amd64.deb to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-agent-dbg_4.9.0-test_amd64.deb
.
.
.
Completed 10.0 MiB/10.3 MiB (7.1 MiB/s) with 1 file(s) remaining   
Completed 10.3 MiB/10.3 MiB (7.3 MiB/s) with 1 file(s) remaining   
upload: ../../../../../tmp/wazuh-agent_4.9.0-test_amd64.deb to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-agent_4.9.0-test_amd[64]
```