### PR TITLE
Fix resource leak in Cluster_Read

### DIFF
--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -126,28 +126,33 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
                 if (!strcmp(child[j]->element, haproxy_disabled)) {
                     if (strcmp(child[j]->content, "yes") && strcmp(child[j]->content, "no")) {
                         merror("Detected an invalid value for the disabled tag '%s'. Valid values are 'yes' and 'no'.", child[j]->element);
+                        OS_ClearNode(child);
                         return OS_INVALID;
                     }
                 } else if (!strcmp(child[j]->element, frequency)) {
                 } else if (!strcmp(child[j]->element, haproxy_address)) {
                     if (!strlen(node[i]->content)) {
                         merror("HAProxy address is missing in the configuration");
+                        OS_ClearNode(child);
                         return OS_INVALID;
                     }
                 } else if (!strcmp(child[j]->element, haproxy_port)) {
                 } else if (!strcmp(child[j]->element, haproxy_protocol)) {
                     if (strcmp(child[j]->content, "http") && strcmp(child[j]->content, "https")) {
                         merror("Detected an invalid value for the haproxy_protocol tag '%s'. Valid values are 'http' and 'https'.", child[j]->element);
+                        OS_ClearNode(child);
                         return OS_INVALID;
                     }
                 } else if (!strcmp(child[j]->element, haproxy_user)) {
                     if (!strlen(node[i]->content)) {
                         merror("HAProxy user is missing in the configuration");
+                        OS_ClearNode(child);
                         return OS_INVALID;
                     }
                 } else if (!strcmp(child[j]->element, haproxy_password)) {
                     if (!strlen(node[i]->content)) {
                         merror("HAProxy password is missing in the configuration");
+                        OS_ClearNode(child);
                         return OS_INVALID;
                     }
                 } else if (!strcmp(child[j]->element, haproxy_backend)) {


### PR DESCRIPTION
|Related issue|
|---|
|#24066|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Closes #24066. It fixes the memory leak produced when having empty or invalid values for the `haproxy_disabled`, `haproxy_address`,  `haproxy_user`, `haproxy_password`, or `haproxy_protocol` parameters of the ossec.conf file.


## Logs/Examples

Configuration sample

```xml
<cluster>
    <name>wazuh</name>
    <node_name>master-node</node_name>
    <node_type>master</node_type>
    <key>9d273b53510fef702b54a92e9cffc82e</key>
    <port>1516</port>
    <bind_addr>0.0.0.0</bind_addr>
    <nodes>
        <node>wazuh-master</node>
    </nodes>
    <hidden>no</hidden>
    <disabled>no</disabled>
    <haproxy_helper>
        <haproxy_disabled>no</haproxy_disabled>
        <haproxy_address>wazuh-proxy</haproxy_address>
        <haproxy_user>haproxy</haproxy_user>
        <haproxy_password>haproxy</haproxy_password>
        <haproxy_protocol>http</haproxy_protocol>
    </haproxy_helper>
  </cluster>
```

<details><summary>Invalid haproxy_disabled</summary>
<p>

```console
root@1c3e8c407d99:/var/ossec# bin/wazuh-control start
2024/06/13 16:18:26 wazuh-db: ERROR: Detected an invalid value for the disabled tag 'haproxy_disabled'. Valid values are 'yes' and 'no'.
2024/06/13 16:18:26 wazuh-db: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2024/06/13 16:18:26 wazuh-db: CRITICAL: Invalid configuration block for Wazuh-DB.
wazuh-db: Configuration error. Exiting
```

</p>
</details> 

<details><summary>Empty haproxy_address</summary>
<p>

```console
root@1c3e8c407d99:/var/ossec# bin/wazuh-control start
2024/06/13 16:19:11 wazuh-modulesd:router: INFO: Loaded router module.
2024/06/13 16:19:11 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-clusterd: Configuration error. Exiting
```

</p>
</details> 

<details><summary>Empty haproxy_user</summary>
<p>

```console
root@1c3e8c407d99:/var/ossec# bin/wazuh-control start
2024/06/13 16:19:11 wazuh-modulesd:router: INFO: Loaded router module.
2024/06/13 16:19:11 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-clusterd: Configuration error. Exiting
```

</p>
</details> 

<details><summary>Empty haproxy_password</summary>
<p>

```console
root@1c3e8c407d99:/var/ossec# bin/wazuh-control start
2024/06/13 16:19:11 wazuh-modulesd:router: INFO: Loaded router module.
2024/06/13 16:19:11 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
wazuh-clusterd: Configuration error. Exiting
```

</p>
</details> 

<details><summary>Invalid haproxy_protocol</summary>
<p>

```console
root@1c3e8c407d99:/var/ossec# bin/wazuh-control start
2024/06/13 16:21:06 wazuh-db: ERROR: Detected an invalid value for the haproxy_protocol tag 'haproxy_protocol'. Valid values are 'http' and 'https'.
2024/06/13 16:21:06 wazuh-db: ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2024/06/13 16:21:06 wazuh-db: CRITICAL: Invalid configuration block for Wazuh-DB.
wazuh-db: Configuration error. Exiting
```

</p>
</details> 

