### PR TITLE
Remove rollback mechanism

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -2319,7 +2319,6 @@ void test_wdb_parse_global_delete_group_query_error(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group test_group");
-    will_return(__wrap_wdb_commit2, OS_SUCCESS);
     expect_string(__wrap_wdb_global_delete_group, group_name, "test_group");
     will_return(__wrap_wdb_global_delete_group, OS_INVALID);
     expect_string(__wrap__mdebug1, formatted_msg, "Error deleting group in global.db.");
@@ -2352,7 +2351,6 @@ void test_wdb_parse_global_delete_group_success(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: delete-group test_group");
-    will_return(__wrap_wdb_commit2, OS_SUCCESS);
     expect_string(__wrap_wdb_global_delete_group, group_name, "test_group");
     will_return(__wrap_wdb_global_delete_group, OS_SUCCESS);
 
@@ -2845,7 +2843,6 @@ void test_wdb_parse_global_set_agent_groups_invalid_json(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
-    will_return(__wrap_wdb_commit2, OS_SUCCESS);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2876,7 +2873,6 @@ void test_wdb_parse_global_set_agent_groups_missing_field(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
-    will_return(__wrap_wdb_commit2, OS_SUCCESS);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2907,7 +2903,6 @@ void test_wdb_parse_global_set_agent_groups_invalid_mode(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
-    will_return(__wrap_wdb_commit2, OS_SUCCESS);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2941,7 +2936,6 @@ void test_wdb_parse_global_set_agent_groups_fail(void **state)
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_w_inc_global_open_time);
-    will_return(__wrap_wdb_commit2, OS_SUCCESS);
     expect_function_call(__wrap_w_inc_global_agent_set_agent_groups);
     expect_function_call(__wrap_gettimeofday);
     expect_function_call(__wrap_gettimeofday);
@@ -2965,7 +2959,6 @@ void test_wdb_parse_global_set_agent_groups_success(void **state)
 
     will_return(__wrap_wdb_open_global, data->wdb);
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: set-agent-groups {\"mode\":\"append\",\"sync_status\":\"synced\",\"data\":[{\"id\":1,\"groups\":[\"default\"]}]}");
-    will_return(__wrap_wdb_commit2, OS_SUCCESS);
     expect_value(__wrap_wdb_global_set_agent_groups, mode, WDB_GROUP_APPEND);
     expect_string(__wrap_wdb_global_set_agent_groups, sync_status, "synced");
     expect_string(__wrap_wdb_global_set_agent_groups, agents_group_info, "[{\"id\":1,\"groups\":[\"default\"]}]");

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -1131,15 +1131,7 @@ int wdb_parse(char * input, char * output, int peer) {
                 result = OS_INVALID;
             } else {
                 gettimeofday(&begin, 0);
-                if (wdb_commit2(wdb) < 0) {
-                    snprintf(output, OS_MAXSTR + 1, "err Cannot commit current transaction to continue");
-                    result = OS_INVALID;
-                } else {
-                    result = wdb_parse_global_delete_group(wdb, next, output);
-                    if (result == OS_INVALID && wdb_rollback2(wdb) < 0) {
-                        mdebug1("Global DB Cannot rollback transaction.");
-                    }
-                }
+                result = wdb_parse_global_delete_group(wdb, next, output);
                 gettimeofday(&end, 0);
                 timersub(&end, &begin, &diff);
                 w_inc_global_group_delete_group_time(diff);
@@ -1174,15 +1166,7 @@ int wdb_parse(char * input, char * output, int peer) {
                 result = OS_INVALID;
             } else {
                 gettimeofday(&begin, 0);
-                if (wdb_commit2(wdb) < 0) {
-                    snprintf(output, OS_MAXSTR + 1, "err Cannot commit current transaction to continue");
-                    result = OS_INVALID;
-                } else {
-                    result = wdb_parse_global_set_agent_groups(wdb, next, output);
-                    if (result == OS_INVALID && wdb_rollback2(wdb) < 0) {
-                        mdebug1("Global DB Cannot rollback transaction.");
-                    }
-                }
+                result = wdb_parse_global_set_agent_groups(wdb, next, output);
                 gettimeofday(&end, 0);
                 timersub(&end, &begin, &diff);
                 w_inc_global_agent_set_agent_groups_time(diff);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23347|

## Description

This PR reverts part of the changes from https://github.com/wazuh/wazuh/pull/16058.

Removed rollback applied on agent group queries, allowing a new transaction to not be started after a group change, resulting in a performance issue in the Wazuh DB daemon.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Added unit tests (for new features)