### PR TITLE
Vulnerability Scanner - Reduce requests to wazuhDB

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -35,7 +35,8 @@ auto constexpr L1_CACHE_SIZE {2048};
  */
 template<typename TDatabaseFeedManager = DatabaseFeedManager,
          typename TScanContext = ScanContext,
-         typename TGlobalData = GlobalData>
+         typename TGlobalData = GlobalData,
+         typename TRemediationDataCache = RemediationDataCache<>>
 class TPackageScanner final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 private:
@@ -562,7 +563,7 @@ private:
         }
 
         // Check that the agent has remediation data.
-        auto agentRemediations = contextData->getRemediationData();
+        auto agentRemediations = TRemediationDataCache::instance().getRemediationData(contextData->agentId().data());
         if (agentRemediations.hotfixes.empty())
         {
             logDebug2(

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
@@ -127,4 +127,5 @@ public:
         m_remediationData.insertKey(agentId, newRemediationData);
     }
 };
+
 #endif // _REMEDIATION_DATA_CACHE_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -254,7 +254,6 @@ public:
                             {
                                 m_type = ScannerType::PackageDelete;
                             }
-                            m_remediationData = TRemediationDataCache::instance().getRemediationData(agentId().data());
                             m_osData = TOsDataCache::instance().getOsData(agentId().data());
                         }
                         else if (delta->data_type() == SyscollectorDeltas::Provider_dbsync_osinfo)
@@ -440,7 +439,6 @@ public:
                             // Set the affected component type
                             m_affectedComponentType = AffectedComponentType::Package;
 
-                            m_remediationData = TRemediationDataCache::instance().getRemediationData(agentId().data());
                             m_osData = TOsDataCache::instance().getOsData(agentId().data());
                         }
                         else if (syncMsg->data_as_state()->attributes_type() ==
@@ -1452,16 +1450,6 @@ public:
     }
 
     /**
-     * @brief Gets the Remediation data.
-     *
-     * @return Remediation The remediation data.
-     */
-    Remediation getRemediationData() const
-    {
-        return m_remediationData;
-    }
-
-    /**
      * @brief Gets manager name.
      * @return Manager name.
      */
@@ -1564,12 +1552,6 @@ private:
      *
      */
     Os m_osData {};
