### PR TITLE
Set file permissions

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -437,3 +437,26 @@ Private Function GetUserSID()
         GetUserSID = oWMI.SID
     End If
 End Function
+
+Public Function SetPermissions()
+    On Error Resume Next
+
+    ' Custom Action parameters
+    strArgs = Session.Property("CustomActionData")
+    args = Split(strArgs, "/+/")
+
+    home_dir= Replace(args(0), Chr(34), "")
+
+    ' Remove last backslash from home_dir
+    install_dir = Left(home_dir, Len(home_dir) - 1)
+
+    Set WshShell = CreateObject("WScript.Shell")
+
+    setPermsInherit = "icacls """ & install_dir & """ /inheritancelevel:e /q"
+    nRet = WshShell.run(setPermsInherit, 0, True)
+
+    grantUserPerm = "icacls """ & install_dir & """ /grant *S-1-1-0:(RX) /t /c"
+    nRet = WshShell.run(grantUserPerm, 0, True)
+
+    SetPermissions = 0 
+End Function

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -193,8 +193,6 @@
             <Custom Action="SetPermissions" After="SetCustomActionDataValue2"></Custom>
         </InstallExecuteSequence>
 
-
-
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder" Name="PFiles">
                 <Directory Id="APPLICATIONFOLDER" Name="ossec-agent">

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -117,6 +117,9 @@
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no"/>
         <CustomAction Id="SetWazuhPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetWazuhPermissions" Return="check" Execute="commit" Impersonate="no"/>
 
+        <CustomAction Id="SetCustomActionDataValue2" Return="check" Property="SetPermissions" Value="&quot;[APPLICATIONFOLDER]&quot;" />
+        <CustomAction Id="SetPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetPermissions" Return="check" Execute="deferred" Impersonate="no"/>
+
         <!-- Explicitely stopping and deleting the OSSEC service to install new Wazuh service -->
         <CustomAction Id="StopOssecService" Directory="APPLICATIONFOLDER" ExeCommand="NET STOP OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
         <CustomAction Id="DeleteOssecService" Directory="APPLICATIONFOLDER" ExeCommand="SC DELETE OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
@@ -185,7 +188,12 @@
             <!-- Stop the service as soon as possible on uninstall, and only on uninstall, in order to unlock the files and folders that must be deleted. -->
 			<Custom Action="SetRemoveAllDataValue" Before="InstallFinalize">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
  		    <Custom Action="CustomAction_RemoveAllScript" After="SetRemoveAllDataValue">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
+ 
+            <Custom Action="SetCustomActionDataValue2" Before="InstallFinalize"/>
+            <Custom Action="SetPermissions" After="SetCustomActionDataValue2"></Custom>
         </InstallExecuteSequence>
+
+
 
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder" Name="PFiles">

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -190,7 +190,7 @@
  		    <Custom Action="CustomAction_RemoveAllScript" After="SetRemoveAllDataValue">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
  
             <Custom Action="SetPermissionsCustomActionDataValue" Before="InstallFinalize"/>
-            <Custom Action="SetPermissions" After="SetPermissionsCustomActionDataValue"></Custom>
+            <Custom Action="SetPermissions" After="SetPermissionsCustomActionDataValue"/>
         </InstallExecuteSequence>
 
         <Directory Id="TARGETDIR" Name="SourceDir">

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -117,7 +117,7 @@
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no"/>
         <CustomAction Id="SetWazuhPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetWazuhPermissions" Return="check" Execute="commit" Impersonate="no"/>
 
-        <CustomAction Id="SetCustomActionDataValue2" Return="check" Property="SetPermissions" Value="&quot;[APPLICATIONFOLDER]&quot;" />
+        <CustomAction Id="SetPermissionsCustomActionDataValue" Return="check" Property="SetPermissions" Value="&quot;[APPLICATIONFOLDER]&quot;" />
         <CustomAction Id="SetPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetPermissions" Return="check" Execute="deferred" Impersonate="no"/>
 
         <!-- Explicitely stopping and deleting the OSSEC service to install new Wazuh service -->
@@ -189,8 +189,8 @@
 			<Custom Action="SetRemoveAllDataValue" Before="InstallFinalize">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
  		    <Custom Action="CustomAction_RemoveAllScript" After="SetRemoveAllDataValue">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
  
-            <Custom Action="SetCustomActionDataValue2" Before="InstallFinalize"/>
-            <Custom Action="SetPermissions" After="SetCustomActionDataValue2"></Custom>
+            <Custom Action="SetPermissionsCustomActionDataValue" Before="InstallFinalize"/>
+            <Custom Action="SetPermissions" After="SetPermissionsCustomActionDataValue"></Custom>
         </InstallExecuteSequence>
 
         <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
|Related issue|
|---|
|#20727|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Modified InstallerScripts.vbs and wazuh-installer.wxs. 

Added a custom function that sets file permissions.
Added function SetPermissions() to InstallerScripts.vbs. This function enables inheritance for the installation folder and sets Read and Execute permission for the folder and all its files and subfolders.

### Evidence:

Installation of v4.7.4-1 and subsequent upgrade to 4.9.1:
[Screencast from 2024-05-09 18-55-52.webm](https://github.com/wazuh/wazuh/assets/100874572/3170d4d3-2ef5-4122-97cf-3785ba1c7955)
 
Upgrade to 4.9.2 following previous test:
[Screencast from 2024-05-09 22-18-23.webm](https://github.com/wazuh/wazuh/assets/100874572/2b391b16-b52f-4ff8-99f3-8e836f59cf53)

Uninstall of previously installed version. Clean 4.9.1 installation. Upgrade to 4.9.2:
[Screencast from 2024-05-09 22-23-21.webm](https://github.com/wazuh/wazuh/assets/100874572/267e7361-ad80-43ab-8747-277e903a1600)


<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [x] Package installation
- [ ] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors