### PR TITLE
Avoid rpm symbol package installation test

### DIFF
--- a/.github/workflows/packages-build-linux-agent.yml
+++ b/.github/workflows/packages-build-linux-agent.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Test install built package
         run: |
-          package_name=$(find /tmp -maxdepth 1 -type f -name "*agent*.${{ inputs.system }}" -exec basename {} 2>/dev/null \;)
+          package_name=$(find /tmp -maxdepth 1 -type f -name "*agent*.${{ inputs.system }}" -exec basename {} 2>/dev/null \; | grep -v -E "^(wazuh-agent-dbg|wazuh-agent-debuginfo)")
           if [ -z "$package_name" ]; then echo "No package found matching the pattern!"; exit 1; fi
           sudo docker run -v $GITHUB_WORKSPACE/.github/actions/test-install-components/:/tests -v /tmp/:/packages --entrypoint '/tests/install_component.sh' $CONTAINER_NAME:${{ env.TAG }} $package_name agent
           # Check if wazuh-agent was installed. The /tmp/status.log file was generated in the previous step.


### PR DESCRIPTION
|Related issue|
|---|
|#22942|
## Description
Fix giuthub's `workflow` due new symbols packages added.

## Configuration options
Follow steps described in [Worflow](https://github.com/wazuh/wazuh/tree/enhancement/9913-generate-debug-symbols-epic/packages#workflow) section of readme file to create any necesary image and test these changes.

test.json
```json
{
    "ref":"22942-upload-symbols-rpm",
    "inputs":
        {
         "docker_image_tag":"symbols-rpm",
         "architecture":"amd64",
         "system":"rpm",
         "revision":"test",
         "is_stage":"false",
         "legacy":"false",
         "checksum":"false"
     }
}
``` 
## Tests
extracted output of the [job](https://github.com/wazuh/wazuh/actions/runs/8740348102/job/23983813924) used for testing
```shell
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-agent-4.9.0-test.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-agent_4.9.0-test_x86_64_1dc9535.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-agent-debuginfo_4.9.0-test_x86_64_1dc9535.rpm
Executing(%clean): /bin/sh -e /usr/local/var/tmp/rpm-tmp.ANgx1t
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-agent-4.9.0
+ rm -fr /build_wazuh/rpmbuild/BUILDROOT/wazuh-agent-4.9.0-test.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
+ return 0
+ get_checksum 4.9.0 1dc9535 no
+ src=no
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ mv /build_wazuh/rpmbuild/RPMS/wazuh-agent-debuginfo_4.9.0-test_x86_64_1dc9535.rpm /build_wazuh/rpmbuild/RPMS/wazuh-agent_4.9.0-test_x86_64_1dc9535.rpm /var/local/wazuh
++ ls -Art /tmp
++ tail -n 1
+ echo 'Package wazuh-agent-debuginfo_4.9.0-test_x86_64_1dc9535.rpm added to /tmp.'
Package wazuh-agent-debuginfo_4.9.0-test_x86_64_1dc9535.rpm added to /tmp.
+ return 0
+ return 0
+ clean 0
+ exit_code=0
+ find /home/runner/work/wazuh/wazuh/packages/rpms/amd64/agent '(' -name '*.sh' -o -name '*.tar.gz' -o -name 'wazuh-*' ')' '!' -name docker_builder.sh -exec rm -rf '{}' +
+ exit 0

Run for file in /tmp/*agent*; do
Completed 256.0 KiB/14.4 MiB (525.2 KiB/s) with 1 file(s) remaining
Completed 512.0 KiB/14.4 MiB (1.0 MiB/s) with 1 file(s) remaining  
.
.
.

upload: ../../../../../tmp/wazuh-agent-debuginfo_4.9.0-test_x86_64_1dc9535.rpm to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-agent-debuginfo_4.9.0-test_x86_64_1dc9535.rpm

Completed 256.0 KiB/10.4 MiB (627.9 KiB/s) with 1 file(s) remaining
Completed 512.0 KiB/10.4 MiB (1.2 MiB/s) with 1 file(s) remaining  
.
.
.

upload: ../../../../../tmp/wazuh-agent_4.9.0-test_x86_64_1dc9535.rpm to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-agent_4.9.0-test_x86_64_1dc9535.rpm



```