### PR TITLE
Migrate bump version.py script from wazuh packages

### DIFF
--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -5,9 +5,63 @@
 # May 2, 2017
 
 # Syntax:
-# bump_version [ <version> ] [ -r <revision> ] [ -p <product_version> ]
+# bump_version [ -v <version> ] [ -r <revision> ] [ -p <product_version> ] [ -d <Date to bump to> ]
+# bump_version [ -d <Date to bump to> ]
+# -d <Date> Format: YYYY-mm-dd. Default: today
+# -r <revision> Specify the new revision number, this field does not impact over packages.
+# Usage:
+# If -v option is present, the script will add the provided version, revision, product version, and date information.
+# If -v option is not present, the script will update the existing version, revision, product version or date information
+# with the values provided for -r, -p, and -d options.
 # Example:
-# ./bump_version.sh v3.0.0-alpha1 -r 3457 -p 3.0.0.1
+# ./bump_version.sh -v v3.0.0-alpha1 -r 3457 -p 3.0.0.1 -d 2024-06-10
+# ./bump_version.sh -d 2024-06-10
+
+
+cd $(dirname $0)
+
+VERSION_FILE="../src/VERSION"
+REVISION_FILE="../src/REVISION"
+DEFS_FILE="../src/headers/defs.h"
+WAZUH_SERVER="../src/init/wazuh-server.sh"
+WAZUH_AGENT="../src/init/wazuh-client.sh"
+WAZUH_LOCAL="../src/init/wazuh-local.sh"
+NSIS_FILE="../src/win32/wazuh-installer.nsi"
+MSI_FILE="../src/win32/wazuh-installer.wxs"
+FW_INIT="../framework/wazuh/__init__.py"
+CLUSTER_INIT="../framework/wazuh/core/cluster/__init__.py"
+API_SETUP="../api/setup.py"
+API_SPEC="../api/api/spec/spec.yaml"
+VERSION_DOCU="../src/Doxyfile"
+WIN_RESOURCE="../src/win32/version.rc"
+
+# Wazuh Packages
+## Find files to bump .spec, changelog, copyright, .pkgproj
+SPEC_FILES=$(find ../packages -name *.spec -type f)
+CHANGELOG_FILES=$(find ../packages -name changelog -type f)
+COPYRIGHT_FILES=$(find ../packages -name copyright -type f)
+PKGPROJ_FILES=$(find ../packages -name *.pkgproj -type f)
+
+help(){
+    echo 'Usage:'
+    echo -e "\tSyntax: $0 [-v  <version> ] [ -r <revision> ] [ -p <product_version> ] [ -d <Date to bump to> ]"
+    echo -e "\tSyntax: $0 -d <Update release date> "
+    echo -e "\t -d <Date>. Format: YYYY-mm-dd. Default: 'today'"
+    echo
+    echo "Note:"
+    echo -e '\t- If -v option is present, the script will add the provided version, revision, product version, and date information.'
+    echo -e '\t- If -v option is not present, the script will update the existing version, revision, product version or date information'
+    echo -e '\t with the values provided for -r, -p, and -d options.'
+    echo 'Example:'
+    echo -e "\t $0 -v v3.0.0-alpha1 -r 3457 -p 3.0.0.1 -d 2024-06-10"
+    echo -e "\t $0 -d 2024-06-10"
+    echo
+    exit 1
+}
+
+if [ $# -le 1 ]; then
+    help
+fi
 
 while [ -n "$1" ]
 do
@@ -34,42 +88,33 @@ do
 
         shift 2
         ;;
-    *)
-        if [[ $1 =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:]]+)?$ ]]
+    "-d")
+        if [[ $2 =~ ^[0-9]{4}-((0[1-9])|(1[0-2]))-(([0-2][1-9])|(3[01]))$ ]]
         then
-            version=$1
+            bump_date=$2
+        else
+            echo "Error: Invalid date. Format expected 'YYYY-mm-dd'."
+            exit 1
+        fi
+
+        shift 2
+        ;;
+    "-v")
+        if [[ $2 =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:]]+)?$ ]]
+        then
+            version=$2
         else
             echo "Error: incorrect version (must have form 'vX.X.X' or 'vX.X.X-...')."
             exit 1
         fi
 
