### PR TITLE
Enhancement/22873 update translations schema

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/schemas/packageTranslation.fbs
+++ b/src/wazuh_modules/vulnerability_scanner/schemas/packageTranslation.fbs
@@ -39,7 +39,7 @@ table TranslationFields {
 table TranslationEntry {
   action:[Action];
   source:SourceFields;
-  target:string;
+  target:[string];
   translation:[TranslationFields];
 }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -422,7 +422,12 @@ public:
             Translation translationQuery = {};
             translationQuery.productRegex = std::move(productRegex);
             translationQuery.vendorRegex = std::move(vendorRegex);
-            translationQuery.target.push_back(queryData->target()->str());
+
+            // Load target platforms into the Translation object
+            for (const auto& target : *queryData->target())
+            {
+                translationQuery.target.push_back(target->str());
+            }
 
             // Load translation data into the Translation object
             for (const auto& translationData : *queryData->translation())

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -100,7 +100,9 @@ const std::string VULNERABILITY_CANDIDATE_EXAMPLE = R"(
 
 const std::string TRANSLATION_EXAMPLE = R"***(
 {
-    "target": "windows",
+    "target": [
+        "windows"
+    ],
     "source":
     {
         "vendor": "Microsoft Corporation",

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -362,7 +362,9 @@ auto constexpr CREATE_TRANSLATION {
                 "context": "translation",
                 "resource": "TID-0001",
                 "payload": {
-                    "target": "windows",
+                    "target": [
+                        "windows"
+                    ],
                     "source": {
                         "vendor": "Microsoft Corporation",
                         "product": "Microsoft Edge",
@@ -423,7 +425,9 @@ auto constexpr UPDATE_TRANSLATION {
 auto constexpr UPDATED_TRANSLATION_DATA {
     R"(
             {
-                "target": "windows",
+                "target": [
+                    "windows"
+                ],
                 "source": {
                     "vendor": "Microsoft",
                     "product": "Microsoft Edge Browser",


### PR DESCRIPTION
|Related issue|
|---|
| #22873 |

## Description
This PR updates the schema for the translations flatbuffer, to align with:
- https://github.com/wazuh/intelligence-data/issues/107

## Test
Inserted new translation into DB (with new schema):
```
./rocks_db_query_testtool -d /var/ossec/queue/vd/feed/ -c "translation" -f /home/sebas/Documents/work/development/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/packageTranslation.fbs -k TID-0049 -v '{"target":["windows"],"source":{"vendor":"^Mozilla","product":"^Mozilla Firefox","version":""},"translation":[{"vendor":"mozilla","product":"firefox","version":""}],"action":["replace_vendor","replace_product_if_matches"]}'
Value inserted.
```

Retrieved new translation (with new schema):
```
./rocks_db_query_testtool -d /var/ossec/queue/vd/feed/ -c "translation" -f /home/sebas/Documents/work/development/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/packageTranslation.fbs -k TID-0049
TID-0049 ==> {
  "action": [
    "replace_vendor",
    "replace_product_if_matches"
  ],
  "source": {
    "vendor": "^Mozilla",
    "product": "^Mozilla Firefox",
    "version": ""
  },
  "target": [
    "windows"
  ],
  "translation": [
    {
      "vendor": "mozilla",
      "product": "firefox",
      "version": ""
    }
  ]
}
```