### PR TITLE
Redirect cat errors correctly in wazuh-control

### DIFF
--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -63,7 +63,7 @@ lock()
         # Waiting 1 second before trying again
         sleep 1;
         i=`expr $i + 1`;
-        pid=`cat ${LOCK_PID}` 2>/dev/null
+        pid=$(cat ${LOCK_PID} 2>/dev/null)
 
         if [ $? = 0 ]
         then

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -70,7 +70,7 @@ lock() {
         # Waiting 1 second before trying again
         sleep 1;
         i=`expr $i + 1`;
-        pid=`cat ${LOCK_PID}` 2>/dev/null
+        pid=$(cat ${LOCK_PID} 2>/dev/null)
 
         if [ $? = 0 ]
         then

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -79,7 +79,7 @@ lock()
         # Waiting 1 second before trying again
         sleep 1;
         i=`expr $i + 1`;
-        pid=`cat ${LOCK_PID}` 2>/dev/null
+        pid=$(cat ${LOCK_PID} 2>/dev/null)
 
         if [ $? = 0 ]
         then


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/21899|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

this PR fixes the cat error output redirection to avoid showing the message when the file is not created. 

The line `pid='cat ${LOCK_PID}' 2>/dev/null` does not correctly suppress the errors because the redirect `2>/dev/null`only applies to the external part of the command (the pid assignment), not to the cat command.