### PR TITLE
Update Wazuh Keystore to allow setting password from file and stdin

### DIFF
--- a/.github/workflows/wazuh-keystore-tests.yml
+++ b/.github/workflows/wazuh-keystore-tests.yml
@@ -1,0 +1,37 @@
+name: Wazuh Keystore
+
+on:
+  workflow_dispatch:
+  pull_request:
+  # Pull request events
+    types: [synchronize, opened, reopened, ready_for_review]
+  # Path filtering
+    paths:
+      - ".github/workflows/wazuh-keystore-tests.yml"
+      - "src/shared_modules/keystore/**"
+      - "src/shared_modules/utils/**"
+
+jobs:
+  wazuh-keystore-qa:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Compile keystore
+        run: |
+          make deps TARGET=server -j2 -C src/
+          make libwazuhext.so TARGET=server -j2 -C src/
+          mkdir -p src/shared_modules/keystore/build
+          cmake -S src/shared_modules/keystore -B  src/shared_modules/keystore/build -DSRC_FOLDER=$(pwd)/src
+          cmake --build src/shared_modules/keystore/build -j2
+
+      - name: Install dependencies
+        run: |
+          pip install -r src/shared_modules/keystore/qa/requirements.txt
+
+      - name: Run tests
+        run: |
+          python -m pytest -vv src/shared_modules/keystore/qa/ --log-cli-level=DEBUG

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ src/wazuh-reportd
 src/wazuh-syscheckd
 src/wazuh-integratord
 src/wazuh-keystore
+src/wazuh-keystore-testtool
 
 # Active responses
 src/firewall-drop

--- a/src/shared_modules/keystore/qa/requirements.txt
+++ b/src/shared_modules/keystore/qa/requirements.txt
@@ -1,0 +1,2 @@
+pytest==7.2.2
+trustme==1.1.0

