### PR TITLE
Disable wazuh-modulesd debug mode in AIT

### DIFF
--- a/api/test/integration/env/base/manager/entrypoint.sh
+++ b/api/test/integration/env/base/manager/entrypoint.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Enable debug mode for the modulesd daemon
-echo 'wazuh_modules.debug=2' >> /var/ossec/etc/local_internal_options.conf
-
 # Apply API configuration
 cp -rf /tmp_volume/config/* /var/ossec/ && chown -R wazuh:wazuh /var/ossec/api
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23195 |

## Description

Disables `wazuh-modulesd` debug mode in the API integration tests which was causing some log tests to fail.