### PR TITLE
Handle default type exception in API error response

### DIFF
--- a/api/api/error_handler.py
+++ b/api/api/error_handler.py
@@ -155,10 +155,9 @@ async def problem_error_handler(request: ConnexionRequest, exc: exceptions.Probl
     """
     problem = {
         "title": exc.title if exc.title else 'Bad Request',
-        "detail": exc.detail if isinstance(exc.detail, dict) \
-                    else _cleanup_detail_field(exc.detail)
+        "detail": exc.detail if isinstance(exc.detail, dict) else _cleanup_detail_field(exc.detail)
     }
-    problem.update({"type": exc.type} if exc.type else {})
+    problem.update({"type": exc.type} if (exc.type and exc.type != 'about:blank') else {})
     problem.update(exc.ext if exc.ext else {})
     if isinstance(problem['detail'], dict):
         for field in ['status', 'type']:

--- a/api/api/test/test_error_handler.py
+++ b/api/api/test/test_error_handler.py
@@ -163,7 +163,7 @@ async def test_problem_error_handler(title, detail, ext, error_type, mock_reques
         detail = _cleanup_detail_field(detail)
     problem = {}
     problem.update({'title': title} if title else {'title': 'Bad Request'})
-    problem.update({'type': error_type} if error_type else {})
+    problem.update({'type': error_type} if (error_type and error_type != 'about:blank') else {})
     problem.update({'detail': detail} if detail else {})
     problem.update(ext if ext else {})
     problem.update({'error': problem.pop('code')} if 'code' in problem else {})


### PR DESCRIPTION
|Related issue|
|---|
| #23525 |



## Description

Avoids showing the `about:blank` value related to the `type` field of the raised exception when an API response results in an error.
Example:
- `POST /agents` request repeating the body results in:
```json
{
  "title": "Bad Request",
  "detail": "There is an agent with the same IP or the IP is invalid: 1.1.1.1",
  "remediation": "Please choose another IP",
  "dapi_errors": {
    "wd_master_1": {
      "error": "There is an agent with the same IP or the IP is invalid: 1.1.1.1"
    }
  },
  "error": 1706
}
```

## Tests

- `Integration tests for Authd - Tier 0 and 1`
```console
root@vagrant:/wazuh/tests/integration/test_authd# pytest test_api_registration/
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.4.0
rootdir: /wazuh/tests/integration, configfile: pytest.ini
plugins: metadata-3.1.1, html-3.1.1
collected 24 items                                                                                                                                                                                        

test_api_registration/test_api_agent_registration.py ........................                                                                                                                       [100%]

====================================================================================== 24 passed in 71.69s (0:01:11) ======================================================================================
```