### PR TITLE
Enhance retrieved CPU name in macOS agents

### DIFF
--- a/src/data_provider/src/hardware/hardwareWrapperImplMac.h
+++ b/src/data_provider/src/hardware/hardwareWrapperImplMac.h
@@ -46,9 +46,8 @@ class OSHardwareWrapperMac final : public IOSHardwareWrapper, public TOsPrimitiv
 
         std::string cpuName() const
         {
-            const std::vector<int> mib{CTL_HW, HW_MODEL};
             size_t len{0};
-            auto ret{this->sysctl(const_cast<int*>(mib.data()), mib.size(), nullptr, &len, nullptr, 0)};
+            auto ret{this->sysctlbyname("machdep.cpu.brand_string", nullptr, &len, nullptr, 0)};
 
             if (ret)
             {
@@ -70,7 +69,7 @@ class OSHardwareWrapperMac final : public IOSHardwareWrapper, public TOsPrimitiv
                 };
             }
 
-            ret = this->sysctl(const_cast<int*>(mib.data()), mib.size(), spBuff.get(), &len, nullptr, 0);
+            ret = this->sysctlbyname("machdep.cpu.brand_string", spBuff.get(), &len, nullptr, 0);
 
             if (ret)
             {

--- a/src/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperMac_test.cpp
+++ b/src/data_provider/tests/sysInfoHardwareMac/sysInfoHardwareWrapperMac_test.cpp
@@ -25,21 +25,19 @@ using ::testing::Return;
 TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuName_Succeed)
 {
     auto wrapper { std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>() };
-    EXPECT_CALL(*wrapper, sysctl(_, _, _, _, _, _))
-    .WillOnce([](int* name, u_int namelen, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
+    EXPECT_CALL(*wrapper, sysctlbyname(_, _, _, _, _))
+    .WillOnce([](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
     {
         (void)name;
-        (void)namelen;
         (void)oldp;
         (void)newp;
         (void)newlen;
         *oldlenp = 8;
         return 0;
     })
-    .WillOnce([](int* name, u_int namelen, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
+    .WillOnce([](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
     {
         (void)name;
-        (void)namelen;
         (void)newp;
         (void)newlen;
         strncpy(static_cast<char*>(oldp), "CpuName", 8);
@@ -54,11 +52,10 @@ TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuName_Succeed)
 TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuName_Failed_Sysctl1)
 {
     auto wrapper { std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>() };
-    EXPECT_CALL(*wrapper, sysctl(_, _, _, _, _, _))
-    .WillOnce([](int* name, u_int namelen, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
+    EXPECT_CALL(*wrapper, sysctlbyname(_, _, _, _, _))
+    .WillOnce([](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
     {
         (void)name;
-        (void)namelen;
         (void)oldp;
         (void)newp;
         (void)newlen;
@@ -71,21 +68,19 @@ TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuName_Failed_Sysctl1)
 TEST_F(SysInfoHardwareWrapperMacTest, Test_CpuName_Failed_Sysctl2)
 {
     auto wrapper { std::make_shared<OSHardwareWrapperMac<OsPrimitivesMacMock>>() };
-    EXPECT_CALL(*wrapper, sysctl(_, _, _, _, _, _))
-    .WillOnce([](int* name, u_int namelen, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
+    EXPECT_CALL(*wrapper, sysctlbyname(_, _, _, _, _))
+    .WillOnce([](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
     {
         (void)name;
-        (void)namelen;
         (void)oldp;
         (void)newp;
         (void)newlen;
         *oldlenp = 8;
         return 0;
     })
-    .WillOnce([](int* name, u_int namelen, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
+    .WillOnce([](const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen)
     {
         (void)name;
-        (void)namelen;
         (void)oldp;
         (void)newp;
         (void)newlen;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/13859|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The retrieved CPU name in the macOS agent was not the real CPU name reported by the system, it was the macOS machine model. Now the retrieved name is the real CPU name.
<!--
Add a clear description of how the problem has been solved.
-->

## Logs/Alerts example

The retrieved info in a macOS with a 4.7.5 wazuh agent package:

```
sqlite> select * from dbsync_hwinfo;
board_serial|cpu_name|cpu_cores|cpu_mhz|ram_total|ram_free|ram_usage|checksum|db_status_field_dm
0|iMac11,3|2|2990.0|4194304|2978428|29|d7bce0d93031ea4d361b088aca9201a248f2d172|1
```

The retrieved info in a macOS with an agent installed used the branch:

```
sqlite> select * from dbsync_hwinfo;
board_serial|cpu_name|cpu_cores|cpu_mhz|ram_total|ram_free|ram_usage|checksum|db_status_field_dm
0|Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz|2|2990.0|3145728|1461808|54|700f952b8a6ef18e7345ce0c93f12e52b46d053d|1

```

<!--

Paste here related logs and alerts
-->