### PR TITLE
Ensure `queue` folder is removed when agent is uninstalled in `deb` systems

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -29,6 +29,7 @@ case "$1" in
             rm -rf ${DIR}/var
             rm -rf ${DIR}/logs
             rm -rf ${DIR}/queue
+            rm -rf ${DIR}/etc/shared
         fi
 
         # Delete old .save

--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -28,6 +28,7 @@ case "$1" in
             rm -rf ${DIR}/ruleset
             rm -rf ${DIR}/var
             rm -rf ${DIR}/logs
+            rm -rf ${DIR}/queue
         fi
 
         # Delete old .save

--- a/packages/debs/SPECS/wazuh-agent/debian/prerm
+++ b/packages/debs/SPECS/wazuh-agent/debian/prerm
@@ -93,11 +93,7 @@ case "$1" in
       if [ -d ${DIR}/etc/shared ]; then
         cp -pr ${DIR}/etc/shared ${DIR}/tmp/conffiles
       fi
-
-      if [ -d ${DIR}/etc/shared/ ]; then
-        rm -rf ${DIR}/etc/shared/
-      fi
-
+      
     ;;
 
     failed-upgrade)

--- a/packages/debs/SPECS/wazuh-agent/debian/prerm
+++ b/packages/debs/SPECS/wazuh-agent/debian/prerm
@@ -89,10 +89,6 @@ case "$1" in
       if [ -f ${DIR}/etc/ossec.conf ]; then
         cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
       fi
-      # Save the shared configuration files
-      if [ -d ${DIR}/etc/shared ]; then
-        cp -pr ${DIR}/etc/shared ${DIR}/tmp/conffiles
-      fi
       
     ;;
 

--- a/packages/debs/SPECS/wazuh-manager/debian/postrm
+++ b/packages/debs/SPECS/wazuh-manager/debian/postrm
@@ -37,6 +37,9 @@ case "$1" in
             rm -rf ${DIR}/ruleset
             rm -rf ${DIR}/var
             rm -rf ${DIR}/logs
+            rm -rf ${DIR}/etc/rootcheck
+            rm -rf ${DIR}/etc/rules
+            rm -rf ${DIR}/etc/decoders
         fi
 
         # Delete old .save

--- a/packages/debs/SPECS/wazuh-manager/debian/prerm
+++ b/packages/debs/SPECS/wazuh-manager/debian/prerm
@@ -41,10 +41,6 @@ case "$1" in
       if [ -f ${DIR}/etc/ossec.conf ]; then
         cp -p ${DIR}/etc/ossec.conf ${DIR}/tmp/conffiles
       fi
-      # Save the local decoders
-      if [ -d ${DIR}/etc/decoders ]; then
-        cp -pr ${DIR}/etc/decoders ${DIR}/tmp/conffiles
-      fi
       # Save the lists
       if [ -d ${DIR}/etc/lists ]; then
         cp -pr ${DIR}/etc/lists ${DIR}/tmp/conffiles
@@ -53,18 +49,15 @@ case "$1" in
       if [ -d ${DIR}/etc/rootcheck ]; then
         cp -pr ${DIR}/etc/rootcheck ${DIR}/tmp/conffiles
       fi
-      # Save the local rules
-      if [ -d ${DIR}/etc/rules ]; then
-        cp -pr ${DIR}/etc/rules ${DIR}/tmp/conffiles
-      fi
       # Save the agent.conf from the group default
       mkdir -p ${DIR}/tmp/conffiles/shared/default
       if [ -f ${DIR}/etc/shared/default/agent.conf ]; then
         cp -p ${DIR}/etc/shared/default/agent.conf ${DIR}/tmp/conffiles/shared/default
       fi
-      # Save the client.keys
+      # Save the api.yaml
       if [ -f ${DIR}/api/configuration/api.yaml ]; then
         cp -p ${DIR}/api/configuration/api.yaml ${DIR}/tmp/conffiles
