### PR TITLE
Migrate deprecated sha1 functions.

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -41,6 +41,12 @@ static void check_pattern_expand_excluded();
 static void set_can_read(int value);
 
 /**
+ * @brief Releases the data structure stored in the hash table 'files_status'.
+ * @param data Structure of the data to be released
+ */
+STATIC void free_files_status_data(os_file_status_t *data);
+
+/**
  * @brief Create files_status hash and load the previous estatus from JSON file
  */
 STATIC void w_initialize_file_status();
@@ -2547,12 +2553,19 @@ int w_update_file_status(const char * path, int64_t pos, EVP_MD_CTX * context) {
 
     if (OSHash_Update_ex(files_status, path, data) != 1) {
         if (OSHash_Add_ex(files_status, path, data) != 2) {
+            EVP_MD_CTX_free(context);
             os_free(data);
             return -1;
         }
     }
 
     return 0;
+}
+
+void free_files_status_data(os_file_status_t *data) {
+    if (!data) return;
+    EVP_MD_CTX_free(data->context);
+    os_free(data);
 }
 
 STATIC void w_initialize_file_status() {
@@ -2566,7 +2579,7 @@ STATIC void w_initialize_file_status() {
         merror_exit(HSETSIZE_ERROR, files_status_name);
     }
 
-    OSHash_SetFreeDataPointer(files_status, (void (*)(void *))free);
+    OSHash_SetFreeDataPointer(files_status, (void (*)(void *))free_files_status_data);
 
     /* Read json file to load last read positions */
     FILE * fd = NULL;
@@ -2675,11 +2688,12 @@ STATIC void w_load_files_status(cJSON * global_json) {
         memcpy(data->hash, hash_str, sizeof(os_sha1));
         data->offset = value_offset;
 
-        EVP_MD_CTX *context = NULL;
+        EVP_MD_CTX *context = EVP_MD_CTX_new();
         os_sha1 output;
 
         if (OS_SHA1_File_Nbytes(path_str, &context, output, OS_BINARY, value_offset) < 0) {
             mdebug1(LOGCOLLECTOR_FILE_NOT_EXIST, path_str);
+            EVP_MD_CTX_free(context);
             os_free(data);
             return;
         }
@@ -2688,6 +2702,7 @@ STATIC void w_load_files_status(cJSON * global_json) {
         if (OSHash_Update_ex(files_status, path_str, data) != 1) {
             if (OSHash_Add_ex(files_status, path_str, data) != 2) {
                 merror(HADD_ERROR, path_str, files_status_name);
+                EVP_MD_CTX_free(context);
                 os_free(data);
             }
         }
@@ -2781,12 +2796,12 @@ STATIC int w_set_to_last_line_read(logreader * lf) {
     }
 
     int64_t result = 0;
-
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     os_sha1 output;
 
     if (OS_SHA1_File_Nbytes(lf->file, &context, output, OS_BINARY, data->offset) < 0) {
         merror(FAIL_SHA1_GEN, lf->file);
+        EVP_MD_CTX_free(context);
         return -1;
     }
 
@@ -2821,11 +2836,12 @@ STATIC int w_update_hash_node(char * path, int64_t pos) {
 
     data->offset = pos;
 
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     os_sha1 output;
 
     if (OS_SHA1_File_Nbytes(path, &context, output, OS_BINARY, pos) < 0) {
         merror(FAIL_SHA1_GEN, path);
+        EVP_MD_CTX_free(context);
         os_free(data);
         return -1;
     }
@@ -2834,6 +2850,7 @@ STATIC int w_update_hash_node(char * path, int64_t pos) {
 
     if (OSHash_Update_ex(files_status, path, data) != 1) {
         if (OSHash_Add_ex(files_status, path, data) != 2) {
+            EVP_MD_CTX_free(context);
             os_free(data);
             return -1;
         }
@@ -2868,7 +2885,8 @@ bool w_get_hash_context(logreader *lf, EVP_MD_CTX ** context, int64_t position) 
             return false;
         }
     } else {
-        *context = data->context;
+        EVP_DigestInit(*context, EVP_sha1());
+        EVP_MD_CTX_copy(*context, data->context);
     }
     return true;
 }

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -267,15 +267,15 @@ int can_read();
  * @brief Update the read position in file status hash table
  * @param path the path is the hash key
  * @param pos new read position
- * @param context SHA1 context.
+ * @param context EVP_MD_CTX context.
  * @return 0 on succes, otherwise -1
  */
 int w_update_file_status(const char * path, int64_t pos, EVP_MD_CTX *context);
 
 /**
- * @brief Get SHA1 context or initialize it
+ * @brief Get EVP_MD_CTX context or initialize it
  * @param lf Structure that contains file information, with `fd` and `file` non-null.
- * @param context SHA1 context.
+ * @param context EVP_MD_CTX context.
  * @param position end file position.
  * @return true if returns a valid context, false in otherwise.
  */

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -216,7 +216,7 @@ typedef struct w_input_range_t{
 ///< Struct to save the position of last line read and the SHA1 hash content
 typedef struct file_status {
     int64_t offset;  ///< Position to read
-    SHA_CTX context;    ///< It stores the hashed data calculated so far
+    EVP_MD_CTX *context;    ///< It stores the hashed data calculated so far
     os_sha1 hash;       ///< Content file SHA1 hash
 } os_file_status_t;
 
@@ -270,7 +270,7 @@ int can_read();
  * @param context SHA1 context.
  * @return 0 on succes, otherwise -1
  */
-int w_update_file_status(const char * path, int64_t pos, SHA_CTX *context);
+int w_update_file_status(const char * path, int64_t pos, EVP_MD_CTX *context);
 
 /**
  * @brief Get SHA1 context or initialize it
@@ -279,7 +279,7 @@ int w_update_file_status(const char * path, int64_t pos, SHA_CTX *context);
  * @param position end file position.
  * @return true if returns a valid context, false in otherwise.
  */
-bool w_get_hash_context(logreader *lf, SHA_CTX *context, int64_t position);
+bool w_get_hash_context(logreader *lf, EVP_MD_CTX **context, int64_t position);
 
 extern int sample_log_length;
 extern int lc_debug_level;

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -59,7 +59,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     offset = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, offset);
 
@@ -75,7 +75,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
 
         if (buffer[rbytes - 1] == '\n') {
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, buffer);
+                OS_SHA1_Stream(context, NULL, buffer);
             }
 
             buffer[rbytes - 1] = '\0';
@@ -96,7 +96,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
                         break;
                     }
                     if (is_valid_context_file) {
-                        OS_SHA1_Stream(&context, NULL, buffer);
+                        OS_SHA1_Stream(context, NULL, buffer);
                     }
 
                     if (buffer[rbytes - 1] == '\n') {
@@ -151,7 +151,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     if (icache > 0)
         audit_send_msg(cache, icache, drop_it, lf);
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, offset, &context);
+        w_update_file_status(lf->file, offset, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -59,7 +59,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     offset = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, offset);
 
@@ -152,6 +152,8 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
         audit_send_msg(cache, icache, drop_it, lf);
     if (is_valid_context_file) {
         w_update_file_status(lf->file, offset, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -92,7 +92,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     }
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -100,7 +100,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     while (can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
 
         if (is_valid_context_file) {
-            OS_SHA1_Stream(&context, NULL, str);
+            OS_SHA1_Stream(context, NULL, str);
         }
 
         lines++;
@@ -193,7 +193,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     current_position = w_ftell(lf->fp);
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -92,7 +92,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     }
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -194,6 +194,8 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -30,7 +30,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -159,6 +159,8 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -30,7 +30,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -46,7 +46,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
 
             str[rbytes - 1] = '\0';
@@ -64,7 +64,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
         else if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
             __ms = 1;
         } else if (feof(lf->fp)) {
@@ -143,7 +143,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
                 }
 
                 if (is_valid_context_file) {
-                    OS_SHA1_Stream(&context, NULL, str);
+                    OS_SHA1_Stream(context, NULL, str);
                 }
 
                 /* Get the last occurrence of \n */
@@ -158,7 +158,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     }
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -41,7 +41,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -152,6 +152,8 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     /* Send whatever is stored */

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -41,7 +41,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -53,7 +53,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
         str_len = strlen(str);
 
         if (is_valid_context_file) {
-            OS_SHA1_Stream(&context, NULL, str);
+            OS_SHA1_Stream(context, NULL, str);
         }
 
         /* Check str_len size. Very useless, but just to make sure */
