### PR TITLE
Fix unstable AIT test

### DIFF
--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1580,6 +1580,313 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /cluster/{node_id}/logs
+
+marks:
+  - cluster
+  - parametrize:
+      key: node_id
+      vals:
+        - master-node
+        - worker1
+        - worker2
+
+stages:
+
+  - name: Read logs {node_id}
+    request: &get_cluster_logs
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> limit=3 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 3
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - &cluster_log
+              description: !anystr
+              level: !anystr
+              tag: !anystr
+              timestamp: !anystr
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> limit=4 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 4
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+            - <<: *cluster_log
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> limit=2, sort=tag {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 2
+        sort: tag
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "tag"
+      status_code: 200
+
+  - name: Read logs with filters -> limit=1, sort=-level {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 1
+        sort: -level
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "level"
+            reverse: true
+      status_code: 200
+
+  - name: Read logs with filters -> offset=2, limit=3 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 3
+        offset: 2
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> offset=5, limit=2 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        limit: 2
+        offset: 5
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> tag=wazuh-analysisd, limit=1 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        tag: wazuh-analysisd
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> tag=wazuh-syscheckd, limit=2 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        tag: wazuh-syscheckd
+        limit: 2
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+              tag: wazuh-syscheckd
+            - <<: *cluster_log
+              tag: wazuh-syscheckd
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters -> tag=wazuh-unknown-daemon {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        tag: wazuh-unknown-daemon
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Read logs with filters -> level=info, limit=1 {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        level: info
+        limit: 1
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - <<: *cluster_log
+              level: info
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+  - name: Read logs with filters by query (tag=wazuh-syscheckd, level=info) {node_id}
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        q: tag=wazuh-syscheckd;level=info
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "tag"
+            expected_values: "wazuh-syscheckd"
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "level"
+            expected_values: "info"
+
+  - name: Read logs using valid select
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        select: 'timestamp,tag'
+    response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'timestamp,tag'
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Try to read logs using invalid select
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        select: 'noexists'
+    response:
+      status_code: 400
+      json: &invalid_select
+        error: 1724
+
+  - name: Get distinct cluster node logs
+    request:
+      verify: False
+      <<: *get_cluster_logs
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
+---
+test_name: GET /cluster/{node_id}/logs/summary
+
+marks:
+  - cluster
+  - parametrize:
+      key: node_id
+      vals:
+        - worker1
+        - worker2
+
+stages:
+
+  - name: Read logs summary {node_id}
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+        message: !anystr
+
+---
 test_name: GET /cluster/{node_id}/daemons/stats
 
 marks:
@@ -1970,313 +2277,6 @@ stages:
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0
-
----
-test_name: GET /cluster/{node_id}/logs
-
-marks:
-  - cluster
-  - parametrize:
-      key: node_id
-      vals:
-        - master-node
-        - worker1
-        - worker2
-
-stages:
-
-  - name: Read logs {node_id}
-    request: &get_cluster_logs
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> limit=3 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 3
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - &cluster_log
-              description: !anystr
-              level: !anystr
-              tag: !anystr
-              timestamp: !anystr
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> limit=4 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 4
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-            - <<: *cluster_log
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> limit=2, sort=tag {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 2
-        sort: tag
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "tag"
-      status_code: 200
-
-  - name: Read logs with filters -> limit=1, sort=-level {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 1
-        sort: -level
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "level"
-            reverse: true
-      status_code: 200
-
-  - name: Read logs with filters -> offset=2, limit=3 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 3
-        offset: 2
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> offset=5, limit=2 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        limit: 2
-        offset: 5
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> tag=wazuh-analysisd, limit=1 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        tag: wazuh-analysisd
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> tag=wazuh-modulesd, limit=2 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        tag: wazuh-modulesd
-        limit: 2
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-              tag: wazuh-modulesd
-            - <<: *cluster_log
-              tag: wazuh-modulesd
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters -> tag=wazuh-unknown-daemon {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        tag: wazuh-unknown-daemon
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: []
-          failed_items: []
-          total_affected_items: 0
-          total_failed_items: 0
-
-  - name: Read logs with filters -> level=info, limit=1 {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        level: info
-        limit: 1
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - <<: *cluster_log
-              level: info
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-
-  - name: Read logs with filters by query (tag=sca, level=info) {node_id}
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        q: tag=sca;level=info
-    response:
-      status_code: 200
-      verify_response_with:
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "tag"
-            expected_values: "sca"
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "level"
-            expected_values: "info"
-
-  - name: Read logs using valid select
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        select: 'timestamp,tag'
-    response:
-      verify_response_with:
-        # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items
-        extra_kwargs:
-          select_key: 'timestamp,tag'
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Try to read logs using invalid select
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        select: 'noexists'
-    response:
-      status_code: 400
-      json: &invalid_select
-        error: 1724
-
-  - name: Get distinct cluster node logs
-    request:
-      verify: False
-      <<: *get_cluster_logs
-      params:
-        distinct: true
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tavern_utils:test_distinct_key
-
----
-test_name: GET /cluster/{node_id}/logs/summary
-
-marks:
-  - cluster
-  - parametrize:
-      key: node_id
-      vals:
-        - worker1
-        - worker2
-
-stages:
-
-  - name: Read logs summary {node_id}
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/cluster/{node_id}/logs/summary"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
-          total_failed_items: 0
-        message: !anystr
 
 ---
 test_name: PUT /cluster/restart

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -582,6 +582,326 @@ stages:
             total_failed_items: 0
 
 ---
+test_name: GET /manager/logs
+
+stages:
+
+  # GET /manager/logs
+  - name: Request
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items: !anything
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> limit=4
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 4
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - &manager_log
+                description: !anystr
+                level: !anystr
+                tag: !anystr
+                timestamp: !anystr
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> limit=2, sort=-level
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 2
+        sort: -level
+    response:
+      verify_response_with:
+        - function: tavern_utils:test_sort_response
+          extra_kwargs:
+            key: "level"
+            reverse: true
+      status_code: 200
+
+  # GET /manager/logs
+  - name: Filters -> offset=3, limit=3
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 3
+        offset: 3
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> offset=3, level=info, limit=4
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        limit: 4
+        offset: 3
+        level: info
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> tag=wazuh-analysisd, limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        tag: wazuh-analysisd
+        limit: 1
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  # GET /manager/logs
+  - name: Filters -> tag=wazuh-syscheckd, limit=1
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        tag: wazuh-syscheckd
+        limit: 1
+    response:
+        status_code: 200
+        json:
+          error: 0
+          data:
+            affected_items:
+              - <<: *manager_log
+            failed_items: []
+            total_affected_items: !anyint
+            total_failed_items: 0
+
+  - name: Filters by query (tag=wazuh-syscheckd, level=info)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        q: tag=wazuh-syscheckd;level=info
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "tag"
+            expected_values: "wazuh-syscheckd"
+        - function: tavern_utils:test_expected_value
+          extra_kwargs:
+            key: "level"
+            expected_values: "info"
+
+  - name: Filters by query (timestamp<2021-07-01)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        q: timestamp<2021-07-01
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Filter by non-existent tag
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        tag: wazuh-unknown-daemon
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items: []
+          failed_items: []
+          total_affected_items: 0
+          total_failed_items: 0
+
+  - name: Read logs using valid select
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: 'timestamp,tag'
+    response:
+      verify_response_with:
+        # Check response item keys are the selected keys
+        function: tavern_utils:test_select_key_affected_items
+        extra_kwargs:
+          select_key: 'timestamp,tag'
+      status_code: 200
+      json:
+        error: 0
+        data:
+          total_affected_items: !anyint
+          failed_items: []
+          total_failed_items: 0
+
+  - name: Try to read logs using invalid select
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        select: 'noexists'
+    response:
+      status_code: 400
+      json: &invalid_select
+        error: 1724
+
+  - name: Get distinct manager logs
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      params:
+        distinct: true
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_distinct_key
+
+---
+test_name: GET /manager/logs/summary
+
+stages:
+
+  # GET /manager/logs/summary
+  - name: Request
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          affected_items:
+            - sca: !anything
+            - wazuh-agentlessd: !anything
+            - wazuh-analysisd: !anything
+            - wazuh-authd: !anything
+            - wazuh-csyslogd: !anything
+            - wazuh-db: !anything
+            - wazuh-dbd: !anything
+            - wazuh-execd: !anything
+            - wazuh-integratord: !anything
+            - wazuh-logcollector: !anything
+            - wazuh-modulesd: !anything
+            - wazuh-modulesd:agent-upgrade: !anything
+            - wazuh-modulesd:ciscat: !anything
+            - wazuh-modulesd:control: !anything
+            - wazuh-modulesd:database: !anything
+            - wazuh-modulesd:download: !anything
+            - wazuh-modulesd:osquery: !anything
+            - wazuh-modulesd:syscollector: !anything
+            - wazuh-modulesd:task-manager: !anything
+            - wazuh-monitord: !anything
+            - wazuh-remoted: !anything
+            - wazuh-rootcheck: !anything
+            - wazuh-syscheckd: !anything
+          failed_items: []
+          total_affected_items: !anyint
+          total_failed_items: 0
+
+---
 test_name: GET /manager/api/config
 
 stages:
@@ -1241,565 +1561,6 @@ stages:
                 log_alert_level: '300'
           failed_items: []
           total_affected_items: 1
-          total_failed_items: 0
-
----
-test_name: GET /manager/version/check
-
-stages:
-  - name: Get wazuh version
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      save:
-        json:
-          wazuh_version: data.api_version
-
-  - name: Get available updates
-    request:
-      verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: !anystr
-          current_version: "v{wazuh_version:s}"
-          update_check: true
-          uuid: !anystr
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
-
-  - name: Get available updates with force option
-    request:
-      verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        force_query: "true"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: !anystr
-          current_version: "v{wazuh_version:s}"
-          update_check: true
-          uuid: !anystr
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
-
-
----
-test_name: GET /manager/version/check with update_check disabled
-
-stages:
-
-  - name: Get wazuh version
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      save:
-        json:
-          wazuh_version: data.api_version
-
-  - name: Disable the update check
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
-      method: PUT
-      data: "{valid_ossec_conf_with_update_check_disabled:s}"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-        content-type: application/octet-stream
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - 'manager'
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-        error: 0
-
-  - name: Restart manager to apply the configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - !anystr
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-    delay_after: 50
-
-  - name: Get available updates
-    request:
-      verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: ''
-          current_version: "v{wazuh_version:s}"
-          update_check: false
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
-
-  - name: Get available updates with force option
-    request:
-      verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        force_query: "true"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          last_check_date: ''
-          current_version: "v{wazuh_version:s}"
-          update_check: false
-      verify_response_with:
-        - function: tavern_utils:validate_update_check_response
-
-  - name: Enable the update check
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
-      method: PUT
-      data: "{valid_ossec_conf:s}"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-        content-type: application/octet-stream
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - 'manager'
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-        error: 0
-
-  - name: Restart manager to apply the configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - !anystr
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-    delay_after: 50
-
----
-test_name: GET /manager/version/check with update check service error
-
-stages:
-
-  - name: Set an invalid CTI url
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/configuration"
-      method: PUT
-      data: "{ossec_conf_with_invalid_cti_url:s}"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-        content-type: application/octet-stream
-    response:
-      status_code: 200
-      json:
-        data:
-          affected_items:
-            - 'manager'
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-        error: 0
-
-  - name: Restart manager to apply the configuration
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/restart"
-      method: PUT
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items:
-            - !anystr
-          failed_items: []
-          total_affected_items: 1
-          total_failed_items: 0
-    delay_after: 50
-
-  - name: Try to get available updates
-    request:
-      verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 500
-      json:
-        error: 2100
-
-  - name: Try to get available updates with force option
-    request:
-      verify: false
-      url: "{protocol:s}://{host:s}:{port:d}/manager/version/check"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        force_query: "true"
-    response:
-      status_code: 500
-      json:
-        error: 2100
-
----
-test_name: GET /manager/logs
-
-stages:
-
-  # GET /manager/logs
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items: !anything
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> limit=4
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 4
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - &manager_log
-                description: !anystr
-                level: !anystr
-                tag: !anystr
-                timestamp: !anystr
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> limit=2, sort=-level
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 2
-        sort: -level
-    response:
-      verify_response_with:
-        - function: tavern_utils:test_sort_response
-          extra_kwargs:
-            key: "level"
-            reverse: true
-      status_code: 200
-
-  # GET /manager/logs
-  - name: Filters -> offset=3, limit=3
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 3
-        offset: 3
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> offset=3, level=debug, limit=4
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        limit: 4
-        offset: 3
-        level: debug
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> tag=wazuh-modulesd, limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        tag: wazuh-modulesd
-        limit: 1
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  # GET /manager/logs
-  - name: Filters -> tag=wazuh-analysisd, limit=1
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        tag: wazuh-analysisd
-        limit: 1
-    response:
-        status_code: 200
-        json:
-          error: 0
-          data:
-            affected_items:
-              - <<: *manager_log
-            failed_items: []
-            total_affected_items: !anyint
-            total_failed_items: 0
-
-  - name: Filters by query (tag=wazuh-modulesd, level=debug)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: tag=wazuh-modulesd;level=debug
-    response:
-      status_code: 200
-      verify_response_with:
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "tag"
-            expected_values: "wazuh-modulesd"
-        - function: tavern_utils:test_expected_value
-          extra_kwargs:
-            key: "level"
-            expected_values: "debug"
-
-  - name: Filters by query (timestamp<2021-07-01)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        q: timestamp<2021-07-01
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: []
-          failed_items: []
-          total_affected_items: 0
-          total_failed_items: 0
-
-  - name: Filter by non-existent tag
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        tag: wazuh-unknown-daemon
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: []
-          failed_items: []
-          total_affected_items: 0
-          total_failed_items: 0
-
-  - name: Read logs using valid select
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        select: 'timestamp,tag'
-    response:
-      verify_response_with:
-        # Check response item keys are the selected keys
-        function: tavern_utils:test_select_key_affected_items
-        extra_kwargs:
-          select_key: 'timestamp,tag'
-      status_code: 200
-      json:
-        error: 0
-        data:
-          total_affected_items: !anyint
-          failed_items: []
-          total_failed_items: 0
-
-  - name: Try to read logs using invalid select
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        select: 'noexists'
-    response:
-      status_code: 400
-      json: &invalid_select
-        error: 1724
-
-  - name: Get distinct manager logs
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      params:
-        distinct: true
-    response:
-      status_code: 200
-      verify_response_with:
-        function: tavern_utils:test_distinct_key
-
----
-test_name: GET /manager/logs/summary
-
-stages:
-
-  # GET /manager/logs/summary
-  - name: Request
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{port:d}/manager/logs/summary"
-      method: GET
-      headers:
-        Authorization: "Bearer {test_login_token}"
-    response:
-      status_code: 200
-      json:
-        error: 0
-        data:
-          affected_items: !anything
-          failed_items: []
-          total_affected_items: !anyint
           total_failed_items: 0
 
 ---


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23195 |

## Description

Reverts the test cases order change applied when `wazuh-modulesd` debugging mode was enabled.

## Tests

<details><summary>test_cluster_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv --disable-warnings test_cluster_endpoints.tavern.yaml
============================================================================ test session starts ============================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'trio': '0.7.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.7.0, asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, aiohttp-1.0.4
asyncio: mode=auto
collected 49 items                                                                                                                                                          

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                                                                  [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                                                                   [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                                                                       [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                                                                    [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                                                                         [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                                                            [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                                                                [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                                                                [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                                                              [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                                                            [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                                                            [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                                                                         [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                                                                        [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                                                                       [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                                                                      [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                                                                    [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                                                           [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                                                                   [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                                                                       [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                                                                       [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] PASSED                                                                                   [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] PASSED                                                                                       [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] PASSED                                                                                       [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                                                               [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                                                               [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                                                                          [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                                                              [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                                                              [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                                                                  [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                                                                      [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                                                                      [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                                                              [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                                                                        [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                                                            [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                                                            [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                                                           [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                                                               [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                                                               [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                                                                          [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                                                              [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                                                              [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                                                           [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                                                               [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                                                               [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                                                                 [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                                                                     [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                                                                     [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                                                                       [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                                                                       [100%]

=============================================================== 49 passed, 50 warnings in 1959.56s (0:32:39) ================================================================
```

</details>

<details><summary>test_manager_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv --disable-warnings test_manager_endpoints.tavern.yaml --nobuild
============================================================================ test session starts ============================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'trio': '0.7.0', 'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: trio-0.7.0, asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, aiohttp-1.0.4
asyncio: mode=auto
collected 33 items                                                                                                                                                          

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                        [  3%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                          [  6%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                               [  9%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                 [ 12%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                              [ 15%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                              [ 18%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                              [ 21%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                               [ 24%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                            [ 27%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                              [ 30%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                               [ 33%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                            [ 36%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                              [ 39%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                  [ 42%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                             [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                         [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detection] PASSED                                                              [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[indexer] PASSED                                                                              [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                 [ 57%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                                 [ 60%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                         [ 63%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                  [ 66%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                  [ 69%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                               [ 72%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                 [ 75%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                          [ 78%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                  [ 81%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                    [ 84%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                 [ 87%]
test_manager_endpoints.tavern.yaml::GET /manager/validation (KO) PASSED                                                                                               [ 90%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                     [ 93%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                                 [ 96%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                       [100%]

================================================================ 33 passed, 34 warnings in 77.64s (0:01:17) =================================================================
```

</details>

