### PR TITLE
Align vulnerability scanner logging with current changes

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -47,7 +47,9 @@ bool VulnerabilityScannerFacade::decompressDatabase(std::string_view databaseVer
         // Check for XZ compressed file.
         if (!std::filesystem::exists(COMPRESSED_DB_PATH))
         {
-            logWarn(WM_VULNSCAN_LOGTAG, "Missing database compressed file. Check DOWNLOAD_CONTENT option.");
+            logDebug2(WM_VULNSCAN_LOGTAG,
+                      "No database compressed file found at '%s'. Skipping decompression.",
+                      COMPRESSED_DB_PATH);
             return ret;
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -63,7 +63,7 @@ public:
      * @brief Decompress database content.
      *
      * @param databaseVersion Current database version.
-     * @return true if the decompression was sucesfull.
+     * @return true if the decompression was successful.
      */
     bool decompressDatabase(std::string_view databaseVersion) const;
 


### PR DESCRIPTION
|Related issue|
|---|
| #23150 |

## Description
This PR updates the logging of the vulnerability scanner decompression step to reflect the actual behavior. If the compressed DB is not found, this is no longer a problem, because the module will download it from the CTI endpoint
