### PR TITLE
Corrections on conf and replacing timeout like agentd enrollment test

### DIFF
--- a/tests/integration/test_enrollment/conftest.py
+++ b/tests/integration/test_enrollment/conftest.py
@@ -68,8 +68,6 @@ def configure_socket_listener(request, test_metadata):
     """
     Configures the socket listener to start listening on the socket.
     """
-    address_family = 'AF_INET6' if 'ipv6' in test_metadata else 'AF_INET'
-    manager_address = '::1' if 'ipv6' in test_metadata else MANAGER_ADDRESS
 
     address_family = 'AF_INET6' if 'ipv6' in test_metadata else 'AF_INET'
     manager_address = '::1' if 'ipv6' in test_metadata else MANAGER_ADDRESS

--- a/tests/integration/test_enrollment/test_agent/test_agent_auth_enrollment.py
+++ b/tests/integration/test_enrollment/test_agent/test_agent_auth_enrollment.py
@@ -45,6 +45,7 @@ import pytest
 from pathlib import Path
 
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 from wazuh_testing.tools.monitors import queue_monitor
 from wazuh_testing.tools.monitors.file_monitor import FileMonitor
@@ -157,7 +158,7 @@ def test_agent_auth_enrollment(test_configuration, test_metadata, set_wazuh_conf
 
         try:
             # Start socket monitoring
-            socket_monitor.start(timeout=10, accumulations=2, callback=lambda received_event: received_event.encode() in event)
+            socket_monitor.start(timeout=60 if sys.platform == WINDOWS else 20, accumulations=2, callback=lambda received_event: received_event.encode() in event)
 
             assert socket_monitor.matches == 2
         except Exception as error:


### PR DESCRIPTION
|Related issue|
|---|
|#23201|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Tests and corrections for itegration test on windows enrolment.
Conf has 2 duplicated lines and we're replicating what's being done on the other integration enrollment test for windows.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors