### PR TITLE
Add helper tools for integration development in the Engine

### DIFF
--- a/src/engine/test/health_test/initialState.py
+++ b/src/engine/test/health_test/initialState.py
@@ -5,9 +5,11 @@ import argparse
 import shutil
 import sys
 import yaml
+from pathlib import Path
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 WAZUH_DIR = os.path.realpath(os.path.join(SCRIPT_DIR, "../../../.."))
+ENGINE_BIN = ""
 
 
 def parse_args():
@@ -120,6 +122,7 @@ def load_policies():
 def main():
     global ENGINE_SRC_DIR
     global ENVIRONMENT_DIR
+    global ENGINE_BIN
 
     args = parse_args()
 
@@ -129,7 +132,7 @@ def main():
 
     ENGINE_SRC_DIR = os.path.join(WAZUH_DIR, 'src', 'engine')
     ENVIRONMENT_DIR = args.environment or WAZUH_DIR
-    ENVIRONMENT_DIR = ENVIRONMENT_DIR.replace('//', '/')
+    ENVIRONMENT_DIR = str(Path(ENVIRONMENT_DIR).resolve())
     ENGINE_BIN = args.binary or os.path.join(ENGINE_SRC_DIR, 'build', 'main')
     update_conf()
     set_mmdb()
@@ -140,9 +143,11 @@ def main():
         ENVIRONMENT_DIR, 'engine', 'general.conf')
     os.environ['ENGINE_BIN'] = ENGINE_BIN
 
-    from handler_engine_instance import up_down
-    up_down_engine = up_down.UpDownEngine()
-    up_down_engine.send_start_command()
+    engine_command = f"{ENGINE_BIN} --config {os.path.join(ENVIRONMENT_DIR, 'engine', 'general.conf')} server start"
+    print(engine_command)
+    engine_proccess = subprocess.Popen(
+        f"{engine_command}", shell=True)
+    time.sleep(5)
 
     # Add the mmdb to the engine
     print("Adding mmdb to the engine")
@@ -158,7 +163,8 @@ def main():
     load_integrations()
     load_policies()
 
-    up_down_engine.send_stop_command()
+    engine_proccess.terminate()
+    engine_proccess.wait(5)
 
 
 if __name__ == "__main__":

--- a/src/engine/test/setupEnvironment.py
+++ b/src/engine/test/setupEnvironment.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import argparse
+from pathlib import Path
 
 
 def setup_engine(engine_dir, engine_src_dir, environment_dir):
@@ -40,6 +41,7 @@ def main():
     ENGINE_SRC_DIR = os.path.join(SCRIPT_DIR, '../')
     WAZUH_DIR = os.path.realpath(os.path.join(SCRIPT_DIR, '../../../'))
     ENVIRONMENT_DIR = environment_directory or os.path.join(WAZUH_DIR, 'environment')
+    ENVIRONMENT_DIR = str(Path(ENVIRONMENT_DIR).resolve())
     ENGINE_DIR = os.path.join(ENVIRONMENT_DIR, 'engine')
 
     setup_engine(ENGINE_DIR, ENGINE_SRC_DIR, ENVIRONMENT_DIR)

--- a/src/engine/tools/compare_expected.py
+++ b/src/engine/tools/compare_expected.py
@@ -112,8 +112,6 @@ if __name__ == '__main__':
                                 default=False)
         arg_parser.add_argument('-m', '--missing', action='store_true',
                                 help='Show missing fields in the output, default: False', default=False)
-        arg_parser.add_argument('--csv', action='store_true', help='Generate a csv file with the results, default: False',
-                                default=False)
 
         args = arg_parser.parse_args()
 
@@ -123,7 +121,6 @@ if __name__ == '__main__':
         output_path = Path(args.output)
         show_extra = args.extra
         show_missing = args.missing
-        generate_csv = args.csv
 
         # Read the table
         df = pd.read_csv(table)
@@ -205,32 +202,11 @@ if __name__ == '__main__':
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(dumps(compare_results, indent=2))
 
-        # Write the csv results
-        # original, missmatches, missing neededs (Wazuh), missing neededs (other), Extra Wazuh, Extra other
-        if generate_csv:
-            csv_output_path = output_path.with_suffix('.csv')
-            csv_str = ''
-            csv_str += 'original, missmatches, missing neededs (Wazuh), missing neededs (other), Extra Wazuh, Extra other\n'
-            for result in compare_results:
-                original = dumps(result['original'])
-                missmatches = dumps([key for key in result['need_to_match']] if 'need_to_match' in result else '')
-                missing_waz = dumps(result['need_by_waz']
-                                    ) if 'need_by_waz' in result else ''
-                missing_oth = dumps(result['need_by_oth']
-                                    ) if 'need_by_oth' in result else ''
-                extra_waz = dumps(result['wazuh_extra']
-                                ) if 'wazuh_extra' in result else ''
-                extra_oth = dumps(result['other_extra']
-                                ) if 'other_extra' in result else ''
-
-                csv_str += f'{original}, {missmatches}, {missing_waz}, {missing_oth}, {extra_waz}, {extra_oth}\n'
-
-            csv_output_path.write_text(csv_str)
         # Notify the user
         print(
             f'{wazuh_output_path.name} and {other_output_path.name} -> {output_path}')
 
     except KeyboardInterrupt:
         print('Interrupted by the user')
