### PR TITLE
Change the trigger size to run a bulk query, to insert, delete or modify elements

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -21,7 +21,7 @@ constexpr auto NOT_USED {-1};
 constexpr auto INDEXER_COLUMN {"indexer"};
 constexpr auto USER_KEY {"username"};
 constexpr auto PASSWORD_KEY {"password"};
-constexpr auto ELEMENTS_PER_BULK {50};
+constexpr auto ELEMENTS_PER_BULK {1000};
 
 namespace Log
 {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23481 |

# Description
This PR aims to change the value to be used as a queue pop limit we wait 10 seconds or 1000 elements to dispatch a single HTTP call with a bulk query payload.

Fewer HTTP calls are equal to better performance because we wait for a refresh to the next call.