### PR TITLE
Capture agent scripts distributed exceptions

### DIFF
--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -6,7 +6,6 @@
 
 import argparse
 import asyncio
-import logging
 from os.path import basename
 from signal import signal, SIGINT
 from sys import exit, argv
@@ -21,8 +20,6 @@ try:
 except Exception as e:
     print("Error importing 'Wazuh' package.\n\n{0}\n".format(e))
     exit()
-
-logger = logging.getLogger('wazuh')
 
 
 # Functions
@@ -53,8 +50,8 @@ async def show_groups():
     unassigned_agents = await cluster_utils.forward_function(func=agent.get_agents,
                                                              f_kwargs={'q': 'id!=000;group=null'})
 
-    check_if_exception(groups)
-    check_if_exception(unassigned_agents)
+    cluster_utils.raise_if_exc(groups)
+    cluster_utils.raise_if_exc(unassigned_agents)
 
     print(f"Groups ({groups.total_affected_items}):")
     for items in groups.affected_items:
@@ -73,7 +70,7 @@ async def show_group(agent_id: str):
     """
     agent_info = await cluster_utils.forward_function(func=agent.get_agents, f_kwargs={'agent_list': [agent_id]})
 
-    check_if_exception(agent_info)
+    cluster_utils.raise_if_exc(agent_info)
 
     if agent_info.total_affected_items == 0:
         msg = list(agent_info.failed_items.keys())[0]
@@ -94,7 +91,7 @@ async def show_synced_agent(agent_id: str):
         ID of the agent.
     """
     result = await cluster_utils.forward_function(func=agent.get_agents_sync_group, f_kwargs={'agent_list': [agent_id]})
-    check_if_exception(result)
+    cluster_utils.raise_if_exc(result)
 
     if result.total_affected_items == 0:
         msg = list(result.failed_items.keys())[0]
@@ -115,7 +112,7 @@ async def show_agents_with_group(group_id: str):
     result = await cluster_utils.forward_function(func=agent.get_agents_in_group,
                                                   f_kwargs={'group_list': [group_id], 'select': ['name'],
                                                             'limit': None})
-    check_if_exception(result)
+    cluster_utils.raise_if_exc(result)
 
     if result.total_affected_items == 0:
         print(f"No agents found in group '{group_id}'.")
