### PR TITLE
Set security level when creating SSL context for HP-UX agents.

### DIFF
--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -26,6 +26,8 @@
 #include "shared.h"
 #include "auth.h"
 
+#define CTX_SECURITY_LEVEL_4 4
+
 /* Global variables */
 BIO *bio_err;
 
@@ -111,6 +113,9 @@ SSL_CTX *get_ssl_context(const char *ciphers, int auto_method)
 
     // If auto_method isn't set, allow TLSv1.2 only
     if (!auto_method) {
+#ifdef HPUX
+        SSL_CTX_set_security_level(ctx, CTX_SECURITY_LEVEL_4);
+#endif
         SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23323|

## Description

Due to the migration to OpenSSL 3.0, HP-UX agents where no longer able to register due to errors during the certificates verification. Setting the security level from the default (1) to 4 fixes the issue by incrementing security to 192 bits.

See: https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_security_level.html

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade