### PR TITLE
Add wodles utils unit tests

### DIFF
--- a/wodles/tests/test_utils.py
+++ b/wodles/tests/test_utils.py
@@ -1,0 +1,75 @@
+import os
+import pytest
+import subprocess
+import sys
+from unittest.mock import Mock, patch
+
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+from utils import find_wazuh_path, call_wazuh_control, get_wazuh_info, get_wazuh_version
+
+
+@pytest.mark.parametrize('path, expected', [
+    ('/var/ossec/wodles/aws', '/var/ossec'),
+    ('/my/custom/path/wodles/aws', '/my/custom/path'),
+    ('/my/fake/path', '')
+])
+def test_find_wazuh_path(path, expected):
+    """Validate that the Wazuh absolute path is returned successfully."""
+    with patch('utils.__file__', new=path):
+        assert (find_wazuh_path.__wrapped__() == expected)
+
+
+def test_find_wazuh_path_relative_path():
+    """Validate that the Wazuh relative path is returned successfully."""
+    with patch('os.path.abspath', return_value='~/wodles'):
+        assert (find_wazuh_path.__wrapped__() == '~')
+
+
+@patch("subprocess.Popen")
+@pytest.mark.parametrize('option', ['info', 'status'])
+def test_call_wazuh_control(mock_popen, option):
+    """Validate that the call_wazuh_control function works correctly."""
+    b_output = b'output'
+    process_mock = Mock()
+    attrs = {'communicate.return_value': (b_output, b'error')}
+    process_mock.configure_mock(**attrs)
+    mock_popen.return_value = process_mock
+
+    output = call_wazuh_control(option)
+    assert output == b_output.decode()
+    mock_popen.assert_called_once_with([os.path.join(find_wazuh_path(), "bin", "wazuh-control"), option], 
+                                               stdout=subprocess.PIPE)
+
+
+def test_call_wazuh_control_ko():
+    """Validate that call_wazuh_control exists with a code 1 when there's a system error."""
+    with pytest.raises(SystemExit) as sys_exit:
+        with patch('subprocess.Popen', side_effect=OSError):
+            call_wazuh_control('info')
+
+    assert sys_exit.type == SystemExit
+    assert sys_exit.value.code == 1
+
+
+@pytest.mark.parametrize('field, wazuh_info, expected', [
+    ('WAZUH_VERSION', 'WAZUH_VERSION="v5.0.0"\nWAZUH_REVISION="50000"\nWAZUH_TYPE="server"\n', 'v5.0.0'),
+    ('WAZUH_REVISION', 'WAZUH_VERSION="v5.0.0"\nWAZUH_REVISION="50000"\nWAZUH_TYPE="server"\n', '50000'),
+    ('WAZUH_TYPE', 'WAZUH_VERSION="v5.0.0"\nWAZUH_REVISION="50000"\nWAZUH_TYPE="server"\n', 'server'),
+    (None, 'WAZUH_REVISION="50000"', 'WAZUH_REVISION="50000"'),
+    ('WAZUH_TYPE', None, 'ERROR')
+])
+def test_get_wazuh_info(field, wazuh_info, expected):
+    """Validate that get_wazuh_info returns the correct information."""
+    with patch('utils.call_wazuh_control', return_value=wazuh_info):
+        actual = get_wazuh_info(field)
+        assert actual == expected
+
+
+def test_get_wazuh_version():
+    """Validate that get_wazuh_version returns the correct information."""
+    wazuh_info = 'WAZUH_VERSION="v5.0.0"\nWAZUH_REVISION="50000"\nWAZUH_TYPE="server"\n'
+    expected = 'v5.0.0'
+    with patch('utils.call_wazuh_control', return_value=wazuh_info):
+        version = get_wazuh_version()
+
+    assert version == expected

--- a/wodles/utils.py
+++ b/wodles/utils.py
@@ -111,32 +111,6 @@ def get_wazuh_version() -> str:
     return get_wazuh_info("WAZUH_VERSION")
 
 
-@lru_cache(maxsize=None)
-def get_wazuh_revision() -> str:
-    """
-    Return the revision of the Wazuh instance installed.
-
-    Returns
-    -------
-    str
-        The revision of the Wazuh instance installed.
-    """
-    return get_wazuh_info("WAZUH_REVISION")
-
-
-@lru_cache(maxsize=None)
-def get_wazuh_type() -> str:
-    """
-    Return the type of Wazuh instance installed.
-
-    Returns
-    -------
-    str
-        The type of Wazuh instance installed.
-    """
-    return get_wazuh_info("WAZUH_TYPE")
-
-
 ANALYSISD = os.path.join(find_wazuh_path(), 'queue', 'sockets', 'queue')
 # Max size of the event that ANALYSISID can handle
 MAX_EVENT_SIZE = 65535


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23305 |

