### PR TITLE
Fix - Update indexer fields for OS vulnerabilities

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -157,11 +157,6 @@ public:
                 populateField(package, "/name"_json_pointer, osFullName);
                 populateField(package, "/type"_json_pointer, osType);
                 populateField(package, "/version"_json_pointer, osVersion);
-
-                // Fill the remaining fields with empty strings.
-                populateField(package, "/description"_json_pointer, EMPTY_FIELD);
-                populateField(package, "/path"_json_pointer, EMPTY_FIELD);
-                populateField(package, "/size"_json_pointer, EMPTY_FIELD);
                 break;
 
             default: break;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -14,11 +14,13 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "loggerHelper.h"
 #include "numericHelper.h"
 #include "scanContext.hpp"
 #include "timeHelper.h"
 
 constexpr auto WAZUH_SCHEMA_VERSION = "1.0.0";
+constexpr auto EMPTY_FIELD = "";
 
 /**
  * @brief TEventDetailsBuilder class.
@@ -96,6 +98,8 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
+        logDebug2(WM_VULNSCAN_LOGTAG, "Building event details for component type: %d", data->affectedComponentType());
+
         // Operating system fullName (OS name + OS version).
         std::string osFullName;
         osFullName.append(data->osName().data());
@@ -153,6 +157,11 @@ public:
                 populateField(package, "/name"_json_pointer, osFullName);
                 populateField(package, "/type"_json_pointer, osType);
                 populateField(package, "/version"_json_pointer, osVersion);
+
+                // Fill the remaining fields with empty strings.
+                populateField(package, "/description"_json_pointer, EMPTY_FIELD);
+                populateField(package, "/path"_json_pointer, EMPTY_FIELD);
+                populateField(package, "/size"_json_pointer, EMPTY_FIELD);
                 break;
 
             default: break;
@@ -185,7 +194,8 @@ public:
                 ecsData["agent"] = agent;
 
                 // ECS package fields.
-                if (data->affectedComponentType() == AffectedComponentType::Package)
+                if (data->affectedComponentType() == AffectedComponentType::Package ||
+                    data->affectedComponentType() == AffectedComponentType::Os)
                 {
                     ecsData["package"] = package;
                 }
@@ -209,8 +219,9 @@ public:
 
                 // ECS wazuh fields.
                 auto vulnerabilityDetection = PolicyManager::instance().getVulnerabilityDetection();
-                ecsData["wazuh"]["cluster"]["name"] =
-                    vulnerabilityDetection.contains("clusterName") ? vulnerabilityDetection.at("clusterName") : "";
+                ecsData["wazuh"]["cluster"]["name"] = vulnerabilityDetection.contains("clusterName")
+                                                          ? vulnerabilityDetection.at("clusterName")
+                                                          : EMPTY_FIELD;
                 ecsData["wazuh"]["manager"]["name"] = data->managerName();
                 ecsData["wazuh"]["schema"]["version"] = WAZUH_SCHEMA_VERSION;
 


### PR DESCRIPTION
|Related issue|
|---|
| #22650 |

## Description
This PR fixes a bad implementation of the event builder for OS events 

Fields that remain empty due to lack of information:
- description
- path
- size

## Tests
- Install an agent on a `Windows Server 2019`
- Run the scanner
- Search for the OS vulnerabilities
- Expected fields are no longer empty
![image](https://github.com/wazuh/wazuh/assets/34063881/0b2fca71-18c9-4225-8ee9-0bd4d1dc940c)
