### PR TITLE
Recalculate agent-group hash when executing Agent-group send/recv full

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -25,7 +25,7 @@ from wazuh import Wazuh
 from wazuh.core import common, exception
 from wazuh.core import utils
 from wazuh.core.cluster import cluster, utils as cluster_utils
-from wazuh.core.wdb import WazuhDBConnection
+from wazuh.core.wdb import WazuhDBConnection, AsyncWazuhDBConnection
 
 class Response:
     """
@@ -1197,6 +1197,22 @@ class WazuhCommon:
     def __init__(self):
         """Class constructor."""
         self.sync_tasks = {}
+
+    @staticmethod
+    async def recalculate_group_hash(logger) -> None:
+        """Recalculate agent-group hash in the DB.
+
+        Parameters
+        ----------
+        logger : Logger object
+            Logger to use during the recalculation process.
+        """
+        try:
+            # Recalculate group hashes before retrieving agent groups info
+            logger.debug('Recalculating agent-group hash.')
+            await AsyncWazuhDBConnection().run_wdb_command(command='global recalculate-agent-group-hashes')
+        except (exception.WazuhInternalError, exception.WazuhError) as e:
+            logger.warning(f'Error {e.code} executing recalculate agent-group hash command: {e.message}')
 
     def get_logger(self, logger_tag: str = '') -> logging.Logger:
         """Get a logger object.

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -666,6 +666,10 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         start_time = get_utc_now()
         logger.info('Starting.')
 
+        # Recalculate group hashes before retrieving agent groups info
+        logger.debug('Recalculating agent-group hash.')
+        await AsyncWazuhDBConnection().run_wdb_command(command='global recalculate-agent-group-hashes')
+
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w_c',
                                            data_retriever=AsyncWazuhDBConnection().run_wdb_command,
                                            get_data_command='global sync-agent-groups-get ',

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -666,9 +666,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
         start_time = get_utc_now()
         logger.info('Starting.')
 
