### PR TITLE
Fix wazuh-integratord unit tests

### DIFF
--- a/src/unit_tests/os_integrator/test_integrator.c
+++ b/src/unit_tests/os_integrator/test_integrator.c
@@ -132,8 +132,6 @@ void test_OS_IntegratorD(void **state) {
     will_return(__wrap_time, 1111);
     will_return(__wrap_os_random, 2222);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/virustotal-1111-2222.alert 123456    0 0 > /dev/null 2>&1");
-
     will_return(__wrap_wpopenv, wfd);
 
     expect_value(__wrap_fgets, __stream, wfd->file_out);
@@ -173,8 +171,6 @@ void test_OS_IntegratorD(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "File /tmp/pagerduty-1111-2222.options was written.");
 
     expect_fclose((FILE *)1, 0);
-
-    expect_string(__wrap__mdebug1, formatted_msg, "Running script with args: integrations /tmp/pagerduty-1111-2222.alert 123456   /tmp/pagerduty-1111-2222.options 0 0 > /dev/null 2>&1");
 
     will_return(__wrap_wpopenv, wfd);
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #23917 |

This PR aims to remove the wrap call to `mdebug1` at _wazuh-integratord_ unit tests as it was already deleted by #23833.

## Test result

```
[==========] Running 1 test(s).
[ RUN      ] test_OS_IntegratorD
[       OK ] test_OS_IntegratorD
[==========] 1 test(s) run.
[  PASSED  ] 1 test(s).
```