### PR TITLE
Fixes helper builder in wrong stages

### DIFF
--- a/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
+++ b/src/engine/ruleset/integrations/suricata/decoders/suricata.yml
@@ -15,11 +15,12 @@ metadata:
   description: Decoder for Suricata open source network analysis and threat detection software.
 
 check:
-  - suricata: parse_json($event.original)
-  - suricata.event_type: exists()
+  - tmp.json.event_type: exists()
 
 normalize:
   - map:
+      - suricata: rename($tmp.json)
+      - tmp: delete()
       - destination.address: $suricata.dest_ip
       - destination.bytes: $suricata.flow.bytes_toclient
       - destination.domain: $suricata.http.hostname

--- a/src/engine/ruleset/wazuh-core/decoders/integrations.yml
+++ b/src/engine/ruleset/wazuh-core/decoders/integrations.yml
@@ -12,3 +12,4 @@ parents:
 normalize:
   - map:
       - wazuh.isInternal: delete()
+      - tmp.json: parse_json($event.original)

--- a/src/engine/source/builder/src/builders/baseHelper.hpp
+++ b/src/engine/source/builder/src/builders/baseHelper.hpp
@@ -20,16 +20,17 @@ TransformBuilder toTransform(const OpBuilder& builder, const Reference& targetFi
 
 base::Expression toExpression(const TransformOp& op, const std::string& name);
 
-base::Expression baseHelperBuilder(const std::string& helperName,
-                                   const Reference& targetField,
-                                   std::vector<OpArg>& opArgs,
-                                   const std::shared_ptr<const IBuildCtx>& buildCtx);
-
 enum class HelperType
 {
     MAP,
     FILTER
 };
+
+base::Expression baseHelperBuilder(const std::string& helperName,
+                                   const Reference& targetField,
+                                   std::vector<OpArg>& opArgs,
+                                   const std::shared_ptr<const IBuildCtx>& buildCtx,
+                                   HelperType helperType);
 
 base::Expression baseHelperBuilder(const json::Json& definition,
                                    const std::shared_ptr<const IBuildCtx>& buildCtx,

--- a/src/engine/source/builder/src/builders/stage/check.cpp
+++ b/src/engine/source/builder/src/builders/stage/check.cpp
@@ -46,7 +46,7 @@ getTermBuilder(const std::shared_ptr<const IBuildCtx>& buildCtx)
     {
         std::function<bool(base::Event)> buildedFn;
 
-        auto op = baseHelperBuilder(token.name, token.targetField, token.args, buildCtx);
+        auto op = baseHelperBuilder(token.name, token.targetField, token.args, buildCtx, builders::HelperType::FILTER);
 
         if (op->isAnd())
         {

--- a/src/engine/source/builder/test/src/component/definitions.hpp
+++ b/src/engine/source/builder/test/src/component/definitions.hpp
@@ -78,6 +78,28 @@ auto constexpr DECODER_STAGE_NOT_FOUND_JSON = R"({
     ]
 })";
 
+auto constexpr DECODER_MAP_ON_CHECK_JSON = R"z({
+    "name": "decoder/test/0",
+    "check": [
+        {
+            "field": "map(1)"
+        }
+    ]
+})z";
+
+auto constexpr DECODER_FILTER_ON_MAP_JSON = R"z({
+    "name": "decoder/test/0",
+    "normalize": [
+        {
+            "map": [
+                {
+                    "field": "filter(1)"
+                }
+            ]
+        }
+    ]
+})z";
+
 auto constexpr DECODER_PARENT_WITHOUT_CHECK_JSON = R"({
     "name": "decoder/parent-test/0",
     "parents": ["decoder/Input"]

--- a/src/engine/source/builder/test/src/unit/builders/stage/check_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/stage/check_test.cpp
@@ -21,7 +21,7 @@ OpBuilderEntry getDummyFilterThrow()
 OpBuilderEntry getDummyFilter(bool result)
 {
     ValidationInfo info {schemf::ValidationToken {}};
-    OpBuilder builder = [result](const Reference& ref,
+    FilterBuilder builder = [result](const Reference& ref,
                                  const std::vector<OpArg>& args,
                                  const std::shared_ptr<const IBuildCtx>& buildCtx) -> FilterOp
     {


### PR DESCRIPTION
This PR enforces helper builders to be called only on the allowed stages, e.g. filter builders can only be defined in stage check or stage blocks. Failing to build the asset otherwise.

Also fixes suricata decoder.