### PR TITLE
Vulnerability Scanner - Improve graceful shutdown when content update is in progress

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -17,6 +17,7 @@
 #include "cacheLRU.hpp"
 #include "contentManager.hpp"
 #include "contentRegister.hpp"
+#include "databaseFeedManagerException.hpp"
 #include "eventDecoder.hpp"
 #include "feedIndexer.hpp"
 #include "globalData.hpp"
@@ -184,7 +185,7 @@ public:
 
                 if (m_shouldStop.load())
                 {
-                    break;
+                    throw DatabaseFeedManagerException("Module stopped.");
                 }
             }
         }
@@ -216,7 +217,7 @@ public:
                 {
                     if (m_shouldStop.load())
                     {
-                        break;
+                        throw DatabaseFeedManagerException("Module stopped.");
                     }
 
                     if (step++ % 1000 == 0)
@@ -237,21 +238,16 @@ public:
                 }
             }
 
-            // If the module is stopped, we do not update the offset.
-            // So that the next time the module is started, it will start from zero.
-            if (!m_shouldStop.load())
+            m_feedDatabase->flush();
+
+            // Update the offset.
+            contentManagerUpdateOffset(topicName, parsedMessage.at("offset"));
+
+            if (parsedMessage.contains("/fileMetadata/hash"_json_pointer))
             {
-                m_feedDatabase->flush();
-
-                // Update the offset.
-                contentManagerUpdateOffset(topicName, parsedMessage.at("offset"));
-
-                if (parsedMessage.contains("/fileMetadata/hash"_json_pointer))
-                {
-                    // Update last parsed file hash.
-                    contentManagerUpdateHash(topicName,
-                                             parsedMessage.at("fileMetadata").at("hash").get_ref<const std::string&>());
-                }
+                // Update last parsed file hash.
+                contentManagerUpdateHash(topicName,
+                                         parsedMessage.at("fileMetadata").at("hash").get_ref<const std::string&>());
             }
         }
         else
@@ -349,6 +345,10 @@ public:
                     // Dispatch the post update Callback
                     postUpdateCallback();
                     logInfo(WM_VULNSCAN_LOGTAG, "Feed update process completed");
+                }
+                catch (const DatabaseFeedManagerException& e)
+                {
+                    logInfo(WM_VULNSCAN_LOGTAG, "Feed update interrupted: %s", e.what());
                 }
                 catch (const std::exception& e)
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManagerException.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManagerException.hpp
@@ -15,7 +15,7 @@
 #include <stdexcept>
 
 /**
- * @brief Custom exception for the @class DatabaseFeedManager.
+ * @brief Custom exception for the @see DatabaseFeedManager class.
  *
  */
 class DatabaseFeedManagerException : public std::exception
@@ -24,7 +24,7 @@ public:
     /**
      * @brief Overload what() method.
      *
-     * @return const char*
+     * @return const char* The message to be shown.
      */
     // LCOV_EXCL_START
     const char* what() const noexcept override
@@ -36,7 +36,7 @@ public:
     /**
      * @brief Construct a new exception object
      *
-     * @param message
+     * @param message The message to be shown.
      */
     explicit DatabaseFeedManagerException(const std::string& message)
         : m_msg {message} // NOLINT

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManagerException.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManagerException.hpp
@@ -1,0 +1,50 @@
+/*
+ * Wazuh Vulnerability scanner
+ * Copyright (C) 2015, Wazuh Inc.
+ * June 04, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _DATABASE_FEED_MANAGER_EXCEPTION_HPP
+#define _DATABASE_FEED_MANAGER_EXCEPTION_HPP
+
+#include <stdexcept>
+
+/**
+ * @brief Custom exception for the @class DatabaseFeedManager.
+ *
+ */
+class DatabaseFeedManagerException : public std::exception
+{
+public:
+    /**
+     * @brief Overload what() method.
+     *
+     * @return const char*
+     */
+    // LCOV_EXCL_START
+    const char* what() const noexcept override
+    {
+        return m_msg.what();
+    }
+    // LCOV_EXCL_STOP
+
+    /**
+     * @brief Construct a new exception object
+     *
+     * @param message
+     */
+    explicit DatabaseFeedManagerException(const std::string& message)
+        : m_msg {message} // NOLINT
+    {
+    }
+
+private:
+    std::runtime_error m_msg;
+};
+
+#endif // _DATABASE_FEED_MANAGER_EXCEPTION_HPP


### PR DESCRIPTION
|Related issue|
|---|
| #22835 |

## Description
This PR adds a custom exception for the databaseFeedManager, to signal better that the content update process was interrupted by a graceful shutdown

## Tests
WIP - Replicate original issue