-    # except Exception as e:
-    #     print(f'Unexpected error: {e}')
+    except Exception as e:
+        print(f'Unexpected error: {e}')

--- a/src/engine/tools/compare_expected.py
+++ b/src/engine/tools/compare_expected.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pathlib import Path
 from argparse import ArgumentParser
 from typing import Optional

--- a/src/engine/tools/flat_output.py
+++ b/src/engine/tools/flat_output.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pathlib import Path
 from argparse import ArgumentParser
 from typing import Callable

--- a/src/engine/tools/flatt_output.py
+++ b/src/engine/tools/flatt_output.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+from argparse import ArgumentParser
+from typing import Callable
+from json import loads, dumps
+
+
+def visitor(path: Path, pattern: str, visit: Callable):
+    for file in path.rglob(pattern):
+        if file.is_file():
+            visit(file)
+        elif file.is_dir():
+            visitor(file, pattern, visit)
+
+
+def dict_merge(dct, merge_dct):
+    """ Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
+    updating only top-level keys, dict_merge recurses down into dicts nested
+    to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
+    ``dct``.
+
+    :param dct: dict onto which the merge is executed
+    :param merge_dct: dct merged into dct
+    :return: None
+    """
+    for k, v in merge_dct.items():
+        if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], dict)):  # noqa
+            dict_merge(dct[k], merge_dct[k])
+        else:
+            dct[k] = merge_dct[k]
+
+
+def get_acumulator(fields: dict, key: str):
+    def acumulator(file):
+        try:
+            data = loads(file.read_text())
+            # Verify data is an array
+            if not isinstance(data, list):
+                raise Exception(f'Expected an array, got {type(data)}')
+
+            if len(key) != 0:
+                for expected in data:
+                    dict_merge(fields, expected[key])
+                print(f'{file.name} -> {key}')
+            else:
+                for expected in data:
+                    dict_merge(fields, expected)
+                print(f'{file.name} -> root')
+        except Exception as e:
+            print(f'{file.name} -> {e}')
+    return acumulator
+
+
+if __name__ == '__main__':
+    try:
+        arg_parser = ArgumentParser(
+            description='Flattens the output json of a root field')
+        arg_parser.add_argument(
+            'path', type=Path, help='Path to the input directory')
+        arg_parser.add_argument('pattern', help='Pattern for the output files')
+        arg_parser.add_argument(
+            '-r', '--root', help='Root field to flatten. Default fllattens all fields', default='')
+
+        args = arg_parser.parse_args()
+
+        path = args.path
+        pattern = args.pattern
+        root = args.root
+
+        # Iterate over files, visiting subfolders recursively
+        fields = {}
+        visitor(path, pattern, get_acumulator(fields, root))
+
+        # In order visit the fiels printing leaf keys with their parents separated by dots
+        # A leaf key is a key that does not contain a dict
+        def visit(keys, fields, prefix=''):
+            for key, value in fields.items():
+                if isinstance(value, dict):
+                    visit(keys, value, prefix + key + '.')
+                else:
+                    keys.append(prefix + key)
+
+        print()
+        print()
+        final = dict()
+        keys = []
+        if len(root) != 0:
+            final[root] = fields
+        else:
+            final = fields
+        visit(keys, final)
+
+        # Sort keys alphabetically
+        keys.sort()
+        for key in keys:
+            print(key)
+    except KeyboardInterrupt:
+        print('Interrupted by the user')
+    except Exception as e:
+        print(f'Unexpected error: {e}')

--- a/src/engine/tools/update_expected.py
+++ b/src/engine/tools/update_expected.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pathlib import Path
 from argparse import ArgumentParser
 from typing import Callable
@@ -74,7 +76,8 @@ if __name__ == '__main__':
         config_path = environment / 'engine/general.conf'
 
         # Start the engine
