### PR TITLE
Fix crash in syscheckd processing paths with invalid characters

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -71,6 +71,7 @@
 #define FIM_WHODATA_POLICY_CHANGE_CHECKER       "(6952): Audit policy change detected. Switching directories to realtime."
 #define FIM_WHODATA_POLICY_CHANGE_CHANNEL       "(6953): Event 4719 received due to changes in audit policy. Switching directories to realtime."
 #define FIM_EMPTY_CHANGED_ATTRIBUTES            "(6954): Entry '%s' does not have any modified fields. No event will be generated."
+#define FIM_INVALID_FILE_NAME                   "(6955): Ignoring file '%s' due to unsupported name (non-UTF8)."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -628,6 +628,11 @@ void fim_checker(const char *path,
     directory_t *configuration;
     int depth;
 
+    if (!w_utf8_valid(path)) {
+        mwarn(FIM_INVALID_FILE_NAME, path);
+        return;
+    }
+
 #ifdef WIN32
     // Ignore the recycle bin.
     if (check_removed_file(path)){

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -2747,6 +2747,13 @@ static void test_fim_scan_no_limit(void **state) {
 
 #endif
 
+static void test_fim_checker_unsupported_path(void **state) {
+    const char * PATH = "Unsupported\xFF\x02";
+    expect_string(__wrap__mwarn, formatted_msg, "(6955): Ignoring file 'Unsupported\xFF\x02' due to unsupported name (non-UTF8).");
+
+    fim_checker(PATH, NULL, NULL, NULL, NULL);
+}
+
 /* fim_check_db_state */
 static void test_fim_check_db_state_normal_to_empty(void **state) {
 
@@ -4388,6 +4395,7 @@ int main(void) {
 #ifndef TEST_WINAGENT
         cmocka_unit_test_setup_teardown(test_fim_checker_fim_directory_on_max_recursion_level, setup_struct_dirent, teardown_struct_dirent),
 #endif
+        cmocka_unit_test(test_fim_checker_unsupported_path),
 
         /* fim_directory */
         cmocka_unit_test_setup_teardown(test_fim_directory, setup_struct_dirent, teardown_struct_dirent),


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23354 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In this PR we are going to introduce some fixes in syscheck and rsync to avoid syscheck crashes when using paths containing non-UTF-8 characters, we have used some try/catch to pick up and report correctly those errors, and thus avoid crashes.

## Configuration options

`<directories whodata="yes" report_changes="yes">/test</directories`

## Logs/Alerts example

Using: `touch $(echo -n "Víctor" | iconv -f UTF-8 -t ISO-8859-1)`
```
2024/05/22 12:21:45 wazuh-syscheckd: WARNING: (6955): Ignoring file '/root/test/fim/V�ctor' due to unsupported name (non-UTF8).
```
Not generate crash in syscheck.


## Tests

### Manual

- [x] First scan with an invalid file on Linux.
- [x] Real-time file change on Linux.
- [x] Who-data file change on Linux.
- [x] First scan with an invalid file on Windows.
- [x] Real-time file change on Windows.
- [x] Who-data file change on Windows.
- [x] Registry key change on Windows.
- [x] The synchronization (Rsync) process works after changing an invalid file.

### Automated

- [X] Coverity scan: **snapshot 79211.**
- [X] Unit tests.
- [X] Propose: https://github.com/wazuh/wazuh/issues/23556