### PR TITLE
Fixed legacy centOS 5 package generation script to set hash commit

### DIFF
--- a/.github/actions/ghcr-pull-and-push/retag_image.sh
+++ b/.github/actions/ghcr-pull-and-push/retag_image.sh
@@ -44,6 +44,8 @@ retag_image(){
         docker tag ${IMAGE_ID}:${OLD_TAG} ${IMAGE_ID}:${NEW_TAG}
         # Upload
         docker push ${IMAGE_ID}:${NEW_TAG}
+        docker rmi ${IMAGE_ID}:${OLD_TAG} -f
+        docker rmi ${IMAGE_ID}:${NEW_TAG} -f
     fi
 }
 

--- a/.github/workflows/packages-retag-images.yml
+++ b/.github/workflows/packages-retag-images.yml
@@ -69,4 +69,4 @@ jobs:
             new_version=${{ env.NEW_VERSION }}
             old_version=${{ env.OLD_VERSION }}
           fi
-          bash $GITHUB_WORKSPACE/.github/actions/ghcr-pull-and-push/retag_image.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.actor}} $old_version $new_version ${{ inputs.single_docker_image }}
+          bash $GITHUB_WORKSPACE/.github/actions/ghcr-pull-and-push/retag_image.sh ${{ secrets.CI_WAZUH_AGENT_PACKAGES_CLASSIC }} ${{ github.actor}} $old_version $new_version ${{ inputs.single_docker_image }}

--- a/packages/build.sh
+++ b/packages/build.sh
@@ -92,7 +92,7 @@ else
       short_commit_hash="$(cd /wazuh-local-src && git rev-parse --short HEAD)"
     else
       # Git package is not available in the CentOS 5 repositories.
-      hash_commit=$(cat /wazuh-local-src/.git/refs/heads/$(cat /wazuh-local-src/.git/HEAD|cut -d"/" -f3))
+      hash_commit=$(cat /wazuh-local-src/.git/$(cat /wazuh-local-src/.git/HEAD|cut -d" " -f2))
       short_commit_hash="$(cut -c 1-11 <<< $hash_commit)"
     fi
 fi


### PR DESCRIPTION
# Description
Hello team,
In this PR we are introducing a fix for the centOS 5 legacy package generation script.
Related issue: https://github.com/wazuh/internal-devel-requests/issues/712
Specifically working on the minor-fixes issue: https://github.com/wazuh/wazuh-agent-packages/issues/21

The error occurs when we use a github branch that contains the “/” character.

> In addition, we have changed the `GITHUB_TOKEN` -> `CI_WAZUH_AGENT_PACKAGES_CLASSIC`  to have permissions to correctly retag ARM Docker images.