--- a/src/shared_modules/keystore/qa/test_keystore.py
+++ b/src/shared_modules/keystore/qa/test_keystore.py
@@ -1,0 +1,168 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+from subprocess import Popen, PIPE
+import logging
+import os
+import pytest
+import trustme
+from pathlib import Path
+
+LOGGER = logging.getLogger(__name__)
+KEYSTORE_BINARY = "./wazuh-keystore"
+KEYSTORE_TESTTOOL_BINARY = "./wazuh-keystore-testtool"
+CERTS_PATH = 'etc/'
+PRIVATE_KEY_FILE = "etc/sslmanager.key"
+CERTIFICATE_FILE ="etc/sslmanager.cert"
+KEYSTORE_DB_PATH = "queue/keystore"
+
+# Helper methods
+
+def run_command(command):
+    """ Runs a command using subprocess.Popen and returns the stdout. In case of failure, it logs the error and fails the test.
+
+    Args:
+        command (str): The command to run
+
+    Returns:
+        str: The stdout of the command
+    """
+    with Popen(command, stdout=PIPE, stderr=PIPE, shell=True) as process:
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            LOGGER.error("Error running command: %s", command)
+            LOGGER.error("stdout: %s", stdout.decode())
+            LOGGER.error("stderr: %s", stderr.decode())
+            pytest.fail()
+    return stdout.decode()
+
+def get_password():
+    """ Runs the testtool to get the password from the keystore and returns it.
+
+    Returns:
+        str: The password stored in the keystore stripped of any leading/trailing whitespaces.
+    """
+    command = [KEYSTORE_TESTTOOL_BINARY, "-c", "indexer", "-k", "password"]
+    command = " ".join(command)
+    return run_command(command).strip()
+
+def set_password(password):
+    """ Sets the password in the keystore using the keystore binary and the value parameter.
+
+    Args:
+        password (str): The password to set in the keystore.
+    """
+    command = [KEYSTORE_BINARY, "-f", "indexer", "-k", "password", "-v", f"'{password}'"]
+    command = " ".join(command)
+    run_command(command)
+
+def set_password_echo(password):
+    """ Sets the password in the keystore using the keystore binary and the 'echo' command.
+
+    Args:
+        password (str): The password to set in the keystore.
+    """
+    command = ["echo",f"'{password}'", "|" , KEYSTORE_BINARY, "-f", "indexer", "-k", "password"]
+    command = " ".join(command)
+    run_command(command)
+
+def set_password_from_file(password):
+    """ Sets the password in the keystore using the keystore binary and the value from path parameter.
+
+    Args:
+        password (str): The password to set in the keystore.
+    """
+    with open("password.txt", "w", encoding='utf-8') as f:
+        f.write(password)
+    command = [KEYSTORE_BINARY, "-f", "indexer", "-k", "password", "-vp", "./password.txt"]
+    command = " ".join(command)
+    run_command(command)
+    os.remove("password.txt")
+
+def set_password_redirect_file(password):
+    """ Sets the password in the keystore using the keystore binary and redirecting the value from a file.
+
+    Args:
+        password (str): The password to set in the keystore.
+    """
+    with open("password.txt", "w", encoding='utf-8') as f:
+        f.write(password)
+    command = [KEYSTORE_BINARY, "-f", "indexer", "-k", "password","<","./password.txt"]
+    command = " ".join(command)
+    run_command(command)
+    os.remove("password.txt")
+
+def set_password_cat_file(password):
+    """ Sets the password in the keystore using the keystore binary and reading the value from a file with cat.
+
+    Args:
+        password (str): The password to set in the keystore.
+    """
+    with open("password.txt", "w", encoding='utf-8') as f:
+        f.write(password)
+    command = ["cat", "./password.txt", "|", KEYSTORE_BINARY, "-f", "indexer", "-k", "password"]
+    command = " ".join(command)
+    run_command(command)
+    os.remove("password.txt")
+
+def clear_password():
+    """ This method clears the password stored in the keystore.
+    """
+    command = [KEYSTORE_BINARY, "-f", "indexer", "-k", "password", "-v", "NOT_USED_PASS"]
+    command = " ".join(command)
+    run_command(command)
+
+# Fixtures
+
+@pytest.fixture(autouse=True, scope='session')
+def setup_teardown():
+    """ Setup and teardown for all tests. The self-signed certificates are created before the tests, and removed after them.
+        Also, the keystore is removed.
+    """
+    # Setup
+
+    # Move to root folder
+    os.chdir(Path(__file__).parent.parent.parent.parent)
+    # Create certs path
+    os.makedirs(CERTS_PATH, exist_ok=True)
+
+    # Create self-signed certs
+    ca = trustme.CA(key_type=trustme.KeyType.RSA)
+    server_cert = ca.issue_cert("test-host.example.org", key_type=trustme.KeyType.RSA)
+    server_cert.private_key_pem.write_to_path(PRIVATE_KEY_FILE)
+    server_cert.cert_chain_pems[0].write_to_path(CERTIFICATE_FILE)
+
+    yield
+
+    # Teardown
+    os.remove(CERTIFICATE_FILE)
+    os.remove(PRIVATE_KEY_FILE)
+    os.system(f"rm -rf {KEYSTORE_DB_PATH}")
+
+# Tests
+
+password_list = ["password",
+                 "kdashf 781264723(/$%&)(IUGHB/)",
+                 """~`R4+$b"Eç-öÇsý~ðe^î4"ôÙÆ-DXõ$ÁW"ô´C©~7ÙU9ZZ9[S£>KPû3ñ{Äñ¦}@ED×DCË`$Ï@©}¸ÉR2ÚðÑqí§XÄ(¬x%ã,ú»cf}céq%~Ð°n¾ëÜKÀ®;sÓí½(Ccô;zÙê³¯â¼{s""",
+                 """"NñÚ?e2"CÀ !Û(z"û>ESÊ¥â½°|NØ3~}¬éØ#ÓÐ`\èï9¤ ¢,Ñ|`Éà©jqø!ßõ§JÐØæ"ê¢8åzL)-yE1ª58Ñõ×ùCd;©6^{Ý¬[Æ:n&F½²Ð 1á(Çt{*¤}^êt2H¬¢ñ0=âËàÕÐ>àBí"""]
+
+insertion_methods = [set_password,
+                     set_password_from_file,
+                     set_password_redirect_file,
+                     set_password_cat_file,
+                     set_password_echo]
+
+@pytest.mark.parametrize("password", password_list)
+@pytest.mark.parametrize("insertion_method", insertion_methods)
+def test_keystore_parameters(password, insertion_method):
+    """ Verifies each password insertion method with different passwords.
+
+    Args:
+        password (str): The password to insert and verify in the keystore.
+        insertion_method: The method to insert the password in the keystore.
+    """
+    insertion_method(password)
+    pass_from_DB = get_password()
+    clear_password()
+    assert pass_from_DB == password

