### PR TITLE
Fix missing resource leak

### DIFF
--- a/src/config/cluster-config.c
+++ b/src/config/cluster-config.c
@@ -173,6 +173,7 @@ int Read_Cluster(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unus
                 } else if (!strcmp(child[j]->element, remove_disconnected_node_after)) {
                 } else {
                     merror(XML_INVELEM, child[i]->element);
+                    OS_ClearNode(child);
                     return OS_INVALID;
                 }
 


### PR DESCRIPTION
|Related issue|
|---|
| #24066|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Closes #24066. It fixes a missing memory leak produced by validating the `haproxy_helper` block in the ossec.conf file.