### PR TITLE
Fix agent disconnection during upgrades causing the script to hang indefinitely

### DIFF
--- a/framework/scripts/tests/test_agent_upgrade.py
+++ b/framework/scripts/tests/test_agent_upgrade.py
@@ -173,6 +173,29 @@ async def test_check_status(mock_sleep, mock_print_result, silent):
         else:
             mock_print_result.assert_not_called()
 
+@pytest.mark.asyncio
+@patch('scripts.agent_upgrade.print_result')
+@patch('scripts.agent_upgrade.sleep')
+async def test_check_status_failed_items(mock_sleep, mock_print_result):
+    """Check if methods inside check_status work as expected when the agents response contains failed items"""
+
+    task_results = MagicMock()
+    task_results.failed_items = {}
+    task_results.failed_items[Exception()] = {'001', '002'}
+    agent_upgrade.args = MagicMock()
+    agent_upgrade.args.version = '4.2.0'
+    result_dict = {'001': {'new_version': '4.4.0'}, '002': {'new_version': '4.3.0'}}
+    with patch('scripts.agent_upgrade.cluster_utils.forward_function', return_value=task_results) as mock_forward_func:
+        await agent_upgrade.check_status(affected_agents=['001', '002'], result_dict=result_dict, failed_agents={}, 
+                                         silent=False)
+
+        mock_forward_func.assert_called_once_with(agent_upgrade.get_upgrade_result, f_kwargs={'agent_list': ANY})
+        
+        mock_print_result.assert_called_once_with(agents_versions={}, failed_agents={
+            '001': 'Agent disconnected during the upgrade',
+            '002': 'Agent disconnected during the upgrade'
+            }
+        )
 
 @pytest.mark.asyncio
 @patch('scripts.agent_upgrade.signal')


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/20901 |

## Description

Adds the logic necessary to remove failed items from the list and stop waiting for their tasks.

## Logs/Alerts example

<details><summary>Agent disconnection during upgrade</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_upgrade.py -a 001 -f /wpk_file

Upgrading...
...
# Debug logs to demonstrate the behavior, won't be present in production
Task results: AffectedItemsWazuhResult({'dikt': {}, '_affected_items': [{'message': 'Success', 'agent': '001', 'task_id': 1, 'node': 'master-node', 'module': 'upgrade_module', 'command': 'upgrade_custom', 'status': 'Updating', 'create_time': '2024-06-25T14:53:30Z', 'update_time': '2024-06-25T14:53:30Z'}], '_failed_items': {}, '_total_affected_items': 1, '_total_failed_items': 0, '_sort_fields': None, '_sort_casting': ['int'], '_sort_ascending': [True], '_all_msg': 'All upgrade tasks were returned', '_some_msg': 'Some upgrade tasks were not returned', '_none_msg': 'No upgrade task was returned'})
Task results: AffectedItemsWazuhResult({'dikt': {}, '_affected_items': [], '_failed_items': {{'type': 'about:blank', 'title': 'Bad Request', 'code': 1707, 'extra_message': None, 'extra_remediation': None, 'cmd_error': False, 'dapi_errors': {}, 'ids': []}: {'001'}}, '_total_affected_items': 0, '_total_failed_items': 1, '_sort_fields': None, '_sort_casting': ['int'], '_sort_ascending': [True], '_all_msg': 'All upgrade tasks were returned', '_some_msg': 'Some upgrade tasks were not returned', '_none_msg': 'No upgrade task was returned'})

Failed upgrades:
  Agent 001 status: Agent disconnected during the upgrade
```

</details>



<details><summary>Multiple agents disconnection during upgrade</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_upgrade.py -a 001 002 -f /wpk_file

Upgrading...
AffectedItemsWazuhResult({'dikt': {}, '_affected_items': [{'message': 'Success', 'agent': '001', 'task_id': 1, 'node': 'master-node', 'module': 'upgrade_module', 'command': 'upgrade_custom', 'status': 'Updating', 'create_time': '2024-06-25T17:28:55Z', 'update_time': '2024-06-25T17:28:55Z'}, {'message': 'Success', 'agent': '002', 'task_id': 1, 'node': 'master-node', 'module': 'upgrade_module', 'command': 'upgrade_custom', 'status': 'Updating', 'create_time': '2024-06-25T17:28:55Z', 'update_time': '2024-06-25T17:28:55Z'}], '_failed_items': {}, '_total_affected_items': 2, '_total_failed_items': 0, '_sort_fields': None, '_sort_casting': ['int'], '_sort_ascending': [True], '_all_msg': 'All upgrade tasks were returned', '_some_msg': 'Some upgrade tasks were not returned', '_none_msg': 'No upgrade task was returned'})
Task results: AffectedItemsWazuhResult({'dikt': {}, '_affected_items': [], '_failed_items': {{'type': 'about:blank', 'title': 'Bad Request', 'code': 1707, 'extra_message': None, 'extra_remediation': None, 'cmd_error': False, 'dapi_errors': {}, 'ids': []}: {'001', '002'}}, '_total_affected_items': 0, '_total_failed_items': 1, '_sort_fields': None, '_sort_casting': ['int'], '_sort_ascending': [True], '_all_msg': 'All upgrade tasks were returned', '_some_msg': 'Some upgrade tasks were not returned', '_none_msg': 'No upgrade task was returned'})

Failed upgrades:
  Agent 001 status: Agent disconnected during the upgrade
  Agent 002 status: Agent disconnected during the upgrade
```

</details>