### PR TITLE
Improved log messages and exceptions handling

### DIFF
--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -182,7 +182,7 @@ class ProxyAPI:
         elif response.status_code == 401:
             raise WazuhHAPHelperError(3046)
         else:
-            raise WazuhHAPHelperError(3045, extra_message=f'Full response: {response.status_code} | {response.json()}')
+            raise WazuhHAPHelperError(3045, extra_message=response.json()['message'])
 
     async def update_configuration_version(self):
         """Get the last version of the configuration schema and set it."""

--- a/framework/wazuh/core/cluster/hap_helper/tests/test_proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/tests/test_proxy.py
@@ -100,7 +100,11 @@ class TestProxyAPI:
         (
             [{'status_code': 401, 'is_success': False}, None, 3046],
             [
-                {'status_code': random.choice([403, 404, 500]), 'is_success': False, 'json.return_value': '{}'},
+                {
+                    'status_code': random.choice([403, 404, 500]),
+                    'is_success': False,
+                    'json.return_value': {'message': 'error'},
+                },
                 None,
                 3045,
             ],
@@ -128,9 +132,7 @@ class TestProxyAPI:
         with pytest.raises(WazuhHAPHelperError, match=f'.*{expected}.*'):
             await getattr(proxy_api, method)(**f_kwargs)
 
-    async def test_update_configuration_version(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_update_configuration_version(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check that `update_configuration_version` method sets the correct version."""
 
         endpoint = 'services/haproxy/configuration/version'
@@ -150,9 +152,7 @@ class TestProxyAPI:
         )
         assert proxy_api.version == version
 
-    async def test_get_runtime_info(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_get_runtime_info(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check the correct output of `get_runtime_info` method."""
 
         endpoint = 'services/haproxy/runtime/info'
@@ -172,9 +172,7 @@ class TestProxyAPI:
         )
         assert ret_val == info
 
-    async def test_get_global_configuration(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_get_global_configuration(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check the correct output of `get_global_configuration` method."""
 
         endpoint = 'services/haproxy/configuration/global'
@@ -194,9 +192,7 @@ class TestProxyAPI:
         )
         assert ret_val == data
 
-    async def test_update_global_configuration(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_update_global_configuration(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check that `update_globla_configuration` method makes the correct request."""
 
         endpoint = 'services/haproxy/configuration/global'
@@ -279,9 +275,7 @@ class TestProxyAPI:
             params={'version': 0},
         )
 
-    async def test_get_backend_servers(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_get_backend_servers(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check the correct output of `get_backend_servers` method."""
 
         endpoint = 'services/haproxy/configuration/servers'
@@ -349,9 +343,7 @@ class TestProxyAPI:
             params={'version': 0},
         )
 
-    async def test_remove_server_from_backend(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_remove_server_from_backend(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check that `remove_server_from_backend` method makes the correct request."""
 
         endpoint = 'services/haproxy/configuration/servers'
@@ -436,9 +428,7 @@ class TestProxyAPI:
             params={'force_reload': True, 'frontend': name, 'version': 1},
         )
 
-    async def test_get_backend_server_runtime_settings(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_get_backend_server_runtime_settings(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check the correct output of `get_backend_server_runtime_settings` method."""
 
         endpoint = 'services/haproxy/runtime/servers'
@@ -492,9 +482,7 @@ class TestProxyAPI:
             params={'backend': backend_name, 'version': 0},
         )
 
-    async def test_get_backend_stats(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_get_backend_stats(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check the correct output of `get_backend_stats` method."""
 
         endpoint = 'services/haproxy/stats/native'
@@ -515,9 +503,7 @@ class TestProxyAPI:
         )
         assert ret_val == data
 
-    async def test_get_backend_server_stats(
-        self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock
-    ):
+    async def test_get_backend_server_stats(self, proxy_api: ProxyAPI, request_mock: mock.AsyncMock):
         """Check the correct output of `get_backend_server_stats` method."""
 
         endpoint = 'services/haproxy/stats/native'
@@ -570,9 +556,7 @@ class TestProxy:
         assert proxy.hard_stop_after == expected
 
     @pytest.mark.parametrize('side_effect', [KeyError, IndexError])
-    async def test_initialize_ko(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy, side_effect: Exception
-    ):
+    async def test_initialize_ko(self, proxy_api_mock: mock.MagicMock, proxy: Proxy, side_effect: Exception):
         """Check the correct error handling of `initialize` method."""
 
         proxy_api_mock.get_runtime_info.side_effect = side_effect
@@ -645,9 +629,7 @@ class TestProxy:
         with mock.patch.object(proxy, 'get_current_backends', return_value=current_backends):
             assert await proxy.exists_backend(backend) == expected
 
-    async def test_get_current_frontends(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy
-    ):
+    async def test_get_current_frontends(self, proxy_api_mock: mock.MagicMock, proxy: Proxy):
         """Check the correct output of `get_current_frontends` method."""
 
         frontends = [
@@ -694,9 +676,7 @@ class TestProxy:
 
         proxy_api_mock.add_frontend.assert_called_once_with(**parameters)
 
-    async def test_get_current_backend_servers(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy
-    ):
+    async def test_get_current_backend_servers(self, proxy_api_mock: mock.MagicMock, proxy: Proxy):
         """Check the correct output of `get_current_backend_servers` method."""
 
         servers = [
@@ -738,9 +718,7 @@ class TestProxy:
             backend=proxy.wazuh_backend, server_name=manager_name
         )
 
-    async def test_restrain_server_new_connections(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy
-    ):
+    async def test_restrain_server_new_connections(self, proxy_api_mock: mock.MagicMock, proxy: Proxy):
         """Check that `restrain_server_new_connections` method makes the correct callback."""
 
         server_name = 'foo'
@@ -751,9 +729,7 @@ class TestProxy:
             backend_name=proxy.wazuh_backend, server_name=server_name, state=ProxyServerState.DRAIN
         )
 
-    async def test_allow_server_new_connections(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy
-    ):
+    async def test_allow_server_new_connections(self, proxy_api_mock: mock.MagicMock, proxy: Proxy):
         """Check that `allow_server_new_connections` method makes the correct callback."""
 
         server_name = 'foo'
@@ -764,9 +740,7 @@ class TestProxy:
             backend_name=proxy.wazuh_backend, server_name=server_name, state=ProxyServerState.READY
         )
 
-    async def test_get_wazuh_server_stats(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy
-    ):
+    async def test_get_wazuh_server_stats(self, proxy_api_mock: mock.MagicMock, proxy: Proxy):
         """Check the correct output of `get_wazuh_server_stats` method."""
 
         stats = {'foo': 'bar'}
@@ -797,9 +771,7 @@ class TestProxy:
             backend_name=proxy.wazuh_backend, server_name=server_name
         )
 
-    async def test_get_wazuh_backend_stats(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy
-    ):
+    async def test_get_wazuh_backend_stats(self, proxy_api_mock: mock.MagicMock, proxy: Proxy):
         """Check the correct output of `get_wazuh_backend_stats` method."""
 
         servers = [
@@ -817,9 +789,7 @@ class TestProxy:
             for server in servers:
                 server_stats_mock.assert_any_call(server_name=server['name'])
 
-    async def test_get_wazuh_backend_server_connections(
-        self, proxy_api_mock: mock.MagicMock, proxy: Proxy
-    ):
+    async def test_get_wazuh_backend_server_connections(self, proxy_api_mock: mock.MagicMock, proxy: Proxy):
         """Check the correct output of `get_wazuh_backend_server_connections` method."""
 
         stats = {

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -505,12 +505,12 @@ class WazuhException(Exception):
         # HAProxy Helper exceptions
         3041: "Server status check timed out after adding new servers",
         3042: "User configuration is not valid",
-        3043: "Cannot initialize Proxy API",
-        3044: "Unexpected error trying to connect to Proxy API",
-        3045: "Unexpected response from the Proxy API",
+        3043: "Could not initialize Proxy API",
+        3044: "Could not connect to the HAProxy dataplane API",
+        3045: "Could not connect to HAProxy",
         3046: "Invalid credentials for the Proxy API",
         3047: "Invalid HAProxy Dataplane API specification configured",
-        3048: "Cannot detect a valid HAProxy process linked to the Dataplane API",
+        3048: "Could not detect a valid HAProxy process linked to the Dataplane API",
         3049: "Unexpected response from HAProxy Dataplane API",
 
         # RBAC exceptions


### PR DESCRIPTION
|Related issue|
|---|
|#23471|

## Description

This issue closes #23471. It improves some log messages related to exceptions and adds better handling for the `WazuhHAPHelperError`.

## Logs/Alerts example

### wazuh_clusterd.debug=0

* Start HAProxy helper when the DataplaneAPI is not running

```
root@wazuh-master:/var/ossec# framework/python/bin/python3 framework/scripts/wazuh_clusterd.py -f
Starting cluster in foreground (pid: 351160)
2024/05/16 23:45:13 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/05/16 23:45:13 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/05/16 23:45:13 INFO: [Master] [Local integrity] Starting.
2024/05/16 23:45:13 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2024/05/16 23:45:13 CRITICAL: [HAPHelper] [Main] Error 3043 - Could not initialize Proxy API: Check connectivity and the configuration in the `ossec.conf`
2024/05/16 23:45:13 INFO: [HAPHelper] [Main] Task ended
2024/05/16 23:45:13 INFO: [Master] [Local integrity] Finished in 0.085s. Calculated metadata of 34 files.
2024/05/16 23:45:16 INFO: [Worker] [Main] Connection from ('172.27.0.4', 47448)
2024/05/16 23:45:16 INFO: [Worker] [Main] Connection from ('172.27.0.3', 52276)
```

* HAProxy is stopped during the helper cycle

```
2024/05/16 23:55:13 INFO: [Worker worker1] [Agent-groups send] Starting.
2024/05/16 23:55:13 INFO: [Worker worker2] [Agent-groups send] Starting.
2024/05/16 23:55:13 INFO: [Worker worker1] [Agent-groups send] Finished in 0.006s. Updated 1 chunks.
2024/05/16 23:55:13 INFO: [Worker worker2] [Agent-groups send] Finished in 0.006s. Updated 1 chunks.
2024/05/16 23:55:14 ERROR: [HAPHelper] [Main] Error 3045 - Could not connect to HAProxy: no data for wazuh_cluster/master-node: not found
2024/05/16 23:55:14 WARNING: [HAPHelper] [Main] Tasks may not perform as expected. Sleeping 60s before trying again...
2024/05/16 23:55:14 INFO: [Master] [Local integrity] Starting.
2024/05/16 23:55:14 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 34 files.
2024/05/16 23:55:20 INFO: [Worker worker1] [Integrity check] Starting.
2024/05/16 23:55:20 INFO: [Worker worker1] [Integrity check] Finished in 0.006s. Received metadata of 34 files. Sync not required.
```

* DataplaneAPI is stopped during the helper cycle

```
2024/05/16 23:58:33 INFO: [Worker worker1] [Agent-groups send] Starting.
2024/05/16 23:58:33 INFO: [Worker worker2] [Agent-groups send] Starting.
2024/05/16 23:58:33 INFO: [Worker worker1] [Agent-groups send] Finished in 0.006s. Updated 1 chunks.
2024/05/16 23:58:33 INFO: [Worker worker2] [Agent-groups send] Finished in 0.020s. Updated 1 chunks.
2024/05/16 23:58:33 ERROR: [HAPHelper] [Main] Error 3044 - Could not connect to the HAProxy dataplane API: All connection attempts failed
2024/05/16 23:58:33 WARNING: [HAPHelper] [Main] Tasks may not perform as expected. Sleeping 60s before trying again...
2024/05/16 23:58:39 INFO: [Master] [Local integrity] Starting.
2024/05/16 23:58:39 INFO: [Master] [Local integrity] Finished in 0.004s. Calculated metadata of 34 files.
2024/05/16 23:58:41 INFO: [Worker worker2] [Agent-info sync] Starting.
```

### wazuh_clusterd.debug=2

* Start HAProxy helper when the DataplaneAPI is not running

```
root@wazuh-master:/var/ossec# framework/python/bin/python3 framework/scripts/wazuh_clusterd.py -f
2024/05/17 00:03:04 DEBUG: [Cluster] [Main] Removing '/var/ossec/queue/cluster/'.
2024/05/17 00:03:04 DEBUG: [Cluster] [Main] Removed '/var/ossec/queue/cluster/'.
Starting cluster in foreground (pid: 363679)
2024/05/17 00:03:04 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/05/17 00:03:04 DEBUG: [Local Server] [Keep alive] Calculating.
2024/05/17 00:03:04 DEBUG: [Local Server] [Keep alive] Calculated.
2024/05/17 00:03:04 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/05/17 00:03:04 DEBUG: [Master] [Keep alive] Calculating.
2024/05/17 00:03:04 DEBUG: [Master] [Keep alive] Calculated.
2024/05/17 00:03:04 INFO: [Master] [Local integrity] Starting.
2024/05/17 00:03:04 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2024/05/17 00:03:04 ERROR: [HAPHelper] [Main] Error 3043 - Could not initialize Proxy API: Check connectivity and the configuration in the `ossec.conf`
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 69, in map_httpcore_exceptions
    yield
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 373, in handle_async_request
    resp = await self._pool.handle_async_request(req)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection_pool.py", line 216, in handle_async_request
    raise exc from None
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection_pool.py", line 196, in handle_async_request
    response = await connection.handle_async_request(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection.py", line 99, in handle_async_request
    raise exc
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection.py", line 76, in handle_async_request
    stream = await self._connect(request)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection.py", line 122, in _connect
    stream = await self._network_backend.connect_tcp(**kwargs)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_backends/auto.py", line 30, in connect_tcp
    return await self._backend.connect_tcp(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_backends/anyio.py", line 114, in connect_tcp
    with map_exceptions(exc_map):
  File "/var/ossec/framework/python/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.ConnectError: All connection attempts failed
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 107, in initialize
    response = await client.get(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1801, in get
    return await self.request(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1574, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1661, in send
    response = await self._send_handling_auth(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1689, in _send_handling_auth
    response = await self._send_handling_redirects(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1726, in _send_handling_redirects
    response = await self._send_single_request(request)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1763, in _send_single_request
    response = await transport.handle_async_request(request)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 372, in handle_async_request
    with map_httpcore_exceptions():
  File "/var/ossec/framework/python/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 86, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: All connection attempts failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/hap_helper.py", line 513, in start
    await helper.initialize_proxy()
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/hap_helper.py", line 86, in initialize_proxy
    await self.proxy.initialize()
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 536, in initialize
    await self.api.initialize()
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 116, in initialize
    raise WazuhHAPHelperError(
wazuh.core.exception.WazuhHAPHelperError: Error 3043 - Could not initialize Proxy API: Check connectivity and the configuration in the `ossec.conf`
2024/05/17 00:03:04 INFO: [HAPHelper] [Main] Task ended
2024/05/17 00:03:04 INFO: [Master] [Local integrity] Finished in 0.094s. Calculated metadata of 34 files.
2024/05/17 00:03:07 INFO: [Worker] [Main] Connection from ('172.27.0.3', 49922)
2024/05/17 00:03:07 DEBUG: [Worker] [Main] Command received: b'hello'
2024/05/17 00:03:07 INFO: [Worker] [Main] Connection from ('172.27.0.4', 52906)
2024/05/17 00:03:07 DEBUG: [Worker] [Main] Command received: b'hello'
^C2024/05/17 00:03:07 INFO: [Cluster] [Main] SIGINT received. Bye!
```

* HAProxy is stopped during the helper cycle

```
2024/05/17 00:06:46 INFO: [Master] [Local agent-groups] Finished in 0.001s.
2024/05/17 00:06:46 INFO: [Worker worker1] [Agent-groups send] Starting.
2024/05/17 00:06:46 INFO: [Worker worker2] [Agent-groups send] Starting.
2024/05/17 00:06:46 DEBUG: [Worker worker1] [Agent-groups send] Sending chunks.
2024/05/17 00:06:46 DEBUG: [Worker worker2] [Agent-groups send] Sending chunks.
2024/05/17 00:06:46 DEBUG: [Worker worker1] [Main] Command received: b'syn_w_g_e'
2024/05/17 00:06:46 INFO: [Worker worker1] [Agent-groups send] Finished in 0.005s. Updated 1 chunks.
2024/05/17 00:06:46 DEBUG: [Worker worker2] [Main] Command received: b'syn_w_g_e'
2024/05/17 00:06:46 INFO: [Worker worker2] [Agent-groups send] Finished in 0.006s. Updated 1 chunks.
2024/05/17 00:06:46 DEBUG2: [HAPHelper] [Proxy] Obtained proxy servers
2024/05/17 00:06:46 ERROR: [HAPHelper] [Main] Error 3045 - Could not connect to HAProxy: no data for wazuh_cluster/master-node: not found
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/hap_helper.py", line 374, in manage_wazuh_cluster_nodes
    await self.backend_servers_state_healthcheck()
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/hap_helper.py", line 139, in backend_servers_state_healthcheck
    if await self.proxy.is_server_drain(server_name=server):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 824, in is_server_drain
    server_stats = await self.api.get_backend_server_runtime_settings(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 422, in get_backend_server_runtime_settings
    return await self._make_hap_request(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 185, in _make_hap_request
    raise WazuhHAPHelperError(3045, extra_message=response.json()['message'])
wazuh.core.exception.WazuhHAPHelperError: Error 3045 - Could not connect to HAProxy: no data for wazuh_cluster/master-node: not found
2024/05/17 00:06:46 WARNING: [HAPHelper] [Main] Tasks may not perform as expected. Sleeping 60s before trying again...
```

* DataplaneAPI is stopped during the helper cycle

```
2024/05/17 00:09:39 INFO: [Worker worker1] [Agent-groups send] Finished in 0.006s. Updated 1 chunks.
2024/05/17 00:09:39 DEBUG: [Worker worker2] [Main] Command received: b'syn_w_g_e'
2024/05/17 00:09:39 INFO: [Worker worker2] [Agent-groups send] Finished in 0.009s. Updated 1 chunks.
2024/05/17 00:09:39 ERROR: [HAPHelper] [Main] Error 3044 - Could not connect to the HAProxy dataplane API: All connection attempts failed
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 69, in map_httpcore_exceptions
    yield
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 373, in handle_async_request
    resp = await self._pool.handle_async_request(req)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection_pool.py", line 216, in handle_async_request
    raise exc from None
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection_pool.py", line 196, in handle_async_request
    response = await connection.handle_async_request(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection.py", line 99, in handle_async_request
    raise exc
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection.py", line 76, in handle_async_request
    stream = await self._connect(request)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_async/connection.py", line 122, in _connect
    stream = await self._network_backend.connect_tcp(**kwargs)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_backends/auto.py", line 30, in connect_tcp
    return await self._backend.connect_tcp(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_backends/anyio.py", line 114, in connect_tcp
    with map_exceptions(exc_map):
  File "/var/ossec/framework/python/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.ConnectError: All connection attempts failed
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 160, in _make_hap_request
    response = await client.request(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1574, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1661, in send
    response = await self._send_handling_auth(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1689, in _send_handling_auth
    response = await self._send_handling_redirects(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1726, in _send_handling_redirects
    response = await self._send_single_request(request)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_client.py", line 1763, in _send_single_request
    response = await transport.handle_async_request(request)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 372, in handle_async_request
    with map_httpcore_exceptions():
  File "/var/ossec/framework/python/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/httpx/_transports/default.py", line 86, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: All connection attempts failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/hap_helper.py", line 374, in manage_wazuh_cluster_nodes
    await self.backend_servers_state_healthcheck()
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/hap_helper.py", line 138, in backend_servers_state_healthcheck
    for server in (await self.proxy.get_current_backend_servers()).keys():
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 701, in get_current_backend_servers
    api_response = await self.api.get_backend_servers(self.wazuh_backend)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 281, in get_backend_servers
    return await self._make_hap_request(
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/hap_helper/proxy.py", line 168, in _make_hap_request
    raise WazuhHAPHelperError(3044, extra_message=str(request_exc))
wazuh.core.exception.WazuhHAPHelperError: Error 3044 - Could not connect to the HAProxy dataplane API: All connection attempts failed
2024/05/17 00:09:39 WARNING: [HAPHelper] [Main] Tasks may not perform as expected. Sleeping 60s before trying again...
```