### PR TITLE
Fix bruteforce test sporadic connection issue

### DIFF
--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/data/test_cases/cases_bruteforce_blocking_system.yaml
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/data/test_cases/cases_bruteforce_blocking_system.yaml
@@ -2,7 +2,7 @@
   description: Check if the blocking time, for IP addresses detected as brute-force attack, works.
   configuration_parameters:
     BLOCK_TIME: 10
-    MAX_LOGIN_ATTEMPTS: 10
+    MAX_LOGIN_ATTEMPTS: 3
     MAX_REQUEST_PER_MINUTE: 300
   metadata:
     expected_message: |

--- a/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
+++ b/tests/integration/test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py
@@ -160,12 +160,11 @@ def test_bruteforce_blocking_system(test_configuration, test_metadata, add_confi
     # Provoke a block from an unknown IP (N attempts (N=max_login_attempts) with incorrect credentials).
     for _ in range(max_login_attempts):
         with pytest.raises(RuntimeError):
-            # Using login_attempts=0 to use a different session on each request
-            login(user='wrong', password='wrong', login_attempts=0, backoff_factor=0)
+            login(user='wrong', password='wrong')
 
     # Verify that the IP address is still blocked even when using the correct credentials within the "block time"
     with pytest.raises(RuntimeError) as login_exception:
-        login(login_attempts=0, backoff_factor=0)
+        login()
 
     # Get values from exception information to verify them later
     exception_message = login_exception.value.args[0]


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/22434 |

## Description

Decreases the test case maximum number of login attempts and modifies the `login()` parameters to use the default values and retry failed requests.

## Tests

A list of executions is detailed [here](https://github.com/wazuh/wazuh/issues/22434#issuecomment-2123116981).

> Failed checks are not related to the changes introduced.