@@ -151,7 +151,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     current_position = w_ftell(lf->fp);
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     /* Send whatever is stored */

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -29,7 +29,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -46,7 +46,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
             str[rbytes - 1] = '\0';
 
@@ -63,7 +63,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
         else if (rbytes == OS_MAX_LOG_SIZE - 1) {
             /* Message size > maximum allowed */
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
             __ms = 1;
         } else if (feof(lf->fp)) {
@@ -129,7 +129,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
                 }
 
                 if (is_valid_context_file) {
-                    OS_SHA1_Stream(&context, NULL, str);
+                    OS_SHA1_Stream(context, NULL, str);
                 }
 
                 /* Get the last occurrence of \n */
@@ -144,7 +144,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     }
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -29,7 +29,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -145,6 +145,8 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -137,7 +137,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
     const int max_line_len = OS_MAXSTR - OS_LOG_HEADER;
 
     /* Continue from last read line */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t initial_pos;
     char * raw_data = NULL;
 
@@ -172,14 +172,14 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
         }
 
         if (is_valid_context_file) {
-            OS_SHA1_Stream(&context, NULL, raw_data);
+            OS_SHA1_Stream(context, NULL, raw_data);
         }
 
         os_free(raw_data);
     }
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, lf->multiline->offset_last_read, &context);
+        w_update_file_status(lf->file, lf->multiline->offset_last_read, context);
     }
 
     return NULL;

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -137,7 +137,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
     const int max_line_len = OS_MAXSTR - OS_LOG_HEADER;
 
     /* Continue from last read line */
-    EVP_MD_CTX *context = EVP_MD_CTX_new();
+    EVP_MD_CTX *context = NULL;
     int64_t initial_pos;
     char * raw_data = NULL;
 
@@ -147,6 +147,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
         lf->multiline->offset_last_read = w_ftell(lf->fp);
     }
 
+    context = EVP_MD_CTX_new();
     bool is_valid_context_file = w_get_hash_context(lf, &context, lf->multiline->offset_last_read);
 
     read_buffer[OS_MAXSTR] = '\0';

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -137,7 +137,7 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
     const int max_line_len = OS_MAXSTR - OS_LOG_HEADER;
 
     /* Continue from last read line */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t initial_pos;
     char * raw_data = NULL;
 
@@ -180,6 +180,8 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, lf->multiline->offset_last_read, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     return NULL;

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -30,7 +30,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -252,6 +252,8 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -30,7 +30,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -42,7 +42,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
         str_len = strlen(str);
 
         if (is_valid_context_file) {
-            OS_SHA1_Stream(&context, NULL, str);
+            OS_SHA1_Stream(context, NULL, str);
         }
 
         /* Get the last occurrence of \n */
