### PR TITLE
Align exception handling from wazuh DB

### DIFF
--- a/src/shared_modules/utils/socketDBWrapper.hpp
+++ b/src/shared_modules/utils/socketDBWrapper.hpp
@@ -184,12 +184,12 @@ public:
             // coverity[missing_lock]
             switch (m_queryStatus)
             {
-                case DbQueryStatus::EMPTY_RESPONSE:
-                case DbQueryStatus::QUERY_ERROR:
-                case DbQueryStatus::QUERY_IGNORE:
-                case DbQueryStatus::QUERY_UNKNOWN:
                 case DbQueryStatus::QUERY_NOT_SYNCED: throw SocketDbWrapperException(m_exceptionStr); break;
+                case DbQueryStatus::EMPTY_RESPONSE:
                 case DbQueryStatus::UNKNOWN:
+                case DbQueryStatus::QUERY_ERROR:
+                case DbQueryStatus::QUERY_UNKNOWN:
+                case DbQueryStatus::QUERY_IGNORE:
                 case DbQueryStatus::JSON_PARSING:
                 case DbQueryStatus::INVALID_RESPONSE:
                 default: throw std::runtime_error(m_exceptionStr); break;

--- a/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
+++ b/src/shared_modules/utils/tests/socketDBWrapper_test.hpp
@@ -12,22 +12,22 @@
 #ifndef _SOCKET_DB_WRAPPER_TEST_HPP
 #define _SOCKET_DB_WRAPPER_TEST_HPP
 
-#include "socketServer.hpp"
 #include "socketDBWrapper.hpp"
+#include "socketServer.hpp"
 #include "gtest/gtest.h"
 #include <chrono>
 #include <thread>
 
 auto constexpr TEST_SOCKET {"queue/db/wdb"};
 
-
 class SocketDBWrapperTest : public ::testing::Test
 {
 protected:
     SocketDBWrapperTest()
-        : m_sleepTime {0} {
-            SocketDBWrapper::instance().init();
-        };
+        : m_sleepTime {0}
+    {
+        SocketDBWrapper::instance().init();
+    };
     ~SocketDBWrapperTest() override = default;
 
     void SetUp() override

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
@@ -64,10 +64,14 @@ public:
             TSocketDBWrapper::instance().query(
                 WazuhDBQueryBuilder::builder().global().selectAll().fromTable("agent").build(), response);
         }
-        catch (const std::exception& e)
+        catch (const SocketDbWrapperException& e)
         {
-            logDebug2(WM_VULNSCAN_LOGTAG, "Error executing query to fetch global agent data. Reason: %s.", e.what());
-            throw WdbDataException("Error executing query to fetch global agent data", "all");
+            throw WdbDataException(e.what(), "all");
+        }
+        catch (std::exception& e)
+        {
+            logError(WM_VULNSCAN_LOGTAG, "Unable to retrieve global agents data. Reason: %s", e.what());
+            return nullptr;
         }
 
         const auto isManagerScanDisabled = PolicyManager::instance().getManagerDisabledScan();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -57,11 +57,19 @@ public:
                     .build(),
                 response);
         }
-        catch (const std::exception& e)
+        catch (const SocketDbWrapperException& e)
         {
-            logDebug2(WM_VULNSCAN_LOGTAG, "Error executing query to fetch global agent data. Reason: %s.", e.what());
-            throw WdbDataException("Error executing query to fetch global agent data", data->agentId().data());
+            throw WdbDataException(e.what(), data->agentId().data());
         }
+        catch (std::exception& e)
+        {
+            logError(WM_VULNSCAN_LOGTAG,
+                     "Unable to retrieve agent-info (agent %s). Reason: %s",
+                     data->agentId().data(),
+                     e.what());
+            return nullptr;
+        }
+
         // Return elements should be one agent.
         if (response.size() == 1)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -62,14 +62,18 @@ private:
             TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder().agentGetOsInfoCommand(agentId).build(),
                                                response);
         }
