### PR TITLE
Fix agent information when an upgrade or re-scan single agent is triggered

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -64,11 +64,15 @@ public:
             throw WdbDataException("Error executing query to fetch global agent data", data->agentId().data());
         }
         // LCOV_EXCL_STOP
-        // Agent in the first element of the array.
-        const auto& agent = response.back();
-        data->m_agents.push_back(
-            {data->agentId().data(), agent.at("name"), Utils::leftTrim(agent.at("version"), "Wazuh "), agent.at("ip")});
-
+        // Return elements should be one agent.
+        if (response.size() == 1)
+        {
+            const auto& agent = response.front();
+            data->m_agents.push_back({data->agentId().data(),
+                                      agent.at("name"),
+                                      Utils::leftTrim(agent.at("version"), "Wazuh "),
+                                      agent.at("ip")});
+        }
         return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -57,13 +57,11 @@ public:
                     .build(),
                 response);
         }
-        // LCOV_EXCL_START
         catch (const std::exception& e)
         {
             logDebug2(WM_VULNSCAN_LOGTAG, "Error executing query to fetch global agent data. Reason: %s.", e.what());
             throw WdbDataException("Error executing query to fetch global agent data", data->agentId().data());
         }
-        // LCOV_EXCL_STOP
         // Return elements should be one agent.
         if (response.size() == 1)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -15,6 +15,7 @@
 #include "chainOfResponsability.hpp"
 #include "loggerHelper.h"
 #include "scanContext.hpp"
+#include "socketDBWrapper.hpp"
 #include "vulnerabilityScanner.hpp"
 #include "wazuhDBQueryBuilder.hpp"
 
@@ -24,8 +25,9 @@
  * This class is responsible for managing the execution of queries within the global Wazuh environment.
  *
  * @tparam TScanContext scan context type.
+ * @tparam TSocketDBWrapper socket database wrapper type
  */
-template<typename TScanContext = ScanContext>
+template<typename TScanContext = ScanContext, typename TSocketDBWrapper = SocketDBWrapper>
 class TBuildSingleAgentListInfoContext final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 
@@ -44,8 +46,29 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
+        nlohmann::json response;
+
+        try
+        {
+            // Execute query
+            TSocketDBWrapper::instance().query(
+                WazuhDBQueryBuilder::builder()
+                    .globalGetCommand(std::string("agent-info ") + data->agentId().data())
+                    .build(),
+                response);
+        }
+        // LCOV_EXCL_START
+        catch (const std::exception& e)
+        {
+            logDebug2(WM_VULNSCAN_LOGTAG, "Error executing query to fetch global agent data. Reason: %s.", e.what());
+            throw WdbDataException("Error executing query to fetch global agent data", data->agentId().data());
+        }
+        // LCOV_EXCL_STOP
+        // Agent in the first element of the array.
+        const auto& agent = response.back();
         data->m_agents.push_back(
-            {data->agentId().data(), data->agentName().data(), data->agentVersion().data(), data->agentIp().data()});
+            {data->agentId().data(), agent.at("name"), Utils::leftTrim(agent.at("version"), "Wazuh "), agent.at("ip")});
+
         return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
@@ -140,3 +140,33 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextMultiple)
 
     EXPECT_EQ(scanContext->m_agents.size(), 0);
 }
