### PR TITLE
Aggregate well formatted event bodies only

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -259,9 +259,10 @@ def custom_logging(user, remote, method, path, query,
 
     if path == '/events' and logger.level >= 20:
         # If log level is info simplify the messages for the /events requests.
-        events = body.get('events', [])
-        body = {'events': len(events)}
-        json_info['body'] = body
+        if isinstance(body, dict):
+            events = body.get('events', [])
+            body = {'events': len(events)}
+            json_info['body'] = body
 
     log_info += f'with parameters {json.dumps(query)} and body '\
                 f'{json.dumps(body)} done in {elapsed_time:.3f}s: {status}'

--- a/api/api/test/test_alogging.py
+++ b/api/api/test/test_alogging.py
@@ -87,6 +87,8 @@ def test_api_logger_size_exceptions():
     ("/agents", 'hashauthcontext', {'bodyfield': 1}, 21),
     ("/events", '', {'bodyfield': 1, 'events' : [{'a': 1, 'b': 2 }]}, 1),
     ("/events", 'hashauthcontext', {'bodyfield': 1, 'events' : [{'a': 1, 'b': 2 }]}, 22),
+    ("/events", 'hashauthcontext', ['foo', 'bar'], 22),
+    ("/events", 'hashauthcontext', 'foo', 22),
 ])
 def test_custom_logging(path, hash_auth_context, body, loggerlevel):
     """Test custom access logging calls."""
@@ -115,9 +117,10 @@ def test_custom_logging(path, hash_auth_context, body, loggerlevel):
                         hash_auth_context=hash_auth_context, headers=headers)
 
         if path == '/events' and loggerlevel >= 20:
-            events = body.get('events', [])
-            body = {'events': len(events)}
-            json_info['body'] = body
+            if isinstance(body, dict):
+                events = body.get('events', [])
+                body = {'events': len(events)}
+                json_info['body'] = body
         log_info += f'with parameters {json.dumps(query)} and body'\
                     f' {json.dumps(body)} done in {elapsed_time:.3f}s: {status}'
         log_info_mock.info.has_calls([call(log_info, {'log_type': 'log'}),


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/24250 |

## Description

Checks if the body is a dictionary before accessing the key `events`. If the body is not a dictionary the log would just contain the variable as it is. 

## Tests

<details><summary>POST /events</summary>

Body:

```json
["foo", "bar"]
```

Response:

```json
{
    "title": "Bad Request",
    "detail": "['foo', 'bar'] is not of type 'object'"
}
```

</details>


<details><summary>Non-dictionary body JSON log</summary>

It just displays the body object

```console
{"timestamp": "2024/06/25 18:45:06", "levelname": "INFO", "data": {"type": "request", "payload": {"user": "wazuh", "ip": "172.18.0.1", "http_method": "POST", "uri": "POST /events", "parameters": {}, "body": ["foo", "bar"], "time": "0.028s", "status_code": 400}}}
```

</details>

<details><summary>Dictionary body JSON log</summary>

Shows the number of events only (log level must be 20 or higher)

```console
{"timestamp": "2024/06/25 18:48:10", "levelname": "INFO", "data": {"type": "request", "payload": {"user": "wazuh", "ip": "172.18.0.1", "http_method": "POST", "uri": "POST /events", "parameters": {}, "body": {"events": 3}, "time": "0.010s", "status_code": 200}}}
```

</details>

<details><summary>test_event_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest -vv test_event_endpoints.tavern.yaml
============================================= test session starts =============================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0 -- /home/gasti/work/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.14', 'Platform': 'Linux-6.1.0-21-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'html': '2.1.1', 'metadata': '3.1.1', 'cov': '4.1.0', 'anyio': '4.1.0', 'trio': '0.8.0', 'aiohttp': '1.0.4'}}
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 5 items                                                                                             

test_event_endpoints.tavern.yaml::POST /events PASSED                                                                                                    [ 20%]
test_event_endpoints.tavern.yaml::POST /events with invalid formats PASSED                                                                               [ 40%]
test_event_endpoints.tavern.yaml::POST /events with more than 100 events PASSED                                                                          [ 60%]
test_event_endpoints.tavern.yaml::POST /events with big events PASSED                                                                                    [ 80%]
test_event_endpoints.tavern.yaml::Try to send more than 30 requests per minute PASSED                                                                    [100%]

======================================================================= warnings summary =======================================================================
../../../venv/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/gasti/work/wazuh/venv/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_event_endpoints.tavern.yaml::POST /events
test_event_endpoints.tavern.yaml::POST /events with invalid formats
test_event_endpoints.tavern.yaml::POST /events with more than 100 events
test_event_endpoints.tavern.yaml::POST /events with big events
test_event_endpoints.tavern.yaml::Try to send more than 30 requests per minute
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 5 passed, 6 warnings in 649.57s (0:10:49) ===========================================================
```

</details>

> Failed checks are not related to the changes introduced