### PR TITLE
Fix compilation errors at wazuh-agentd

### DIFF
--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -284,7 +284,7 @@ int receive_msg()
                                     send_msg(msg_output, -1);
                                 }
                                 else {
-                                    if (cldir_ex_ignore(SHAREDCFG_DIR, ignore_list)) {
+                                    if (cldir_ex_ignore(SHAREDCFG_DIR, (const char **)ignore_list)) {
                                         mwarn("Could not clean up shared directory.");
                                     }
                                     clear_merged_hash_cache();

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -230,7 +230,7 @@ int MergeAppendFile(FILE *finalfp, const char *files, int path_offset) __attribu
  * @param mode Indicates if the merged file must be readed as a binary file  or not. Use `#OS_TEXT`, `#OS_BINARY`.
  * @return 1 if the file was unmerged, 0 on error.
  */
-int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char ***unmerged_files) __attribute__((nonnull(1)));
+int UnmergeFiles(const char *finalpath, const char *optdir, int mode, char ***unmerged_files) __attribute__((nonnull(1)));
 
 
 /**

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -623,7 +623,7 @@ void DeleteState() {
 }
 
 
-int UnmergeFiles(const char *finalpath, const char *optdir, int mode, const char ***unmerged_files)
+int UnmergeFiles(const char *finalpath, const char *optdir, int mode, char ***unmerged_files)
 {
     int ret = 1;
     int state_ok;


### PR DESCRIPTION
|Related issue|
|---|
| Closes #23568 |

## Description

This PR aims to fix two issues in the _wazuh-agentd_'s source code that currently produce warnings on compilation time, and as of GCC 14, they will become errors that will stop the build.

Currently, GCC refuses to compile the agent on:

- Fedora 40
- Arch Linux

## Changes

They are related to the `ignore_list` array of strings, which holds a list of files that the agent unmerged from the shared configuration. This list is used then to find which files in the shared configuration directory are old.

So, this list is declared as:
```c
char ** ignore_list;
```

- `UnmergeFiles()`:
  This function gets `const char ***` ("reference" to `char **`) but indeed fills the string list. That's why it should simply receive `char ***` (not `const`).
- `cldir_ex_ignore()`:
  This function gets `const char **` and it just reads the array. In addition, it's used by multiple modules. Because of that, removing `const` has no sense. Instead, we're casting the array to `const char **` in the function call.

## Impact

None in the practice. In fact, **both versions of _wazuh-agentd_ have the same SHA1 sum**, proving that the executable code is exactly similar.

### Hash when built on Ubuntu 22.04

|W/ patch|W/o patch|
|--|--|
|2d8db0e2df25aa63e391b82dca7597f70ffcf7cd|2d8db0e2df25aa63e391b82dca7597f70ffcf7cd|

## Tests

- [X] The agent builds on Fedora 40.
- [X] Both _wazuh-agentd_ binaries are exactly the same (as explained above)
