### PR TITLE
Add AWS Integration Tests workflow

### DIFF
--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -7,10 +7,6 @@ on:
         description: 'Base branch'
         required: true
         default: 'main'
-  pull_request:
-    types: [opened, ready_for_review]
-    paths:
-      - wodles/aws/**
 
 jobs:
   build:
@@ -80,8 +76,105 @@ jobs:
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
+      - name: Set AWS credentials file
+        run: |
+          cat >> /root/.aws/credentials << EOF
+          [default]
+          aws_access_key_id=$AWS_ACCESS_KEY_ID
+          aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+          region=us-east-1
+          EOF
       # Run AWS integration tests.
-      - name: Run AWS integration tests
+      - name: Run Parser related tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_s3.py') ||
+            contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_tools.py')
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 0 --tier 1 test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/test_parser.py
+      - name: Run every test due to base WazuhIntegration class change
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/wazuh_integration.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/
+      - name: Run Buckets tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_s3.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_tools.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/test_parser.py
+      # Bucket tests
+      - name: Run Buckets tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k macie test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k trusted_advisor test_aws/
+      - name: Run Config tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/config.py') ||
+            contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k config test_aws/
+      - name: Run GuardDuty tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/guardduty.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k guardduty test_aws/
+      - name: Run CloudTrail tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/cloudtrail.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k config test_aws/
+      - name: Run Load Balancers tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/load_balancers.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k alb test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k clb test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k nlb test_aws/
+      - name: Run Server Access tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/server_access.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k server_access test_aws/
+      - name: Run Umbrella tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/umbrella.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k cisco test_aws/
+      - name: Run VPC Flow tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/vpcflow.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k vpc test_aws/
+      - name: Run WAF tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/waf.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k waf test_aws/
+      # Services tests
+      - name: Run CloudWatch tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/cloudwatchlogs.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/aws_service.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k cloudwatch test_aws/
+      - name: Run Inspector tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/inspector.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/aws_service.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k inspector test_aws/
+      # Custom Logs Buckets tests
+      - name: Run Inspector tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/subscribers/**')
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 test_aws/test_custom_bucket.py

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -13,6 +13,7 @@ on:
         default: 'main'
   pull_request:
     paths:
+      - ".github/workflows/integration-tests-aws-tier-0-1.yml"
       - "wodles/aws/**"
 
 jobs:
@@ -20,7 +21,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-      QA_IT_FW_BRANCH: ${{ inputs.base_qa_it_fw_branch }}
+      QA_IT_FW_BRANCH: ${{ github.base_ref || inputs.base_qa_it_fw_branch }}
       AWS_ACCESS_KEY_ID: ${{ secrets.IT_AWS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: 'us-east-1'
@@ -33,15 +34,12 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Set AWS credentials file
-        run: |
-          sudo aws configure set aws_access_key_id ${{ secrets.IT_AWS_KEY_ID }} --profile default
-          sudo aws configure set aws_secret_access_key ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }} --profile default
-          sudo aws configure set default.region us-east-1 --profile default
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${QA_IT_FW_BRANCH}`" != "X" ]; then
+          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${QA_IT_FW_BRANCH}`" != "X" ]; then
               QA_BRANCH=${QA_IT_FW_BRANCH}
           else
               QA_BRANCH="main"
@@ -49,6 +47,11 @@ jobs:
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
+      - name: Set AWS credentials file
+        run: |
+          sudo aws configure set aws_access_key_id ${{ secrets.IT_AWS_KEY_ID }} --profile default
+          sudo aws configure set aws_secret_access_key ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }} --profile default
+          sudo aws configure set default.region ${AWS_DEFAULT_REGION} --profile default
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -125,7 +128,7 @@ jobs:
           contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
         run: |
           cd tests/integration
-          sudo python3 -m pytest --tier 0 --tier 1 -k config test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k cloudtrail test_aws/
       - name: Run Load Balancers tests
         if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/load_balancers.py') ||
           contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -16,8 +16,8 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.ITS_AWS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.ITS_AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.IT_AWS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: 'us-east-1'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -1,0 +1,87 @@
+name: Integration tests for AWS - Tier 0 and 1
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
+  pull_request:
+    types: [opened, ready_for_review]
+    paths:
+      - wodles/aws/**
+
+jobs:
+  build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.ITS_AWS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.ITS_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: 'us-east-1'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: ".github/workflows/.python-version-it"
+          architecture: x64
+      # Install wazuh server for linux.
+      - name: Install wazuh server for linux
+        run: |
+          echo 'USER_LANGUAGE="en"' > ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_NO_STOP="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_INSTALL_TYPE="server"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo "USER_DIR=/var/ossec" >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_EMAIL="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSCHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ROOTCHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSCOLLECTOR="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SCA="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_WHITE_LIST="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_UPDATE_CHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          sudo sh install.sh
+          rm ./etc/preloaded-vars.conf
+      # Build wazuh server for linux.
+      - name: Build wazuh server for linux
+        run: |
+          make deps -C src TARGET=server -j2
+          make -C src TARGET=server -j2
+      # Download and install integration tests framework.
+      - name: Download and install integration tests framework
+        run: |
+          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_NAME}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
+          sudo pip install qa-integration-framework/
+          sudo rm -rf qa-integration-framework/
+      # Run AWS integration tests.
+      - name: Run AWS integration tests
+        run: |
+          cd tests/integration
+          sudo python -m pytest --tier 0 --tier 1 test_aws/

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -28,6 +28,16 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
+      - name: Set AWS credentials file
+        run: |
+          sudo aws configure set aws_access_key_id ${{ secrets.IT_AWS_KEY_ID }} --profile default
+          sudo aws configure set aws_secret_access_key ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }} --profile default
+          sudo aws configure set default.region us-east-1 --profile default
+      # Build wazuh server for linux.
+      - name: Build wazuh server for linux
+        run: |
+          make deps -C src TARGET=server -j2
+          make -C src TARGET=server -j2
       # Install wazuh server for linux.
       - name: Install wazuh server for linux
         run: |
@@ -61,11 +71,6 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           sudo sh install.sh
           rm ./etc/preloaded-vars.conf
-      # Build wazuh server for linux.
-      - name: Build wazuh server for linux
-        run: |
-          make deps -C src TARGET=server -j2
-          make -C src TARGET=server -j2
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
@@ -77,16 +82,9 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
+          sudo pip install -r qa-integration-framework/requirements.txt
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
-      - name: Set AWS credentials file
-        run: |
-          cat >> /root/.aws/credentials << EOF
-          [default]
-          aws_access_key_id=$AWS_ACCESS_KEY_ID
-          aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
-          region=us-east-1
-          EOF
       # Run AWS integration tests.
       - name: Run Parser related tests
         if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_s3.py') ||
@@ -180,5 +178,6 @@ jobs:
       # Custom Logs Buckets tests
       - name: Run Inspector tests
         if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/subscribers/**')
+        run: |
           cd tests/integration
           sudo python3 -m pytest --tier 0 --tier 1 test_aws/test_custom_bucket.py

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -7,6 +7,10 @@ on:
         description: 'Base branch'
         required: true
         default: 'main'
+      base_qa_it_fw_branch:
+        description: 'Base qa-integration-framework branch'
+        required: true
+        default: 'main'
   pull_request:
     paths:
       - "wodles/aws/**"
@@ -16,6 +20,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
+      QA_IT_FW_BRANCH: ${{ inputs.base_qa_it_fw_branch }}
       AWS_ACCESS_KEY_ID: ${{ secrets.IT_AWS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: 'us-east-1'
@@ -33,6 +38,17 @@ jobs:
           sudo aws configure set aws_access_key_id ${{ secrets.IT_AWS_KEY_ID }} --profile default
           sudo aws configure set aws_secret_access_key ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }} --profile default
           sudo aws configure set default.region us-east-1 --profile default
+      # Download and install integration tests framework.
+      - name: Download and install integration tests framework
+        run: |
+          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${QA_IT_FW_BRANCH}`" != "X" ]; then
+              QA_BRANCH=${QA_IT_FW_BRANCH}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
+          sudo pip install qa-integration-framework/
+          sudo rm -rf qa-integration-framework/
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -71,41 +87,21 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           sudo sh install.sh
           rm ./etc/preloaded-vars.conf
-      # Download and install integration tests framework.
-      - name: Download and install integration tests framework
-        run: |
-          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_NAME}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_NAME}
-          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
-              QA_BRANCH=${BRANCH_BASE}
-          else
-              QA_BRANCH="main"
-          fi
-          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install -r qa-integration-framework/requirements.txt
-          sudo pip install qa-integration-framework/
-          sudo rm -rf qa-integration-framework/
       # Run AWS integration tests.
       - name: Run Parser related tests
         if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_s3.py') ||
             contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_tools.py')
         run: |
           cd tests/integration
-          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/test_parser.py
-      - name: Run every test due to base WazuhIntegration class change
+          sudo python3 -m pytest --tier 0 --tier 1 test_aws/test_parser.py
+      - name: Run every test due to base WazuhIntegration class change or manual dispatch
         if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/wazuh_integration.py') ||
             ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           cd tests/integration
-          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/
-      - name: Run Buckets tests
-        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_s3.py') ||
-          contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_tools.py')
-        run: |
-          cd tests/integration
-          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/test_parser.py
+          sudo python3 -m pytest --tier 0 --tier 1 test_aws/
       # Bucket tests
-      - name: Run Buckets tests
+      - name: Run Custom Buckets tests
         if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
         run: |
           cd tests/integration

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -7,6 +7,9 @@ on:
         description: 'Base branch'
         required: true
         default: 'main'
+  pull_request:
+    paths:
+      - "wodles/aws/**"
 
 jobs:
   build:
@@ -92,7 +95,8 @@ jobs:
           cd tests/integration
           sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/test_parser.py
       - name: Run every test due to base WazuhIntegration class change
-        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/wazuh_integration.py')
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/wazuh_integration.py') ||
+            ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           cd tests/integration
           sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/

--- a/tests/integration/test_aws/README.md
+++ b/tests/integration/test_aws/README.md
@@ -72,10 +72,56 @@ aws_access_key_id = <access-key-value>
 aws_secret_access_key = <secret-key-value>
 ```
 
-The tests do not expect a particular profile given these can be executed for any AWS environment in which the 
-profile has the corresponding permissions to create, delete and list S3, VPC (like Flow Logs) and
-CloudWatch Logs resources. If a particular profile is required, it can be defined by declaring the `AWS_PROFILE` 
-environment variable.
+The provided credentials must have the following set of minimum permissions defined in AWS:
+```
+    "s3:PutObject",
+    "s3:PutObjectAcl",
+    "s3:GetObject",
+    "s3:GetObjectAcl",
+    "s3:ListBucket",
+    "s3:CreateBucket",
+    "s3:DeleteObject",
+    "s3:DeleteBucket",
+    "s3:PutBucketNotification",
+    "s3:GetBucketAcl"
+
+    "ec2:CreateVpc",
+    "ec2:CreateSubnet",
+    "ec2:DescribeAvailabilityZones",
+    "ec2:CreateRouteTable",
+    "ec2:CreateRoute",
+    "ec2:AssociateRouteTable",
+    "ec2:ModifyVpcAttribute",
+    "ec2:DeleteFlowLogs",
+    "ec2:DeleteVpc",
+    "ec2:DeleteRouteTable",
+    "ec2:DeleteRoute",
+    "ec2:CreateFlowLogs",
+    "ec2:DescribeFlowLogs",
+    "ec2:CreateTags"
+
+   "logs:CreateLogStream",
+    "logs:DeleteLogGroup",
+    "logs:DescribeLogStreams",
+    "logs:CreateLogGroup",
+    "logs:GetLogEvents",
+    "logs:DeleteLogStream",
+    "logs:PutLogEvents",
+    "logs:CreateLogDelivery",
+    "logs:DeleteLogDelivery",
+    "logs:PutResourcePolicy"
+
+    "sqs:ReceiveMessage",
+    "sqs:CreateQueue",
+    "sqs:DeleteMessage",
+    "sqs:DeleteQueue",
+    "sqs:SetQueueAttributes",
+    "sqs:GetQueueAttributes",
+    "sqs:GetQueueUrl"
+
+    "inspector:ListFindings",
+    "inspector:DescribeFindings"
+```
 
 ## Setting up a test environment
 

--- a/tests/integration/test_aws/README.md
+++ b/tests/integration/test_aws/README.md
@@ -105,7 +105,7 @@ _We are using **Ubuntu 22.04** for this example:_
     ```shell script
     # Install pip
     apt install python3-pip git -y
-  
+
     # Clone `wazuh` repository within your testing environment
     git clone https://github.com/wazuh/wazuh.git
 


### PR DESCRIPTION
|Related issue|
|---|
| #20975 |

## Description

Adds the GitHub Actions workflow to run the AWS module integration tests taking into account the modified files to avoid running every test in each launch.

> The `Run workflow` option appears only after it's merged.

## Tests

Manual execution using GitHub CLI:
```console
gh api  --method POST   -H "Accept: application/vnd.github+json"   -H "X-GitHub-Api-Version: 2022-11-28"   /repos/wazuh/wazuh/actions/workflows/integration-tests-aws-tier-0-1.yml/dispatches    -f "ref=enhancement/20975-add-aws-it-ga-workflow" -f "inputs[base_branch]=enhancement/20975-add-aws-it-ga-workflow" -f "inputs[base_qa_it_fw_branch]=17788-migrate-aws-integration-tests"
```

[Integration tests for AWS - Tier 0 and 1](https://github.com/wazuh/wazuh/actions/workflows/integration-tests-aws-tier-0-1.yml)

The expected results are the following (until https://github.com/wazuh/wazuh/issues/23431 is merged):
https://github.com/wazuh/wazuh/actions/runs/9269028458/job/25498966467
```
========================================================================================= short test summary info =========================================================================================
FAILED wazuh/tests/integration/test_aws/test_regions.py::test_regions[cloudtrail_inexistent_region] - AssertionError: The AWS module did not show correct message about non-existent region
FAILED wazuh/tests/integration/test_aws/test_regions.py::test_regions[vpc_inexistent_region] - AssertionError: The AWS module did not show correct message about non-existent region
FAILED wazuh/tests/integration/test_aws/test_regions.py::test_regions[config_inexistent_region] - AssertionError: The AWS module did not show correct message about non-existent region
FAILED wazuh/tests/integration/test_aws/test_regions.py::test_regions[alb_inexistent_region] - AssertionError: The AWS module did not show correct message about non-existent region
FAILED wazuh/tests/integration/test_aws/test_regions.py::test_regions[clb_inexistent_region] - AssertionError: The AWS module did not show correct message about non-existent region
FAILED wazuh/tests/integration/test_aws/test_regions.py::test_regions[nlb_inexistent_region] - AssertionError: The AWS module did not show correct message about non-existent region
=============================================================== 6 failed, 188 passed, 3 skipped, 2 xfailed, 1 warning in 5265.21s (1:27:45) ===============================================================
```