### PR TITLE
Fix certificate validations on HAProxy helper requests

### DIFF
--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -103,7 +103,7 @@ class ProxyAPI:
             In case of errors communicating with the HAProxy REST API.
         """
         try:
-            async with httpx.AsyncClient(verify=False) as client:
+            async with httpx.AsyncClient() as client:
                 response = await client.get(
                     join(f'{self.protocol}://', f'{self.address}:{self.port}', self.HAP_ENDPOINT, 'health'),
                     auth=(self.username, self.password),
@@ -156,7 +156,7 @@ class ProxyAPI:
         query_parameters.update({'version': self.version})
 
         try:
-            async with httpx.AsyncClient(verify=False, follow_redirects=True) as client:
+            async with httpx.AsyncClient(follow_redirects=True) as client:
                 response = await client.request(
                     method=method.value,
                     url=uri,


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23913 |

## Description

Removes the `verify` parameter in the requests to the HAProxy helper to use the default CA bundle.

## Tests

<details><summary>HAProxy configuration</summary>

```console
root@wazuh-master:/# cat /etc/haproxy/haproxy.cfg
global
      chroot      /var/lib/haproxy
      pidfile     /var/run/haproxy.pid
      maxconn     4000
      user        haproxy
      group       haproxy
      stats socket /var/lib/haproxy/stats level admin
      log 127.0.0.1 local2 info

defaults
      mode http
      maxconn 4000
      log global
      option redispatch
      option dontlognull
      option tcplog
      timeout check 10s
      timeout connect 10s
      timeout client 1m
      timeout queue 1m
      timeout server 1m
      retries 3

frontend wazuh_register
      mode tcp
      bind :1517
      default_backend wazuh_register

backend wazuh_register
      mode tcp
      balance leastconn
      server master wazuh-master:1518 check
      server worker1 wazuh-worker1:1518 check
      server workern wazuh-worker2:1518 check
```

</details>

<details><summary>Starting HAProxy</summary>

```console
root@wazuh-master:/# service haproxy start
 * Starting haproxy haproxy                                                                                            [ OK ]
```

</details>

<details><summary>Dataplane API configuration</summary>

```console
</details>
root@wazuh-master:/# cat /etc/haproxy/dataplaneapi.yml
dataplaneapi:
   host: 0.0.0.0
   port: 5555
   transaction:
         transaction_dir: /tmp/haproxy
   user:
   - insecure: true
     password: wazuh
     name: wazuh
haproxy:
   config_file: /etc/haproxy/haproxy.cfg
   haproxy_bin: /usr/sbin/haproxy
   reload:
         reload_delay: 5
         reload_cmd: service haproxy reload
         restart_cmd: service haproxy restart
```

</details>

<details><summary>Starting the Dataplane API</summary>

```console
root@wazuh-master:/# dataplaneapi -f /etc/haproxy/dataplaneapi.yml &
[1] 10955
```

</details>

<details><summary>Verify the Datplante API is reachable</summary>

```console
root@wazuh-master:/# curl -X GET --user wazuh:wazuh http://localhost:5555/v2/info
{"api":{"build_date":"2024-05-13T12:09:33.000Z","version":"v2.8.7 13ba2b34"},"system":{}}
```

</details>

<details><summary>Manager configuration</summary>

```console
root@wazuh-master:/# vim /var/ossec/etc/ossec.conf 
...
<cluster>
    <name>wazuh</name>
    <node_name>master-node</node_name>
    <node_type>master</node_type>
    <key>9d273b53510fef702b54a92e9cffc82e</key>
    <port>1516</port>
    <bind_addr>0.0.0.0</bind_addr>
    <nodes>
        <node>wazuh-master</node>
    </nodes>
    <hidden>no</hidden>
    <disabled>no</disabled>
    <haproxy_helper>
      <haproxy_disabled>no</haproxy_disabled>
      <haproxy_address>0.0.0.0</haproxy_address>
      <haproxy_user>wazuh</haproxy_user>
      <haproxy_password>wazuh</haproxy_password>
    </haproxy_helper>
</cluster>
...
```

</details>

<details><summary>Manager restart</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-control restart
2024/06/07 14:35:22 wazuh-db[22932] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/07 14:35:22 wazuh-db[22932] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/06/07 14:35:22 wazuh-remoted[22937] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/07 14:35:22 wazuh-remoted[22937] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/06/07 14:35:22 wazuh-remoted[22937] main.c:148 at main(): DEBUG: This is not a worker
2024/06/07 14:35:22 wazuh-modulesd:router: INFO: Loaded router module.
2024/06/07 14:35:22 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Killing wazuh-clusterd...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.9.0 Stopped
Starting Wazuh v4.9.0...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2024/06/07 14:35:27 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
2024/06/07 14:35:27 wazuh-authd[23167] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/07 14:35:27 wazuh-authd[23167] config.c:24 at authd_read_config(): DEBUG: Reading configuration 'etc/ossec.conf'
2024/06/07 14:35:27 wazuh-authd[23167] authd-config.c:276 at Read_Authd(): DEBUG: The tag <force><after_registration_time> is not defined. Applied default value: '3600'
2024/06/07 14:35:27 wazuh-authd[23167] authd-config.c:278 at Read_Authd(): DEBUG: The tag <force><key_mismatch> is not defined. Applied default value: 'true'
2024/06/07 14:35:27 wazuh-authd[23167] main-server.c:465 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-authd...
2024/06/07 14:35:27 wazuh-db[23180] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/07 14:35:27 wazuh-db[23180] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
2024/06/07 14:35:28 wazuh-remoted[23326] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/07 14:35:28 wazuh-remoted[23326] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/06/07 14:35:28 wazuh-remoted[23326] main.c:148 at main(): DEBUG: This is not a worker
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2024/06/07 14:35:29 wazuh-modulesd:router: INFO: Loaded router module.
2024/06/07 14:35:29 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.
```

</details>

<details><summary>HAProxy configuration after restart</summary>

```console
root@wazuh-master:/# cat /etc/haproxy/haproxy.cfg
# _md5hash=1f8723f4e50c6bd44a2aadbce8e31b77
# _version=8
# Dataplaneapi managed File
# changing file directly can cause a conflict if dataplaneapi is running

global
  chroot /var/lib/haproxy
  user haproxy
  group haproxy
  maxconn 4000
  pidfile /var/run/haproxy.pid
  stats socket /var/lib/haproxy/stats level admin
  hard-stop-after 30016
  log 127.0.0.1 local2 info

defaults unnamed_defaults_1
  mode http
  maxconn 4000
  log global
  option tcplog
  option redispatch
  option dontlognull
  timeout check 10s
  timeout connect 10s
  timeout client 1m
  timeout queue 1m
  timeout server 1m
  retries 3

frontend wazuh_register from unnamed_defaults_1
  mode tcp
  bind :1517
  default_backend wazuh_register

frontend wazuh_reporting_front from unnamed_defaults_1
  mode tcp
  default_backend wazuh_reporting

backend wazuh_register from unnamed_defaults_1
  mode tcp
  balance leastconn
  server master wazuh-master:1518 check
  server worker1 wazuh-worker1:1518 check
  server workern wazuh-worker2:1518 check

backend wazuh_reporting from unnamed_defaults_1
  mode tcp
  balance leastconn
  server master-node wazuh-master:1514 check
  server wazuh-worker1 172.18.0.5:1514 check
  server wazuh-worker2 172.18.0.2:1514 check
```

</details>

<details><summary>Cluster logs</summary>

```console
root@wazuh-master:/# tail -n 50 /var/ossec/logs/cluster.log | grep HAP
2024/06/07 14:37:06 INFO: [HAPHelper] [Main] Proxy was initialized
2024/06/07 14:37:18 INFO: [HAPHelper] [Main] Setting a value for `hard-stop-after` configuration.
2024/06/07 14:37:18 INFO: [HAPHelper] [Proxy] Set `hard-stop-after` with 30.016666666666666 seconds.
2024/06/07 14:37:18 INFO: [HAPHelper] [Main] Reconnecting 1 agents.
2024/06/07 14:37:23 INFO: [HAPHelper] [Main] Starting HAProxy Helper
2024/06/07 14:37:23 INFO: [HAPHelper] [Main] Detected changes in Wazuh cluster nodes. Current cluster: {'master-node': 'wazuh-master', 'wazuh-worker1': '172.18.0.5', 'wazuh-worker2': '172.18.0.2'}
2024/06/07 14:37:23 INFO: [HAPHelper] [Main] Attempting to update proxy backend
2024/06/07 14:37:23 INFO: [HAPHelper] [Main] Setting a value for `hard-stop-after` configuration.
2024/06/07 14:37:26 INFO: [HAPHelper] [Main] Migrating 1 connections from server 'wazuh-worker1'
2024/06/07 14:37:41 INFO: [HAPHelper] [Main] Waiting for agent connections stability
2024/06/07 14:38:41 INFO: [HAPHelper] [Main] Load balancer backend is up to date
2024/06/07 14:38:41 INFO: [HAPHelper] [Main] Load balancer backend is balanced
```

</details>

> RPM build check failed because of https://github.com/wazuh/wazuh/issues/23831.