### PR TITLE
Fix some dovecot related authentication failed logs that are not correctly parsed

### DIFF
--- a/ruleset/decoders/0445-exim_decoders.xml
+++ b/ruleset/decoders/0445-exim_decoders.xml
@@ -5,6 +5,7 @@
 <!-- Exim 4 decoders
   Examples:
     2017-01-23 03:44:14 dovecot_login authenticator failed for (hydra) [10.101.1.18]:35686: 535 Incorrect authentication data (set_id=user)
+    2017-01-23 03:44:14 dovecot_login authenticator failed for (hydra) [10.101.1.18]:35686: 535 Incorrect authentication data (set_id=user@domain)
     2017-01-24 05:22:29 dovecot_plain authenticator failed for (test) [::1]:39454: 535 Incorrect authentication data (set_id=test)
     2017-01-24 03:09:46 SMTP connection from [10.101.1.10]:55010 (TCP/IP connection count = 1)
     2017-01-24 02:53:13 SMTP connection from (hydra) [10.101.1.10]:53682 lost
@@ -16,7 +17,7 @@
 <decoder name="exim-authfailed">
   <parent>windows-date-format</parent>
   <prematch offset="after_parent">authenticator failed</prematch>
-  <regex offset="after_prematch">[(\S+)]:\d+: \d+ Incorrect authentication data \(set_id=(\w+)\)</regex>
+  <regex offset="after_prematch">[(\S+)]:\d+: \d+ Incorrect authentication data \(set_id=(\S+)\)</regex>
   <order>srcip,user</order>
 </decoder>
 


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh/issues/23625
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Some *dovecot_login authenticator failed* messages don't parse srcip address correctly and this impact any active response that may require this info.

## Logs/Alerts example

This log is parsed ok:

```
2024-05-06 04:59:49 dovecot_login authenticator failed for (localhost) [12.34.56.78]:63624: 535 Incorrect authentication data (set_id=line)
```

This log is not able to get the data srcip correctly:

```
2024-05-06 04:59:49 dovecot_login authenticator failed for (User) [12.34.56.78]:51406: 535 Incorrect authentication data (set_id=webmaster@somedomain.com)
```


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ *] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors