### PR TITLE
Keystore refactor

### DIFF
--- a/src/shared_modules/keystore/src/main.cpp
+++ b/src/shared_modules/keystore/src/main.cpp
@@ -12,14 +12,73 @@
 #include "argsParser.hpp"
 #include "homedirHelper.hpp"
 #include "keyStore.hpp"
+#include "loggerHelper.h"
 #include <filesystem>
+#include <iostream>
 
-namespace Log
+void setWorkingDirectory()
 {
-    std::function<void(
-        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
-        GLOBAL_LOG_FUNCTION;
-};
+    try
+    {
+        std::filesystem::path home_path = Utils::findHomeDirectory();
+        std::filesystem::current_path(home_path);
+        logDebug1("keystore", "Set current working directory to: %s", home_path.c_str());
+    }
+    catch (const std::exception& e)
+    {
+        logError("keystore", "Failed to set working directory: %s", e.what());
+        throw;
+    }
+}
+
+void parseArguments(int argc, char* argv[], std::string& family, std::string& key, std::string& value)
+{
+    try
+    {
+        CmdLineArgs args(argc, argv);
+        family = args.getColumnFamily();
+        key = args.getKey();
+        value = args.getValue();
+
+        if (family.empty() || key.empty() || value.empty())
+        {
+            throw std::invalid_argument("Column family, key, and value must be provided");
+        }
+
+        logDebug1("keystore", "Parsed arguments - Family: %s, Key: %s", family.c_str(), key.c_str());
+    }
+    catch (const CmdLineArgsException& e)
+    {
+        logError("keystore", "Command line argument error: %s", e.what());
+        CmdLineArgs::showHelp();
+        throw;
+    }
+    catch (const std::invalid_argument& e)
+    {
+        logError("keystore", "Invalid argument: %s", e.what());
+        CmdLineArgs::showHelp();
+        throw;
+    }
+    catch (const std::exception& e)
+    {
+        logError("keystore", "Failed to parse arguments: %s", e.what());
+        throw;
+    }
+}
+
+void storeKeyValue(const std::string& family, const std::string& key, const std::string& value)
+{
+    try
+    {
+        Keystore::put(family, key, value);
+        logDebug1("keystore", "Stored key-value pair - Family: %s, Key: %s", family.c_str(), key.c_str());
+    }
+    catch (const std::exception& e)
+    {
+        logError("keystore", "Exception during keystore operation: %s", e.what());
+        throw;
+    }
+}
 
 int main(int argc, char* argv[])
 {
@@ -29,27 +88,13 @@ int main(int argc, char* argv[])
 
     try
     {
-        // Define current working directory
-        std::filesystem::path home_path = Utils::findHomeDirectory();
-        std::filesystem::current_path(home_path);
-
-        CmdLineArgs args(argc, argv);
-
-        family = args.getColumnFamily();
-        key = args.getKey();
-        value = args.getValue();
-
-        Keystore::put(family, key, value);
-    }
-    catch (const CmdLineArgsException& e)
-    {
-        std::cerr << e.what() << "\n";
-        CmdLineArgs::showHelp();
-        return 1;
+        setWorkingDirectory();
+        parseArguments(argc, argv, family, key, value);
+        storeKeyValue(family, key, value);
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what() << "\n";
+        std::cerr << "Error: " << e.what() << "\n";
         return 1;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/24544 |

## Description

After upgrading to Wazuh 4.8.0, I had issues with keystore. Unfortunately all I got was `wazuh-modulesd:vulnerability-scanner: ERROR: VulnerabilityScannerFacade::start: RSA decryption failed`, and it is not helpful in troubleshooting.

In order to improve internal visibility, I only added some `logDebug2` options. Also did some refactoring around keystore application.

## Configuration options

## Logs/Alerts example

Before:
```
wazuh-modulesd:vulnerability-scanner: ERROR: VulnerabilityScannerFacade::start: RSA decryption failed
```
After:

```
[DEBUG] keystore: Encryption successful for key: myKey
[DEBUG] keystore: Inserted encrypted value for key: myKey into column family: myFamily
```

```
[DEBUG] keystore: Decryption successful for key: myKey
```

```
[ERROR] keystore: Exception during encryption for key: myKey, Error: RSA encryption failed
```

```
[DEBUG] keystore: Encryption successful for key: myKey
[ERROR] keystore: Exception during database insertion for key: myKey, Error: Failed to put key-value pair into RocksDB
```

```
[DEBUG] keystore: Encryption successful for key: myKey
[DEBUG] keystore: Inserted encrypted value for key: myKey into column family: myFamily
[ERROR] keystore: Exception during decryption for key: myKey, Error: RSA decryption failed
```

```
[ERROR] keystore: Exception during database retrieval for key: myKey, Error: Failed to get value from RocksDB
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors