### PR TITLE
Update python paths locations for macOS

### DIFF
--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -442,7 +442,7 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
     pypyMacOSPaths.emplace("/Library/Python/*/*-packages");
     pypyMacOSPaths.emplace("/Library/Frameworks/Python.framework/Versions/*/lib/python*/*-packages");
     pypyMacOSPaths.emplace(
-        "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/*/lib/python*/*-package");
+        "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/*/lib/python*/*-packages");
     pypyMacOSPaths.emplace("/System/Library/Frameworks/Python.framework/*-packages");
 
     static const std::map<std::string, std::set<std::string>> searchPaths =

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -434,7 +434,7 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
     // Add all the unix default paths
     std::set<std::string> pypyMacOSPaths =
     {
-        UNIX_PYPI_DEFAULT_BASE_DIRS.begin(), 
+        UNIX_PYPI_DEFAULT_BASE_DIRS.begin(),
         UNIX_PYPI_DEFAULT_BASE_DIRS.end()
     };
 

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -431,9 +431,23 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
         }
     }
 
+    // Add all the unix default paths
+    std::set<std::string> pypyMacOSPaths =
+    {
+        UNIX_PYPI_DEFAULT_BASE_DIRS.begin(), 
+        UNIX_PYPI_DEFAULT_BASE_DIRS.end()
+    };
+
+    // Add macOS specific paths
+    pypyMacOSPaths.emplace("/Library/Python/*/*-packages");
+    pypyMacOSPaths.emplace("/Library/Frameworks/Python.framework/Versions/*/lib/python*/*-packages");
+    pypyMacOSPaths.emplace(
+        "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/*/lib/python*/*-package");
+    pypyMacOSPaths.emplace("/System/Library/Frameworks/Python.framework/*-packages");
+
     static const std::map<std::string, std::set<std::string>> searchPaths =
     {
-        {"PYPI", UNIX_PYPI_DEFAULT_BASE_DIRS},
+        {"PYPI", pypyMacOSPaths},
         {"NPM", UNIX_NPM_DEFAULT_BASE_DIRS}
     };
     ModernFactoryPackagesCreator<HAS_STDFILESYSTEM>::getPackages(searchPaths, callback);


### PR DESCRIPTION
|Related issue|
|---|
| #23507 |

## Description
This PR updates the paths where the sysinfo module for macOS searches for PyPI packages (based on [this analysis](https://github.com/wazuh/wazuh/issues/23507#issuecomment-2120998531))

The paths were added specifically to the macOS provider and not to the default paths:
https://github.com/wazuh/wazuh/blob/53521ac89eff643ef5d2d0988a35a95a7cc90e8c/src/data_provider/src/sharedDefs.h#L113-L124

To reduce the impact of the search on UNIX systems that don't contain these paths (because each path needs to be expanded based on wildcards)