### PR TITLE
Update Shuffle integration to easily ignore messages based on description

### DIFF
--- a/integrations/shuffle.py
+++ b/integrations/shuffle.py
@@ -58,6 +58,10 @@ SKIP_RULE_IDS = [
     '87928',
     '5710',
 ]
+SKIP_DESCRIPTIONS = [
+    "Custom Test Rule to ignore",
+    "Other test rule"
+]
 
 # Log path
 LOG_FILE = f'{pwd}/logs/integrations.log'
@@ -168,6 +172,11 @@ def filter_msg(alert) -> bool:
 
     return alert['rule']['id'] not in SKIP_RULE_IDS
 
+def filter_msg_by_description(alert) -> bool:
+    # SKIP_DESCRIPTIONS contains the descriptions that should be filtered
+
+    return not any(alert["rule"]["description"].startswith(description) for description in SKIP_DESCRIPTIONS)
+
 
 def generate_msg(alert: any, options: any) -> str:
     """Generate the JSON object with the message to be send
@@ -188,6 +197,10 @@ def generate_msg(alert: any, options: any) -> str:
     if not filter_msg(alert):
         print('Skipping rule %s' % alert['rule']['id'])
         return ''
+    
+    if not filter_msg_by_description(alert):
+        print("Skipping rule with this description: %s" % alert["rule"]["description"])
+        return ""
 
     level = alert['rule']['level']
 


### PR DESCRIPTION
|Related issue|
|---|
||

## Description

I need a quick way to ignore some kind of messages

## Configuration options

no new options

## Logs/Alerts example

No related logs

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [X] Linux
  - [X] Windows
  - [X] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors