### PR TITLE
Synchronizing packages with wazuh-packages

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -2,25 +2,37 @@ wazuh-agent (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Tue, 14 May 2024 00:00:00 +0000
-
-wazuh-agent (4.8.2-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
-
- -- Wazuh, Inc <info@wazuh.com>  Tue, 26 Mar 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 10 Jul 2024 00:00:00 +0000
 
 wazuh-agent (4.8.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 
- -- Wazuh, Inc <info@wazuh.com>  Wed, 28 Feb 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 26 Jun 2024 00:00:00 +0000
 
 wazuh-agent (4.8.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Wed, 21 Feb 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 12 Jun 2024 00:00:00 +0000
+
+wazuh-agent (4.7.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 30 May 2024 00:00:00 +0000
+
+wazuh-agent (4.7.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-7-4.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 25 Apr 2024 00:00:00 +0000
+
+wazuh-agent (4.7.3-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-7-3.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 27 Feb 2024 00:00:00 +0000
 
 wazuh-agent (4.7.2-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-agent/debian/copyright
+++ b/packages/debs/SPECS/wazuh-agent/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 10 Jul 2024 00:00:00 +0000
 
 It was downloaded from:
 

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -2,25 +2,31 @@ wazuh-manager (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Tue, 14 May 2024 00:00:00 +0000
-
-wazuh-manager (4.8.2-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
-
- -- Wazuh, Inc <info@wazuh.com>  Tue, 26 Mar 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 10 Jul 2024 00:00:00 +0000
 
 wazuh-manager (4.8.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
 
- -- Wazuh, Inc <info@wazuh.com>  Wed, 28 Feb 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 26 Jun 2024 00:00:00 +0000
 
 wazuh-manager (4.8.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Wed, 20 Mar 2024 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 12 Jun 2024 00:00:00 +0000
+
+wazuh-manager (4.7.5-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 30 May 2024 00:00:00 +0000
+
+wazuh-manager (4.7.4-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-7-4.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Thu, 25 Apr 2024 00:00:00 +0000
 
 wazuh-manager (4.7.3-RELEASE) stable; urgency=low
 
@@ -596,4 +602,3 @@ wazuh-manager (2.0-1) stable; urgency=low
   * wazuh-manager - base 2.0
 
  -- Wazuh, Inc <info@wazuh.com>  Mon, 01 Jul 2016 08:43:10 +0000
- 

--- a/packages/debs/SPECS/wazuh-manager/debian/copyright
+++ b/packages/debs/SPECS/wazuh-manager/debian/copyright
@@ -1,26 +1,10 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 10 Jul 2024 00:00:00 +0000
 
 It was downloaded from:
 
     https://www.wazuh.com
-
-Upstream Authors:
-
-    dcid@dcid.me
-    Jia-BingJB_Cheng@trendmicro.com
-    vichargrave@gmail.com
-    ossec@michaelstarks.com
-    ddpbsd@gmail.com
-    scott@atomicorp.com
-    brad.lhotsky@gmail.com
-    jeremy@jeremyrossy.com
-    santiago.bassett@gmail.com
-    pedro@wazuh.com
-    alberto.rodriguez@wazuh.com
-    braulio@wazuh.com
-    jose.fernandez@wazuh.com
 
 Copyright:
 

--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -64,7 +64,7 @@ override_dh_install:
 	USER_GENERATE_AUTHD_CERT="y" \
 	USER_AUTO_START="n" \
 	USER_CREATE_SSL_CERT="n" \
-	DOWNLOAD_CONTENT="yes" \
+	DOWNLOAD_CONTENT="y" \
 	./install.sh
 
 	# Copying init.d script
@@ -156,11 +156,11 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/20/04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/22/04
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/windows
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sunos/5/11
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/almalinux/9
-	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rocky/8
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rocky/9
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/almalinux/8
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/almalinux/9
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sunos/5/11
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rocky/8
 
 	cp -r ruleset/sca/* ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca
 
@@ -219,8 +219,8 @@ override_dh_install:
 	cp etc/templates/config/ubuntu/20/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/20/04
 	cp etc/templates/config/ubuntu/22/04/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ubuntu/22/04
 
-	cp etc/templates/config/rocky/9/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rocky/8
-	cp etc/templates/config/rocky/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rocky/9
+	cp etc/templates/config/rocky/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rocky/8
+	cp etc/templates/config/rocky/9/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rocky/9
 
 	cp etc/templates/config/almalinux/8/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/almalinux/8
 	cp etc/templates/config/almalinux/9/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/almalinux/9

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -118,7 +118,6 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/su
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora/{29,30,31,32,33,34}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/{8,9}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/{8,9}
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/{8,9}
 
 cp -r ruleset/sca/{generic,centos,rhel,ol,sles,amazon,rocky,almalinux} ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp
 
@@ -160,13 +159,11 @@ cp etc/templates/config/fedora/32/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/t
 cp etc/templates/config/fedora/33/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora/33
 cp etc/templates/config/fedora/34/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/fedora/34
 
+cp etc/templates/config/almalinux/8/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/8
 cp etc/templates/config/almalinux/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/9
 
 cp etc/templates/config/rocky/8/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/8
 cp etc/templates/config/rocky/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/9
-
-cp etc/templates/config/almalinux/8/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/8
-
 
 # Add configuration scripts
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/packages_files/agent_installation_scripts/
@@ -656,8 +653,6 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rocky/*
-%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux
-%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/almalinux/*
 %dir %attr(1770, root, wazuh) %{_localstatedir}/tmp
 %dir %attr(750, root, wazuh) %{_localstatedir}/var
 %dir %attr(770, root, wazuh) %{_localstatedir}/var/incoming
@@ -678,14 +673,19 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Tue May 14 2024 support <info@wazuh.com> - 4.9.0
+%changelog
+* Wed Jul 10 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
-* Tue Mar 26 2024 support <info@wazuh.com> - 4.8.2
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
-* Wed Feb 28 2024 support <info@wazuh.com> - 4.8.1
+* Wed Jun 26 2024 support <info@wazuh.com> - 4.8.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
-* Wed Feb 21 2024 support <info@wazuh.com> - 4.8.0
+* Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
+* Thu May 30 2024 support <info@wazuh.com> - 4.7.5
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html
+* Thu Apr 25 2024 support <info@wazuh.com> - 4.7.4
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-7-4.html
+* Tue Feb 27 2024 support <info@wazuh.com> - 4.7.3
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-7-3.html
 * Tue Jan 09 2024 support <info@wazuh.com> - 4.7.2
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-2.html
 * Wed Dec 13 2023 support <info@wazuh.com> - 4.7.1

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -673,7 +673,6 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-%changelog
 * Wed Jul 10 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 * Wed Jun 26 2024 support <info@wazuh.com> - 4.8.1

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -895,16 +895,16 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Tue May 14 2024 support <info@wazuh.com> - 4.9.0
+* Wed Jul 10 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
+* Wed Jun 26 2024 support <info@wazuh.com> - 4.8.1
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
+* Wed Jun 12 2024 support <info@wazuh.com> - 4.8.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
+* Thu May 30 2024 support <info@wazuh.com> - 4.7.5
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-7-5.html
 * Thu Apr 25 2024 support <info@wazuh.com> - 4.7.4
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-4.html
-* Wed Apr 17 2024 support <info@wazuh.com> - 4.8.2
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-2.html
-* Wed Apr 03 2024 support <info@wazuh.com> - 4.8.1
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-1.html
-* Wed Mar 20 2024 support <info@wazuh.com> - 4.8.0
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-8-0.html
 * Tue Feb 27 2024 support <info@wazuh.com> - 4.7.3
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-7-3.html
 * Tue Jan 09 2024 support <info@wazuh.com> - 4.7.2


### PR DESCRIPTION
|Related issue|
|---|
|#23999|

## Description

With this RP, we have removed and modified all references to versions that should not exist or should be updated, such as: 
- Add `4.7.5`.
- Remove `4.8.2`.
- Modify `4.8.1`.

## Tests

These changes should not affect any functionality, as it is merely informative. 
But to confirm that it doesn't give problems, I'm going to run the package build for _wazuh-manager_ and _wazuh-agent_ from both _RPM_ and _Deb_.
- [x] wazuh-manager - Deb: https://github.com/wazuh/wazuh/actions/runs/9466377230
- [x] wazuh-manager - RPM: https://github.com/wazuh/wazuh/actions/runs/9466382517
- [x] wazuh-agent - Deb: https://github.com/wazuh/wazuh-agent-packages/actions/runs/9466413309
- [x] wazuh-agent - RPM: https://github.com/wazuh/wazuh-agent-packages/actions/runs/9466416906
