### PR TITLE
Use secret for AWS region

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
-          aws-region: us-east-1
+          aws-region: ${{ secrets.CI_AWS_REGION }}
 
       - name: Upload package to S3
         working-directory: packages

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: | 
+        description: |
           Revision used to naming Filebeat package wazuh-filebeat-X.X.tar.gz.
           Default 0.0.
         required: false
@@ -16,7 +16,7 @@ on:
         required: false
         default: "0.0"
         type: string
-    
+
 jobs:
   Filebeat-module-generation:
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
-          aws-region: us-east-1
+          aws-region: ${{ secrets.CI_AWS_REGION }}
 
       - name: Package files, change permissions, create tar and upload to S3
         working-directory: extensions/filebeat/7.x/wazuh-module


### PR DESCRIPTION
|Related issue|
|---|
|#23085|

## Description

With this PR, you set the _AWS region_ secret for AWS authentication, so that workflows do not use a hard-coded region.

The secret name is: `CI_AWS_REGION`.

```
      - name: Configure AWS CLI
        uses: aws-actions/configure-aws-credentials@v4
        with:
          aws-access-key-id: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_ACCESS_KEY }}
          aws-secret-access-key: ${{ secrets.CI_INTERNAL_DEVELOPMENT_BUCKET_USER_SECRET_KEY }}
          aws-region: ${{ secrets.CI_AWS_REGION }}
```

## Tests

- https://github.com/wazuh/wazuh/actions/runs/8818583228/job/24207710896 - :green_circle: 