-        catch (const std::exception& e)
+        catch (const SocketDbWrapperException& e)
         {
             throw WdbDataException(e.what(), agentId);
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error("Unable to retrieve OS data from Wazuh-DB (agent " + agentId + "). Reason: " + e.what());
         }
 
         if (response.empty())
         {
-            throw WdbDataException("Empty response from Wazuh-DB", agentId);
+            throw std::runtime_error("Empty OS data from Wazuh-DB (agent " + agentId + ").");
         }
 
         Os osData;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -68,7 +68,8 @@ private:
         }
         catch (const std::exception& e)
         {
-            throw std::runtime_error("Unable to retrieve OS data from Wazuh-DB (agent " + agentId + "). Reason: " + e.what());
+            throw std::runtime_error("Unable to retrieve OS data from Wazuh-DB (agent " + agentId +
+                                     "). Reason: " + e.what());
         }
 
         if (response.empty())

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
@@ -63,9 +63,17 @@ public:
                     WazuhDBQueryBuilder::builder().agentGetHotfixesCommand(data->agentId().data()).build(),
                     responseHotfixes);
             }
-            catch (const std::exception& e)
+            catch (const SocketDbWrapperException& e)
             {
                 throw WdbDataException(e.what(), data->agentId());
+            }
+            catch (const std::exception& e)
+            {
+                logError(WM_VULNSCAN_LOGTAG,
+                         "Unable to retrieve hotfixes for agent %s. Reason: %s",
+                         data->agentId().data(),
+                         e.what());
+                return nullptr;
             }
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
@@ -50,9 +50,13 @@ private:
             TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder().agentGetHotfixesCommand(agentId).build(),
                                                response);
         }
-        catch (const std::exception& e)
+        catch (const SocketDbWrapperException& e)
         {
             throw WdbDataException(e.what(), agentId);
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error("Unable to retrieve remediation data from Wazuh-DB (agent " + agentId + "). Reason: " + e.what());
         }
 
         Remediation remediationData;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
@@ -56,7 +56,8 @@ private:
         }
         catch (const std::exception& e)
         {
-            throw std::runtime_error("Unable to retrieve remediation data from Wazuh-DB (agent " + agentId + "). Reason: " + e.what());
+            throw std::runtime_error("Unable to retrieve remediation data from Wazuh-DB (agent " + agentId +
+                                     "). Reason: " + e.what());
         }
 
         Remediation remediationData;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -46,11 +46,25 @@ private:
      */
     void scanAgentOs(const AgentData& agent)
     {
-
         nlohmann::json response;
 
-        TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder().agentGetOsInfoCommand(agent.id).build(),
-                                           response);
+        try
+        {
+            TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder().agentGetOsInfoCommand(agent.id).build(),
+                                               response);
+        }
+        catch (const SocketDbWrapperException& e)
+        {
+            throw WdbDataException(e.what(), agent.id);
+        }
+        catch (std::exception& e)
+        {
+            logError(WM_VULNSCAN_LOGTAG,
+                     "Unable to retrieve OS agent data (agent %s). Reason: %s",
+                     agent.id.c_str(),
+                     e.what());
+            return;
+        }
 
         // Validate the response
         if (response.empty())
@@ -114,11 +128,25 @@ private:
      */
     void scanAgentPackages(const AgentData& agent)
     {
-
         nlohmann::json response;
 
-        TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder().agentGetPackagesCommand(agent.id).build(),
-                                           response);
+        try
+        {
+            TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder().agentGetPackagesCommand(agent.id).build(),
+                                               response);
+        }
+        catch (const SocketDbWrapperException& e)
+        {
+            throw WdbDataException(e.what(), agent.id);
+        }
+        catch (std::exception& e)
+        {
+            logError(WM_VULNSCAN_LOGTAG,
+                     "Unable to retrieve packages agent data (agent %s). Reason: %s",
+                     agent.id.c_str(),
+                     e.what());
+            return;
+        }
 
         // Validate the response
         if (response.empty())
@@ -213,7 +241,7 @@ public:
                 scanAgentOs(agent);
                 scanAgentPackages(agent);
             }
