### PR TITLE
Add HAProxy files

### DIFF
--- a/framework/Makefile
+++ b/framework/Makefile
@@ -34,12 +34,14 @@ install:
 	$(INSTALL_DIR) $(INSTALLDIR)/framework/wazuh
 	$(INSTALL_DIR) $(INSTALLDIR)/framework/wazuh/core/cluster
 	$(INSTALL_DIR) $(INSTALLDIR)/framework/wazuh/core/cluster/dapi
+	$(INSTALL_DIR) $(INSTALLDIR)/framework/wazuh/core/cluster/hap_helper
 
 	$(INSTALL_FILE) scripts/*.py ${INSTALLDIR}/framework/scripts
 	$(INSTALL_FILE) wazuh/*.py ${INSTALLDIR}/framework/wazuh
 	$(INSTALL_FILE) wazuh/core/cluster/*.json ${INSTALLDIR}/framework/wazuh/core/cluster
 	$(INSTALL_FILE) wazuh/core/cluster/*.py ${INSTALLDIR}/framework/wazuh/core/cluster
 	$(INSTALL_FILE) wazuh/core/cluster/dapi/*.py ${INSTALLDIR}/framework/wazuh/core/cluster/dapi
+	$(INSTALL_FILE) wazuh/core/cluster/hap_helper/*.py ${INSTALLDIR}/framework/wazuh/core/cluster/hap_helper
 
 #	Remove update_ruleset script when upgrading to >=4.2.0 (deprecated)
 	[ ! -e ${INSTALLDIR}/bin/update_ruleset ] || $(RM_FILE) ${INSTALLDIR}/bin/update_ruleset


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh-jenkins/issues/6395 |

## Description

Modifies the framework installation to include the files inside the `hap_helper` folder.

### Tests

Packages builder: https://ci.wazuh.info/job/Packages_builder/196224
Test upgrade: https://ci.wazuh.info/job/Test_upgrade/134679/
