### PR TITLE
Added S3 URI output to package generation upload

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -151,8 +151,12 @@ jobs:
         working-directory: packages
         run: |
           aws s3 cp /tmp/${{ env.PACKAGE_NAME }} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{ env.PACKAGE_NAME }}"
+          echo "S3 URI: ${s3uri}"
 
       - name: Upload checksum to S3
-        if: ${{ inputs.checksum == true }}
+        if: ${{ inputs.checksum }}
         run: |
           aws s3 cp /tmp/${{ env.PACKAGE_NAME }}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/${{ env.PACKAGE_NAME }}.sha512"
+          echo "S3 sha512 URI: ${s3uri}"

--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -1,4 +1,5 @@
 run-name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }} ${{ inputs.is_stage && '- is stage' || '' }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.debug && '- debug' || '' }} ${{ inputs.id }}
+name: Build Wazuh manager
 
 on:
   workflow_dispatch:

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -1,4 +1,5 @@
 run-name: Build Filebeat module ${{ inputs.revision }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.id }}
+name: Build Filebeat module
 
 on:
   workflow_dispatch:

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -1,4 +1,4 @@
-run-name: Build Filebeat module ${{ inputs.revision }} ${{ inputs.id }}
+run-name: Build Filebeat module ${{ inputs.revision }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.id }}
 
 on:
   workflow_dispatch:
@@ -10,6 +10,10 @@ on:
         required: false
         default: "0.0"
         type: string
+      checksum:
+        description: Generate package checksum.
+        required: false
+        type: boolean
       id:
         type: string
         description: |
@@ -22,6 +26,9 @@ on:
         required: false
         default: "0.0"
         type: string
+      checksum:
+        required: false
+        type: boolean
       id:
         type: string
         required: false
@@ -95,8 +102,24 @@ jobs:
           if [ $(diff -r wazuh wazuh2) ]; then exit 1; fi
           echo "MODULE_CHECKED=yes" >> $GITHUB_ENV
 
+      - name: Generate SHA512
+        if: ${{ inputs.checksum }}
+        working-directory: extensions/filebeat/7.x/wazuh-module
+        run: |
+          sha512sum "${{ env.FILEBEAT_TAR_NAME }}" > "${{ env.FILEBEAT_TAR_NAME }}.sha512"
+
       - name: Upload Filebeat module to S3
         if: env.MODULE_CHECKED == 'yes'
         working-directory: extensions/filebeat/7.x/wazuh-module
         run: |
           aws s3 cp ${{ env.FILEBEAT_TAR_NAME }} s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/${{ env.FILEBEAT_TAR_NAME }}"
+          echo "S3 URI: ${s3uri}"
+
+      - name: Upload Filebeat module SHA512 to S3
+        if: ${{ env.MODULE_CHECKED == 'yes' && inputs.checksum }}
+        working-directory: extensions/filebeat/7.x/wazuh-module
+        run: |
+          aws s3 cp ${{ env.FILEBEAT_TAR_NAME }}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/${{ env.FILEBEAT_TAR_NAME }}.sha512"
+          echo "S3 sha512 URI: ${s3uri}"


### PR DESCRIPTION
# Description

This PR adds an S3 URI output in the Wazuh manager package and Filebeat module generation to comply with an objective requisite
This output is standardized and used on all package generation workflows
This output is used by the stage generation script to obtain the S3 object URI
This PR also improves the checksum upload
This PR adds a checksum option to the Filebeat module

## Workflow tests

- https://github.com/wazuh/wazuh/actions/runs/9372987359
- https://github.com/wazuh/wazuh/actions/runs/9372987457
- https://github.com/wazuh/wazuh/actions/runs/9372989363

```
Run aws s3 cp wazuh-filebeat-99.0.tar.gz s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/
Completed 1.8 KiB/1.8 KiB (4.3 KiB/s) with 1 file(s) remaining
upload: ./wazuh-filebeat-99.0.tar.gz to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/wazuh-filebeat-99.0.tar.gz
S3 URI: s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/wazuh-filebeat-99.0.tar.gz

Run aws s3 cp wazuh-filebeat-99.0.tar.gz.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/
Completed 157 Bytes/157 Bytes (451 Bytes/s) with 1 file(s) remaining
upload: ./wazuh-filebeat-99.0.tar.gz.sha512 to s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/wazuh-filebeat-99.0.tar.gz.sha512
S3 sha512 URI: s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/secondary/filebeat/modules/wazuh-filebeat-99.0.tar.gz.sha512
```