### PR TITLE
Add conditional to avoid full-scan in content generation, to avoid failure.

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -400,18 +400,22 @@ void VulnerabilityScannerFacade::start(
             true,
             reloadGlobalMapsStartup,
             initContentUpdater,
-            [this]()
+            [this, reloadGlobalMapsStartup]()
             {
-                nlohmann::json actionData;
-                actionData["action"] = "reboot";
-                // We shouldn't index if we are in a cluster environment
-                actionData["no-index"] = PolicyManager::instance().getClusterStatus();
+                // Re-scan all agent after content update, only if is an instance of vulnerability scanner.
+                if (reloadGlobalMapsStartup)
+                {
+                    nlohmann::json actionData;
+                    actionData["action"] = "reboot";
+                    // We shouldn't index if we are in a cluster environment
+                    actionData["no-index"] = PolicyManager::instance().getClusterStatus();
 
-                const std::string actionDataString = actionData.dump();
-                const std::vector<char> actionMessage(actionDataString.begin(), actionDataString.end());
+                    const std::string actionDataString = actionData.dump();
+                    const std::vector<char> actionMessage(actionDataString.begin(), actionDataString.end());
 
-                pushEvent(actionMessage, BufferType::BufferType_JSON);
-                logInfo(WM_VULNSCAN_LOGTAG, "Triggered a re-scan after content update");
+                    pushEvent(actionMessage, BufferType::BufferType_JSON);
+                    logInfo(WM_VULNSCAN_LOGTAG, "Triggered a re-scan after content update");
+                }
             });
 
         // Add subscribers for policy updates.


### PR DESCRIPTION
|Related issue|
|---|
|Close #23654|

## Description

This pr aims to add a conditional to avoid full-scan trigger during the content generation mode in the VD component.