### PR TITLE
Downgrade macOS image version for scan-build test

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -63,7 +63,7 @@ jobs:
         run: exit 1
 
   scan-build-macos-agent:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23176|

This PR aims to fix the following error at the scan-build workflow by changing the executable path:

```
/usr/local/opt/llvm@14/bin/scan-build: No such file or directory
```