### PR TITLE
Add new path to look for PyPi packages

### DIFF
--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -444,6 +444,7 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
     pypyMacOSPaths.emplace(
         "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/*/lib/python*/*-packages");
     pypyMacOSPaths.emplace("/System/Library/Frameworks/Python.framework/*-packages");
+    pypyMacOSPaths.emplace("/opt/homebrew/lib/python*/*-packages");
 
     static const std::map<std::string, std::set<std::string>> searchPaths =
     {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/23842|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team, as requested in the related issue, the new path for Python packages has been added.

## Testing
Using a Sonoma ARM machine the Django package is installed as follows:
```
ec2-user@WAZUH wazuh % pip3 install Django==3.2.13 --break-system-packages 
```

After that, the syscollector scan can retrieve the package successfully:
``` console
ec2-user@ip-WAZUH wazuh % sudo sqlite3 /var/ossec/queue/syscollector/db/local.db
SQLite version 3.43.2 2023-10-10 13:08:14
Enter ".help" for usage hints.
sqlite> select * from dbsync_packages where name='Django';
Django|3.2.13| | |/opt/homebrew/lib/python3.12/site-packages/Django-3.2.13.dist-info/METADATA| | | |0| || |pypi|e37898be21c8f950e59f7b5cf829ee549862bfb6|cda26abe6500ba3a03bfe979e3ef725153415473|1
```
