### PR TITLE
Fix macOS package generation script

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -130,11 +130,10 @@ function build_package() {
         SOURCES_DIRECTORY="${CURRENT_PATH}/repository"
         WAZUH_PATH="${SOURCES_DIRECTORY}/wazuh"
         git clone --depth=1 -b ${BRANCH_TAG} ${WAZUH_SOURCE_REPOSITORY} "${WAZUH_PATH}"
-        short_commit_hash="$(git rev-parse -C "${WAZUH_PATH}" --short HEAD)"
     else
         WAZUH_PATH="${CURRENT_PATH}/../.."
-        short_commit_hash="$(git rev-parse --short HEAD)"
     fi
+    short_commit_hash="$(cd "${WAZUH_PATH}" && git rev-parse --short HEAD)"
 
     export CONFIG="${WAZUH_PATH}/etc/preloaded-vars.conf"
     WAZUH_PACKAGES_PATH="${WAZUH_PATH}/packages/macos"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23974|

# Description
In this PR we are fixing the macos package generation script, as there was a small bug when trying to get the commit hash we use for the package name.

# Test
- [x] Build macOS intel: https://github.com/wazuh/wazuh-agent-packages/actions/runs/9414204593
- [x] Build macOS arm: https://github.com/wazuh/wazuh-agent-packages/actions/runs/9414123961