### PR TITLE
integratord - Remove sensitive information from log files

### DIFF
--- a/integrations/maltiverse.py
+++ b/integrations/maltiverse.py
@@ -234,12 +234,12 @@ def main(args: list):
         if len(args) >= 4:
             debug_enabled = len(args) > 4 and args[4] == 'debug'
         else:
-            msg = '# ERROR: Wrong arguments'
+            msg = '# ERROR: Wrong arguments\n'
             bad_arguments = True
 
         # Logging the call
         with open(LOG_FILE, 'a') as f:
-            f.write(msg + '\n')
+            f.write(msg)
 
         if bad_arguments:
             debug('# ERROR: Exiting, bad arguments. Inputted: %s' % args)

--- a/integrations/maltiverse.py
+++ b/integrations/maltiverse.py
@@ -230,10 +230,8 @@ def main(args: list):
     try:
         # Read arguments
         bad_arguments = False
+        msg = ''
         if len(args) >= 4:
-            msg = '{0} {1} {2} {3} {4}'.format(
-                args[1], args[2], args[3], args[4] if len(args) > 4 else '', args[5] if len(args) > 5 else ''
-            )
             debug_enabled = len(args) > 4 and args[4] == 'debug'
         else:
             msg = '# ERROR: Wrong arguments'

--- a/integrations/pagerduty.py
+++ b/integrations/pagerduty.py
@@ -48,10 +48,8 @@ def main(args):
     try:
         # Read arguments
         bad_arguments: bool = False
+        msg = ''
         if len(args) >= 4:
-            msg = '{0} {1} {2} {3} {4}'.format(
-                args[1], args[2], args[3], args[4] if len(args) > 4 else '', args[5] if len(args) > 5 else ''
-            )
             debug_enabled = len(args) > 4 and args[4] == 'debug'
         else:
             msg = '# ERROR: Wrong arguments'

--- a/integrations/pagerduty.py
+++ b/integrations/pagerduty.py
@@ -52,12 +52,12 @@ def main(args):
         if len(args) >= 4:
             debug_enabled = len(args) > 4 and args[4] == 'debug'
         else:
-            msg = '# ERROR: Wrong arguments'
+            msg = '# ERROR: Wrong arguments\n'
             bad_arguments = True
 
         # Logging the call
         with open(LOG_FILE, 'a') as f:
-            f.write(msg + '\n')
+            f.write(msg)
 
         if bad_arguments:
             debug('# ERROR: Exiting, bad arguments. Inputted: %s' % args)

--- a/integrations/virustotal.py
+++ b/integrations/virustotal.py
@@ -69,12 +69,12 @@ def main(args):
             if len(args) > RETRIES_INDEX:
                 retries = int(args[RETRIES_INDEX])
         else:
-            msg = '# Error: Wrong arguments'
+            msg = '# Error: Wrong arguments\n'
             bad_arguments = True
 
         # Logging the call
         with open(LOG_FILE, 'a') as f:
-            f.write(msg + '\n')
+            f.write(msg)
 
         if bad_arguments:
             debug('# Error: Exiting, bad arguments. Inputted: %s' % args)

--- a/integrations/virustotal.py
+++ b/integrations/virustotal.py
@@ -61,16 +61,8 @@ def main(args):
     try:
         # Read arguments
         bad_arguments: bool = False
+        msg = ''
         if len(args) >= 4:
-            msg = '{0} {1} {2} {3} {4} {5} {6}'.format(
-                args[1],
-                args[2],
-                args[3],
-                args[4] if len(args) > 4 else '',
-                args[5] if len(args) > 5 else '',
-                args[TIMEOUT_INDEX] if len(args) > TIMEOUT_INDEX else timeout,
-                args[RETRIES_INDEX] if len(args) > RETRIES_INDEX else retries,
-            )
             debug_enabled = len(args) > 4 and args[4] == 'debug'
             if len(args) > TIMEOUT_INDEX:
                 timeout = int(args[TIMEOUT_INDEX])

--- a/src/os_integrator/integrator.c
+++ b/src/os_integrator/integrator.c
@@ -441,8 +441,6 @@ void OS_IntegratorD(IntegratorConfig **integrator_config)
 
             if (dbg_lvl <= 0) strcat(exec_full_cmd, " > /dev/null 2>&1");
 
-            mdebug1("Running script with args: %s", exec_full_cmd);
-
             char **cmd = OS_StrBreak(' ', exec_full_cmd, 9);
 
             if (cmd) {


### PR DESCRIPTION
|Related issue|
|---|
|#23648|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The objective of this PR is to prevent the publication of sensitive information in log files.

- Sensitive information will no longer be printed in the `ossec.log` file by removing a debug log statement from the `integrator.c` file.
- Sensitive information will no longer be printed in the `integrations.log` file by initializing the `msg` variable as empty in each integration script.

## Tests
### `integrations.log`
#### After
![image](https://github.com/wazuh/wazuh/assets/106940255/3540168d-898e-4988-9637-5b287c6832ce)

#### Before
![image](https://github.com/wazuh/wazuh/assets/106940255/72d8a974-7cc0-460b-97eb-155278e6d10b)


### `ossec.log`
#### After
![image](https://github.com/wazuh/wazuh/assets/106940255/10cb7966-61ad-42c1-848b-e10d43b3f20f)

#### Before
![image](https://github.com/wazuh/wazuh/assets/106940255/715b5940-c64c-4ed2-80db-608f586b8139)
