### PR TITLE
fix: Improve how deb package descriptions are shown in Software Updater

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/control
+++ b/packages/debs/SPECS/wazuh-agent/debian/control
@@ -11,4 +11,8 @@ Architecture: any
 Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
 Conflicts: ossec-hids-agent, wazuh-manager, ossec-hids, wazuh-api
 Breaks: ossec-hids-agent, wazuh-manager, ossec-hids
-Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+Description: Wazuh agent
+ Wazuh helps you to gain security visibility into your infrastructure by
+ monitoring hosts at an operating system and application level. It provides
+ the following capabilities: log analysis, file integrity monitoring,
+ intrusions detection and policy and compliance monitoring.

--- a/packages/debs/SPECS/wazuh-manager/debian/control
+++ b/packages/debs/SPECS/wazuh-manager/debian/control
@@ -12,4 +12,8 @@ Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
 Suggests: expect
 Conflicts: ossec-hids-agent, wazuh-agent, ossec-hids, wazuh-api
 Replaces: wazuh-api
-Description: Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring
+Description: Wazuh manager
+ Wazuh helps you to gain security visibility into your infrastructure by monitoring
+ hosts at an operating system and application level. It provides the following
+ capabilities: log analysis, file integrity monitoring, intrusions detection
+ and policy and compliance monitoring.


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/2156|

## Description
To improve the user experience and ensure users access accurate information, this PR fixes the field within Debian packages: Title and technical description in the Software Updater.

## Tests
I generated a local package manager server. 

```
mkdir -p /srv/local_packages
# Copy the package generated with the fix
cp wazuh-agent_4.9.0-0_amd64_493c261.deb /srv/local_packages
# Create an appropriate Packages.gz file
dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
# Add the local source to sources.list.d
# cat /etc/apt/sources.list.d/local-repo.list 
deb [trusted=yes] file:///srv/local_packages ./
apt update
```
Then open Software Updater.

|                                                 Software Updater: now                                                  |                                                               Software Updater: This PR                                                               | 
|:------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------:|
| <img width="576" alt="Software Updater now" src="https://github.com/wazuh/wazuh/assets/21695385/c3c25a75-a2f4-4d6b-944f-2fe9c0fbe5e3)"> | <img width="576" alt="Software Updater fixed" src="https://github.com/wazuh/wazuh/assets/21695385/3419905a-bf5e-4cb5-9c92-ee3513a25762"> |  

**Note:** I also applied this change to the manager.
  - [x] Linux
   - [x] Package upgrade