## Description

Adds unit tests to cover the methods under `wodles/utils.py` and removes unused methods.

## Tests

<details><summary>Tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest wodles/tests/test_utils.py --cov
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/wodles
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 13 items                                                                                                                                                              

wodles/tests/test_utils.py .............                                                                                                                                  [100%]

---------- coverage: platform linux, python 3.10.14-final-0 ----------
Name                         Stmts   Miss  Cover
------------------------------------------------
wodles/tests/test_utils.py      42      0   100%
wodles/utils.py                 52      0   100%
------------------------------------------------
TOTAL                           94      0   100%


============================================================================== 13 passed in 0.08s ===============================================================================
```

</details>

Python unit tests coverage action: https://github.com/wazuh/wazuh/actions/runs/9305481326

<details><summary>Wodles coverage</summary>

 ### WODLES

| | | | | |
|--|--|--|--|--|
| **Name** | **Stmts** | **Miss** | **Cover** | **Status** |
| wodles/__init__.py | 0 | 0 | 100% | :green_square: |
| wodles/aws/__init__.py | 0 | 0 | 100% | :green_square: |
| wodles/aws/aws_s3.py | 94 | 18 | 81% | :green_square: |
| wodles/aws/aws_tools.py | 147 | 15 | 90% | :green_square: |
| wodles/aws/buckets_s3/__init__.py | 10 | 0 | 100% | :green_square: |
| wodles/aws/buckets_s3/aws_bucket.py | 426 | 16 | 96% | :green_square: |
| wodles/aws/buckets_s3/cloudtrail.py | 26 | 3 | 88% | :green_square: |
| wodles/aws/buckets_s3/config.py | 91 | 7 | 92% | :green_square: |
| wodles/aws/buckets_s3/guardduty.py | 64 | 1 | 98% | :green_square: |
| wodles/aws/buckets_s3/load_balancers.py | 69 | 0 | 100% | :green_square: |
| wodles/aws/buckets_s3/server_access.py | 137 | 12 | 91% | :green_square: |
| wodles/aws/buckets_s3/umbrella.py | 22 | 0 | 100% | :green_square: |
| wodles/aws/buckets_s3/vpcflow.py | 102 | 15 | 85% | :green_square: |
| wodles/aws/buckets_s3/waf.py | 38 | 0 | 100% | :green_square: |
| wodles/aws/services/__init__.py | 4 | 0 | 100% | :green_square: |
| wodles/aws/services/aws_service.py | 45 | 0 | 100% | :green_square: |
| wodles/aws/services/cloudwatchlogs.py | 191 | 7 | 96% | :green_square: |
| wodles/aws/services/inspector.py | 56 | 6 | 89% | :green_square: |
| wodles/aws/subscribers/__init__.py | 4 | 0 | 100% | :green_square: |
| wodles/aws/subscribers/s3_log_handler.py | 114 | 12 | 89% | :green_square: |
| wodles/aws/subscribers/sqs_message_processor.py | 35 | 1 | 97% | :green_square: |
| wodles/aws/subscribers/sqs_queue.py | 60 | 7 | 88% | :green_square: |
| wodles/aws/tests/__init__.py | 0 | 0 | 100% | :green_square: |
| wodles/aws/tests/aws_utils.py | 113 | 0 | 100% | :green_square: |
| wodles/aws/wazuh_integration.py | 231 | 20 | 91% | :green_square: |
| wodles/azure/azure-logs.py | 437 | 36 | 92% | :green_square: |
| wodles/azure/orm.py | 141 | 0 | 100% | :green_square: |
| wodles/docker-listener/DockerListener.py | 93 | 6 | 94% | :green_square: |
| wodles/gcloud/buckets/access_logs.py | 16 | 0 | 100% | :green_square: |
| wodles/gcloud/buckets/bucket.py | 128 | 2 | 98% | :green_square: |
| wodles/gcloud/exceptions.py | 23 | 0 | 100% | :green_square: |
| wodles/gcloud/gcloud.py | 68 | 1 | 99% | :green_square: |
| wodles/gcloud/integration.py | 38 | 2 | 95% | :green_square: |
| wodles/gcloud/pubsub/subscriber.py | 60 | 2 | 97% | :green_square: |
| wodles/gcloud/tools.py | 41 | 0 | 100% | :green_square: |
| wodles/utils.py | 52 | 0 | 100% | :green_square: |
| TOTAL | 3176 | 189 | 94% | :green_square: |


</details>