### PR TITLE
Improve Vulnerability Scanner logging

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/001/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/001/expected_002.out
@@ -1,7 +1,7 @@
 [
-    "Match found, the package 'systemd', is vulnerable to 'CVE-2013-4392'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u4'). - Agent '' (ID: '001', Version: '').",
-    "Match found, the package 'systemd', is vulnerable to 'CVE-2020-13529'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u4'). - Agent '' (ID: '001', Version: '').",
-    "Match found, the package 'systemd', is vulnerable to 'CVE-2023-31437'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u4'). - Agent '' (ID: '001', Version: '').",
-    "Match found, the package 'systemd', is vulnerable to 'CVE-2023-31438'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u4'). - Agent '' (ID: '001', Version: '').",
-    "Match found, the package 'systemd', is vulnerable to 'CVE-2023-31439'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u4'). - Agent '' (ID: '001', Version: '')."
+    "Match found, the package 'systemd', is vulnerable to 'CVE-2013-4392'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u5'). - Agent '' (ID: '001', Version: '').",
+    "Match found, the package 'systemd', is vulnerable to 'CVE-2020-13529'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u5'). - Agent '' (ID: '001', Version: '').",
+    "Match found, the package 'systemd', is vulnerable to 'CVE-2023-31437'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u5'). - Agent '' (ID: '001', Version: '').",
+    "Match found, the package 'systemd', is vulnerable to 'CVE-2023-31438'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u5'). - Agent '' (ID: '001', Version: '').",
+    "Match found, the package 'systemd', is vulnerable to 'CVE-2023-31439'. Current version: '247.3-7+deb11u4' (less than '' or equal to '247.3-7+deb11u5'). - Agent '' (ID: '001', Version: '')."
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/009/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/009/expected_002.out
@@ -11,14 +11,8 @@
   "Match found, the package 'firefox' is vulnerable to 'CVE-2009-2469' due to default status. - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox' is vulnerable to 'CVE-2009-4102' due to default status. - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox' is vulnerable to 'CVE-2009-4129' due to default status. - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2009-4130' due to default status. - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2009-4630' due to default status. - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2011-0064' due to default status. - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2012-4929' due to default status. - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2012-4930' due to default status. - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox' is vulnerable to 'CVE-2014-6492' due to default status. - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox' is vulnerable to 'CVE-2016-7152' due to default status. - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2016-7153' due to default status. - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2023-4573'. Current version: '116.0.2-1' (less than '117.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2023-4574'. Current version: '116.0.2-1' (less than '117.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2023-4575'. Current version: '116.0.2-1' (less than '117.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
@@ -88,5 +82,11 @@
   "Match found, the package 'firefox', is vulnerable to 'CVE-2024-0752'. Current version: '116.0.2-1' (less than '122.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2024-0753'. Current version: '116.0.2-1' (less than '122.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2024-0754'. Current version: '116.0.2-1' (less than '122.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox', is vulnerable to 'CVE-2024-0755'. Current version: '116.0.2-1' (less than '122.0' or equal to ''). - Agent '' (ID: '009', Version: '')."
+  "Match found, the package 'firefox', is vulnerable to 'CVE-2024-0755'. Current version: '116.0.2-1' (less than '122.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2009-4130",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2009-4630",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2011-0064",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2012-4929",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2012-4930",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2016-7153"
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/019/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/019/expected_002.out
@@ -1,10 +1,9 @@
 [
     "Match found, the package 'python-unversioned-command' is vulnerable to 'CVE-2021-23336' due to default status. - Agent '' (ID: '018', Version: '').",
-    "Match found, the package 'python-unversioned-command' is vulnerable to 'CVE-2022-0391' due to default status. - Agent '' (ID: '018', Version: '').",
     "Match found, the package 'python-unversioned-command', is vulnerable to 'CVE-2023-27043'. Current version: '3.9.18-1.el9_3' (less than '0:3.9.18-1.el9_3.1' or equal to ''). - Agent '' (ID: '018', Version: '').",
     "Match found, the package 'python-unversioned-command' is vulnerable to 'CVE-2023-36632' due to default status. - Agent '' (ID: '018', Version: '').",
     "Processing and publish key: CVE-2023-36632",
     "Processing and publish key: CVE-2023-27043",
-    "Processing and publish key: CVE-2022-0391",
-    "Processing and publish key: CVE-2021-23336"
+    "Processing and publish key: CVE-2021-23336",
+    "No match due to default status for Package: python-unversioned-command, Version: 3.9.18-1.el9_3 while scanning for Vulnerability: CVE-2022-0391"
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/019/expected_003.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/019/expected_003.out
@@ -1,11 +1,10 @@
 [
     "Match found, the package 'python3' is vulnerable to 'CVE-2021-23336' due to default status. - Agent '' (ID: '018', Version: '').",
-    "Match found, the package 'python3' is vulnerable to 'CVE-2022-0391' due to default status. - Agent '' (ID: '018', Version: '').",
     "Match found, the package 'python3', is vulnerable to 'CVE-2023-27043'. Current version: '3.9.18-1.el9_3' (less than '0:3.9.18-1.el9_3.1' or equal to ''). - Agent '' (ID: '018', Version: '').",
     "Match found, the package 'python3' is vulnerable to 'CVE-2023-36632' due to default status. - Agent '' (ID: '018', Version: '').",
     "Processing and publish key: CVE-2023-36632",
     "Processing and publish key: CVE-2023-27043",
-    "Processing and publish key: CVE-2022-0391",
-    "Processing and publish key: CVE-2021-23336"
-    ]
+    "Processing and publish key: CVE-2021-23336",
+    "No match due to default status for Package: python3, Version: 3.9.18-1.el9_3 while scanning for Vulnerability: CVE-2022-0391"
+]
 

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/019/expected_004.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/019/expected_004.out
@@ -1,10 +1,9 @@
 [
     "Match found, the package 'python3-libs' is vulnerable to 'CVE-2021-23336' due to default status. - Agent '' (ID: '018', Version: '').",
-    "Match found, the package 'python3-libs' is vulnerable to 'CVE-2022-0391' due to default status. - Agent '' (ID: '018', Version: '').",
     "Match found, the package 'python3-libs', is vulnerable to 'CVE-2023-27043'. Current version: '3.9.18-1.el9_3' (less than '0:3.9.18-1.el9_3.1' or equal to ''). - Agent '' (ID: '018', Version: '').",
     "Match found, the package 'python3-libs' is vulnerable to 'CVE-2023-36632' due to default status. - Agent '' (ID: '018', Version: '').",
     "Processing and publish key: CVE-2023-36632",
     "Processing and publish key: CVE-2023-27043",
-    "Processing and publish key: CVE-2022-0391",
-    "Processing and publish key: CVE-2021-23336"
+    "Processing and publish key: CVE-2021-23336",
+    "No match due to default status for Package: python3-libs, Version: 3.9.18-1.el9_3 while scanning for Vulnerability: CVE-2022-0391"
 ]

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -147,6 +147,16 @@ void VulnerabilityScannerFacade::initEventDispatcher()
         // coverity[copy_constructor_call]
         [scanOrchestrator](std::queue<rocksdb::PinnableSlice>& dataQueue)
         {
+            const auto parseEventMessage = [](const rocksdb::PinnableSlice& element) -> std::string
+            {
+                if (const auto eventMessageBuffer = GetMessageBuffer(element.data()); eventMessageBuffer)
+                {
+                    return std::string(eventMessageBuffer->data()->begin(), eventMessageBuffer->data()->end());
+                }
+
+                return "unable to parse";
+            };
+
             const auto& element = dataQueue.front();
             try
             {
@@ -169,9 +179,18 @@ void VulnerabilityScannerFacade::initEventDispatcher()
                     scanOrchestrator->pushReScanToDelayedDispatcher(agentData.id, e.noIndex());
                 }
             }
+            catch (const nlohmann::json::exception& e)
+            {
+                logError(WM_VULNSCAN_LOGTAG,
+                         "VulnerabilityScannerFacade::initEventDispatcher: json exception (%d) - Event message: %s",
+                         e.id,
+                         parseEventMessage(element).c_str());
+            }
             catch (const std::exception& e)
             {
-                logError(WM_VULNSCAN_LOGTAG, "VulnerabilityScannerFacade::initEventDispatcher: %s", e.what());
+                logError(WM_VULNSCAN_LOGTAG,
+                         "VulnerabilityScannerFacade::initEventDispatcher: General exception - Event message: %s",
+                         parseEventMessage(element).c_str());
             }
         });
 }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -189,7 +189,8 @@ void VulnerabilityScannerFacade::initEventDispatcher()
             catch (const std::exception& e)
             {
                 logError(WM_VULNSCAN_LOGTAG,
-                         "VulnerabilityScannerFacade::initEventDispatcher: General exception - Event message: %s",
+                         "VulnerabilityScannerFacade::initEventDispatcher: %s - Event message: %s",
+                         e.what(),
                          parseEventMessage(element).c_str());
             }
         });


