### PR TITLE
Create wazuh-db template file after dropping permissions

### DIFF
--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -137,7 +137,6 @@ int main(int argc, char ** argv)
     snprintf(path_template, sizeof(path_template), "%s/%s/%s", home_path, WDB2_DIR, WDB_PROF_NAME);
     unlink(path_template);
     mdebug1("Template file removed: %s", path_template);
-    wdb_create_profile();
 
     // Set max open files limit
     struct rlimit rlimit = { nofile, nofile };
@@ -203,6 +202,10 @@ int main(int argc, char ** argv)
     // Global stats uptime
 
     wdb_state.uptime = time(NULL);
+
+    // Create template
+
+    wdb_create_profile();
 
     // Start threads
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #23623 |

## Description

The upgrade check for version 4.7.5 identified a discrepancy in the permission set of the Wazuh-DB template file for agents compared to version 4.7.4. 

```
-rw-r-----  1 root  wazuh 278528 May 27 08:18 .template.db
              ^^^^
```

### Rationale

This issue arises because Wazuh-DB attempts to create the file during startup, but does so prematurely—before it has relinquished root permissions.

## Proposed fix

The proposed solution is to postpone the file creation until after the process has dropped root privileges and switched to the "wazuh" user, but before initiating the worker threads:

```
-rw-r-----  1 wazuh wazuh 278528 May 27 08:18 .template.db
              ^^^^^
```

## Tests

- [X] **Check file permissions.**
    The problem reported does no longer occur.
- [x] **Stress tests.**
    Check that the fix applied by #23467 is still valid. 