### PR TITLE
Wazuh manager workflow continued when the package build failed

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -90,6 +90,7 @@ on:
 jobs:
   Build-manager-packages:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
     steps:

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   Filebeat-module-generation:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/packages-retag-images.yml
+++ b/.github/workflows/packages-retag-images.yml
@@ -22,7 +22,7 @@ on:
         required: false
         default: ''
   push:
-    branches: 
+    branches:
       - '[0-9]+.[0-9]+.[0-9]+'
       - 'master'
     paths:
@@ -31,6 +31,7 @@ on:
 jobs:
   Upload-package-building-images:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: Package - Retag Docker images
 
     steps:
@@ -59,7 +60,7 @@ jobs:
         run: |
           VERSION=$(sed 's/^v\([0-9]*\.[0-9]*\.[0-9]*\)/\1/' $GITHUB_WORKSPACE/src/VERSION)
           echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV;
-    
+
       - name: Run retag script
         run: |
           if [ "${{ inputs.old_version }}" != "none" ] && [ "${{ inputs.new_version }}" != "none" ]; then

--- a/.github/workflows/packages-upload-manager-images.yml
+++ b/.github/workflows/packages-upload-manager-images.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   Upload-package-building-images:
     runs-on: ubuntu-latest
+    timeout-minutes: 140
     name: Package - Upload pkg_${{ inputs.system }}_manager_builder_amd64 with tag ${{ inputs.docker_image_tag }}
 
     steps:

--- a/packages/build.sh
+++ b/packages/build.sh
@@ -7,6 +7,7 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
+set -e
 
 build_directories() {
   local build_folder=$1

--- a/packages/debs/utils/helper_function.sh
+++ b/packages/debs/utils/helper_function.sh
@@ -56,6 +56,7 @@ build_package(){
     else
         linux32 debuild --rootcmd=sudo -ai386 -b -uc -us -nc
     fi
+    return $?
 }
 
 get_package_and_checksum(){

--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -8,7 +8,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -x
+set -ex
 CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 WAZUH_PATH="$(cd $CURRENT_PATH/..; pwd -P)"
 ARCHITECTURE="amd64"

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ex
 # Program to build and package OSX wazuh-agent
 # Wazuh package generator
 # Copyright (C) 2015, Wazuh Inc.

--- a/packages/rpms/utils/helper_function.sh
+++ b/packages/rpms/utils/helper_function.sh
@@ -80,7 +80,7 @@ build_package(){
         --define "_localstatedir ${INSTALLATION_PATH}" --define "_debugenabled ${debug}" \
         --define "_version ${wazuh_version}" --define "_hashcommit ${short_commit_hash}" \
         --target $ARCH -ba ${rpm_build_dir}/SPECS/${package_name}.spec
-    return 0
+    return $?
 }
 
 get_package_and_checksum(){

--- a/packages/windows/generate_compiled_windows_agent.sh
+++ b/packages/windows/generate_compiled_windows_agent.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-set -x
+set -ex
 
 BRANCH=""
 JOBS="4"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23779|

## Description
This PR fixed the issue when a build process failed but the process continued when it should have been stopped.

I have also added a timeout for all the packages workflows.

<div align="center">

| Workflow                                     | Timeout |
|----------------------------------------------|---------|
| packages-build-manager.yml                   | 35      |
| packages-filebeat.yml                        | 1       |
| packages-retag-images.yml                    | 20      |
| packages-upload-manager-images.yml           | 140     |

</div>

## Tests
To test whether the process stops after a failure, I created a branch from the commit https://github.com/wazuh/wazuh/commit/efb7bc307cc08a2f9a2a1d89fc11f0950fc21a36 where the failure was reported, and then I added my changes.

![image](https://github.com/wazuh/wazuh/assets/21695385/144f0420-984a-4a75-be32-20da49c09c91)

**Branch used:** _delete/23779-Testing-fix-on-commit-efb7bc3_
Workflow run: https://github.com/wazuh/wazuh/actions/runs/9349913765/job/25732265466