### PR TITLE
Changed archicteture to i386 for windows docker images

### DIFF
--- a/.github/workflows/packages-upload-images.yml
+++ b/.github/workflows/packages-upload-images.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Request compile_windows_agent update
         if: steps.changes.outputs.compile_windows_agent == 'true'
         run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=windows -f architecture=windows -f source_reference=${{ github.ref_name }}
+          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=windows -f architecture=i386 -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23866|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team, this PR fixes a typo where the architecture for Windows docker images was set to Windows. Now it's set to `i386`.

## Testing

The workflow has been manually triggered with the new arguments: 

```console
gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r 4.9.0 -f docker_image_tag=4.9.0 -f system=windows -f architecture=i386 -f source_reference=4.9.0
```

[The jobs](https://github.com/wazuh/wazuh-agent-packages/actions/runs/9365344702/job/25780360155) is properly executed.

