### PR TITLE
Fix VD step in RPM Spec file

### DIFF
--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -752,7 +752,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%attr(750, wazuh, wazuh) %{_localstatedir}/tmp/%{_vdfilename}
+%attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/%{_vdfilename}
 %dir %attr(750, root, wazuh) %{_localstatedir}/queue
 %attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless


### PR DESCRIPTION
|Related issue|
|---|
|#24374|

## Objective
This PR aims to standardize file permissions, ownership, and configuration management for files installed by our RPM packages. By applying the fix `%attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/%{_vdfilename}` in the spec files, we enhance security and ensure consistent handling of configuration files during package installations and upgrades.

----------------------