@@ -134,7 +131,7 @@ async def show_group_files(group_id: str):
         ID of the group we want to check the configuration files from.
     """
     result = await cluster_utils.forward_function(func=agent.get_group_files, f_kwargs={'group_list': [group_id]})
-    check_if_exception(result)
+    cluster_utils.raise_if_exc(result)
 
     print("{0} files for '{1}' group:".format(result.total_affected_items, group_id))
 
@@ -171,7 +168,7 @@ async def unset_group(agent_id: str, group_id: str = None, quiet: bool = False):
     if ans.lower() == 'y':
         result = await cluster_utils.forward_function(func=agent.remove_agent_from_groups,
                                                       f_kwargs={'agent_list': [agent_id], 'group_list': [group_id]})
-        check_if_exception(result)
+        cluster_utils.raise_if_exc(result)
 
         if result.total_affected_items != 0:
             msg = f"Agent '{agent_id}' removed from {group_id}."
@@ -198,7 +195,7 @@ async def remove_group(group_id: str, quiet: bool = False):
     msg = ''
     if ans.lower() == 'y':
         result = await cluster_utils.forward_function(func=agent.delete_groups, f_kwargs={'group_list': [group_id]})
-        check_if_exception(result)
+        cluster_utils.raise_if_exc(result)
 
         if result.total_affected_items == 0:
             msg = list(result.failed_items.keys())[0]
@@ -232,7 +229,7 @@ async def set_group(agent_id: str, group_id: str, quiet: bool = False, replace: 
         result = await cluster_utils.forward_function(func=agent.assign_agents_to_group,
                                                       f_kwargs={'group_list': [group_id], 'agent_list': [agent_id],
                                                                 'replace': replace})
-        check_if_exception(result)
+        cluster_utils.raise_if_exc(result)
 
         if result.total_affected_items != 0:
             msg = f"Group '{group_id}' added to agent '{agent_id}'."
@@ -259,30 +256,13 @@ async def create_group(group_id: str, quiet: bool = False):
 
     if ans.lower() == 'y':
         result = await cluster_utils.forward_function(func=agent.create_group, f_kwargs={'group_id': group_id})
-        check_if_exception(result)
+        cluster_utils.raise_if_exc(result)
 
         msg = result.dikt['message']
     else:
         msg = "Cancelled."
 
     print(msg)
-
-
-def check_if_exception(result: object):
-    """Check if a specified object is an exception.
-    If the object is an exception, raise it.
-
-    Raises
-    ------
-    Exception
-
-    Parameters
-    ----------
-    result : object
-        Object to be checked.
-    """
-    if isinstance(result, Exception):
-        raise result
 
 
 def usage():

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -5,7 +5,6 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import argparse
-import logging
 from asyncio import run
 from os.path import dirname
 from signal import signal, SIGINT
@@ -19,18 +18,13 @@ path.append(dirname(argv[0]) + '/../framework')  # It is necessary to import Waz
 # Import framework
 try:
     import wazuh.agent
-    from api.util import raise_if_exc
     from wazuh.agent import upgrade_agents, get_upgrade_result, get_agents
     from wazuh.core import common
-    from wazuh.core.agent import Agent
-    from wazuh.core.cluster.dapi.dapi import DistributedAPI
     from wazuh.core.exception import WazuhError
     from wazuh.core.cluster import utils as cluster_utils
 except Exception as e:
     print("Error importing 'Wazuh' package.\n\n{0}\n".format(e))
     exit()
-
-logger = logging.getLogger('wazuh')
 
 
 # Functions
@@ -96,6 +90,7 @@ async def get_agents_versions(agents: list) -> dict:
         "limit": len(agents)
     }
     agent_versions = await cluster_utils.forward_function(get_agents, f_kwargs=f_kwargs)
+    cluster_utils.raise_if_exc(agent_versions)
     return {agent['id']: {"prev_version": agent['version'], "new_version": None}
             for agent in agent_versions.affected_items}
 
@@ -119,6 +114,7 @@ async def get_agent_version(agent_id: str) -> str:
         "limit": 1
     }
     result = await cluster_utils.forward_function(get_agents, f_kwargs=f_kwargs)
+    cluster_utils.raise_if_exc(result)
     return result.affected_items[0]['version']
 
 
@@ -179,6 +175,7 @@ async def check_status(affected_agents: list, result_dict: dict, failed_agents: 
     while len(affected_agents):
         task_results = await cluster_utils.forward_function(get_upgrade_result,
                                                             f_kwargs={'agent_list': list(affected_agents)})
+        cluster_utils.raise_if_exc(task_results)
 
         for task_result in task_results.affected_items.copy():
             if task_result['status'] == 'Updated' or 'Legacy upgrade' in task_result['status']:
@@ -218,6 +215,7 @@ async def main():
             exit(0)
 
         result = await cluster_utils.forward_function(upgrade_agents, f_kwargs=create_command())
+        cluster_utils.raise_if_exc(result)
 
         not args.silent and len(result.failed_items.keys()) > 0 and print("Agents that cannot be upgraded:")
         if not args.silent:

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -12,7 +12,8 @@ with patch('wazuh.core.common.getgrnam'):
                 sys.modules['wazuh.rbac.orm'] = MagicMock()
 
                 from wazuh.core.cluster import utils
-                from wazuh import WazuhError, WazuhException, WazuhInternalError
+                from wazuh.core.exception import WazuhError, WazuhException, WazuhInternalError, WazuhPermissionError, \
+                    WazuhResourceNotFound
                 from wazuh.core.results import WazuhResult
 
 default_cluster_config = {
@@ -327,3 +328,21 @@ def test_running_on_master_node(read_cluster_config_mock, cluster_config, expect
     read_cluster_config_mock.return_value = cluster_config
 
     assert utils.running_in_master_node() == expected
+
+@pytest.mark.parametrize('result', [
+    WazuhError(6001),
+    WazuhInternalError(1000),
+    WazuhPermissionError(4000),
+    WazuhResourceNotFound(1710),
+    'value',
+    1,
+    False,
+    {'key': 'value'}
+])
+def test_raise_if_exc(result):
+    """Check that raise_if_exc raises an exception if the result is one."""
+    if isinstance(result, Exception):
+        with pytest.raises(Exception):
+            utils.raise_if_exc(result)
+    else:
+        utils.raise_if_exc(result)

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -390,3 +390,19 @@ def running_in_master_node() -> bool:
     cluster_config = read_cluster_config()
 
     return cluster_config['disabled'] or cluster_config['node_type'] == 'master'
+
+
+def raise_if_exc(result: object) -> None:
+    """Check if a specified object is an exception and raise it.
+
+    Raises
+    ------
+    Exception
+
+    Parameters
+    ----------
+    result : object
+        Object to be checked.
+    """
+    if isinstance(result, Exception):
+        raise result


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23218 |

## Description

Captures the exceptions raised in distributed functions.

## Tests

<details><summary>Trying to upgrade a non existent agent</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_upgrade.py -a 003 -f /wpk_file
Agents that cannot be upgraded:
  Agent 003 upgrade failed. Status: Error 1701 - Agent does not exist
```

</details>

<details><summary>Deleting the agent database</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_upgrade.py -a 001 -f /wpk_file
Agents that cannot be upgraded:
  Agent 001 upgrade failed. Status: Error 1707 - Cannot send request, agent is not active
```

</details>

<details><summary>Forcing the mentioned exception</summary>

> The trace log is still shown as explained in https://github.com/wazuh/wazuh/issues/18560.

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_upgrade.py -a 001 -f /wpk_file
concurrent.futures.process._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/concurrent/futures/process.py", line 246, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/dapi/dapi.py", line 239, in run_local
    data = f(**f_kwargs)
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/rbac/decorators.py", line 494, in wrapper
    result = func(*args, **kwargs) if not skip_execution else None
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/agent.py", line 1139, in upgrade_agents
    raise WazuhInternalError(1816, 'Agent information not found in database')
wazuh.core.exception.WazuhInternalError: Error 1816 - Agent information not found in database
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/dapi/dapi.py", line 285, in execute_local_request
    data = await asyncio.wait_for(task, timeout=timeout)
  File "/var/ossec/framework/python/lib/python3.10/asyncio/tasks.py", line 408, in wait_for
    return await fut
wazuh.core.exception.WazuhInternalError: Error 1816 - Agent information not found in database
Internal error: Error 1816 - Agent information not found in database
```

</details>

<details><summary>agent_groups execution to show that it's working</summary>

```console
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -l
Groups (1):
  default (0)
Unassigned agents: 0.
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/agent_groups.py -s -i 000
The agent 'wazuh-master' with ID '000' belongs to groups: Null
```

</details>