### PR TITLE
AIT environment improvements

### DIFF
--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -106,6 +106,8 @@ def build_and_up(env_mode: str, interval: int = 10, build: bool = True):
         response = requests.get(f"https://github.com/wazuh/wazuh/tarball/{current_branch}")
         if response.status_code == 404:
             pytest.fail("Current branch tarball doesn't exist")
+        elif not response.ok:
+            pytest.fail(f"Couldn't obtain branch tarball: {response.reason}")
 
     os.chdir(env_path)
     max_retries = 3

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -138,7 +138,7 @@ def down_env(env_mode: str):
     """Stop and remove all Docker containers."""
     os.chdir(env_path)
     with open(docker_log_path, mode='a') as f_docker:
-        current_process = subprocess.Popen(["docker", "compose", "--profile", env_mode, "down" ],
+        current_process = subprocess.Popen(["docker", "compose", "--profile", env_mode, "down"],
                                            stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
         current_process.wait()
     os.chdir(current_path)
@@ -370,7 +370,7 @@ def api_test(request: _pytest.fixtures.SubRequest):
     os.makedirs(test_logs_path, exist_ok=True)
 
     # Add clean_up_env as fixture finalizer
-    request.addfinalizer(clean_up_env(env_mode))
+    request.addfinalizer(lambda: clean_up_env(env_mode))
 
     test_filename = request.node.config.args[0].split('_')
     if 'rbac' in test_filename:
@@ -395,7 +395,6 @@ def api_test(request: _pytest.fixtures.SubRequest):
     retries = 0
 
     while retries < max_retries:
-        time.sleep(10)
         managers_health = check_health(only_check_master_health=env_mode == standalone_env_mode)
         agents_health = check_health(node_type='agent', agents=list(range(1, 9)))
         nginx_health = check_health(node_type='nginx-lb')
@@ -412,6 +411,7 @@ def api_test(request: _pytest.fixtures.SubRequest):
             return
 
         retries += 1
+        time.sleep(10)
 
 
 def get_health():

--- a/api/test/integration/conftest.py
+++ b/api/test/integration/conftest.py
@@ -80,8 +80,7 @@ def pytest_tavern_beta_before_every_test_run(test_dict, variables):
     variables["test_login_token"] = get_token_login_api()
 
 
-def build_and_up(env_mode: str, interval: int = 10, interval_build_env: int = 10,
-                 build: bool = True) -> dict:
+def build_and_up(env_mode: str, interval: int = 10, build: bool = True):
     """Build all Docker environments needed for the current test.
 
     Parameters
@@ -89,81 +88,68 @@ def build_and_up(env_mode: str, interval: int = 10, interval_build_env: int = 10
     env_mode : str
         Indicates the environment to be used in the process.
     interval : int
-        Time interval between every healthcheck.
-    interval_build_env : int
-        Time interval between every docker environment healthcheck.
+        Time interval between every build.
     build : bool
         Flag to indicate if images need to be built.
-
-    Returns
-    -------
-    dict
-        Dict with healthchecks parameters.
     """
-    os.chdir(env_path)
-    values = {
-        'interval': interval,
-        'max_retries': 90,
-        'retries': 0
-    }
-    values_build_env = {
-        'interval': interval_build_env,
-        'max_retries': 3,
-        'retries': 0
-    }
-   # Get current branch or tag
-    with open('../../../../.git/HEAD', 'r') as f:
+    # Get current branch or tag
+    with open('../../../.git/HEAD', 'r') as f:
         ref = f.readline().strip()
+
     if ref.startswith("ref:"):
         current_branch = ref.split("refs/heads/")[1]
     else:
         current_branch = ref.split("/")[-1]
-        
-    os.makedirs(test_logs_path, exist_ok=True)
+
+    if build:
+        # Ping the current branch tarball used to build the manager image.
+        response = requests.get(f"https://github.com/wazuh/wazuh/tarball/{current_branch}")
+        if response.status_code == 404:
+            pytest.fail("Current branch tarball doesn't exist")
+
+    os.chdir(env_path)
+    max_retries = 3
+    retries = 0
+
     with open(docker_log_path, mode='w') as f_docker:
-        while values_build_env['retries'] < values_build_env['max_retries']:
+        while retries < max_retries:
             if build:
-                current_process = subprocess.Popen(["docker", "compose", "--profile", env_mode,
-                    "build", "--build-arg", f"WAZUH_BRANCH={current_branch}", 
-                    "--build-arg", f"ENV_MODE={env_mode}",
-                    "--no-cache"],
+                build_process = subprocess.Popen(["docker", "compose", "--profile", env_mode,
+                    "build", "--build-arg", f"WAZUH_BRANCH={current_branch}",
+                    "--build-arg", f"ENV_MODE={env_mode}", "--no-cache"],
                     stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
-                current_process.wait()
-            current_process = subprocess.Popen(
+                build_process.wait()
+            up_process = subprocess.Popen(
                 ["docker", "compose", "--profile", env_mode, "up", "-d"],
                 env=dict(os.environ, ENV_MODE=env_mode),
                 stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
-            current_process.wait()
+            up_process.wait()
 
-            if current_process.returncode == 0:
-                time.sleep(values_build_env['interval'])
+            if up_process.returncode == 0:
                 break
-            else:
-                time.sleep(values_build_env['interval'])
-                values_build_env['retries'] += 1
+            
+            time.sleep(interval)
+            retries += 1
+
     os.chdir(current_path)
 
-    return values
 
-
-def down_env():
+def down_env(env_mode: str):
     """Stop and remove all Docker containers."""
     os.chdir(env_path)
     with open(docker_log_path, mode='a') as f_docker:
-        current_process = subprocess.Popen(["docker", "compose", "down", "-t0" ], stdout=f_docker,
-                                           stderr=subprocess.STDOUT, universal_newlines=True)
+        current_process = subprocess.Popen(["docker", "compose", "--profile", env_mode, "down" ],
+                                           stdout=f_docker, stderr=subprocess.STDOUT, universal_newlines=True)
         current_process.wait()
     os.chdir(current_path)
 
 
-def check_health(interval: int = 10, node_type: str = 'manager', agents: list = None,
+def check_health(node_type: str = 'manager', agents: list = None,
                  only_check_master_health: bool = False):
     """Check the Wazuh nodes health.
 
     Parameters
     ----------
-    interval : int
-        Time interval between every healthcheck.
     node_type : str
         Can be agent, manager or nginx-lb.
     agents : list
@@ -177,7 +163,6 @@ def check_health(interval: int = 10, node_type: str = 'manager', agents: list = 
     bool
         True if all healthchecks passed, False otherwise.
     """
-    time.sleep(interval)
     if node_type == 'manager':
         nodes_to_check = ['master'] if only_check_master_health else env_cluster_nodes
         for node in nodes_to_check:
@@ -368,7 +353,7 @@ def api_test(request: _pytest.fixtures.SubRequest):
         Object that contains information about the current test
     """
 
-    def clean_up_env():
+    def clean_up_env(env_mode: str):
         """Clean temporary folder, save environment logs and status; and stop and remove all Docker containers."""
         clean_tmp_folder()
         if request.session.testsfailed > 0:
@@ -377,14 +362,15 @@ def api_test(request: _pytest.fixtures.SubRequest):
         # Get the environment current status
         global environment_status
         environment_status = get_health()
-        down_env()
+        down_env(env_mode)
 
     # Get the value of the mark indicating the test mode. This value will vary between 'cluster' or 'standalone'
     mode = request.node.config.getoption("-m")
     env_mode = standalone_env_mode if mode == 'standalone' else cluster_env_mode
+    os.makedirs(test_logs_path, exist_ok=True)
 
     # Add clean_up_env as fixture finalizer
-    request.addfinalizer(clean_up_env)
+    request.addfinalizer(clean_up_env(env_mode))
 
     test_filename = request.node.config.args[0].split('_')
     if 'rbac' in test_filename:
@@ -403,27 +389,29 @@ def api_test(request: _pytest.fixtures.SubRequest):
         enable_white_mode()
 
     general_procedure(module)
-    values = build_and_up(interval=10, build=request.config.getoption('--nobuild'), env_mode=env_mode)
+    build_and_up(build=request.config.getoption('--nobuild'), env_mode=env_mode)
 
-    while values['retries'] < values['max_retries']:
-        managers_health = check_health(interval=values['interval'],
-                                       only_check_master_health=env_mode == standalone_env_mode)
-        agents_health = check_health(interval=values['interval'], node_type='agent', agents=list(range(1, 9)))
-        nginx_health = check_health(interval=values['interval'], node_type='nginx-lb')
+    max_retries = 30
+    retries = 0
+
+    while retries < max_retries:
+        time.sleep(10)
+        managers_health = check_health(only_check_master_health=env_mode == standalone_env_mode)
+        agents_health = check_health(node_type='agent', agents=list(range(1, 9)))
+        nginx_health = check_health(node_type='nginx-lb')
+
         # Check if entrypoint was successful
         try:
-            error_message = subprocess.check_output(["docker", "exec", "-t",
-                                                     "env-wazuh-master-1", "sh", "-c",
+            error_message = subprocess.check_output(["docker", "exec", "-t", "env-wazuh-master-1", "sh", "-c",
                                                      "cat /entrypoint_error"]).decode().strip()
             pytest.fail(error_message)
         except subprocess.CalledProcessError:
             pass
 
         if managers_health and agents_health and nginx_health:
-            time.sleep(values['interval'])
             return
-        else:
-            values['retries'] += 1
+
+        retries += 1
 
 
 def get_health():

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -221,4 +221,3 @@ services:
     image: integration_test_nginx-lb
     entrypoint:
       - /scripts/entrypoint.sh
-      - ${ENV_MODE}

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -209,5 +209,3 @@ services:
       - ${ENV_MODE}
     depends_on:
       - wazuh-master
-      - wazuh-worker1
-      - wazuh-worker2

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -92,7 +92,6 @@ services:
       - nginx-lb
       - wazuh-agent2
     depends_on:
-      - wazuh-agent1
       - nginx-lb
 
   wazuh-agent3:
@@ -112,7 +111,6 @@ services:
       - nginx-lb
       - wazuh-agent3
     depends_on:
-      - wazuh-agent2
       - nginx-lb
 
   wazuh-agent4:
@@ -132,7 +130,6 @@ services:
       - nginx-lb
       - wazuh-agent4
     depends_on:
-      - wazuh-agent3
       - nginx-lb
 
   wazuh-agent5:
@@ -153,7 +150,6 @@ services:
       - wazuh-agent5
       - agent_old
     depends_on:
-      - wazuh-agent4
       - nginx-lb
 
   wazuh-agent6:
@@ -174,7 +170,6 @@ services:
       - wazuh-agent6
       - agent_old
     depends_on:
-      - wazuh-agent5
       - nginx-lb
 
   wazuh-agent7:
@@ -195,7 +190,6 @@ services:
       - wazuh-agent7
       - agent_old
     depends_on:
-      - wazuh-agent6
       - nginx-lb
 
   wazuh-agent8:
@@ -216,7 +210,6 @@ services:
       - wazuh-agent8
       - agent_old
     depends_on:
-      - wazuh-agent7
       - nginx-lb
 
   nginx-lb:

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -25,9 +25,6 @@ services:
   wazuh-worker1:
     profiles:
       - cluster
-    build:
-      context: .
-      dockerfile: base/manager/manager.Dockerfile
     image: integration_test_wazuh-manager
     hostname: wazuh-worker1
     volumes:
@@ -38,13 +35,12 @@ services:
       - wazuh-master
       - worker1
       - worker
+    depends_on:
+      - wazuh-master
 
   wazuh-worker2:
     profiles:
       - cluster
-    build:
-      context: .
-      dockerfile: base/manager/manager.Dockerfile
     image: integration_test_wazuh-manager
     hostname: wazuh-worker2
     volumes:
@@ -55,6 +51,8 @@ services:
       - wazuh-master
       - worker2
       - worker
+    depends_on:
+      - wazuh-master
 
   wazuh-agent1:
     profiles:
@@ -79,9 +77,6 @@ services:
     profiles:
       - standalone
       - cluster
-    build:
-      context: .
-      dockerfile: base/agent/new.Dockerfile
     image: integration_test_wazuh-agent
     hostname: wazuh-agent2
     volumes:
@@ -92,15 +87,13 @@ services:
       - nginx-lb
       - wazuh-agent2
     depends_on:
+      - wazuh-agent1
       - nginx-lb
 
   wazuh-agent3:
     profiles:
       - standalone
       - cluster
-    build:
-      context: .
-      dockerfile: base/agent/new.Dockerfile
     image: integration_test_wazuh-agent
     hostname: wazuh-agent3
     volumes:
@@ -111,15 +104,13 @@ services:
       - nginx-lb
       - wazuh-agent3
     depends_on:
+      - wazuh-agent1
       - nginx-lb
 
   wazuh-agent4:
     profiles:
       - standalone
       - cluster
-    build:
-      context: .
-      dockerfile: base/agent/new.Dockerfile
     image: integration_test_wazuh-agent
     hostname: wazuh-agent4
     volumes:
@@ -130,6 +121,7 @@ services:
       - nginx-lb
       - wazuh-agent4
     depends_on:
+      - wazuh-agent1
       - nginx-lb
 
   wazuh-agent5:
@@ -156,9 +148,6 @@ services:
     profiles:
       - standalone
       - cluster
-    build:
-      context: .
-      dockerfile: base/agent/old.Dockerfile
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent6
     volumes:
@@ -170,15 +159,13 @@ services:
       - wazuh-agent6
       - agent_old
     depends_on:
+      - wazuh-agent5
       - nginx-lb
 
   wazuh-agent7:
     profiles:
       - standalone
       - cluster
-    build:
-      context: .
-      dockerfile: base/agent/old.Dockerfile
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent7
     volumes:
@@ -190,15 +177,13 @@ services:
       - wazuh-agent7
       - agent_old
     depends_on:
+      - wazuh-agent5
       - nginx-lb
 
   wazuh-agent8:
     profiles:
       - standalone
       - cluster
-    build:
-      context: .
-      dockerfile: base/agent/old.Dockerfile
     image: integration_test_wazuh-agent_old
     hostname: wazuh-agent8
     volumes:
@@ -210,6 +195,7 @@ services:
       - wazuh-agent8
       - agent_old
     depends_on:
+      - wazuh-agent5
       - nginx-lb
 
   nginx-lb:
@@ -219,5 +205,11 @@ services:
     build:
       context: ./base/nginx-lb
     image: integration_test_nginx-lb
+    restart: always
     entrypoint:
       - /scripts/entrypoint.sh
+      - ${ENV_MODE}
+    depends_on:
+      - wazuh-master
+      - wazuh-worker1
+      - wazuh-worker2

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   wazuh-master:
     profiles:

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -815,7 +815,7 @@ stages:
     delay_after: !float "{global_db_delay}"
 
     # DELETE /agents
-  - name: Delete all agents (006,007,008)
+  - name: Delete all agents
     request:
       verify: False
       url: "{protocol:s}://{host:s}:{port:d}/agents"
@@ -835,4 +835,5 @@ stages:
             - "006"
             - "007"
             - "008"
-          total_affected_items: 3
+            - "013"
+          total_affected_items: 4


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/22891 |

## Description

Introduces changes to the API integration tests environment to improve its efficiency and reliability.

### Tests

Integration burst: [artifacts.zip](https://github.com/wazuh/wazuh/files/15221496/artifacts.zip)

#### Test with a branch that is not on remote (no tarball)

The manager image uses the current branch tarball to build Wazuh, if the local branch is not on remote it should fail early.

<details><summary>Logs</summary>

```console
(venv_connexion) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_active_response_endpoints.tavern.yaml --disable-warnings
================================================================= test session starts ==================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, metadata-3.1.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 2 items                                                                                                                                      

test_active_response_endpoints.tavern.yaml EEE                                                                                                   [100%]

======================================================================== ERRORS ========================================================================
...
=============================================================== short test summary info ================================================================
ERROR test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} - Failed: Current branch tarball doesn't exist
ERROR test_active_response_endpoints.tavern.yaml::PUT /active-response - Failed: Current branch tarball doesn't exist
ERROR test_active_response_endpoints.tavern.yaml::PUT /active-response - TypeError: 'NoneType' object is not callable
============================================================= 1 warning, 3 errors in 1.08s =============================================================
```

</details>

#### Test after pushing the changes

docker.log: [docker_log.zip](https://github.com/wazuh/wazuh/files/15169102/docker_log.zip)

<details><summary>Logs</summary>

```console
(venv_connexion) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_active_response_endpoints.tavern.yaml --disable-warnings
================================================================= test session starts ==================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0 -- /home/gasti/work/wazuh/venv_connexion/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.4.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'metadata': '3.1.1', 'html': '2.1.1', 'anyio': '4.3.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, metadata-3.1.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 2 items                                                                                                                                      

test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} PASSED                                                              [ 50%]
test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                          [100%]

====================================================== 2 passed, 3 warnings in 520.57s (0:08:40) =======================================================

```

</details>

#### Docker images before and after the changes in the docker-compose.yaml

Before the changes we were building one image per node and agent, now we are reusing them.

<details><summary>Before</summary>

```console
gasti@pop-os:~/work/wazuh/api/test/integration$ docker images
REPOSITORY                         TAG       IMAGE ID       CREATED              SIZE
<none>                             <none>    b892328b9b94   About a minute ago   2.28GB
<none>                             <none>    0c861d926de9   About a minute ago   2.28GB
integration_test_wazuh-manager     latest    c4a46c14bda1   About a minute ago   2.28GB
<none>                             <none>    f24083273883   2 minutes ago        1.21GB
<none>                             <none>    73aa0eda5c19   2 minutes ago        1.21GB
<none>                             <none>    075cd8f4d8fe   2 minutes ago        1.21GB
integration_test_wazuh-agent       latest    f30e6ca8f2a9   2 minutes ago        1.21GB
<none>                             <none>    827aeed56891   4 minutes ago        160MB
integration_test_wazuh-agent_old   latest    cab85f426790   4 minutes ago        160MB
<none>                             <none>    4163237b0eff   4 minutes ago        160MB
<none>                             <none>    4affc4c5136f   4 minutes ago        160MB
integration_test_nginx-lb          latest    1cd99f4565c8   5 minutes ago        188MB
```

</details>

<details><summary>After</summary>

```console
gasti@pop-os:~/work/wazuh/api/test/integration/env$ docker images
REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
integration_test_wazuh-manager     latest    1c3fed9836cc   12 minutes ago   2.28GB
integration_test_wazuh-agent       latest    ee2e738c3fc1   14 minutes ago   1.21GB
integration_test_wazuh-agent_old   latest    e688c0da1885   17 minutes ago   160MB
integration_test_nginx-lb          latest    9847182cbcbb   17 minutes ago   188MB
```

</details>

#### Launching the test with the `--nobuild` flag doesn't recreate the images

docker.log: [docker_log.zip](https://github.com/wazuh/wazuh/files/15169168/docker_log.zip)

<details><summary>Logs</summary>

Window 1

```console
(venv_connexion) gasti@pop-os:~/work/wazuh/api/test/integration$ pytest -vv test_active_response_endpoints.tavern.yaml --disable-warnings --nobuild
================================================================= test session starts ==================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0 -- /home/gasti/work/wazuh/venv_connexion/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-6.6.10-76060610-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.4.0'}, 'Plugins': {'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'metadata': '3.1.1', 'html': '2.1.1', 'anyio': '4.3.0'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.8.0, asyncio-0.18.1, tavern-1.23.5, metadata-3.1.1, html-2.1.1, anyio-4.3.0
asyncio: mode=auto
collected 2 items                                                                                                                                      

test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} PASSED                                                              [ 50%]
test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                          [100%]

====================================================== 2 passed, 3 warnings in 133.44s (0:02:13) =======================================================
```

Window 2

```console
gasti@pop-os:~/work/wazuh/api/test/integration/env$ docker images
REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
integration_test_wazuh-agent_old   latest    8cd3ea05c80b   13 minutes ago   160MB
integration_test_nginx-lb          latest    5a200b749c23   13 minutes ago   188MB
integration_test_wazuh-manager     latest    1c3fed9836cc   26 minutes ago   2.28GB
integration_test_wazuh-agent       latest    ee2e738c3fc1   28 minutes ago   1.21GB
```

</details>