### PR TITLE
Revert changes made in agent_upgrade.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 
-- Fixed bug in `upgrade_agent` CLI where it would sometimes hang without showing a response. ([#24308](https://github.com/wazuh/wazuh/pull/24308))
 - Fixed bug in `upgrade_agent` CLI where it would sometimes raise an unhandled exception. ([#24341](https://github.com/wazuh/wazuh/pull/24341))
 
 ### Agent

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -188,13 +188,6 @@ async def check_status(affected_agents: list, result_dict: dict, failed_agents: 
                     else task_result['status']
                 result_dict.pop(task_result['agent'])
                 affected_agents.discard(task_result['agent'])
-            
-        for failed_ids in task_results.failed_items.values():
-            for id in affected_agents.copy():
-                if id in failed_ids:
-                    failed_agents[id] = 'Agent disconnected during the upgrade'
-                    result_dict.pop(id)
-                    affected_agents.discard(id)
         sleep(3)
 
     not silent and print_result(agents_versions=result_dict, failed_agents=failed_agents)

--- a/framework/scripts/tests/test_agent_upgrade.py
+++ b/framework/scripts/tests/test_agent_upgrade.py
@@ -174,30 +174,6 @@ async def test_check_status(mock_sleep, mock_print_result, silent):
             mock_print_result.assert_not_called()
 
 @pytest.mark.asyncio
-@patch('scripts.agent_upgrade.print_result')
-@patch('scripts.agent_upgrade.sleep')
-async def test_check_status_failed_items(mock_sleep, mock_print_result):
-    """Check if methods inside check_status work as expected when the agents response contains failed items"""
-
-    task_results = MagicMock()
-    task_results.failed_items = {}
-    task_results.failed_items[Exception()] = {'001', '002'}
-    agent_upgrade.args = MagicMock()
-    agent_upgrade.args.version = '4.2.0'
-    result_dict = {'001': {'new_version': '4.4.0'}, '002': {'new_version': '4.3.0'}}
-    with patch('scripts.agent_upgrade.cluster_utils.forward_function', return_value=task_results) as mock_forward_func:
-        await agent_upgrade.check_status(affected_agents=['001', '002'], result_dict=result_dict, failed_agents={}, 
-                                         silent=False)
-
-        mock_forward_func.assert_called_once_with(agent_upgrade.get_upgrade_result, f_kwargs={'agent_list': ANY})
-        
-        mock_print_result.assert_called_once_with(agents_versions={}, failed_agents={
-            '001': 'Agent disconnected during the upgrade',
-            '002': 'Agent disconnected during the upgrade'
-            }
-        )
-
-@pytest.mark.asyncio
 @patch('scripts.agent_upgrade.signal')
 @patch('scripts.agent_upgrade.exit')
 @patch('scripts.agent_upgrade.list_outdated')


### PR DESCRIPTION
|Related issue|
|---|
| #24501  |

The changes added in https://github.com/wazuh/wazuh/issues/20901 that were introduced for `4.8.1` were reverted

## Unit_test 

<details>

```console

PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/scripts/tests/test_agent_upgrade.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.4.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.3.0, aiohttp-1.0.4, trio-0.8.0, html-2.1.1, metadata-3.1.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 16 items                                                                                                                                                                                                

framework/scripts/tests/test_agent_upgrade.py ................                                                                                                                                              [100%]
```
</details>

## Testing after reverting the code

### Agent before updating

<details>

```console
root@c45c6df79e3f:/# /var/ossec/bin/wazuh-control start
Starting Wazuh v4.8.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
root@c45c6df79e3f:/# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.8.0"
WAZUH_REVISION="40812"
WAZUH_TYPE="agent"
```
</details>


### Manager

<details>

```console
root@wazuh-master:/# /var/ossec/bin/agent_control -i 002

Wazuh agent_control. Agent information:
   Agent ID:   002
   Agent Name: c45c6df79e3f
   IP address: any
   Status:     Active

   Operating system:    Linux |c45c6df79e3f |6.5.0-35-generic |#35~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue May  7 09:00:52 UTC 2 |x86_64
   Client version:      Wazuh v4.8.0
   Configuration hash:  ab73af41699f13fdd81903b5f23d8d00
   Shared file hash:    4a8724b20dee0124ff9656783c490c4e
   Last keep alive:     1720601748

   Syscheck last started at:  Wed Jul 10 08:52:49 2024
   Syscheck last ended at:    Wed Jul 10 08:52:49 2024
   
   
root@wazuh-master:/home# /var/ossec/bin/agent_upgrade -a 002 -f /home/wazuh_agent_v4.8.1_linux_x86_64.wpk

Upgrading...

Upgraded agents:
	Agent 002 upgraded: Wazuh v4.8.0 -> Wazuh v4.8.1
```
</details>

### Agent after the update

<details>

```console
root@c45c6df79e3f:/# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.8.1"
WAZUH_REVISION="40815"
WAZUH_TYPE="agent"
```
</details>

### GET /agents/upgrade_result

<details>

```console
{
    "data": {
        "affected_items": [
            {
                "message": "Success",
                "agent": "002",
                "task_id": 2,
                "node": "master-node",
                "module": "upgrade_module",
                "command": "upgrade_custom",
                "status": "Updated",
                "create_time": "2024-07-10T08:57:51Z",
                "update_time": "2024-07-10T09:00:20Z"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All upgrade tasks were returned",
    "error": 0
}

```
</details>