-        engine_command = [binary, '--config', str(config_path), 'server', 'start']
+        engine_command = [binary, '--config',
+                          str(config_path), 'server', 'start']
         print(f'Starting engine with command: {" ".join(engine_command)}')
         engine = subprocess.Popen(
             engine_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/src/engine/tools/update_expected.py
+++ b/src/engine/tools/update_expected.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+from argparse import ArgumentParser
+from typing import Callable
+import subprocess
+import time
+from json import dumps, loads
+
+
+def visitor(path: Path, pattern: str, visit: Callable):
+    for file in path.rglob(pattern):
+        if file.is_file():
+            visit(file)
+        elif file.is_dir():
+            visitor(file, pattern, visit)
+
+
+def get_executor(test_command: str, output: Path):
+    def executor(file):
+        # Set up command
+        output_file = output / file.with_name(
+            file.stem.replace('input', 'expected') + '.json').name
+        command = f'cat {file} | {test_command}'
+
+        try:
+            # Execute command
+            print(f'Running: {command}')
+            result = subprocess.run(
+                command, shell=True, capture_output=True, text=True, check=True)
+
+            # For each line in the output, parse it as JSON and remove the TestSessionID
+            expecteds = []
+            for line in result.stdout.splitlines():
+                parsed = loads(line)
+                parsed.pop('TestSessionID', None)
+                expecteds.append(parsed)
+
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text(dumps(expecteds, indent=2))
+
+            # Notify the user
+            print(f'{file.name} -> {output_file.name}')
+        except Exception as e:
+            print(f'{file.name} -> {e}')
+
+    return executor
+
+
+if __name__ == '__main__':
+    try:
+        arg_parser = ArgumentParser(description='Update expected results')
+        arg_parser.add_argument(
+            'environment', help='Environment folder where the test configuration is stored.', type=Path)
+        arg_parser.add_argument(
+            'path', type=Path, help='Path to the directory with input files')
+        arg_parser.add_argument('pattern', help='Pattern for the input files')
+        arg_parser.add_argument(
+            'test_integration', help='engine-test integration if any')
+        arg_parser.add_argument(
+            'test_integration_conf_file', help='engine-test integration configuration file')
+        arg_parser.add_argument('-o', '--output', type=Path,
+                                help='Path to the output file, default: /tmp/update_expected/', default='/tmp/update_expected/')
+        arg_parser.add_argument(
+            '-b', '--binary', help='Specify the path to the engine binary', default='wazuh-engine')
+        args = arg_parser.parse_args()
+
+        path = Path(args.path).resolve()
+        pattern = args.pattern
+        environment = Path(args.environment).resolve()
+        test_integration = args.test_integration
+        api_sock = environment / 'queue/sockets/engine-api'
+        test_command = f'engine-test -c {args.test_integration_conf_file} run {test_integration} --api-socket {api_sock} -j'
+        output = args.output
+        binary = args.binary
+        config_path = environment / 'engine/general.conf'
+
+        # Start the engine
+        engine_command = [binary, '--config', str(config_path), 'server', 'start']
+        print(f'Starting engine with command: {" ".join(engine_command)}')
+        engine = subprocess.Popen(
+            engine_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        time.sleep(5)
+        # Check if the engine is running
+        if engine.poll() is not None:
+            print('Engine failed to start')
+            exit(1)
+
+        # Iterate over files, visiting subfolders recursively
+        visitor(path, pattern, get_executor(test_command, output))
+
+        engine.terminate()
+        engine.wait(5)
+
+        # Notify the user
+        print(f'Updated expected results in {output}')
+    except KeyboardInterrupt:
+        print('Interrupted by the user')
+    except Exception as e:
+        print(f'Unexpected error: {e}')


### PR DESCRIPTION
|Related issue|
|---|
|#24046|

This PR adds the following helper python scripts:
- flatt output:
```
$ python3 tools/flatt_output.py -h
usage: flatt_output.py [-h] [-r ROOT] path pattern

Flattens the output json of a root field

positional arguments:
  path                  Path to the input directory
  pattern               Pattern for the output files

options:
  -h, --help            show this help message and exit
  -r ROOT, --root ROOT  Root field to flatten. Default fllattens all fields
```

- update expected:
```
$ python3 tools/update_expected.py -h
usage: update_expected.py [-h] [-o OUTPUT] [-b BINARY] environment path pattern test_integration test_integration_conf_file

Update expected results

positional arguments:
  environment           Environment folder where the test configuration is stored.
  path                  Path to the directory with input files
  pattern               Pattern for the input files
  test_integration      engine-test integration if any
  test_integration_conf_file
                        engine-test integration configuration file

options:
  -h, --help            show this help message and exit
  -o OUTPUT, --output OUTPUT
                        Path to the output file, default: /tmp/update_expected/
  -b BINARY, --binary BINARY
                        Specify the path to the engine binary
```

Also QoL changes on:
- src/engine/test/health_test/initialState.py
- src/engine/test/setupEnvironment.py
- src/engine/tools/compare_expected.py