@@ -251,7 +251,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     current_position = w_ftell(lf->fp);
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -144,7 +144,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -153,7 +153,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
         lines++;
 
         if (is_valid_context_file) {
-            OS_SHA1_Stream(&context, NULL, str);
+            OS_SHA1_Stream(context, NULL, str);
         }
 
         /* If need clear is set, we need to clear the line */
@@ -273,7 +273,7 @@ file_error:
 
     current_position = w_ftell(lf->fp);
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -144,7 +144,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -266,6 +266,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
 file_error:
 
         merror("Bad formated nmap grepable file.");
+        EVP_MD_CTX_free(context);
         *rc = -1;
         return (NULL);
 
@@ -274,6 +275,8 @@ file_error:
     current_position = w_ftell(lf->fp);
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -31,7 +31,6 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
     EVP_MD_CTX *context = EVP_MD_CTX_new();
     os_sha1 output;
     int64_t current_position = w_ftell(lf->fp);
-    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     if (OS_SHA1_File_Nbytes(lf->file, &context, output, OS_BINARY, current_position) < 0) {
         merror(FAIL_SHA1_GEN, lf->file);

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -28,9 +28,10 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
     }
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     os_sha1 output;
     int64_t current_position = w_ftell(lf->fp);
+    bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     if (OS_SHA1_File_Nbytes(lf->file, &context, output, OS_BINARY, current_position) < 0) {
         merror(FAIL_SHA1_GEN, lf->file);

--- a/src/logcollector/read_ossecalert.c
+++ b/src/logcollector/read_ossecalert.c
@@ -28,7 +28,7 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
     }
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     os_sha1 output;
     int64_t current_position = w_ftell(lf->fp);
 
@@ -36,7 +36,7 @@ void *read_ossecalert(logreader *lf, __attribute__((unused)) int *rc, int drop_i
         merror(FAIL_SHA1_GEN, lf->file);
     }
 
-    w_update_file_status(lf->file, current_position, &context);
+    w_update_file_status(lf->file, current_position, context);
 
     memset(syslog_msg, '\0', OS_SIZE_2048 + 1);
 

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -38,7 +38,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -50,7 +50,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
         str_len = strlen(str);
 
         if (is_valid_context_file) {
-            OS_SHA1_Stream(&context, NULL, str);
+            OS_SHA1_Stream(context, NULL, str);
         }
 
         /* Check str_len size. Very useless, but just to make sure.. */
@@ -150,7 +150,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
 
     current_position = w_ftell(lf->fp);
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -38,7 +38,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -151,6 +151,8 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     current_position = w_ftell(lf->fp);
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -28,7 +28,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -118,6 +118,7 @@ file_error:
 
         merror("Bad formated snort full file.");
         *rc = -1;
+        EVP_MD_CTX_free(context);
         return (NULL);
 
     }
@@ -126,6 +127,8 @@ file_error:
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -28,7 +28,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -37,7 +37,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
         lines++;
 
         if (is_valid_context_file) {
-            OS_SHA1_Stream(&context, NULL, str);
+            OS_SHA1_Stream(context, NULL, str);
         }
 
         /* Remove \n at the end of the string */
@@ -125,7 +125,7 @@ file_error:
     current_position = w_ftell(lf->fp);
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -31,7 +31,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     current_position = w_ftell(lf->fp);
 
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
@@ -145,6 +145,8 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -31,7 +31,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     /* Obtain context to calculate hash */
     current_position = w_ftell(lf->fp);
 
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
@@ -46,7 +46,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
             str[rbytes - 1] = '\0';
 
@@ -64,7 +64,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
             /* Message size > maximum allowed */
             __ms = 1;
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
             str[rbytes - 1] = '\0';
         } else {
@@ -130,7 +130,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
                 }
 
                 if (is_valid_context_file) {
-                    OS_SHA1_Stream(&context, NULL, str);
+                    OS_SHA1_Stream(context, NULL, str);
                 }
 
                 /* Get the last occurrence of \n */
@@ -144,7 +144,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     }
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -29,7 +29,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -47,7 +47,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if (str[rbytes - 1] == '\n') {
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
             str[rbytes - 1] = '\0';
         }
@@ -57,7 +57,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
         else if (rbytes == OS_MAXSTR_BE - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, str);
+                OS_SHA1_Stream(context, NULL, str);
             }
             __ms = 1;
             str[rbytes - 1] = '\0';
@@ -147,7 +147,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
                 }
 
                 if (is_valid_context_file) {
-                    OS_SHA1_Stream(&context, NULL, str);
+                    OS_SHA1_Stream(context, NULL, str);
                 }
 
                 /* Get the last occurrence of \n */
@@ -161,7 +161,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
     }
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -29,7 +29,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -162,6 +162,8 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -29,7 +29,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    SHA_CTX context;
+    EVP_MD_CTX *context = NULL;
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -48,7 +48,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
         /* Get the last occurrence of \n */
         if ((n = wcsrchr(str, L'\n')) != NULL) {
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, (char *) str);
+                OS_SHA1_Stream(context, NULL, (char *) str);
             }
             *n = '\0';
         }
