### PR TITLE
Use dedicated RSA keys for keystore encryption

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1306,7 +1306,12 @@ InstallServer()
     ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/keystore
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} wazuh-keystore ${INSTALLDIR}/bin/
 
-    GenerateKeystoreCert
+    if [ "X${update_only}" = "Xyes" ]; then
+      cp -pn ${INSTALLDIR}/etc/sslmanager.cert ${INSTALLDIR}/etc/keystore.cert
+      cp -pn ${INSTALLDIR}/etc/sslmanager.key ${INSTALLDIR}/etc/keystore.key
+    else
+      GenerateKeystoreCert
+    fi
 }
 
 InstallAgent()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -234,6 +234,21 @@ GenerateAuthCert()
     fi
 }
 
+#########################
+#GenerateKeystoreCert()
+#########################
+GenerateKeystoreCert()
+{
+  keystore_key=/etc/keystore.key
+  keystore_cert=/etc/keystore.cert
+  if [ ! -f "X${INSTALLDIR}${keystore_key}" ] && [ ! -f "${INSTALLDIR}${keystore_cert}" ]; then
+      echo "Generating RSA keys for Keystore."
+      ${INSTALLDIR}/bin/wazuh-authd -C 365 -B 2048 -K ${INSTALLDIR}${keystore_key} -X ${INSTALLDIR}${keystore_cert} -S "/C=US/ST=California/CN=wazuh/"
+      chmod 600 ${INSTALLDIR}${keystore_key}
+      chmod 600 ${INSTALLDIR}${keystore_cert}
+  fi
+}
+
 ##########
 # WriteLogs()
 ##########
@@ -1290,6 +1305,8 @@ InstallServer()
     # Keystore
     ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/keystore
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} wazuh-keystore ${INSTALLDIR}/bin/
+
+    GenerateKeystoreCert
 }
 
 InstallAgent()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -239,17 +239,13 @@ GenerateAuthCert()
 #########################
 GenerateKeystoreCert()
 {
+  # Regenerate keys if they are not valid.
   keystore_key=/etc/keystore.key
   keystore_cert=/etc/keystore.cert
-  # Testing keys
-  ${INSTALLDIR}/bin/wazuh-keystore -f default -k username -v test_user
-  # Regenerate keys if they are not valid.
-  if [ $? -eq 1 ] || [ ! -f "${INSTALLDIR}${keystore_key}" ] || [ ! -f "${INSTALLDIR}${keystore_cert}" ]; then
-      echo "Generating RSA keys for Keystore."
-      ${INSTALLDIR}/bin/wazuh-authd -C 365 -B 2048 -K ${INSTALLDIR}${keystore_key} -X ${INSTALLDIR}${keystore_cert} -S "/C=US/ST=California/CN=wazuh/"
-      chmod 600 ${INSTALLDIR}${keystore_key}
-      chmod 600 ${INSTALLDIR}${keystore_cert}
-  fi
+  echo "Generating RSA keys for Keystore."
+  ${INSTALLDIR}/bin/wazuh-authd -C 365 -B 2048 -K ${INSTALLDIR}${keystore_key} -X ${INSTALLDIR}${keystore_cert} -S "/C=US/ST=California/CN=wazuh/"
+  chmod 600 ${INSTALLDIR}${keystore_key}
+  chmod 600 ${INSTALLDIR}${keystore_cert}
 }
 
 ##########
@@ -1311,16 +1307,16 @@ InstallServer()
 
     # Since the Keystore tool previously used sslmanager keys for encryption
     # we copy them to the new location to be able to recover the information.
-    if [ "X${update_only}" = "Xyes" ]; then
-      keystore_key=/etc/keystore.key
-      keystore_cert=/etc/keystore.cert
-      if [ ! -f "${INSTALLDIR}${keystore_key}" ] || [ ! -f "${INSTALLDIR}${keystore_cert}" ]; then
-        cp -p ${INSTALLDIR}/etc/sslmanager.cert ${INSTALLDIR}${keystore_cert}
-        cp -p ${INSTALLDIR}/etc/sslmanager.key ${INSTALLDIR}${keystore_key}
+    keystore_key=/etc/keystore.key
+    keystore_cert=/etc/keystore.cert
+    if [ ! -f "${INSTALLDIR}${keystore_key}" ] || [ ! -f "${INSTALLDIR}${keystore_cert}" ]; then
+      cp -p ${INSTALLDIR}/etc/sslmanager.cert ${INSTALLDIR}${keystore_cert}
+      cp -p ${INSTALLDIR}/etc/sslmanager.key ${INSTALLDIR}${keystore_key}
+      ${INSTALLDIR}/bin/wazuh-keystore -f default -k username -v test_user
+      if [ $? -eq 1 ]; then
+            GenerateKeystoreCert
       fi
     fi
