### PR TITLE
Update macOS workflows runners

### DIFF
--- a/.github/workflows/macos-build-tests.yml
+++ b/.github/workflows/macos-build-tests.yml
@@ -6,24 +6,6 @@ on:
       - "src/**"
 
 jobs:
-  build-bigsur:
-    runs-on: macos-11
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Build wazuh agent for macOS 11
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
-  build-monterey:
-    runs-on: macos-12
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Build wazuh agent for macOS 12
-        run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
   build-ventura:
     runs-on: macos-13
     steps:
@@ -31,5 +13,14 @@ jobs:
         uses: actions/checkout@v3
       - name: Build wazuh agent for macOS 13
         run: |
-          make deps -C src TARGET=agent -j2
-          make -C src TARGET=agent -j2
+          make deps -C src TARGET=agent -j4
+          make -C src TARGET=agent -j4
+  build-sonoma:
+    runs-on: macos-14
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Build wazuh agent for macOS 14
+        run: |
+          make deps -C src TARGET=agent -j3
+          make -C src TARGET=agent -j3

--- a/.github/workflows/macos-syscollector-tests.yml
+++ b/.github/workflows/macos-syscollector-tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -19,17 +19,17 @@ jobs:
       - name: Build wazuh agent for macOS
         run: |
           rm -rf src/VERSION
-          make deps -C src TARGET=agent -j2
-          make -C src build_syscollector TARGET=agent -j2
+          make deps -C src TARGET=agent -j4
+          make -C src build_syscollector TARGET=agent -j4
       - name: Install dependencies
         run: |
           brew install wget
           pip3 install -r src/data_provider/qa/requirements.txt
       - name: Install macports package manager
         run: |
-          wget https://github.com/macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-11-BigSur.pkg
-          sudo installer -pkg MacPorts-2.8.1-11-BigSur.pkg -target /
-          rm -rf MacPorts-2.8.1-11-BigSur.pkg
+          wget https://github.com/macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-13-Ventura.pkg
+          sudo installer -pkg MacPorts-2.8.1-13-Ventura.pkg -target /
+          rm -rf MacPorts-2.8.1-13-Ventura.pkg
       - name: Install port
         run: |
           sudo /opt/local/bin/port -b install nano

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -6,50 +6,6 @@ on:
       - "src/**"
 
 jobs:
-  build-bigsur:
-    runs-on: macos-11
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Install cmocka and lcov
-        run: |
-          brew install cmocka lcov
-      - name: Build wazuh agent for macOS 11 with tests flags
-        run: |
-          make deps -C src TARGET=agent -j3
-          LIBRARY_PATH=/usr/local/lib make -C src TARGET=agent -j3 DEBUG=1 TEST=1
-      - name: Run wazuh unit tests for macOS 11
-        run: |
-          cd src/data_provider/build
-          ctest -V
-          cd ../../shared_modules/dbsync/build
-          ctest -V
-          cd ../../rsync/build
-          ctest -V
-          cd ../../../wazuh_modules/syscollector/build
-          ctest -V
-  build-monterey:
-    runs-on: macos-12
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Install cmocka and lcov
-        run: |
-          brew install cmocka lcov
-      - name: Build wazuh agent for macOS 12 with tests flags
-        run: |
-          make deps -C src TARGET=agent -j3
-          LIBRARY_PATH=/usr/local/lib make -C src TARGET=agent -j3 DEBUG=1 TEST=1
-      - name: Run wazuh unit tests for macOS 12
-        run: |
-          cd src/data_provider/build
-          ctest -V
-          cd ../../shared_modules/dbsync/build
-          ctest -V
-          cd ../../rsync/build
-          ctest -V
-          cd ../../../wazuh_modules/syscollector/build
-          ctest -V
   build-ventura:
     runs-on: macos-13
     steps:
@@ -60,9 +16,31 @@ jobs:
           brew install cmocka lcov
       - name: Build wazuh agent for macOS 13 with tests flags
         run: |
+          make deps -C src TARGET=agent -j4
+          LIBRARY_PATH=/usr/local/lib make -C src TARGET=agent -j4 DEBUG=1 TEST=1
+      - name: Run wazuh unit tests for macOS 13
+        run: |
+          cd src/data_provider/build
+          ctest -V
+          cd ../../shared_modules/dbsync/build
+          ctest -V
+          cd ../../rsync/build
+          ctest -V
+          cd ../../../wazuh_modules/syscollector/build
+          ctest -V
+  build-sonoma:
+    runs-on: macos-14
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Install cmocka and lcov
+        run: |
+          brew install cmocka lcov
+      - name: Build wazuh agent for macOS 14 with tests flags
+        run: |
           make deps -C src TARGET=agent -j3
           LIBRARY_PATH=/usr/local/lib make -C src TARGET=agent -j3 DEBUG=1 TEST=1
-      - name: Run wazuh unit tests for macOS 13
+      - name: Run wazuh unit tests for macOS 14
         run: |
           cd src/data_provider/build
           ctest -V


### PR DESCRIPTION
|Related issue|
|---|
|#24133|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Since GHA has deprecated `macos-11` runners, causing the jobs to fail and rest as canceled, we have removed the use of this kind of runner and we add the new `macos-13` and `macos-14` runners. 

The `-j` option used in workflows with these runners has been updated to use all their capabilities.