### PR TITLE
Fixed package generation error in centos 7

### DIFF
--- a/packages/rpms/amd64/manager/Dockerfile
+++ b/packages/rpms/amd64/manager/Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:7
 
 # Install all the necessary tools to build the packages
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum install -y gcc make wget git \
     openssh-clients sudo gnupg file-devel\
     automake autoconf libtool policycoreutils-python \
@@ -21,7 +23,7 @@ RUN yum install -y gcc make wget git \
     redhat-rpm-config sqlite-devel gdb tar tcl-devel tix-devel tk-devel \
     valgrind-devel python-rpm-macros python3
 
-    # Install Perl 5.10
+# Install Perl 5.10
 RUN curl -OL http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz && \
     gunzip perl-5.10.1.tar.gz && tar -xf perl*.tar && \
     cd /perl-5.10.1 && ./Configure -des -Dcc='gcc' -Dusethreads && \


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24397|

## Description

While running the command:

```bash

./generate_package.sh -t manager --system rpm -j 16 -r test -b 4.9.0
```

we encountered the following error:

```vbnet

0.532 Loaded plugins: fastestmirror, ovl
0.668 Determining fastest mirrors
0.696 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
0.696 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
0.697
0.697
0.697  One of the configured repositories failed (Unknown),
0.697  and yum doesn't have enough cached data to continue. At this point the only
0.697  safe thing yum can do is fail. There are a few ways to work "fix" this:
0.697
0.697      1. Contact the upstream for the repository and get them to fix the problem.
0.697
0.697      2. Reconfigure the baseurl/etc. for the repository, to point to a working
0.697         upstream. This is most often useful if you are using a newer
0.697         distribution release than is supported by the repository (and the
0.697         packages for the previous distribution release still work).
0.697
0.697      3. Run the command with the repository temporarily disabled
0.697             yum --disablerepo=<repoid> ...
0.697
0.697      4. Disable the repository permanently, so yum won't use it by default. Yum
0.697         will then just ignore the repository until you permanently enable it
0.697         again or use --enablerepo for temporary usage:
0.697
Last login: Tue Jul  2 10:28:32 on ttys000
```

## Proposed Fix

The error occurs because the mirrorlist.centos.org cannot be resolved. This can be fixed by modifying the CentOS 7 Dockerfiles to use the vault repository instead. The proposed fix includes adding the following lines to the Dockerfiles:

```Dockerfile

RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
```

## Fixed Output

After applying the fix, the output is as follows, indicating that the build process completes successfully:

```ruby

=> CACHED [ 1/13] FROM docker.io/library/centos:7@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4                                                                                              0.0s 
 => [ 2/13] RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*                                                                                                                                           0.2s 
 => [ 3/13] RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*                                                                                                0.3s 
 => [ 4/13] RUN yum install -y gcc make wget git     openssh-clients sudo gnupg file-devel    automake autoconf libtool policycoreutils-python     yum-utils system-rpm-config rpm-devel     gettext nspr nspr-devel   77.2s 
 => [ 5/13] RUN curl -OL http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz &&     gunzip perl-5.10.1.tar.gz && tar -xf perl*.tar &&     cd /perl-5.10.1 && ./Configure -des -Dcc='gcc' -Dusethreads &&     mak  144.1s
 => [ 6/13] RUN curl -O http://packages.wazuh.com/utils/autoconf/autoconf-2.69.tar.gz &&     gunzip autoconf-2.69.tar.gz && tar xvf autoconf-2.69.tar &&     cd autoconf-2.69 && ./configure && make -j$(nproc) &&      4.0s
 => [ 7/13] RUN curl -O http://packages.wazuh.com/utils/rpm/rpm-4.15.1.tar.bz2 &&     tar -xjf rpm-4.15.1.tar.bz2 && cd rpm-4.15.1 &&     ./configure --without-lua && make -j$(nproc) && make install && cd / && rm   38.6s
 => [ 8/13] RUN mkdir -p /usr/local/var/lib/rpm &&     cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages &&     /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild                                          1.1s
 => [ 9/13] RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz &&     tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ &&     ./contrib/download_prerequisites &&     ./configure --prefix=/usr/local/gcc-  5081.5s
 => [10/13] RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz &&     tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 &&     ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc         829.1s 
 => [11/13] ADD build.sh /usr/local/bin/build_package                                                                                                                                                                   0.0s 
 => [12/13] RUN chmod +x /usr/local/bin/build_package                                                                                                                                                                   0.2s 
 => [13/13] ADD helper_function.sh /usr/local/bin/helper_function.sh                                                                                                                                                    0.0s 
 => exporting to image                                                                                                                                                                                                 14.6s 
 => => exporting layers                                                                                                                                                                                                14.6s
 => => writing image sha256:7d3510d031f02e2a4b562d63cc011f0eb231bcecb0ebb25e775cef47ef4f75e5                                                                                                                            0.0s
 => => naming to docker.io/library/pkg_rpm_manager_builder_amd64:latest
```     