### PR TITLE
Fix arguments mismatch

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -541,12 +541,15 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
             // type is an attribute of the subscriber tag
             if (!strcmp(*nodes[i]->attributes, XML_SUBSCRIBER_TYPE)) {
                 if (!nodes[i]->values) {
-                    mterror(WM_AWS_LOGTAG, "Empty subscriber type. Valid ones are '%s' or '%s'", SECURITY_LAKE_SUBSCRIBER_TYPE, BUCKETS_SUBSCRIBER_TYPE, SECURITY_HUB_SUBSCRIBER_TYPE);
+                    mterror(WM_AWS_LOGTAG, "Empty subscriber type. Valid ones are '%s', '%s' or '%s'",
+                        SECURITY_LAKE_SUBSCRIBER_TYPE, BUCKETS_SUBSCRIBER_TYPE, SECURITY_HUB_SUBSCRIBER_TYPE);
                     return OS_INVALID;
                 } else if (!strcmp(*nodes[i]->values, SECURITY_LAKE_SUBSCRIBER_TYPE) || !strcmp(*nodes[i]->values, BUCKETS_SUBSCRIBER_TYPE) || !strcmp(*nodes[i]->values, SECURITY_HUB_SUBSCRIBER_TYPE)) {
                     os_strdup(*nodes[i]->values, cur_subscriber->type);
                 } else {
-                    mterror(WM_AWS_LOGTAG, "Invalid subscriber type '%s'. Valid ones are '%s' or '%s'", *nodes[i]->values, SECURITY_LAKE_SUBSCRIBER_TYPE, BUCKETS_SUBSCRIBER_TYPE, SECURITY_HUB_SUBSCRIBER_TYPE);
+                    mterror(WM_AWS_LOGTAG, "Invalid subscriber type '%s'. Valid ones are '%s', '%s' or '%s'",
+                        *nodes[i]->values, SECURITY_LAKE_SUBSCRIBER_TYPE, BUCKETS_SUBSCRIBER_TYPE,
+                        SECURITY_HUB_SUBSCRIBER_TYPE);
                     return OS_INVALID;
                 }
             } else {


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/24067 |

## Description

Adds a string placeholder to the log message to match the number of arguments given.

## Configuration options

```xml
<wodle name="aws-s3">
    <disabled>no</disabled>
    <interval>1h</interval>
    <run_on_start>yes</run_on_start>
    <subscriber type="<type>">
        <sqs_name>SQS-QUEUE-NAME</sqs_name>
        <aws_profile>dev</aws_profile>
    </subscriber>
</wodle>
```

## Logs/Alerts example

<details><summary>Valid subscriber type</summary>

```log
2024/06/13 14:00:26 wazuh-modulesd:aws-s3[24708] wm_aws.c:62 at wm_aws_main(): INFO: Module AWS started
2024/06/13 14:00:26 wazuh-modulesd:aws-s3[24708] wm_aws.c:84 at wm_aws_main(): INFO: Starting fetching of logs.
2024/06/13 14:00:26 wazuh-modulesd:aws-s3[24708] wm_aws.c:196 at wm_aws_main(): INFO: Executing Subscriber fetch: (Type and SQS: security_hub SQS-QUEUE-NAME)
2024/06/13 14:00:26 wazuh-modulesd:aws-s3[24708] wm_aws.c:727 at wm_aws_run_subscriber(): DEBUG: Create argument list
2024/06/13 14:00:26 wazuh-modulesd:aws-s3[24708] wm_aws.c:806 at wm_aws_run_subscriber(): DEBUG: Launching S3 Subscriber Command: wodles/aws/aws-s3 --subscriber security_hub --queue SQS-QUEUE-NAME --aws_profile dev --debug 2
2024/06/13 14:00:59 wazuh-modulesd:aws-s3[24708] wm_aws.c:847 at wm_aws_run_subscriber(): DEBUG: Subscriber: security_hub SQS-QUEUE-NAME  -  OUTPUT: DEBUG: +++ Debug mode on - Level: 2
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: The SQS queue is: https://queue.amazonaws.com/XXX/SQS-QUEUE-NAME
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: Retrieving messages from: SQS-QUEUE-NAME
DEBUG: The message is: {'Records': [{'eventVersion': '2.1', 'eventSource': 'aws:s3', 'awsRegion': 'REGION', 'eventTime': '2024-06-13T16:41:24.385Z', 'eventName': 'ObjectCreated:Put', 'userIdentity': {'principalId': 'AWS:ID:AWSFirehoseToS3'}, 'requestParameters': {'sourceIPAddress': '0.0.0.0'}, 'responseElements': {'x-amz-request-id': '...' , 'x-amz-id-2': '...'}, 's3': {'s3SchemaVersion': '1.0', 'configurationId': 'New security hub event', 'bucket': {'name': 'wazuh-aws-wodle-security-hub', 'ownerIdentity': {'principalId': 'ID'}, 'arn': 'arn:aws:s3:::wazuh-aws-wodle-security-hub'}, 'object': {'key': '2024/06/13/20/wazuh-security-hub-findings-1-YYYY-MM-DD-HH-HASH', 'size': 9168, 'eTag': '...', 'sequencer': '...'}}}]}
DEBUG: Message deleted from queue: SQS-QUEUE-NAME
DEBUG: Retrieving messages from: SQS-QUEUE-NAME
DEBUG: The message is: {'Records': [{'eventVersion': '2.1', 'eventSource': 'aws:s3', 'awsRegion': 'REGION', 'eventTime': '2024-06-13T16:54:58.470Z', 'eventName': 'ObjectCreated:Put', 'userIdentity': {'principalId': 'AWS:ID:AWSFirehoseToS3'}, 'requestParameters': {'sourceIPAddress': '0.0.0.0'}, 'responseElements': {'x-amz-request-id': '...' , 'x-amz-id-2': '...'}, 's3': {'s3SchemaVersion': '1.0', 'configurationId': 'New security hub event', 'bucket': {'name': 'wazuh-aws-wodle-security-hub', 'ownerIdentity': {'principalId': 'ID'}, 'arn': 'arn:aws:s3:::wazuh-aws-wodle-security-hub'}, 'object': {'key': '2024/06/13/20/wazuh-security-hub-findings-1-YYYY-MM-DD-HH-HASH', 'size': 242160, 'eTag': '...', 'sequencer': '...'}}}]}
DEBUG: Message deleted from queue: SQS-QUEUE-NAME
DEBUG: Retrieving messages from: SQS-QUEUE-NAME
2024/06/13 18:00:59 wazuh-modulesd:aws-s3[24708] wm_aws.c:201 at wm_aws_main(): INFO: Fetching logs finished.
2024/06/13 18:00:59 wazuh-modulesd:aws-s3[24708] wm_aws.c:80 at wm_aws_main(): DEBUG: Sleeping until: 2024/06/13 15:00:26
```

</details>

<details><summary>Empty subscriber type</summary>

```log
root@wazuh-master:/# /var/ossec/bin/wazuh-control start
2024/06/13 12:52:35 wazuh-db[2710] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/13 12:52:35 wazuh-db[2710] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/06/13 12:52:53 wazuh-remoted[2834] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/13 12:52:53 wazuh-remoted[2834] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/06/13 12:52:53 wazuh-remoted[2834] main.c:148 at main(): DEBUG: This is not a worker
2024/06/13 12:52:53 wazuh-modulesd:aws-s3: ERROR: Empty subscriber type. Valid ones are 'security_lake', 'buckets' or 'security_hub'
2024/06/13 12:52:53 wazuh-modulesd: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
wazuh-modulesd: Configuration error. Exiting
```

</details>

<details><summary>Invalid subscriber type</summary>

```log
root@wazuh-master:/# /var/ossec/bin/wazuh-control start
2024/06/13 12:53:42 wazuh-db[2710] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/13 12:53:42 wazuh-db[2710] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/06/13 12:54:26 wazuh-remoted[2834] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/06/13 12:54:26 wazuh-remoted[2834] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/06/13 12:54:26 wazuh-remoted[2834] main.c:148 at main(): DEBUG: This is not a worker
2024/06/13 12:54:26 wazuh-modulesd:aws-s3: ERROR: Invalid subscriber type 'test'. Valid ones are 'security_lake', 'buckets' or 'security_hub'
2024/06/13 12:54:26 wazuh-modulesd: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
wazuh-modulesd: Configuration error. Exiting
```

</details>

> Failed checks are not related to the changes introduced