-
-    /**
-     * @brief Remediation data.
-     *
-     */
-    Remediation m_remediationData {};
 
     /**
      * @brief Agent id.

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -25,6 +25,7 @@
 #include "json.hpp"
 
 using ::testing::_;
+using TrampolineScanContext = TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>;
 
 namespace NSPackageScannerTest
 {
@@ -428,20 +429,18 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualTo)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult != nullptr);
@@ -529,20 +528,18 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedEqualTo)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     EXPECT_TRUE(scanContextResult == nullptr);
@@ -620,20 +617,18 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThan)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult != nullptr);
@@ -721,20 +716,18 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMissing)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult == nullptr);
@@ -812,20 +805,18 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMismatch)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult == nullptr);
@@ -903,20 +894,18 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMatch)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult != nullptr);
@@ -1004,20 +993,18 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanOrEqual)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult != nullptr);
@@ -1105,20 +1092,18 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanWithVersionNotZero)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult != nullptr);
@@ -1206,20 +1191,18 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedLessThan)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     EXPECT_TRUE(scanContextResult == nullptr);
@@ -1297,20 +1280,18 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusAffected)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult != nullptr);
@@ -1397,20 +1378,18 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusUnaffected)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     EXPECT_TRUE(scanContextResult == nullptr);
@@ -1462,20 +1441,18 @@ TEST_F(PackageScannerTest, TestPackageGetVulnerabilitiesCandidatesGeneratesExcep
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     EXPECT_TRUE(scanContextResult == nullptr);
@@ -1515,15 +1492,13 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlma8)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -1565,15 +1540,13 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas1)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -1615,15 +1588,13 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -1665,15 +1636,13 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2022)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -1715,15 +1684,13 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToRedHat7)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -1765,15 +1732,13 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLED)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -1815,15 +1780,13 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLES)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -1906,20 +1869,18 @@ TEST_F(PackageScannerTest, TestGetTranslationFromL2)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
-    std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
+    std::shared_ptr<TrampolineScanContext> scanContextResult;
     EXPECT_NO_THROW(scanContextResult = packageScanner.handleRequest(scanContextOriginal));
 
     ASSERT_TRUE(scanContextResult != nullptr);
@@ -1971,15 +1932,13 @@ TEST_F(PackageScannerTest, TestGetCnaNameByPrefix)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -2024,15 +1983,13 @@ TEST_F(PackageScannerTest, TestGetCnaNameByContains)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -2077,15 +2034,13 @@ TEST_F(PackageScannerTest, TestGetCnaNameBySource)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
@@ -2130,14 +2085,12 @@ TEST_F(PackageScannerTest, TestGetDefaultCna)
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
-    auto scanContextOriginal =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
-            syscollectorDelta);
+    auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
 
     TPackageScanner<MockDatabaseFeedManager,
-                    TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                    TrampolineScanContext,
                     TrampolineGlobalData,
                     TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -437,7 +437,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualTo)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -537,7 +538,8 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedEqualTo)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -627,7 +629,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThan)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -727,7 +730,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMissing)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -817,7 +821,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMismatch)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -907,7 +912,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMatch)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1007,7 +1013,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanOrEqual)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1107,7 +1114,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanWithVersionNotZero)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1207,7 +1215,8 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedLessThan)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1297,7 +1306,8 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusAffected)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1396,7 +1406,8 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusUnaffected)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1460,7 +1471,8 @@ TEST_F(PackageScannerTest, TestPackageGetVulnerabilitiesCandidatesGeneratesExcep
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1512,7 +1524,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlma8)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -1561,7 +1574,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas1)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -1610,7 +1624,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -1659,7 +1674,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2022)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -1708,7 +1724,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToRedHat7)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -1757,7 +1774,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLED)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -1806,7 +1824,8 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLES)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -1896,7 +1915,8 @@ TEST_F(PackageScannerTest, TestGetTranslationFromL2)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     std::shared_ptr<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>> scanContextResult;
@@ -1960,7 +1980,8 @@ TEST_F(PackageScannerTest, TestGetCnaNameByPrefix)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -2012,7 +2033,8 @@ TEST_F(PackageScannerTest, TestGetCnaNameByContains)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -2064,7 +2086,8 @@ TEST_F(PackageScannerTest, TestGetCnaNameBySource)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));
@@ -2115,7 +2138,8 @@ TEST_F(PackageScannerTest, TestGetDefaultCna)
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                    TrampolineGlobalData>
+                    TrampolineGlobalData,
+                    TrampolineRemediationDataCache>
         packageScanner(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(packageScanner.handleRequest(scanContextOriginal));


### PR DESCRIPTION
|Related issue|
|---|
| #23926 |

## Description
This PR aims to reduce the load over the wazuhDB, we performed unnecessary queries to retrieve remediation information each time the scanContext was initialized. The queries were moved to the package scanner at the time we needed that information

## Testing
### 20 agents after changes
![image](https://github.com/wazuh/wazuh/assets/34063881/2ecd07cc-0332-4044-bb69-16c253345f86)


### 20 agents before changes
![image](https://github.com/wazuh/wazuh/assets/34063881/758bd6eb-5b9c-498c-a5fb-f1791bbe8979)

We can see a %151 reduction in the number of reads to the wazuhDB

### Vulnerabilities indexed
![image](https://github.com/wazuh/wazuh/assets/34063881/338da697-08a0-4d39-b329-f159300abb81)

### Alerts generated
```
grep -iE 'CVE.*id":"004' /var/ossec/logs/alerts/alerts.json | wc -l
4369
```
![image](https://github.com/wazuh/wazuh/assets/34063881/ba77a8f3-1af7-4a04-a6c4-b35e551d76b5)

