### PR TITLE
Fix OS vulnerability events categorization

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -188,17 +188,27 @@ public:
                 ecsData["agent"] = agent;
 
                 // ECS package fields.
-                if (data->affectedComponentType() == AffectedComponentType::Package ||
-                    data->affectedComponentType() == AffectedComponentType::Os)
+                switch (data->affectedComponentType())
                 {
-                    ecsData["package"] = package;
+                    case AffectedComponentType::Package:
+                        ecsData["package"] = package;
+                        ecsData["vulnerability"]["category"] = "Packages";
+                        break;
+
+                    case AffectedComponentType::Os:
+                        ecsData["package"] = package;
+                        ecsData["vulnerability"]["category"] = "OS";
+                        break;
+
+                    default:
+                        // No fields required.
+                        break;
                 }
 
                 // ECS os fields.
                 ecsData["host"]["os"] = os;
 
                 // ECS vulnerability fields.
-                ecsData["vulnerability"]["category"] = "Packages";
                 ecsData["vulnerability"]["classification"] = returnData.data->classification()->str();
                 ecsData["vulnerability"]["description"] = returnData.data->description()->str();
                 ecsData["vulnerability"]["detected_at"] = Utils::getCurrentISO8601();

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -743,7 +743,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
     EXPECT_STREQ(elementData.at("host").at("os").at("version").get_ref<const std::string&>().c_str(),
                  elementOsVersion.c_str());
 
-    EXPECT_STREQ(elementData.at("vulnerability").at("category").get_ref<const std::string&>().c_str(), "Packages");
+    EXPECT_STREQ(elementData.at("vulnerability").at("category").get_ref<const std::string&>().c_str(), "OS");
     EXPECT_STREQ(elementData.at("vulnerability").at("classification").get_ref<const std::string&>().c_str(),
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->classification()->c_str());
     EXPECT_STREQ(elementData.at("vulnerability").at("description").get_ref<const std::string&>().c_str(),


### PR DESCRIPTION
|Related issue|
|---|
| #23368  |

## Description
This PR fixes the categorization of OS vulnerability events, they were categorized as "Packages". The category was changed to "OS"

