### PR TITLE
policyManager - Fixed url format validation error

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -347,7 +347,7 @@ private:
         }
 
         if (!configData.contains("url") || !configData.at("url").is_string() ||
-            !Utils::startsWith(configData.at("url"), "http") || !Utils::startsWith(configData.at("url"), "https"))
+            (!Utils::startsWith(configData.at("url"), "http") && !Utils::startsWith(configData.at("url"), "https")))
         {
             throw std::runtime_error("Missing url field or invalid value.");
         }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
@@ -413,6 +413,14 @@ TEST_F(PolicyManagerTest, updaterValidConfiguration)
     EXPECT_EQ(m_policyManager->getCTIUrl(), "https://updater-url.com");
 }
 
+TEST_F(PolicyManagerTest, updaterValidUrlhttp)
+{
+    nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;
+    basicConfigCopy.at("updater").at("configData").at("url") = "http://updater-url.com";
+
+    EXPECT_NO_THROW(m_policyManager->initialize(basicConfigCopy));
+}
+
 TEST_F(PolicyManagerTest, updaterInvalidConfigurationMissingInterval)
 {
     nlohmann::json basicConfigCopy = UPDATER_BASIC_CONFIG;


### PR DESCRIPTION
|Related issue|
|---|
| #23116 |

## Description

This PR fixes the error in the url format validation logic in the policyManager for the updater configuration.

## Test
![image](https://github.com/wazuh/wazuh/assets/106940255/34775483-7982-4a34-af2e-4e55942801a2)

## Scanner testtool using `https`
![image](https://github.com/wazuh/wazuh/assets/106940255/863af54c-36f5-4edc-8520-98bbadd4651b)

## Scanner testtool using `http`
![image](https://github.com/wazuh/wazuh/assets/106940255/b5e58cae-3027-4c3f-913d-fdfa65d5edb4)