-            catch (const SocketDbWrapperException& e)
+            catch (const WdbDataException& e)
             {
                 logDebug2(
                     WM_VULNSCAN_LOGTAG, "Error executing query to fetch agent data for agents. Reason: %s.", e.what());

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -153,14 +153,18 @@ void VulnerabilityScannerFacade::initEventDispatcher()
             }
             catch (const WdbDataException& e)
             {
+                logDebug2(WM_VULNSCAN_LOGTAG, "WdbDataException (Agent %s). Reason: %s", e.agentId().c_str(), e.what());
                 scanOrchestrator->pushEventToDelayedDispatcher(element, e.agentId());
             }
             catch (const AgentReScanException& e)
             {
+                logDebug2(
+                    WM_VULNSCAN_LOGTAG, "AgentReScanException (Agent %s). Reason: %s", e.agentId().c_str(), e.what());
                 scanOrchestrator->pushEventToDelayedDispatcher(element, e.agentId());
             }
             catch (const AgentReScanListException& e)
             {
+                logDebug2(WM_VULNSCAN_LOGTAG, "AgentReScanListException. Reason: %s", e.what());
                 for (const auto& agentData : e.agentList())
                 {
                     scanOrchestrator->pushEventToDelayedDispatcher(element, agentData.id);

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
@@ -166,4 +166,3 @@ TEST_F(OsDataCacheTest, RecoverableExceptionOnDB)
     EXPECT_THROW(cache.getOsData(agentId), WdbDataException);
     spSocketDBWrapperMock.reset();
 }
-

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
@@ -25,7 +25,7 @@ TEST_F(OsDataCacheTest, TestSetAndGetSuccess)
     std::string agentId {"1"};
 
     // Try to get value from empty cache
-    EXPECT_THROW(cache.getOsData(agentId), WdbDataException);
+    EXPECT_THROW(cache.getOsData(agentId), std::runtime_error);
 
     // Set value in cache
     Os osData {.hostName = "hostName",
@@ -134,10 +134,10 @@ TEST_F(OsDataCacheTest, EmptyResponse)
     std::string agentId {"1"};
 
     // Try to get value from empty cache
-    EXPECT_THROW(cache.getOsData(agentId), WdbDataException);
+    EXPECT_THROW(cache.getOsData(agentId), std::runtime_error);
 }
 
-TEST_F(OsDataCacheTest, ExceptionOnDB)
+TEST_F(OsDataCacheTest, UnrecoverableExceptionOnDB)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
     OsDataCache<TrampolineSocketDBWrapper> cache;
@@ -148,6 +148,22 @@ TEST_F(OsDataCacheTest, ExceptionOnDB)
 
     std::string agentId {"1"};
 
+    EXPECT_THROW(cache.getOsData(agentId), std::runtime_error);
+    spSocketDBWrapperMock.reset();
+}
+
+TEST_F(OsDataCacheTest, RecoverableExceptionOnDB)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+    OsDataCache<TrampolineSocketDBWrapper> cache;
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::Throw(SocketDbWrapperException("Warning on DB")));
+
+    std::string agentId {"1"};
+
     EXPECT_THROW(cache.getOsData(agentId), WdbDataException);
     spSocketDBWrapperMock.reset();
 }
+

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/remediationDataCache_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/remediationDataCache_test.cpp
@@ -143,7 +143,7 @@ TEST_F(RemediationDataCacheTest, ResponseFromDB)
     EXPECT_TRUE(remediationsAreEqual(remediationData, expected));
 }
 
-TEST_F(RemediationDataCacheTest, ExceptionOnDB)
+TEST_F(RemediationDataCacheTest, UnrecoverableExceptionOnDB)
 {
     RemediationDataCache<TrampolineSocketDBWrapper> cache;
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
@@ -151,6 +151,22 @@ TEST_F(RemediationDataCacheTest, ExceptionOnDB)
     EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
         .Times(1)
         .WillOnce(testing::Throw(std::runtime_error("Error on DB")));
+
+    std::string agentId {"1"};
+
+    // Attempt to get value from the cache
+    EXPECT_THROW(cache.getRemediationData(agentId), std::runtime_error);
+    spSocketDBWrapperMock.reset();
+}
+
+TEST_F(RemediationDataCacheTest, RecoverableExceptionOnDB)
+{
+    RemediationDataCache<TrampolineSocketDBWrapper> cache;
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::Throw(SocketDbWrapperException("Warning on DB")));
 
     std::string agentId {"1"};
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
@@ -299,8 +299,8 @@ TEST_F(ScanAgentListTest, UnrecoverableException)
         .WillRepeatedly(testing::Return(Remediation {}));
 
     EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
-        .Times(1)
-        .WillOnce(testing::Throw(std::runtime_error("FAILURE")));
+        .Times(2)
+        .WillRepeatedly(testing::Throw(std::runtime_error("ERROR on DB")));
 
     auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
 


### PR DESCRIPTION
|Related issue|
|---|
| #23512 |

## Description
This PR aims to align all the exception handling for all the classes that use the socketDBWrapper to obtain information

It would be useful to repeat the test performed in
- https://github.com/wazuh/wazuh-qa/issues/5397

In order to truly validate that the issue has been resolved