### PR TITLE
Change the way to iterate over `osCpeMap`

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -173,11 +173,12 @@ private:
         m_osData.cpeName = "cpe:/o:";
 
         std::string cpe;
-        for (auto& [key, value] : osCpeMaps.items())
+        for (auto it = osCpeMaps.rbegin(); it != osCpeMaps.rend(); ++it)
         {
-            if (Utils::startsWith(m_osData.name, key) || m_osData.platform.compare(key) == 0)
+            if (m_osData.name.compare(it.key()) == 0 || Utils::startsWith(m_osData.name, it.key()) ||
+                m_osData.platform.compare(it.key()) == 0)
             {
-                cpe = value;
+                cpe = it.value();
                 break;
             }
         }


### PR DESCRIPTION
|Related issue|
|---|
|#23336|

## Objective
This PR addresses an issue identified in the Vulnerability Detection system where incorrect operating system (OS) scanning mappings led to inaccurate vulnerability assessments. By utilizing a reverse iterator over `cpeMap` and adjusting the match of keys, this update aims to enhance the accuracy of OS mapping and, consequently, the reliability of vulnerability detection.

## Description
- During the vulnerability detection process, it was discovered that the mapping of operating systems was not accurately reflecting the actual OS versions due to a suboptimal order of operations in iterating through `cpeMap`. This misalignment caused some systems to be incorrectly assessed, potentially overlooking critical vulnerabilities.
- To resolve this issue, we have modified the approach to use a reverse iterator when traversing the `cpeMap`. This ensures that the most specific and relevant OS entries are considered first, greatly improving the accuracy of OS identification and mapping.
- Additionally, we refined the logic for matching keys within the map to enhance precision in identifying the correct OS entry for a given system. These adjustments not only correct the current issue but also make the vulnerability detection more robust against similar problems in the future.

## Quality Assurance

### Static Analysis
- The revised mapping logic underwent a comprehensive static analysis to ensure it adheres to best practices and avoids introducing new issues. The analysis confirmed the robustness of the new implementation and its compliance with our coding standards.

### Testing

#### Unit Testing
N/A

#### Integration Testing
Use the scanner testtool and insert a OS information with for example `Windows 8.1`. Prior this PR the scan was performed with `windows_8` CPE. Now is with `windows_8.1`

-------------------------------