--- a/src/shared_modules/keystore/src/argsParser.hpp
+++ b/src/shared_modules/keystore/src/argsParser.hpp
@@ -47,7 +47,8 @@ public:
     explicit CmdLineArgs(int argc, char* argv[])
         : m_columnFamily {paramValueOf(argc, argv, "-f")}
         , m_key {paramValueOf(argc, argv, "-k")}
-        , m_value {paramValueOf(argc, argv, "-v")}
+        , m_value {paramValueOf(argc, argv, "-v", std::make_pair(false, ""))}
+        , m_valuePath {paramValueOf(argc, argv, "-vp", std::make_pair(false, ""))}
     {
     }
 
@@ -79,6 +80,16 @@ public:
     }
 
     /**
+     * @brief Get the file path with the value.
+     *
+     * @return Path to a file containing the value.
+     */
+    const std::string& getValuePath() const
+    {
+        return m_valuePath;
+    }
+
+    /**
      * @brief Shows the help to the user.
      */
     static void showHelp()
@@ -88,9 +99,15 @@ public:
                   << "\t-h \t\t\tShow this help message\n"
                   << "\t-f COLUMN_FAMILY\tSpecifies the target column family for the insertion.\n"
                   << "\t-k KEY\t\t\tSpecifies the key for the key-value pair.\n"
-                  << "\t-v VALUE\t\tSpecifies the value associated with the key.\n"
+                  << "\t-v VALUE\t\tSpecifies the value associated with the key. Only use one value option at the time.\n"
+                  << "\t-vp VALUE_PATH\t\tPath to a file containing the value to read (single line). Only use one value option at the time.\n"
+                  << "\tNOTE: if both value parameters are empty, stdin will be read.\n"
                   << "\nExample:"
                   << "\n\t./wazuh-keystore -f indexer -k username -v admin\n"
+                  << "\n\t./wazuh-keystore -f indexer -k password -vp /path/to/file.txt\n"
+                  << "\n\t./wazuh-keystore -f indexer -k password < /path/to/file.txt\n"
+                  << "\n\techo 'pass' | ./wazuh-keystore -f indexer -k password\n"
+                  << "\n\tcat /path/to/file.txt | ./wazuh-keystore -f indexer -k password\n"
                   << std::endl;
     }
 
@@ -133,6 +150,7 @@ private:
     const std::string m_columnFamily;
     const std::string m_key;
     const std::string m_value;
+    const std::string m_valuePath;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/shared_modules/keystore/src/main.cpp
+++ b/src/shared_modules/keystore/src/main.cpp
@@ -13,6 +13,7 @@
 #include "homedirHelper.hpp"
 #include "keyStore.hpp"
 #include <filesystem>
