### PR TITLE
New vd_scanner_testtool configuration to download only the snapshot of the CTI feed

### DIFF
--- a/.github/actions/vulnerability_scanner/content_generation/action.yml
+++ b/.github/actions/vulnerability_scanner/content_generation/action.yml
@@ -10,7 +10,7 @@ inputs:
   config_path:
     required: true
     description: "Path to the configuration file"
-    default: src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.json
+    default: src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
 
   indexer_template_path:
     required: true

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -212,37 +212,31 @@ private:
      */
     void validateVulnerabilityDetectionConfiguration(const nlohmann::json& vdObj) const
     {
-        if (!vdObj.at("vulnerability-detection").contains("enabled"))
+        if (!vdObj.contains("enabled"))
         {
             throw std::runtime_error("Missing enabled field.");
         }
 
-        if (!vdObj.at("vulnerability-detection").contains("index-status"))
+        if (!vdObj.contains("index-status"))
         {
             throw std::runtime_error("Missing index-status field.");
         }
 
-        if (vdObj.at("vulnerability-detection").contains("feed-update-interval"))
+        if (vdObj.contains("feed-update-interval"))
         {
-            if (Utils::parseStrToTime(vdObj.at("vulnerability-detection").at("feed-update-interval")) == -1)
+            if (Utils::parseStrToTime(vdObj["feed-update-interval"]) == -1)
             {
                 throw std::runtime_error("Invalid feed update interval.");
             }
         }
 
-        if (vdObj.at("vulnerability-detection").contains("offline-url"))
+        if (vdObj.contains("offline-url"))
         {
-            if (!(Utils::startsWith(vdObj.at("vulnerability-detection").at("offline-url"), "file") ||
-                  Utils::startsWith(vdObj.at("vulnerability-detection").at("offline-url"), "http") ||
-                  Utils::startsWith(vdObj.at("vulnerability-detection").at("offline-url"), "https")))
+            if (!(Utils::startsWith(vdObj["offline-url"], "file") || Utils::startsWith(vdObj["offline-url"], "http") ||
+                  Utils::startsWith(vdObj["offline-url"], "https")))
             {
                 throw std::runtime_error("Invalid URL provided.");
             }
-        }
-
-        if (!vdObj.at("vulnerability-detection").contains("cti-url") && !vdObj.contains("updater"))
-        {
-            throw std::runtime_error("Missing cti-url field.");
         }
     }
 
@@ -310,63 +304,55 @@ private:
             throw std::runtime_error("Missing configData field.");
         }
 
-        if (!configuration.at("configData").contains("consumerName") ||
-            !configuration.at("configData").at("consumerName").is_string())
+        const auto& configData = configuration.at("configData");
+
+        if (!configData.contains("consumerName") || !configData.at("consumerName").is_string())
         {
             throw std::runtime_error("Missing consumerName field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("contentSource") ||
-            !configuration.at("configData").at("contentSource").is_string())
+        if (!configData.contains("contentSource") || !configData.at("contentSource").is_string())
         {
             throw std::runtime_error("Missing contentSource field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("compressionType") ||
-            !configuration.at("configData").at("compressionType").is_string())
+        if (!configData.contains("compressionType") || !configData.at("compressionType").is_string())
         {
             throw std::runtime_error("Missing compressionType field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("versionedContent") ||
-            !configuration.at("configData").at("versionedContent").is_string())
+        if (!configData.contains("versionedContent") || !configData.at("versionedContent").is_string())
         {
             throw std::runtime_error("Missing versionedContent field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("deleteDownloadedContent") ||
-            !configuration.at("configData").at("deleteDownloadedContent").is_boolean())
+        if (!configData.contains("deleteDownloadedContent") || !configData.at("deleteDownloadedContent").is_boolean())
         {
             throw std::runtime_error("Missing deleteDownloadedContent field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("outputFolder") ||
-            !configuration.at("configData").at("outputFolder").is_string())
+        if (!configData.contains("outputFolder") || !configData.at("outputFolder").is_string())
         {
             throw std::runtime_error("Missing outputFolder field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("contentFileName") ||
-            !configuration.at("configData").at("contentFileName").is_string())
+        if (!configData.contains("contentFileName") || !configData.at("contentFileName").is_string())
         {
             throw std::runtime_error("Missing contentFileName field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("databasePath") ||
-            !configuration.at("configData").at("databasePath").is_string())
+        if (!configData.contains("databasePath") || !configData.at("databasePath").is_string())
         {
             throw std::runtime_error("Missing databasePath field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("url") || !configuration.at("configData").at("url").is_string() ||
-            !Utils::startsWith(configuration.at("configData").at("url"), "http") ||
-            !Utils::startsWith(configuration.at("configData").at("url"), "https"))
+        if (!configData.contains("url") || !configData.at("url").is_string() ||
+            !Utils::startsWith(configData.at("url"), "http") || !Utils::startsWith(configData.at("url"), "https"))
         {
             throw std::runtime_error("Missing url field or invalid value.");
         }
 
-        if (!configuration.at("configData").contains("offset") ||
-            !configuration.at("configData").at("offset").is_number())
+        if (!configData.contains("offset") || !configData.at("offset").is_number())
         {
             throw std::runtime_error("Missing offset field or invalid value.");
         }
@@ -461,7 +447,7 @@ public:
         if (configuration.contains("vulnerability-detection"))
         {
             // Validate vulnerability-detection configuration
-            validateVulnerabilityDetectionConfiguration(configuration);
+            validateVulnerabilityDetectionConfiguration(configuration.at("vulnerability-detection"));
         }
         else
         {
@@ -477,9 +463,18 @@ public:
 
         // If the "updater" configuration exists, validate it.
         // Otherwise, since it is not mandatory, the default policy will be used.
+        //
+        // Note: The updater configuration is for internal use. The consumer of this module should not send the updater
+        // configuration.
         if (configuration.contains("updater"))
         {
             validateUpdaterConfiguration(configuration.at("updater"));
+        }
+
+        // Check if the URL is set.
+        if (!configuration.at("vulnerability-detection").contains("cti-url") && !configuration.contains("updater"))
+        {
+            throw std::runtime_error("Missing URL setting.");
         }
     }
 
@@ -644,11 +639,7 @@ public:
      */
     std::string getCTIUrl() const
     {
-        if (m_configuration.contains("updater"))
-        {
-            return m_configuration.at("updater").at("configData").at("url").get_ref<const std::string&>();
-        }
-        return m_configuration.at("vulnerability-detection").at("cti-url").get_ref<const std::string&>();
+        return m_configuration.at("updater").at("configData").at("url").get_ref<const std::string&>();
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -212,34 +212,35 @@ private:
      */
     void validateVulnerabilityDetectionConfiguration(const nlohmann::json& vdObj) const
     {
-        if (!vdObj.contains("enabled"))
+        if (!vdObj.at("vulnerability-detection").contains("enabled"))
         {
             throw std::runtime_error("Missing enabled field.");
         }
 
-        if (!vdObj.contains("index-status"))
+        if (!vdObj.at("vulnerability-detection").contains("index-status"))
         {
             throw std::runtime_error("Missing index-status field.");
         }
 
-        if (vdObj.contains("feed-update-interval"))
+        if (vdObj.at("vulnerability-detection").contains("feed-update-interval"))
         {
-            if (Utils::parseStrToTime(vdObj["feed-update-interval"]) == -1)
+            if (Utils::parseStrToTime(vdObj.at("vulnerability-detection").at("feed-update-interval")) == -1)
             {
                 throw std::runtime_error("Invalid feed update interval.");
             }
         }
 
-        if (vdObj.contains("offline-url"))
+        if (vdObj.at("vulnerability-detection").contains("offline-url"))
         {
-            if (!(Utils::startsWith(vdObj["offline-url"], "file") || Utils::startsWith(vdObj["offline-url"], "http") ||
-                  Utils::startsWith(vdObj["offline-url"], "https")))
+            if (!(Utils::startsWith(vdObj.at("vulnerability-detection").at("offline-url"), "file") ||
+                  Utils::startsWith(vdObj.at("vulnerability-detection").at("offline-url"), "http") ||
+                  Utils::startsWith(vdObj.at("vulnerability-detection").at("offline-url"), "https")))
             {
                 throw std::runtime_error("Invalid URL provided.");
             }
         }
 
-        if (!vdObj.contains("cti-url"))
+        if (!vdObj.at("vulnerability-detection").contains("cti-url") && !vdObj.contains("updater"))
         {
             throw std::runtime_error("Missing cti-url field.");
         }
@@ -272,6 +273,102 @@ private:
             {
                 throw std::runtime_error("Indexer cannot be disabled while vulnerability detection index is enabled.");
             }
+        }
+    }
+
+    /**
+     * @brief Validates and configures the content manager based on the provided JSON object.
+     *
+     * This function takes a JSON object as input, which is expected to contain configuration
+     * information for the content manager. It validates the JSON object to ensure it contains the
+     * required fields and has valid values. If the validation passes, no exception is thrown.
+     *
+     * @param configuration A constant reference to a JSON object representing the content manager configuration.
+     *
+     * @note This function assumes that the provided JSON object follows a specific format.
+     * @note If validation fails, this function throws std::runtime exception.
+     */
+    void validateUpdaterConfiguration(const nlohmann::json& configuration) const
+    {
+        if (!configuration.contains("interval") || !configuration.at("interval").is_number())
+        {
+            throw std::runtime_error("Missing interval field or invalid value.");
+        }
+
+        if (!configuration.contains("ondemand") || !configuration.at("ondemand").is_boolean())
+        {
+            throw std::runtime_error("Missing ondemand field or invalid value.");
+        }
+
+        if (!configuration.contains("topicName") || !configuration.at("topicName").is_string())
+        {
+            throw std::runtime_error("Missing topicName field or invalid value.");
+        }
+
+        if (!configuration.contains("configData"))
+        {
+            throw std::runtime_error("Missing configData field.");
+        }
+
+        if (!configuration.at("configData").contains("consumerName") ||
+            !configuration.at("configData").at("consumerName").is_string())
+        {
+            throw std::runtime_error("Missing consumerName field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("contentSource") ||
+            !configuration.at("configData").at("contentSource").is_string())
+        {
+            throw std::runtime_error("Missing contentSource field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("compressionType") ||
+            !configuration.at("configData").at("compressionType").is_string())
+        {
+            throw std::runtime_error("Missing compressionType field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("versionedContent") ||
+            !configuration.at("configData").at("versionedContent").is_string())
+        {
+            throw std::runtime_error("Missing versionedContent field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("deleteDownloadedContent") ||
+            !configuration.at("configData").at("deleteDownloadedContent").is_boolean())
+        {
+            throw std::runtime_error("Missing deleteDownloadedContent field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("outputFolder") ||
+            !configuration.at("configData").at("outputFolder").is_string())
+        {
+            throw std::runtime_error("Missing outputFolder field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("contentFileName") ||
+            !configuration.at("configData").at("contentFileName").is_string())
+        {
+            throw std::runtime_error("Missing contentFileName field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("databasePath") ||
+            !configuration.at("configData").at("databasePath").is_string())
+        {
+            throw std::runtime_error("Missing databasePath field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("url") || !configuration.at("configData").at("url").is_string() ||
+            !Utils::startsWith(configuration.at("configData").at("url"), "http") ||
+            !Utils::startsWith(configuration.at("configData").at("url"), "https"))
+        {
+            throw std::runtime_error("Missing url field or invalid value.");
+        }
+
+        if (!configuration.at("configData").contains("offset") ||
+            !configuration.at("configData").at("offset").is_number())
+        {
+            throw std::runtime_error("Missing offset field or invalid value.");
         }
     }
 
@@ -364,17 +461,25 @@ public:
         if (configuration.contains("vulnerability-detection"))
         {
             // Validate vulnerability-detection configuration
-            validateVulnerabilityDetectionConfiguration(configuration.at("vulnerability-detection"));
+            validateVulnerabilityDetectionConfiguration(configuration);
         }
         else
         {
             throw std::runtime_error("Missing vulnerability-detection field.");
         }
 
-        // if the configuration exist, validate it, otherwise, it is not mandatory, default policy will be used.
+        // If the "indexer" configuration exists, validate it.
+        // Otherwise, since it is not mandatory, the default policy will be used.
         if (configuration.contains("indexer"))
         {
             validateIndexerConfiguration(configuration);
+        }
+
+        // If the "updater" configuration exists, validate it.
+        // Otherwise, since it is not mandatory, the default policy will be used.
+        if (configuration.contains("updater"))
+        {
+            validateUpdaterConfiguration(configuration.at("updater"));
         }
     }
 
@@ -539,6 +644,10 @@ public:
      */
     std::string getCTIUrl() const
     {
+        if (m_configuration.contains("updater"))
+        {
+            return m_configuration.at("updater").at("configData").at("url").get_ref<const std::string&>();
+        }
         return m_configuration.at("vulnerability-detection").at("cti-url").get_ref<const std::string&>();
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
@@ -377,3 +377,262 @@ TEST_F(PolicyManagerTest, validConfigurationCheckFeedUpdateIntervalGreaterThan60
 
     EXPECT_EQ(m_policyManager->getUpdaterConfiguration().at("interval"), 3660);
 }
+
+const auto& UPDATER_BASIC_CONFIG {nlohmann::json::parse(R"({
+      "vulnerability-detection": {
+        "enabled": "yes",
+        "index-status": "yes",
+        "managerNodeName": "wazuh-manager",
+        "managerDisabledScan": 1
+      },
+      "updater": {
+        "interval": 3600,
+        "ondemand": true,
+        "topicName": "vulnerability_feed_manager",
+        "configData": {
+          "consumerName": "Wazuh VulnerabilityDetector",
+          "contentSource": "cti-snapshot",
+          "compressionType": "zip",
+          "versionedContent": "false",
+          "deleteDownloadedContent": true,
+          "outputFolder": "queue/vd_updater/tmp",
+          "contentFileName": "api_file.json",
+          "databasePath": "queue/vd_updater/rocksdb",
+          "url": "https://updater-url.com",
+          "offset": 0
+        }
+      }
+    })")};
+
+TEST_F(PolicyManagerTest, updaterValidConfiguration)
+{
+    EXPECT_NO_THROW(m_policyManager->initialize(UPDATER_BASIC_CONFIG));
+
+    EXPECT_EQ(m_policyManager->getFeedUpdateTime(), 3600);
+    EXPECT_EQ(m_policyManager->getUpdaterConfiguration(), UPDATER_BASIC_CONFIG.at("updater"));
+    EXPECT_EQ(m_policyManager->getCTIUrl(), "https://updater-url.com");
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingInterval)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").erase("interval");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingOndemand)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").erase("ondemand");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingTopicName)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").erase("topicName");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingConfigData)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").erase("configData");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingConsumerName)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("consumerName");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingContentSource)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("contentSource");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingCompressionType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("compressionType");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingVersionedContent)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("versionedContent");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingDeleteDownloadedContent)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("deleteDownloadedContent");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingOutputFolder)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("outputFolder");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingContentFileName)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("contentFileName");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingDatabasePath)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("databasePath");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingUrl)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("url");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingOffset)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").erase("offset");
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongIntervalType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("interval") = "3600";
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongOndemandType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("ondemand") = "true";
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongTopicNameType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("topicName") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongConsumerNameType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("consumerName") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongContentSourceType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("contentSource") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongCompressionTypeType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("compressionType") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongVersionedContentType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("versionedContent") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongDeleteDownloadedContentType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("deleteDownloadedContent") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongOutputFolderType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("outputFolder") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongContentFileNameType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("contentFileName") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongDatabasePathType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("databasePath") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongUrlType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("url") = 123;
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongUrlType2)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("url") = "cti-url.com";
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}
+
+TEST_F(PolicyManagerTest, updaterInvalidConfigurationWrongOffsetType)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("offset") = "0";
+
+    EXPECT_THROW(m_policyManager->initialize(basicConfigCopy), std::runtime_error);
+}

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
@@ -1,0 +1,40 @@
+{
+    "vulnerability-detection": {
+        "enabled": "yes",
+        "index-status": "yes",
+        "managerNodeName": "wazuh-manager",
+        "managerDisabledScan": 1
+    },
+    "indexer": {
+        "enabled": "yes",
+        "hosts": [
+            "https://0.0.0.0:9200"
+        ],
+        "username": "admin",
+        "password": "admin",
+        "ssl": {
+            "certificate_authorities": [
+                "/home/dwordcito/Development/wazuh/src/root-ca.pem"
+            ],
+            "certificate": "/home/dwordcito/Development/wazuh/src/node-1.pem",
+            "key": "/home/dwordcito/Development/wazuh/src/node-1-key.pem"
+        }
+    },
+    "updater": {
+        "interval": 3600,
+        "ondemand": true,
+        "topicName": "vulnerability_feed_manager",
+        "configData": {
+            "consumerName": "Wazuh VulnerabilityDetector",
+            "contentSource": "cti-snapshot",
+            "compressionType": "zip",
+            "versionedContent": "false",
+            "deleteDownloadedContent": true,
+            "outputFolder": "queue/vd_updater/tmp",
+            "contentFileName": "api_file.json",
+            "databasePath": "queue/vd_updater/rocksdb",
+            "url": "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0",
+            "offset": 0
+        }
+    }
+}


### PR DESCRIPTION
|Related issue|
|---|
|#22953|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR add a new vd_scanner_testtool configuration to download only the snapshot of the CTI feed, and then makes use of this configuration in the `Vulnerability Scanner - Database Generation` workflow.

## Test

### Wokflow
by [running the manual workflow](https://github.com/wazuh/wazuh/actions/runs/8740835210/job/23985428821) you can see that the snapshot download step is created correctly
![image](https://github.com/wazuh/wazuh/assets/106940255/245da04d-2221-447f-bde5-87a262de536b)


### vd_scanner_testtool - New configuration
![image](https://github.com/wazuh/wazuh/assets/106940255/5b6f0da8-a539-422b-a590-5f1eb239a13f)

### vd_scanner_testtool - Previous configuration
![image](https://github.com/wazuh/wazuh/assets/106940255/04c8f4b5-42df-461c-a4f6-11621a5da2ba)
