### PR TITLE
Change log level when tag not defined in Azure configuration

### DIFF
--- a/src/config/wmodules-azure.c
+++ b/src/config/wmodules-azure.c
@@ -353,7 +353,7 @@ int wm_azure_request_read(XML_NODE nodes, wm_azure_request_t * request, unsigned
 
     /* Validation process */
     if (!request->tag) {
-        minfo("At module '%s': No request tag defined. Setting it randomly...", WM_AZURE_CONTEXT.name);
+        mdebug2("At module '%s': No request tag defined. Setting it randomly...", WM_AZURE_CONTEXT.name);
         int random_id = os_random();
         char * rtag;
 
@@ -475,7 +475,7 @@ int wm_azure_storage_read(const OS_XML *xml, XML_NODE nodes, wm_azure_storage_t 
     }
 
     if (!storage->tag) {
-        minfo("At module '%s': No storage tag defined. Setting it randomly...", WM_AZURE_CONTEXT.name);
+        mdebug2("At module '%s': No storage tag defined. Setting it randomly...", WM_AZURE_CONTEXT.name);
         int random_id = os_random();
         char * rtag;
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #23329 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Modifies the used function to log in `ossec.log` when the tag field is not defined in the Azure module configuration section to avoid spam in the log file.

## Logs example

<details><summary>ossec.log without debug level 2</summary>

```log
2024/05/08 12:06:43 wazuh-modulesd:azure-logs: INFO: Module started.
2024/05/08 12:06:43 wazuh-modulesd:azure-logs: INFO: Starting fetching of logs.
2024/05/08 12:06:43 wazuh-modulesd:azure-logs: INFO: Starting Log Analytics collection for the domain 'TENANT'.
2024/05/08 12:06:48 wazuh-modulesd:azure-logs: INFO: Finished Log Analytics collection for request 'request_1169087121'.
2024/05/08 12:06:48 wazuh-modulesd:azure-logs: INFO: Finished Log Analytics collection for the domain 'TENANT'.
2024/05/08 12:06:48 wazuh-modulesd:azure-logs: INFO: Starting Storage log collection for 'storage_1431669653'.
```

</details>

After setting `wazuh_modules.debug=2` in the `/var/ossec/etc/local_internal_options.conf ` file:

<details><summary>ossec.log with debug level 2</summary>

```log
2024/05/08 12:08:31 wazuh-modulesd[5466] wmodules-azure.c:356 at wm_azure_request_read(): DEBUG: At module 'azure-logs': No request tag defined. Setting it randomly...
2024/05/08 12:08:31 wazuh-modulesd[5466] wmodules-azure.c:478 at wm_azure_storage_read(): DEBUG: At module 'azure-logs': No storage tag defined. Setting it randomly...
2024/05/08 12:08:31 wazuh-modulesd[5466] main.c:95 at main(): DEBUG: Created new thread for the 'azure-logs' module.
2024/05/08 12:08:31 wazuh-modulesd:azure-logs[5466] wm_azure.c:54 at wm_azure_main(): INFO: Module started.
2024/05/08 12:08:31 wazuh-modulesd:azure-logs[5466] wm_azure.c:74 at wm_azure_main(): INFO: Starting fetching of logs.
2024/05/08 12:08:31 wazuh-modulesd:azure-logs[5466] wm_azure.c:81 at wm_azure_main(): INFO: Starting Log Analytics collection for the domain 'TENANT'.
2024/05/08 12:08:31 wazuh-modulesd:azure-logs[5466] wm_azure.c:120 at wm_azure_log_analytics(): DEBUG: Creating argument list.
2024/05/08 12:08:31 wazuh-modulesd:azure-logs[5466] wm_azure.c:167 at wm_azure_log_analytics(): DEBUG: Launching command: wodles/azure/azure-logs --log_analytics --la_auth_path /var/ossec/wodles/azure/credentials-analytics --la_tenant_domain TENANT --la_tag request_1069165979 --la_query "AzureActivity" --workspace 7d18bf81-3fc9-4b41-ae28-680f8a3494fe --la_time_offset 50d --debug 2
2024/05/08 12:08:33 wazuh-modulesd:azure-logs[5466] wm_azure.c:184 at wm_azure_log_analytics(): INFO: Finished Log Analytics collection for request 'request_1069165979'.
2024/05/08 12:08:33 wazuh-modulesd:azure-logs[5466] wm_azure.c:83 at wm_azure_main(): INFO: Finished Log Analytics collection for the domain 'TENANT'.
2024/05/08 12:08:33 wazuh-modulesd:azure-logs[5466] wm_azure.c:92 at wm_azure_main(): INFO: Starting Storage log collection for 'storage_980559964'.
2024/05/08 12:08:33 wazuh-modulesd:azure-logs[5466] wm_azure.c:287 at wm_azure_storage(): DEBUG: Creating argument list.
2024/05/08 12:08:33 wazuh-modulesd:azure-logs[5466] wm_azure.c:349 at wm_azure_storage(): DEBUG: Launching command: wodles/azure/azure-logs --storage --storage_auth_path /var/ossec/wodles/azure/credentials-storage --container "container" --blobs "*" --storage_tag storage_980559964 --json_inline --storage_time_offset 260d --debug 2
2024/05/08 12:08:35 wazuh-modulesd:azure-logs[5466] wm_azure.c:366 at wm_azure_storage(): INFO: Finished Storage log collection for container 'container'.
2024/05/08 12:08:35 wazuh-modulesd:azure-logs[5466] wm_azure.c:94 at wm_azure_main(): INFO: Finished Storage log collection for 'storage_980559964'.
2024/05/08 12:08:35 wazuh-modulesd:azure-logs[5466] wm_azure.c:100 at wm_azure_main(): DEBUG: Fetching logs finished.
2024/05/08 12:08:35 wazuh-modulesd:azure-logs[5466] wm_azure.c:70 at wm_azure_main(): DEBUG: Sleeping until: 2024/05/08 12:18:31
```

</details>


