### PR TITLE
Increment agents' healtcheck time waited

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5157,10 +5157,10 @@ components:
                     format: alphanumeric_symbols
                   platform:
                     type: string
-                    format: alphanumeric
+                    format: alphanumeric_symbols
                   version:
                     type: string
-                    format: alphanumeric
+                    format: alphanumeric_symbols
         agent_status:
           $ref: '#/components/schemas/AgentsSummaryStatus'
         agent_version:
@@ -5174,7 +5174,7 @@ components:
                 format: int32
               version:
                 type: string
-                format: alphanumeric
+                format: alphanumeric_symbols
         last_registered_agent:
           type: array
           items:

--- a/api/test/integration/env/base/agent/new.Dockerfile
+++ b/api/test/integration/env/base/agent/new.Dockerfile
@@ -9,4 +9,4 @@ RUN /wazuh/install.sh
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp_volume/healthcheck/healthcheck.py || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=40s --start-period=30s CMD /usr/bin/python3 /tmp_volume/healthcheck/healthcheck.py || exit 1

--- a/api/test/integration/env/base/agent/old.Dockerfile
+++ b/api/test/integration/env/base/agent/old.Dockerfile
@@ -2,4 +2,4 @@ FROM public.ecr.aws/o5x5t0j3/amd64/api_development:integration_test_wazuh-agent_
 
 COPY base/agent/entrypoint.sh /scripts/entrypoint.sh
 
-HEALTHCHECK --retries=900 --interval=1s --timeout=30s --start-period=30s CMD /usr/bin/python3 /tmp_volume/healthcheck/legacy_healthcheck.py || exit 1
+HEALTHCHECK --retries=900 --interval=1s --timeout=40s --start-period=30s CMD /usr/bin/python3 /tmp_volume/healthcheck/legacy_healthcheck.py || exit 1

--- a/api/test/integration/env/docker-compose.yml
+++ b/api/test/integration/env/docker-compose.yml
@@ -209,3 +209,5 @@ services:
       - ${ENV_MODE}
     depends_on:
       - wazuh-master
+      - wazuh-worker1
+      - wazuh-worker2

--- a/api/test/integration/env/tools/healthcheck_utils.py
+++ b/api/test/integration/env/tools/healthcheck_utils.py
@@ -80,11 +80,12 @@ def get_agent_health_base():
             if not agent_restarted and re.match(r'.*Agent is restarting due to shared configuration changes.*', log):
                 agent_restarted = True
             if agent_restarted and re.match(r'.*Connected to the server.*', log):
-                # Wait to avoid the worst case:
-                # +10 seconds for the agent to report the worker
-                # +10 seconds for the worker to report master
-                # After this time, the agent appears as active in the master node
-                time.sleep(20)
+                # Wait to avoid the worst case scenario:
+                # +10 seconds for the agent to report to the worker
+                # +10 seconds for the worker to report to the master
+                # +10 seconds for the shared configuration to be synced
+                # After this time, the agent appears as active and synced in the master node
+                time.sleep(30)
                 return 0
     return 1
 

--- a/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_DELETE_endpoints.tavern.yaml
@@ -831,9 +831,5 @@ stages:
       json:
         error: 0
         data:
-          affected_items:
-            - "006"
-            - "007"
-            - "008"
-            - "013"
-          total_affected_items: 4
+          affected_items: !anything
+          total_affected_items: !anyint


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23314 |

## Description

Increases the amount of time we are sleeping in the agents' healtcheck script to give time for the shared configuration to be synced.

> It also includes API spec changes related to https://github.com/wazuh/wazuh/issues/22744 which may be discarded in this PR.

## Tests

<details><summary>test_active_response_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_active_response_endpoints.tavern.yaml --disable-warnings --nobuild
============================================================ test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 2 items                                                                                                                           

test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} 	PASSED                                                   [ 50%]
test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                               [100%]

