### PR TITLE
Change approach to manage multi queue

### DIFF
--- a/src/shared_modules/utils/rocksDBOptions.hpp
+++ b/src/shared_modules/utils/rocksDBOptions.hpp
@@ -18,8 +18,8 @@
 
 namespace Utils
 {
-    constexpr auto ROCKSDB_WRITE_BUFFER_SIZE = 64 * 1024 * 1024;
-    constexpr auto ROCKSDB_WRITE_BUFFER_MANAGER_SIZE = 64 * 1024 * 1024;
+    constexpr auto ROCKSDB_WRITE_BUFFER_SIZE = 32 * 1024 * 1024;
+    constexpr auto ROCKSDB_WRITE_BUFFER_MANAGER_SIZE = 32 * 1024 * 1024;
     constexpr auto ROCKSDB_MAX_WRITE_BUFFER_NUMBER = 2;
     constexpr auto ROCKSDB_MAX_OPEN_FILES = 256;
     constexpr auto ROCKSDB_NUM_LEVELS = 4;

--- a/src/shared_modules/utils/rocksDBQueueCF.hpp
+++ b/src/shared_modules/utils/rocksDBQueueCF.hpp
@@ -12,11 +12,11 @@
 #ifndef _ROCKSDB_QUEUE_CF_HPP
 #define _ROCKSDB_QUEUE_CF_HPP
 
-#include "rocksDBColumnFamily.hpp"
 #include "rocksDBOptions.hpp"
 #include "rocksdb/db.h"
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/table.h"
+#include "stringHelper.h"
 #include <filesystem>
 #include <stdexcept>
 #include <string>
@@ -26,7 +26,7 @@ template<typename T, typename U = T>
 class RocksDBQueueCF final
 {
 private:
-    struct ColumnFamilyQueue : public Utils::ColumnFamilyRAII
+    struct QueueMetadata final
     {
         uint64_t head = 0;
         uint64_t tail = 0;
@@ -34,89 +34,36 @@ private:
 
         // Time from epoch + postpone time.
         std::chrono::time_point<std::chrono::system_clock> postponeTime;
-
-        ColumnFamilyQueue(const std::shared_ptr<rocksdb::DB>& db, rocksdb::ColumnFamilyHandle* rawHandle)
-            : Utils::ColumnFamilyRAII(db, rawHandle)
-        {
-        }
     };
 
-    void dropColumn(std::string_view columnFamily)
+    void initializeQueueData()
     {
-        if (const auto it = std::find_if(m_columnsInstances.begin(),
-                                         m_columnsInstances.end(),
-                                         [&columnFamily](const ColumnFamilyQueue& handle)
-                                         { return columnFamily == handle->GetName(); });
-            it != m_columnsInstances.end())
-        {
-            it->drop();
-            m_columnsInstances.erase(it);
-        }
-    }
+        constexpr auto ID_QUEUE = 0;
+        constexpr auto QUEUE_NUMBER = 1;
 
-    void createColumn(std::string_view columnName)
-    {
-        if (columnName.empty())
-        {
-            throw std::invalid_argument {"Column name is empty"};
-        }
-
-        rocksdb::ColumnFamilyHandle* pColumnFamily;
-
-        if (const auto status {m_db->CreateColumnFamily(
-                Utils::RocksDBOptions::buildColumnFamilyOptions(m_readCache), columnName.data(), &pColumnFamily)};
-            !status.ok())
-        {
-            throw std::runtime_error {"Couldn't create column family: " + std::string {status.getState()}};
-        }
-        auto& element = m_columnsInstances.emplace_back(m_db, pColumnFamily);
-        element.head = 1;
-        element.tail = 0;
-    }
-
-    bool columnExists(std::string_view columnName) const
-    {
-        if (columnName.empty())
-        {
-            throw std::invalid_argument {"Column name is empty"};
-        }
-
-        return std::find_if(m_columnsInstances.begin(),
-                            m_columnsInstances.end(),
-                            [&columnName](const ColumnFamilyQueue& handle)
-                            { return columnName == handle->GetName(); }) != m_columnsInstances.end();
-    }
-
-    void initializeQueueData(ColumnFamilyQueue& element)
-    {
-        // RocksDB counter initialization.
-        element.size = 0;
-
-        auto it = std::unique_ptr<rocksdb::Iterator>(m_db->NewIterator(rocksdb::ReadOptions(), element.handle()));
-        it->SeekToFirst();
-        if (it->Valid())
-        {
-            const auto key = std::stoull(it->key().ToString());
-            element.head = key;
-            element.tail = key;
-        }
-        else
-        {
-            element.head = 1;
-            element.tail = 0;
-        }
-
+        auto it = std::unique_ptr<rocksdb::Iterator>(m_db->NewIterator(rocksdb::ReadOptions()));
         while (it->Valid())
         {
-            const auto key = std::stoull(it->key().ToString());
-            if (key > element.tail)
+            // Split key to get the ID and queue number.
+            const auto data = Utils::split(it->key().ToString(), '_');
+            const auto& id = data.at(ID_QUEUE);
+            const auto queueNumber = std::stoull(data.at(QUEUE_NUMBER));
+
+            if (m_queueMetadata.find(id.data()) == m_queueMetadata.end())
             {
-                element.tail = key;
+                m_queueMetadata.emplace(id, QueueMetadata {1, 0, 0, std::chrono::system_clock::now()});
             }
 
-            if (key < element.head)
+            auto& element = m_queueMetadata[id];
+
+            if (queueNumber > element.tail)
             {
-                element.head = key;
+                element.tail = queueNumber;
+            }
+
+            if (queueNumber < element.head)
+            {
+                element.head = queueNumber;
             }
             ++element.size;
 
@@ -145,37 +92,7 @@ public:
         // Create directories recursively if they do not exist
         std::filesystem::create_directories(databasePath);
 
-        // Get a list of the existing columns descriptors.
-        if (const auto databaseFile {databasePath / "CURRENT"}; std::filesystem::exists(databaseFile))
-        {
-            // Read columns names.
-            std::vector<std::string> columnsNames;
-            if (const auto listStatus {rocksdb::DB::ListColumnFamilies(options, path, &columnsNames)}; !listStatus.ok())
-            {
-                throw std::runtime_error("Failed to list columns: " + std::string {listStatus.getState()});
-            }
-
-            // Create a set of column descriptors. This includes the default column.
-            for (auto& columnName : columnsNames)
-            {
-                columnsDescriptors.emplace_back(columnName, columnFamilyOptions);
-            }
-        }
-        else
-        {
-            // Database doesn't exist: Set just the default column descriptor.
-            columnsDescriptors.emplace_back(rocksdb::kDefaultColumnFamilyName, columnFamilyOptions);
-        }
-
-        // Create a vector of column handles.
-        // This vector will be used to store the column handles created by the Open method and based on the
-        // columnsDescriptors.
-        std::vector<rocksdb::ColumnFamilyHandle*> columnHandles;
-        columnHandles.reserve(columnsDescriptors.size());
-
-        // Open database with a list of columns descriptors.
-        if (const auto status {rocksdb::DB::Open(options, path, columnsDescriptors, &columnHandles, &dbRawPtr)};
-            !status.ok())
+        if (const auto status = rocksdb::DB::Open(options, path, &dbRawPtr); !status.ok())
         {
             throw std::runtime_error("Failed to open RocksDB database. Reason: " + std::string {status.getState()});
         }
@@ -184,88 +101,59 @@ public:
         // allocated RocksDB instance.
         m_db.reset(dbRawPtr);
 
-        // Create a RAII wrapper for each column handle.
-        for (const auto& handle : columnHandles)
-        {
-            if (handle->GetName() != rocksdb::kDefaultColumnFamilyName)
-            {
-                auto& element = m_columnsInstances.emplace_back(m_db, handle);
-                initializeQueueData(element);
-            }
-            else
-            {
-                // Close the default column handle.
-                // The default column handle is not used in this class.
-                if (const auto status {m_db->DestroyColumnFamilyHandle(handle)}; !status.ok())
-                {
-                    throw std::runtime_error("Failed to free RocksDB column family: " +
-                                             std::string {status.getState()});
-                }
-            }
-        }
+        // Initialize queue data.
+        initializeQueueData();
     }
 
-    void push(std::string_view columnFamily, const T& data)
+    void push(std::string_view id, const T& data)
     {
-        if (!columnExists(columnFamily))
+        if (m_queueMetadata.find(id.data()) == m_queueMetadata.end())
         {
-            createColumn(columnFamily);
+            m_queueMetadata.emplace(id, QueueMetadata {1, 0, 0, std::chrono::system_clock::now()});
         }
 
-        const auto it {std::find_if(m_columnsInstances.begin(),
-                                    m_columnsInstances.end(),
-                                    [&columnFamily](const ColumnFamilyQueue& handle)
-                                    { return columnFamily == handle.handle()->GetName(); })};
-
-        if (it != m_columnsInstances.end())
+        if (const auto it {m_queueMetadata.find(id.data())}; it != m_queueMetadata.end())
         {
-            ++it->tail;
-            if (const auto status = m_db->Put(rocksdb::WriteOptions(), it->handle(), std::to_string(it->tail), data);
+            ++it->second.tail;
+            if (const auto status =
+                    m_db->Put(rocksdb::WriteOptions(), std::string(id) + "_" + std::to_string(it->second.tail), data);
                 !status.ok())
             {
                 throw std::runtime_error("Failed to enqueue element");
             }
-            ++it->size;
+            ++it->second.size;
         }
     }
 
-    void pop(std::string_view columnFamily)
+    void pop(std::string_view id)
     {
-        if (const auto it {std::find_if(m_columnsInstances.begin(),
-                                        m_columnsInstances.end(),
-                                        [&columnFamily](const ColumnFamilyQueue& handle)
-                                        { return columnFamily == handle.handle()->GetName(); })};
-            it != m_columnsInstances.end())
+        if (const auto it {m_queueMetadata.find(id.data())}; it != m_queueMetadata.end())
         {
             // RocksDB dequeue element.
-            if (!m_db->Delete(rocksdb::WriteOptions(), it->handle(), std::to_string(it->head)).ok())
+            if (!m_db->Delete(rocksdb::WriteOptions(), std::string(id) + "_" + std::to_string(it->second.head)).ok())
             {
                 throw std::runtime_error("Failed to dequeue element, can't delete it");
             }
 
-            ++it->head;
-            --it->size;
+            ++it->second.head;
+            --it->second.size;
 
-            if (it->size == 0)
+            if (it->second.size == 0)
             {
-                dropColumn(columnFamily);
+                m_queueMetadata.erase(it);
             }
         }
         else
         {
-            throw std::runtime_error("Couldn't find column family: " + std::string {columnFamily});
+            throw std::runtime_error("Couldn't find ID: " + std::string {id});
         }
     }
 
-    uint64_t size(std::string_view columnName) const
+    uint64_t size(std::string_view id) const
     {
-        if (const auto it {std::find_if(m_columnsInstances.begin(),
-                                        m_columnsInstances.end(),
-                                        [&columnName](const ColumnFamilyQueue& handle)
-                                        { return columnName == handle.handle()->GetName(); })};
-            it != m_columnsInstances.end())
+        if (const auto it = m_queueMetadata.find(id.data()); it != m_queueMetadata.end())
         {
-            return it->size;
+            return it->second.size;
         }
 
         return 0;
@@ -277,64 +165,59 @@ public:
         // Count if there is any column with elements.
         const auto currentSystemTime = std::chrono::system_clock::now();
         auto count =
-            std::count_if(m_columnsInstances.begin(),
-                          m_columnsInstances.end(),
-                          [&](const ColumnFamilyQueue& handle) { return handle.postponeTime < currentSystemTime; });
+            std::count_if(m_queueMetadata.begin(),
+                          m_queueMetadata.end(),
+                          [&](const auto& metadata) { return metadata.second.postponeTime < currentSystemTime; });
         return count == 0;
     }
 
     const std::string& getAvailableColumn()
     {
-        if (m_columnsInstances.empty())
+        if (m_queueMetadata.empty())
         {
-            throw std::runtime_error("No column family available");
+            throw std::runtime_error("No queue ids available");
         }
 
         // Only consider the columns that are not postponed.
         const auto currentSystemTime = std::chrono::system_clock::now();
-        auto it =
-            std::find_if(m_columnsInstances.begin(),
-                         m_columnsInstances.end(),
-                         [&](const ColumnFamilyQueue& handle) { return handle.postponeTime < currentSystemTime; });
+        auto it = std::find_if(m_queueMetadata.begin(),
+                               m_queueMetadata.end(),
+                               [&](const auto& metadata) { return metadata.second.postponeTime < currentSystemTime; });
 
-        if (it == m_columnsInstances.end())
+        if (it == m_queueMetadata.end())
         {
-            throw std::runtime_error("Probably race condition, no column family available");
+            throw std::runtime_error("Probably race condition, no queue id available");
         }
 
-        return it->handle()->GetName();
+        return it->first;
     }
 
-    void postpone(std::string_view columnName, const std::chrono::seconds& time) noexcept
+    void postpone(std::string_view id, const std::chrono::seconds& time) noexcept
     {
-        if (const auto it {std::find_if(m_columnsInstances.begin(),
-                                        m_columnsInstances.end(),
-                                        [&columnName](const ColumnFamilyQueue& handle)
-                                        { return columnName == handle.handle()->GetName(); })};
-            it != m_columnsInstances.end())
+        if (const auto it {m_queueMetadata.find(id.data())}; it != m_queueMetadata.end())
         {
-            it->postponeTime = std::chrono::system_clock::now() + time;
+            it->second.postponeTime = std::chrono::system_clock::now() + time;
         }
     }
 
-    U front(std::string_view columnFamily) const
+    U front(std::string_view id) const
     {
         U value;
-        if (const auto it {std::find_if(m_columnsInstances.begin(),
-                                        m_columnsInstances.end(),
-                                        [&columnFamily](const ColumnFamilyQueue& handle)
-                                        { return columnFamily == handle.handle()->GetName(); })};
-            it != m_columnsInstances.end())
+        if (const auto it {m_queueMetadata.find(id.data())}; it != m_queueMetadata.end())
         {
-            if (!m_db->Get(rocksdb::ReadOptions(), it->handle(), std::to_string(it->head), &value).ok())
+            if (!m_db->Get(rocksdb::ReadOptions(),
+                           m_db->DefaultColumnFamily(),
+                           std::string(id) + "_" + std::to_string(it->second.head),
+                           &value)
+                     .ok())
             {
-                throw std::runtime_error("Failed to get front element, column family: " + std::string {columnFamily} +
-                                         " key: " + std::to_string(it->head));
+                throw std::runtime_error("Failed to get front element, id: " + std::string {id} +
+                                         " key: " + std::to_string(it->second.head));
             }
         }
         else
         {
-            throw std::runtime_error("Couldn't find column family: " + std::string {columnFamily});
+            throw std::runtime_error("Couldn't find id: " + std::string {id});
         }
 
         return value;
@@ -344,7 +227,7 @@ private:
     std::shared_ptr<rocksdb::DB> m_db;
     std::shared_ptr<rocksdb::Cache> m_readCache;
     std::shared_ptr<rocksdb::WriteBufferManager> m_writeManager;
-    std::vector<ColumnFamilyQueue> m_columnsInstances; ///< List of column family.
+    std::map<std::string, QueueMetadata> m_queueMetadata; ///< Map queue.
 };
 
 #endif // _ROCKSDB_QUEUE_CF_HPP

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ file(GLOB UTIL_CXX_UNITTEST_LINUX_SRC
     "socketWrapper_test.cpp"
     "socket_test.cpp"
     "rocksDBSafeQueue_test.cpp"
+    "rocksDBSafeQueuePrefix_test.cpp"
     "rocksDBWrapper_test.cpp"
     "threadEventDispatcher_test.cpp"
     "xzHelper_test.cpp"

--- a/src/shared_modules/utils/tests/rocksDBSafeQueuePrefix_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBSafeQueuePrefix_test.cpp
@@ -1,0 +1,153 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * Jun 4, 2023.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "rocksDBSafeQueuePrefix_test.hpp"
+#include <filesystem>
+#include <thread>
+
+void RocksDBSafeQueuePrefixTest::SetUp()
+{
+    std::error_code ec;
+    std::filesystem::remove_all("test.db", ec);
+    queue = std::make_unique<Utils::TSafeMultiQueue<std::string, std::string, RocksDBQueueCF<std::string>>>(
+        RocksDBQueueCF<std::string>("test.db"));
+};
+
+void RocksDBSafeQueuePrefixTest::TearDown() {};
+
+TEST_F(RocksDBSafeQueuePrefixTest, PopInCancelledQueue)
+{
+    queue->cancel();
+    EXPECT_TRUE(queue->cancelled());
+    EXPECT_TRUE(queue->empty());
+    auto queueSize {queue->size("000")};
+    EXPECT_NO_THROW(queue->pop("000"));
+    EXPECT_EQ(queueSize, queue->size("000"));
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, PopEmptyQueue)
+{
+    EXPECT_TRUE(queue->empty());
+    EXPECT_FALSE(queue->cancelled());
+    const auto front {queue->front()};
+    EXPECT_STREQ("", front.first.c_str());
+    EXPECT_STREQ("", front.second.c_str());
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, PopWithData)
+{
+    queue->push("000", "test");
+    EXPECT_EQ(1, queue->size("000"));
+    auto front {queue->front()};
+    EXPECT_NO_THROW(queue->pop(front.second));
+    EXPECT_EQ(0, queue->size("000"));
+    EXPECT_STREQ("000", front.second.c_str());
+    EXPECT_STREQ("test", front.first.c_str());
+
+    EXPECT_ANY_THROW(queue->pop("000"));
+
+    queue->push("000", "test2");
+    EXPECT_EQ(1, queue->size("000"));
+    front = queue->front();
+    EXPECT_NO_THROW(queue->pop(front.second));
+    EXPECT_EQ(0, queue->size("000"));
+    EXPECT_STREQ("000", front.second.c_str());
+    EXPECT_STREQ("test2", front.first.c_str());
+
+    queue->cancel();
+    EXPECT_TRUE(queue->cancelled());
+    EXPECT_TRUE(queue->empty());
+    queue->push("000", "test3");
+    EXPECT_TRUE(queue->empty());
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, PopWithMultipleData)
+{
+    const int ITERATION_COUNT = 10000;
+    std::string data = "test";
+
+    for (int i = 0; i < ITERATION_COUNT; i++)
+    {
+        queue->push("000", data + std::to_string(i));
+    }
+
+    EXPECT_EQ(ITERATION_COUNT, queue->size("000"));
+
+    for (int i = 0; i < ITERATION_COUNT; i++)
+    {
+        auto front {queue->front()};
+        EXPECT_NO_THROW(queue->pop(front.second));
+        EXPECT_EQ(data + std::to_string(i), front.first);
+    }
+
+    EXPECT_TRUE(queue->empty());
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, PopWithMultipleIDData)
+{
+    const int ITERATION_COUNT = 10000;
+    std::string data = "test";
+
+    for (int i = 0; i < ITERATION_COUNT; i++)
+    {
+        queue->push(std::to_string(i), data);
+    }
+
+    for (int i = 0; i < ITERATION_COUNT; i++)
+    {
+        auto front {queue->front()};
+        EXPECT_EQ(1, queue->size(front.second));
+        EXPECT_NO_THROW(queue->pop(front.second));
+        EXPECT_EQ(0, queue->size(front.second));
+        EXPECT_EQ(data, front.first);
+    }
+
+    EXPECT_TRUE(queue->empty());
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, BlockingPopByRef)
+{
+    std::thread t1 {[this]()
+                    {
+                        auto front {queue->front()};
+                        EXPECT_NO_THROW(queue->pop(front.second));
+                        EXPECT_EQ("0", front.first);
+                    }};
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    queue->push("000", "0");
+    t1.join();
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, CancelBlockingPop)
+{
+    std::thread t {[this]()
+                   {
+                       auto front {queue->front()};
+                       EXPECT_STREQ("", front.first.c_str());
+                       EXPECT_STREQ("", front.second.c_str());
+                       EXPECT_TRUE(queue->cancelled());
+                   }};
+    queue->cancel();
+    t.join();
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, CreateFolderRecursively)
+{
+    const std::string DATABASE_NAME {"folder1/folder2/test.db"};
+
+    EXPECT_NO_THROW({
+        (std::make_unique<Utils::TSafeMultiQueue<std::string, std::string, RocksDBQueueCF<std::string>>>(
+            RocksDBQueueCF<std::string>(DATABASE_NAME)));
+    });
+
+    std::error_code ec;
+    std::filesystem::remove_all(DATABASE_NAME, ec);
+}

--- a/src/shared_modules/utils/tests/rocksDBSafeQueuePrefix_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBSafeQueuePrefix_test.cpp
@@ -151,3 +151,36 @@ TEST_F(RocksDBSafeQueuePrefixTest, CreateFolderRecursively)
     std::error_code ec;
     std::filesystem::remove_all(DATABASE_NAME, ec);
 }
+
+TEST_F(RocksDBSafeQueuePrefixTest, ClearQueue)
+{
+    queue->push("000", "test");
+    queue->push("000", "test2");
+    queue->push("000", "test3");
+    queue->push("001", "test4");
+    queue->push("001", "test5");
+
+    EXPECT_EQ(3, queue->size("000"));
+    EXPECT_EQ(2, queue->size("001"));
+
+    queue->clear("000");
+    EXPECT_EQ(0, queue->size("000"));
+    EXPECT_EQ(2, queue->size("001"));
+
+    queue->clear("001");
+    EXPECT_EQ(0, queue->size("001"));
+}
+
+TEST_F(RocksDBSafeQueuePrefixTest, ClearAllQueue)
+{
+    queue->push("000", "test");
+    queue->push("000", "test2");
+    queue->push("000", "test3");
+    queue->push("001", "test4");
+    queue->push("001", "test5");
+
+    queue->clear("");
+    EXPECT_EQ(0, queue->size("000"));
+    EXPECT_EQ(0, queue->size("001"));
+    EXPECT_TRUE(queue->empty());
+}

--- a/src/shared_modules/utils/tests/rocksDBSafeQueuePrefix_test.hpp
+++ b/src/shared_modules/utils/tests/rocksDBSafeQueuePrefix_test.hpp
@@ -1,0 +1,29 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * May 4, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _ROCKSDB_SAFEQUEUE_PREFIX_TEST_HPP
+#define _ROCKSDB_SAFEQUEUE_PREFIX_TEST_HPP
+
+#include "rocksDBQueueCF.hpp"
+#include "threadSafeMultiQueue.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+
+class RocksDBSafeQueuePrefixTest : public ::testing::Test
+{
+protected:
+    RocksDBSafeQueuePrefixTest() = default;
+    ~RocksDBSafeQueuePrefixTest() override = default;
+    std::unique_ptr<Utils::TSafeMultiQueue<std::string, std::string, RocksDBQueueCF<std::string>>> queue;
+    void SetUp() override;
+    void TearDown() override;
+};
+#endif //_ROCKSDB_SAFEQUEUE_PREFIX_TEST_HPP

--- a/src/shared_modules/utils/tests/threadSafeMultiQueue_test.cpp
+++ b/src/shared_modules/utils/tests/threadSafeMultiQueue_test.cpp
@@ -133,3 +133,54 @@ TEST_F(ThreadSafeMultiQueueTest, Postpone)
     EXPECT_TRUE(count == EXPECTED_COUNT_MSGS);
 }
 
+TEST_F(ThreadSafeMultiQueueTest, Clear)
+{
+    Utils::
+        TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>>
+            queue(RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>("test"));
+
+    rocksdb::Slice slice("DATA");
+    queue.push("000", slice);
+    queue.push("001", slice);
+    queue.push("002", slice);
+    EXPECT_FALSE(queue.empty());
+    EXPECT_EQ(1, queue.size("000"));
+    EXPECT_EQ(1, queue.size("001"));
+    EXPECT_EQ(1, queue.size("002"));
+    queue.clear("000");
+    EXPECT_EQ(0, queue.size("000"));
+    EXPECT_EQ(1, queue.size("001"));
+    EXPECT_EQ(1, queue.size("002"));
+    EXPECT_FALSE(queue.empty());
+    queue.clear("001");
+    EXPECT_EQ(0, queue.size("000"));
+    EXPECT_EQ(0, queue.size("001"));
+    EXPECT_EQ(1, queue.size("002"));
+    EXPECT_FALSE(queue.empty());
+    queue.clear("002");
+    EXPECT_EQ(0, queue.size("000"));
+    EXPECT_EQ(0, queue.size("001"));
+    EXPECT_EQ(0, queue.size("002"));
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST_F(ThreadSafeMultiQueueTest, ClearAll)
+{
+    Utils::
+        TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>>
+            queue(RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>("test"));
+
+    rocksdb::Slice slice("DATA");
+    queue.push("000", slice);
+    queue.push("001", slice);
+    queue.push("002", slice);
+    EXPECT_FALSE(queue.empty());
+    EXPECT_EQ(1, queue.size("000"));
+    EXPECT_EQ(1, queue.size("001"));
+    EXPECT_EQ(1, queue.size("002"));
+    queue.clear("");
+    EXPECT_EQ(0, queue.size("000"));
+    EXPECT_EQ(0, queue.size("001"));
+    EXPECT_EQ(0, queue.size("002"));
+    EXPECT_TRUE(queue.empty());
+}

--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -81,14 +81,28 @@ public:
         }
     }
 
-    void push(std::string_view columnName, const T& value)
+    void push(std::string_view prefix, const T& value)
     {
         if constexpr (std::is_same_v<Utils::TSafeMultiQueue<T, U, RocksDBQueueCF<T, U>>, TSafeQueueType>)
         {
-            if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue->size(columnName) < m_maxQueueSize))
+            if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue->size(prefix) < m_maxQueueSize))
             {
-                m_queue->push(columnName, value);
+                m_queue->push(prefix, value);
             }
