### PR TITLE
Change the order of the files to check when getting the OS version

### DIFF
--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -586,19 +586,6 @@ os_info *get_unix_version()
 
             regfree(&regexCompiled);
             fclose(version_release);
-        // Ubuntu
-        } else if (version_release = wfopen("/etc/lsb-release","r"), version_release){
-            info->os_name = strdup("Ubuntu");
-            info->os_platform = strdup("ubuntu");
-            while (fgets(buff, sizeof(buff) - 1, version_release)) {
-                tag = strtok_r(buff, "=", &save_ptr);
-                if (tag && strcmp(tag,"DISTRIB_RELEASE") == 0){
-                    info->os_version = strdup(strtok_r(NULL, "\n", &save_ptr));
-                    break;
-                }
-            }
-
-            fclose(version_release);
         // Gentoo
         } else if (version_release = wfopen("/etc/gentoo-release","r"), version_release){
             info->os_name = strdup("Gentoo");
@@ -634,6 +621,18 @@ os_info *get_unix_version()
                 }
             }
             regfree(&regexCompiled);
+            fclose(version_release);
+        // Ubuntu
+        } else if (version_release = wfopen("/etc/lsb-release","r"), version_release){
+            info->os_name = strdup("Ubuntu");
+            info->os_platform = strdup("ubuntu");
+            while (fgets(buff, sizeof(buff) - 1, version_release)) {
+                tag = strtok_r(buff, "=", &save_ptr);
+                if (tag && strcmp(tag,"DISTRIB_RELEASE") == 0){
+                    info->os_version = strdup(strtok_r(NULL, "\n", &save_ptr));
+                    break;
+                }
+            }
             fclose(version_release);
         // Debian
         } else if (version_release = wfopen("/etc/debian_version","r"), version_release){

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -659,6 +659,16 @@ void test_get_unix_version_fail_os_release_ubuntu(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
+    // Open /etc/gentoo-release
+    expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Open /etc/SuSE-release
+    expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
     // Open /etc/lsb-release
     expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -717,11 +727,6 @@ void test_get_unix_version_fail_os_release_gentoo(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -777,11 +782,6 @@ void test_get_unix_version_fail_os_release_suse(void **state)
 
     // Fail to open /etc/arch-release
     expect_string(__wrap_wfopen, path, "/etc/arch-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -900,11 +900,6 @@ void test_get_unix_version_fail_os_release_debian(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -912,6 +907,11 @@ void test_get_unix_version_fail_os_release_debian(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -973,11 +973,6 @@ void test_get_unix_version_fail_os_release_slackware(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -985,6 +980,11 @@ void test_get_unix_version_fail_os_release_slackware(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1051,11 +1051,6 @@ void test_get_unix_version_fail_os_release_alpine(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1063,6 +1058,11 @@ void test_get_unix_version_fail_os_release_alpine(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1135,11 +1135,6 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1147,6 +1142,11 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1298,11 +1298,6 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1310,6 +1305,11 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1455,11 +1455,6 @@ void test_get_unix_version_fail_os_release_uname_sunos(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1467,6 +1462,11 @@ void test_get_unix_version_fail_os_release_uname_sunos(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1562,11 +1562,6 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one(void **st
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1574,6 +1569,11 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one(void **st
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1669,11 +1669,6 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two(void **st
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1681,6 +1676,11 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two(void **st
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1774,11 +1774,6 @@ void test_get_unix_version_fail_os_release_uname_hp_ux(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1786,6 +1781,11 @@ void test_get_unix_version_fail_os_release_uname_hp_ux(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1880,11 +1880,6 @@ void test_get_unix_version_fail_os_release_uname_bsd(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1892,6 +1887,11 @@ void test_get_unix_version_fail_os_release_uname_bsd(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -1986,11 +1986,6 @@ void test_get_unix_version_zscaler(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -1998,6 +1993,11 @@ void test_get_unix_version_zscaler(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
@@ -2089,11 +2089,6 @@ void test_get_unix_version_fail_os_release_uname_aix(void **state)
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 
-    // Fail to open /etc/lsb-release
-    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, 0);
-
     // Fail to open /etc/gentoo-release
     expect_string(__wrap_wfopen, path, "/etc/gentoo-release");
     expect_string(__wrap_wfopen, mode, "r");
@@ -2101,6 +2096,11 @@ void test_get_unix_version_fail_os_release_uname_aix(void **state)
 
     // Fail to open /etc/SuSE-release
     expect_string(__wrap_wfopen, path, "/etc/SuSE-release");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, 0);
+
+    // Fail to open /etc/lsb-release
+    expect_string(__wrap_wfopen, path, "/etc/lsb-release");
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, 0);
 


### PR DESCRIPTION
|Related issue|
|---|
|#23083|


## Description

This PR changes the order in which the files are checked to find the OS version in case the os-release file is not found. The lsb-release file check is now performed after the SuSE-release file check.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
- Memory tests for Windows
  - [x] Scan-build report
- Memory tests for macOS
  - [x] Scan-build report

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)