@@ -58,7 +58,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
         if (rbytes == OS_MAXSTR - OS_LOG_HEADER - 1) {
             /* Message size > maximum allowed */
             if (is_valid_context_file) {
-                OS_SHA1_Stream(&context, NULL, (char *) str);
+                OS_SHA1_Stream(context, NULL, (char *) str);
             }
             __ms = 1;
             str[rbytes - 1] = '\0';
@@ -140,7 +140,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
                 }
 
                 if (is_valid_context_file) {
-                    OS_SHA1_Stream(&context, NULL, (char *) str);
+                    OS_SHA1_Stream(context, NULL, (char *) str);
                 }
 
                 /* Get the last occurrence of \n */
@@ -155,7 +155,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
     }
 
     if (is_valid_context_file) {
-        w_update_file_status(lf->file, current_position, &context);
+        w_update_file_status(lf->file, current_position, context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -29,7 +29,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
     *rc = 0;
 
     /* Obtain context to calculate hash */
-    EVP_MD_CTX *context = NULL;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
@@ -156,6 +156,8 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
 
     if (is_valid_context_file) {
         w_update_file_status(lf->file, current_position, context);
+    } else {
+        EVP_MD_CTX_free(context);
     }
 
     mdebug2("Read %d lines from %s", lines, lf->file);

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -26,7 +26,7 @@
 */
 
 int OS_SHA1_File(const char *fname, os_sha1 output, int mode) {
-    SHA_CTX c;
+    EVP_MD_CTX *sha1_ctx = EVP_MD_CTX_new();
     FILE *fp;
     unsigned char buf[2048 + 2];
     unsigned char md[SHA_DIGEST_LENGTH];
@@ -40,13 +40,13 @@ int OS_SHA1_File(const char *fname, os_sha1 output, int mode) {
         return (-1);
     }
 
-    SHA1_Init(&c);
+    EVP_DigestInit(sha1_ctx, EVP_sha1());
     while ((n = fread(buf, 1, 2048, fp)) > 0) {
         buf[n] = '\0';
-        SHA1_Update(&c, buf, n);
+        EVP_DigestUpdate(sha1_ctx, buf, n);
     }
 
-    SHA1_Final(&(md[0]), &c);
+    EVP_DigestFinal(sha1_ctx, md, NULL);
 
     for (n = 0; n < SHA_DIGEST_LENGTH; n++) {
         snprintf(output, 3, "%02x", md[n]);
@@ -54,6 +54,7 @@ int OS_SHA1_File(const char *fname, os_sha1 output, int mode) {
     }
 
     fclose(fp);
+    EVP_MD_CTX_free(sha1_ctx);
 
     return (0);
 }
@@ -62,15 +63,17 @@ int OS_SHA1_Str(const char *str, ssize_t length, os_sha1 output) {
     unsigned char md[SHA_DIGEST_LENGTH];
     size_t n;
 
-    SHA_CTX c;
-    SHA1_Init(&c);
-    SHA1_Update(&c, (const unsigned char *)str, length < 0 ? (unsigned)strlen(str) : (unsigned)length);
-    SHA1_Final(&(md[0]), &c);
+    EVP_MD_CTX *sha1_ctx = EVP_MD_CTX_new();
+    EVP_DigestInit(sha1_ctx, EVP_sha1());
+    EVP_DigestUpdate(sha1_ctx, (const unsigned char *)str, length < 0 ? (unsigned)strlen(str) : (unsigned)length);
+    EVP_DigestFinal(sha1_ctx, md, NULL);
 
     for (n = 0; n < SHA_DIGEST_LENGTH; n++) {
         snprintf(output, 3, "%02x", md[n]);
         output += 2;
     }
+
+    EVP_MD_CTX_free(sha1_ctx);
 
     return (0);
 }
@@ -93,22 +96,24 @@ int OS_SHA1_Str2(const char *str, ssize_t length, os_sha1 output) {
 int OS_SHA1_strings(os_sha1 output, ...) {
     unsigned char md[SHA_DIGEST_LENGTH];
     size_t n;
-    SHA_CTX c;
-    SHA1_Init(&c);
+    EVP_MD_CTX *sha1_ctx = EVP_MD_CTX_new();
+    EVP_DigestInit(sha1_ctx, EVP_sha1());
 
     va_list parameters;
     char* parameter = NULL;
     va_start(parameters, output);
     while (parameter = va_arg(parameters, char*), parameter) {
-        SHA1_Update(&c, parameter, strlen(parameter));
+        EVP_DigestUpdate(sha1_ctx, parameter, strlen(parameter));
     }
     va_end(parameters);
-    SHA1_Final(&(md[0]), &c);
+    EVP_DigestFinal(sha1_ctx, md, NULL);
 
     for (n = 0; n < SHA_DIGEST_LENGTH; n++) {
         snprintf(output, 3, "%02x", md[n]);
         output += 2;
     }
+
+    EVP_MD_CTX_free(sha1_ctx);
 
     return (0);
 }
@@ -123,15 +128,15 @@ void OS_SHA1_Hexdigest(const unsigned char * digest, os_sha1 output) {
     }
 }
 
-int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode, int64_t nbytes) {
+int OS_SHA1_File_Nbytes(const char *fname, EVP_MD_CTX **c, os_sha1 output, int mode, int64_t nbytes) {
     return OS_SHA1_File_Nbytes_with_fp_check(fname, c, output, mode, nbytes, 0);
 }
 
 #ifndef WIN32
-int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sha1 output, int mode, int64_t nbytes,
                                       ino_t fd_check) {
 #else
-int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sha1 output, int mode, int64_t nbytes,
                                       DWORD fd_check) {
 #endif
 
@@ -143,7 +148,8 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 o
     memset(output, 0, sizeof(os_sha1));
     buf[OS_MAXSTR - 1] = '\0';
 
-    SHA1_Init(c);
+    *c = EVP_MD_CTX_new();
+    EVP_DigestInit(*c, EVP_sha1());
 
     /* It's important to read \r\n instead of \n to generate the correct hash */
 #ifdef WIN32
@@ -192,35 +198,39 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 o
         }
 
         buf[n] = '\0';
-        SHA1_Update(c, buf, n);
+        EVP_DigestUpdate(*c, buf, n);
     }
 
-    SHA_CTX aux = *c;
+    EVP_MD_CTX *aux = EVP_MD_CTX_new();
+    EVP_MD_CTX_copy(aux, *c);
 
-    SHA1_Final(&(md[0]), &aux);
+    EVP_DigestFinal(aux, md, NULL);
 
     OS_SHA1_Hexdigest(md, output);
+
+    EVP_MD_CTX_free(aux);
 
     fclose(fp);
 
     return (0);
 }
 
