### PR TITLE
Fix content generation configuration

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
@@ -34,5 +34,7 @@
             "url": "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0",
             "offset": 0
         }
-    }
+    },
+    "clusterName":"cluster01",
+    "clusterEnabled":false
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23458 |

## Description

This issue aims to solve a problem during the content generation process, basically, an exception because the cluster name is missed.

