### PR TITLE
Extend wazuh-control lock timeout to 60 seconds

### DIFF
--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -29,7 +29,7 @@ LOCK_PID="${LOCK}/pid"
 # This number should be more than enough (even if it is
 # started multiple times together). It will try for up
 # to 10 attempts (or 10 seconds) to execute.
-MAX_ITERATION="10"
+MAX_ITERATION="60"
 
 MAX_KILL_TRIES=600
 

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -38,7 +38,7 @@ LOCK_PID="${LOCK}/pid"
 # This number should be more than enough (even if it is
 # started multiple times together). It will try for up
 # to 10 attempts (or 10 seconds) to execute.
-MAX_ITERATION="10"
+MAX_ITERATION="60"
 
 MAX_KILL_TRIES=600
 

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -42,7 +42,7 @@ LOCK_PID="${LOCK}/pid"
 # This number should be more than enough (even if it is
 # started multiple times together). It will try for up
 # to 10 attempts (or 10 seconds) to execute.
-MAX_ITERATION="10"
+MAX_ITERATION="60"
 
 MAX_KILL_TRIES=600
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #23221 |

This PR aims to extend the wazuh-control's lock timeout from 10 seconds to one minute. This is visible if wazuh-control is called under these conditions:
1. There is already another instance of wazuh-control running.
2. The above instance takes too long to finish.

## Test

1. Run a manager (or an agent).
2. Attach GDB to any two processes to prevent them from exiting.
3. Stop Wazuh.
4. Meanwhile, run `wazuh-control stop` again.

```shell
gdb -p `pidof wazuh-modulesd` /var/ossec/bin/wazuh-modulesd & \
gdb -p `pidof wazuh-logcollector` /var/ossec/bin/wazuh-logcollector & \
wazuh-control stop & \
time wazuh-control stop
```

> ERROR: Another instance is locking this process.
> If you are sure that no other instance is running, please remove /var/ossec/var/start-script-lock
>
> real    1m0.366s

(We expect ~1 minute execution time).

- [X] Tested on Wazuh Manager.
- [ ] Tested on Wazuh Agent.