### PR TITLE
Cache request body before calling the endpoint controller

### DIFF
--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -232,6 +232,17 @@ class WazuhAccessLoggerMiddleware(BaseHTTPMiddleware):
             Returned response.
         """
         prev_time = time.time()
+
+        body = await request.body()
+        if body:
+            try:
+                # Load the request body to the _json field before calling the controller so it's cached before the stream 
+                # is consumed. If there's a json error we skip it so it's handled later.
+                # Related to https://github.com/wazuh/wazuh/issues/24060.
+                _ = await request.json()
+            except json.decoder.JSONDecodeError:
+                pass
+
         response = await call_next(request)
         await access_log(ConnexionRequest.from_starlette_request(request), response, prev_time)
         return response

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -279,8 +279,9 @@ async def test_access_log_ko(mock_req, exception):
 
 @pytest.mark.asyncio
 @freeze_time(datetime(1970, 1, 1, 0, 0, 10))
-async def test_wazuh_access_logger_middleware(mock_req):
+async def test_wazuh_access_logger_middleware():
     """Test access logger middleware."""
+    mock_req = AsyncMock()
     response = MagicMock()
     response.status_code = 200
     dispatch_mock = AsyncMock(return_value=response)


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/24060 |

## Description

Loads the request body before calling the controller to cache it inside the object and avoid consuming a runtime error because the stream was already consumed.

## Tests

 <details><summary>Body 1</summary>

```
No body
```

</details>

<details><summary>Body 2</summary>

```json
{
  "name": "Initial_auth",
  "auth": {
    "name": "test",
  }
}
```

</details>

<details><summary>Body 3</summary>

```json
{
  "name": "Initial_auth",
  "auth": {
    "name": "test",
    "office": [
      "20",
      "21",
      "30"
    ]
  }
}
```

</details>

<details><summary>Logs</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
2024/06/12 14:33:00 INFO: Starting API in foreground
2024/06/12 14:33:00 INFO: Checking RBAC database integrity...
2024/06/12 14:33:00 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2024/06/12 14:33:00 INFO: RBAC database integrity check finished successfully
2024/06/12 14:33:02 INFO: Listening on 0.0.0.0:55000.
2024/06/12 14:33:02 INFO: Getting installation UID...
2024/06/12 14:33:02 INFO: Getting updates information...
2024/06/12 14:33:06 INFO: wazuh (2afb9b83f9314e5d029766197f539792) 172.19.0.1 "POST /security/user/authenticate/run_as" with parameters {} and body {} done in 0.154s: 400 # Empty body
2024/06/12 14:33:06 INFO: wazuh (2afb9b83f9314e5d029766197f539792) 172.19.0.1 "POST /security/user/authenticate/run_as" with parameters {} and body {} done in 0.123s: 400 # Invalid body
2024/06/12 14:33:15 INFO: wazuh (5a5e646ea0bc6e3653cfc593d62b16f7) 172.19.0.1 "POST /security/user/authenticate/run_as" with parameters {} and body {"name": "Initial_auth", "auth": {"name": "test", "office": ["20", "21", "30"]}} done in 0.147s: 200
```

</details>