### PR TITLE
Fix no-index behavior to index data in agent sync event.

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanAgentInventory.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanAgentInventory.hpp
@@ -80,6 +80,8 @@ public:
                 {
                     auto listCve = Utils::split(dbQuery.second.ToString(), ',');
                     auto context = std::make_shared<TScanContext>();
+                    context->m_noIndex = data->m_noIndex;
+
                     for (const auto& cve : listCve)
                     {
                         data->m_isInventoryEmpty = false;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanInventory.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanInventory.hpp
@@ -80,6 +80,7 @@ public:
 
                         // We use elementKey as the id of the element, because it is unique.
                         auto context = std::make_shared<TScanContext>();
+                        context->m_noIndex = data->m_noIndex;
                         context->m_elements.emplace(elementKey,
                                                     TInventorySync<TScanContext>::buildElement("DELETED", elementKey));
                         m_subOrchestration->handleRequest(std::move(context));


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23849|

## Description

This change aims to propagate the no-index value in sub-orchestration in charge of the cleanup.