+#include <fstream>
 
 namespace Log
 {
@@ -26,6 +27,7 @@ int main(int argc, char* argv[])
     std::string family;
     std::string key;
     std::string value;
+    std::string valuePath;
 
     try
     {
@@ -38,8 +40,48 @@ int main(int argc, char* argv[])
         family = args.getColumnFamily();
         key = args.getKey();
         value = args.getValue();
+        valuePath = args.getValuePath();
 
-        Keystore::put(family, key, value);
+        if (value.empty() && valuePath.empty())
+        {
+            std::string valueFromStdin;
+            std::getline(std::cin, valueFromStdin);
+
+            if (!valueFromStdin.empty())
+            {
+                Keystore::put(family, key, valueFromStdin);
+            }
+            else
+            {
+                throw CmdLineArgsException("Error reading from stdin.");
+            }
+        }
+        else if (!value.empty() && valuePath.empty())
+        {
+            Keystore::put(family, key, value);
+        }
+        else if (!valuePath.empty() && value.empty())
+        {
+            std::ifstream file(valuePath);
+            if (!file.is_open())
+            {
+                throw CmdLineArgsException("Error opening file.");
+            }
+
+            std::string content;
+            if (std::getline(file, content))
+            {
+                Keystore::put(family, key, content);
+            }
+            else
+            {
+                throw CmdLineArgsException("Error reading file.");
+            }
+        }
+        else
+        {
+            throw CmdLineArgsException("Invalid arguments.");
+        }
     }
     catch (const CmdLineArgsException& e)
     {

--- a/src/shared_modules/keystore/testtool/CMakeLists.txt
+++ b/src/shared_modules/keystore/testtool/CMakeLists.txt
@@ -1,25 +1,13 @@
 cmake_minimum_required(VERSION 3.12.4)
 
-project(keystore)
-
-# enable_testing()
+project(wazuh-keystore-testtool)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-fPIC")
 
 if(FSANITIZE)
   set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address,leak,undefined")
 endif(FSANITIZE)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SRC_FOLDER})
-
-
-
-file(GLOB KEYSTORE_SRC
-    "src/*.cpp"
-    )
-
 
 if (NOT SRC_FOLDER)
     get_filename_component(SRC_FOLDER     ${CMAKE_SOURCE_DIR}/../../ ABSOLUTE)
@@ -29,8 +17,6 @@ if (NOT SHARED_MODULES)
     get_filename_component(SHARED_MODULES ${CMAKE_SOURCE_DIR}/../ ABSOLUTE)
 endif()
 
-include_directories(include)
-include_directories(src)
 include_directories(${SRC_FOLDER}/external/rocksdb/include)
 include_directories(${SRC_FOLDER}/external/openssl/include)
 include_directories(${SRC_FOLDER}/external/cJSON)
@@ -40,17 +26,5 @@ include_directories(${SHARED_MODULES}/common)
 link_directories(${SRC_FOLDER})
 link_directories(${SRC_FOLDER}/external/rocksdb/build)
 
-add_library(keystore STATIC ${KEYSTORE_SRC})
-
-target_link_libraries(keystore rocksdb wazuhext)
-
-add_executable(wazuh-keystore src/main.cpp)
-
-target_link_libraries(wazuh-keystore keystore)
-
-set_target_properties(wazuh-keystore PROPERTIES
-    BUILD_RPATH_USE_ORIGIN TRUE
-    BUILD_RPATH "$ORIGIN/../lib"
-)
-
-add_subdirectory(testtool)
+add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} rocksdb wazuhext)

