### PR TITLE
Exclude containerd folders from Rootcheck scan

### DIFF
--- a/etc/templates/config/alpine/rootcheck.agent.template
+++ b/etc/templates/config/alpine/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/5/rootcheck.agent.template
+++ b/etc/templates/config/centos/5/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/5/rootcheck.manager.template
+++ b/etc/templates/config/centos/5/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/6/rootcheck.agent.template
+++ b/etc/templates/config/centos/6/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/6/rootcheck.manager.template
+++ b/etc/templates/config/centos/6/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/7/rootcheck.agent.template
+++ b/etc/templates/config/centos/7/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/7/rootcheck.manager.template
+++ b/etc/templates/config/centos/7/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/8/rootcheck.agent.template
+++ b/etc/templates/config/centos/8/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/8/rootcheck.manager.template
+++ b/etc/templates/config/centos/8/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/rootcheck.agent.template
+++ b/etc/templates/config/centos/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/centos/rootcheck.manager.template
+++ b/etc/templates/config/centos/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/debian/10/rootcheck.agent.template
+++ b/etc/templates/config/debian/10/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/debian/10/rootcheck.manager.template
+++ b/etc/templates/config/debian/10/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/debian/rootcheck.agent.template
+++ b/etc/templates/config/debian/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/debian/rootcheck.manager.template
+++ b/etc/templates/config/debian/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/fedora/rootcheck.agent.template
+++ b/etc/templates/config/fedora/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/fedora/rootcheck.manager.template
+++ b/etc/templates/config/fedora/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/generic/rootcheck.agent.template
+++ b/etc/templates/config/generic/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/generic/rootcheck.manager.template
+++ b/etc/templates/config/generic/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/5/rootcheck.agent.template
+++ b/etc/templates/config/rhel/5/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/5/rootcheck.manager.template
+++ b/etc/templates/config/rhel/5/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/6/rootcheck.agent.template
+++ b/etc/templates/config/rhel/6/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/6/rootcheck.manager.template
+++ b/etc/templates/config/rhel/6/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/7/rootcheck.agent.template
+++ b/etc/templates/config/rhel/7/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/7/rootcheck.manager.template
+++ b/etc/templates/config/rhel/7/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/8/rootcheck.agent.template
+++ b/etc/templates/config/rhel/8/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/8/rootcheck.manager.template
+++ b/etc/templates/config/rhel/8/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/9/rootcheck.agent.template
+++ b/etc/templates/config/rhel/9/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/9/rootcheck.manager.template
+++ b/etc/templates/config/rhel/9/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/rootcheck.agent.template
+++ b/etc/templates/config/rhel/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/rhel/rootcheck.manager.template
+++ b/etc/templates/config/rhel/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/sles/11/rootcheck.agent.template
+++ b/etc/templates/config/sles/11/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/sles/11/rootcheck.manager.template
+++ b/etc/templates/config/sles/11/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/sles/12/rootcheck.agent.template
+++ b/etc/templates/config/sles/12/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/sles/12/rootcheck.manager.template
+++ b/etc/templates/config/sles/12/rootcheck.manager.template
@@ -14,6 +14,9 @@
 
     <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
-  
+
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/sles/15/rootcheck.agent.template
+++ b/etc/templates/config/sles/15/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/sles/15/rootcheck.manager.template
+++ b/etc/templates/config/sles/15/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/suse/11/rootcheck.agent.template
+++ b/etc/templates/config/suse/11/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/suse/11/rootcheck.manager.template
+++ b/etc/templates/config/suse/11/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/suse/12/rootcheck.agent.template
+++ b/etc/templates/config/suse/12/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/suse/12/rootcheck.manager.template
+++ b/etc/templates/config/suse/12/rootcheck.manager.template
@@ -14,6 +14,9 @@
 
     <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
-  
+
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/suse/15/rootcheck.agent.template
+++ b/etc/templates/config/suse/15/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/suse/15/rootcheck.manager.template
+++ b/etc/templates/config/suse/15/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/ubuntu/rootcheck.agent.template
+++ b/etc/templates/config/ubuntu/rootcheck.agent.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/shared/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>

--- a/etc/templates/config/ubuntu/rootcheck.manager.template
+++ b/etc/templates/config/ubuntu/rootcheck.manager.template
@@ -16,4 +16,7 @@
     <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>
 
     <skip_nfs>yes</skip_nfs>
+
+    <ignore>/var/lib/containerd</ignore>
+    <ignore>/var/lib/docker/overlay2</ignore>
   </rootcheck>


### PR DESCRIPTION
|Related issue|
|---|
|Closes #22966|

We've identified that Docker and Containerd generate files in the directories _/var/lib/containerd_ and _/var/docker/overlay2_, granting write permissions to all users. As a result, Rootcheck generates numerous alerts, which we've determined to be **false positives**.

This PR proposes modifying the default Rootcheck configuration to exclude these directories from scanning, thereby mitigating the influx of erroneous alerts.

## Tests

- [X] No extra rootcheck files exist in the sources' _etc_ folder:
```shell
git show | grep -- "--- a/etc/templates" | grep -o "etc/.*" | sort > grep.txt
find etc -name "rootcheck.*.template" | sort > find.txt
diff grep.txt find.txt
```
- [X] The installer puts the updated configuration:
```xml
<!-- Policy monitoring -->
<rootcheck>
  <disabled>no</disabled>
  <check_files>yes</check_files>
  <check_trojans>yes</check_trojans>
  <check_dev>yes</check_dev>
  <check_sys>yes</check_sys>
  <check_pids>yes</check_pids>
  <check_ports>yes</check_ports>
  <check_if>yes</check_if>

  <!-- Frequency that rootcheck is executed - every 12 hours -->
  <frequency>43200</frequency>

  <rootkit_files>etc/rootcheck/rootkit_files.txt</rootkit_files>
  <rootkit_trojans>etc/rootcheck/rootkit_trojans.txt</rootkit_trojans>

  <skip_nfs>yes</skip_nfs>

  <ignore>/var/lib/containerd</ignore>
  <ignore>/var/lib/docker/overlay2</ignore>
</rootcheck>
```