### PR TITLE
Destination path accepts backslash

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -16,7 +16,7 @@ INSTALLATION_PATH="/Library/Ossec"    # Installation path.
 VERSION=""                            # Default VERSION (branch/tag).
 REVISION="1"                          # Package revision.
 BRANCH_TAG=""                         # Branch that will be downloaded to build package.
-DESTINATION="${CURRENT_PATH}/output/" # Where package will be stored.
+DESTINATION="${CURRENT_PATH}/output"  # Where package will be stored.
 JOBS="2"                              # Compilation jobs.
 VERBOSE="no"                          # Enables the full log by using `set -exf`.
 DEBUG="no"                            # Enables debug symbols while compiling.
@@ -171,8 +171,8 @@ function build_package() {
         symbols_pkg_name=$(echo "${pkg_name}" | tr '\n' ' ' | cut -d ' ' -f 1)
         symbols_pkg_name="${symbols_pkg_name}_debug_symbols"
         cp -R "${WAZUH_PATH}/src/symbols"  "${DESTINATION}"
-        zip -r "${DESTINATION}${symbols_pkg_name}.zip" "${DESTINATION}symbols"
-        rm -rf "${DESTINATION}symbols"
+        zip -r "${DESTINATION}/${symbols_pkg_name}.zip" "${DESTINATION}/symbols"
+        rm -rf "${DESTINATION}/symbols"
         sign_pkg
         if [[ "${CHECKSUM}" == "yes" ]]; then
             mkdir -p ${CHECKSUMDIR}
@@ -294,7 +294,7 @@ function main() {
             ;;
         "-s"|"--store-path")
             if [ -n "$2" ]; then
-                DESTINATION="$2"
+                DESTINATION=$(echo "$2" | sed 's:/*$::')
                 shift 2
             else
                 help 1


### PR DESCRIPTION
|Related issue|
|---|
|#9913|

The macOS script was not accepting "/tmp" as a destionation parameter as stated in the documentation.
This PR fix this behaviour by sanitizing the parameter, removing any backslash that might be used and using the parameter accordingly.
