### PR TITLE
Make saved files consistent between RPM and DEB manager

### DIFF
--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -548,8 +548,8 @@ if [ $1 = 0 ];then
 
   # Backup agents centralized configuration (etc/shared)
   if [ -d %{_localstatedir}/etc/shared ]; then
-      rm -rf %{_localstatedir}/etc/shared.save/
-      mv %{_localstatedir}/etc/shared/ %{_localstatedir}/etc/shared.save/
+    find %{_localstatedir}/etc/ -type f  -name "*save" ! -name "*rpmsave" -exec rm -f {} \;
+    find %{_localstatedir}/etc/ -type f ! -name "*shared*" ! -name "*rpmsave" -exec mv {} {}.save \;
   fi
 
   # Backup registration service certificates (sslmanager.cert,sslmanager.key)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2259|

Hi team, 

has reported in the related issue, the `list` and `shared` folders' files were not being saved properly in RPM managers. With this fix the remaining files are as follows:

```console
[root@linux-rocky vagrant]# tree /var/ossec/
/var/ossec/
├── backup
│   └── db
│       └── global.db-backup-2024-06-13-10:54:18.gz
└── etc
    ├── lists
    │   ├── amazon
    │   │   └── aws-eventnames.cdb.save
    │   ├── audit-keys.cdb.save
    │   └── security-eventchannel.cdb.save
    ├── ossec.conf.rpmsave
    ├── shared
    │   ├── ar.conf.save
    │   └── default
    │       └── merged.mg.save
    ├── sslmanager.cert.save
    └── sslmanager.key.save

7 directories, 9 files

```