+        }
+        else
+        {
+            // static assert to avoid compilation
+            static_assert(std::is_same_v<Utils::TSafeMultiQueue<T, U, RocksDBQueueCF<T, U>>, TSafeQueueType>,
+                          "This method is not supported for this queue type");
+        }
+    }
+
+    void clear(std::string_view prefix = "")
+    {
+        if constexpr (std::is_same_v<Utils::TSafeMultiQueue<T, U, RocksDBQueueCF<T, U>>, TSafeQueueType>)
+        {
+            m_queue->clear(prefix);
         }
         else
         {
@@ -123,11 +137,11 @@ public:
         }
     }
 
-    size_t size(std::string_view columnName) const
+    size_t size(std::string_view prefix) const
     {
         if constexpr (std::is_same_v<Utils::TSafeMultiQueue<T, U, RocksDBQueueCF<T, U>>, TSafeQueueType>)
         {
-            return m_queue->size(columnName);
+            return m_queue->size(prefix);
         }
         else
         {
@@ -137,11 +151,11 @@ public:
         }
     }
 
-    void postpone(std::string_view columnName, const std::chrono::seconds& time) noexcept
+    void postpone(std::string_view prefix, const std::chrono::seconds& time) noexcept
     {
         if constexpr (std::is_same_v<Utils::TSafeMultiQueue<T, U, RocksDBQueueCF<T, U>>, TSafeQueueType>)
         {
-            m_queue->postpone(columnName, time);
+            m_queue->postpone(prefix, time);
         }
         else
         {

--- a/src/shared_modules/utils/threadSafeMultiQueue.hpp
+++ b/src/shared_modules/utils/threadSafeMultiQueue.hpp
@@ -46,12 +46,12 @@ namespace Utils
             cancel();
         }
 
-        void push(std::string_view columnName, const T& value)
+        void push(std::string_view prefix, const T& value)
         {
             std::scoped_lock lock {m_mutex};
             if (!m_canceled)
             {
-                m_queue.push(columnName, value);
+                m_queue.push(prefix, value);
                 m_cv.notify_one();
             }
         }
@@ -84,12 +84,12 @@ namespace Utils
             return std::pair<U, std::string> {};
         }
 
