### PR TITLE
Issue #24244: external_id is not passed as arg into any Python Class

### DIFF
--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -90,7 +90,8 @@ def main(argv):
                                  discard_regex=options.discard_regex,
                                  sts_endpoint=options.sts_endpoint,
                                  service_endpoint=options.service_endpoint,
-                                 iam_role_duration=options.iam_role_duration
+                                 iam_role_duration=options.iam_role_duration,
+                                 external_id=options.external_id
                                  )
             # check if bucket is empty or credentials are wrong
             bucket.check_bucket()
@@ -143,7 +144,8 @@ def main(argv):
                                        discard_regex=options.discard_regex,
                                        sts_endpoint=options.sts_endpoint,
                                        service_endpoint=options.service_endpoint,
-                                       iam_role_duration=options.iam_role_duration
+                                       iam_role_duration=options.iam_role_duration,
+                                       external_id=options.external_id
                                        )
                 service.get_alerts()
         elif options.subscriber:

--- a/wodles/aws/buckets_s3/aws_bucket.py
+++ b/wodles/aws/buckets_s3/aws_bucket.py
@@ -85,7 +85,7 @@ class AWSBucket(wazuh_integration.WazuhAWSDatabase):
 
     def __init__(self, db_table_name, bucket, reparse, profile, iam_role_arn,
                  only_logs_after, skip_on_error, account_alias, prefix, suffix, delete_file, aws_organization_id,
-                 region, discard_field, discard_regex, sts_endpoint, service_endpoint, iam_role_duration=None):
+                 region, discard_field, discard_regex, sts_endpoint, service_endpoint, iam_role_duration=None, external_id=None):
         # common SQL queries
         self.sql_already_processed = """
             SELECT
@@ -194,6 +194,7 @@ class AWSBucket(wazuh_integration.WazuhAWSDatabase):
                                                     sts_endpoint=sts_endpoint,
                                                     service_endpoint=service_endpoint,
                                                     iam_role_duration=iam_role_duration,
+                                                    external_id=external_id,
                                                     skip_on_error=skip_on_error)
         self.retain_db_records = MAX_RECORD_RETENTION
         self.reparse = reparse


### PR DESCRIPTION
|Issue #24244: external_id is not passed as arg into any Class|
|---|

## Description

external_id is not passed as arg into any AWSClass except for security lake for aws session initialisation. When iam_role_arn parameter is passed it may or may not requires external_id flag, we can not restrict external-id for only security lake. it will be use in assuming s3 bucket or cloudwatch logs. Allow adding external_id param for all the services offered by wazuh 


## Configuration options
--external_id

## Logs/Alerts example
external id is not passed and made default None, because of which no errors or alert logs.

## Tests
```
root@wazuh-manager-master-0:/var/ossec# wodles/aws/aws-s3 --bucket <bucket-name> --external_id <external-id> --type cloudtrail --debug 2 --iam_role_arn <iam-arn>
DEBUG: +++ Debug mode on - Level: 2
DEBUG: Generating default configuration for retries: mode standard - max_attempts 10
DEBUG: +++ Working on <account-id> - us-east-1
DEBUG: +++ Marker: AWSLogs/<account-id>/CloudTrail/us-east-1/2024/06/21/<xyz>.json.gz
DEBUG: ++ Found new log: AWSLogs/<account-id>/CloudTrail/us-east-1/2024/06/21/<xyz>.gz
```
