### PR TITLE
added mutex to protect self->table

### DIFF
--- a/src/headers/hash_op.h
+++ b/src/headers/hash_op.h
@@ -86,6 +86,8 @@ OSHash *OSHash_Duplicate(const OSHash *hash) __attribute__((nonnull));
 OSHash *OSHash_Duplicate_ex(const OSHash *hash) __attribute__((nonnull));
 
 OSHashNode *OSHash_Begin(const OSHash *self, unsigned int *i);
+OSHashNode *OSHash_Begin_ex(const OSHash *self, unsigned int *i);
+
 OSHashNode *OSHash_Next(const OSHash *self, unsigned int *i, OSHashNode *current);
 void *OSHash_Clean(OSHash *self, void (*cleaner)(void*));
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -43,8 +43,6 @@ size_t global_counter;
 
 _Atomic (time_t) current_ts;
 
-/* remoted agents state mutex */
-extern pthread_mutex_t remoted_agents_state_mutex;
 OSHash *remoted_agents_state;
 
 extern remoted_state_t remoted_state;

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -43,6 +43,8 @@ size_t global_counter;
 
 _Atomic (time_t) current_ts;
 
+/* remoted agents state mutex */
+extern pthread_mutex_t remoted_agents_state_mutex;
 OSHash *remoted_agents_state;
 
 extern remoted_state_t remoted_state;

