### PR TITLE
Modify the installer process to include a dump generation option

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -460,3 +460,32 @@ Public Function SetPermissions()
 
     SetPermissions = 0 
 End Function
+
+Public Function VerifyOrCreateRegistryKey()
+    On Error Resume Next
+    Dim strKeyPath, oReg
+    Dim objCtx, objLocator, objServices
+    Const HKEY_LOCAL_MACHINE = &H80000002
+
+    Set objCtx = CreateObject("WbemScripting.SWbemNamedValueSet")
+    objCtx.Add "__ProviderArchitecture", 64
+    objCtx.Add "__RequiredArchitecture", True
+
+    Set objLocator = CreateObject("WbemScripting.SWbemLocator")
+    Set objServices = objLocator.ConnectServer(".", "root\default", "", "", , , , objCtx)
+    Set oReg = objServices.Get("StdRegProv")
+
+    strKeyPath = "SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\wazuh-agent.exe"
+
+    oReg.CreateKey HKEY_LOCAL_MACHINE, strKeyPath
+    oReg.SetStringValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpFolder", "C:\Dumps"
+    oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpType", 2
+    oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpCount", 10
+
+    Set objCtx = Nothing
+    Set objLocator = Nothing
+    Set objServices = Nothing
+    Set oReg = Nothing
+
+    VerifyOrCreateRegistryKey = 0
+End Function

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -462,6 +462,8 @@ Public Function SetPermissions()
 End Function
 
 Public Function VerifyOrCreateRegistryKey()
+
+Public Function CreateDumpRegistryKey()
     On Error Resume Next
     Dim strKeyPath, oReg
     Dim objCtx, objLocator, objServices
@@ -478,7 +480,7 @@ Public Function VerifyOrCreateRegistryKey()
     strKeyPath = "SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\wazuh-agent.exe"
 
     oReg.CreateKey HKEY_LOCAL_MACHINE, strKeyPath
-    oReg.SetStringValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpFolder", "C:\Users\wazuh\AppData\Local\CrashDumps"
+    oReg.SetStringValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpFolder", "%LOCALAPPDATA%\WazuhCrashDumps"
     oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpType", 2
     oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpCount", 10
 
@@ -487,5 +489,6 @@ Public Function VerifyOrCreateRegistryKey()
     Set objServices = Nothing
     Set oReg = Nothing
 
-    VerifyOrCreateRegistryKey = 0
+    CreateDumpRegistryKey = 0
 End Function
+

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -478,7 +478,7 @@ Public Function VerifyOrCreateRegistryKey()
     strKeyPath = "SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\wazuh-agent.exe"
 
     oReg.CreateKey HKEY_LOCAL_MACHINE, strKeyPath
-    oReg.SetStringValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpFolder", "C:\Dumps"
+    oReg.SetStringValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpFolder", "C:\Users\wazuh\AppData\Local\CrashDumps"
     oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpType", 2
     oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpCount", 10
 

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -482,7 +482,6 @@ Public Function CreateDumpRegistryKey()
     oReg.CreateKey HKEY_LOCAL_MACHINE, strKeyPath
     oReg.SetStringValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpFolder", "%LOCALAPPDATA%\WazuhCrashDumps"
     oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpType", 2
-    oReg.SetDWORDValue HKEY_LOCAL_MACHINE, strKeyPath, "DumpCount", 10
 
     Set objCtx = Nothing
     Set objLocator = Nothing

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -47,6 +47,7 @@
         <WixVariable Id="WixUIBannerBmp" Value="ui\bannrbmp.jpg" />
         <WixVariable Id="WixUIDialogBmp" Value="ui\dlgbmp.jpg" />
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Run Agent configuration interface" />
+        <Property Id="GENERATE_DUMP" Value="1" />
         <Property Id="ARPNOMODIFY" Value="yes" />
         <Property Id="ARPNOREPAIR" Value="yes" />
         <Property Id="ApplicationFolderName" Value="ossec-agent" />
@@ -65,6 +66,7 @@
 
         <Property Id="WixShellExecTarget" Value="[APPLICATIONFOLDER]win32ui.exe" />
         <CustomAction Id="LaunchUI" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+        <CustomAction Id="GenerateDumpAction" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
         <Property Id="OSSECINSTALLED">
             <RegistrySearch Id="OssecInstalled" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Services\OssecSvc" Name="DisplayName" />
