### PR TITLE
Fix some Coverity defects in syscheck and syscollector

### DIFF
--- a/src/config/wmodules-syscollector.c
+++ b/src/config/wmodules-syscollector.c
@@ -114,7 +114,7 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
             }
 
             if (syscollector->interval < W_MINUTE_SECONDS) {
-                mwarn("The scan interval value '%ld second/s' is too small. Option set to 60 seconds.");
+                mwarn("The scan interval value '%d seconds' is too small. Option set to 60 seconds.", syscollector->interval);
                 syscollector->interval = W_MINUTE_SECONDS;
             }
         } else if (!strcmp(node[i]->element, XML_SCAN_ON_START)) {

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -1369,7 +1369,7 @@ void fim_get_checksum (fim_file_data * data) {
 
     size = snprintf(0,
             0,
-            "%d:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
+            "%lu:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
             data->size,
             data->perm ? data->perm : "",
             data->attributes ? data->attributes : "",
@@ -1386,7 +1386,7 @@ void fim_get_checksum (fim_file_data * data) {
     os_calloc(size + 1, sizeof(char), checksum);
     snprintf(checksum,
             size + 1,
-            "%d:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
+            "%lu:%s:%s:%s:%s:%s:%s:%lu:%llu:%s:%s:%s",
             data->size,
             data->perm ? data->perm : "",
             data->attributes ? data->attributes : "",

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -1163,7 +1163,11 @@ static void test_fim_get_checksum_wrong_size(void **state) {
     strcpy(fim_data->local_data->checksum, "");
 
     fim_get_checksum(fim_data->local_data);
-    assert_string_equal(fim_data->local_data->checksum, "551cab7f774d4633a3be09207b4cdea1db03b9c0");
+#ifndef TEST_WINAGENT
+    assert_string_equal(fim_data->local_data->checksum, "0a0070d140761418be81531ad48f5909f410e161");
+#else
+    assert_string_equal(fim_data->local_data->checksum, "82f41449afd19d3e1ed2ad37c0a35624f09f5dfe");
+#endif
 }
 
 static void test_fim_check_depth_success(void **state) {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1019,6 +1019,8 @@ void Syscollector::updateChanges(const std::string& table,
 
 Syscollector::Syscollector()
     : m_intervalValue { 0 }
+    , m_currentIntervalValue { 0 }
+    , m_lastSyncMsg { 0 }
     , m_scanOnStart { false }
     , m_hardware { false }
     , m_os { false }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24071#top|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In this PR we are introducing multiple fixes related to Coverity reporting.

## Testing Coverity again
- First iteration:
![image](https://github.com/wazuh/wazuh/assets/60003131/c0c909d0-64a4-4996-adfc-ec49ef653840)
- Second iteration:
![image](https://github.com/wazuh/wazuh/assets/60003131/4548dd30-2a5c-4d1c-9526-d6cc841057a9)

Finally, this snapshot shows every defects fixed:
https://scan9.scan.coverity.com/#/project-view/55587/12779