-void OS_SHA1_Stream(SHA_CTX *c, os_sha1 output, char * buf) {
+void OS_SHA1_Stream(EVP_MD_CTX *c, os_sha1 output, char * buf) {
     if(buf) {
         size_t n = strlen(buf);
 
-        SHA1_Update(c, buf, n);
+        EVP_DigestUpdate(c, buf, n);
     }
 
     if(output) {
         memset(output, 0, sizeof(os_sha1));
         unsigned char md[SHA_DIGEST_LENGTH];
-        SHA_CTX aux = *c;
+        EVP_MD_CTX *aux = EVP_MD_CTX_new();
+        EVP_MD_CTX_copy(aux, c);
 
-        SHA1_Final(&(md[0]), &aux);
-
+        EVP_DigestFinal(aux, md, NULL);
         OS_SHA1_Hexdigest(md, output);
+        EVP_MD_CTX_free(aux);
     }
 
 }

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -146,6 +146,11 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sh
     int64_t n;
     unsigned char md[SHA_DIGEST_LENGTH];
 
+    if (c == NULL || *c == NULL) {
+        mdebug1("Context for file '%s' can not be NULL.", fname);
+        return -3;
+    }
+
     memset(output, 0, sizeof(os_sha1));
     buf[OS_MAXSTR - 1] = '\0';
 

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -37,6 +37,7 @@ int OS_SHA1_File(const char *fname, os_sha1 output, int mode) {
 
     fp = wfopen(fname, mode == OS_BINARY ? "rb" : "r");
     if (!fp) {
+        EVP_MD_CTX_free(sha1_ctx);
         return (-1);
     }
 
@@ -148,7 +149,6 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sh
     memset(output, 0, sizeof(os_sha1));
     buf[OS_MAXSTR - 1] = '\0';
 
-    *c = EVP_MD_CTX_new();
     EVP_DigestInit(*c, EVP_sha1());
 
     /* It's important to read \r\n instead of \n to generate the correct hash */

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -13,10 +13,11 @@
 
 #include <sys/types.h>
 #include <openssl/sha.h>
-#include <openssl/evp.h>
 #ifdef WIN32
+#include <winsock2.h>
 #include <windef.h>
 #endif
+#include <openssl/evp.h>
 
 #define OS_SHA1_HEXDIGEST_SIZE (SHA_DIGEST_LENGTH * 2) // Sha1 digest len (20) * 2 (hex chars per byte)
 
@@ -46,7 +47,7 @@ void OS_SHA1_Hexdigest(const unsigned char * digest, os_sha1 output);
  * @brief Calculates the SHA1 of a file until N byte and save the context
  *
  * @param fname[in] File name to calculate SHA1.
- * @param c[out] SHA1 context.
+ * @param c[out] EVP_MD_CTX context.
  * @param output[out] Output string.
  * @param nbytes[in] Number of bytes to read.
  * @return 0 on success, -1 when failure opening file.
@@ -57,7 +58,7 @@ int OS_SHA1_File_Nbytes(const char *fname, EVP_MD_CTX **c, os_sha1 output, int m
  * @brief If fp corresponds to fname then calculates the SHA1 of the `fname` file until N byte and save the context
  *
  * @param[in] fname File name to calculate SHA1.
- * @param[out] c SHA1 context.
+ * @param[out] c EVP_MD_CTX context.
  * @param[out] output Output string.
  * @param[in] nbytes Number of bytes to read.
  * @param[in] fd_check File serial number, Is checked against `fname`
@@ -75,7 +76,7 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sh
 /**
  * @brief update the context and calculates the SHA1
  *
- * @param c[out] SHA1 context.
+ * @param c[out] EVP_MD_CTX context.
  * @param output[out] Output string.
  * @param buf[in] String to update the SHA1 context
  */

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -45,17 +45,24 @@ void OS_SHA1_Hexdigest(const unsigned char * digest, os_sha1 output);
 
 /**
  * @brief Calculates the SHA1 of a file until N byte and save the context
+ * The context is not created, it is only reset, so the function that calls this function must previously do the creation of the context.
+ * Saved context must be freed after use.
  *
  * @param fname[in] File name to calculate SHA1.
  * @param c[out] EVP_MD_CTX context.
  * @param output[out] Output string.
  * @param nbytes[in] Number of bytes to read.
- * @return 0 on success, -1 when failure opening file.
+ * @return 0 on success.
+ * @return -1 when failure opening file.
+ * @retval -2 When fp does not correspond to the `fname` file.
+ * @retval -3 When context is NULL.
  */
 int OS_SHA1_File_Nbytes(const char *fname, EVP_MD_CTX **c, os_sha1 output, int mode, int64_t nbytes);
 
 /**
- * @brief If fp corresponds to fname then calculates the SHA1 of the `fname` file until N byte and save the context
+ * @brief If fp corresponds to fname then calculates the SHA1 of the `fname` file until N byte and save the context.
+ * The context is not created, it is only reset, so the function that calls this function must previously do the creation of the context.
+ * Saved context must be freed after use.
  *
  * @param[in] fname File name to calculate SHA1.
  * @param[out] c EVP_MD_CTX context.
@@ -64,7 +71,8 @@ int OS_SHA1_File_Nbytes(const char *fname, EVP_MD_CTX **c, os_sha1 output, int m
  * @param[in] fd_check File serial number, Is checked against `fname`
  * @retval 0 on success
  * @retval -1 when failure opening file.
- * @retval -2 When fp does not correspond to the `fname` file
+ * @retval -2 When fp does not correspond to the `fname` file.
+ * @retval -3 When context is NULL.
  */
 #ifndef WIN32
 int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sha1 output, int mode, int64_t nbytes,
@@ -74,7 +82,7 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sh
                                       DWORD fd_check);
 #endif
 /**
- * @brief update the context and calculates the SHA1
+ * @brief update the context and calculates the SHA1, the context can not be null.
  *
  * @param c[out] EVP_MD_CTX context.
  * @param output[out] Output string.

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -13,6 +13,7 @@
 
 #include <sys/types.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #ifdef WIN32
 #include <windef.h>
 #endif
@@ -50,7 +51,7 @@ void OS_SHA1_Hexdigest(const unsigned char * digest, os_sha1 output);
  * @param nbytes[in] Number of bytes to read.
  * @return 0 on success, -1 when failure opening file.
  */
-int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode, int64_t nbytes);
+int OS_SHA1_File_Nbytes(const char *fname, EVP_MD_CTX **c, os_sha1 output, int mode, int64_t nbytes);
 
 /**
  * @brief If fp corresponds to fname then calculates the SHA1 of the `fname` file until N byte and save the context
@@ -65,10 +66,10 @@ int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode,
  * @retval -2 When fp does not correspond to the `fname` file
  */
 #ifndef WIN32
-int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sha1 output, int mode, int64_t nbytes,
                                       ino_t fd_check);
 #else