@@ -128,12 +130,13 @@
         <!-- Close the Wazuh agent GUI -->
         <CustomAction Id="CloseGUI" BinaryKey="InstallerScripts" VBScriptCall="KillGUITask" Return="check" Execute="deferred" Impersonate="no"/>
 
-
         <UI>
             <UIRef Id="WixUI_Advanced" />
-            <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4"><![CDATA[WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"]]></Publish>
-            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="CustomCheckDialog" Order="4"><![CDATA[WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"]]></Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomCheckDialog" />
             <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchUI">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
+            <Publish Dialog="CustomCheckDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" />
+            <Publish Dialog="CustomCheckDialog" Control="Back" Event="NewDialog" Value="InstallDirDlg" />
         </UI>
         <InstallExecuteSequence>
             <!-- Set OS VERSION -->
@@ -699,4 +702,24 @@
         </Feature>
         <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
     </Product>
+    <Fragment>
+        <UI>
+	        <Dialog Id="CustomCheckDialog" Width="370" Height="270" Title="Wazuh Agent Setup">
+                <Control Id="Description" Type="Text" X="20" Y="60" Width="330" Height="30"
+                    Text="Select this option to enable automatic core dump generation in case the installation fails." />
+
+                <Control Id="GenerateDumpCheckbox" Type="CheckBox" X="20" Y="100" Width="330" Height="17"
+                    Property="GENERATE_DUMP" CheckBoxValue="1"
+                    Text="Enable automatic dump generation" />
+
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="75" Height="23" Default="yes" Text="Next">
+                    <Publish Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+                </Control>
+
+                <Control Id="Back" Type="PushButton" X="156" Y="243" Width="75" Height="23" Text="Back">
+                    <Publish Event="NewDialog" Value="InstallDirDlg">1</Publish>
+                </Control>
+            </Dialog>
+        </UI>
+    </Fragment>
 </Wix>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -48,6 +48,7 @@
         <WixVariable Id="WixUIDialogBmp" Value="ui\dlgbmp.jpg" />
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Run Agent configuration interface" />
         <Property Id="GENERATE_DUMP" Value="1" />
+        <Property Id="DEFAULT_GENERATE_DUMP" Value="1" />
         <Property Id="ARPNOMODIFY" Value="yes" />
         <Property Id="ARPNOREPAIR" Value="yes" />
         <Property Id="ApplicationFolderName" Value="ossec-agent" />
@@ -130,7 +131,7 @@
         <!-- Close the Wazuh agent GUI -->
         <CustomAction Id="CloseGUI" BinaryKey="InstallerScripts" VBScriptCall="KillGUITask" Return="check" Execute="deferred" Impersonate="no"/>
 
-        <CustomAction Id="VerifyOrCreateRegistryKey" BinaryKey="InstallerScripts" VBScriptCall="VerifyOrCreateRegistryKey" Return="check" Execute="deferred" Impersonate="yes" />
+        <CustomAction Id="CreateDumpRegistryKey" BinaryKey="InstallerScripts" VBScriptCall="CreateDumpRegistryKey" Return="check" Execute="deferred" Impersonate="yes" />
         <UI>
             <UIRef Id="WixUI_Advanced" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="CustomCheckDialog" Order="4"><![CDATA[WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"]]></Publish>
@@ -196,7 +197,7 @@
             <Custom Action="SetPermissionsCustomActionDataValue" Before="InstallFinalize"/>
             <Custom Action="SetPermissions" After="SetPermissionsCustomActionDataValue"/>
 
-            <Custom Action="VerifyOrCreateRegistryKey" Before="InstallFinalize">GENERATE_DUMP = "1"</Custom>
+            <Custom Action="CreateDumpRegistryKey" Before="InstallFinalize">GENERATE_DUMP = "1" AND DEFAULT_GENERATE_DUMP = "1"</Custom>
         </InstallExecuteSequence>
 
         <Directory Id="TARGETDIR" Name="SourceDir">

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -712,12 +712,12 @@
                 <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" 
                     Text="CustomImage" />
 
-                <Control Id="Description" Type="Text" X="20" Y="60" Width="330" Height="30"
-                    Text="Enable this option to activate crash dump generation on process failure." />
+                <Control Id="Description" Type="Text" X="20" Y="60" Width="330" Height="60"
+                    Text="Enabling this option allows Wazuh to generate debug information in the event of an agent failure.&#x0A;This information could be useful to detect and fix the problem that caused it." />
 
-                <Control Id="GenerateDumpCheckbox" Type="CheckBox" X="20" Y="100" Width="330" Height="17"
+                <Control Id="GenerateDumpCheckbox" Type="CheckBox" X="20" Y="150" Width="330" Height="17"
                     Property="GENERATE_DUMP" CheckBoxValue="1"
-                    Text="Enable crash dump generation" />
+                    Text="Enable debug information generation" />
 
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="75" Height="23" Default="yes" Text="Next">
                     <Publish Event="NewDialog" Value="VerifyReadyDlg">1</Publish>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -706,14 +706,18 @@
         <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
     </Product>
     <Fragment>
+        <Binary Id="CustomImage" SourceFile="ui\bannrbmp.jpg" />
         <UI>
 	        <Dialog Id="CustomCheckDialog" Width="370" Height="270" Title="Wazuh Agent Setup">
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" 
+                    Text="CustomImage" />
+
                 <Control Id="Description" Type="Text" X="20" Y="60" Width="330" Height="30"
-                    Text="Select this option to enable automatic core dump generation in case the installation fails." />
+                    Text="Enable this option to activate crash dump generation on process failure." />
 
                 <Control Id="GenerateDumpCheckbox" Type="CheckBox" X="20" Y="100" Width="330" Height="17"
                     Property="GENERATE_DUMP" CheckBoxValue="1"
-                    Text="Enable automatic dump generation" />
+                    Text="Enable crash dump generation" />
 
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="75" Height="23" Default="yes" Text="Next">
                     <Publish Event="NewDialog" Value="VerifyReadyDlg">1</Publish>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -130,6 +130,7 @@
         <!-- Close the Wazuh agent GUI -->
         <CustomAction Id="CloseGUI" BinaryKey="InstallerScripts" VBScriptCall="KillGUITask" Return="check" Execute="deferred" Impersonate="no"/>
 
+        <CustomAction Id="VerifyOrCreateRegistryKey" BinaryKey="InstallerScripts" VBScriptCall="VerifyOrCreateRegistryKey" Return="check" Execute="deferred" Impersonate="yes" />
         <UI>
             <UIRef Id="WixUI_Advanced" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="CustomCheckDialog" Order="4"><![CDATA[WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"]]></Publish>
@@ -194,6 +195,8 @@
  
             <Custom Action="SetPermissionsCustomActionDataValue" Before="InstallFinalize"/>
             <Custom Action="SetPermissions" After="SetPermissionsCustomActionDataValue"/>
+
+            <Custom Action="VerifyOrCreateRegistryKey" Before="InstallFinalize">GENERATE_DUMP = "1"</Custom>
         </InstallExecuteSequence>
 
         <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
| Related Issue |
| -- |
| #21737|

## Description

This pull request aims to modify the installation process to include a Windows dump generation option, this includes the generation of an additional screen in the installer which contains a checkbox that will allow to enable or disable the generation of crash dumps, To achieve this, a key is created in the registry `HKEY_LOCAL_MACHINE_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps` that will specify the executable that will be monitored and once it has a crash, the file will be generated `.dmp` file will be generated in the location `%LOCALAPPDATA%\WazuhCrashDumps`.

### Crash dump enable screen

![image](https://github.com/wazuh/wazuh/assets/106568370/da709a18-ddb8-488c-b56a-7aeedd859afb)

To access this screen, click on the `Advanced` option in the first screen of the installer and then click on `Next` in the installation directory selection screen, the crash dump enable screen would be the third to be displayed, if any user does not enter the advanced installation options and runs the installation from the initial screen, by default the crash dump option would be enabled.

When the dump checkbox is enabled and the Wazuh agent is installed, the Key is created automatically as follows

![image](https://github.com/wazuh/wazuh/assets/106568370/88ce066d-121a-446e-be46-9d6fbbc8ded5)

When the crash is generated, the `.dmp` file is automatically generated in the directory `C:\UsersersAwazuh\AppData\Local\CrashDumps`.

![Screenshot from 2024-05-13 10-11-21](https://github.com/wazuh/wazuh/assets/106568370/489c084b-a992-49b7-865b-4b49133aef97)