--- a/src/shared_modules/keystore/testtool/main.cpp
+++ b/src/shared_modules/keystore/testtool/main.cpp
@@ -1,0 +1,49 @@
+/*
+ * Wazuh keystore
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 1, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "testtoolArgsParser.hpp"
+#include "keyStore.hpp"
+#include <iostream>
+
+namespace Log
+{
+    std::function<void(
+        const int, const std::string&, const std::string&, const int, const std::string&, const std::string&, va_list)>
+        GLOBAL_LOG_FUNCTION;
+};
+
+int main(int argc, char* argv[])
+{
+    CmdLineArgs args(argc, argv);
+    std::string key = args.getKey();
+    std::string column = args.getColumnFamily();
+    std::string value = args.getValue();
+
+    try
+    {
+        if (value.empty())
+        {
+            Keystore::get(column, key, value);
+            std::cout << value << std::endl;
+        }
+        else
+        {
+            Keystore::put(column, key, value);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/shared_modules/keystore/testtool/testtoolArgsParser.hpp
+++ b/src/shared_modules/keystore/testtool/testtoolArgsParser.hpp
@@ -1,0 +1,120 @@
+/*
+ * Wazuh cmdLineParser
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 2, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _TESTTOOL_ARGS_PARSER_HPP_
+#define _TESTTOOL_ARGS_PARSER_HPP_
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Class to parse command line arguments.
+ */
+class CmdLineArgs
+{
+public:
+    /**
+     * @brief Constructor for CmdLineArgs.
+     * @param argc Number of arguments.
+     * @param argv Arguments.
+     */
+    explicit CmdLineArgs(int argc, char* argv[])
+        : m_key {paramValueOf(argc, argv, "-k", std::make_pair(true, ""))}
+        , m_columnFamily {paramValueOf(argc, argv, "-c", std::make_pair(true, ""))}
+        , m_value {paramValueOf(argc, argv, "-v", std::make_pair(false, ""))}
+    {
+    }
+
+    /**
+     * @brief Get the requested key.
+     *
+     * @return std::string Key.
+     */
+    std::string getKey()
+    {
+        return m_key;
+    }
+
+    /**
+     * @brief Get the requested value to insert.
+     *
+     * @return std::string Value.
+     */
+    std::string getValue()
+    {
+        return m_value;
+    }
+
+    /**
+     * @brief Get the requested column family.
+     *
+     * @return std::string Column family.
+     */
+    std::string getColumnFamily()
+    {
+        return m_columnFamily;
+    }
+
+    /**
+     * @brief Shows the help to the user.
+     */
+    static void showHelp()
+    {
+        std::cout << "\nUsage: keystore-testtool <option(s)>\n"
+                  << "Options:\n"
+                  << "\t-h \t\t\tShow this help message\n"
+                  << "\t-k <key> \t\tKey to query or insert.\n"
+                  << "\t-c <columnFamily> \tColumn family to query or insert.\n"
+                  << "\t-v <value> \t\tValue to insert for. Optional, performs a get if not present.\n"
+                  << "\nExample:"
+                  << "\n\t./keystore-testtool -k key -c column \n"
+                  << "\n\t./keystore-testtool -k key -c column -v val1\n"
+                  << std::endl;
+    }
+
+private:
+    static std::string paramValueOf(int argc,
+                                    char* argv[],
+                                    const std::string& switchValue,
+                                    const std::pair<bool, std::string>& required = std::make_pair(true, ""))
+    {
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string currentValue {argv[i]};
+
+            if (currentValue == "-h")
+            {
+                showHelp();
+                exit(0);
+            }
+
+            if (currentValue == switchValue && i + 1 < argc)
+            {
+                // Switch found
+                return argv[i + 1];
+            }
+        }
+
+        if (required.first)
+        {
+            throw std::runtime_error {"Switch value: " + switchValue + " not found."};
+        }
+
+        return required.second;
+    }
+
+    const std::string m_key;
+    const std::string m_columnFamily;
+    const std::string m_value;
+};
+
+#endif // _TESTTOOL_ARGS_PARSER_HPP_


### PR DESCRIPTION
|Related issue|
|---|
|Closes #24110|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds more secure ways to provide the password to the `wazuh-keystore`.
A small test tool was added to make the testing easier.

The Github Actions workflow verifies the new feature with different passwords and insertion methods.

## Tests

Manual tests:

As expected, the `-v` parameter makes the password visible

```
./wazuh-keystore -f indexer -k password -v 'SecretPassword'
```

![2024-07-03_19-53](https://github.com/wazuh/wazuh/assets/65046601/dab907b2-b98f-4cc3-a87e-0b625fc8ad05)

But using the `echo` doesn't

```
echo 'SecretPassword' | ./wazuh-keystore -f indexer -k password
```

![2024-07-03_19-55](https://github.com/wazuh/wazuh/assets/65046601/de648eb7-8780-43bb-9fce-41bc372ef6e2)

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] QA templates contemplate the added capabilities

- [x] Added unit tests (for new features)

