### PR TITLE
Change VD index name

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "wazuh-states-vulnerabilities"
+    "wazuh-states-vulnerabilities-*"
   ],
   "priority": 1,
   "template": {

--- a/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/policyManager/policyManager.hpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 constexpr auto UNKNOWN_VALUE {" "};
-constexpr auto STATES_VD_INDEX_NAME {"wazuh-states-vulnerabilities"};
+constexpr auto STATES_VD_INDEX_NAME_PREFIX {"wazuh-states-vulnerabilities-"};
 constexpr auto DEFAULT_TRANSLATION_LRU_SIZE {2048};
 constexpr auto DEFAULT_OSDATA_LRU_SIZE {1000};
 const static std::string UPDATER_PATH {"queue/vd_updater"};
@@ -115,7 +115,11 @@ private:
             newPolicy["indexer"]["ssl"]["certificate"] = "";
             newPolicy["indexer"]["ssl"]["key"] = "";
         }
-        newPolicy["indexer"]["name"] = STATES_VD_INDEX_NAME;
+        newPolicy["indexer"]["name"] =
+            STATES_VD_INDEX_NAME_PREFIX +
+            (newPolicy.at("vulnerability-detection").contains("clusterName")
+                 ? newPolicy.at("vulnerability-detection").at("clusterName").get_ref<const std::string&>()
+                 : "default");
 
         if (!newPolicy.at("vulnerability-detection").contains("feed-update-interval"))
         {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/policyManager_test.cpp
@@ -263,6 +263,43 @@ TEST_F(PolicyManagerTest, validConfigurationDefaultValues)
     EXPECT_EQ(m_policyManager->getCTIUrl(), "cti-url.com");
     EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 2048);
     EXPECT_EQ(m_policyManager->getOsdataLRUSize(), 1000);
+    EXPECT_STREQ("wazuh-states-vulnerabilities-default",
+                 m_policyManager->getIndexerConfiguration().at("name").get_ref<const std::string&>().c_str());
+}
+
+TEST_F(PolicyManagerTest, validConfigurationDefaultValuesWithClusterName)
+{
+    const auto& configJson {nlohmann::json::parse(R"({
+      "vulnerability-detection": {
+        "enabled": "yes",
+        "index-status": "yes",
+        "cti-url": "cti-url.com",
+        "clusterName":"cluster01"
+      },
+      "indexer": {
+        "enabled": "yes"
+      }
+    })")};
+
+    m_policyManager->initialize(configJson);
+
+    EXPECT_TRUE(m_policyManager->isVulnerabilityDetectionEnabled());
+    EXPECT_TRUE(m_policyManager->isIndexerEnabled());
+
+    EXPECT_EQ(m_policyManager->getFeedUpdateTime(), 3600);
+
+    EXPECT_EQ(m_policyManager->getHostList().count("http://localhost:9200"), 1);
+
+    EXPECT_STREQ(m_policyManager->getUsername().c_str(), "");
+    EXPECT_STREQ(m_policyManager->getPassword().c_str(), "");
+    EXPECT_STREQ(m_policyManager->getCertificate().c_str(), "");
+    EXPECT_STREQ(m_policyManager->getKey().c_str(), "");
+    EXPECT_EQ(m_policyManager->getCAList().size(), 0);
+    EXPECT_EQ(m_policyManager->getCTIUrl(), "cti-url.com");
+    EXPECT_EQ(m_policyManager->getTranslationLRUSize(), 2048);
+    EXPECT_EQ(m_policyManager->getOsdataLRUSize(), 1000);
+    EXPECT_STREQ("wazuh-states-vulnerabilities-cluster01",
+                 m_policyManager->getIndexerConfiguration().at("name").get_ref<const std::string&>().c_str());
 }
 
 TEST_F(PolicyManagerTest, invalidConfigurationNoCTIUrl)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23265 |

## Description

This PR aims to add the cluster name to the index name. This change prevents a possible collision between two or more clusters with the same agent IDs and different vulnerabilities.