### PR TITLE
Add ID input to workflows

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -1,4 +1,5 @@
-run-name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }} ${{ inputs.is_stage && '- is stage' || '' }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.debug && '- debug' || '' }}
+run-name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }} ${{ inputs.is_stage && '- is stage' || '' }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.debug && '- debug' || '' }} ${{ inputs.id }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -51,6 +52,11 @@ on:
         description: Generate package checksum.
         type: boolean
         required: false
+      id:
+        type: string
+        description: |
+          ID used to identify the workflow uniquely.
+        required: false
 
   workflow_call:
     inputs:
@@ -76,6 +82,9 @@ on:
         required: false
       checksum:
         type: boolean
+        required: false
+      id:
+        type: string
         required: false
 
 jobs:

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -1,4 +1,5 @@
-name: Packages - Build Filebeat Package
+run-name: Build Filebeat module ${{ inputs.revision }} ${{ inputs.id }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -9,6 +10,11 @@ on:
         required: false
         default: "0.0"
         type: string
+      id:
+        type: string
+        description: |
+          ID used to identify the workflow uniquely.
+        required: false
 
   workflow_call:
     inputs:
@@ -16,6 +22,9 @@ on:
         required: false
         default: "0.0"
         type: string
+      id:
+        type: string
+        required: false
 
 jobs:
   Filebeat-module-generation:


### PR DESCRIPTION
## Description

This PR adds the `id` input to the packages generation workflows so the workflow can be identified with a unique string

The workflow can be executed with or without the input, as it is not required

Tests: 
- https://github.com/wazuh/wazuh-jenkins/issues/6371#issuecomment-2115914391
- https://github.com/wazuh/wazuh/actions/runs/9117119056 Manager DEB without ID
- https://github.com/wazuh/wazuh/actions/runs/9117118910 Manager RPM without ID
- https://github.com/wazuh/wazuh/actions/runs/9117119132 Filebeat without ID
- https://github.com/wazuh/wazuh/actions/runs/9117098795 Filebeat with ID
- https://github.com/wazuh/wazuh/actions/runs/9117098736 Manager DEB with ID
- https://github.com/wazuh/wazuh/actions/runs/9117098718 Manager RPM with ID

RPM error reported at https://github.com/wazuh/wazuh/issues/23475
