### PR TITLE
Fix Git head reference at RPM5 package building

### DIFF
--- a/packages/build.sh
+++ b/packages/build.sh
@@ -93,7 +93,8 @@ else
       short_commit_hash="$(cd /wazuh-local-src && git rev-parse --short HEAD)"
     else
       # Git package is not available in the CentOS 5 repositories.
-      hash_commit=$(cat /wazuh-local-src/.git/$(cat /wazuh-local-src/.git/HEAD|cut -d" " -f2))
+      head=$(cat /wazuh-local-src/.git/HEAD)
+      hash_commit=$(echo "$head" | grep "ref: " >/dev/null && cat /wazuh-local-src/.git/$(echo $head | cut -d' ' -f2) || echo $head)
       short_commit_hash="$(cut -c 1-11 <<< $hash_commit)"
     fi
 fi


### PR DESCRIPTION
|Related issue|
|---|
|#24249|

## Description

With this PR, we fix the problem to get the commit hash of a tag.
The problem arises because the header reference (`.git/HEAD`) of a tag always points to the commit hash. Whereas in the case of a branch, the `.git/HEAD` reference points to `ref: refs/heads/<branch_name>`.

So, we've added a condition to check if the `.git/HEAD` file points via `ref: ` to the branch reference path, or we're left with the contents of the file `.git/HEAD` (which is the commit tag).

## Examples
- Branch:
```sh
$ cat .git/HEAD
ref: refs/heads/fix/24249-rpm-git-refs
$ cat .git/refs/heads/fix/24249-rpm-git-refs 
57306dc8a004c31c1de64f5b388e286c64e10804
```

- Tag:
```sh
git checkout v4.9.0-alpha1 
Note: switching to 'v4.9.0-alpha1'.
...
$cat .git/HEAD                             
d51c99141f272e07a8cba70814b9b42bfbbc29fb
```

## Tests
- Uploading image with change and generating packages - :green_circle: 
