### PR TITLE
Improve preinstall and postinstall scripts

### DIFF
--- a/packages/macos/package_files/postinstall.sh
+++ b/packages/macos/package_files/postinstall.sh
@@ -13,24 +13,17 @@ USER="wazuh"
 DIR="/Library/Ossec"
 INSTALLATION_SCRIPTS_DIR="${DIR}/packages_files/agent_installation_scripts"
 SCA_BASE_DIR="${INSTALLATION_SCRIPTS_DIR}/sca"
+UPGRADE_FILE_FLAG="${DIR}/WAZUH_PKG_UPGRADE"
 
-if [ -f "${DIR}/WAZUH_PKG_UPGRADE" ]; then
-    upgrade="true"
-fi
-
-if [ -f "${DIR}/WAZUH_PKG_UPGRADE" ]; then
-    rm -f ${DIR}/WAZUH_PKG_UPGRADE
-fi
 
 if [ -f "${DIR}/WAZUH_RESTART" ]; then
     restart="true"
-fi
-
-if [ -f "${DIR}/WAZUH_RESTART" ]; then
     rm -f ${DIR}/WAZUH_RESTART
 fi
 
-if [ -n "${upgrade}" ]; then
+if [ -f "${UPGRADE_FILE_FLAG}" ]; then
+    upgrade="true"
+    rm -f ${UPGRADE_FILE_FLAG}
     echo "Restoring configuration files from ${DIR}/config_files/ to ${DIR}/etc/"
     rm -rf ${DIR}/etc/{ossec.conf,client.keys,local_internal_options.conf,shared}
     cp -rf ${DIR}/config_files/{ossec.conf,client.keys,local_internal_options.conf,shared} ${DIR}/etc/
@@ -76,7 +69,6 @@ chown root:${GROUP} ${DIR}/etc/ossec.conf
 chmod 660 ${DIR}/etc/ossec.conf
 chown root:${GROUP} ${DIR}/etc/wpk_root.pem
 chmod 640 ${DIR}/etc/wpk_root.pem
-
 
 chmod 770 ${DIR}/.ssh
 
@@ -160,7 +152,6 @@ echo "Removing temporary files..."
 rm -rf ${DIR}/packages_files
 
 # Remove old ossec user and group if exists and change ownwership of files
-
 if [[ $(dscl . -read /Groups/ossec) ]]; then
     echo "Changing group from Ossec to Wazuh"
     find ${DIR}/ -group ossec -user root -exec chown root:wazuh {} \ > /dev/null 2>&1 || true


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh-packages#2220|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR focuses on improving the pre-install and post-install scripts. I wasn't able to implement the pre-upgrade and post-upgrade functionalities at this time.

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
<details>
<summary> Workflow test</summary>

run: https://github.com/wazuh/wazuh-agent-packages/actions/runs/9810672023/job/27091302202
</details>

<details>
<summary> Local install test</summary>

Generated the package ```sudo ./generate_wazuh_packages.sh``` and tested it locally.

```bash
ec2-user@ip-172-31-47-73 macos % echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg output/wazuh-agent_4.10.0-1_intel64_acbe362e7a.pkg -target / 
installer: Package name is Wazuh Agent
installer: Installing at base path /
installer: The install was successful.
ec2-user@ip-172-31-47-73 macos % sudo /Library/Ossec/bin/wazuh-control start
Starting Wazuh v4.10.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
ec2-user@ip-172-31-47-73 macos % sudo head -n 20 /Library/Ossec/etc/ossec.conf                   
<!--
  Wazuh - Agent - Default configuration for darwin 21.6
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <client>
    <server>
      <address>10.0.0.2</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
    <config-profile>darwin, darwin21, darwin21.6</config-profile>
    <notify_time>10</notify_time>
    <time-reconnect>60</time-reconnect>
    <auto_restart>yes</auto_restart>
    <crypto_method>aes</crypto_method>
  </client>
....
sh-3.2# ./bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...

```
</details>

<details>
<summary> Local upgrade test</summary>

To test the functionality, I installed ```wazuh-agent-4.8.0-1.intel64.pkg``` and then upgraded to ```wazuh-agent_4.10.0-1_intel64_acbe362e7a.pkg```

```bash
ec2-user@ip-172-31-47-73 macos % echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg wazuh-agent-4.8.0-1.intel64.pkg -target /
installer: Package name is Wazuh Agent
installer: Installing at base path /
installer: The install was successful.
ec2-user@ip-172-31-47-73 macos % sudo /Library/Ossec/bin/wazuh-control start                                                                                
Starting Wazuh v4.8.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
ec2-user@ip-172-31-47-73 macos % sudo /Library/Ossec/bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
ec2-user@ip-172-31-47-73 macos % echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg output/wazuh-agent_4.10.0-1_intel64_acbe362e7a.pkg -target / -verbose
installer: Package name is Wazuh Agent
installer: Upgrading at base path /
installer: The upgrade was successful.
ec2-user@ip-172-31-47-73 macos % sudo /Library/Ossec/bin/wazuh-control status                                                                                                  
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```
</details>