-        void pop(std::string_view columnName)
+        void pop(std::string_view prefix)
         {
             std::scoped_lock lock {m_mutex};
             if (!m_canceled)
             {
-                m_queue.pop(columnName);
+                m_queue.pop(prefix);
             }
         }
 
@@ -99,10 +99,16 @@ namespace Utils
             return m_queue.empty();
         }
 
-        size_t size(std::string_view columnName) const
+        void clear(std::string_view prefix)
         {
             std::scoped_lock lock {m_mutex};
-            return m_queue.size(columnName);
+            m_queue.clear(prefix);
+        }
+
+        size_t size(std::string_view prefix) const
+        {
+            std::scoped_lock lock {m_mutex};
+            return m_queue.size(prefix);
         }
 
         void cancel()
@@ -119,10 +125,10 @@ namespace Utils
             return m_canceled;
         }
 
-        void postpone(std::string_view columnName, const std::chrono::seconds& time) noexcept
+        void postpone(std::string_view prefix, const std::chrono::seconds& time) noexcept
         {
             std::scoped_lock lock {m_mutex};
-            m_queue.postpone(columnName, time);
+            m_queue.postpone(prefix, time);
         }
 
     private:

--- a/src/shared_modules/utils/threadSafeMultiQueue.hpp
+++ b/src/shared_modules/utils/threadSafeMultiQueue.hpp
@@ -87,7 +87,10 @@ namespace Utils
         void pop(std::string_view columnName)
         {
             std::scoped_lock lock {m_mutex};
-            m_queue.pop(columnName);
+            if (!m_canceled)
+            {
+                m_queue.pop(columnName);
+            }
         }
 
         bool empty() const

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -265,12 +265,20 @@ private:
                     m_integrityClearOrchestration->handleRequest(std::move(context));
                     break;
                 // LCOV_EXCL_START
