### PR TITLE
 Wazuh manager workflow: Improve installers' naming handling 

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -126,12 +126,12 @@ jobs:
           # Every call to this workflow will be internally managed as amd64, which is synonymous with x86_64
           echo "generate_package.sh -a amd64 --tag ${{ env.TAG }} --system ${{ inputs.system }} $FLAGS"
           bash generate_package.sh -a amd64 --tag ${{ env.TAG }} --system ${{ inputs.system }} $FLAGS
+          echo "PACKAGE_NAME=$(find /tmp -maxdepth 1 -type f -name *manager*.${{ inputs.system }} -exec basename {} 2>/dev/null \;)" | tee -a $GITHUB_ENV
 
       - name: Test install built manager
         run: |
-          package_name=$(find /tmp -maxdepth 1 -type f -name "*manager*.${{ inputs.system }}" -exec basename {} 2>/dev/null \;)
-          if [ -z "$package_name" ]; then echo "No package found matching the pattern!"; exit 1; fi
-          sudo docker run -v $GITHUB_WORKSPACE/.github/actions/test-install-components/:/tests -v /tmp/:/packages --entrypoint '/tests/install_component.sh' $CONTAINER_NAME:${{ env.TAG }} $package_name manager
+          if [ -z "${{ env.PACKAGE_NAME }}" ]; then echo "No package found matching the pattern!"; exit 1; fi
+          sudo docker run -v $GITHUB_WORKSPACE/.github/actions/test-install-components/:/tests -v /tmp/:/packages --entrypoint '/tests/install_component.sh' $CONTAINER_NAME:${{ env.TAG }} $PACKAGE_NAME manager
           # Check if Wazuh was installed. The /tmp/status.log file was generated in the previous step.
           if grep -iq " installed.*wazuh-manager" /tmp/status.log ; then
             echo "Installation successfully."
@@ -150,9 +150,9 @@ jobs:
       - name: Upload package to S3
         working-directory: packages
         run: |
-          aws s3 cp /tmp/*manager*.${{ inputs.system }} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          aws s3 cp /tmp/${{ env.PACKAGE_NAME }} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
 
       - name: Upload checksum to S3
         if: ${{ inputs.checksum == true }}
         run: |
-          aws s3 cp /tmp/*manager*.${{ inputs.system }}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          aws s3 cp /tmp/${{ env.PACKAGE_NAME }}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23777|

## Description

To avoid the use of a wildcard when pushing the package to s3, we define a GitHub environment variable with the package name.

## Tests
Workflow run: https://github.com/wazuh/wazuh/actions/runs/9293743483/job/25577557479


![use_github_env_pkg_name](https://github.com/wazuh/wazuh/assets/21695385/6ad70348-3fc5-4e0f-8b78-bd0004e65ea8)