--- a/src/remoted/state.c
+++ b/src/remoted/state.c
@@ -238,7 +238,7 @@ STATIC void w_remoted_clean_agents_state(int *sock) {
     OSHashNode *hash_node;
     unsigned int inode_it = 0;
 
-    hash_node = OSHash_Begin(remoted_agents_state, &inode_it);
+    hash_node = OSHash_Begin_ex(remoted_agents_state, &inode_it);
 
     if (hash_node == NULL) {
         return;

--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -16,6 +16,8 @@ static unsigned int _os_genhash(const OSHash *self, const char *key) __attribute
 
 int _OSHash_Add(OSHash *self, const char *key, void *data, int update);
 
+pthread_mutex_t remoted_agents_state_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 /* Create hash
  * Returns NULL on error
  */
@@ -287,7 +289,9 @@ int _OSHash_Add(OSHash *self, const char *key, void *data, int update)
 
     /* Add to table */
     if (!self->table[index]) {
+        w_mutex_lock(&remoted_agents_state_mutex);
         self->table[index] = new_node;
+        w_mutex_unlock(&remoted_agents_state_mutex);
     }
     /* If there is duplicated, add to the beginning */
     else {
@@ -590,7 +594,10 @@ OSHashNode *OSHash_Begin(const OSHash *self, unsigned int *i){
 
     if (self) {
         while (*i <= self->rows) {
+            w_mutex_lock(&remoted_agents_state_mutex);
             curr_node = self->table[*i];
+            w_mutex_unlock(&remoted_agents_state_mutex);
+
             if (curr_node && curr_node->key) {
                 return curr_node;
             }

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -80,7 +80,7 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,ReadConfig -Wl,--wrap,_merror -Wl,--wrap
                              -Wl,--wrap,OSList_SetMaxSize -Wl,--wrap,OSHash_setSize -Wl,--wrap,OSHash_Delete_ex \
                              -Wl,--wrap,OSHash_Free -Wl,--wrap,os_remove_rules_list -Wl,--wrap,os_remove_decoders_list \
                              -Wl,--wrap,os_remove_cdblist -Wl,--wrap,os_remove_cdbrules -Wl,--wrap,os_remove_eventlist \
-                             -Wl,--wrap,sleep -Wl,--wrap,OSHash_Begin -Wl,--wrap,time -Wl,--wrap,difftime \
+                             -Wl,--wrap,sleep -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Begin_ex -Wl,--wrap,time -Wl,--wrap,difftime \
                              -Wl,--wrap,OSHash_Next -Wl,--wrap,FOREVER -Wl,--wrap,OS_CreateEventList \
                              -Wl,--wrap,ReadDecodeXML -Wl,--wrap,Lists_OP_LoadList -Wl,--wrap,Lists_OP_MakeAll \
                              -Wl,--wrap,Rules_OP_ReadRules -Wl,--wrap,OS_ListLoadRules -Wl,--wrap,_setlevels \
@@ -157,7 +157,7 @@ LIST(APPEND analysisd_flags "${DEBUG_OP_WRAPPERS}")
 
 list(APPEND analysisd_names "test_analysis-state")
 list(APPEND analysisd_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \
-                            -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin \
+                            -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Begin_ex \
                             -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Clean \
                             -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_SetFreeDataPointer \
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -43,7 +43,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_mdebug2 -Wl,--wrap,_mdebug1 -Wl,--wrap,w_
                             -Wl,--wrap,OS_SHA256_String -Wl,--wrap,readdir -Wl,--wrap,strerror -Wl,--wrap,wfopen \
                             -Wl,--wrap,fopen -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,fclose -Wl,--wrap,remove \
                             -Wl,--wrap,fgets -Wl,--wrap,fflush -Wl,--wrap,fseek -Wl,--wrap,fgetpos -Wl,--wrap=fgetc \
-                            -Wl,--wrap,w_copy_file -Wl,--wrap,OSHash_Begin -Wl,--wrap,req_save -Wl,--wrap,send_msg \
+                            -Wl,--wrap,w_copy_file -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Begin_ex -Wl,--wrap,req_save -Wl,--wrap,send_msg \
                             -Wl,--wrap,wdb_update_agent_keepalive -Wl,--wrap,parse_agent_update_msg \
                             -Wl,--wrap,wdb_update_agent_data -Wl,--wrap,linked_queue_push_ex \
                             -Wl,--wrap,wdb_update_agent_connection_status -Wl,--wrap,wdb_update_agent_status_code -Wl,--wrap,SendMSG -Wl,--wrap,StartMQ \
@@ -94,7 +94,7 @@ list(APPEND remoted_flags "-W")
 
 list(APPEND remoted_names "test_remote-state")
 list(APPEND remoted_flags "-Wl,--wrap,time -Wl,--wrap,rem_get_qsize -Wl,--wrap,rem_get_tsize \
-                            -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin \
+                            -Wl,--wrap,OSHash_Create -Wl,--wrap,OSHash_Add -Wl,--wrap,OSHash_Add_ex -Wl,--wrap,OSHash_Begin -Wl,--wrap,OSHash_Begin_ex \
                             -Wl,--wrap,OSHash_Delete_ex -Wl,--wrap,OSHash_Delete -Wl,--wrap,OSHash_Get -Wl,--wrap,OSHash_Clean \
                             -Wl,--wrap,OSHash_Get_ex -Wl,--wrap,OSHash_Next -Wl,--wrap,OSHash_SetFreeDataPointer \
                             -Wl,--wrap,OSHash_Update_ex -Wl,--wrap,OSHash_Update -Wl,--wrap,OSHash_Get_Elem_ex \

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -333,8 +333,8 @@ void test_rem_get_node_existing_node(void ** state) {
 }
 
 void test_w_remoted_clean_agents_state_empty_table(void ** state) {
-    expect_value(__wrap_OSHash_Begin, self, remoted_agents_state);
-    will_return(__wrap_OSHash_Begin, NULL);
+    expect_value(__wrap_OSHash_Begin_ex, self, remoted_agents_state);
+    will_return(__wrap_OSHash_Begin_ex, NULL);
 
     int sock = 1;
 
@@ -344,8 +344,8 @@ void test_w_remoted_clean_agents_state_empty_table(void ** state) {
 void test_w_remoted_clean_agents_state_completed(void ** state) {
     test_struct_t *test_data  = (test_struct_t *)*state;
 
-    expect_value(__wrap_OSHash_Begin, self, remoted_agents_state);
-    will_return(__wrap_OSHash_Begin, test_data->hash_node);
+    expect_value(__wrap_OSHash_Begin_ex, self, remoted_agents_state);
+    will_return(__wrap_OSHash_Begin_ex, test_data->hash_node);
 
     int *connected_agents = NULL;
     os_calloc(1, sizeof(int), connected_agents);
@@ -371,8 +371,8 @@ void test_w_remoted_clean_agents_state_completed(void ** state) {
 void test_w_remoted_clean_agents_state_completed_without_delete(void ** state) {
     test_struct_t *test_data  = (test_struct_t *)*state;
 
-    expect_value(__wrap_OSHash_Begin, self, remoted_agents_state);
-    will_return(__wrap_OSHash_Begin, test_data->hash_node);
+    expect_value(__wrap_OSHash_Begin_ex, self, remoted_agents_state);
+    will_return(__wrap_OSHash_Begin_ex, test_data->hash_node);
 
     int *connected_agents = NULL;
     os_calloc(1, sizeof(int), connected_agents);
@@ -396,8 +396,8 @@ void test_w_remoted_clean_agents_state_completed_without_delete(void ** state) {
 void test_w_remoted_clean_agents_state_query_fail(void ** state) {
     test_struct_t *test_data  = (test_struct_t *)*state;
 
-    expect_value(__wrap_OSHash_Begin, self, remoted_agents_state);
-    will_return(__wrap_OSHash_Begin, test_data->hash_node);
+    expect_value(__wrap_OSHash_Begin_ex, self, remoted_agents_state);
+    will_return(__wrap_OSHash_Begin_ex, test_data->hash_node);
 
     int *connected_agents = NULL;
 

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.c
@@ -80,6 +80,23 @@ void *__wrap_OSHash_Begin(const OSHash *self, __attribute__((unused)) unsigned i
     return mock_type(OSHashNode*);
 }
 
+void * __real_OSHash_Begin_ex(const OSHash *self, unsigned int *i);
+void * __wrap_OSHash_Begin_ex(const OSHash *self, __attribute__((unused)) unsigned int *i) {
+    OSHashNode* retval;
+
+    if (test_mode){
+        check_expected(self);
+        retval = mock_type(OSHashNode*);
+
+        if (mock_hashmap != NULL) {
+            __real_OSHash_Begin(mock_hashmap, i);
+        }
+
+        return retval;
+    }
+    return __real_OSHash_Begin_ex(self, i);
+}
+
 void *__real_OSHash_Clean(OSHash *self, void (*cleaner)(void*));
 void *__wrap_OSHash_Clean(__attribute__((unused)) OSHash *self,
                           __attribute__((unused)) void (*cleaner)(void*)) {

--- a/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/hash_op_wrappers.h
@@ -27,6 +27,9 @@ int __wrap_OSHash_Add_ex(__attribute__((unused)) OSHash *self, const char *key, 
 void *__real_OSHash_Begin(const OSHash *self, unsigned int *i);
 void *__wrap_OSHash_Begin(const OSHash *self, unsigned int *i);
 
+void *__real_OSHash_Begin_ex(const OSHash *self, unsigned int *i);
+void *__wrap_OSHash_Begin_ex(const OSHash *self, __attribute__((unused)) unsigned int *i);
+
 void *__real_OSHash_Clean(OSHash *self, void (*cleaner)(void*));
 void *__wrap_OSHash_Clean(OSHash *self, void (*cleaner)(void*));
 

--- a/src/unit_tests/wrappers/wazuh/shared/shared.cmake
+++ b/src/unit_tests/wrappers/wazuh/shared/shared.cmake
@@ -1,6 +1,7 @@
 set(HASH_OP_WRAPPERS "-Wl,--wrap,OSHash_Add \
                       -Wl,--wrap,OSHash_Add_ex \
                       -Wl,--wrap,OSHash_Begin \
+                      -Wl,--wrap,OSHash_Begin_ex \
                       -Wl,--wrap,OSHash_Clean \
                       -Wl,--wrap,OSHash_Create \
                       -Wl,--wrap,OSHash_Delete_ex \


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21562|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes the race condition in remoted [bug](https://github.com/wazuh/wazuh/issues/21562), the solution was add mutex to self->table.

<!--
Add a clear description of how the problem has been solved.
-->

<!--
Paste here related logs and alerts
-->

## Tests
1. delete  `Privsep_Chroot()` and `nowChroot()` from  `remoted/main.c`
2. delete fork from ῢremoted/main.c`
    ```C
       i = 0;
    //while (logr.conn[i] != 0) {
    //    /* Fork for each connection handler */
    //    if (fork() == 0) {
    //        /* On the child */
    //        mdebug1("Forking remoted: '%d'.", i);
            logr.position = i;
            HandleRemote(uid);
    //    } else {
    //        i++;
    //        continue;
    //    }
    //}

    ```
3. add flags to compile with thread-sanitizer `CFLAGS="-g -fsanitize=thread -fno-omit-frame-pointer" LDFLAGS="-g -fsanitize=thread -fno-omit-frame-pointer"`
4. build wazuh like this `sudo make clean && make clean-deps && rm -rf external/* && make -j12 deps && make -j12 TARGET=server DEBUG=1 CFLAGS="-g -fsanitize=thread -fno-omit-frame-pointer" LDFLAGS="-g -fsanitize=thread -fno-omit-frame-pointer"`
5. copy the binary file `sudo cp wazuh-remoted /var/ossec/bin/`
6. kill wazuh-remoted process `sudo kill -9 $(pidof /var/ossec/bin/wazuh-remoted)`
7. run wazuh-remoted `sudo /var/ossec/bin/wazuh-remoted -f -u root` or `/var/ossec/bin/wazuh-remoted -f -u root &> threadsanitizer.log` in order to save the console output.

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
