### PR TITLE
Fix: remove permissions for Authenticated users

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -348,10 +348,10 @@ public function config()
         setPermsInherit = "icacls """ & install_dir & """ /inheritancelevel:r /q"
         WshShell.run setPermsInherit, 0, True
 
-        grantAdminPerm = "icacls """ & install_dir & """ /grant *S-1-5-32-544:F /t"
+        grantAdminPerm = "icacls """ & install_dir & """ /grant *S-1-5-32-544:(OI)(CI)F"
         WshShell.run grantAdminPerm, 0, True
 
-        grantSystemPerm = "icacls """ & install_dir & """ /grant *S-1-5-18:F /t"
+        grantSystemPerm = "icacls """ & install_dir & """ /grant *S-1-5-18:(OI)(CI)F"
         WshShell.run grantSystemPerm, 0, True
 
         userSID = GetUserSID()

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -351,6 +351,9 @@ public function config()
         grantAdminPerm = "icacls """ & install_dir & """ /grant *S-1-5-32-544:F /t"
         WshShell.run grantAdminPerm, 0, True
 
+        grantSystemPerm = "icacls """ & install_dir & """ /grant *S-1-5-18:F /t"
+        WshShell.run grantSystemPerm, 0, True
+
         userSID = GetUserSID()
         grantUserPerm = "icacls """ & install_dir & """ /grant *" & userSID & ":(RX) /t"
         WshShell.run grantUserPerm, 0, True

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -79,7 +79,7 @@ public function config()
             Else
                 protocol_list=Array(LCase(WAZUH_PROTOCOL))
             End If
-            If WAZUH_MANAGER <> "" Then 
+            If WAZUH_MANAGER <> "" Then
                 Set re = new regexp
                 re.Pattern = "\s+<server>(.|\n)+?</server>"
                 If InStr(WAZUH_MANAGER,",") Then
@@ -91,7 +91,7 @@ public function config()
                 unique_protocol_list=get_unique_array_values(protocol_list)
 
                 if ( UBound(protocol_list) >= UBound(ip_list) And UBound(unique_protocol_list) = 0 ) Or (WAZUH_PROTOCOL = "") Or ( UBound(unique_protocol_list) = 0 And LCase(unique_protocol_list(0)) = "tcp" ) Then
-                    ip_list=get_unique_array_values(ip_list) 
+                    ip_list=get_unique_array_values(ip_list)
                 End If
 
                 not_replaced = True
@@ -151,7 +151,7 @@ public function config()
                 End If
             End If
         End If
-        
+
         If WAZUH_REGISTRATION_SERVER <> "" or WAZUH_REGISTRATION_PORT <> "" or WAZUH_REGISTRATION_PASSWORD <> "" or WAZUH_REGISTRATION_CA <> "" or WAZUH_REGISTRATION_CERTIFICATE <> "" or WAZUH_REGISTRATION_KEY <> "" or WAZUH_AGENT_NAME <> "" or WAZUH_AGENT_GROUP <> "" or ENROLLMENT_DELAY <> "" Then
             enrollment_list = "    <enrollment>" & vbCrLf
             enrollment_list = enrollment_list & "      <enabled>yes</enabled>" & vbCrLf
@@ -162,12 +162,12 @@ public function config()
 
             If WAZUH_REGISTRATION_SERVER <> "" Then
                 strText = Replace(strText, "    </enrollment>", "      <manager_address>" & WAZUH_REGISTRATION_SERVER & "</manager_address>"& vbCrLf &"    </enrollment>")
-            End If  
-            
+            End If
+
             If WAZUH_REGISTRATION_PORT <> "" Then
                 strText = Replace(strText, "    </enrollment>", "      <port>" & WAZUH_REGISTRATION_PORT & "</port>"& vbCrLf &"    </enrollment>")
             End If
-            
+
             If WAZUH_REGISTRATION_PASSWORD <> "" Then
                 Set objFile = objFSO.CreateTextFile(home_dir & "authd.pass", ForWriting)
                 objFile.WriteLine WAZUH_REGISTRATION_PASSWORD
@@ -345,11 +345,11 @@ public function config()
         ' Remove last backslash from home_dir
         install_dir = Left(home_dir, Len(home_dir) - 1)
 
-        setPermsInherit = "icacls """ & install_dir & """ /inheritancelevel:d /q"
+        setPermsInherit = "icacls """ & install_dir & """ /inheritancelevel:r /q"
         WshShell.run setPermsInherit, 0, True
 
-        remUserPerm = "icacls """ & install_dir & """ /remove *S-1-5-32-545 /q"
-        WshShell.run remUserPerm, 0, True
+        grantAdminPerm = "icacls """ & install_dir & """ /grant *S-1-5-32-544:F /t"
+        WshShell.run grantAdminPerm, 0, True
 
         userSID = GetUserSID()
         grantUserPerm = "icacls """ & install_dir & """ /grant *" & userSID & ":(RX) /t"

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -113,7 +113,9 @@
         <CustomAction Id="CheckSvcRunning" BinaryKey="InstallerScripts" VBScriptCall="CheckSvcRunning" Return="check" Execute="immediate" Impersonate="no"/>
 
         <CustomAction Id="SetCustomActionDataValue" Return="check" Property="CustomAction_InstallerScripts" Value="&quot;[APPLICATIONFOLDER]&quot;/+/&quot;[OS_VERSION]&quot;/+/&quot;[WAZUH_MANAGER]&quot;/+/&quot;[WAZUH_MANAGER_PORT]&quot;/+/&quot;[WAZUH_PROTOCOL]&quot;/+/&quot;[NOTIFY_TIME]&quot;/+/&quot;[WAZUH_REGISTRATION_SERVER]&quot;/+/&quot;[WAZUH_REGISTRATION_PORT]&quot;/+/&quot;[WAZUH_REGISTRATION_PASSWORD]&quot;/+/&quot;[WAZUH_KEEP_ALIVE_INTERVAL]&quot;/+/&quot;[WAZUH_TIME_RECONNECT]&quot;/+/&quot;[WAZUH_REGISTRATION_CA]&quot;/+/&quot;[WAZUH_REGISTRATION_CERTIFICATE]&quot;/+/&quot;[WAZUH_REGISTRATION_KEY]&quot;/+/&quot;[WAZUH_AGENT_NAME]&quot;/+/&quot;[WAZUH_AGENT_GROUP]&quot;/+/&quot;[ENROLLMENT_DELAY]&quot;" />
+        <CustomAction Id="SetCustomActionDataForSetWazuhPermissions" Return="check" Property="SetWazuhPermissions" Value="&quot;[APPLICATIONFOLDER]&quot;/+/&quot;[OS_VERSION]&quot;/+/&quot;[WAZUH_MANAGER]&quot;/+/&quot;[WAZUH_MANAGER_PORT]&quot;/+/&quot;[WAZUH_PROTOCOL]&quot;/+/&quot;[NOTIFY_TIME]&quot;/+/&quot;[WAZUH_REGISTRATION_SERVER]&quot;/+/&quot;[WAZUH_REGISTRATION_PORT]&quot;/+/&quot;[WAZUH_REGISTRATION_PASSWORD]&quot;/+/&quot;[WAZUH_KEEP_ALIVE_INTERVAL]&quot;/+/&quot;[WAZUH_TIME_RECONNECT]&quot;/+/&quot;[WAZUH_REGISTRATION_CA]&quot;/+/&quot;[WAZUH_REGISTRATION_CERTIFICATE]&quot;/+/&quot;[WAZUH_REGISTRATION_KEY]&quot;/+/&quot;[WAZUH_AGENT_NAME]&quot;/+/&quot;[WAZUH_AGENT_GROUP]&quot;/+/&quot;[ENROLLMENT_DELAY]&quot;" />
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no"/>
+        <CustomAction Id="SetWazuhPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetWazuhPermissions" Return="check" Execute="commit" Impersonate="no"/>
 
         <!-- Explicitely stopping and deleting the OSSEC service to install new Wazuh service -->
         <CustomAction Id="StopOssecService" Directory="APPLICATIONFOLDER" ExeCommand="NET STOP OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
@@ -172,6 +174,10 @@
             <!-- Install functions -->
             <Custom Action="SetCustomActionDataValue" After="InstallInitialize">(NOT WIX_UPGRADE_DETECTED) AND (NOT PATCH) AND (NOT Installed)</Custom>
             <Custom Action="CustomAction_InstallerScripts" After="SetCustomActionDataValue">(NOT WIX_UPGRADE_DETECTED) AND (NOT PATCH) AND (NOT Installed)</Custom>
+
+            <!-- Set Wazuh permissions on upgrade -->
+            <Custom Action="SetCustomActionDataForSetWazuhPermissions" After="InstallInitialize">(WIX_UPGRADE_DETECTED) OR (PATCH)</Custom>
+            <Custom Action="SetWazuhPermissions" After="SetCustomActionDataForSetWazuhPermissions">(WIX_UPGRADE_DETECTED) OR (PATCH)</Custom>
 
             <!-- Start services if necessary -->
             <Custom Action="StartWazuhSvc" After="InstallServices">((WIX_UPGRADE_DETECTED) OR (PATCH)) AND ((OSSECRUNNING = "Running") OR (WAZUHRUNNING = "Running"))</Custom>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/internal-devel-requests/issues/1091|

## Description
The PR removes all permissions from the ossec-agent's folder and sets Administrator(Full control), System(Full control), and for the user(Read&Execute) permissions. 

## Tests

|                                                  C:\Program Files (x86)\ossec-agent                                                  |                                                               C:\ossec-agent                                                               | 
|:------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------:|
| <img width="576" alt="ossec_default_path" src="https://github.com/wazuh/wazuh/assets/21695385/d3d50d3c-b99f-4d0c-8882-5f34bb7968ff"> | <img width="576" alt="ossec_on_root_path" src="https://github.com/wazuh/wazuh/assets/21695385/3c003c92-79e5-4533-b2dd-5edb5985c467"> |  
|                                                  **C:\Users\Public\ossec-agent**                                                  |                                                               **C:\Users\vagrant\Desktop\ossec-agent**                  | 
| <img width="576" alt="ossec_public_path" src="https://github.com/wazuh/wazuh/assets/21695385/953d7531-82d6-41c0-8e53-01a8177777c8"> | <img width="576" alt="ossec_on_Desktop_path" src="https://github.com/wazuh/wazuh/assets/21695385/339b9e74-3bb7-4a82-8f3a-a2860df02d69"> |  

## Test Upgrade

|    Verssion 4.6.0               |            Verssion 4.9.0      |
|:------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------:|
C:\Program Files (x86)\ossec-agent    |  C:\Program Files (x86)\ossec-agent      | 
| <img width="576" alt="ossec_default_path" src="https://github.com/wazuh/wazuh/assets/21695385/8c7e2973-e87b-4f5a-8a29-f1f9d0931ce7"> | <img width="576" alt="ossec_on_root_path" src="https://github.com/wazuh/wazuh/assets/21695385/0b7f51ed-9d6b-4dc2-b0bc-a602e0c1d1d3"> |  
 Check subfolders:                                            |C:\Program Files (x86)\ossec-agent\active-response |
| <img width="576" alt="ossec_default_path" src="https://github.com/wazuh/wazuh/assets/21695385/b6655cfd-ba29-4187-8349-23335de1e9a9"> | <img width="576" alt="ossec_on_root_path" src="https://github.com/wazuh/wazuh/assets/21695385/13f69d0a-9473-425b-b508-18ca467a6306"> |  
| Different Path:   |  C:\ossec-agent      | 
| <img width="576" alt="ossec_root_path_4_6" src="https://github.com/wazuh/wazuh/assets/21695385/667bd4c5-6f38-4d62-b2f9-62a663e322dd"> | <img width="576" alt="ossec_on_root_path_4_9" src="https://github.com/wazuh/wazuh/assets/21695385/f77b62f3-63fc-4b1d-82d6-260978fee243"> |  
 Check subfolders:                                            |C:\ossec-agent\active-response |
| <img width="576" alt="ossec_root_path_4_6" src="https://github.com/wazuh/wazuh/assets/21695385/eba8ddcc-0dac-4cdf-bb62-8ee430aadce8"> | <img width="576" alt="ossec_on_root_path_4_9" src="https://github.com/wazuh/wazuh/assets/21695385/45137411-e73c-473e-84b7-ada975ddf3f4"> |  


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Package installation
- [x] Package upgrade