-    GenerateKeystoreCert
-
 }
 
 InstallAgent()

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1306,6 +1306,8 @@ InstallServer()
     ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/keystore
     ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} wazuh-keystore ${INSTALLDIR}/bin/
 
+    # Since the keystore previously used sslmanager keys for encryption
+    # we copy them to the new location to be able to recover the information.
     if [ "X${update_only}" = "Xyes" ]; then
       cp -pn ${INSTALLDIR}/etc/sslmanager.cert ${INSTALLDIR}/etc/keystore.cert
       cp -pn ${INSTALLDIR}/etc/sslmanager.key ${INSTALLDIR}/etc/keystore.key

--- a/src/shared_modules/keystore/include/keyStore.hpp
+++ b/src/shared_modules/keystore/include/keyStore.hpp
@@ -19,9 +19,8 @@
 #include "rsaHelper.hpp"
 
 constexpr auto DATABASE_PATH {"queue/keystore"};
-constexpr auto PRIVATE_KEY_FILE {"etc/sslmanager.key"};
-constexpr auto CERTIFICATE_FILE {"etc/sslmanager.cert"};
-
+constexpr auto PRIVATE_KEY_FILE {"etc/keystore.key"};
+constexpr auto CERTIFICATE_FILE {"etc/keystore.cert"};
 constexpr auto KS_NAME {"keystore"};
 template<typename TRSAPrimitive = RSAHelper<>>
 class TKeystore final


### PR DESCRIPTION
|Related issue|
|---|
|#24111|

## Description 

Using dedicated RSA keys for Keystore

## DoD (Update)

v4.8.0
```console
root@jammy:/home/vagrant/INDEXER# manage_agents -V

Wazuh v4.8.0 - Wazuh Inc.

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License (version 2) as
published by the Free Software Foundation. For more details, go to
https://www.gnu.org/licenses/gpl.html
```

Non-RSA sslmanager keys
```console
root@jammy:/home/vagrant/INDEXER# openssl x509 -in /var/ossec/etc/sslmanager.cert -text | grep Public
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (384 bit)
```

wazuh-keystore tool fails
```console
root@jammy:/home/vagrant/INDEXER# /var/ossec/bin/wazuh-keystore -f default -k username -v test_user
Unsupported key type
```

Upgrade
```console
 Wazuh v4.8.1 (Rev. 40813) Installation Script - https://www.wazuh.com

 You are about to start the installation process of Wazuh.
 You must have a C compiler pre-installed in your system.

  - System: Linux jammy 5.15.0-113-generic (ubuntu 22.04)
  - User: root
  - Host: jammy


  -- Press ENTER to continue or Ctrl-C to abort. --


 - You already have Wazuh installed. Do you want to update it? (y/n):
```

```console
Unsupported key type
Generating RSA keys for Keystore.
```

Valid keys, indexer-connector successfully connected
```console
root@jammy:/home/vagrant/wazuh# grep "indexer-connector" /var/ossec/logs/ossec.log
2024/07/01 16:33:22 indexer-connector[378247] indexerConnector.cpp:88 at initConfiguration(): WARNING: No username found in the keystore, using default value.
2024/07/01 16:33:22 indexer-connector[378247] indexerConnector.cpp:319 at initialize(): INFO: IndexerConnector initialized successfully for index: wazuh-states-vulnerabilities-jammy.
root@jammy:/home/vagrant/wazuh# diff /var/ossec/etc/{sslmanager.key,keystore.key} -q
Files /var/ossec/etc/sslmanager.key and /var/ossec/etc/keystore.key differ
```

