### PR TITLE
Revert syscheck and syscollector endpoints deprecation

### DIFF
--- a/api/api/controllers/experimental_controller.py
+++ b/api/api/controllers/experimental_controller.py
@@ -14,7 +14,7 @@ import wazuh.syscheck as syscheck
 import wazuh.syscollector as syscollector
 from api import configuration
 from api.controllers.util import json_response
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deprecate_endpoint
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.exception import WazuhResourceNotFound
 
@@ -73,7 +73,6 @@ async def clear_rootcheck_database(pretty: bool = False, wait_for_complete: bool
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def clear_syscheck_database(pretty: bool = False, wait_for_complete: bool = False,
                                   agents_list: list = None) -> ConnexionResponse:
@@ -192,7 +191,6 @@ async def get_cis_cat_results(pretty: bool = False, wait_for_complete: bool = Fa
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_hardware_info(pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                             offset: int = 0, limit: int = None, select: str = None, sort: str = None,
@@ -257,7 +255,6 @@ async def get_hardware_info(pretty: bool = False, wait_for_complete: bool = Fals
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_network_address_info(pretty: bool = False, wait_for_complete: bool = False,
                                    agents_list: str = '*', offset: int = 0, limit: str = None, select: str = None,
@@ -330,7 +327,6 @@ async def get_network_address_info(pretty: bool = False, wait_for_complete: bool
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_network_interface_info(pretty: bool = False, wait_for_complete: bool = False,
                                      agents_list: str = '*', offset: int = 0, limit: int = None, select: str = None,
@@ -404,7 +400,6 @@ async def get_network_interface_info(pretty: bool = False, wait_for_complete: bo
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_network_protocol_info(pretty: bool = False, wait_for_complete: bool = False,
                                     agents_list: str = '*', offset: int = 0, limit: int = None, select: str = None,
@@ -472,7 +467,6 @@ async def get_network_protocol_info(pretty: bool = False, wait_for_complete: boo
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_os_info(pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                       offset: int = 0, limit: int = None, select: str = None, sort: str = None, search: str = None,
@@ -545,7 +539,6 @@ async def get_os_info(pretty: bool = False, wait_for_complete: bool = False, age
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_packages_info(pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                             offset: int = 0, limit: int = None, select: str = None, sort: str = None,
@@ -616,7 +609,6 @@ async def get_packages_info(pretty: bool = False, wait_for_complete: bool = Fals
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_ports_info(pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                          offset: int = 0, limit: int = None, select: str = None, sort: str = None, search: str = None,
@@ -695,7 +687,6 @@ async def get_ports_info(pretty: bool = False, wait_for_complete: bool = False, 
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_processes_info(pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                              offset: int = 0, limit: int = None, select: str = None, sort: str = None,
@@ -797,7 +788,6 @@ async def get_processes_info(pretty: bool = False, wait_for_complete: bool = Fal
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 @check_experimental_feature_value
 async def get_hotfixes_info(pretty: bool = False, wait_for_complete: bool = False, agents_list: str = '*',
                             offset: int = 0, limit: int = None, sort: str = None, search: str = None,

--- a/api/api/controllers/syscheck_controller.py
+++ b/api/api/controllers/syscheck_controller.py
@@ -8,7 +8,7 @@ from connexion import request
 from connexion.lifecycle import ConnexionResponse
 
 from api.controllers.util import json_response
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deprecate_endpoint
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.syscheck import run, clear, files, last_scan
 
@@ -49,7 +49,6 @@ async def put_syscheck(agents_list: str = '*', pretty: bool = False,
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_syscheck_agent(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                              offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                              search: str = None, distinct: bool = False, summary: bool = False, md5: str = None,
@@ -123,7 +122,6 @@ async def get_syscheck_agent(agent_id: str, pretty: bool = False, wait_for_compl
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def delete_syscheck_agent(agent_id: str = '*', pretty: bool = False,
                                 wait_for_complete: bool = False) -> ConnexionResponse:
     """Clear file integrity monitoring scan results for a specified agent.

--- a/api/api/controllers/syscollector_controller.py
+++ b/api/api/controllers/syscollector_controller.py
@@ -9,13 +9,12 @@ from connexion.lifecycle import ConnexionResponse
 
 import wazuh.syscollector as syscollector
 from api.controllers.util import json_response
-from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc, deprecate_endpoint
+from api.util import remove_nones_to_dict, parse_api_param, raise_if_exc
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 
 logger = logging.getLogger('wazuh-api')
 
 
-@deprecate_endpoint()
 async def get_hardware_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                             select: str = None) -> ConnexionResponse:
     """Get hardware info of an agent.
@@ -52,7 +51,6 @@ async def get_hardware_info(agent_id: str, pretty: bool = False, wait_for_comple
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_hotfix_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                           offset: int = 0, limit: int = None, sort: str = None, search: str = None, select: str = None,
                           hotfix: str = None, q: str = None, distinct: bool = False) -> ConnexionResponse:
@@ -116,7 +114,6 @@ async def get_hotfix_info(agent_id: str, pretty: bool = False, wait_for_complete
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_network_address_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                    offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                    search: str = None, iface: str = None, proto: str = None, address: str = None,
@@ -193,7 +190,6 @@ async def get_network_address_info(agent_id: str, pretty: bool = False, wait_for
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_network_interface_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                      offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                      search: str = None, name: str = None, adapter: str = None, state: str = None,
@@ -271,7 +267,6 @@ async def get_network_interface_info(agent_id: str, pretty: bool = False, wait_f
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_network_protocol_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                                     offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                                     search: str = None, iface: str = None, gateway: str = None, dhcp: str = None,
@@ -342,7 +337,6 @@ async def get_network_protocol_info(agent_id: str, pretty: bool = False, wait_fo
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_os_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                       select: str = None) -> ConnexionResponse:
     """Get OS info of an agent.
@@ -380,7 +374,6 @@ async def get_os_info(agent_id: str, pretty: bool = False, wait_for_complete: bo
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_packages_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                             offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                             search: str = None, vendor: str = None, name: str = None, architecture: str = None,
@@ -454,7 +447,6 @@ async def get_packages_info(agent_id: str, pretty: bool = False, wait_for_comple
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_ports_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                          limit: int = None, select: str = None, sort: str = None, search: str = None, pid: str = None,
                          protocol: str = None, tx_queue: str = None, state: str = None, process: str = None,
@@ -534,7 +526,6 @@ async def get_ports_info(agent_id: str, pretty: bool = False, wait_for_complete:
     return json_response(data, pretty=pretty)
 
 
-@deprecate_endpoint()
 async def get_processes_info(agent_id: str, pretty: bool = False, wait_for_complete: bool = False,
                              offset: int = 0, limit: int = None, select: str = None, sort: str = None,
                              search: str = None, pid: str = None, state: str = None, ppid: str = None,

--- a/api/api/signals.py
+++ b/api/api/signals.py
@@ -92,6 +92,7 @@ async def lifespan_handler(_: ConnexionMiddleware):
         tasks.append(asyncio.create_task(check_installation_uid()))
         if update_check_is_enabled():
             tasks.append(asyncio.create_task(get_update_information()))
+
     # Log the initial server startup message.
     logger.info(f'Listening on {configuration.api_conf["host"]}:{configuration.api_conf["port"]}.')
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -14548,7 +14548,6 @@ paths:
     get:
       tags:
         - Syscheck
-      deprecated: true
       summary: "Get results"
       description: "Return FIM findings in the specified agent"
       operationId: api.controllers.syscheck_controller.get_syscheck_agent
@@ -14641,7 +14640,6 @@ paths:
     delete:
       tags:
         - Syscheck
-      deprecated: true
       summary: "Clear results"
       description: "Clear file integrity monitoring scan results for a specified agent. Only available for agents < 3.12.0, it doesn't apply for more recent ones"
       operationId: api.controllers.syscheck_controller.delete_syscheck_agent
@@ -15235,7 +15233,6 @@ paths:
     delete:
       tags:
         - Experimental
-      deprecated: true
       summary: "Clear agents FIM results"
       description: "Clear the syscheck database for all agents or a list of them"
       operationId: api.controllers.experimental_controller.clear_syscheck_database
@@ -15386,7 +15383,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents hardware"
       description: "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info
       among others of all agents"
@@ -15482,7 +15478,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents netaddr"
       description: "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network
       interfaces. This information include used IP protocol, interface, and IP address among others"
@@ -15561,7 +15556,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents netiface"
       description: "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx
       info and some network information among other"
@@ -15682,7 +15676,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents netproto"
       description: "Return all agents (or a list of them) routing configuration for each network interface. This
       information includes interface, type protocol information among other"
@@ -15758,7 +15751,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents OS"
       description: "Return all agents (or a list of them) OS info. This information includes os information,
       architecture information among other"
@@ -15862,7 +15854,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents packages"
       description: "Return all agents (or a list of them) packages info. This information includes name, section, size,
       and priority information of all packages among other"
@@ -15963,7 +15954,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents ports"
       description: "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP,
       protocol information among other"
@@ -16067,7 +16057,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents processes"
       description: "Return all agents (or a list of them) processes info"
       operationId: api.controllers.experimental_controller.get_processes_info
@@ -16195,7 +16184,6 @@ paths:
     get:
       tags:
         - Experimental
-      deprecated: true
       summary: "Get agents hotfixes"
       description: "Return all agents (or a list of them) hotfixes info"
       operationId: api.controllers.experimental_controller.get_hotfixes_info
@@ -16254,7 +16242,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent hardware"
       description: "Return the agent's hardware info. This information include cpu, ram, scan info among others"
       operationId: api.controllers.syscollector_controller.get_hardware_info
@@ -16313,7 +16300,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent hotfixes"
       description: "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)"
       operationId: api.controllers.syscollector_controller.get_hotfix_info
@@ -16370,7 +16356,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent netaddr"
       description: "Return the agent's network address info. This information include used IP protocol, interface, IP
       address  among others"
@@ -16436,7 +16421,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent netiface"
       description: "Return the agent's network interface info. This information include rx, scan, tx info and some
       network information among others"
@@ -16521,7 +16505,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent netproto"
       description: "Return the agent's routing configuration for each network interface"
       operationId: api.controllers.syscollector_controller.get_network_protocol_info
@@ -16584,7 +16567,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent OS"
       description: "Return the agent's OS info. This information include os information, architecture information among
       others of all agents"
@@ -16647,7 +16629,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent packages"
       description: "Return the agent's packages info. This information include name, section, size, priority
       information of all packages among others"
@@ -16755,7 +16736,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent ports"
       description: "Return the agent's ports info. This information include local IP, Remote IP, protocol information
       among others"
@@ -16865,7 +16845,6 @@ paths:
     get:
       tags:
         - Syscollector
-      deprecated: true
       summary: "Get agent processes"
       description: "Return the agent's processes info"
       operationId: api.controllers.syscollector_controller.get_processes_info


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/24522 |

## Description

Reverts the syscheck and syscollector endpoints deprecation.

> API unit tests fail because of https://github.com/wazuh/wazuh/issues/24506. The others are not related to the changes introduced in this PR.