### PR TITLE
Clean http-request on make clean-deps

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2727,7 +2727,7 @@ ifneq ($(wildcard external/cpython/*),)
 endif
 
 clean-deps:
-	rm -rf $(EXTERNAL_DIR) $(EXTERNAL_CPYTHON) external/$(WPYTHON_TAR) $(EXTERNAL_ROCKSDB)
+	rm -rf $(EXTERNAL_DIR) $(EXTERNAL_TAR) shared_modules/http-request/* shared_modules/http-request/.??*
 
 clean-internals: clean-unit-tests
 	rm -f $(BUILD_SERVER)


### PR DESCRIPTION
|Related issue|
|---|
| Fixes #23504 |

This PR aims to let `make clean-deps` remove the contents from folder _shared_modules/http-request_.

This change affects `make clean-deps` only.

## Test

```shell
make clean-deps && find shared_modules/http-request -type f
```

<details><summary>Before</summary>

```
rm -rf external/cJSON external/curl external/libdb external/libffi external/libyaml external/openssl external/procps external/sqlite external/zlib external/audit-userspace external/msgpack external/bzip2 external/nlohmann external/googletest external/libpcre2 external/libplist external/pacman external/libarchive external/popt external/lua external/rpm external/rocksdb external/lzma external/cpp-httplib external/benchmark external/cpython external/jemalloc external/flatbuffers external/cpython/ external/cpython.tar.gz external/rocksdb/

shared_modules/http-request/README.md
shared_modules/http-request/.github/workflows/cmake.yml
shared_modules/http-request/.github/workflows/cmake-debug.yml
shared_modules/http-request/doxygen.cfg
shared_modules/http-request/.clang-format
shared_modules/http-request/src/urlRequest.hpp
shared_modules/http-request/src/curlMultiHandler.hpp
shared_modules/http-request/src/ICURLHandler.hpp
shared_modules/http-request/src/curlSingleHandler.hpp
shared_modules/http-request/src/HTTPRequest.cpp
shared_modules/http-request/src/factoryRequestImplemetator.hpp
shared_modules/http-request/src/curlWrapper.hpp
shared_modules/http-request/src/IRequestImplementator.hpp
shared_modules/http-request/src/UNIXSocketRequest.cpp
shared_modules/http-request/src/curlHandlerCache.hpp
shared_modules/http-request/.gitignore
shared_modules/http-request/rtr_input.json
shared_modules/http-request/.rtr/rtrtests.py
shared_modules/http-request/.rtr/.gitignore
shared_modules/http-request/.rtr/rtr.py
shared_modules/http-request/.rtr/Dockerfile
shared_modules/http-request/CODEOWNERS
shared_modules/http-request/CMakeLists.txt
shared_modules/http-request/test_tool/actions.hpp
shared_modules/http-request/test_tool/main.cpp
shared_modules/http-request/test_tool/cmdArgsParser.hpp
shared_modules/http-request/test_tool/CMakeLists.txt
shared_modules/http-request/test_tool/factoryAction.hpp
shared_modules/http-request/shared/singleton.hpp
shared_modules/http-request/shared/tests/mocks/mockFsWrapper.hpp
shared_modules/http-request/shared/customDeleter.hpp
shared_modules/http-request/shared/builder.hpp
shared_modules/http-request/shared/curlException.hpp
shared_modules/http-request/shared/fsWrapper.hpp
shared_modules/http-request/rtr
shared_modules/http-request/test/component/main.cpp
shared_modules/http-request/test/component/component_test.hpp
shared_modules/http-request/test/component/component_test.cpp
shared_modules/http-request/test/component/CMakeLists.txt
shared_modules/http-request/test/CMakeLists.txt
shared_modules/http-request/test/unit/unit_test.hpp
shared_modules/http-request/test/unit/secureCommunication_test.cpp
shared_modules/http-request/test/unit/unit_test.cpp
shared_modules/http-request/test/unit/main.cpp
shared_modules/http-request/test/unit/curlHandlerCache_test.cpp
shared_modules/http-request/test/unit/CMakeLists.txt
shared_modules/http-request/test/unit/curlHandlerCache_test.hpp
shared_modules/http-request/test/unit/mocks/MockRequest.hpp
shared_modules/http-request/test/unit/mocks/MockRequestImplementator.hpp
shared_modules/http-request/test/unit/secureCommunication_test.hpp
shared_modules/http-request/test/benchmark/main.cpp
shared_modules/http-request/test/benchmark/CMakeLists.txt
shared_modules/http-request/include/HTTPRequest.hpp
shared_modules/http-request/include/secureCommunication.hpp
shared_modules/http-request/include/UNIXSocketRequest.hpp
shared_modules/http-request/include/IURLRequest.hpp
```

</details>

<details><summary>After</summary>

```
rm -rf external/cJSON external/curl external/libdb external/libffi external/libyaml external/openssl external/procps external/sqlite external/zlib external/audit-userspace external/msgpack external/bzip2 external/nlohmann external/googletest external/libpcre2 external/libplist external/pacman external/libarchive external/popt external/lua external/rpm external/rocksdb external/lzma external/cpp-httplib external/benchmark external/cpython external/jemalloc external/flatbuffers external/cJSON.tar.gz external/curl.tar.gz external/libdb.tar.gz external/libffi.tar.gz external/libyaml.tar.gz external/openssl.tar.gz external/procps.tar.gz external/sqlite.tar.gz external/zlib.tar.gz external/audit-userspace.tar.gz external/msgpack.tar.gz external/bzip2.tar.gz external/nlohmann.tar.gz external/googletest.tar.gz external/libpcre2.tar.gz external/libplist.tar.gz external/pacman.tar.gz external/libarchive.tar.gz external/popt.tar.gz external/lua.tar.gz external/rpm.tar.gz external/rocksdb.tar.gz external/lzma.tar.gz external/cpp-httplib.tar.gz external/benchmark.tar.gz external/cpython.tar.gz external/jemalloc.tar.gz external/flatbuffers.tar.gz shared_modules/http-request/* shared_modules/http-request/.??*
```

</details>