+        rm -rf ${DIR}/api/*
       fi
     ;;
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2195|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes the situation when the uninstall of a wazuh-agent does not completely remove the desired folders, specifically the `queue` folder.

Additionally, we have deleted the files and folders for the Deb packages in the uninstall, to make it more like the RPM uninstall.

## Testing

<details><summary> :green_circle: Testing the solution</summary>

Install wazuh-agent with new branch:

```console
root@agent1-ubu22:/home/vagrant# apt install /vagrant/wazuh-agent_4.9.0-0_amd64_0aa014f.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of '/vagrant/wazuh-agent_4.9.0-0_amd64_0aa014f.deb'
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/10.7 MB of archives.
After this operation, 37.2 MB of additional disk space will be used.
Get:1 /vagrant/wazuh-agent_4.9.0-0_amd64_0aa014f.deb wazuh-agent amd64 4.9.0-0 [10.7 MB]
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package wazuh-agent.
(Reading database ... 71365 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.9.0-0_amd64_0aa014f.deb ...
Unpacking wazuh-agent (4.9.0-0) ...
Setting up wazuh-agent (4.9.0-0) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78.)
debconf: falling back to frontend: Readline
Scanning processes...                                                                                                                   
Scanning linux images...                                                                                                                

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
```

Agent starts and try to connect to the manger:

```console
root@agent1-ubu22:/home/vagrant# cat /var/ossec/logs/ossec.log | grep "agentd"
2024/06/04 10:45:27 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2024/06/04 10:45:27 wazuh-agentd: INFO: Using notify time: 10 and max time to reconnect: 60
2024/06/04 10:45:27 wazuh-agentd: INFO: Version detected -> Linux |agent1-ubu22 |5.15.0-25-generic |#25-Ubuntu SMP Wed Mar 30 15:54:22 UTC 2022 |x86_64 [Ubuntu|ubuntu: 22.04 (Jammy Jellyfish)] - Wazuh v4.9.0
2024/06/04 10:45:27 wazuh-agentd: INFO: Started (pid: 2912).
2024/06/04 10:45:27 wazuh-agentd: INFO: Requesting a key from server: 11.11.11.11
2024/06/04 10:47:36 wazuh-agentd: ERROR: (1208): Unable to connect to enrollment service at '[11.11.11.11]:1515'
2024/06/04 10:47:41 wazuh-agentd: INFO: Requesting a key from server: 11.11.11.11
```

Agent is removed and residual files are checked:

```console
root@agent1-ubu22:/home/vagrant# apt remove wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-agent
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 37.2 MB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 71789 files and directories currently installed.)
Removing wazuh-agent (4.9.0-0) ...

root@agent1-ubu22:/home/vagrant# tree /var/ossec/
/var/ossec/
└── etc
    ├── client.keys.save
    ├── local_internal_options.conf.save
    ├── ossec.conf.save
    └── shared
        ├── cis_apache2224_rcl.txt.save
        ├── cis_debian_linux_rcl.txt.save
        ├── cis_mysql5-6_community_rcl.txt.save
        ├── cis_mysql5-6_enterprise_rcl.txt.save
        ├── cis_rhel5_linux_rcl.txt.save
        ├── cis_rhel6_linux_rcl.txt.save
        ├── cis_rhel7_linux_rcl.txt.save
        ├── cis_rhel_linux_rcl.txt.save
        ├── cis_sles11_linux_rcl.txt.save
        ├── cis_sles12_linux_rcl.txt.save
        ├── cis_win2012r2_domainL1_rcl.txt.save
        ├── cis_win2012r2_domainL2_rcl.txt.save
        ├── cis_win2012r2_memberL1_rcl.txt.save
        ├── cis_win2012r2_memberL2_rcl.txt.save
        ├── rootkit_files.txt.save
        ├── rootkit_trojans.txt.save
        ├── system_audit_rcl.txt.save
        ├── system_audit_ssh.txt.save
        ├── win_applications_rcl.txt.save
        ├── win_audit_rcl.txt.save
        └── win_malware_rcl.txt.save

2 directories, 24 files

```

</details>

- Tests of the last [commit](https://github.com/wazuh/wazuh/pull/23873/commits/9caa12b0f1cb96a8e57a9304358e53762357b401): https://github.com/wazuh/wazuh/pull/23873#issuecomment-2160202357