### PR TITLE
Add requests timeouts

### DIFF
--- a/wodles/azure/azure_services/analytics.py
+++ b/wodles/azure/azure_services/analytics.py
@@ -183,7 +183,7 @@ def get_log_analytics_events(
     """
     logging.info('Log Analytics: Sending a request to the Log Analytics API.')
     logging.debug(f"Log Analytics request - URL: {url} - Params: {body} - Headers: {headers}")
-    response = get(url, params=body, headers=headers)
+    response = get(url, params=body, headers=headers, timeout=10)
     if response.status_code == 200:
         try:
             columns = response.json()['tables'][0]['columns']

--- a/wodles/azure/azure_services/graph.py
+++ b/wodles/azure/azure_services/graph.py
@@ -174,7 +174,7 @@ def get_graph_events(url: str, headers: dict, md5_hash: str, query: str, tag: st
 
     logging.debug(f"Graph request - URL: {url} - Headers: {headers}")
     logging.info("Graph: Requesting data")
-    response = get(url=url, headers=headers)
+    response = get(url=url, headers=headers, timeout=10)
 
     if response.status_code == 200:
         response_json = response.json()

--- a/wodles/azure/azure_utils.py
+++ b/wodles/azure/azure_utils.py
@@ -371,7 +371,7 @@ def get_token(client_id: str, secret: str, domain: str, scope: str):
     auth_url = f'{URL_LOGGING}/{domain}/oauth2/v2.0/token'
     token_response = {}
     try:
-        token_response = post(auth_url, data=body).json()
+        token_response = post(auth_url, data=body, timeout=10).json()
         return token_response['access_token']
     except (ValueError, KeyError):
         if token_response['error'] == 'unauthorized_client':

--- a/wodles/azure/tests/azure_services/test_analytics.py
+++ b/wodles/azure/tests/azure_services/test_analytics.py
@@ -221,7 +221,7 @@ def test_get_log_analytics_events(mock_get, mock_position, mock_iter, mock_updat
     headers = 'headers'
     tag = 'test'
     get_log_analytics_events(url=url, body=body, headers=headers, md5_hash='', query=la_query, tag=tag)
-    mock_get.assert_called_with(url, params=body, headers=headers)
+    mock_get.assert_called_with(url, params=body, headers=headers, timeout=10)
     if rows is None or (len(rows) > 0 and time_position is None):
         mock_logging.assert_called_once()
     elif len(rows) == 0:

--- a/wodles/azure/tests/azure_services/test_graph.py
+++ b/wodles/azure/tests/azure_services/test_graph.py
@@ -206,7 +206,7 @@ def test_get_graph_events(mock_get, mock_update, mock_send):
 
     headers = 'headers'
     get_graph_events(url=url, headers=headers, md5_hash='', query='query', tag='tag')
-    mock_get.assert_called_with(url=url, headers=headers)
+    mock_get.assert_called_with(url=url, headers=headers, timeout=10)
     assert mock_update.call_count == num_events
     assert mock_send.call_count == num_events
 

--- a/wodles/azure/tests/test_azure_utils.py
+++ b/wodles/azure/tests/test_azure_utils.py
@@ -176,7 +176,7 @@ def test_get_token(mock_post):
     mock_post.return_value = m
     token = get_token(client_id, secret, domain, scope)
     auth_url = f'{URL_LOGGING}/{domain}/oauth2/v2.0/token'
-    mock_post.assert_called_with(auth_url, data=body)
+    mock_post.assert_called_with(auth_url, data=body, timeout=10)
     assert token == expected_token
 
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/20603 |

## Description

Adds timeouts to multiple requests to avoid indefinite hangouts while awaiting a response. 

Fixes:
- https://github.com/wazuh/wazuh/security/code-scanning/3338
- https://github.com/wazuh/wazuh/security/code-scanning/3340
- https://github.com/wazuh/wazuh/security/code-scanning/3342

### Tests

Integration tests of the changes can be found in https://github.com/wazuh/wazuh/pull/20638.

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest wodles/azure
============================================== test session starts ===============================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/wodles
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 148 items                                                                                              

wodles/azure/tests/test_azure_utils.py ...................................................                 [ 34%]
wodles/azure/tests/azure_services/test_analytics.py ..................                                     [ 46%]
wodles/azure/tests/azure_services/test_graph.py ............                                               [ 54%]
wodles/azure/tests/azure_services/test_storage.py ...........................                              [ 72%]
wodles/azure/tests/db/test_db_utils.py .........                                                           [ 79%]
wodles/azure/tests/db/test_orm.py ...............................                                          [100%]

============================================== 148 passed in 0.67s ===============================================
```

</details>

> Unit tests fail in the checks because of https://github.com/wazuh/wazuh/issues/23839.