### PR TITLE
Fix corrupt agent database creation due to a race condition

### DIFF
--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -227,6 +227,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define WDB_GLOB_NAME          "global"
 #define WDB_MITRE_NAME         "mitre"
 #define WDB_PROF_NAME          ".template.db"
+#define WDB_PROF_PATH          WDB2_DIR "/" WDB_PROF_NAME
 #define WDB_TASK_DIR           "queue/tasks"
 #define WDB_TASK_NAME          "tasks"
 #define WDB_BACKUP_FOLDER      "backup/db"

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -137,6 +137,7 @@ int main(int argc, char ** argv)
     snprintf(path_template, sizeof(path_template), "%s/%s/%s", home_path, WDB2_DIR, WDB_PROF_NAME);
     unlink(path_template);
     mdebug1("Template file removed: %s", path_template);
+    wdb_create_profile();
 
     // Set max open files limit
     struct rlimit rlimit = { nofile, nofile };

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -29,7 +29,7 @@ wnotify_t * notify_queue;
 //static w_queue_t * sock_queue;
 static pthread_mutex_t queue_mutex = PTHREAD_MUTEX_INITIALIZER;
 //static pthread_cond_t sock_cond = PTHREAD_COND_INITIALIZER;
-static volatile int running = 1;
+static volatile _Atomic(int) running = 1;
 rlim_t nofile;
 
 int main(int argc, char ** argv)

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -475,18 +475,16 @@ int wdb_create_agent_db2(const char * agent_id) {
     size_t nbytes;
     int result = 0;
 
-    snprintf(path, OS_FLSIZE, "%s/%s", WDB2_DIR, WDB_PROF_NAME);
-
-    if (!(source = fopen(path, "r"))) {
+    if (!(source = fopen(WDB_PROF_PATH, "r"))) {
         mdebug1("Profile database not found, creating.");
 
-        if (wdb_create_profile(path) < 0)
+        if (wdb_create_profile() < 0)
             return -1;
 
         // Retry to open
 
-        if (!(source = fopen(path, "r"))) {
-            merror("Couldn't open profile '%s'.", path);
+        if (!(source = fopen(WDB_PROF_PATH, "r"))) {
+            merror("Couldn't open profile '%s'.", WDB_PROF_PATH);
             return -1;
         }
     }
@@ -634,8 +632,8 @@ int wdb_create_global(const char *path) {
 }
 
 /* Create profile database */
-int wdb_create_profile(const char *path) {
-    return wdb_create_file(path, schema_agents_sql);
+int wdb_create_profile() {
+    return wdb_create_file(WDB_PROF_PATH, schema_agents_sql);
 }
 
 /* Create new database file from SQL script */

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -729,7 +729,7 @@ int wdb_commit2(wdb_t * wdb);
 int wdb_create_global(const char *path);
 
 /* Create profile database */
-int wdb_create_profile(const char *path);
+int wdb_create_profile();
 
 /* Create new database file from SQL script */
 int wdb_create_file(const char *path, const char *source);

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -364,7 +364,7 @@ typedef struct wdb_t {
     int peer;
     unsigned int refcount;
     unsigned int transaction:1;
-    time_t last;
+    _Atomic(time_t) last;
     time_t transaction_begin_time;
     pthread_mutex_t mutex;
     struct stmt_cache_list *cache_list;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -362,7 +362,7 @@ typedef struct wdb_t {
     sqlite3_stmt * stmt[WDB_STMT_SIZE];
     char * id;
     int peer;
-    unsigned int refcount;
+    _Atomic(unsigned int) refcount;
     unsigned int transaction:1;
     _Atomic(time_t) last;
     time_t transaction_begin_time;


### PR DESCRIPTION
|Related issue|
|---|
| Closes #22847 |

When _wazuh-db_ starts, it deletes the existing template to handle upgrades. As new agents connect, the template is copied. If the template doesn't exist, it is created. This process is handled by multiple threads simultaneously, leading to a situation where each thread may copy parts of the new template being created by another thread, resulting in incomplete or corrupted templates.

## Proposed fix

1. **Pre-create the template before starting the threads.**
Ensure the template is fully created and exists before any thread starts copying or modifying it. This prevents concurrent access issues and ensures the template's consistency.

2. **Encapsulate the template creation in a mutex.**
Implement a mutex to lock the template creation process, ensuring that only one thread can create the template at a time. This avoids race conditions and guarantees that the template is created without interference from other threads.

## Tests

- [x] **Verify template creation on startup.**
Ensure that the template is correctly created when _wazuh-db_ starts. For this, **run _wazuh-db_ standalone**.
- [x] **Simulate multiple agent connections.**
Connect multiple agents simultaneously and verify that the template is copied correctly without any corruption.
- [x] **Check post-startup template creation.**
Comment the call to `wdb_create_profile()` at _main.c_ and repeat the previous test.
- [X] **Unit tests.**
All manager unit tests pass. No new functions have been added.
- [x] **Run on ThreadSanitizer.**
Build _wazuh-db_ with sanitization flags, run that and check the logs.

### ThreadSanitizer

```shell
make TARGET=server DEBUG=1 CFLAGS="-fsanitize=thread -fno-omit-frame-pointer" LDFLAGS="-fsanitize=thread -fno-omit-frame-pointer" wazuh-db
cp wazuh-db /var/ossec/bin/wazuh-db-ts
TSAN_OPTIONS="log_path=/tmp/tsan.log" /var/ossec/bin/wazuh-db-ts -f
```

<details><summary>Report</summary>

```
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=93894)
    #0 calloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:672 (libtsan.so.0+0x31edc)
    #1 w_get_timestamp shared/time_op.c:88 (wazuh-db-ts+0x16c4e7)
    #2 CallUserSignalHandler ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1924 (libtsan.so.0+0x2d883)
    #3 main wazuh_db/main.c:238 (wazuh-db-ts+0x173eb)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal shared/time_op.c:88 in w_get_timestamp
==================
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=93894)
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:655 (libtsan.so.0+0x31c57)
    #1 __fopen_internal libio/iofopen.c:65 (libc.so.6+0x7f64d)
    #2 _IO_new_fopen libio/iofopen.c:86 (libc.so.6+0x7f64d)
    #3 _log_function shared/debug_op.c:201 (wazuh-db-ts+0x1499a6)
    #4 CallUserSignalHandler ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1924 (libtsan.so.0+0x2d883)
    #5 main wazuh_db/main.c:238 (wazuh-db-ts+0x173eb)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal libio/iofopen.c:65 in __fopen_internal
==================
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=93894)
    #0 malloc ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:655 (libtsan.so.0+0x31c57)
    #1 __GI__IO_file_doallocate libio/filedoalloc.c:101 (libc.so.6+0x7eba3)
    #2 fprintf ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:1721 (libtsan.so.0+0x441b2)
    #3 _log_function shared/debug_op.c:235 (wazuh-db-ts+0x149bc3)
    #4 CallUserSignalHandler ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1924 (libtsan.so.0+0x2d883)
    #5 main wazuh_db/main.c:238 (wazuh-db-ts+0x173eb)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal libio/filedoalloc.c:101 in __GI__IO_file_doallocate
==================
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=93894)
    #0 free ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:711 (libtsan.so.0+0x37ab8)
    #1 __GI__IO_setb libio/genops.c:331 (libc.so.6+0x8dc78)
    #2 _log_function shared/debug_op.c:256 (wazuh-db-ts+0x149e13)
    #3 CallUserSignalHandler ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1924 (libtsan.so.0+0x2d883)
    #4 main wazuh_db/main.c:238 (wazuh-db-ts+0x173eb)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal libio/genops.c:331 in __GI__IO_setb
==================
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=93894)
    #0 free ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:711 (libtsan.so.0+0x37ab8)
    #1 _IO_deallocate_file libio/libioP.h:862 (libc.so.6+0x7ed26)
    #2 _IO_new_fclose libio/iofclose.c:74 (libc.so.6+0x7ed26)
    #3 _log_function shared/debug_op.c:256 (wazuh-db-ts+0x149e13)
    #4 CallUserSignalHandler ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1924 (libtsan.so.0+0x2d883)
    #5 main wazuh_db/main.c:238 (wazuh-db-ts+0x173eb)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal libio/libioP.h:862 in _IO_deallocate_file
==================
==================
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=93894)
    #0 free ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:711 (libtsan.so.0+0x37ab8)
    #1 _log_function shared/debug_op.c:265 (wazuh-db-ts+0x149e7e)
    #2 CallUserSignalHandler ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1924 (libtsan.so.0+0x2d883)
    #3 main wazuh_db/main.c:238 (wazuh-db-ts+0x173eb)

SUMMARY: ThreadSanitizer: signal-unsafe call inside of a signal shared/debug_op.c:265 in _log_function
==================
==================
WARNING: ThreadSanitizer: signal handler spoils errno (pid=93894)
    #0 handler wazuh_db/main.c:546 (wazuh-db-ts+0x18ac4)
    #1 main wazuh_db/main.c:238 (wazuh-db-ts+0x173eb)

SUMMARY: ThreadSanitizer: signal handler spoils errno wazuh_db/main.c:546 in handler
==================
```

</details>

We're ignoring signal handler related reports.