### PR TITLE
Reporting all installed Ubuntu/Debian packages regardless of their selection state

### DIFF
--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -56,7 +56,7 @@ namespace PackageLinuxHelper
                           'config-files', 'half-installed', 'unpacked', 'half-configured', 'triggers-awaited',
                           'triggers-pending', or 'installed'.
 
-           We'll collect packages in any selection state, but not broken ('ok') and correctly installed.
+           We'll collect packages in any selection state, with 'ok' FLAG and 'installed' PACKAGE_STATE.
          */
         if (!info.empty() && info.at("Status").find("ok installed") != std::string::npos)
         {

--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -45,13 +45,18 @@ namespace PackageLinuxHelper
         }
 
         /*
-           Status is SELECTION_STATE FLAG PACKAGE_STATE.
-           Package selection states (wanted state, marked as): install, hold, deinstall, purge, unknown.
-           Package flags: ok, reinstreq.
-           Package states (current state): not-installed, config-files, half-installed, unpacked, half-configured,
-                                           triggers-awaited, triggers-pending, installed.
+           According to dpkg documentation, the status of the package consists in three fields separated by spaces:
+           'SELECTION_STATE FLAG PACKAGE_STATE'.
 
-           We'll collect packages in any selection state, but not broken and correctly installed.
+           SELECTION_STATE: the desired action to take by the package manager. It could be 'install', 'hold',
+                            'deinstall', 'purge', or 'unknown'.
+           FLAG: indicates if the package requires a reinstall or if no issues were found. It could be 'ok',
+                 or 'reinstreq'.
+           PACKAGE_STATE: this is the real status of package at this moment. It could be 'not-installed',
+                          'config-files', 'half-installed', 'unpacked', 'half-configured', 'triggers-awaited',
+                          'triggers-pending', or 'installed'.
+
+           We'll collect packages in any selection state, but not broken ('ok') and correctly installed.
          */
         if (!info.empty() && info.at("Status").find("ok installed") != std::string::npos)
         {

--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -44,7 +44,16 @@ namespace PackageLinuxHelper
             }
         }
 
-        if (!info.empty() && info.at("Status") == "install ok installed")
+        /*
+           Status is SELECTION_STATE FLAG PACKAGE_STATE.
+           Package selection states (wanted state, marked as): install, hold, deinstall, purge, unknown.
+           Package flags: ok, reinstreq.
+           Package states (current state): not-installed, config-files, half-installed, unpacked, half-configured,
+                                           triggers-awaited, triggers-pending, installed.
+
+           We'll collect packages in any selection state, but not broken and correctly installed.
+         */
+        if (!info.empty() && info.at("Status").find("ok installed") != std::string::npos)
         {
             ret["name"] = info.at("Package");
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #21909|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR makes the DPKG package reader more flexible to report all installed packages.
The current implementation only considered the **install** selection state.



## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Some packages were manually marked with different states and it was confirmed that the **sysinfo** test tool shows them properly

```
root@2023430c3aba:/# dpkg-remove vim
Selected vim for removal.
root@2023430c3aba:/# dpkg-purge vim-common
Selected vim-common for purge.
root@2023430c3aba:/# dpkg-query -s vim-common | grep Status
Status: purge ok installed
root@2023430c3aba:/# dpkg-query -s vim | grep Status
Status: deinstall ok installed
root@2023430c3aba:/# dpkg-query -s vim-runtime | grep Status
Status: install ok installed
``` 

```
root@2023430c3aba:/workspaces/wazuh/src/data_provider/build/bin# ./sysinfo_test_tool --packages | grep vim | grep -v source
      "name": "vim",
      "name": "vim-common",
      "name": "vim-runtime",
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
 