### PR TITLE
Fixes for coverity issues (uncheck return value and unhandled exception)

### DIFF
--- a/src/shared_modules/keystore/src/main.cpp
+++ b/src/shared_modules/keystore/src/main.cpp
@@ -23,16 +23,16 @@ namespace Log
 
 int main(int argc, char* argv[])
 {
-    // Define current working directory
-    std::filesystem::path home_path = Utils::findHomeDirectory();
-    std::filesystem::current_path(home_path);
-
     std::string family;
     std::string key;
     std::string value;
 
     try
     {
+        // Define current working directory
+        std::filesystem::path home_path = Utils::findHomeDirectory();
+        std::filesystem::current_path(home_path);
+
         CmdLineArgs args(argc, argv);
 
         family = args.getColumnFamily();
@@ -43,13 +43,13 @@ int main(int argc, char* argv[])
     }
     catch (const CmdLineArgsException& e)
     {
-        std::cerr << e.what() << std::endl;
+        std::cerr << e.what() << "\n";
         CmdLineArgs::showHelp();
         return 1;
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what() << std::endl;
+        std::cerr << e.what() << "\n";
         return 1;
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/expected_004.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/expected_004.out
@@ -1,4 +1,3 @@
 [
-    "Initiating a vulnerability scan for package 'brotli' (pkg) ( ) with CVE Numbering Authorities (CNA) 'nvd' on Agent '' (ID: '002', Version: '').",
-    "The vendor information is not available for Package: brotli, Version: 1.1.0, CVE: CVE-2020-8927, Content vendor: google"
+    "Initiating a vulnerability scan for package 'brotli' (pkg) ( ) with CVE Numbering Authorities (CNA) 'homebrew' on Agent '' (ID: '002', Version: '')."
 ]

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -379,7 +379,10 @@ void VulnerabilityScannerFacade::start(
 
         // Query the current database version.
         std::string databaseVersion;
-        stateDB->get(VD_DATABASE_VERSION_KEY, databaseVersion);
+        if (stateDB->get(VD_DATABASE_VERSION_KEY, databaseVersion))
+        {
+            logDebug1(WM_VULNSCAN_LOGTAG, "Database version: %s", databaseVersion.c_str());
+        }
 
         // Decompress database content.
         if (decompressDatabase(databaseVersion) && !m_shouldStop.load())


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23738|
|Closes #23739|

## Description
This PR aims to solve some problems discovered by the Coverity static analysis.

To mention these problems, the first one is an Unhandled exception in the tool to write the credentials used by the indexer connector, and the second one is an unchecked return value during the content load in some content upgrades.