### PR TITLE
Disable update check service in the API integration tests tier 0-1 and 2

### DIFF
--- a/.github/workflows/integration-tests-api-tier-0-1.yml
+++ b/.github/workflows/integration-tests-api-tier-0-1.yml
@@ -61,6 +61,8 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_UPDATE_CHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           sudo sh install.sh

--- a/.github/workflows/integration-tests-api-tier-2.yml
+++ b/.github/workflows/integration-tests-api-tier-2.yml
@@ -54,6 +54,8 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_UPDATE_CHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           sudo sh install.sh


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23247 |

## Description

Sets `USER_ENABLE_UPDATE_CHECK` to `n` in the API integration tests tier 0-1 and 2 preloaded variables.