-                case ScannerType::ReScanAllAgents: m_reScanAllOrchestration->handleRequest(std::move(context)); break;
-                case ScannerType::ReScanSingleAgent: m_reScanOrchestration->handleRequest(std::move(context)); break;
+                case ScannerType::ReScanAllAgents:
+                    m_eventDelayedDispatcher->clear();
+                    m_reScanAllOrchestration->handleRequest(std::move(context));
+                    break;
+                case ScannerType::ReScanSingleAgent:
+                    m_eventDelayedDispatcher->clear(context->agentId());
+                    m_reScanOrchestration->handleRequest(std::move(context));
+                    break;
                 case ScannerType::CleanupAllAgentData:
+                    m_eventDelayedDispatcher->clear();
                     m_cleanUpDataOrchestration->handleRequest(std::move(context));
                     break;
                 case ScannerType::CleanupSingleAgentData:
+                    m_eventDelayedDispatcher->clear(context->agentId());
                     m_deleteAgentScanOrchestration->handleRequest(std::move(context));
                     break;
                 case ScannerType::GlobalSyncInventory:


### PR DESCRIPTION
|Related issue|
|---|
|Close #23202|

## Description
This PR aims to change the approach from the multi-queue with column families to a single column family (default) using a prefix to identify an id (for the VD implementation is used the agent id is in the delayed list).


This approach decreases the FD usage.