-int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sha1 output, int mode, int64_t nbytes,
                                       DWORD fd_check);
 #endif
 /**
@@ -78,6 +79,6 @@ int OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 o
  * @param output[out] Output string.
  * @param buf[in] String to update the SHA1 context
  */
-void OS_SHA1_Stream(SHA_CTX *c, os_sha1 output, char * buf);
+void OS_SHA1_Stream(EVP_MD_CTX *c, os_sha1 output, char * buf);
 
 #endif /* SHA1_OP_H */

--- a/src/unit_tests/logcollector/test_read_multiline.c
+++ b/src/unit_tests/logcollector/test_read_multiline.c
@@ -37,15 +37,19 @@ int __wrap_can_read() {
     return mock_type(int);
 }
 
-bool __wrap_w_get_hash_context(const char * path, SHA_CTX * context, int64_t position) {
+bool __wrap_w_get_hash_context(const char * path, EVP_MD_CTX * context, int64_t position) {
     return mock_type(bool);
 }
 
-int __wrap_w_update_file_status(const char * path, int64_t pos, SHA_CTX * context) {
+int __wrap_w_update_file_status(const char * path, int64_t pos, EVP_MD_CTX * context) {
+    bool free_context = mock_type(bool);
+    if (free_context) {
+        EVP_MD_CTX_free(context);
+    }
     return mock_type(int);
 }
 
-void __wrap_OS_SHA1_Stream(SHA_CTX *c, os_sha1 output, char * buf) {
+void __wrap_OS_SHA1_Stream(EVP_MD_CTX *c, os_sha1 output, char * buf) {
     function_called();
     return;
 }
@@ -107,7 +111,62 @@ void test_buffer_space(void ** state) {
 
     will_return(__wrap_can_read, 0);
 
+    will_return(__wrap_w_update_file_status, true);
     will_return(__wrap_w_update_file_status, 0);
+
+    read_multiline(&lf, &rc, 1);
+
+    free(input_str);
+}
+
+void test_buffer_space_invalid_context(void ** state) {
+    logreader lf = { .file = "test", .linecount = 3 };
+    int rc;
+    char * input_str = malloc(OS_MAX_LOG_SIZE);
+    memset(input_str, '.', OS_MAX_LOG_SIZE - 1);
+    input_str[OS_MAX_LOG_SIZE - 1] = '\0';
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_w_get_hash_context, false);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, input_str);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) OS_MAX_LOG_SIZE - 1);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, "\n");
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) OS_MAX_LOG_SIZE);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, input_str);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) (OS_MAX_LOG_SIZE) * 2 - 1);
+
+    expect_any(__wrap__merror, formatted_msg);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, NULL);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) (OS_MAX_LOG_SIZE) * 2 - 1);
+
+    will_return(__wrap_can_read, 0);
 
     read_multiline(&lf, &rc, 1);
 
@@ -117,6 +176,7 @@ void test_buffer_space(void ** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_buffer_space),
+        cmocka_unit_test(test_buffer_space_invalid_context),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);

--- a/src/unit_tests/logcollector/test_read_multiline_regex.c
+++ b/src/unit_tests/logcollector/test_read_multiline_regex.c
@@ -60,15 +60,19 @@ int __wrap_w_msg_hash_queues_push(const char * str, char * file, unsigned long s
     return mock_type(int);
 }
 