================================================= 2 passed, 3 warnings in 159.54s (0:02:39) =================================================
```

</details>

<details><summary>test_cluster_endpoints.tavern.yaml</summary>

Related to https://github.com/wazuh/wazuh/issues/23195, should be fixed after upward merge.

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_cluster_endpoints.tavern.yaml --disable-warnings --nobuild
====================================================== test session starts =======================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 49 items                                                                                                               

test_cluster_endpoints.tavern.yaml::GET /cluster/local/config PASSED                                                       [  2%]
test_cluster_endpoints.tavern.yaml::GET /cluster/healthcheck PASSED                                                        [  4%]
test_cluster_endpoints.tavern.yaml::GET /cluster/ruleset/synchronization PASSED                                            [  6%]
test_cluster_endpoints.tavern.yaml::GET /cluster/local/info PASSED                                                         [  8%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes PASSED                                                              [ 10%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[master-node] PASSED                                                 [ 12%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker1] PASSED                                                     [ 14%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes[worker2] PASSED                                                     [ 16%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[ip] PASSED                                                   [ 18%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[name] PASSED                                                 [ 20%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[type] PASSED                                                 [ 22%]
test_cluster_endpoints.tavern.yaml::GET /cluster/nodes select[version] PASSED                                              [ 24%]
test_cluster_endpoints.tavern.yaml::GET /cluster/status PASSED                                                             [ 26%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration PASSED                                            [ 28%]
test_cluster_endpoints.tavern.yaml::GET /cluster/configuration/validation PASSED                                           [ 30%]
test_cluster_endpoints.tavern.yaml::GET /cluster/api/config PASSED                                                         [ 32%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/configuration/{component}/{configuration} PASSED                [ 34%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[master-node] PASSED                                        [ 36%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker1] PASSED                                            [ 38%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/info[worker2] PASSED                                            [ 40%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[master-node] PASSED                               [ 42%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker1] PASSED                                   [ 44%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/daemons/stats[worker2] PASSED                                   [ 46%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[master-node] PASSED                                       [ 48%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker1] PASSED                                           [ 51%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats[worker2] PASSED                                           [ 53%]
test_cluster_endpoints.tavern.yaml::GET /cluster/wrong_node/stats PASSED                                                   [ 55%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[master-node] PASSED                             [ 57%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker1] PASSED                                 [ 59%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/analysisd[worker2] PASSED                                 [ 61%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[master-node] PASSED                                [ 63%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker1] PASSED                                    [ 65%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/hourly[worker2] PASSED                                    [ 67%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[master-node] PASSED                               [ 69%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker1] PASSED                                   [ 71%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/remoted[worker2] PASSED                                   [ 73%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[master-node] PASSED                                [ 75%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker1] PASSED                                    [ 77%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/stats/weekly[worker2] PASSED                                    [ 79%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[master-node] PASSED                                      [ 81%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker1] PASSED                                          [ 83%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/status[worker2] PASSED                                          [ 85%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node] FAILED                                        [ 87%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1] FAILED                                            [ 89%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2] FAILED                                            [ 91%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker1] PASSED                                    [ 93%]
test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs/summary[worker2] PASSED                                    [ 95%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/restart PASSED                                                            [ 97%]
test_cluster_endpoints.tavern.yaml::PUT /cluster/{node_id}/configuration PASSED                                            [100%]

==================================================== short test summary info =====================================================
FAILED test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[master-node]
FAILED test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker1]
FAILED test_cluster_endpoints.tavern.yaml::GET /cluster/{node_id}/logs[worker2]
===================================== 3 failed, 46 passed, 50 warnings in 440.61s (0:07:20) ======================================
```

</details>

<details><summary>test_agent_DELETE_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_agent_DELETE_endpoints.tavern.yaml --disable-warnings --nobuild
=================================== test session starts ====================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 6 items                                                                          

test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group/{group_id} PASSED [ 16%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents/{agent_id}/group PASSED      [ 33%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents/group PASSED                                                                      [ 50%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /groups (only one group) PASSED                                                           [ 66%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /groups (several groups) PASSED                                                           [ 83%]
test_agent_DELETE_endpoints.tavern.yaml::DELETE /agents PASSED                                                                            [100%]

=================================================== 6 passed, 7 warnings in 412.86s (0:06:52) ===================================================
```

</details>

<details><summary>test_overview_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_overview_endpoints.tavern.yaml --disable-warnings
============================================================ test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                            

test_overview_endpoints.tavern.yaml::GET /overview/agents PASSED                                                                      [100%]

================================================= 1 passed, 2 warnings in 979.81s (0:16:19) =================================================
```

</details>

<details><summary>test_rbac_black_overview_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_black_overview_endpoints.tavern.yaml --disable-warnings --nobuild
============================================================ test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                            

test_rbac_black_overview_endpoints.tavern.yaml::GET /overview/agents PASSED                                                           [100%]

================================================= 1 passed, 2 warnings in 129.66s (0:02:09) =================================================
```

</details>

<details><summary>test_rbac_white_overview_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_white_overview_endpoints.tavern.yaml --disable-warnings --nobuild
============================================================ test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                            

test_rbac_white_overview_endpoints.tavern.yaml::GET /overview/agents PASSED                                                           [100%]

================================================= 1 passed, 2 warnings in 169.78s (0:02:49) =================================================
```

</details>


<details><summary>Overview AIT three consecutive executions</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_black_overview_endpoints.tavern.yaml --disable-warnings --nobuild
============================================================ test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                            

test_rbac_black_overview_endpoints.tavern.yaml::GET /overview/agents PASSED                                                           [100%]

================================================= 1 passed, 2 warnings in 161.78s (0:02:41) =================================================
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_black_overview_endpoints.tavern.yaml --disable-warnings --nobuild
============================================================ test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                            

test_rbac_black_overview_endpoints.tavern.yaml::GET /overview/agents PASSED                                                           [100%]

================================================= 1 passed, 2 warnings in 149.16s (0:02:29) =================================================
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_rbac_black_overview_endpoints.tavern.yaml --disable-warnings --nobuild
============================================================ test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-20-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                            

test_rbac_black_overview_endpoints.tavern.yaml::GET /overview/agents PASSED                                                           [100%]

================================================= 1 passed, 2 warnings in 140.40s (0:02:20) =================================================
```

</details>

> test_cluster_endpoints will fail in the check because of the issue mentioned inside the test's result summary