### PR TITLE
Force no index on re-scan in cluster environment

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -126,7 +126,7 @@ bool IndexerConnector::abuseControl(const std::string& agentId)
         // If the last sync was less than MINIMAL_SYNC_TIME minutes ago, return true.
         if (diff.count() < MINIMAL_SYNC_TIME)
         {
-            logDebug2(IC_NAME, "Agent '%s' sync ommited due to abuse control.", agentId.c_str());
+            logDebug2(IC_NAME, "Agent '%s' sync omitted due to abuse control.", agentId.c_str());
             return true;
         }
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
@@ -60,9 +60,25 @@ public:
 
         try
         {
-            // Execute query
-            TSocketDBWrapper::instance().query(
-                WazuhDBQueryBuilder::builder().global().selectAll().fromTable("agent").build(), response);
+            if (data->clusterStatus())
+            {
+                // Execute query
+                const std::string clusterNodeName {data->clusterNodeName()};
+                TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder()
+                                                       .global()
+                                                       .selectAll()
+                                                       .fromTable("agent")
+                                                       .whereColumn("node_name")
+                                                       .equalsTo(clusterNodeName)
+                                                       .build(),
+                                                   response);
+            }
+            else
+            {
+                // Execute query
+                TSocketDBWrapper::instance().query(
+                    WazuhDBQueryBuilder::builder().global().selectAll().fromTable("agent").build(), response);
+            }
         }
         catch (const SocketDbWrapperException& e)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
@@ -60,25 +60,9 @@ public:
 
         try
         {
-            if (data->clusterStatus())
-            {
-                // Execute query
-                const std::string clusterNodeName {data->clusterNodeName()};
-                TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder()
-                                                       .global()
-                                                       .selectAll()
-                                                       .fromTable("agent")
-                                                       .whereColumn("node_name")
-                                                       .equalsTo(clusterNodeName)
-                                                       .build(),
-                                                   response);
-            }
-            else
-            {
-                // Execute query
-                TSocketDBWrapper::instance().query(
-                    WazuhDBQueryBuilder::builder().global().selectAll().fromTable("agent").build(), response);
-            }
+            // Execute query
+            TSocketDBWrapper::instance().query(
+                WazuhDBQueryBuilder::builder().global().selectAll().fromTable("agent").build(), response);
         }
         catch (const SocketDbWrapperException& e)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -286,7 +286,7 @@ void VulnerabilityScannerFacade::clusterConfigurationChange(Utils::RocksDBWrappe
     stateDB.put(CLUSTER_NAME_KEY, clusterName);
 }
 
