### PR TITLE
Remove wait_for_api_start fixture when in test using the error level

### DIFF
--- a/tests/integration/test_api/test_config/test_logs/test_logs_format.py
+++ b/tests/integration/test_api/test_config/test_logs/test_logs_format.py
@@ -87,8 +87,7 @@ daemons_handler_configuration = {'daemons': API_DAEMONS_REQUIREMENTS}
 # Tests
 @pytest.mark.tier(level=1)
 @pytest.mark.parametrize('test_configuration,test_metadata', zip(test_configuration, test_metadata), ids=test_cases_ids)
-def test_logs_formats(test_configuration, test_metadata, add_configuration, truncate_monitored_files, daemons_handler,
-                      wait_for_api_start):
+def test_logs_formats(test_configuration, test_metadata, add_configuration, truncate_monitored_files, daemons_handler):
     """
     description: Check if the logs of the API are stored in the specified formats and the content of the log
                  files are the expected.
@@ -127,9 +126,6 @@ def test_logs_formats(test_configuration, test_metadata, add_configuration, trun
         - daemons_handler:
             type: fixture
             brief: Wrapper of a helper function to handle Wazuh daemons.
-        - wait_for_api_start:
-            type: fixture
-            brief: Monitor the API log file to detect whether it has been started or not.
 
     assertions:
         - Verify that the response status code is the expected one.

--- a/tests/integration/test_api/test_config/test_logs/test_logs_format.py
+++ b/tests/integration/test_api/test_config/test_logs/test_logs_format.py
@@ -148,10 +148,10 @@ def test_logs_formats(test_configuration, test_metadata, add_configuration, trun
 
     if current_level == 'error':
         with pytest.raises(RuntimeError) as exception:
-            login()
+            login(timeout=10, login_attempts=5)
         response = exception.value.args[1]
     else:
-        _, response = login()
+        _, response = login(timeout=10, login_attempts=5)
 
     assert response.status_code == expected_code, f"The status code was {response.status_code}." \
                                                   f"\nExpected: {expected_code}."


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/22846 |

## Description

Removes the `wait_for_api` fixture from the `test_logs_format` test. The fixture expected a `INFO: Listening on` message that never appeared in the cases using the `error` log level.

## Tests

<details><summary>test_logs_format.py</summary>

```console
root@wazuh-master:/wazuh/tests/integration# python3 -m pytest --tier 0 --tier 1 test_api/test_config/test_logs/test_logs_format.py
============================================================== test session starts ==============================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.4.0
rootdir: /wazuh/tests/integration, configfile: pytest.ini
plugins: metadata-3.1.1, html-3.1.1
collected 8 items                                                                                                                               

test_api/test_config/test_logs/test_logs_format.py ........                                                                               [100%]

========================================================= 8 passed in 88.68s (0:01:28) ==========================================================
```

</details>

> The brute-force test that failed in the check is because of https://github.com/wazuh/wazuh/issues/22434 