-        shift 1
+        shift 2
+        ;;
+    *)
+        help
     esac
 done
 
-if [ -z "$version" ] && [ -z "$revision" ] && [ -z "$product" ]
-then
-    echo "Error: no arguments given."
-    echo "Syntax: $0 [ <version> ] [ -r <revision> ] [ -p <product_version> ]"
-    exit 1
-fi
-
-cd $(dirname $0)
-
-VERSION_FILE="../src/VERSION"
-REVISION_FILE="../src/REVISION"
-DEFS_FILE="../src/headers/defs.h"
-WAZUH_SERVER="../src/init/wazuh-server.sh"
-WAZUH_AGENT="../src/init/wazuh-client.sh"
-WAZUH_LOCAL="../src/init/wazuh-local.sh"
-NSIS_FILE="../src/win32/wazuh-installer.nsi"
-MSI_FILE="../src/win32/wazuh-installer.wxs"
-FW_INIT="../framework/wazuh/__init__.py"
-CLUSTER_INIT="../framework/wazuh/core/cluster/__init__.py"
-API_SETUP="../api/setup.py"
-API_SPEC="../api/api/spec/spec.yaml"
-VERSION_DOCU="../src/Doxyfile"
-WIN_RESOURCE="../src/win32/version.rc"
 
 if [ -n "$version" ]
 then
@@ -217,3 +262,60 @@ then
 
     sed -E -i'' -e "s/^(VIProductVersion \").+\"/\1$product\"/g" $NSIS_FILE
 fi
