### PR TITLE
Vulnerability scanner QA tests: Adding more details in case of failure

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/qa/Readme.md
+++ b/src/wazuh_modules/vulnerability_scanner/qa/Readme.md
@@ -1,0 +1,20 @@
+# QA Tests
+
+This document is meant to describe the current component test behavior and the steps required for its maintenance.
+
+## Efficacy test
+
+### Description
+
+The purpose of this test is to verify the scanner's accuracy when some specific inputs are applied. The results are verified by analyzing the logs written by the test tool.
+
+The `test_data` folder is read in ascending order, and for each one of them, the corresponding inputs are sent. There is an output expected file that contains all the lines that should be found for those specific inputs. If the line isn't found after the timeout expires, the corresponding error message is printed. The test also verifies that the scan begins/ends properly, and that all the events are processed.
+
+Consider also that folder `000` only verifies that the DB is properly decompressed, that's why it doesn't contain input files.
+
+### How to add cases
+
+When a new test is being added, these are the general steps to follow:
+- Create a new folder, use the next available number
+- Add `input_xxx.json` files that contain the sync/deltas messages that the vulnerability scanner test tool will process
+- For each input, create an `expected_xxx.out` file. The logs in the array will be looked for in the test output. If the inputs only prepares the tests and no output is expected (for example, agent OS information), the file can contain an empty array.

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
@@ -105,7 +105,7 @@ def tail_log(file, expected_lines, found_lines, timeout):
             # Check if the line contains the expected output
             for expected in expected_lines:
                 if expected in line and not found_lines[expected]:
-                    LOGGER.debug(f"Found line: {line}")
+                    LOGGER.info(f"Found log line: {line}")
                     found_lines[expected] = True
 
 @pytest.fixture
@@ -174,13 +174,13 @@ def run_process_and_monitor_log(request, run_on_end):
     if test_folder.name == '000':
         LOGGER.debug(f"Waiting for the decompression to start.")
         found = find_regex_in_file(r"Starting database file decompression.", log_file)
-        assert found, "The decompression did not start."
-        LOGGER.debug(f"Decompression started")
+        assert found, "The decompression of the DB did not start."
+        LOGGER.info(f"Decompression started")
     else:
         LOGGER.debug(f"Wating for the process to be initialized")
         found = find_regex_in_file(r"Vulnerability scanner module started", log_file)
-        assert found, "The process is not initialized"
-        LOGGER.debug(f"Process initialized")
+        assert found, "The process is not initialized, timeout waiting vulnerability scanner module to start."
+        LOGGER.info(f"Process initialized")
 
     expected_json_files = sorted(Path(test_folder).glob("expected_*.out"))
     expected_lines = []
@@ -233,18 +233,19 @@ def run_process_and_monitor_log(request, run_on_end):
         found = find_regex_in_file(regex, log_file, len(expected_json_files))
         regex = r"Discarded event: DB query not synced"
         found = found or find_regex_in_file(regex, log_file, len(expected_json_files))
-        assert found, "The scan is not finished"
+        assert found, "The scan is not finished, some events were not processed"
+        LOGGER.info(f"Scan finished, all events were processed")
 
     basetimeout = timeout
     for expected_line in expected_lines:
         while not found_lines[expected_line]:
-            LOGGER.debug(f"Waiting for: {expected_line}")
+            LOGGER.debug(f"Waiting for log line: {expected_line}")
             if timeout < 8*basetimeout:
                 tail_log(log_file, expected_lines, found_lines, timeout)
                 timeout = 1.5*timeout
             else:
-                LOGGER.error(f"Timeout waiting for: {expected_line}")
-                basetimeout = timeout
+                LOGGER.error(f"Timeout waiting for log line: {expected_line}")
+                timeout = basetimeout
                 break
 
     process.terminate()
@@ -261,4 +262,7 @@ def test_false_negatives(run_process_and_monitor_log):
     os.chdir(Path(__file__).parent.parent.parent.parent)
 
     found_lines = run_process_and_monitor_log
-    assert all(found_lines.values()), "The test is failed because the expected output is not found"
+    for line, found in found_lines.items():
+        if not found:
+            LOGGER.error(f"Log entry not found: {line}")
+    assert all(found_lines.values()), "The test failed because some expected lines were not found"


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23226 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds more details to the vulnerability scanner integration test logs. If the tests fail, it will be easier to determine the cause.


## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

In case of failure, we can see all the missing lines at the end of the log

![2024-05-15_21-48](https://github.com/wazuh/wazuh/assets/65046601/474b32c3-997a-41d1-8b75-005d96c60a4b)


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

