### PR TITLE
Add upgrade_delay parameter to upgrade task creation test

### DIFF
--- a/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_PUT_endpoints.tavern.yaml
@@ -973,6 +973,7 @@ stages:
           total_failed_items: 0
           failed_items: [ ]
         message: !anystr
+    delay_after: !float "{upgrade_delay}"
 
   - name: Try to upgrade an agent that is updated to the latest version
     request:


### PR DESCRIPTION
|Related issue|
|---|
| #23463 |


## Description

Adds the `upgrade_delay` variable to the `test_agent_PUT_endpoints.tavern.yaml::PUT /agents/upgrade` test due to a possible failure in the later executed `test_agent_PUT_endpoints.tavern.yaml::PUT /agents/{agent_id}/upgrade_custom` test. The error's origin is a longer duration in the upgrade task for the `005` agent which first upgrades from `3.x`.


## Tests

```console
(integrationtest-env) fdalmau@wazuhFW:~/.../api/test/integration(enhancement/23463-ait-upgrade-delay)$ pytest test_agent_PUT_endpoints.tavern.yaml 
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.8.10, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 10 items                                                                                                                                                                                        

test_agent_PUT_endpoints.tavern.yaml ..........                                                                                                                                                     [100%]

============================================================================================ warnings summary =============================================================================================
../../../../../venv/integrationtest-env/lib/python3.8/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 10 passed, 1 warning in 1182.80s (0:19:42) ================================================================================
(integrationtest-env) fdalmau@wazuhFW:~/.../api/test/integration(enhancement/23463-ait-upgrade-delay)$ pytest test_agent_PUT_endpoints.tavern.yaml --nobuild
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.8.10, pytest-7.3.1, pluggy-0.13.1
rootdir: /home/fdalmau/git/wazuh/api/test/integration
configfile: pytest.ini
plugins: aiohttp-1.0.4, trio-0.7.0, metadata-2.0.2, tavern-1.23.5, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 10 items                                                                                                                                                                                        

test_agent_PUT_endpoints.tavern.yaml ..........                                                                                                                                                     [100%]

============================================================================================ warnings summary =============================================================================================
../../../../../venv/integrationtest-env/lib/python3.8/site-packages/_pytest/nodes.py:642
  /home/fdalmau/venv/integrationtest-env/lib/python3.8/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================ 10 passed, 1 warning in 677.66s (0:11:17) ================================================================================
```