+
+# Wazuh Packages
+if [ -z "$version" ]
+then
+    UPDATE_RELESE_DATE="yes"
+    version=$(cat $VERSION_FILE)
+fi
+
+VERSION=$(sed 's/v//' <<< $version)
+mayor=${VERSION%%.*}
+minor=$(cut -d"." -f1 <<< ${VERSION#*.})
+patch=${VERSION##*.}
+
+if [ -z "$bump_date" ]
+then
+    bump_date=$(LC_ALL=en_US.UTF-8 TZ="UTC" date +"%F")
+    echo "Use default date: $bump_date"
+fi
+
+bump_date=$(LC_ALL=en_US.UTF-8 TZ="UTC" date -d "$bump_date" +"%a, %d %b %Y %H:%M:%S %z")
+
+# SPECS files
+spec_date=$(LC_ALL=en_US.UTF-8 TZ="UTC" date -d "$bump_date" +"%a %b %d %Y")
+for spec_file in $SPEC_FILES; do
+    echo "Bumping version in $spec_file"
+    if [ -z "$UPDATE_RELESE_DATE" ] ; then
+        sed -E -i'' "/%changelog/a * $spec_date support <info@wazuh.com> - ${VERSION}\n\
+- More info: https://documentation.wazuh.com/current/release-notes/release-$mayor-$minor-$patch.html" $spec_file
+    else
+       sed -E -i'' "/%changelog/{N;s/\n.*support/\n* $spec_date support/}" $spec_file
+    fi
+done
+
+# Deb changelog files
+for changelog_file in $CHANGELOG_FILES; do
+    echo "Bumping version in $changelog_file"
+    install_type=$(sed -E 's/.*wazuh-(manager|agent).*/wazuh-\1/' <<< $changelog_file)
+    if [ -z "$UPDATE_RELESE_DATE" ] ; then
+        changelog_string="$install_type (${VERSION}-RELEASE) stable; urgency=low\n\n  * More info: https://documentation.wazuh.com/current/release-notes/release-$mayor-$minor-$patch.html\
+\n\n -- Wazuh, Inc <info@wazuh.com>  $bump_date\n"
+        # Add new version to changelog
+        sed -i'' "1i $changelog_string" $changelog_file
+    else
+       sed -E -i'' "/$install_type \(${VERSION}-RELEASE\) stable; urgency=low/{N;N;N;N; s/> .*/>  $bump_date/}" $changelog_file
+    fi
+done
+
+## Deb copyright files
+for copyright_file in $COPYRIGHT_FILES; do
+    sed -E -i'' "s/(\sWazuh, Inc <info@wazuh.com> on).*/\1 $bump_date/" $copyright_file
+done
+
+# MacOS pkgproj files
+for pkgproj_file in $PKGPROJ_FILES; do
+    sed -E -i'' "s/(<string>)([0-9]+\.){2}[0-9]+-[0-9]+(<\/string>)/\1$VERSION-1\3/" $pkgproj_file
+    sed -E -i'' "s/(<string>wazuh-agent-)([0-9]+\.){2}[0-9]+-[0-9]+/\1$VERSION-1/" $pkgproj_file
+done

--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -89,7 +89,7 @@ do
         shift 2
         ;;
     "-d")
-        if [[ $2 =~ ^[0-9]{4}-((0[1-9])|(1[0-2]))-(([0-2][1-9])|(3[01]))$ ]]
+        if [[ $2 =~ ^[0-9]{4}-((0[1-9])|(1[0-2]))-(([0-2][1-9])|([12]0)|(3[01]))$ ]]
         then
             bump_date=$2
         else
@@ -266,7 +266,7 @@ fi
 # Wazuh Packages
 if [ -z "$version" ]
 then
-    UPDATE_RELESE_DATE="yes"
+    UPDATE_RELEASE_DATE="yes"
     version=$(cat $VERSION_FILE)
 fi
 
@@ -286,8 +286,8 @@ bump_date=$(LC_ALL=en_US.UTF-8 TZ="UTC" date -d "$bump_date" +"%a, %d %b %Y %H:%
 # SPECS files
 spec_date=$(LC_ALL=en_US.UTF-8 TZ="UTC" date -d "$bump_date" +"%a %b %d %Y")
 for spec_file in $SPEC_FILES; do
-    echo "Bumping version in $spec_file"
-    if [ -z "$UPDATE_RELESE_DATE" ] ; then
+    echo "Updating the release date of $version in $spec_file"
+    if [ -z "$UPDATE_RELEASE_DATE" ] ; then
         sed -E -i'' "/%changelog/a * $spec_date support <info@wazuh.com> - ${VERSION}\n\
 - More info: https://documentation.wazuh.com/current/release-notes/release-$mayor-$minor-$patch.html" $spec_file
     else
@@ -297,9 +297,9 @@ done
 
 # Deb changelog files
 for changelog_file in $CHANGELOG_FILES; do
-    echo "Bumping version in $changelog_file"
+    echo "Updating the release date of $version in $changelog_file"
     install_type=$(sed -E 's/.*wazuh-(manager|agent).*/wazuh-\1/' <<< $changelog_file)
-    if [ -z "$UPDATE_RELESE_DATE" ] ; then
+    if [ -z "$UPDATE_RELEASE_DATE" ] ; then
         changelog_string="$install_type (${VERSION}-RELEASE) stable; urgency=low\n\n  * More info: https://documentation.wazuh.com/current/release-notes/release-$mayor-$minor-$patch.html\
 \n\n -- Wazuh, Inc <info@wazuh.com>  $bump_date\n"
         # Add new version to changelog


### PR DESCRIPTION
|Related issue|
|---|
|#23953|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR migrates the `bump_version.py` script to a Bash version and introduces a feature for updating release dates. The bump_version.sh script is updated with the functionality required from the original Python script ([link to bump_version.py](https://github.com/wazuh/wazuh-packages/blob/master/bump_version.py)), along with the addition of an option to update the release date.

### How to use

![image](https://github.com/wazuh/wazuh/assets/21695385/19baa358-ebf1-4b07-85c3-3da2cf5ad202)

## Tests
Using the bump_version.py script I got:
<details>
<summary>Python script output:  </summary>

```bash
# Date: 10 Jun 2024
python3 ../tools/bump_version.py -v 4.10.0
git diff package > python_script.diff
```

```diff
diff --git a/packages/debs/SPECS/wazuh-agent/debian/changelog b/packages/debs/SPECS/wazuh-agent/debian/changelog
index aadf3c6586..65ea2e57bb 100644
--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -1,3 +1,9 @@
+wazuh-agent (4.10.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 10 Jun 2024 00:00:00 +0000
+
 wazuh-agent (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
diff --git a/packages/debs/SPECS/wazuh-agent/debian/copyright b/packages/debs/SPECS/wazuh-agent/debian/copyright
index 9d0f205188..a66319a8d3 100644
--- a/packages/debs/SPECS/wazuh-agent/debian/copyright
+++ b/packages/debs/SPECS/wazuh-agent/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Mon, 10 Jun 2024 00:00:00 +0000
 
 It was downloaded from:
 
diff --git a/packages/debs/SPECS/wazuh-manager/debian/changelog b/packages/debs/SPECS/wazuh-manager/debian/changelog
index c72a0434eb..1f97a3d259 100644
--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -1,3 +1,9 @@
+wazuh-manager (4.10.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 10 Jun 2024 00:00:00 +0000
+
 wazuh-manager (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
diff --git a/packages/debs/SPECS/wazuh-manager/debian/copyright b/packages/debs/SPECS/wazuh-manager/debian/copyright
index 9d0f205188..a66319a8d3 100644
--- a/packages/debs/SPECS/wazuh-manager/debian/copyright
+++ b/packages/debs/SPECS/wazuh-manager/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Mon, 10 Jun 2024 00:00:00 +0000
 
 It was downloaded from:
 
diff --git a/packages/macos/specs/wazuh-agent-arm64.pkgproj b/packages/macos/specs/wazuh-agent-arm64.pkgproj
index 9c463b1a19..c06df83893 100644
--- a/packages/macos/specs/wazuh-agent-arm64.pkgproj
+++ b/packages/macos/specs/wazuh-agent-arm64.pkgproj
@@ -812,7 +812,7 @@
 				<key>USE_HFS+_COMPRESSION</key>
 				<false/>
 				<key>VERSION</key>
-				<string>4.9.0-1</string>
+				<string>4.10.0-1</string>
 			</dict>
 			<key>TYPE</key>
 			<integer>0</integer>
@@ -1240,7 +1240,7 @@
 				</dict>
 			</array>
 			<key>NAME</key>
-			<string>wazuh-agent-4.9.0-1.arm64</string>
+			<string>wazuh-agent-4.10.0-1.arm64</string>
 			<key>PAYLOAD_ONLY</key>
 			<false/>
 			<key>TREAT_MISSING_PRESENTATION_DOCUMENTS_AS_WARNING</key>
diff --git a/packages/macos/specs/wazuh-agent-intel64.pkgproj b/packages/macos/specs/wazuh-agent-intel64.pkgproj
index 743fd71890..271c372a43 100644
--- a/packages/macos/specs/wazuh-agent-intel64.pkgproj
+++ b/packages/macos/specs/wazuh-agent-intel64.pkgproj
@@ -812,7 +812,7 @@
 				<key>USE_HFS+_COMPRESSION</key>
 				<false/>
 				<key>VERSION</key>
-				<string>4.9.0-1</string>
+				<string>4.10.0-1</string>
 			</dict>
 			<key>TYPE</key>
 			<integer>0</integer>
@@ -1239,7 +1239,7 @@
 				</dict>
 			</array>
 			<key>NAME</key>
-			<string>wazuh-agent-4.9.0-1.intel64</string>
+			<string>wazuh-agent-4.10.0-1.intel64</string>
 			<key>PAYLOAD_ONLY</key>
 			<false/>
 			<key>TREAT_MISSING_PRESENTATION_DOCUMENTS_AS_WARNING</key>
diff --git a/packages/rpms/SPECS/wazuh-agent.spec b/packages/rpms/SPECS/wazuh-agent.spec
index 5ccbeac5f4..4a4dccb577 100644
--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -678,6 +678,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
+* Mon Jun 10 2024 support <info@wazuh.com> - 4.10.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
 * Tue May 14 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 * Tue Mar 26 2024 support <info@wazuh.com> - 4.8.2
diff --git a/packages/rpms/SPECS/wazuh-manager.spec b/packages/rpms/SPECS/wazuh-manager.spec
index 56e66f2f9d..fa4b9aeeb5 100644
--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -895,6 +895,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
+* Mon Jun 10 2024 support <info@wazuh.com> - 4.10.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
 * Tue May 14 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 * Thu Apr 25 2024 support <info@wazuh.com> - 4.7.4
```

</details>









<details>
<summary>Bash script output:  </summary>

```bash
# Date: 12 Jun 2024
./bump_version.sh -r 1 -v v4.10.0
```

```diff
diff --git a/packages/debs/SPECS/wazuh-agent/debian/changelog b/packages/debs/SPECS/wazuh-agent/debian/changelog
index aadf3c6586..a97afbcc6e 100644
--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -1,3 +1,9 @@
+wazuh-agent (4.10.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 12 Jun 2024 00:00:00 +0000
+
 wazuh-agent (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
diff --git a/packages/debs/SPECS/wazuh-agent/debian/copyright b/packages/debs/SPECS/wazuh-agent/debian/copyright
index 9d0f205188..e8acc4748d 100644
--- a/packages/debs/SPECS/wazuh-agent/debian/copyright
+++ b/packages/debs/SPECS/wazuh-agent/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 12 Jun 2024 00:00:00 +0000
 
 It was downloaded from:
 
diff --git a/packages/debs/SPECS/wazuh-manager/debian/changelog b/packages/debs/SPECS/wazuh-manager/debian/changelog
index c72a0434eb..8ef6e32bec 100644
--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -1,3 +1,9 @@
+wazuh-manager (4.10.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 12 Jun 2024 00:00:00 +0000
+
 wazuh-manager (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
diff --git a/packages/debs/SPECS/wazuh-manager/debian/copyright b/packages/debs/SPECS/wazuh-manager/debian/copyright
index 9d0f205188..e8acc4748d 100644
--- a/packages/debs/SPECS/wazuh-manager/debian/copyright
+++ b/packages/debs/SPECS/wazuh-manager/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 12 Jun 2024 00:00:00 +0000
 
 It was downloaded from:
 
diff --git a/packages/macos/specs/wazuh-agent-arm64.pkgproj b/packages/macos/specs/wazuh-agent-arm64.pkgproj
index 9c463b1a19..c06df83893 100644
--- a/packages/macos/specs/wazuh-agent-arm64.pkgproj
+++ b/packages/macos/specs/wazuh-agent-arm64.pkgproj
@@ -812,7 +812,7 @@
 				<key>USE_HFS+_COMPRESSION</key>
 				<false/>
 				<key>VERSION</key>
-				<string>4.9.0-1</string>
+				<string>4.10.0-1</string>
 			</dict>
 			<key>TYPE</key>
 			<integer>0</integer>
@@ -1240,7 +1240,7 @@
 				</dict>
 			</array>
 			<key>NAME</key>
-			<string>wazuh-agent-4.9.0-1.arm64</string>
+			<string>wazuh-agent-4.10.0-1.arm64</string>
 			<key>PAYLOAD_ONLY</key>
 			<false/>
 			<key>TREAT_MISSING_PRESENTATION_DOCUMENTS_AS_WARNING</key>
diff --git a/packages/macos/specs/wazuh-agent-intel64.pkgproj b/packages/macos/specs/wazuh-agent-intel64.pkgproj
index 743fd71890..271c372a43 100644
--- a/packages/macos/specs/wazuh-agent-intel64.pkgproj
+++ b/packages/macos/specs/wazuh-agent-intel64.pkgproj
@@ -812,7 +812,7 @@
 				<key>USE_HFS+_COMPRESSION</key>
 				<false/>
 				<key>VERSION</key>
-				<string>4.9.0-1</string>
+				<string>4.10.0-1</string>
 			</dict>
 			<key>TYPE</key>
 			<integer>0</integer>
@@ -1239,7 +1239,7 @@
 				</dict>
 			</array>
 			<key>NAME</key>
-			<string>wazuh-agent-4.9.0-1.intel64</string>
+			<string>wazuh-agent-4.10.0-1.intel64</string>
 			<key>PAYLOAD_ONLY</key>
 			<false/>
 			<key>TREAT_MISSING_PRESENTATION_DOCUMENTS_AS_WARNING</key>
diff --git a/packages/rpms/SPECS/wazuh-agent.spec b/packages/rpms/SPECS/wazuh-agent.spec
index 5ccbeac5f4..0cd5699165 100644
--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -678,6 +678,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
+* Wed Jun 12 2024 support <info@wazuh.com> - 4.10.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
 * Tue May 14 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 * Tue Mar 26 2024 support <info@wazuh.com> - 4.8.2
diff --git a/packages/rpms/SPECS/wazuh-manager.spec b/packages/rpms/SPECS/wazuh-manager.spec
index 56e66f2f9d..cad368184b 100644
--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -895,6 +895,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
+* Wed Jun 12 2024 support <info@wazuh.com> - 4.10.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
 * Tue May 14 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 * Thu Apr 25 2024 support <info@wazuh.com> - 4.7.4
```
</details>









<details>
<summary>Diff output between python and bas script: </summary>
The only difference here is the date bump date.

`diff bash_script.diff python_script.py`
```diff
2c2
< index aadf3c6586..a97afbcc6e 100644
---
> index aadf3c6586..65ea2e57bb 100644
10c10
< + -- Wazuh, Inc <info@wazuh.com>  Wed, 12 Jun 2024 00:00:00 +0000
---
> + -- Wazuh, Inc <info@wazuh.com>  Mon, 10 Jun 2024 00:00:00 +0000
16c16
< index 9d0f205188..e8acc4748d 100644
---
> index 9d0f205188..a66319a8d3 100644
23c23
< +    Wazuh, Inc <info@wazuh.com> on Wed, 12 Jun 2024 00:00:00 +0000
---
> +    Wazuh, Inc <info@wazuh.com> on Mon, 10 Jun 2024 00:00:00 +0000
28c28
< index c72a0434eb..8ef6e32bec 100644
---
> index c72a0434eb..1f97a3d259 100644
36c36
< + -- Wazuh, Inc <info@wazuh.com>  Wed, 12 Jun 2024 00:00:00 +0000
---
> + -- Wazuh, Inc <info@wazuh.com>  Mon, 10 Jun 2024 00:00:00 +0000
42c42
< index 9d0f205188..e8acc4748d 100644
---
> index 9d0f205188..a66319a8d3 100644
49c49
< +    Wazuh, Inc <info@wazuh.com> on Wed, 12 Jun 2024 00:00:00 +0000
---
> +    Wazuh, Inc <info@wazuh.com> on Mon, 10 Jun 2024 00:00:00 +0000
98c98
< index 5ccbeac5f4..0cd5699165 100644
---
> index 5ccbeac5f4..4a4dccb577 100644
105c105
< +* Wed Jun 12 2024 support <info@wazuh.com> - 4.10.0
---
> +* Mon Jun 10 2024 support <info@wazuh.com> - 4.10.0
111c111
< index 56e66f2f9d..cad368184b 100644
---
> index 56e66f2f9d..fa4b9aeeb5 100644
118c118
< +* Wed Jun 12 2024 support <info@wazuh.com> - 4.10.0
---
> +* Mon Jun 10 2024 support <info@wazuh.com> - 4.10.0
```
</details>


<details>
<summary>Using update release date: </summary>

```bash
./bump_version.sh -d 2024-06-10 
git diff package > bash_script_update_bump_date.diff
```
</details>

<details>
<summary> bash_script_update_bump_date.diff </summary>

```
diff --git a/packages/debs/SPECS/wazuh-agent/debian/changelog b/packages/debs/SPECS/wazuh-agent/debian/changelog
index aadf3c6586..65ea2e57bb 100644
--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -1,3 +1,9 @@
+wazuh-agent (4.10.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 10 Jun 2024 00:00:00 +0000
+
 wazuh-agent (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
diff --git a/packages/debs/SPECS/wazuh-agent/debian/copyright b/packages/debs/SPECS/wazuh-agent/debian/copyright
index 9d0f205188..a66319a8d3 100644
--- a/packages/debs/SPECS/wazuh-agent/debian/copyright
+++ b/packages/debs/SPECS/wazuh-agent/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Mon, 10 Jun 2024 00:00:00 +0000
 
 It was downloaded from:
 
diff --git a/packages/debs/SPECS/wazuh-manager/debian/changelog b/packages/debs/SPECS/wazuh-manager/debian/changelog
index c72a0434eb..1f97a3d259 100644
--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -1,3 +1,9 @@
+wazuh-manager (4.10.0-RELEASE) stable; urgency=low
+
+  * More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
+
+ -- Wazuh, Inc <info@wazuh.com>  Mon, 10 Jun 2024 00:00:00 +0000
+
 wazuh-manager (4.9.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
diff --git a/packages/debs/SPECS/wazuh-manager/debian/copyright b/packages/debs/SPECS/wazuh-manager/debian/copyright
index 9d0f205188..a66319a8d3 100644
--- a/packages/debs/SPECS/wazuh-manager/debian/copyright
+++ b/packages/debs/SPECS/wazuh-manager/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Tue, 14 May 2024 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Mon, 10 Jun 2024 00:00:00 +0000
 
 It was downloaded from:
 
diff --git a/packages/macos/specs/wazuh-agent-arm64.pkgproj b/packages/macos/specs/wazuh-agent-arm64.pkgproj
index 9c463b1a19..c06df83893 100644
--- a/packages/macos/specs/wazuh-agent-arm64.pkgproj
+++ b/packages/macos/specs/wazuh-agent-arm64.pkgproj
@@ -812,7 +812,7 @@
                                <key>USE_HFS+_COMPRESSION</key>
                                <false/>
                                <key>VERSION</key>
-                               <string>4.9.0-1</string>
+                               <string>4.10.0-1</string>
                        </dict>
                        <key>TYPE</key>
                        <integer>0</integer>
@@ -1240,7 +1240,7 @@
                                </dict>
                        </array>
                        <key>NAME</key>
-                       <string>wazuh-agent-4.9.0-1.arm64</string>
+                       <string>wazuh-agent-4.10.0-1.arm64</string>
                        <key>PAYLOAD_ONLY</key>
                        <false/>
                        <key>TREAT_MISSING_PRESENTATION_DOCUMENTS_AS_WARNING</key>
diff --git a/packages/macos/specs/wazuh-agent-intel64.pkgproj b/packages/macos/specs/wazuh-agent-intel64.pkgproj
index 743fd71890..271c372a43 100644
--- a/packages/macos/specs/wazuh-agent-intel64.pkgproj
+++ b/packages/macos/specs/wazuh-agent-intel64.pkgproj
@@ -812,7 +812,7 @@
                                <key>USE_HFS+_COMPRESSION</key>
                                <false/>
                                <key>VERSION</key>
-                               <string>4.9.0-1</string>
+                               <string>4.10.0-1</string>
                        </dict>
                        <key>TYPE</key>
                        <integer>0</integer>
@@ -1239,7 +1239,7 @@
                                </dict>
                        </array>
                        <key>NAME</key>
-                       <string>wazuh-agent-4.9.0-1.intel64</string>
+                       <string>wazuh-agent-4.10.0-1.intel64</string>
                        <key>PAYLOAD_ONLY</key>
                        <false/>
                        <key>TREAT_MISSING_PRESENTATION_DOCUMENTS_AS_WARNING</key>
diff --git a/packages/rpms/SPECS/wazuh-agent.spec b/packages/rpms/SPECS/wazuh-agent.spec
index 5ccbeac5f4..4a4dccb577 100644
--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -678,6 +678,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
+* Mon Jun 10 2024 support <info@wazuh.com> - 4.10.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
 * Tue May 14 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 * Tue Mar 26 2024 support <info@wazuh.com> - 4.8.2
diff --git a/packages/rpms/SPECS/wazuh-manager.spec b/packages/rpms/SPECS/wazuh-manager.spec
index 56e66f2f9d..fa4b9aeeb5 100644
--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -895,6 +895,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
+* Mon Jun 10 2024 support <info@wazuh.com> - 4.10.0
+- More info: https://documentation.wazuh.com/current/release-notes/release-4-10-0.html
 * Tue May 14 2024 support <info@wazuh.com> - 4.9.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-9-0.html
 * Thu Apr 25 2024 support <info@wazuh.com> - 4.7.4
```
</details>

**Note:** The `diff bash_script_update_bump_date.diff python_script.diff` is **empty**.