### PR DESCRIPTION
|Related issue|
|---|
| #24533 |

## Description
This PR improves the logging message for the `vulnerabilityScannerFacade` class. It treats the nlohmann json exceptions differently, as they were difficult to validate when appeared

## Tests
Using the router testtool I've sent messages and test the result:

- JSON parse error (id 101)
  - Invalid character at the end
```bash
2024/07/10 19:41:21 wazuh-modulesd:vulnerability-scanner[348440] vulnerabilityScannerFacade.cpp:184 at operator()(): ERROR: VulnerabilityScannerFacade::initEventDispatcher: JSON exception (101) - Event message: {"agent_info":{"agent_id":"001","node_name":""},"action":"deletePackage","data":{"name":"name","version":"version","architecture":"architecture","format":"format","location":"location","item_id":"item_id"}}☺
```

- JSON out of range (id 403)
  - Missing action field
```bash
2024/07/10 19:41:57 wazuh-modulesd:vulnerability-scanner[348440] vulnerabilityScannerFacade.cpp:184 at operator()(): ERROR: VulnerabilityScannerFacade::initEventDispatcher: JSON exception (403) - Event message: {"agent_info":{"agent_id":"001","node_name":""},"data":{"name":"name","version":"version","architecture":"architecture","format":"format","location":"location","item_id":"item_id"}}
```

- General exception
  - Unknow event type
```bash
2024/07/10 21:57:01 wazuh-modulesd:vulnerability-scanner: ERROR: VulnerabilityScannerFacade::initEventDispatcher: Unable to build scan context. Unknown action - Event message: {"action":"invalid"}
```

- General exception
  - Non expected json format
```bash
2024/07/10 21:58:57 wazuh-modulesd:vulnerability-scanner: ERROR: VulnerabilityScannerFacade::initEventDispatcher: Unable to build scan context. Unknown JSON format - Event message: [{}]
```

- General exception
  - Invalid flatbuffer
```bash
2024/07/10 21:59:44 wazuh-modulesd:vulnerability-scanner: ERROR: VulnerabilityScannerFacade::initEventDispatcher: Operation not found in delta. - Event message: ...
```