### PR TITLE
Fix initialization warning in syscollector

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1020,7 +1020,6 @@ void Syscollector::updateChanges(const std::string& table,
 Syscollector::Syscollector()
     : m_intervalValue { 0 }
     , m_currentIntervalValue { 0 }
-    , m_lastSyncMsg { 0 }
     , m_scanOnStart { false }
     , m_hardware { false }
     , m_os { false }
@@ -1032,6 +1031,7 @@ Syscollector::Syscollector()
     , m_hotfixes { false }
     , m_stopping { true }
     , m_notify { false }
+    , m_lastSyncMsg { 0 }
 {}
 
 std::string Syscollector::getCreateStatement() const


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24508|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

this PR solves a warning when compiling Syscollector regarding variables order. Now the warning does not appear.