-bool __wrap_w_get_hash_context(const char * path, SHA_CTX * context, int64_t position) {
+bool __wrap_w_get_hash_context(const char * path, EVP_MD_CTX * context, int64_t position) {
     return mock_type(bool);
 }
 
-int __wrap_w_update_file_status(const char * path, int64_t pos, SHA_CTX * context) {
+int __wrap_w_update_file_status(const char * path, int64_t pos, EVP_MD_CTX * context) {
+    bool free_context = mock_type(bool);
+    if (free_context) {
+        EVP_MD_CTX_free(context);
+    }
     return mock_type(int);
 }
 
-void __wrap_OS_SHA1_Stream(SHA_CTX *c, os_sha1 output, char * buf) {
+void __wrap_OS_SHA1_Stream(EVP_MD_CTX *c, os_sha1 output, char * buf) {
     function_called();
     return;
 }
@@ -1579,6 +1583,7 @@ void test_read_multiline_regex_log_process(void ** state) {
     will_return(__wrap_fgets, NULL);
 
     expect_function_call(__wrap_OS_SHA1_Stream);
+    will_return(__wrap_w_update_file_status, true);
     will_return(__wrap_w_update_file_status, 0);
 
     void * retval = read_multiline_regex(&lf, &rc, drop_it);
@@ -1608,6 +1613,7 @@ void test_read_multiline_regex_no_aviable_log(void ** state) {
     expect_any(__wrap_fgets, __stream);
     will_return(__wrap_fgets, NULL);
 
+    will_return(__wrap_w_update_file_status, true);
     will_return(__wrap_w_update_file_status, 0);
 
     void * retval = read_multiline_regex(&lf, &rc, drop_it);
@@ -1731,6 +1737,7 @@ void test_read_multiline_regex_log_ignored(void ** state) {
     will_return(__wrap_fgets, NULL);
 
     expect_function_call(__wrap_OS_SHA1_Stream);
+    will_return(__wrap_w_update_file_status, true);
     will_return(__wrap_w_update_file_status, 0);
 
     void * retval = read_multiline_regex(&lf, &rc, drop_it);

--- a/src/unit_tests/os_crypto/sha1/test_sha1_op.c
+++ b/src/unit_tests/os_crypto/sha1/test_sha1_op.c
@@ -34,6 +34,18 @@ static int teardown_group(void **state) {
 
 /* OS_SHA1_File_Nbytes */
 
+void OS_SHA1_File_Nbytes_context_null (void **state)
+{
+    const char *path = "/home/test_file";
+    EVP_MD_CTX *context = NULL;
+    os_sha1 output;
+    ssize_t nbytes = 4096;
+
+    int mode = OS_BINARY;
+
+    assert_int_equal(OS_SHA1_File_Nbytes(path, &context, output, mode, nbytes), -3);
+}
+
 void OS_SHA1_File_Nbytes_unable_open_file (void **state)
 {
     const char *path = "/home/test_file";
@@ -193,6 +205,7 @@ void test_sha1_file_fail(void **state)
 int main(void) {
     const struct CMUnitTest tests[] = {
         // Tests OS_SHA1_File_Nbytes
+        cmocka_unit_test(OS_SHA1_File_Nbytes_context_null),
         cmocka_unit_test(OS_SHA1_File_Nbytes_unable_open_file),
         cmocka_unit_test(OS_SHA1_File_Nbytes_ok),
         cmocka_unit_test(OS_SHA1_File_Nbytes_num_bytes_exceded),

--- a/src/unit_tests/os_crypto/sha1/test_sha1_op.c
+++ b/src/unit_tests/os_crypto/sha1/test_sha1_op.c
@@ -17,7 +17,7 @@
 #include "../../wrappers/libc/stdio_wrappers.h"
 #include "../../wrappers/common.h"
 
-int OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode, int64_t nbytes);
+int OS_SHA1_File_Nbytes(const char *fname, EVP_MD_CTX **c, os_sha1 output, int mode, int64_t nbytes);
 
 /* setups/teardowns */
 static int setup_group(void **state) {
@@ -37,7 +37,7 @@ static int teardown_group(void **state) {
 void OS_SHA1_File_Nbytes_unable_open_file (void **state)
 {
     const char *path = "/home/test_file";
-    SHA_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     os_sha1 output;
     ssize_t nbytes = 4096;
 
@@ -48,12 +48,14 @@ void OS_SHA1_File_Nbytes_unable_open_file (void **state)
     will_return(__wrap_wfopen, NULL);
 
     assert_int_equal(OS_SHA1_File_Nbytes(path, &context, output, mode, nbytes), -1);
+
+    EVP_MD_CTX_free(context);
 }
 
 void OS_SHA1_File_Nbytes_ok (void **state)
 {
     const char *path = "/home/test_file";
-    SHA_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     os_sha1 output;
     ssize_t nbytes = 4000;
 
@@ -73,12 +75,14 @@ void OS_SHA1_File_Nbytes_ok (void **state)
     will_return(__wrap_fclose, 1);
 
     assert_int_equal(OS_SHA1_File_Nbytes(path, &context, output, mode, nbytes), 0);
+
+    EVP_MD_CTX_free(context);
 }
 
 void OS_SHA1_File_Nbytes_num_bytes_exceded (void **state)
 {
     const char *path = "/home/test_file";
-    SHA_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
     os_sha1 output;
     ssize_t nbytes = 6;
 
@@ -95,6 +99,8 @@ void OS_SHA1_File_Nbytes_num_bytes_exceded (void **state)
     will_return(__wrap_fclose, 1);
 
     assert_int_equal(OS_SHA1_File_Nbytes(path, &context, output, mode, nbytes), 0);
+
+    EVP_MD_CTX_free(context);
 }
 
 /* OS_SHA1_Stream */
@@ -103,22 +109,25 @@ void OS_SHA1_Stream_ok (void **state)
 {
     char *buf = "hello";
     os_sha1 output;
-    SHA_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
 
-    SHA1_Init(&context);
+    EVP_DigestInit(context, EVP_sha1());
 
-    OS_SHA1_Stream(&context, output, buf);
+    OS_SHA1_Stream(context, output, buf);
+
+    EVP_MD_CTX_free(context);
 }
 
 void OS_SHA1_Stream_buf_null (void **state)
 {
     char *buf = NULL;
     os_sha1 output;
-    SHA_CTX context;
+    EVP_MD_CTX *context = EVP_MD_CTX_new();
 
-    SHA1_Init(&context);
+    EVP_DigestInit(context, EVP_sha1());
 
-    OS_SHA1_Stream(&context, output, buf);
+    OS_SHA1_Stream(context, output, buf);
+    EVP_MD_CTX_free(context);
 }
 
 void test_sha1_string(void **state)

--- a/src/unit_tests/syscheckd/test_fim_diff_changes.c
+++ b/src/unit_tests/syscheckd/test_fim_diff_changes.c
@@ -579,6 +579,7 @@ void test_initialize_file_diff_data_abspath_fail(void **state) {
     diff_data *diff = *state;
 
     expect_abspath(GENERIC_PATH, 0);
+    errno = 0;
 #ifdef TEST_WINAGENT
     expect_string(__wrap__merror, formatted_msg, "(6711): Cannot get absolute path of 'c:\\file\\path': Success (0)");
 #else

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.c
@@ -22,7 +22,7 @@ int __wrap_OS_SHA1_File(const char *fname, os_sha1 output, int mode) {
     return mock();
 }
 
-int __wrap_OS_SHA1_File_Nbytes(const char *fname, __attribute__((unused))SHA_CTX *c, os_sha1 output, int mode, ssize_t nbytes) {
+int __wrap_OS_SHA1_File_Nbytes(const char *fname, __attribute__((unused))EVP_MD_CTX **c, os_sha1 output, int mode, ssize_t nbytes) {
     check_expected(fname);
     check_expected(mode);
     check_expected(nbytes);
@@ -32,7 +32,7 @@ int __wrap_OS_SHA1_File_Nbytes(const char *fname, __attribute__((unused))SHA_CTX
     return mock();
 }
 
-void __wrap_OS_SHA1_Stream(__attribute__((unused))SHA_CTX *c, os_sha1 output, char * buf) {
+void __wrap_OS_SHA1_Stream(__attribute__((unused))EVP_MD_CTX *c, os_sha1 output, char * buf) {
     check_expected(buf);
 
     snprintf(output, 41, "%s", mock_type(char *));
@@ -40,7 +40,7 @@ void __wrap_OS_SHA1_Stream(__attribute__((unused))SHA_CTX *c, os_sha1 output, ch
 }
 
 #ifndef WIN32
-int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((unused))SHA_CTX * c, os_sha1 output,
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((unused))EVP_MD_CTX ** c, os_sha1 output,
                                       int mode, int64_t nbytes, ino_t fd_check) {
     check_expected(fname);
     check_expected(mode);
@@ -52,7 +52,7 @@ int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((
     return mock();
 }
 #else
-int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((unused))SHA_CTX * c, os_sha1 output,
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, __attribute__((unused))EVP_MD_CTX ** c, os_sha1 output,
                                       int mode, int64_t nbytes, DWORD fd_check) {
     check_expected(fname);
     check_expected(mode);

--- a/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/sha1_op_wrappers.h
@@ -18,13 +18,13 @@
 typedef char os_sha1[41];
 
 int __wrap_OS_SHA1_File(const char *fname, os_sha1 output, int mode);
-int __wrap_OS_SHA1_File_Nbytes(const char *fname, SHA_CTX *c, os_sha1 output, int mode, ssize_t nbytes);
-void __wrap_OS_SHA1_Stream(SHA_CTX *c, os_sha1 output, char * buf);
+int __wrap_OS_SHA1_File_Nbytes(const char *fname, EVP_MD_CTX **c, os_sha1 output, int mode, ssize_t nbytes);
+void __wrap_OS_SHA1_Stream(EVP_MD_CTX *c, os_sha1 output, char * buf);
 #ifndef WIN32
-int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sha1 output, int mode, int64_t nbytes,
                                       ino_t fd_check);
 #else
-int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, SHA_CTX * c, os_sha1 output, int mode, int64_t nbytes,
+int __wrap_OS_SHA1_File_Nbytes_with_fp_check(const char * fname, EVP_MD_CTX ** c, os_sha1 output, int mode, int64_t nbytes,
                                       DWORD fd_check);
 #endif
 


### PR DESCRIPTION
|Related issue|
|---|
|#21565|

## Description

This PR migrates the SHA1 hash functions (SHA1_Init, SHA1_Update, SHA1_Final), deprecated in OpenSSL 3.0, to the new EVP_XX API

Changes:

- Uses the new functions in sha1_op.c
- Uses the new functions in logcollector
- Fixes UTs in test_sha1_op
- Fixes UTs in test_read_multiline
- Fixes UTs in test_read_multiline_regex
- Fixes UTs in test_logcollector


## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
- Memory tests for macOS
  - [x] Scan-build report

