### PR TITLE
Fix exceptions catched at the scanAgentList

### DIFF
--- a/src/shared_modules/utils/socketDBWrapper.hpp
+++ b/src/shared_modules/utils/socketDBWrapper.hpp
@@ -189,7 +189,10 @@ public:
                 case DbQueryStatus::QUERY_IGNORE:
                 case DbQueryStatus::QUERY_UNKNOWN:
                 case DbQueryStatus::QUERY_NOT_SYNCED: throw SocketDbWrapperException(m_exceptionStr); break;
-                default: throw std::runtime_error(m_exceptionStr);
+                case DbQueryStatus::UNKNOWN:
+                case DbQueryStatus::JSON_PARSING:
+                case DbQueryStatus::INVALID_RESPONSE:
+                default: throw std::runtime_error(m_exceptionStr); break;
             }
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
@@ -64,13 +64,11 @@ public:
             TSocketDBWrapper::instance().query(
                 WazuhDBQueryBuilder::builder().global().selectAll().fromTable("agent").build(), response);
         }
-        // LCOV_EXCL_START
         catch (const std::exception& e)
         {
             logDebug2(WM_VULNSCAN_LOGTAG, "Error executing query to fetch global agent data. Reason: %s.", e.what());
             throw WdbDataException("Error executing query to fetch global agent data", "all");
         }
-        // LCOV_EXCL_STOP
 
         const auto isManagerScanDisabled = PolicyManager::instance().getManagerDisabledScan();
         for (const auto& agent : response)

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -558,7 +558,7 @@ private:
 
         // Check that the agent has remediation data.
         auto agentRemediations = contextData->getRemediationData();
-        if (!agentRemediations.hotfixes.empty())
+        if (agentRemediations.hotfixes.empty())
         {
             logDebug2(
                 WM_VULNSCAN_LOGTAG, "No remediations for agent '%s' have been found.", contextData->agentId().data());

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -213,13 +213,13 @@ public:
                 scanAgentOs(agent);
                 scanAgentPackages(agent);
             }
-            catch (const WdbDataException& e)
+            catch (const SocketDbWrapperException& e)
             {
                 logDebug2(
                     WM_VULNSCAN_LOGTAG, "Error executing query to fetch agent data for agents. Reason: %s.", e.what());
                 data->m_agentsWithIncompletedScan.push_back(agent);
             }
-            catch (const std::exception& e)
+            catch (const std::runtime_error& e)
             {
                 logError(WM_VULNSCAN_LOGTAG, "Error handling request: %s", e.what());
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -219,7 +219,7 @@ public:
                     WM_VULNSCAN_LOGTAG, "Error executing query to fetch agent data for agents. Reason: %s.", e.what());
                 data->m_agentsWithIncompletedScan.push_back(agent);
             }
-            catch (const std::runtime_error& e)
+            catch (const std::exception& e)
             {
                 logError(WM_VULNSCAN_LOGTAG, "Error handling request: %s", e.what());
             }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
@@ -156,6 +156,180 @@ TEST_F(ScanAgentListTest, EmptyPackagesWDBResponseTest)
     scanAgentList->handleRequest(contextData);
 }
 
+TEST_F(ScanAgentListTest, MutipleRecoverableExceptions)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(testing::_))
+        .WillRepeatedly(testing::Return(Remediation {}));
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(2)
+        .WillRepeatedly(testing::Throw(SocketDbWrapperException("Temporal error on DB")));
+
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
+
+    auto spPackageInsertOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
+
+    // Called twice because the server socket response has two packages.
+    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(testing::_)).Times(0);
+
+    auto scanAgentList = std::make_shared<TScanAgentList<TrampolineScanContext,
+                                                         MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>,
+                                                         TrampolineSocketDBWrapper>>(spOsOrchestrationMock,
+                                                                                     spPackageInsertOrchestrationMock);
+
+    nlohmann::json jsonData = nlohmann::json::parse(
+        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"upgradeAgentDB"})");
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto contextData = std::make_shared<TrampolineScanContext>(data);
+    contextData->m_agents.push_back({"001", "test_agent_name_1", "4.8.0", "192.168.0.1"});
+    contextData->m_agents.push_back({"002", "test_agent_name_2", "4.8.0", "192.168.0.2"});
+
+    EXPECT_THROW(scanAgentList->handleRequest(contextData), AgentReScanListException);
+    spSocketDBWrapperMock.reset();
+}
+
+TEST_F(ScanAgentListTest, OneRecoverableException)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(testing::_))
+        .WillRepeatedly(testing::Return(Remediation {}));
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::Throw(SocketDbWrapperException("Temporal error on DB")));
+
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
+
+    auto spPackageInsertOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
+
+    // Called twice because the server socket response has two packages.
+    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(testing::_)).Times(0);
+
+    auto scanAgentList = std::make_shared<TScanAgentList<TrampolineScanContext,
+                                                         MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>,
+                                                         TrampolineSocketDBWrapper>>(spOsOrchestrationMock,
+                                                                                     spPackageInsertOrchestrationMock);
+
+    nlohmann::json jsonData = nlohmann::json::parse(
+        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"upgradeAgentDB"})");
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto contextData = std::make_shared<TrampolineScanContext>(data);
+    contextData->m_agents.push_back({"001", "test_agent_name", "4.8.0", "192.168.0.1"});
+
+    EXPECT_THROW(scanAgentList->handleRequest(contextData), AgentReScanException);
+    spSocketDBWrapperMock.reset();
+}
+
+TEST_F(ScanAgentListTest, UnrecoverableException)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "upstream",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(testing::_))
+        .WillRepeatedly(testing::Return(Remediation {}));
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::Throw(std::runtime_error("FAILURE")));
+
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
+
+    auto spPackageInsertOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
+
+    // Called twice because the server socket response has two packages.
+    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(testing::_)).Times(0);
+
+    auto scanAgentList = std::make_shared<TScanAgentList<TrampolineScanContext,
+                                                         MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>,
+                                                         TrampolineSocketDBWrapper>>(spOsOrchestrationMock,
+                                                                                     spPackageInsertOrchestrationMock);
+
+    nlohmann::json jsonData = nlohmann::json::parse(
+        R"({"agent_info":{"agent_id":"001","agent_version":"4.8.0","agent_name":"test_agent_name","agent_ip":"10.0.0.1","node_name":"node01"},  "action":"upgradeAgentDB"})");
+
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        data = &jsonData;
+
+    auto contextData = std::make_shared<TrampolineScanContext>(data);
+    contextData->m_agents.push_back({"001", "test_agent_name", "4.8.0", "192.168.0.1"});
+
+    EXPECT_NO_THROW(scanAgentList->handleRequest(contextData));
+    spRemediationDataCacheMock.reset();
+    spSocketDBWrapperMock.reset();
+    spOsDataCacheMock.reset();
+}
+
 TEST_F(ScanAgentListTest, DISABLED_InsertAllTestNotSyncedResponse)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();


### PR DESCRIPTION
|Related issue|
|---|
| #23478 |

## Description
This PR updated the exception handling in the scanAgentList class to properly handle the different scenarios

### Notes
At first hand, I wanted to use the [WdbDataException](https://github.com/wazuh/wazuh/blob/b67e8553f7a8f5fd377f3a479a08ef4b0834a0d5/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/wdbDataException.hpp#L21-L22) type but is defined on another module so it's not accessible from the socketDBWrapper

Instead, I properly managed the exceptions on the caller. So, for the socketDBWrapper the exceptions mean the following:
- SocketDbWrapperException -> Temporal and recoverable exceptions
- runtime_error -> Unrecoverable exceptions