### PR TITLE
Change variable value setting condition in Docker retag workflow

### DIFF
--- a/.github/workflows/packages-retag-images.yml
+++ b/.github/workflows/packages-retag-images.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run retag script
         run: |
-          if [ "${{ inputs.old_version }}" != "none" ] && [ "${{ inputs.new_version }}" != "none" ]; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             new_version=${{ inputs.new_version }}
             old_version=${{ inputs.old_version }}
           else


### PR DESCRIPTION
|Related issue|
|---|
|#24182|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR causes the last step of the workflow file `.github/workflows/packages-retag-images.yml` to correctly set the values of the variables used in the script call, basing the variable values on the event that triggered the workflow instead of the default values of the input variables that may not be set if the workflow is triggered by an event that is not `workflow_dispatch`.

- https://github.com/wazuh/wazuh/actions/runs/9596107657 - :green_circle: 