### PR TITLE
Adaptation of the upgrade script for Windows to the new package nomenclature

### DIFF
--- a/src/win32/upgrade.bat
+++ b/src/win32/upgrade.bat
@@ -4,7 +4,7 @@ IF "%1"=="B" GOTO background
 
 COPY upgrade\upgrade.bat . > NUL
 COPY upgrade\do_upgrade.ps1 . > NUL
-COPY upgrade\wazuh-agent-*.msi . > NUL
+COPY upgrade\wazuh-agent*.msi . > NUL
 
 START /B upgrade.bat B
 GOTO end


### PR DESCRIPTION
|Related issue|
|---|
|#24296|

## Description

Due to the newly added nomenclature for development packages applied in the following development:
> As subsystem owners, teams must follow this naming convention for development package names: `<SubsystemName>_<VersionNumber>-<Revision>_{<OSName>-<OSVersion>_}<Architecture>_<GitReference>.<PackageType>`.
- https://github.com/wazuh/wazuh/issues/21755

It has been necessary to adapt the regex found in the `upgrade.bat` script, to copy the `.msi` package into its corresponding folder and be able to run it, so that it can continue with the installation (upgrade) process.

Therefore, as packages can have the following nomenclatures in 4.9.0:
- `wazuh-agent-*.msi` - Releases
- `wazuh-agent_*.msi` - Developments

We have simply applied the following change to the regex, so that it can correctly copy both cases:
- `wazuh-agent*.msi`.


## Logs/Alerts example

- Remote upgrade (manager):
```
# /var/ossec/bin/agent_upgrade -a 021 -f /share/wazuh-agent_4.9.0-0_windows_82a761b.msi.wpk 

Upgrading...

Upgraded agents:
	Agent 021 upgraded: Wazuh v4.7.5 -> Wazuh v4.9.0
```

- `upgrade.log`:
```
2024-06-25 10:30:17Z - Sysnative Powershell will be used to access the registry.
2024-06-25 10:30:18Z - Current version: v4.7.5.
2024-06-25 10:30:19Z - Starting upgrade process.
2024-06-25 10:30:27Z - Restarting Wazuh-Agent service.
2024-06-25 10:30:29Z - Installation finished.
2024-06-25 10:30:31Z - Process ID: 7748.
2024-06-25 10:30:41Z - Reading status file: status='connected'.
2024-06-25 10:30:41Z - Upgrade finished successfully.
2024-06-25 10:30:41Z - New version: v4.9.0.
```
