### PR TITLE
Remove zip compression

### DIFF
--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -101,45 +101,6 @@ build_pkg() {
 
     echo "Packages $(ls -Art ${OUTDIR} | tail -n 2) added to ${OUTDIR}."
 
-
-    # Find all files containing "-dbg"
-    if [ "${SYSTEM}" == "deb" ]; then 
-        EXT="*-dbg*.deb"
-        files_to_zip=$(ls ${OUTDIR}/${EXT} | grep -- -dbg)
-    else
-        EXT="*-debuginfo*.rpm"
-        files_to_zip=$(ls ${OUTDIR}/${EXT} | grep -- -debuginfo)
-    fi
-
- 
-
-    # Check if any files were found
-    if [[ -z "$files_to_zip" ]]; then
-        echo "No debug symbols found in current directory."
-        echo "Output path listing:"
-        ls -l ${OUTDIR}
-        exit 0
-    fi
-
-    # Extract filename without extension
-    base_filename="${files_to_zip%.*}"
-
-    # Create the archive name with .zip extension
-    archive_name="$base_filename.zip"
-
-    # Compress files into a zip archive named after the first (and only) file
-    zip -q -r "$archive_name" "$files_to_zip"
-
-    # Print confirmation message
-    echo "Compressed debug symbols into '${archive_name}'"
-
-    echo "Output path listing:"
-    ls -l ${OUTDIR}
-    
-    echo "Deleting uncompressed symbols file"
-    delete_file=${files_to_zip}
-    rm ${delete_file}
-
     return 0
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23452
https://github.com/wazuh/wazuh/issues/23451|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Removed zip compression to debug symbols.

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors