### PR TITLE
Shuffle: SSL cert error fix in default configuration

### DIFF
--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -29,6 +29,11 @@ except ModuleNotFoundError:
     print("No module 'requests' found. Install: pip install requests")
     sys.exit(ERR_NO_REQUEST_MODULE)
 
+try:
+    requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+except Exception as e:
+    print(f"Failed to disable SSL warnings: {e}")
+
 # ossec.conf configuration structure
 # <integration>
 #  <name>shuffle</name>

--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -226,7 +226,7 @@ def send_msg(msg: str, url: str) -> None:
         URL of the integration.
     """
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
-    res = requests.post(url, data=msg, headers=headers, timeout=10)
+    res = requests.post(url, data=msg, headers=headers, timeout=10, verify=False)
     debug('# Response received: %s' % res.json)
 
 

--- a/integrations/tests/test_shuffle.py
+++ b/integrations/tests/test_shuffle.py
@@ -197,4 +197,4 @@ def test_send_msg():
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
     with patch('requests.post', return_value=requests.Response) as request_post:
         shuffle.send_msg(msg_template, sys_args_template[3])
-        request_post.assert_called_once_with(sys_args_template[3], data=msg_template, headers=headers, timeout=10)
+        request_post.assert_called_once_with(sys_args_template[3], data=msg_template, headers=headers, timeout=10, verify=False)   


### PR DESCRIPTION
## Description

Hey! I'm Aditya, an SRE at Shuffle. We often see users trying to integrate Wazuh with Shuffle, but they run into an SSL error due to the self-signed certificate that comes with the default Shuffle setup. This causes issues when users try to use the default HTTPS shuffle instance link in Wazuh, leading to errors. To fix this, users need to generate a new certificate with something like certbot, which can be frustrating and cause them to give up. It would be much easier if we could update the script to skip SSL certificate verification.

## Configuration options

N/A

## Logs/Alerts example

N/A

## Tests
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors