### PR TITLE
Add error message to exceptions thrown when updating the configuration

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -1263,8 +1263,8 @@ def write_ossec_conf(new_conf: str):
     try:
         with open(common.OSSEC_CONF, 'w') as f:
             f.writelines(new_conf)
-    except Exception:
-        raise WazuhError(1126)
+    except Exception as e:
+        raise WazuhError(1126, extra_message=str(e))
 
 
 def update_check_is_enabled() -> bool:


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23330 |

## Description

Adds the message from the exception to the error thrown by the API when trying to update the manager configuration file.