### PR TITLE
Fixed typo in the “Starting upgrade process” log.

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -241,7 +241,7 @@ function install
 {
     kill -processname win32ui -ErrorAction SilentlyContinue -Force
     Remove-Item .\upgrade\upgrade_result -ErrorAction SilentlyContinue
-    write-output "$(Get-Date -format u) - Starting upgrade processs." >> .\upgrade\upgrade.log
+    write-output "$(Get-Date -format u) - Starting upgrade process." >> .\upgrade\upgrade.log
     cmd /c start /wait (Get-Item ".\wazuh-agent*.msi").Name -quiet -norestart -log installer.log
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#21328|

## Description

This PR fixes the typo in the “Starting upgrade process.” log of the do_upgrade.ps1 script.

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Windows
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

