### PR TITLE
Add warning when exists multiple frontends binding the same port

### DIFF
--- a/framework/wazuh/core/cluster/hap_helper/hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/hap_helper.py
@@ -515,7 +515,7 @@ class HAPHelper:
 
             if await helper.proxy.check_multiple_frontends(port=connection_port):
                 logger.warning(
-                    f'Exists several frontends binding the port "{connection_port}". '
+                    f'Several frontends exist binding the port "{connection_port}". '
                     'To ensure the proper function of the helper, '
                     f'keep only the one related to the backend "{helper_config[HAPROXY_BACKEND]}".',
                 )

--- a/framework/wazuh/core/cluster/hap_helper/hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/hap_helper.py
@@ -513,7 +513,9 @@ class HAPHelper:
 
             await helper.initialize_proxy()
 
-            if await helper.proxy.check_multiple_frontends(port=connection_port):
+            if await helper.proxy.check_multiple_frontends(
+                port=connection_port, frontend_to_skip=f'{helper.proxy.wazuh_backend}_front'
+            ):
                 logger.warning(
                     f'Several frontends exist binding the port "{connection_port}". '
                     'To ensure the proper function of the helper, '

--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -491,6 +491,11 @@ class ProxyAPI:
     async def get_binds(self, frontend: str) -> PROXY_API_RESPONSE:
         """Returns the binds configured for the given frontend.
 
+        Parameters
+        ----------
+        frontend : str
+            Frontend to query.
+
         Returns
         -------
         PROXY_API_RESPONSE

--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -670,13 +670,16 @@ class Proxy:
         """
         return frontend_name in await self.get_current_frontends()
 
-    async def check_multiple_frontends(self, port: int) -> bool:
+    async def check_multiple_frontends(self, port: int, frontend_to_skip: str) -> bool:
         """Check if there are multiple frontends binding the given port.
 
         Parameters
         ----------
         port : int
             Port number to check.
+        frontend_to_skip: str
+            Skip the comprobation for the given frontend name.
+
 
         Returns
         -------
@@ -685,16 +688,15 @@ class Proxy:
         """
         self.logger.debug(f'Checking multiple frontends for port {port}')
         frontends = await self.get_current_frontends()
-        port_bind_exists = False
 
         for frontend in frontends.keys():
+            if frontend == frontend_to_skip:
+                continue
+
             data = (await self.api.get_binds(frontend=frontend))['data']
             binds = [bind for bind in data if bind.get('port') == port]
-
-            if binds and port_bind_exists:
+            if binds:
                 return True
-            elif binds:
-                port_bind_exists = True
 
         return False
 

--- a/framework/wazuh/core/cluster/hap_helper/tests/test_hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/tests/test_hap_helper.py
@@ -590,7 +590,7 @@ class TestHAPHelper:
         proxy_api = mock.MagicMock()
         proxy_api_mock.return_value = proxy_api
 
-        proxy = mock.MagicMock(hard_stop_after=hard_stop_after)
+        proxy = mock.MagicMock(hard_stop_after=hard_stop_after, wazuh_backend=HAPROXY_BACKEND_VALUE)
         proxy.check_multiple_frontends = mock.AsyncMock(return_value=multiple_frontends)
         proxy_mock.return_value = proxy
 
@@ -632,7 +632,9 @@ class TestHAPHelper:
 
                                 HAPHelper.initialize_proxy.assert_called_once()
 
-                                proxy.check_multiple_frontends.assert_called_once_with(port=WAZUH_PORT)
+                                proxy.check_multiple_frontends.assert_called_once_with(
+                                    port=WAZUH_PORT, frontend_to_skip=f'{HAPROXY_BACKEND_VALUE}_front'
+                                )
                                 if multiple_frontends:
                                     logger_mock.warning.assert_called_once()
                                 else:


### PR DESCRIPTION
|Related issue|
|---|
|#23531|

## Description

This PR closes #23531. Adds a validation to check if multiple frontends are binding the same port. In the affirmative case shows a warning message.

## Logs/Alerts example

Having two frontends binding the port 1514

![image](https://github.com/wazuh/wazuh/assets/7127104/5e56e174-3af2-47df-8395-e4ed4bc90233)

When the helper starts will show a warning message about it.

```console
root@wazuh-master:/var/ossec# framework/python/bin/python3 framework/scripts/wazuh_clusterd.py -r -f
2024/05/21 20:21:07 DEBUG: [Cluster] [Main] Removing '/var/ossec/queue/cluster/'.
2024/05/21 20:21:07 DEBUG: [Cluster] [Main] Removed '/var/ossec/queue/cluster/'.
Starting cluster in foreground (pid: 914125)
2024/05/21 20:21:08 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/05/21 20:21:08 DEBUG: [Local Server] [Keep alive] Calculating.
2024/05/21 20:21:08 DEBUG: [Local Server] [Keep alive] Calculated.
2024/05/21 20:21:08 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/05/21 20:21:08 DEBUG: [Master] [Keep alive] Calculating.
2024/05/21 20:21:08 DEBUG: [Master] [Keep alive] Calculated.
2024/05/21 20:21:08 INFO: [Master] [Local integrity] Starting.
2024/05/21 20:21:08 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2024/05/21 20:21:08 INFO: [HAPHelper] [Main] Proxy was initialized
2024/05/21 20:21:08 DEBUG: [HAPHelper] [Proxy] Checking multiple frontends for port 1514
2024/05/21 20:21:08 DEBUG2: [HAPHelper] [Proxy] Obtained proxy frontends
2024/05/21 20:21:08 WARNING: [HAPHelper] [Main] Exists several frontends binding the port "1514". To ensure the proper function of the helper, keep only the one related to the backend "wazuh_reporting".
2024/05/21 20:21:08 INFO: [HAPHelper] [Main] Ensuring only exists one HAProxy process. Sleeping 30s before start...
2024/05/21 20:21:08 INFO: [Master] [Local integrity] Finished in 0.095s. Calculated metadata of 34 files.
2024/05/21 20:21:12 INFO: [Worker] [Main] Connection from ('172.20.0.3', 44264)
2024/05/21 20:21:12 DEBUG: [Worker] [Main] Command received: b'hello'
```

When only we have one frontend

![image](https://github.com/wazuh/wazuh/assets/7127104/cbfa9b20-9818-4d57-b251-c523bd8f2d4d)

```console
root@wazuh-master:/var/ossec# framework/python/bin/python3 framework/scripts/wazuh_clusterd.py -r -f
2024/05/21 20:25:28 DEBUG: [Cluster] [Main] Removing '/var/ossec/queue/cluster/'.
2024/05/21 20:25:28 DEBUG: [Cluster] [Main] Removed '/var/ossec/queue/cluster/'.
Starting cluster in foreground (pid: 917213)
2024/05/21 20:25:29 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/05/21 20:25:29 DEBUG: [Local Server] [Keep alive] Calculating.
2024/05/21 20:25:29 DEBUG: [Local Server] [Keep alive] Calculated.
2024/05/21 20:25:29 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/05/21 20:25:29 DEBUG: [Master] [Keep alive] Calculating.
2024/05/21 20:25:29 DEBUG: [Master] [Keep alive] Calculated.
2024/05/21 20:25:29 INFO: [Master] [Local integrity] Starting.
2024/05/21 20:25:29 INFO: [Master] [Local agent-groups] Sleeping 30s before starting the agent-groups task, waiting for the workers connection.
2024/05/21 20:25:29 INFO: [HAPHelper] [Main] Proxy was initialized
2024/05/21 20:25:29 DEBUG: [HAPHelper] [Proxy] Checking multiple frontends for port 1514
2024/05/21 20:25:29 DEBUG2: [HAPHelper] [Proxy] Obtained proxy frontends
2024/05/21 20:25:29 INFO: [HAPHelper] [Main] Ensuring only exists one HAProxy process. Sleeping 30s before start...
2024/05/21 20:25:29 INFO: [Master] [Local integrity] Finished in 0.093s. Calculated metadata of 34 files.
```