### PR TITLE
Fix path used by homebrew for macOS Sonoma UTs

### DIFF
--- a/.github/workflows/macos-build-tests.yml
+++ b/.github/workflows/macos-build-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - ".github/workflows/macos-build-tests.yml"
 
 jobs:
   build-ventura:

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - ".github/workflows/macos-unit-tests.yml"
 
 jobs:
   build-ventura:
@@ -39,7 +40,7 @@ jobs:
       - name: Build wazuh agent for macOS 14 with tests flags
         run: |
           make deps -C src TARGET=agent -j3
-          LIBRARY_PATH=/usr/local/lib make -C src TARGET=agent -j3 DEBUG=1 TEST=1
+          C_INCLUDE_PATH=$C_INCLUDE_PATH:/opt/homebrew/include LIBRARY_PATH=/opt/homebrew/lib make -C src TARGET=agent -j3 DEBUG=1 TEST=1
       - name: Run wazuh unit tests for macOS 14
         run: |
           cd src/data_provider/build


### PR DESCRIPTION
|Related issue|
|---|
|#24517|

## Description

The _Homebrew_ path for **_macOS Sonoma_** has been modified, so it has been necessary to adapt the compiler paths to find the `cmocka` package installed via `brew`.
- macOS Ventura: `/usr/local/`
- macOS Sonoma: `/opt/homebrew/`

Base branch changed to `4.9.0`, as `4.8.1` does not have the necessary dependencies to compile macOS ARM.
- Issue related: https://github.com/wazuh/wazuh/issues/23148
  - PR: https://github.com/wazuh/wazuh/pull/23927 

## Logs/Alerts example

```
2: [----------] Global test environment tear-down
2: [==========] 16 tests from 1 test suite ran. (31 ms total)
2: [  PASSED  ] 16 tests.
2/2 Test #2: sys_normalizer_unit_test .........   Passed    0.05 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  46.25 sec
```

## Tests

- https://github.com/wazuh/wazuh/actions/runs/9859053975/job/27221845643?pr=24519
- https://github.com/wazuh/wazuh/actions/runs/9859053953/job/27221844887?pr=24519