-        # Recalculate group hashes before retrieving agent groups info
-        logger.debug('Recalculating agent-group hash.')
-        await AsyncWazuhDBConnection().run_wdb_command(command='global recalculate-agent-group-hashes')
+        await self.recalculate_group_hash(logger)
 
         sync_object = c_common.SyncWazuhdb(manager=self, logger=logger, cmd=b'syn_g_m_w_c',
                                            data_retriever=AsyncWazuhDBConnection().run_wdb_command,

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -13,7 +13,7 @@ import os
 import sys
 from contextvars import ContextVar
 from datetime import datetime
-from unittest.mock import patch, MagicMock, mock_open, call, ANY
+from unittest.mock import patch, MagicMock, AsyncMock, mock_open, call, ANY
 
 import cryptography
 import pytest
@@ -1253,6 +1253,55 @@ def test_wazuh_common_init():
     wazuh_common_test = cluster_common.WazuhCommon()
     assert wazuh_common_test.sync_tasks == {}
 
+
+@pytest.mark.asyncio
+@patch("wazuh.core.cluster.common.AsyncWazuhDBConnection", return_value=AsyncMock())
+async def test_wazuh_common_recalculate_group_hash(asyncwazuhdbconnection_mock):
+    class LoggerMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self._debug = []
+
+        def debug(self, data):
+            """Auxiliary method."""
+            self._debug.append(data)
+
+    logger = LoggerMock()
+    await wazuh_common.recalculate_group_hash(logger)
+    assert logger._debug == ['Recalculating agent-group hash.']
+
+
+@pytest.mark.asyncio
+@patch("wazuh.core.cluster.common.AsyncWazuhDBConnection")
+async def test_wazuh_common_recalculate_group_hash_ko(asyncwazuhdbconnection_mock):
+    class LoggerMock:
+        """Auxiliary class."""
+
+        def __init__(self):
+            self._warning = []
+            self._debug = []
+
+        def debug(self, data):
+            """Auxiliary method."""
+            self._debug.append(data)
+
+        def warning(self, data):
+            """Auxiliary method."""
+            self._warning.append(data)
+
+    logger = LoggerMock()
+    asyncwazuhdbconnection_mock.side_effect = [exception.WazuhInternalError(2007), exception.WazuhError(2003)]
+
+    await wazuh_common.recalculate_group_hash(logger)
+    assert logger._debug == ['Recalculating agent-group hash.']
+    assert logger._warning == ['Error 2007 executing recalculate agent-group hash command: '
+                               'Error retrieving data from Wazuh DB']
+
+    logger = LoggerMock()
+    await wazuh_common.recalculate_group_hash(logger)
+    assert logger._debug == ['Recalculating agent-group hash.']
+    assert logger._warning == ['Error 2003 executing recalculate agent-group hash command: Error in wazuhdb request']
 
 def test_wazuh_common_get_logger():
     """Check if a Logger object is properly returned."""

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -896,9 +896,9 @@ async def test_master_handler_sync_wazuh_db_info(get_chunks_mock, update_chunks_
 
 
 @pytest.mark.asyncio
-@patch("wazuh.core.cluster.master.AsyncWazuhDBConnection", return_value=AsyncMock())
+@patch("wazuh.core.cluster.master.MasterHandler.recalculate_group_hash", return_value=AsyncMock())
 @patch('wazuh.core.cluster.common.SyncWazuhdb')
-async def test_manager_handler_send_entire_agent_groups_information(syncwazuhdb_mock, asyncwazuhdbconnection_mock):
+async def test_manager_handler_send_entire_agent_groups_information(syncwazuhdb_mock, recalculate_group_hash_mock):
     """Check if the data chunks are being properly forward to the Wazuh-db socket."""
 
     class LoggerMock:
@@ -908,9 +908,6 @@ async def test_manager_handler_send_entire_agent_groups_information(syncwazuhdb_
             self._debug = []
             self._info = []
             self._error = []
-
-        def debug(self, debug):
-            self._debug.append(debug)
 
         def info(self, data):
             """Auxiliary method."""
@@ -932,7 +929,6 @@ async def test_manager_handler_send_entire_agent_groups_information(syncwazuhdb_
     syncwazuhdb_mock.return_value.retrieve_information.assert_called_once()
     syncwazuhdb_mock.return_value.sync.assert_called_once_with(start_time=ANY, chunks=ANY)
     assert logger._info == ['Starting.']
-    assert logger._debug == ['Recalculating agent-group hash.']
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -896,17 +896,21 @@ async def test_master_handler_sync_wazuh_db_info(get_chunks_mock, update_chunks_
 
 
 @pytest.mark.asyncio
-@patch("wazuh.core.cluster.master.AsyncWazuhDBConnection")
+@patch("wazuh.core.cluster.master.AsyncWazuhDBConnection", return_value=AsyncMock())
 @patch('wazuh.core.cluster.common.SyncWazuhdb')
-async def test_manager_handler_send_entire_agent_groups_information(SyncWazuhdb_mock, AsyncWazuhDBConnection_mock):
+async def test_manager_handler_send_entire_agent_groups_information(syncwazuhdb_mock, asyncwazuhdbconnection_mock):
     """Check if the data chunks are being properly forward to the Wazuh-db socket."""
 
     class LoggerMock:
         """Auxiliary class."""
 
         def __init__(self):
+            self._debug = []
             self._info = []
             self._error = []
+
+        def debug(self, debug):
+            self._debug.append(debug)
 
         def info(self, data):
             """Auxiliary method."""
@@ -915,24 +919,25 @@ async def test_manager_handler_send_entire_agent_groups_information(SyncWazuhdb_
     master_handler = get_master_handler()
     logger = LoggerMock()
     master_handler.task_loggers["Agent-groups send full"] = logger
-    SyncWazuhdb_mock.return_value.retrieve_information = AsyncMock()
-    SyncWazuhdb_mock.return_value.sync = AsyncMock()
+    syncwazuhdb_mock.return_value.retrieve_information = AsyncMock()
+    syncwazuhdb_mock.return_value.sync = AsyncMock()
     assert await master_handler.send_entire_agent_groups_information() is None
-    SyncWazuhdb_mock.assert_called_once_with(manager=master_handler, logger=logger, cmd=b'syn_g_m_w_c',
+    syncwazuhdb_mock.assert_called_once_with(manager=master_handler, logger=logger, cmd=b'syn_g_m_w_c',
                                              data_retriever=ANY,
                                              get_data_command='global sync-agent-groups-get ',
                                              get_payload={'condition': 'all', 'set_synced': False,
                                                           'get_global_hash': False, 'last_id': 0},
                                              pivot_key='last_id', set_data_command='global set-agent-groups',
                                              set_payload={'mode': 'override', 'sync_status': 'synced'})
-    SyncWazuhdb_mock.return_value.retrieve_information.assert_called_once()
-    SyncWazuhdb_mock.return_value.sync.assert_called_once_with(start_time=ANY, chunks=ANY)
+    syncwazuhdb_mock.return_value.retrieve_information.assert_called_once()
+    syncwazuhdb_mock.return_value.sync.assert_called_once_with(start_time=ANY, chunks=ANY)
     assert logger._info == ['Starting.']
+    assert logger._debug == ['Recalculating agent-group hash.']
 
 
 @pytest.mark.asyncio
 @patch("wazuh.core.cluster.master.AsyncWazuhDBConnection")
-async def test_manager_handler_send_agent_groups_information(AsyncWazuhDBConnection_mock):
+async def test_manager_handler_send_agent_groups_information(asyncwazuhdbconnection_mock):
     """Check if the data chunks are being properly forward to the Wazuh-db socket."""
 
     class LoggerMock:

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -607,12 +607,14 @@ async def test_worker_check_agent_groups_checksums(send_request_mock):
 
 @pytest.mark.asyncio
 @freeze_time('1970-01-01')
+@patch("wazuh.core.cluster.worker.AsyncWazuhDBConnection")
 @patch('wazuh.core.cluster.worker.WorkerHandler.check_agent_groups_checksums', return_value='')
 @patch('wazuh.core.cluster.common.Handler.send_request', return_value='check')
 @patch('wazuh.core.cluster.common.Handler.update_chunks_wdb', return_value={'updated_chunks': 1})
 @patch('wazuh.core.cluster.common.Handler.get_chunks_in_task_id', return_value='chunks')
 async def test_worker_handler_recv_agent_groups_information(get_chunks_in_task_id_mock, update_chunks_wdb_mock,
-                                                            send_request_mock, check_agent_groups_checksums_mock):
+                                                            send_request_mock, check_agent_groups_checksums_mock,
+                                                            asyncwazuhdbconnection_mock):
     """Check that the wazuh-db data reception task is created."""
 
     class LoggerMock:
@@ -644,6 +646,7 @@ async def test_worker_handler_recv_agent_groups_information(get_chunks_in_task_i
     assert 'Finished in 0.000s. Updated 1 chunks.' in logger._info
     reset_mock()
 
+    asyncwazuhdbconnection_mock.return_value = AsyncMock()
     assert await worker_handler.recv_agent_groups_entire_information(task_id=b'17', info_type='agent-groups') == 'check'
     get_chunks_in_task_id_mock.assert_called_once_with(b'17', b'syn_wgc_err')
     update_chunks_wdb_mock.assert_called_once_with('chunks', 'agent-groups', logger_c, b'syn_wgc_err', 0)

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -607,14 +607,14 @@ async def test_worker_check_agent_groups_checksums(send_request_mock):
 
 @pytest.mark.asyncio
 @freeze_time('1970-01-01')
-@patch("wazuh.core.cluster.worker.AsyncWazuhDBConnection")
+@patch("wazuh.core.cluster.worker.WorkerHandler.recalculate_group_hash", return_value=AsyncMock())
 @patch('wazuh.core.cluster.worker.WorkerHandler.check_agent_groups_checksums', return_value='')
 @patch('wazuh.core.cluster.common.Handler.send_request', return_value='check')
 @patch('wazuh.core.cluster.common.Handler.update_chunks_wdb', return_value={'updated_chunks': 1})
 @patch('wazuh.core.cluster.common.Handler.get_chunks_in_task_id', return_value='chunks')
 async def test_worker_handler_recv_agent_groups_information(get_chunks_in_task_id_mock, update_chunks_wdb_mock,
                                                             send_request_mock, check_agent_groups_checksums_mock,
-                                                            asyncwazuhdbconnection_mock):
+                                                            recalculate_group_hash_mock):
     """Check that the wazuh-db data reception task is created."""
 
     class LoggerMock:
@@ -646,7 +646,6 @@ async def test_worker_handler_recv_agent_groups_information(get_chunks_in_task_i
     assert 'Finished in 0.000s. Updated 1 chunks.' in logger._info
     reset_mock()
 
-    asyncwazuhdbconnection_mock.return_value = AsyncMock()
     assert await worker_handler.recv_agent_groups_entire_information(task_id=b'17', info_type='agent-groups') == 'check'
     get_chunks_in_task_id_mock.assert_called_once_with(b'17', b'syn_wgc_err')
     update_chunks_wdb_mock.assert_called_once_with('chunks', 'agent-groups', logger_c, b'syn_wgc_err', 0)

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -483,6 +483,9 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         data = await super().get_chunks_in_task_id(task_id, error_command)
         result = await super().update_chunks_wdb(data, info_type, logger, error_command, timeout)
         response = await self.send_request(command=command, data=json.dumps(result).encode())
+        if command == b'syn_wgc_e':
+            # Recalculate group hash before comparing with master's
+            await AsyncWazuhDBConnection().run_wdb_command(command='global recalculate-agent-group-hashes')
         await self.check_agent_groups_checksums(data, logger)
 
         end_time = datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -452,7 +452,11 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         error_command = b'syn_wgc_err'
         timeout = self.cluster_items['intervals']['worker']['timeout_agent_groups']
 
-        return await self.recv_agent_groups_information(task_id, info_type, logger, command, error_command, timeout)
+        master_groups_info = await self.recv_agent_groups_information(task_id, info_type, logger,
+                                                                      command, error_command, timeout)
+        await self.recalculate_group_hash(logger)
+
+        return master_groups_info
 
     async def recv_agent_groups_information(self, task_id: bytes, info_type: str, logger: logging.Logger,
                                             command: bytes, error_command: bytes, timeout: int):
@@ -483,9 +487,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
         data = await super().get_chunks_in_task_id(task_id, error_command)
         result = await super().update_chunks_wdb(data, info_type, logger, error_command, timeout)
         response = await self.send_request(command=command, data=json.dumps(result).encode())
-        if command == b'syn_wgc_e':
-            # Recalculate group hash before comparing with master's
-            await AsyncWazuhDBConnection().run_wdb_command(command='global recalculate-agent-group-hashes')
         await self.check_agent_groups_checksums(data, logger)
 
         end_time = datetime.utcnow().replace(tzinfo=timezone.utc)


### PR DESCRIPTION
|Related issue|
|---|
| #23432 |

## Description

Adds the `global recalculate-agent-group-hashes` command to recalculate the agent-groups hash both in the master and workers when the `Agent-group send full`  is triggered.


## Logs example

Description of the manual tests executed in https://github.com/wazuh/wazuh/issues/23432#issuecomment-2112919762.

## Unit Tests

```
$ pytest framework/wazuh/core/cluster/tests/ --disable-warnings
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.9.19, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/framework
plugins: cov-2.12.0, aiohttp-1.0.4, trio-0.7.0, anyio-3.6.2, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 303 items                                                                                                                                                                                       

framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                  [  5%]
framework/wazuh/core/cluster/tests/test_cluster.py ...................................                                                                                                              [ 16%]
framework/wazuh/core/cluster/tests/test_common.py ......................................................................................                                                            [ 45%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                           [ 47%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                                                              [ 51%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                    [ 59%]
framework/wazuh/core/cluster/tests/test_master.py ...............................................                                                                                                   [ 75%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                                     [ 84%]
framework/wazuh/core/cluster/tests/test_utils.py ............                                                                                                                                       [ 88%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                                                                [100%]

==================================================================================== 303 passed, 24 warnings in 1.45s =====================================================================================
```