### PR TITLE
Add `user-agent` header to the CTI request

### DIFF
--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -34,7 +34,7 @@ RELEASE_UPDATES_URL = os.path.join(CTI_URL, 'api', 'v1', 'ping')
 ONE_DAY_SLEEP = 60 * 60 * 24
 WAZUH_UID_KEY = 'wazuh-uid'
 WAZUH_TAG_KEY = 'wazuh-tag'
-
+USER_AGENT_KEY = 'user-agent'
 
 class LoggingFormat(Enum):
     plain = "plain"
@@ -318,7 +318,11 @@ async def query_update_check_service(installation_uid: str) -> dict:
         Updates information.
     """
     current_version = f'v{wazuh.__version__}'
-    headers = {WAZUH_UID_KEY: installation_uid, WAZUH_TAG_KEY: current_version}
+    headers = {
+        WAZUH_UID_KEY: installation_uid,
+        WAZUH_TAG_KEY: current_version,
+        USER_AGENT_KEY: f'Wazuh UpdateCheckService/{current_version}'
+    }
 
     update_information = get_update_information_template(
         update_check=True, current_version=current_version, last_check_date=get_utc_now()


### PR DESCRIPTION
|Related issue|
|---|
|#24347|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR closes #24347. Set the `user-agent` in the requests to the CTI service.

## Logs/Alerts example

* API start up

```
root@wazuh-master:/var/ossec# wpy api/scripts/wazuh_apid.py -f
2024/06/28 18:16:20 INFO: Starting API in foreground
2024/06/28 18:16:20 INFO: Checking RBAC database integrity...
2024/06/28 18:16:20 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2024/06/28 18:16:20 INFO: RBAC database integrity check finished successfully
2024/06/28 18:16:23 INFO: Listening on 0.0.0.0:55000.
2024/06/28 18:16:23 INFO: Getting installation UID...
2024/06/28 18:16:23 INFO: Getting updates information...
2024/06/28 18:16:26 INFO: wazuh 172.20.0.1 "GET /security/user/authenticate" with parameters {"raw": "true"} and body {} done in 0.263s: 200
2024/06/28 18:16:29 INFO: wazuh 172.20.0.1 "GET /manager/version/check" with parameters {} and body {} done in 0.046s: 200
```

* Request to `manager/version/check`

```json
➜  ~ curl -k --silent -H  "Authorization: Bearer $TOKEN" https://localhost:55050/manager/version/check | jq
{
  "data": {
    "last_check_date": "2024-06-28T18:16:23.980519+00:00",
    "current_version": "v4.9.0",
    "update_check": true,
    "last_available_major": {},
    "last_available_minor": {},
    "last_available_patch": {},
    "uuid": "f80907f0-1f7c-4ffd-90b0-4a9a75d82f5d"
  },
  "error": 0
}
```