+
+TEST_F(BuildSingleAgentListContextTest, ExceptionOnDB)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::Throw(SocketDbWrapperException("Error on DB")));
+
+    const auto jsonData = R"(
+        {
+            "agent_info": {
+                "agent_id":"001"
+            },
+            "action":"upgradeAgentDB"
+        })"_json;
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto singleAgentContext = std::make_shared<
+        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
+
+    // Context is not used
+    EXPECT_THROW(singleAgentContext->handleRequest(scanContext), WdbDataException);
+
+    spSocketDBWrapperMock.reset();
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
@@ -1,0 +1,142 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * February 21, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "buildSingleAgentListContext_test.hpp"
+#include "TrampolineOsDataCache.hpp"
+#include "TrampolineSocketDBWrapper.hpp"
+#include "buildSingleAgentListContext.hpp"
+
+TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContext)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_)).Times(1);
+
+    const auto jsonData =
+        R"({
+        "agent_info": {
+          "agent_id":"001"
+        },
+        "action":"upgradeAgentDB"})"_json;
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto singleAgentContext = std::make_shared<
+        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
+    singleAgentContext->handleRequest(scanContext);
+}
+
+TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextEmpty)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    nlohmann::json queryResult = R"([])"_json;
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    const auto jsonData =
+        R"({
+        "agent_info": {
+          "agent_id":"001"
+        },
+        "action":"upgradeAgentDB"})"_json;
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto singleAgentContext = std::make_shared<
+        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
+
+    // Context is not used
+    singleAgentContext->handleRequest(scanContext);
+
+    EXPECT_EQ(scanContext->m_agents.size(), 0);
+}
+
+TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElements)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+    const auto jsonData =
+        R"({
+        "agent_info": {
+          "agent_id":"001"
+        },
+        "action":"upgradeAgentDB"})"_json;
+
+    nlohmann::json queryResult = R"([{
+        "id": 1,
+        "name": "name",
+        "version": "Wazuh v4.4.4",
+        "ip": "192.168.0.1",
+        "node_name": "node_1"
+    }])"_json;
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto singleAgentContext = std::make_shared<
+        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
+
+    // Context is not used
+    singleAgentContext->handleRequest(scanContext);
+
+    EXPECT_EQ(scanContext->m_agents.size(), 1);
+
+    auto agent = scanContext->m_agents[0];
+
+    EXPECT_EQ(agent.id, "001");
+    EXPECT_EQ(agent.name, "name");
+    EXPECT_EQ(agent.version, "v4.4.4");
+    EXPECT_EQ(agent.ip, "192.168.0.1");
+}
+
+TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextMultiple)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    nlohmann::json queryResult = R"([{"element":"element1"},{"element":"element2"}])"_json;
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    const auto jsonData =
+        R"({
+        "agent_info": {
+          "agent_id":"001"
+        },
+        "action":"upgradeAgentDB"})"_json;
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto singleAgentContext = std::make_shared<
+        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
+
+    // Context is not used
+    singleAgentContext->handleRequest(scanContext);
+
+    EXPECT_EQ(scanContext->m_agents.size(), 0);
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.hpp
@@ -1,0 +1,42 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * May 15, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _BUILD_SINGLE_AGENT_LIST_CONTEXT_HPP
+#define _BUILD_SINGLE_AGENT_LIST_CONTEXT_HPP
+
+#include "socketServer.hpp"
+#include "gtest/gtest.h"
+
+/**
+ * @brief FetchFromGlobalDB test class.
+ */
+class BuildSingleAgentListContextTest : public ::testing::Test
+{
+protected:
+    // LCOV_EXCL_START
+    BuildSingleAgentListContextTest() = default;
+    ~BuildSingleAgentListContextTest() override = default;
+
+    /**
+     * @brief Set the environment for testing.
+     *
+     */
+    void SetUp() override {}
+
+    /**
+     * @brief Clean the environment after testing.
+     *
+     */
+    void TearDown() override {}
+    // LCOV_EXCL_STOP
+};
+
+#endif // _BUILD_SINGLE_AGENT_LIST_CONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -219,8 +219,25 @@ int main(const int argc, const char* argv[])
                     {
                         if (tokens[0] == "global")
                         {
-                            std::string successMessage = "ok " + fakeGlobalData.dump();
-                            fakeDBServer->send(fd, successMessage.c_str(), successMessage.size());
+                            if (tokens[1] == "get-agent-info")
+                            {
+                                const auto agentId = std::stoi(tokens[2]);
+                                for (const auto& agent : fakeGlobalData)
+                                {
+                                    if (agent["id"] == agentId)
+                                    {
+                                        std::string responseMessage = "ok " + agent.dump();
+                                        std::cout << "Response message for global get-agent-info: " << responseMessage;
+                                        fakeDBServer->send(fd, responseMessage.c_str(), responseMessage.size());
+                                        return;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                std::string successMessage = "ok " + fakeGlobalData.dump();
+                                fakeDBServer->send(fd, successMessage.c_str(), successMessage.size());
+                            }
                         }
                         else if (tokens[0] == "agent" && Utils::isNumber(tokens[1]))
                         {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23421 |

This issue aims to solve a problem that caused certain information not to be indexed when an upgrade was performed or when the manager was rescanned after a policy change it.