### PR TITLE
Fix segmentation fault in multiline-regex configuration

### DIFF
--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -19,7 +19,7 @@
 #define MULTI_LINE_REGEX_MAX_TIMEOUT  120
 #define DATE_MODIFIED   1
 #define DEFAULT_EVENTCHANNEL_REC_TIME 5
-#define DIFF_DEFAULT_SIZE 10 * 1024 * 1024
+#define DIFF_DEFAULT_SIZE (10 * 1024 * 1024)
 #define DEFAULT_FREQUENCY_SECS  360
 #define DIFF_MAX_SIZE (2 * 1024 * 1024 * 1024LL)
 
@@ -72,7 +72,7 @@ typedef struct _logtarget {
     logsocket * log_socket;
 } logtarget;
 
-/* Logreader config */
+/* -- Multiline regex log format specific configuration -- */
 /**
  * @brief Specifies end-of-line replacement type in multiline log (multi-line-regex log format)
  */
@@ -118,6 +118,7 @@ typedef struct {
     int64_t offset_last_read;  ///< absolut file offset of last complete multiline log processed
 } w_multiline_config_t;
 
+/* -- macos log format specific configuration -- */
 typedef enum _w_macos_log_state_t {
     LOG_NOT_RUNNING,
     LOG_RUNNING_STREAM,
@@ -186,8 +187,8 @@ typedef struct _logreader {
     char *ffile;
     char *file;
     char *logformat;
-    w_multiline_config_t * multiline; ///< Multiline regex config & state
-    w_macos_log_config_t * macos_log;   ///< macOS log config & state
+    w_multiline_config_t* multiline;     ///< Multiline regex config & state
+    w_macos_log_config_t* macos_log;     ///< macOS log config & state
     long linecount;
     char *djb_program_name;
     char * channel_str;
@@ -239,10 +240,25 @@ typedef struct _logreader_config {
 void Free_Localfile(logreader_config * config);
 
 /* Frees a localfile  */
-void Free_Logreader(logreader * config);
+void Free_Logreader(logreader * logf);
 
 /* Removes a specific localfile of an array */
 int Remove_Localfile(logreader **logf, int i, int gl, int fr, logreader_glob *globf);
+
+/**
+ * @brief Free the multiline log config and all its resources
+ *
+ * @param multiline Multiline log config
+ */
+void w_multiline_log_config_free(w_multiline_config_t ** config);
+
+/**
+ * @brief Clone a multiline log config
+ *
+ * @param config Multiline log config to clone
+ * @return w_multiline_config_t* Cloned multiline log config
+ */
+w_multiline_config_t* w_multiline_log_config_clone(w_multiline_config_t * config);
 
 /**
  * @brief Get match attribute for multiline regex

--- a/src/headers/expression.h
+++ b/src/headers/expression.h
@@ -95,7 +95,7 @@ bool w_expression_add_osip(w_expression_t ** var, char * ip);
  * @param flags Compilation flags (dependent on expression type)
  * @return false on error. True otherwise
  */
-bool w_expression_compile(w_expression_t * expression, char * pattern, int flags);
+bool w_expression_compile(w_expression_t * expression, const char * pattern, int flags);
 
 /**
  * @brief Test match a compiled pattern to string

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1388,6 +1388,8 @@ int check_pattern_expand(int do_seek) {
 
                         /* Copy the current item to the end mark as it should be a pattern */
                         memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+                        // Clone the multiline configuration if it exists
+                        globs[j].gfiles[i + 1].multiline = w_multiline_log_config_clone(globs[j].gfiles[i].multiline);
 
                         os_strdup(g.gl_pathv[glob_offset], globs[j].gfiles[i].file);
                         w_mutex_init(&globs[j].gfiles[i].mutex, &attr);
@@ -1415,6 +1417,8 @@ int check_pattern_expand(int do_seek) {
 
                         /* Copy the current item to the end mark as it should be a pattern */
                         memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+                        // Clone the multiline configuration if it exists
+                        globs[j].gfiles[i + 1].multiline = w_multiline_log_config_clone(globs[j].gfiles[i].multiline);
 
                         os_strdup(g.gl_pathv[glob_offset], globs[j].gfiles[i].file);
                         w_mutex_init(&globs[j].gfiles[i].mutex, &attr);
@@ -1574,6 +1578,8 @@ int check_pattern_expand(int do_seek) {
                             os_realloc(globs[j].gfiles, (i + 2) * sizeof(logreader), globs[j].gfiles);
                             /* Copy the current item to the end mark as it should be a pattern */
                             memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+                            // Clone the multiline configuration if it exists
+                            globs[j].gfiles[i + 1].multiline = w_multiline_log_config_clone(globs[j].gfiles[i].multiline);
 
                             os_strdup(full_path, globs[j].gfiles[i].file);
                             w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);
@@ -1602,6 +1608,8 @@ int check_pattern_expand(int do_seek) {
 
                             /* Copy the current item to the end mark as it should be a pattern */
                             memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));
+                            // Clone the multiline configuration if it exists
+                            globs[j].gfiles[i + 1].multiline = w_multiline_log_config_clone(globs[j].gfiles[i].multiline);
 
                             os_strdup(full_path, globs[j].gfiles[i].file);
                             w_mutex_init(&globs[j].gfiles[i].mutex, &win_el_mutex_attr);

--- a/src/shared/expression.c
+++ b/src/shared/expression.c
@@ -144,7 +144,7 @@ bool w_expression_add_osip(w_expression_t ** var, char * ip) {
     return true;
 }
 
-bool w_expression_compile(w_expression_t * expression, char * pattern, int flags) {
+bool w_expression_compile(w_expression_t * expression, const char * pattern, int flags) {
 
     bool retval = true;
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/external-devel-requests/issues/2136|

This PR fix a segmentation fault in the configuration of multiline-regex.

### Description
After a thorough investigation, it appears that the segmentation fault in `wazuh-logcollector` is likely caused by improper handling of globs in combination with multiline regex usage. Specifically, the issue occurs when:

```c
/* Copy the current item to the end mark as it should be a pattern */
memcpy(globs[j].gfiles + i + 1, globs[j].gfiles + i, sizeof(logreader));

os_strdup(g.gl_pathv[glob_offset], globs[j].gfiles[i].file);
```

In this code snippet (found [here](https://github.com/wazuh/wazuh/blob/v4.4.1/src/logcollector/logcollector.c#L1360-L1363)), when a new file is discovered, the state of the previous glob, including multiline-regex pointers, is copied. If the state is not null—indicating ongoing multiline regex processing—two logreaders may end up sharing the same buffer state.

Additionally, when a multiline regex is removed from the globs, the associated state is not adequately cleared in the `Remove_Localfile` function, leading to potential double-free errors. This issue can be seen in the code segment [here](https://github.com/wazuh/wazuh/blob/v4.4.1/src/config/localfile-config.c#L735-L774).

This problem has been addressed in a later fix ([commit c3c709a](https://github.com/wazuh/wazuh/commit/c3c709a7fdb0d0d97e53a0415da293f7cdffbc8e)) and is part of the improvements in Wazuh v4.9.0. The corrected handling can be observed in the modified function [here](https://github.com/wazuh/wazuh/blob/4.9.0/src/config/localfile-config.c#L876-L929).