### PR TITLE
Fix full scan, to exclude the manager scan if the setting is disabled

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -430,7 +430,7 @@ vulnerability-detection.osdata_lru_size=1000
 # Vulnerability detector - Enable or disable the scan manager
 # 0. Enabled
 # 1. Disabled
-vulnerability-detection.disable_scan_manager=0
+vulnerability-detection.disable_scan_manager=1
 
 # Debug options.
 # Debug 0 -> no debug

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/args_004.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/args_004.json
@@ -1,6 +1,6 @@
 [
     "-c",
-    "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configDisabled.json",
+    "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configDisabledAndManagerDisabled.json",
     "-t",
     "wazuh_modules/vulnerability_scanner/indexer/template/index-template.json",
     "-l",
@@ -11,7 +11,7 @@
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/agentHotfixesData.json",
     "-p",
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/agentPackagesData.json",
-    "-v",
+    "-b",
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/agentOsData.json",
     "-g",
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/globalData.json",

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/args_005.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/args_005.json
@@ -1,6 +1,6 @@
 [
     "-c",
-    "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configDisabled.json",
+    "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configManagerDisabled.json",
     "-t",
     "wazuh_modules/vulnerability_scanner/indexer/template/index-template.json",
     "-l",
@@ -11,7 +11,7 @@
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/agentHotfixesData.json",
     "-p",
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/agentPackagesData.json",
-    "-v",
+    "-b",
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/agentOsData.json",
     "-g",
     "wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/globalData.json",

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configDisabledAndManagerDisabled.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configDisabledAndManagerDisabled.json
@@ -1,0 +1,24 @@
+{
+    "vulnerability-detection": {
+        "enabled": "no",
+        "index-status": "yes",
+        "cti-url": "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0"
+    },
+    "indexer": {
+        "enabled": "yes",
+        "hosts": [
+            "https://0.0.0.0:9200"
+        ],
+        "username": "admin",
+        "password": "admin",
+        "ssl": {
+            "certificate_authorities": [
+                "/home/dwordcito/Development/wazuh/src/root-ca.pem"
+            ],
+            "certificate": "/home/dwordcito/Development/wazuh/src/node-1.pem",
+            "key": "/home/dwordcito/Development/wazuh/src/node-1-key.pem"
+        }
+    },
+    "managerNodeName": "wazuh-manager",
+    "managerDisabledScan": 1
+}

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configManagerDisabled.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/configManagerDisabled.json
@@ -1,0 +1,24 @@
+{
+    "vulnerability-detection": {
+        "enabled": "yes",
+        "index-status": "yes",
+        "cti-url": "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0"
+    },
+    "indexer": {
+        "enabled": "yes",
+        "hosts": [
+            "https://0.0.0.0:9200"
+        ],
+        "username": "admin",
+        "password": "admin",
+        "ssl": {
+            "certificate_authorities": [
+                "/home/dwordcito/Development/wazuh/src/root-ca.pem"
+            ],
+            "certificate": "/home/dwordcito/Development/wazuh/src/node-1.pem",
+            "key": "/home/dwordcito/Development/wazuh/src/node-1-key.pem"
+        }
+    },
+    "managerNodeName": "wazuh-manager",
+    "managerDisabledScan": 1
+}

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/expected_003.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/expected_003.out
@@ -3,6 +3,7 @@
     "Vulnerability scanner module is enabled. Re-scanning all agents.",
     "Event type: 9 processed",
     "Vulnerability scan for OS 'Ubuntu' on Agent '000' has completed.",
+    "Fetched 2 agents from Wazuh-DB.",
     "Translation for package 'gzip' in platform 'ubuntu' not found. Using provided packageName.",
     "Initiating a vulnerability scan for package 'gzip' (deb) (ubuntu developers <ubuntu-devel-discuss@lists.ubuntu.com>) with CVE Numbering Authorities (CNA) 'canonical' on Agent 'agent_ubuntu_22' (ID: '000', Version: 'v4.7.1').",
     "Scanning package - 'gzip' (Installed Version: 1.10-0ubuntu4.1, Security Vulnerability: CVE-2022-1271). Identified vulnerability: Version: 0. Required Version Threshold: 1.10-4ubuntu4. Required Version Threshold (or Equal): .",

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/expected_004.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/expected_004.out
@@ -1,0 +1,3 @@
+[
+    "Vulnerability scanner module is disabled"
+]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/expected_005.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data_policy/001/expected_005.out
@@ -1,0 +1,11 @@
+[
+    "Vulnerability scanner module started",
+    "Vulnerability scanner module is enabled. Re-scanning all agents.",
+    "Fetched 1 agents from Wazuh-DB.",
+    "Skipping manager agent with id 0.",
+    "Vulnerability scan for OS 'enterprise_linux' on Agent '001' has completed.",
+    "Translation for package 'lua-libs' in platform 'rhel' not found. Using provided packageName.",
+    "Initiating a vulnerability scan for package 'lua-libs' (rpm) (red hat, inc.) with CVE Numbering Authorities (CNA) 'redhat_8' on Agent 'agent_redhat_8' (ID: '001', Version: 'v4.7.1').",
+    "Vulnerability scan for package 'lua-libs' on Agent '001' has completed.",
+    "Event type: 7 processed"
+]

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
@@ -73,21 +73,32 @@ public:
             throw WdbDataException("Error executing query to fetch global agent data", "all");
         }
 
+        const auto isManagerScanDisabled = PolicyManager::instance().getManagerDisabledScan();
         for (const auto& agent : response)
         {
             try
             {
-                data->m_agents.push_back({Utils::padString(std::to_string(agent.at("id").get<int>()), '0', 3),
-                                          agent.at("name"),
-                                          Utils::leftTrim(agent.at("version"), "Wazuh "),
-                                          agent.at("ip"),
-                                          agent.at("node_name")});
+                // If the agent is the manager and the manager scan is disabled, skip it
+                if (!(isManagerScanDisabled == DisableManagerScanStatus::DISABLE_MANAGER_SCAN &&
+                      agent.at("id").get<int>() == 0))
+                {
+                    data->m_agents.push_back({Utils::padString(std::to_string(agent.at("id").get<int>()), '0', 3),
+                                              agent.at("name"),
+                                              Utils::leftTrim(agent.at("version"), "Wazuh "),
+                                              agent.at("ip"),
+                                              agent.at("node_name")});
+                }
+                else
+                {
+                    logDebug2(WM_VULNSCAN_LOGTAG, "Skipping manager agent with id 0.");
+                }
             }
             catch (const std::exception& e)
             {
                 logDebug2(WM_VULNSCAN_LOGTAG, "Error reading global agent data: %s", e.what());
             }
         }
+        logDebug2(WM_VULNSCAN_LOGTAG, "Fetched %d agents from Wazuh-DB.", data->m_agents.size());
         return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
@@ -304,7 +304,8 @@ public:
                                 if (std::find_if(responseHotfixes.begin(),
                                                  responseHotfixes.end(),
                                                  [&](const auto& element) {
-                                                     return element.at("hotfix") == remediation->str();
+                                                     return element.contains("hotfix") &&
+                                                            element.at("hotfix") == remediation->str();
                                                  }) != responseHotfixes.end())
                                 {
                                     logDebug2(WM_VULNSCAN_LOGTAG,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -244,7 +244,7 @@ public:
             // If there are multiple agents with incomplete scan, throw agentReScanListException
             else
             {
-                throw AgentReScanListException("Error executing rescan for mutiple agents.",
+                throw AgentReScanListException("Error executing rescan for multiple agents.",
                                                data->m_agentsWithIncompletedScan);
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildAllAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildAllAgentListContext_test.cpp
@@ -33,8 +33,8 @@ TEST_F(BuildAllAgentListContextTest, BuildAllAgentListContext)
 
     auto allAgentContext = std::make_shared<TBuildAllAgentListContext<TScanContext<TrampolineOsDataCache>>>();
 
-    // Context is not used
-    allAgentContext->handleRequest(nullptr);
+    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>();
+    allAgentContext->handleRequest(scanContext);
 }
 
 TEST_F(BuildAllAgentListContextTest, BuildAllAgentListContextWithElements)

--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -64,7 +64,7 @@ router_provider_send_fb_func router_provider_send_fb_func_ptr = NULL;
 ROUTER_PROVIDER_HANDLE rsync_handle = NULL;
 ROUTER_PROVIDER_HANDLE syscollector_handle = NULL;
 char *manager_node_name = NULL;
-int disable_manager_scan = 0;
+int disable_manager_scan = 1;
 #endif // CLIENT
 
 long syscollector_sync_max_eps = 10;    // Database synchronization number of events per second (default value)
@@ -185,7 +185,7 @@ void* wm_sys_main(wm_sys_t *sys) {
         }
 #ifndef CLIENT
         // Load router module only for manager if is enabled
-        disable_manager_scan = getDefine_Int("vulnerability-detection", "disable_scan_manager",0 ,1);
+        disable_manager_scan = getDefine_Int("vulnerability-detection", "disable_scan_manager", 0, 1);
         if (router_module_ptr = so_get_module_handle("router"), router_module_ptr) {
                 router_provider_create_func_ptr = so_get_function_sym(router_module_ptr, "router_provider_create");
                 router_provider_send_fb_func_ptr = so_get_function_sym(router_module_ptr, "router_provider_send_fb");


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23340 |

## Description

This PR aims to fix the full scan to exclude the manager if the "scan manager" setting is disabled.

It checks the current value of the policy setting to decide if we need to scan or not the agent 000.