-void VulnerabilityScannerFacade::handlePolicyChange(Utils::RocksDBWrapper& stateDB) const
+void VulnerabilityScannerFacade::handlePolicyChange() const
 {
     if (m_shouldRescan)
     {
@@ -296,6 +296,8 @@ void VulnerabilityScannerFacade::handlePolicyChange(Utils::RocksDBWrapper& state
         actionData["action"] = "reboot";
         // We shouldn't index if we are in a cluster environment
         actionData["no-index"] = PolicyManager::instance().getClusterStatus();
+
+        logDebug2(WM_VULNSCAN_LOGTAG, "actionData: %s", actionData.dump().c_str());
 
         const std::string actionDataString = actionData.dump();
         const std::vector<char> actionMessage(actionDataString.begin(), actionDataString.end());
@@ -364,7 +366,7 @@ void VulnerabilityScannerFacade::start(
         handleManagerScanPolicyChange(*stateDB);
 
         // Checks for the actions to be performed after the policy change (vulnerability scanner).
-        handlePolicyChange(*stateDB);
+        handlePolicyChange();
 
         // Subscription to syscollector delta events.
         initDeltasSubscription();

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -292,10 +292,15 @@ void VulnerabilityScannerFacade::handlePolicyChange(Utils::RocksDBWrapper& state
     {
         logInfo(WM_VULNSCAN_LOGTAG, "Policy changed. Re-scanning all agents");
 
-        // Create and queue the reboot event (force scan)
-        std::string dataValueReScan = R"({"action":"reboot"})";
-        const std::vector<char> messageReScan(dataValueReScan.begin(), dataValueReScan.end());
-        pushEvent(messageReScan, BufferType::BufferType_JSON);
+        nlohmann::json actionData;
+        actionData["action"] = "reboot";
+        // We shouldn't index if we are in a cluster environment
+        actionData["no-index"] = PolicyManager::instance().getClusterStatus();
+
+        const std::string actionDataString = actionData.dump();
+        const std::vector<char> actionMessage(actionDataString.begin(), actionDataString.end());
+
+        pushEvent(actionMessage, BufferType::BufferType_JSON);
     }
 }
 
@@ -395,10 +400,15 @@ void VulnerabilityScannerFacade::start(
             initContentUpdater,
             [this]()
             {
-                // Create a JSON object 'dataValue' to specify the action as "reboot."
-                std::string dataValueReScan = R"({"action":"reboot","no-index":true})";
-                const std::vector<char> messageReScan(dataValueReScan.begin(), dataValueReScan.end());
-                pushEvent(messageReScan, BufferType::BufferType_JSON);
+                nlohmann::json actionData;
+                actionData["action"] = "reboot";
+                // We shouldn't index if we are in a cluster environment
+                actionData["no-index"] = PolicyManager::instance().getClusterStatus();
+
+                const std::string actionDataString = actionData.dump();
+                const std::vector<char> actionMessage(actionDataString.begin(), actionDataString.end());
+
+                pushEvent(actionMessage, BufferType::BufferType_JSON);
                 logInfo(WM_VULNSCAN_LOGTAG, "Triggered a re-scan after content update");
             });
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -123,11 +123,10 @@ public:
 
     /**
      * @brief Performs the corresponding actions related to the policy changes.
-     * @param stateDB RocksDBWrapper object to access to the state database.
      *
      * @note Should be called after @see clusterConfigurationChange and @see vulnerabilityScanPolicyChange methods
      */
-    void handlePolicyChange(Utils::RocksDBWrapper& stateDB) const;
+    void handlePolicyChange() const;
 
     /**
      * @brief Get seconds from epoch.

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildAllAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildAllAgentListContext_test.cpp
@@ -17,8 +17,40 @@
 
 using TrampolineScanContext = TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>;
 
+const auto configClusterEnable = nlohmann::json::parse(R"(
+    {
+        "vulnerability-detection": {
+            "enabled": "yes",
+            "index-status": "yes",
+            "feed-update-interval": "60m",
+            "cti-url": "https://cti-url.com"
+        },
+        "managerDisabledScan": false,
+        "clusterNodeName": "node_1",
+        "clusterName":"clusterName",
+        "clusterEnabled":true
+    })");
+
+const auto configClusterDisabled = nlohmann::json::parse(R"(
+    {
+        "vulnerability-detection": {
+            "enabled": "yes",
+            "index-status": "yes",
+            "feed-update-interval": "60m",
+            "cti-url": "https://cti-url.com"
+        },
+        "managerDisabledScan": false,
+        "clusterNodeName": "node_1",
+        "clusterName":"clusterName",
+        "clusterEnabled":false
+    })");
+
 TEST_F(BuildAllAgentListContextTest, BuildAllAgentListContext)
 {
+    // Initialize policy manager
+    auto policyManager = std::make_unique<PolicyManager>();
+    policyManager->initialize(configClusterDisabled);
+
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
     EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_)).Times(1);
 
@@ -61,6 +93,10 @@ TEST_F(BuildAllAgentListContextTest, BuildAllAgentListContextWithElements)
 
 TEST_F(BuildAllAgentListContextTest, MissingField)
 {
+    // Initialize policy manager
+    auto policyManager = std::make_unique<PolicyManager>();
+    policyManager->initialize(configClusterDisabled);
+
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
 
     nlohmann::json queryResult = nlohmann::json::parse(R"(
@@ -88,6 +124,10 @@ TEST_F(BuildAllAgentListContextTest, MissingField)
 
 TEST_F(BuildAllAgentListContextTest, ExceptionOnDB)
 {
+    // Initialize policy manager
+    auto policyManager = std::make_unique<PolicyManager>();
+    policyManager->initialize(configClusterDisabled);
+
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
 
     const std::string agentId {"1"};
@@ -104,4 +144,38 @@ TEST_F(BuildAllAgentListContextTest, ExceptionOnDB)
     EXPECT_THROW(allAgentContext->handleRequest(scanContext), WdbDataException);
 
     spSocketDBWrapperMock.reset();
+}
+
+TEST_F(BuildAllAgentListContextTest, BuildAllAgentListContextWithElementsInCluster)
+{
+    // Initialize policy manager
+    auto policyManager = std::make_unique<PolicyManager>();
+    policyManager->initialize(configClusterEnable);
+
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    nlohmann::json queryResult = nlohmann::json::parse(R"(
+    [
+        {
+            "id": 1,
+            "name": "name",
+            "version": "Wazuh 4.4.4",
+            "ip": "192.168.0.1",
+            "node_name": "node_1"
+        }
+    ])");
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    auto allAgentContext =
+        std::make_shared<TBuildAllAgentListContext<TrampolineScanContext, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<TrampolineScanContext>();
+
+    // Context is not used
+    allAgentContext->handleRequest(scanContext);
+
+    EXPECT_EQ(scanContext->m_agents.size(), 1);
 }


### PR DESCRIPTION
|Related issue|
|---|
| #23646 |

## Description
This PR updates the re-scan logic used on the vulnerability scanner to prevent data loss in a cluster environment

If we are running in a cluster environment we shouldn't index the re-scanned data, but relly on the synchronization mechanism between indices