### PR TITLE
Engine Policy API now allows to save invalid policies

### DIFF
--- a/src/engine/source/api/include/api/policy/handlers.hpp
+++ b/src/engine/source/api/include/api/policy/handlers.hpp
@@ -15,6 +15,7 @@ api::HandlerSync storeGet(const std::shared_ptr<policy::IPolicy>& policyManager)
 api::HandlerSync policyAssetPost(const std::shared_ptr<policy::IPolicy>& policyManager);
 api::HandlerSync policyAssetDelete(const std::shared_ptr<policy::IPolicy>& policyManager);
 api::HandlerSync policyAssetGet(const std::shared_ptr<policy::IPolicy>& policyManager);
+api::HandlerSync policyCleanDeleted(const std::shared_ptr<policy::IPolicy>& policyManager);
 
 /* Default parent policy handlers */
 api::HandlerSync policyDefaultParentGet(const std::shared_ptr<policy::IPolicy>& policyManager);

--- a/src/engine/source/api/include/api/policy/policy.hpp
+++ b/src/engine/source/api/include/api/policy/policy.hpp
@@ -30,9 +30,10 @@ private:
      * @brief Upsert a policy document to the store
      *
      * @param policy Policy representation
-     * @return base::OptError
+     * @param ignoreValidation Ignore validation errors
+     * @return base::RespOrError<std::string>
      */
-    base::OptError upsert(const PolicyRep& policy);
+    base::RespOrError<std::string> upsert(const PolicyRep& policy, bool ignoreValidation = false);
 
 public:
     Policy(std::shared_ptr<store::IStore> store, std::shared_ptr<builder::IValidator> validator)
@@ -77,13 +78,13 @@ public:
     /**
      * @copydoc IPolicy::addAsset
      */
-    base::OptError
+    base::RespOrError<std::string>
     addAsset(const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName) override;
 
     /**
      * @copydoc IPolicy::delAsset
      */
-    base::OptError
+    base::RespOrError<std::string>
     delAsset(const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName) override;
 
     /**
@@ -101,16 +102,16 @@ public:
     /**
      * @copydoc IPolicy::setDefaultParent
      */
-    base::OptError setDefaultParent(const base::Name& policyName,
-                                    const store::NamespaceId& namespaceId,
-                                    const base::Name& assetName) override;
+    base::RespOrError<std::string> setDefaultParent(const base::Name& policyName,
+                                                    const store::NamespaceId& namespaceId,
+                                                    const base::Name& parentName) override;
 
     /**
      * @copydoc IPolicy::delDefaultParent
      */
-    base::OptError delDefaultParent(const base::Name& policyName,
-                                    const store::NamespaceId& namespaceId,
-                                    const base::Name& assetName) override;
+    base::RespOrError<std::string> delDefaultParent(const base::Name& policyName,
+                                                    const store::NamespaceId& namespaceId,
+                                                    const base::Name& parentName) override;
 
     /**
      * @copydoc IPolicy::listNamespaces
@@ -126,6 +127,11 @@ public:
      * @copydoc IPolicy::copy
      */
     base::OptError copy(const base::Name& policyName, const base::Name& newPolicyName) override;
+
+    /**
+     * @copydoc IPolicy::cleanDeleted
+     */
+    base::RespOrError<std::string> cleanDeleted(const base::Name& policyName) override;
 };
 } // namespace api::policy
 

--- a/src/engine/source/api/interface/api/policy/ipolicy.hpp
+++ b/src/engine/source/api/interface/api/policy/ipolicy.hpp
@@ -52,9 +52,10 @@ public:
      * @param policyName Policy name
      * @param namespaceId Namespace of the asset
      * @param assetName Asset name
-     * @return base::OptError Error if cannot add the asset to the policy
+     * @return base::RespOrError<std::string> Error if cannot add the asset to the policy, warning message if validation
+     * errors on the policy, empty string if success
      */
-    virtual base::OptError
+    virtual base::RespOrError<std::string>
     addAsset(const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName) = 0;
 
     /**
@@ -63,9 +64,10 @@ public:
      * @param policyName Policy name to delete the asset from
      * @param namespaceId Namespace of the asset
      * @param assetName Asset name
-     * @return base::OptError Error if cannot remove the asset from the policy
+     * @return base::RespOrError<std::string> Error if cannot add the asset to the policy, warning message if validation
+     * errors on the policy, empty string if success
      */
-    virtual base::OptError
+    virtual base::RespOrError<std::string>
     delAsset(const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName) = 0;
 
     /**
@@ -94,22 +96,24 @@ public:
      * @param policyName Policy name to set the default parent to
      * @param namespaceId Namespace of the default parent
      * @param parentName Default parent name
-     * @return base::OptError Error if cannot set the default parent to the policy
+     * @return base::RespOrError<std::string> Error if cannot add the asset to the policy, warning message if validation
+     * errors on the policy, empty string if success
      */
-    virtual base::OptError setDefaultParent(const base::Name& policyName,
-                                            const store::NamespaceId& namespaceId,
-                                            const base::Name& parentName) = 0;
+    virtual base::RespOrError<std::string> setDefaultParent(const base::Name& policyName,
+                                                            const store::NamespaceId& namespaceId,
+                                                            const base::Name& parentName) = 0;
 
     /**
      * @brief Delete namespace default parent from a policy
      *
      * @param policyName Policy name to delete the default parent from
      * @param namespaceId Namespace of the default parent
-     * @return base::OptError Error if cannot delete the default parent from the policy
+     * @return base::RespOrError<std::string> Error if cannot add the asset to the policy, warning message if validation
+     * errors on the policy, empty string if success
      */
-    virtual base::OptError delDefaultParent(const base::Name& policyName,
-                                            const store::NamespaceId& namespaceId,
-                                            const base::Name& parentName) = 0;
+    virtual base::RespOrError<std::string> delDefaultParent(const base::Name& policyName,
+                                                            const store::NamespaceId& namespaceId,
+                                                            const base::Name& parentName) = 0;
 
     /**
      * @brief Get the list of namespaces from a policy
@@ -135,6 +139,14 @@ public:
      * @return base::OptError Error if cannot copy the policy
      */
     virtual base::OptError copy(const base::Name& policyName, const base::Name& newPolicyName) = 0;
+
+    /**
+     * @brief Delete all deleted assets from the policy, returning the deleted assets
+     *
+     * @param policyName Policy name to clean
+     * @return base::RespOrError<std::string> Deleted assets or an error
+     */
+    virtual base::RespOrError<std::string> cleanDeleted(const base::Name& policyName) = 0;
 };
 } // namespace api::policy
 

--- a/src/engine/source/api/test/mocks/api/policy/mockPolicy.hpp
+++ b/src/engine/source/api/test/mocks/api/policy/mockPolicy.hpp
@@ -17,11 +17,11 @@ public:
                 (const base::Name& policyName, const std::vector<store::NamespaceId>& namespaceIds),
                 (const, override));
     MOCK_METHOD(base::RespOrError<std::vector<base::Name>>, list, (), (const, override));
-    MOCK_METHOD(base::OptError,
+    MOCK_METHOD(base::RespOrError<std::string>,
                 addAsset,
                 (const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName),
                 (override));
-    MOCK_METHOD(base::OptError,
+    MOCK_METHOD(base::RespOrError<std::string>,
                 delAsset,
                 (const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName),
                 (override));
@@ -29,12 +29,25 @@ public:
                 listAssets,
                 (const base::Name& policyName, const store::NamespaceId& namespaceId),
                 (const, override));
-    MOCK_METHOD(base::RespOrError<std::list<base::Name>>, getDefaultParent, (const base::Name& policyName, const store::NamespaceId& namespaceId), (const, override));
-    MOCK_METHOD(base::OptError, setDefaultParent, (const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName), (override));
-    MOCK_METHOD(base::OptError, delDefaultParent, (const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName), (override));
-    MOCK_METHOD(base::RespOrError<std::list<store::NamespaceId>>, listNamespaces, (const base::Name& policyName), (const, override));
+    MOCK_METHOD(base::RespOrError<std::list<base::Name>>,
+                getDefaultParent,
+                (const base::Name& policyName, const store::NamespaceId& namespaceId),
+                (const, override));
+    MOCK_METHOD(base::RespOrError<std::string>,
+                setDefaultParent,
+                (const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName),
+                (override));
+    MOCK_METHOD(base::RespOrError<std::string>,
+                delDefaultParent,
+                (const base::Name& policyName, const store::NamespaceId& namespaceId, const base::Name& assetName),
+                (override));
+    MOCK_METHOD(base::RespOrError<std::list<store::NamespaceId>>,
+                listNamespaces,
+                (const base::Name& policyName),
+                (const, override));
     MOCK_METHOD(base::RespOrError<std::string>, getHash, (const base::Name& policyName), (const, override));
     MOCK_METHOD(base::OptError, copy, (const base::Name& policyName, const base::Name& newPolicyName), (override));
+    MOCK_METHOD(base::RespOrError<std::string>, cleanDeleted, (const base::Name& policyName), (override));
 };
 } // namespace api::policy::mocks
 

--- a/src/engine/source/api/test/src/unit/policy/handlers_test.cpp
+++ b/src/engine/source/api/test/src/unit/policy/handlers_test.cpp
@@ -3,8 +3,8 @@
  * @brief Unit tests for policy handlers.
  *
  * This file contains unit tests for the policy handlers, which are responsible for processing policy-related requests.
- * The tests cover various scenarios, including successful and failed requests, and different combinations of parameters.
- * The tests use a mock policy object to simulate policy data and behavior.
+ * The tests cover various scenarios, including successful and failed requests, and different combinations of
+ * parameters. The tests use a mock policy object to simulate policy data and behavior.
  *
  */
 #include <gtest/gtest.h>
@@ -16,19 +16,18 @@
 using namespace api::policy::mocks;
 using namespace api::policy::handlers;
 
-
 /***
  * @brief Represent the type signature of the all function to test
  *
  * The handlers is created with a function that return the handler to test.
-*/
+ */
 using GetHandlerToTest = std::function<api::HandlerSync(const std::shared_ptr<api::policy::IPolicy>&)>;
 
 /**
  * @brief Represent the type signature of the expected function
  *
  * The expected function return the response of the handler.
-*/
+ */
 using ExpectedFn = std::function<api::wpResponse(const std::shared_ptr<MockPolicy>&)>;
 
 /**
@@ -36,7 +35,7 @@ using ExpectedFn = std::function<api::wpResponse(const std::shared_ptr<MockPolic
  * @param getHandlerFn Function that return the handler to test.
  * @param params Parameters to pass to the handler.
  * @param expectedFn Function that return the expected response.
-*/
+ */
 using TestPolT = std::tuple<GetHandlerToTest, json::Json, ExpectedFn>;
 
 /**
@@ -51,7 +50,7 @@ using Behaviour = std::function<void(std::shared_ptr<MockPolicy>)>;
  * json::Json is the return type
  *
  * Its used for build a success or fail response
-*/
+ */
 using BehaviourWRet = std::function<json::Json(std::shared_ptr<MockPolicy>)>;
 
 const std::string STATUS_PATH = "/status";
@@ -235,7 +234,6 @@ struct JPayload
     operator std::string() const { return m_json.str(); }
 };
 
-
 class PolicyHandlerTest : public ::testing::TestWithParam<TestPolT>
 {
 protected:
@@ -402,14 +400,16 @@ INSTANTIATE_TEST_SUITE_P(
         // [policyAssetPost]: Ok
         TestPolT(policyAssetPost,
                  JParams(POLICY_NAME).namespace_(NAMESPACE_U).asset(ASSET_NAME_A),
-                 success(
+                 successWPayload(
                      [](auto policy)
                      {
                          EXPECT_CALL(*policy,
                                      addAsset(base::Name {POLICY_NAME},
                                               store::NamespaceId {NAMESPACE_U},
                                               base::Name {ASSET_NAME_A}))
-                             .WillOnce(::testing::Return(std::nullopt));
+                             .WillOnce(::testing::Return(std::string()));
+
+                         return JPayload().setString("", "/warning");
                      })),
         // [policyAssetDelete]: Fail
         TestPolT(policyAssetDelete, JParams(""), failure()),
@@ -443,14 +443,16 @@ INSTANTIATE_TEST_SUITE_P(
         // [policyAssetDelete]: Ok
         TestPolT(policyAssetDelete,
                  JParams(POLICY_NAME).namespace_(NAMESPACE_U).asset(ASSET_NAME_A),
-                 success(
+                 successWPayload(
                      [](auto policy)
                      {
                          EXPECT_CALL(*policy,
                                      delAsset(base::Name {POLICY_NAME},
                                               store::NamespaceId {NAMESPACE_U},
                                               base::Name {ASSET_NAME_A}))
-                             .WillOnce(::testing::Return(std::nullopt));
+                             .WillOnce(::testing::Return(std::string()));
+
+                         return JPayload().setString("", "/warning");
                      })),
         // [policyAssetGet]: Fail
         TestPolT(policyAssetGet, R"( { "name": "test" } )", failure()),
@@ -563,14 +565,16 @@ INSTANTIATE_TEST_SUITE_P(
         // [policyDefaultParentPost]: ok
         TestPolT(policyDefaultParentPost,
                  JParams(POLICY_NAME).namespace_(NAMESPACE_U).parent(ASSET_NAME_A),
-                 success(
+                 successWPayload(
                      [](auto policy)
                      {
                          EXPECT_CALL(*policy,
                                      setDefaultParent(base::Name {POLICY_NAME},
                                                       store::NamespaceId {NAMESPACE_U},
                                                       base::Name {ASSET_NAME_A}))
-                             .WillOnce(::testing::Return(std::nullopt));
+                             .WillOnce(::testing::Return(std::string()));
+
+                         return JPayload().setString("", "/warning");
                      })),
         // [policyDefaultParentDelete]: Fail
         TestPolT(policyDefaultParentDelete, R"( { "name": "test" } )", failure()),
@@ -589,19 +593,23 @@ INSTANTIATE_TEST_SUITE_P(
                  failure(
                      [](auto policy)
                      {
-                         EXPECT_CALL(*policy,
-                                     delDefaultParent(base::Name {POLICY_NAME}, store::NamespaceId {NAMESPACE_U}, testing::_))
+                         EXPECT_CALL(
+                             *policy,
+                             delDefaultParent(base::Name {POLICY_NAME}, store::NamespaceId {NAMESPACE_U}, testing::_))
                              .WillOnce(::testing::Return(base::Error {}));
                      })),
         // [policyDefaultParentDelete]: ok
         TestPolT(policyDefaultParentDelete,
                  JParams(POLICY_NAME).namespace_(NAMESPACE_U).parent(ASSET_NAME_B),
-                 success(
+                 successWPayload(
                      [](auto policy)
                      {
-                         EXPECT_CALL(*policy,
-                                     delDefaultParent(base::Name {POLICY_NAME}, store::NamespaceId {NAMESPACE_U}, testing::_))
-                             .WillOnce(::testing::Return(std::nullopt));
+                         EXPECT_CALL(
+                             *policy,
+                             delDefaultParent(base::Name {POLICY_NAME}, store::NamespaceId {NAMESPACE_U}, testing::_))
+                             .WillOnce(::testing::Return(std::string()));
+
+                         return JPayload().setString("", "/warning");
                      })),
         // [policiesGet]: Fail
         TestPolT(policiesGet,

--- a/src/engine/source/cmds/include/cmds/policy.hpp
+++ b/src/engine/source/cmds/include/cmds/policy.hpp
@@ -33,6 +33,7 @@ void runRemoveAsset(std::shared_ptr<apiclnt::Client> client,
 void runListAssets(std::shared_ptr<apiclnt::Client> client,
                    const std::string& policyName,
                    const std::string& namespaceId);
+void runCleanDeletedAssets(std::shared_ptr<apiclnt::Client> client, const std::string& policyName);
 
 void runGetDefaultParent(std::shared_ptr<apiclnt::Client> client,
                          const std::string& policyName,

--- a/src/engine/source/proto/include/eMessages/policy.pb.cc
+++ b/src/engine/source/proto/include/eMessages/policy.pb.cc
@@ -100,6 +100,22 @@ struct AssetPost_RequestDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetPost_RequestDefaultTypeInternal _AssetPost_Request_default_instance_;
+PROTOBUF_CONSTEXPR AssetPost_Response::AssetPost_Response(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.error_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.warning_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.status_)*/0} {}
+struct AssetPost_ResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR AssetPost_ResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~AssetPost_ResponseDefaultTypeInternal() {}
+  union {
+    AssetPost_Response _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetPost_ResponseDefaultTypeInternal _AssetPost_Response_default_instance_;
 PROTOBUF_CONSTEXPR AssetDelete_Request::AssetDelete_Request(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_._has_bits_)*/{}
@@ -116,6 +132,22 @@ struct AssetDelete_RequestDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetDelete_RequestDefaultTypeInternal _AssetDelete_Request_default_instance_;
+PROTOBUF_CONSTEXPR AssetDelete_Response::AssetDelete_Response(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.error_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.warning_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.status_)*/0} {}
+struct AssetDelete_ResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR AssetDelete_ResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~AssetDelete_ResponseDefaultTypeInternal() {}
+  union {
+    AssetDelete_Response _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetDelete_ResponseDefaultTypeInternal _AssetDelete_Response_default_instance_;
 PROTOBUF_CONSTEXPR AssetGet_Request::AssetGet_Request(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_._has_bits_)*/{}
@@ -147,6 +179,36 @@ struct AssetGet_ResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetGet_ResponseDefaultTypeInternal _AssetGet_Response_default_instance_;
+PROTOBUF_CONSTEXPR AssetCleanDeleted_Request::AssetCleanDeleted_Request(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.policy_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}} {}
+struct AssetCleanDeleted_RequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR AssetCleanDeleted_RequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~AssetCleanDeleted_RequestDefaultTypeInternal() {}
+  union {
+    AssetCleanDeleted_Request _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetCleanDeleted_RequestDefaultTypeInternal _AssetCleanDeleted_Request_default_instance_;
+PROTOBUF_CONSTEXPR AssetCleanDeleted_Response::AssetCleanDeleted_Response(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.error_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.data_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.status_)*/0} {}
+struct AssetCleanDeleted_ResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR AssetCleanDeleted_ResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~AssetCleanDeleted_ResponseDefaultTypeInternal() {}
+  union {
+    AssetCleanDeleted_Response _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetCleanDeleted_ResponseDefaultTypeInternal _AssetCleanDeleted_Response_default_instance_;
 PROTOBUF_CONSTEXPR DefaultParentGet_Request::DefaultParentGet_Request(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_._has_bits_)*/{}
@@ -194,6 +256,22 @@ struct DefaultParentPost_RequestDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DefaultParentPost_RequestDefaultTypeInternal _DefaultParentPost_Request_default_instance_;
+PROTOBUF_CONSTEXPR DefaultParentPost_Response::DefaultParentPost_Response(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.error_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.warning_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.status_)*/0} {}
+struct DefaultParentPost_ResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR DefaultParentPost_ResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~DefaultParentPost_ResponseDefaultTypeInternal() {}
+  union {
+    DefaultParentPost_Response _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DefaultParentPost_ResponseDefaultTypeInternal _DefaultParentPost_Response_default_instance_;
 PROTOBUF_CONSTEXPR DefaultParentDelete_Request::DefaultParentDelete_Request(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_._has_bits_)*/{}
@@ -210,6 +288,22 @@ struct DefaultParentDelete_RequestDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DefaultParentDelete_RequestDefaultTypeInternal _DefaultParentDelete_Request_default_instance_;
+PROTOBUF_CONSTEXPR DefaultParentDelete_Response::DefaultParentDelete_Response(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.error_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.warning_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.status_)*/0} {}
+struct DefaultParentDelete_ResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR DefaultParentDelete_ResponseDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~DefaultParentDelete_ResponseDefaultTypeInternal() {}
+  union {
+    DefaultParentDelete_Response _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DefaultParentDelete_ResponseDefaultTypeInternal _DefaultParentDelete_Response_default_instance_;
 PROTOBUF_CONSTEXPR PoliciesGet_Request::PoliciesGet_Request(
     ::_pbi::ConstantInitialized) {}
 struct PoliciesGet_RequestDefaultTypeInternal {
@@ -272,7 +366,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 }  // namespace api
 }  // namespace wazuh
 }  // namespace com
-static ::_pb::Metadata file_level_metadata_policy_2eproto[16];
+static ::_pb::Metadata file_level_metadata_policy_2eproto[22];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_policy_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_policy_2eproto = nullptr;
 
@@ -327,6 +421,18 @@ const uint32_t TableStruct_policy_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(p
   0,
   1,
   2,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetPost_Response, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetPost_Response, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetPost_Response, _impl_.status_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetPost_Response, _impl_.error_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetPost_Response, _impl_.warning_),
+  ~0u,
+  0,
+  1,
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetDelete_Request, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetDelete_Request, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -339,6 +445,18 @@ const uint32_t TableStruct_policy_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(p
   0,
   1,
   2,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetDelete_Response, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetDelete_Response, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetDelete_Response, _impl_.status_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetDelete_Response, _impl_.error_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetDelete_Response, _impl_.warning_),
+  ~0u,
+  0,
+  1,
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetGet_Request, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetGet_Request, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -361,6 +479,26 @@ const uint32_t TableStruct_policy_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(p
   ~0u,
   0,
   ~0u,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Request, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Request, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Request, _impl_.policy_),
+  0,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Response, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Response, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Response, _impl_.status_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Response, _impl_.error_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::AssetCleanDeleted_Response, _impl_.data_),
+  ~0u,
+  0,
+  1,
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentGet_Request, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentGet_Request, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -395,6 +533,18 @@ const uint32_t TableStruct_policy_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(p
   0,
   1,
   2,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentPost_Response, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentPost_Response, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentPost_Response, _impl_.status_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentPost_Response, _impl_.error_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentPost_Response, _impl_.warning_),
+  ~0u,
+  0,
+  1,
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentDelete_Request, _impl_._has_bits_),
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentDelete_Request, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -407,6 +557,18 @@ const uint32_t TableStruct_policy_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(p
   0,
   1,
   2,
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentDelete_Response, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentDelete_Response, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentDelete_Response, _impl_.status_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentDelete_Response, _impl_.error_),
+  PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::DefaultParentDelete_Response, _impl_.warning_),
+  ~0u,
+  0,
+  1,
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::com::wazuh::api::engine::policy::PoliciesGet_Request, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -452,17 +614,23 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 16, 24, -1, sizeof(::com::wazuh::api::engine::policy::StoreGet_Request)},
   { 26, 35, -1, sizeof(::com::wazuh::api::engine::policy::StoreGet_Response)},
   { 38, 47, -1, sizeof(::com::wazuh::api::engine::policy::AssetPost_Request)},
-  { 50, 59, -1, sizeof(::com::wazuh::api::engine::policy::AssetDelete_Request)},
-  { 62, 70, -1, sizeof(::com::wazuh::api::engine::policy::AssetGet_Request)},
-  { 72, 81, -1, sizeof(::com::wazuh::api::engine::policy::AssetGet_Response)},
-  { 84, 92, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentGet_Request)},
-  { 94, 103, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentGet_Response)},
-  { 106, 115, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentPost_Request)},
-  { 118, 127, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentDelete_Request)},
-  { 130, -1, -1, sizeof(::com::wazuh::api::engine::policy::PoliciesGet_Request)},
-  { 136, 145, -1, sizeof(::com::wazuh::api::engine::policy::PoliciesGet_Response)},
-  { 148, 155, -1, sizeof(::com::wazuh::api::engine::policy::NamespacesGet_Request)},
-  { 156, 165, -1, sizeof(::com::wazuh::api::engine::policy::NamespacesGet_Response)},
+  { 50, 59, -1, sizeof(::com::wazuh::api::engine::policy::AssetPost_Response)},
+  { 62, 71, -1, sizeof(::com::wazuh::api::engine::policy::AssetDelete_Request)},
+  { 74, 83, -1, sizeof(::com::wazuh::api::engine::policy::AssetDelete_Response)},
+  { 86, 94, -1, sizeof(::com::wazuh::api::engine::policy::AssetGet_Request)},
+  { 96, 105, -1, sizeof(::com::wazuh::api::engine::policy::AssetGet_Response)},
+  { 108, 115, -1, sizeof(::com::wazuh::api::engine::policy::AssetCleanDeleted_Request)},
+  { 116, 125, -1, sizeof(::com::wazuh::api::engine::policy::AssetCleanDeleted_Response)},
+  { 128, 136, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentGet_Request)},
+  { 138, 147, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentGet_Response)},
+  { 150, 159, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentPost_Request)},
+  { 162, 171, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentPost_Response)},
+  { 174, 183, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentDelete_Request)},
+  { 186, 195, -1, sizeof(::com::wazuh::api::engine::policy::DefaultParentDelete_Response)},
+  { 198, -1, -1, sizeof(::com::wazuh::api::engine::policy::PoliciesGet_Request)},
+  { 204, 213, -1, sizeof(::com::wazuh::api::engine::policy::PoliciesGet_Response)},
+  { 216, 223, -1, sizeof(::com::wazuh::api::engine::policy::NamespacesGet_Request)},
+  { 224, 233, -1, sizeof(::com::wazuh::api::engine::policy::NamespacesGet_Response)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -471,13 +639,19 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::com::wazuh::api::engine::policy::_StoreGet_Request_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_StoreGet_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_AssetPost_Request_default_instance_._instance,
+  &::com::wazuh::api::engine::policy::_AssetPost_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_AssetDelete_Request_default_instance_._instance,
+  &::com::wazuh::api::engine::policy::_AssetDelete_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_AssetGet_Request_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_AssetGet_Response_default_instance_._instance,
+  &::com::wazuh::api::engine::policy::_AssetCleanDeleted_Request_default_instance_._instance,
+  &::com::wazuh::api::engine::policy::_AssetCleanDeleted_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_DefaultParentGet_Request_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_DefaultParentGet_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_DefaultParentPost_Request_default_instance_._instance,
+  &::com::wazuh::api::engine::policy::_DefaultParentPost_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_DefaultParentDelete_Request_default_instance_._instance,
+  &::com::wazuh::api::engine::policy::_DefaultParentDelete_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_PoliciesGet_Request_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_PoliciesGet_Response_default_instance_._instance,
   &::com::wazuh::api::engine::policy::_NamespacesGet_Request_default_instance_._instance,
@@ -497,44 +671,64 @@ const char descriptor_table_protodef_policy_2eproto[] PROTOBUF_SECTION_VARIABLE(
   "B\007\n\005_data\"w\n\021AssetPost_Request\022\023\n\006policy"
   "\030\001 \001(\tH\000\210\001\001\022\022\n\005asset\030\002 \001(\tH\001\210\001\001\022\026\n\tnames"
   "pace\030\003 \001(\tH\002\210\001\001B\t\n\007_policyB\010\n\006_assetB\014\n\n"
-  "_namespace\"y\n\023AssetDelete_Request\022\023\n\006pol"
-  "icy\030\001 \001(\tH\000\210\001\001\022\022\n\005asset\030\002 \001(\tH\001\210\001\001\022\026\n\tna"
-  "mespace\030\003 \001(\tH\002\210\001\001B\t\n\007_policyB\010\n\006_assetB"
-  "\014\n\n_namespace\"X\n\020AssetGet_Request\022\023\n\006pol"
+  "_namespace\"\210\001\n\022AssetPost_Response\0222\n\006sta"
+  "tus\030\001 \001(\0162\".com.wazuh.api.engine.ReturnS"
+  "tatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022\024\n\007warning\030\003 \001"
+  "(\tH\001\210\001\001B\010\n\006_errorB\n\n\010_warning\"y\n\023AssetDe"
+  "lete_Request\022\023\n\006policy\030\001 \001(\tH\000\210\001\001\022\022\n\005ass"
+  "et\030\002 \001(\tH\001\210\001\001\022\026\n\tnamespace\030\003 \001(\tH\002\210\001\001B\t\n"
+  "\007_policyB\010\n\006_assetB\014\n\n_namespace\"\212\001\n\024Ass"
+  "etDelete_Response\0222\n\006status\030\001 \001(\0162\".com."
+  "wazuh.api.engine.ReturnStatus\022\022\n\005error\030\002"
+  " \001(\tH\000\210\001\001\022\024\n\007warning\030\003 \001(\tH\001\210\001\001B\010\n\006_erro"
+  "rB\n\n\010_warning\"X\n\020AssetGet_Request\022\023\n\006pol"
   "icy\030\001 \001(\tH\000\210\001\001\022\026\n\tnamespace\030\002 \001(\tH\001\210\001\001B\t"
   "\n\007_policyB\014\n\n_namespace\"s\n\021AssetGet_Resp"
   "onse\0222\n\006status\030\001 \001(\0162\".com.wazuh.api.eng"
   "ine.ReturnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022\014\n\004"
-  "data\030\003 \003(\tB\010\n\006_error\"`\n\030DefaultParentGet"
-  "_Request\022\023\n\006policy\030\001 \001(\tH\000\210\001\001\022\026\n\tnamespa"
-  "ce\030\002 \001(\tH\001\210\001\001B\t\n\007_policyB\014\n\n_namespace\"{"
-  "\n\031DefaultParentGet_Response\0222\n\006status\030\001 "
-  "\001(\0162\".com.wazuh.api.engine.ReturnStatus\022"
-  "\022\n\005error\030\002 \001(\tH\000\210\001\001\022\014\n\004data\030\003 \003(\tB\010\n\006_er"
-  "ror\"\201\001\n\031DefaultParentPost_Request\022\023\n\006pol"
-  "icy\030\001 \001(\tH\000\210\001\001\022\026\n\tnamespace\030\002 \001(\tH\001\210\001\001\022\023"
-  "\n\006parent\030\003 \001(\tH\002\210\001\001B\t\n\007_policyB\014\n\n_names"
-  "paceB\t\n\007_parent\"\203\001\n\033DefaultParentDelete_"
-  "Request\022\023\n\006policy\030\001 \001(\tH\000\210\001\001\022\026\n\tnamespac"
-  "e\030\002 \001(\tH\001\210\001\001\022\023\n\006parent\030\003 \001(\tH\002\210\001\001B\t\n\007_po"
-  "licyB\014\n\n_namespaceB\t\n\007_parent\"\025\n\023Policie"
-  "sGet_Request\"v\n\024PoliciesGet_Response\0222\n\006"
-  "status\030\001 \001(\0162\".com.wazuh.api.engine.Retu"
-  "rnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022\014\n\004data\030\003 \003"
-  "(\tB\010\n\006_error\"7\n\025NamespacesGet_Request\022\023\n"
-  "\006policy\030\001 \001(\tH\000\210\001\001B\t\n\007_policy\"x\n\026Namespa"
-  "cesGet_Response\0222\n\006status\030\001 \001(\0162\".com.wa"
-  "zuh.api.engine.ReturnStatus\022\022\n\005error\030\002 \001"
-  "(\tH\000\210\001\001\022\014\n\004data\030\003 \003(\tB\010\n\006_errorb\006proto3"
+  "data\030\003 \003(\tB\010\n\006_error\";\n\031AssetCleanDelete"
+  "d_Request\022\023\n\006policy\030\001 \001(\tH\000\210\001\001B\t\n\007_polic"
+  "y\"\212\001\n\032AssetCleanDeleted_Response\0222\n\006stat"
+  "us\030\001 \001(\0162\".com.wazuh.api.engine.ReturnSt"
+  "atus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022\021\n\004data\030\003 \001(\tH\001"
+  "\210\001\001B\010\n\006_errorB\007\n\005_data\"`\n\030DefaultParentG"
+  "et_Request\022\023\n\006policy\030\001 \001(\tH\000\210\001\001\022\026\n\tnames"
+  "pace\030\002 \001(\tH\001\210\001\001B\t\n\007_policyB\014\n\n_namespace"
+  "\"{\n\031DefaultParentGet_Response\0222\n\006status\030"
+  "\001 \001(\0162\".com.wazuh.api.engine.ReturnStatu"
+  "s\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022\014\n\004data\030\003 \003(\tB\010\n\006_"
+  "error\"\201\001\n\031DefaultParentPost_Request\022\023\n\006p"
+  "olicy\030\001 \001(\tH\000\210\001\001\022\026\n\tnamespace\030\002 \001(\tH\001\210\001\001"
+  "\022\023\n\006parent\030\003 \001(\tH\002\210\001\001B\t\n\007_policyB\014\n\n_nam"
+  "espaceB\t\n\007_parent\"\220\001\n\032DefaultParentPost_"
+  "Response\0222\n\006status\030\001 \001(\0162\".com.wazuh.api"
+  ".engine.ReturnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001"
+  "\022\024\n\007warning\030\003 \001(\tH\001\210\001\001B\010\n\006_errorB\n\n\010_war"
+  "ning\"\203\001\n\033DefaultParentDelete_Request\022\023\n\006"
+  "policy\030\001 \001(\tH\000\210\001\001\022\026\n\tnamespace\030\002 \001(\tH\001\210\001"
+  "\001\022\023\n\006parent\030\003 \001(\tH\002\210\001\001B\t\n\007_policyB\014\n\n_na"
+  "mespaceB\t\n\007_parent\"\222\001\n\034DefaultParentDele"
+  "te_Response\0222\n\006status\030\001 \001(\0162\".com.wazuh."
+  "api.engine.ReturnStatus\022\022\n\005error\030\002 \001(\tH\000"
+  "\210\001\001\022\024\n\007warning\030\003 \001(\tH\001\210\001\001B\010\n\006_errorB\n\n\010_"
+  "warning\"\025\n\023PoliciesGet_Request\"v\n\024Polici"
+  "esGet_Response\0222\n\006status\030\001 \001(\0162\".com.waz"
+  "uh.api.engine.ReturnStatus\022\022\n\005error\030\002 \001("
+  "\tH\000\210\001\001\022\014\n\004data\030\003 \003(\tB\010\n\006_error\"7\n\025Namesp"
+  "acesGet_Request\022\023\n\006policy\030\001 \001(\tH\000\210\001\001B\t\n\007"
+  "_policy\"x\n\026NamespacesGet_Response\0222\n\006sta"
+  "tus\030\001 \001(\0162\".com.wazuh.api.engine.ReturnS"
+  "tatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022\014\n\004data\030\003 \003(\tB"
+  "\010\n\006_errorb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_policy_2eproto_deps[1] = {
   &::descriptor_table_engine_2eproto,
 };
 static ::_pbi::once_flag descriptor_table_policy_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_policy_2eproto = {
-    false, false, 1639, descriptor_table_protodef_policy_2eproto,
+    false, false, 2417, descriptor_table_protodef_policy_2eproto,
     "policy.proto",
-    &descriptor_table_policy_2eproto_once, descriptor_table_policy_2eproto_deps, 1, 16,
+    &descriptor_table_policy_2eproto_once, descriptor_table_policy_2eproto_deps, 1, 22,
     schemas, file_default_instances, TableStruct_policy_2eproto::offsets,
     file_level_metadata_policy_2eproto, file_level_enum_descriptors_policy_2eproto,
     file_level_service_descriptors_policy_2eproto,
@@ -1886,6 +2080,315 @@ void AssetPost_Request::InternalSwap(AssetPost_Request* other) {
 
 // ===================================================================
 
+class AssetPost_Response::_Internal {
+ public:
+  using HasBits = decltype(std::declval<AssetPost_Response>()._impl_._has_bits_);
+  static void set_has_error(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_warning(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+};
+
+AssetPost_Response::AssetPost_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.policy.AssetPost_Response)
+}
+AssetPost_Response::AssetPost_Response(const AssetPost_Response& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  AssetPost_Response* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_error()) {
+    _this->_impl_.error_.Set(from._internal_error(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_warning()) {
+    _this->_impl_.warning_.Set(from._internal_warning(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.status_ = from._impl_.status_;
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.policy.AssetPost_Response)
+}
+
+inline void AssetPost_Response::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){0}
+  };
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+AssetPost_Response::~AssetPost_Response() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.policy.AssetPost_Response)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void AssetPost_Response::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.error_.Destroy();
+  _impl_.warning_.Destroy();
+}
+
+void AssetPost_Response::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void AssetPost_Response::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.policy.AssetPost_Response)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _impl_.error_.ClearNonDefaultToEmpty();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _impl_.warning_.ClearNonDefaultToEmpty();
+    }
+  }
+  _impl_.status_ = 0;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* AssetPost_Response::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .com.wazuh.api.engine.ReturnStatus status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_status(static_cast<::com::wazuh::api::engine::ReturnStatus>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.AssetPost_Response.error"));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string warning = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_warning();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.AssetPost_Response.warning"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* AssetPost_Response::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.policy.AssetPost_Response)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_status(), target);
+  }
+
+  // optional string error = 2;
+  if (_internal_has_error()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.AssetPost_Response.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  // optional string warning = 3;
+  if (_internal_has_warning()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_warning().data(), static_cast<int>(this->_internal_warning().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.AssetPost_Response.warning");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_warning(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.policy.AssetPost_Response)
+  return target;
+}
+
+size_t AssetPost_Response::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.policy.AssetPost_Response)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional string error = 2;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_error());
+    }
+
+    // optional string warning = 3;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_warning());
+    }
+
+  }
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_status());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData AssetPost_Response::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    AssetPost_Response::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*AssetPost_Response::GetClassData() const { return &_class_data_; }
+
+
+void AssetPost_Response::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<AssetPost_Response*>(&to_msg);
+  auto& from = static_cast<const AssetPost_Response&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.policy.AssetPost_Response)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_internal_set_error(from._internal_error());
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_internal_set_warning(from._internal_warning());
+    }
+  }
+  if (from._internal_status() != 0) {
+    _this->_internal_set_status(from._internal_status());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void AssetPost_Response::CopyFrom(const AssetPost_Response& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.policy.AssetPost_Response)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool AssetPost_Response::IsInitialized() const {
+  return true;
+}
+
+void AssetPost_Response::InternalSwap(AssetPost_Response* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.error_, lhs_arena,
+      &other->_impl_.error_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.warning_, lhs_arena,
+      &other->_impl_.warning_, rhs_arena
+  );
+  swap(_impl_.status_, other->_impl_.status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata AssetPost_Response::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
+      file_level_metadata_policy_2eproto[5]);
+}
+
+// ===================================================================
+
 class AssetDelete_Request::_Internal {
  public:
   using HasBits = decltype(std::declval<AssetDelete_Request>()._impl_._has_bits_);
@@ -2215,7 +2718,316 @@ void AssetDelete_Request::InternalSwap(AssetDelete_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AssetDelete_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[5]);
+      file_level_metadata_policy_2eproto[6]);
+}
+
+// ===================================================================
+
+class AssetDelete_Response::_Internal {
+ public:
+  using HasBits = decltype(std::declval<AssetDelete_Response>()._impl_._has_bits_);
+  static void set_has_error(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_warning(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+};
+
+AssetDelete_Response::AssetDelete_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.policy.AssetDelete_Response)
+}
+AssetDelete_Response::AssetDelete_Response(const AssetDelete_Response& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  AssetDelete_Response* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_error()) {
+    _this->_impl_.error_.Set(from._internal_error(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_warning()) {
+    _this->_impl_.warning_.Set(from._internal_warning(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.status_ = from._impl_.status_;
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.policy.AssetDelete_Response)
+}
+
+inline void AssetDelete_Response::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){0}
+  };
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+AssetDelete_Response::~AssetDelete_Response() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.policy.AssetDelete_Response)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void AssetDelete_Response::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.error_.Destroy();
+  _impl_.warning_.Destroy();
+}
+
+void AssetDelete_Response::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void AssetDelete_Response::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.policy.AssetDelete_Response)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _impl_.error_.ClearNonDefaultToEmpty();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _impl_.warning_.ClearNonDefaultToEmpty();
+    }
+  }
+  _impl_.status_ = 0;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* AssetDelete_Response::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .com.wazuh.api.engine.ReturnStatus status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_status(static_cast<::com::wazuh::api::engine::ReturnStatus>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.AssetDelete_Response.error"));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string warning = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_warning();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.AssetDelete_Response.warning"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* AssetDelete_Response::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.policy.AssetDelete_Response)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_status(), target);
+  }
+
+  // optional string error = 2;
+  if (_internal_has_error()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.AssetDelete_Response.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  // optional string warning = 3;
+  if (_internal_has_warning()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_warning().data(), static_cast<int>(this->_internal_warning().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.AssetDelete_Response.warning");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_warning(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.policy.AssetDelete_Response)
+  return target;
+}
+
+size_t AssetDelete_Response::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.policy.AssetDelete_Response)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional string error = 2;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_error());
+    }
+
+    // optional string warning = 3;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_warning());
+    }
+
+  }
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_status());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData AssetDelete_Response::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    AssetDelete_Response::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*AssetDelete_Response::GetClassData() const { return &_class_data_; }
+
+
+void AssetDelete_Response::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<AssetDelete_Response*>(&to_msg);
+  auto& from = static_cast<const AssetDelete_Response&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.policy.AssetDelete_Response)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_internal_set_error(from._internal_error());
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_internal_set_warning(from._internal_warning());
+    }
+  }
+  if (from._internal_status() != 0) {
+    _this->_internal_set_status(from._internal_status());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void AssetDelete_Response::CopyFrom(const AssetDelete_Response& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.policy.AssetDelete_Response)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool AssetDelete_Response::IsInitialized() const {
+  return true;
+}
+
+void AssetDelete_Response::InternalSwap(AssetDelete_Response* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.error_, lhs_arena,
+      &other->_impl_.error_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.warning_, lhs_arena,
+      &other->_impl_.warning_, rhs_arena
+  );
+  swap(_impl_.status_, other->_impl_.status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata AssetDelete_Response::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
+      file_level_metadata_policy_2eproto[7]);
 }
 
 // ===================================================================
@@ -2494,7 +3306,7 @@ void AssetGet_Request::InternalSwap(AssetGet_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AssetGet_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[6]);
+      file_level_metadata_policy_2eproto[8]);
 }
 
 // ===================================================================
@@ -2780,7 +3592,533 @@ void AssetGet_Response::InternalSwap(AssetGet_Response* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata AssetGet_Response::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[7]);
+      file_level_metadata_policy_2eproto[9]);
+}
+
+// ===================================================================
+
+class AssetCleanDeleted_Request::_Internal {
+ public:
+  using HasBits = decltype(std::declval<AssetCleanDeleted_Request>()._impl_._has_bits_);
+  static void set_has_policy(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+};
+
+AssetCleanDeleted_Request::AssetCleanDeleted_Request(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+}
+AssetCleanDeleted_Request::AssetCleanDeleted_Request(const AssetCleanDeleted_Request& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  AssetCleanDeleted_Request* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.policy_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.policy_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.policy_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_policy()) {
+    _this->_impl_.policy_.Set(from._internal_policy(), 
+      _this->GetArenaForAllocation());
+  }
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+}
+
+inline void AssetCleanDeleted_Request::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.policy_){}
+  };
+  _impl_.policy_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.policy_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+AssetCleanDeleted_Request::~AssetCleanDeleted_Request() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void AssetCleanDeleted_Request::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.policy_.Destroy();
+}
+
+void AssetCleanDeleted_Request::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void AssetCleanDeleted_Request::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    _impl_.policy_.ClearNonDefaultToEmpty();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* AssetCleanDeleted_Request::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // optional string policy = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          auto str = _internal_mutable_policy();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.AssetCleanDeleted_Request.policy"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* AssetCleanDeleted_Request::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // optional string policy = 1;
+  if (_internal_has_policy()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_policy().data(), static_cast<int>(this->_internal_policy().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.AssetCleanDeleted_Request.policy");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_policy(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+  return target;
+}
+
+size_t AssetCleanDeleted_Request::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // optional string policy = 1;
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_policy());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData AssetCleanDeleted_Request::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    AssetCleanDeleted_Request::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*AssetCleanDeleted_Request::GetClassData() const { return &_class_data_; }
+
+
+void AssetCleanDeleted_Request::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<AssetCleanDeleted_Request*>(&to_msg);
+  auto& from = static_cast<const AssetCleanDeleted_Request&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_policy()) {
+    _this->_internal_set_policy(from._internal_policy());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void AssetCleanDeleted_Request::CopyFrom(const AssetCleanDeleted_Request& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool AssetCleanDeleted_Request::IsInitialized() const {
+  return true;
+}
+
+void AssetCleanDeleted_Request::InternalSwap(AssetCleanDeleted_Request* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.policy_, lhs_arena,
+      &other->_impl_.policy_, rhs_arena
+  );
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata AssetCleanDeleted_Request::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
+      file_level_metadata_policy_2eproto[10]);
+}
+
+// ===================================================================
+
+class AssetCleanDeleted_Response::_Internal {
+ public:
+  using HasBits = decltype(std::declval<AssetCleanDeleted_Response>()._impl_._has_bits_);
+  static void set_has_error(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_data(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+};
+
+AssetCleanDeleted_Response::AssetCleanDeleted_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+}
+AssetCleanDeleted_Response::AssetCleanDeleted_Response(const AssetCleanDeleted_Response& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  AssetCleanDeleted_Response* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.data_){}
+    , decltype(_impl_.status_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_error()) {
+    _this->_impl_.error_.Set(from._internal_error(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.data_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.data_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_data()) {
+    _this->_impl_.data_.Set(from._internal_data(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.status_ = from._impl_.status_;
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+}
+
+inline void AssetCleanDeleted_Response::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.data_){}
+    , decltype(_impl_.status_){0}
+  };
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.data_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.data_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+AssetCleanDeleted_Response::~AssetCleanDeleted_Response() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void AssetCleanDeleted_Response::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.error_.Destroy();
+  _impl_.data_.Destroy();
+}
+
+void AssetCleanDeleted_Response::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void AssetCleanDeleted_Response::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _impl_.error_.ClearNonDefaultToEmpty();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _impl_.data_.ClearNonDefaultToEmpty();
+    }
+  }
+  _impl_.status_ = 0;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* AssetCleanDeleted_Response::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .com.wazuh.api.engine.ReturnStatus status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_status(static_cast<::com::wazuh::api::engine::ReturnStatus>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.AssetCleanDeleted_Response.error"));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string data = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_data();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.AssetCleanDeleted_Response.data"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* AssetCleanDeleted_Response::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_status(), target);
+  }
+
+  // optional string error = 2;
+  if (_internal_has_error()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.AssetCleanDeleted_Response.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  // optional string data = 3;
+  if (_internal_has_data()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_data().data(), static_cast<int>(this->_internal_data().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.AssetCleanDeleted_Response.data");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_data(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+  return target;
+}
+
+size_t AssetCleanDeleted_Response::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional string error = 2;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_error());
+    }
+
+    // optional string data = 3;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_data());
+    }
+
+  }
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_status());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData AssetCleanDeleted_Response::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    AssetCleanDeleted_Response::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*AssetCleanDeleted_Response::GetClassData() const { return &_class_data_; }
+
+
+void AssetCleanDeleted_Response::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<AssetCleanDeleted_Response*>(&to_msg);
+  auto& from = static_cast<const AssetCleanDeleted_Response&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_internal_set_error(from._internal_error());
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_internal_set_data(from._internal_data());
+    }
+  }
+  if (from._internal_status() != 0) {
+    _this->_internal_set_status(from._internal_status());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void AssetCleanDeleted_Response::CopyFrom(const AssetCleanDeleted_Response& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool AssetCleanDeleted_Response::IsInitialized() const {
+  return true;
+}
+
+void AssetCleanDeleted_Response::InternalSwap(AssetCleanDeleted_Response* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.error_, lhs_arena,
+      &other->_impl_.error_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.data_, lhs_arena,
+      &other->_impl_.data_, rhs_arena
+  );
+  swap(_impl_.status_, other->_impl_.status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata AssetCleanDeleted_Response::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
+      file_level_metadata_policy_2eproto[11]);
 }
 
 // ===================================================================
@@ -3059,7 +4397,7 @@ void DefaultParentGet_Request::InternalSwap(DefaultParentGet_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DefaultParentGet_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[8]);
+      file_level_metadata_policy_2eproto[12]);
 }
 
 // ===================================================================
@@ -3345,7 +4683,7 @@ void DefaultParentGet_Response::InternalSwap(DefaultParentGet_Response* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DefaultParentGet_Response::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[9]);
+      file_level_metadata_policy_2eproto[13]);
 }
 
 // ===================================================================
@@ -3679,7 +5017,316 @@ void DefaultParentPost_Request::InternalSwap(DefaultParentPost_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata DefaultParentPost_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[10]);
+      file_level_metadata_policy_2eproto[14]);
+}
+
+// ===================================================================
+
+class DefaultParentPost_Response::_Internal {
+ public:
+  using HasBits = decltype(std::declval<DefaultParentPost_Response>()._impl_._has_bits_);
+  static void set_has_error(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_warning(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+};
+
+DefaultParentPost_Response::DefaultParentPost_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+}
+DefaultParentPost_Response::DefaultParentPost_Response(const DefaultParentPost_Response& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  DefaultParentPost_Response* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_error()) {
+    _this->_impl_.error_.Set(from._internal_error(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_warning()) {
+    _this->_impl_.warning_.Set(from._internal_warning(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.status_ = from._impl_.status_;
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+}
+
+inline void DefaultParentPost_Response::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){0}
+  };
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+DefaultParentPost_Response::~DefaultParentPost_Response() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void DefaultParentPost_Response::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.error_.Destroy();
+  _impl_.warning_.Destroy();
+}
+
+void DefaultParentPost_Response::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void DefaultParentPost_Response::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _impl_.error_.ClearNonDefaultToEmpty();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _impl_.warning_.ClearNonDefaultToEmpty();
+    }
+  }
+  _impl_.status_ = 0;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* DefaultParentPost_Response::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .com.wazuh.api.engine.ReturnStatus status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_status(static_cast<::com::wazuh::api::engine::ReturnStatus>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.DefaultParentPost_Response.error"));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string warning = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_warning();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.DefaultParentPost_Response.warning"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* DefaultParentPost_Response::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_status(), target);
+  }
+
+  // optional string error = 2;
+  if (_internal_has_error()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.DefaultParentPost_Response.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  // optional string warning = 3;
+  if (_internal_has_warning()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_warning().data(), static_cast<int>(this->_internal_warning().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.DefaultParentPost_Response.warning");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_warning(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+  return target;
+}
+
+size_t DefaultParentPost_Response::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional string error = 2;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_error());
+    }
+
+    // optional string warning = 3;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_warning());
+    }
+
+  }
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_status());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DefaultParentPost_Response::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    DefaultParentPost_Response::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DefaultParentPost_Response::GetClassData() const { return &_class_data_; }
+
+
+void DefaultParentPost_Response::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<DefaultParentPost_Response*>(&to_msg);
+  auto& from = static_cast<const DefaultParentPost_Response&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_internal_set_error(from._internal_error());
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_internal_set_warning(from._internal_warning());
+    }
+  }
+  if (from._internal_status() != 0) {
+    _this->_internal_set_status(from._internal_status());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void DefaultParentPost_Response::CopyFrom(const DefaultParentPost_Response& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DefaultParentPost_Response::IsInitialized() const {
+  return true;
+}
+
+void DefaultParentPost_Response::InternalSwap(DefaultParentPost_Response* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.error_, lhs_arena,
+      &other->_impl_.error_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.warning_, lhs_arena,
+      &other->_impl_.warning_, rhs_arena
+  );
+  swap(_impl_.status_, other->_impl_.status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata DefaultParentPost_Response::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
+      file_level_metadata_policy_2eproto[15]);
 }
 
 // ===================================================================
@@ -4013,7 +5660,316 @@ void DefaultParentDelete_Request::InternalSwap(DefaultParentDelete_Request* othe
 ::PROTOBUF_NAMESPACE_ID::Metadata DefaultParentDelete_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[11]);
+      file_level_metadata_policy_2eproto[16]);
+}
+
+// ===================================================================
+
+class DefaultParentDelete_Response::_Internal {
+ public:
+  using HasBits = decltype(std::declval<DefaultParentDelete_Response>()._impl_._has_bits_);
+  static void set_has_error(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_warning(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+};
+
+DefaultParentDelete_Response::DefaultParentDelete_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+}
+DefaultParentDelete_Response::DefaultParentDelete_Response(const DefaultParentDelete_Response& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  DefaultParentDelete_Response* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_error()) {
+    _this->_impl_.error_.Set(from._internal_error(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_warning()) {
+    _this->_impl_.warning_.Set(from._internal_warning(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.status_ = from._impl_.status_;
+  // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+}
+
+inline void DefaultParentDelete_Response::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.error_){}
+    , decltype(_impl_.warning_){}
+    , decltype(_impl_.status_){0}
+  };
+  _impl_.error_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.error_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.warning_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+DefaultParentDelete_Response::~DefaultParentDelete_Response() {
+  // @@protoc_insertion_point(destructor:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void DefaultParentDelete_Response::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.error_.Destroy();
+  _impl_.warning_.Destroy();
+}
+
+void DefaultParentDelete_Response::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void DefaultParentDelete_Response::Clear() {
+// @@protoc_insertion_point(message_clear_start:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _impl_.error_.ClearNonDefaultToEmpty();
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _impl_.warning_.ClearNonDefaultToEmpty();
+    }
+  }
+  _impl_.status_ = 0;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* DefaultParentDelete_Response::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .com.wazuh.api.engine.ReturnStatus status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_status(static_cast<::com::wazuh::api::engine::ReturnStatus>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.DefaultParentDelete_Response.error"));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string warning = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_warning();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.policy.DefaultParentDelete_Response.warning"));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* DefaultParentDelete_Response::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_status(), target);
+  }
+
+  // optional string error = 2;
+  if (_internal_has_error()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.DefaultParentDelete_Response.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  // optional string warning = 3;
+  if (_internal_has_warning()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_warning().data(), static_cast<int>(this->_internal_warning().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.policy.DefaultParentDelete_Response.warning");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_warning(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+  return target;
+}
+
+size_t DefaultParentDelete_Response::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    // optional string error = 2;
+    if (cached_has_bits & 0x00000001u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_error());
+    }
+
+    // optional string warning = 3;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_warning());
+    }
+
+  }
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  if (this->_internal_status() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_status());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DefaultParentDelete_Response::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    DefaultParentDelete_Response::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DefaultParentDelete_Response::GetClassData() const { return &_class_data_; }
+
+
+void DefaultParentDelete_Response::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<DefaultParentDelete_Response*>(&to_msg);
+  auto& from = static_cast<const DefaultParentDelete_Response&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000003u) {
+    if (cached_has_bits & 0x00000001u) {
+      _this->_internal_set_error(from._internal_error());
+    }
+    if (cached_has_bits & 0x00000002u) {
+      _this->_internal_set_warning(from._internal_warning());
+    }
+  }
+  if (from._internal_status() != 0) {
+    _this->_internal_set_status(from._internal_status());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void DefaultParentDelete_Response::CopyFrom(const DefaultParentDelete_Response& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DefaultParentDelete_Response::IsInitialized() const {
+  return true;
+}
+
+void DefaultParentDelete_Response::InternalSwap(DefaultParentDelete_Response* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.error_, lhs_arena,
+      &other->_impl_.error_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.warning_, lhs_arena,
+      &other->_impl_.warning_, rhs_arena
+  );
+  swap(_impl_.status_, other->_impl_.status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata DefaultParentDelete_Response::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
+      file_level_metadata_policy_2eproto[17]);
 }
 
 // ===================================================================
@@ -4053,7 +6009,7 @@ const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*PoliciesGet_Request::GetClassD
 ::PROTOBUF_NAMESPACE_ID::Metadata PoliciesGet_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[12]);
+      file_level_metadata_policy_2eproto[18]);
 }
 
 // ===================================================================
@@ -4339,7 +6295,7 @@ void PoliciesGet_Response::InternalSwap(PoliciesGet_Response* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PoliciesGet_Response::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[13]);
+      file_level_metadata_policy_2eproto[19]);
 }
 
 // ===================================================================
@@ -4556,7 +6512,7 @@ void NamespacesGet_Request::InternalSwap(NamespacesGet_Request* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata NamespacesGet_Request::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[14]);
+      file_level_metadata_policy_2eproto[20]);
 }
 
 // ===================================================================
@@ -4842,7 +6798,7 @@ void NamespacesGet_Response::InternalSwap(NamespacesGet_Response* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata NamespacesGet_Response::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_policy_2eproto_getter, &descriptor_table_policy_2eproto_once,
-      file_level_metadata_policy_2eproto[15]);
+      file_level_metadata_policy_2eproto[21]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -4872,9 +6828,17 @@ template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetPost_Reques
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetPost_Request >(Arena* arena) {
   return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::AssetPost_Request >(arena);
 }
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetPost_Response*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetPost_Response >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::AssetPost_Response >(arena);
+}
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetDelete_Request*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetDelete_Request >(Arena* arena) {
   return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::AssetDelete_Request >(arena);
+}
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetDelete_Response*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetDelete_Response >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::AssetDelete_Response >(arena);
 }
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetGet_Request*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetGet_Request >(Arena* arena) {
@@ -4883,6 +6847,14 @@ Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetGet_Request >
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetGet_Response*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetGet_Response >(Arena* arena) {
   return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::AssetGet_Response >(arena);
+}
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetCleanDeleted_Request*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetCleanDeleted_Request >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::AssetCleanDeleted_Request >(arena);
+}
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::AssetCleanDeleted_Response*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::AssetCleanDeleted_Response >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::AssetCleanDeleted_Response >(arena);
 }
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::DefaultParentGet_Request*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::DefaultParentGet_Request >(Arena* arena) {
@@ -4896,9 +6868,17 @@ template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::DefaultParentPos
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::DefaultParentPost_Request >(Arena* arena) {
   return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::DefaultParentPost_Request >(arena);
 }
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::DefaultParentPost_Response*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::DefaultParentPost_Response >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::DefaultParentPost_Response >(arena);
+}
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::DefaultParentDelete_Request*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::DefaultParentDelete_Request >(Arena* arena) {
   return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::DefaultParentDelete_Request >(arena);
+}
+template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::DefaultParentDelete_Response*
+Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::DefaultParentDelete_Response >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::com::wazuh::api::engine::policy::DefaultParentDelete_Response >(arena);
 }
 template<> PROTOBUF_NOINLINE ::com::wazuh::api::engine::policy::PoliciesGet_Request*
 Arena::CreateMaybeMessage< ::com::wazuh::api::engine::policy::PoliciesGet_Request >(Arena* arena) {

--- a/src/engine/source/proto/include/eMessages/policy.pb.h
+++ b/src/engine/source/proto/include/eMessages/policy.pb.h
@@ -51,9 +51,18 @@ namespace wazuh {
 namespace api {
 namespace engine {
 namespace policy {
+class AssetCleanDeleted_Request;
+struct AssetCleanDeleted_RequestDefaultTypeInternal;
+extern AssetCleanDeleted_RequestDefaultTypeInternal _AssetCleanDeleted_Request_default_instance_;
+class AssetCleanDeleted_Response;
+struct AssetCleanDeleted_ResponseDefaultTypeInternal;
+extern AssetCleanDeleted_ResponseDefaultTypeInternal _AssetCleanDeleted_Response_default_instance_;
 class AssetDelete_Request;
 struct AssetDelete_RequestDefaultTypeInternal;
 extern AssetDelete_RequestDefaultTypeInternal _AssetDelete_Request_default_instance_;
+class AssetDelete_Response;
+struct AssetDelete_ResponseDefaultTypeInternal;
+extern AssetDelete_ResponseDefaultTypeInternal _AssetDelete_Response_default_instance_;
 class AssetGet_Request;
 struct AssetGet_RequestDefaultTypeInternal;
 extern AssetGet_RequestDefaultTypeInternal _AssetGet_Request_default_instance_;
@@ -63,9 +72,15 @@ extern AssetGet_ResponseDefaultTypeInternal _AssetGet_Response_default_instance_
 class AssetPost_Request;
 struct AssetPost_RequestDefaultTypeInternal;
 extern AssetPost_RequestDefaultTypeInternal _AssetPost_Request_default_instance_;
+class AssetPost_Response;
+struct AssetPost_ResponseDefaultTypeInternal;
+extern AssetPost_ResponseDefaultTypeInternal _AssetPost_Response_default_instance_;
 class DefaultParentDelete_Request;
 struct DefaultParentDelete_RequestDefaultTypeInternal;
 extern DefaultParentDelete_RequestDefaultTypeInternal _DefaultParentDelete_Request_default_instance_;
+class DefaultParentDelete_Response;
+struct DefaultParentDelete_ResponseDefaultTypeInternal;
+extern DefaultParentDelete_ResponseDefaultTypeInternal _DefaultParentDelete_Response_default_instance_;
 class DefaultParentGet_Request;
 struct DefaultParentGet_RequestDefaultTypeInternal;
 extern DefaultParentGet_RequestDefaultTypeInternal _DefaultParentGet_Request_default_instance_;
@@ -75,6 +90,9 @@ extern DefaultParentGet_ResponseDefaultTypeInternal _DefaultParentGet_Response_d
 class DefaultParentPost_Request;
 struct DefaultParentPost_RequestDefaultTypeInternal;
 extern DefaultParentPost_RequestDefaultTypeInternal _DefaultParentPost_Request_default_instance_;
+class DefaultParentPost_Response;
+struct DefaultParentPost_ResponseDefaultTypeInternal;
+extern DefaultParentPost_ResponseDefaultTypeInternal _DefaultParentPost_Response_default_instance_;
 class NamespacesGet_Request;
 struct NamespacesGet_RequestDefaultTypeInternal;
 extern NamespacesGet_RequestDefaultTypeInternal _NamespacesGet_Request_default_instance_;
@@ -105,14 +123,20 @@ extern StorePost_RequestDefaultTypeInternal _StorePost_Request_default_instance_
 }  // namespace wazuh
 }  // namespace com
 PROTOBUF_NAMESPACE_OPEN
+template<> ::com::wazuh::api::engine::policy::AssetCleanDeleted_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetCleanDeleted_Request>(Arena*);
+template<> ::com::wazuh::api::engine::policy::AssetCleanDeleted_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetCleanDeleted_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::AssetDelete_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetDelete_Request>(Arena*);
+template<> ::com::wazuh::api::engine::policy::AssetDelete_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetDelete_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::AssetGet_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetGet_Request>(Arena*);
 template<> ::com::wazuh::api::engine::policy::AssetGet_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetGet_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::AssetPost_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetPost_Request>(Arena*);
+template<> ::com::wazuh::api::engine::policy::AssetPost_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::AssetPost_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::DefaultParentDelete_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::DefaultParentDelete_Request>(Arena*);
+template<> ::com::wazuh::api::engine::policy::DefaultParentDelete_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::DefaultParentDelete_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::DefaultParentGet_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::DefaultParentGet_Request>(Arena*);
 template<> ::com::wazuh::api::engine::policy::DefaultParentGet_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::DefaultParentGet_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::DefaultParentPost_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::DefaultParentPost_Request>(Arena*);
+template<> ::com::wazuh::api::engine::policy::DefaultParentPost_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::DefaultParentPost_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::NamespacesGet_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::NamespacesGet_Request>(Arena*);
 template<> ::com::wazuh::api::engine::policy::NamespacesGet_Response* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::NamespacesGet_Response>(Arena*);
 template<> ::com::wazuh::api::engine::policy::PoliciesGet_Request* Arena::CreateMaybeMessage<::com::wazuh::api::engine::policy::PoliciesGet_Request>(Arena*);
@@ -1017,6 +1041,195 @@ class AssetPost_Request final :
 };
 // -------------------------------------------------------------------
 
+class AssetPost_Response final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.AssetPost_Response) */ {
+ public:
+  inline AssetPost_Response() : AssetPost_Response(nullptr) {}
+  ~AssetPost_Response() override;
+  explicit PROTOBUF_CONSTEXPR AssetPost_Response(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  AssetPost_Response(const AssetPost_Response& from);
+  AssetPost_Response(AssetPost_Response&& from) noexcept
+    : AssetPost_Response() {
+    *this = ::std::move(from);
+  }
+
+  inline AssetPost_Response& operator=(const AssetPost_Response& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline AssetPost_Response& operator=(AssetPost_Response&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const AssetPost_Response& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const AssetPost_Response* internal_default_instance() {
+    return reinterpret_cast<const AssetPost_Response*>(
+               &_AssetPost_Response_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    5;
+
+  friend void swap(AssetPost_Response& a, AssetPost_Response& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(AssetPost_Response* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(AssetPost_Response* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  AssetPost_Response* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<AssetPost_Response>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const AssetPost_Response& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const AssetPost_Response& from) {
+    AssetPost_Response::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(AssetPost_Response* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.policy.AssetPost_Response";
+  }
+  protected:
+  explicit AssetPost_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kErrorFieldNumber = 2,
+    kWarningFieldNumber = 3,
+    kStatusFieldNumber = 1,
+  };
+  // optional string error = 2;
+  bool has_error() const;
+  private:
+  bool _internal_has_error() const;
+  public:
+  void clear_error();
+  const std::string& error() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_error(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_error();
+  PROTOBUF_NODISCARD std::string* release_error();
+  void set_allocated_error(std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // optional string warning = 3;
+  bool has_warning() const;
+  private:
+  bool _internal_has_warning() const;
+  public:
+  void clear_warning();
+  const std::string& warning() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_warning(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_warning();
+  PROTOBUF_NODISCARD std::string* release_warning();
+  void set_allocated_warning(std::string* warning);
+  private:
+  const std::string& _internal_warning() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_warning(const std::string& value);
+  std::string* _internal_mutable_warning();
+  public:
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  void clear_status();
+  ::com::wazuh::api::engine::ReturnStatus status() const;
+  void set_status(::com::wazuh::api::engine::ReturnStatus value);
+  private:
+  ::com::wazuh::api::engine::ReturnStatus _internal_status() const;
+  void _internal_set_status(::com::wazuh::api::engine::ReturnStatus value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.policy.AssetPost_Response)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr warning_;
+    int status_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_policy_2eproto;
+};
+// -------------------------------------------------------------------
+
 class AssetDelete_Request final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.AssetDelete_Request) */ {
  public:
@@ -1065,7 +1278,7 @@ class AssetDelete_Request final :
                &_AssetDelete_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    6;
 
   friend void swap(AssetDelete_Request& a, AssetDelete_Request& b) {
     a.Swap(&b);
@@ -1215,6 +1428,195 @@ class AssetDelete_Request final :
 };
 // -------------------------------------------------------------------
 
+class AssetDelete_Response final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.AssetDelete_Response) */ {
+ public:
+  inline AssetDelete_Response() : AssetDelete_Response(nullptr) {}
+  ~AssetDelete_Response() override;
+  explicit PROTOBUF_CONSTEXPR AssetDelete_Response(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  AssetDelete_Response(const AssetDelete_Response& from);
+  AssetDelete_Response(AssetDelete_Response&& from) noexcept
+    : AssetDelete_Response() {
+    *this = ::std::move(from);
+  }
+
+  inline AssetDelete_Response& operator=(const AssetDelete_Response& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline AssetDelete_Response& operator=(AssetDelete_Response&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const AssetDelete_Response& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const AssetDelete_Response* internal_default_instance() {
+    return reinterpret_cast<const AssetDelete_Response*>(
+               &_AssetDelete_Response_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    7;
+
+  friend void swap(AssetDelete_Response& a, AssetDelete_Response& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(AssetDelete_Response* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(AssetDelete_Response* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  AssetDelete_Response* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<AssetDelete_Response>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const AssetDelete_Response& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const AssetDelete_Response& from) {
+    AssetDelete_Response::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(AssetDelete_Response* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.policy.AssetDelete_Response";
+  }
+  protected:
+  explicit AssetDelete_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kErrorFieldNumber = 2,
+    kWarningFieldNumber = 3,
+    kStatusFieldNumber = 1,
+  };
+  // optional string error = 2;
+  bool has_error() const;
+  private:
+  bool _internal_has_error() const;
+  public:
+  void clear_error();
+  const std::string& error() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_error(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_error();
+  PROTOBUF_NODISCARD std::string* release_error();
+  void set_allocated_error(std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // optional string warning = 3;
+  bool has_warning() const;
+  private:
+  bool _internal_has_warning() const;
+  public:
+  void clear_warning();
+  const std::string& warning() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_warning(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_warning();
+  PROTOBUF_NODISCARD std::string* release_warning();
+  void set_allocated_warning(std::string* warning);
+  private:
+  const std::string& _internal_warning() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_warning(const std::string& value);
+  std::string* _internal_mutable_warning();
+  public:
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  void clear_status();
+  ::com::wazuh::api::engine::ReturnStatus status() const;
+  void set_status(::com::wazuh::api::engine::ReturnStatus value);
+  private:
+  ::com::wazuh::api::engine::ReturnStatus _internal_status() const;
+  void _internal_set_status(::com::wazuh::api::engine::ReturnStatus value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.policy.AssetDelete_Response)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr warning_;
+    int status_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_policy_2eproto;
+};
+// -------------------------------------------------------------------
+
 class AssetGet_Request final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.AssetGet_Request) */ {
  public:
@@ -1263,7 +1665,7 @@ class AssetGet_Request final :
                &_AssetGet_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    8;
 
   friend void swap(AssetGet_Request& a, AssetGet_Request& b) {
     a.Swap(&b);
@@ -1441,7 +1843,7 @@ class AssetGet_Response final :
                &_AssetGet_Response_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    7;
+    9;
 
   friend void swap(AssetGet_Response& a, AssetGet_Response& b) {
     a.Swap(&b);
@@ -1588,6 +1990,353 @@ class AssetGet_Response final :
 };
 // -------------------------------------------------------------------
 
+class AssetCleanDeleted_Request final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.AssetCleanDeleted_Request) */ {
+ public:
+  inline AssetCleanDeleted_Request() : AssetCleanDeleted_Request(nullptr) {}
+  ~AssetCleanDeleted_Request() override;
+  explicit PROTOBUF_CONSTEXPR AssetCleanDeleted_Request(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  AssetCleanDeleted_Request(const AssetCleanDeleted_Request& from);
+  AssetCleanDeleted_Request(AssetCleanDeleted_Request&& from) noexcept
+    : AssetCleanDeleted_Request() {
+    *this = ::std::move(from);
+  }
+
+  inline AssetCleanDeleted_Request& operator=(const AssetCleanDeleted_Request& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline AssetCleanDeleted_Request& operator=(AssetCleanDeleted_Request&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const AssetCleanDeleted_Request& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const AssetCleanDeleted_Request* internal_default_instance() {
+    return reinterpret_cast<const AssetCleanDeleted_Request*>(
+               &_AssetCleanDeleted_Request_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    10;
+
+  friend void swap(AssetCleanDeleted_Request& a, AssetCleanDeleted_Request& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(AssetCleanDeleted_Request* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(AssetCleanDeleted_Request* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  AssetCleanDeleted_Request* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<AssetCleanDeleted_Request>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const AssetCleanDeleted_Request& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const AssetCleanDeleted_Request& from) {
+    AssetCleanDeleted_Request::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(AssetCleanDeleted_Request* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.policy.AssetCleanDeleted_Request";
+  }
+  protected:
+  explicit AssetCleanDeleted_Request(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPolicyFieldNumber = 1,
+  };
+  // optional string policy = 1;
+  bool has_policy() const;
+  private:
+  bool _internal_has_policy() const;
+  public:
+  void clear_policy();
+  const std::string& policy() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_policy(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_policy();
+  PROTOBUF_NODISCARD std::string* release_policy();
+  void set_allocated_policy(std::string* policy);
+  private:
+  const std::string& _internal_policy() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_policy(const std::string& value);
+  std::string* _internal_mutable_policy();
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.policy.AssetCleanDeleted_Request)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr policy_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_policy_2eproto;
+};
+// -------------------------------------------------------------------
+
+class AssetCleanDeleted_Response final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.AssetCleanDeleted_Response) */ {
+ public:
+  inline AssetCleanDeleted_Response() : AssetCleanDeleted_Response(nullptr) {}
+  ~AssetCleanDeleted_Response() override;
+  explicit PROTOBUF_CONSTEXPR AssetCleanDeleted_Response(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  AssetCleanDeleted_Response(const AssetCleanDeleted_Response& from);
+  AssetCleanDeleted_Response(AssetCleanDeleted_Response&& from) noexcept
+    : AssetCleanDeleted_Response() {
+    *this = ::std::move(from);
+  }
+
+  inline AssetCleanDeleted_Response& operator=(const AssetCleanDeleted_Response& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline AssetCleanDeleted_Response& operator=(AssetCleanDeleted_Response&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const AssetCleanDeleted_Response& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const AssetCleanDeleted_Response* internal_default_instance() {
+    return reinterpret_cast<const AssetCleanDeleted_Response*>(
+               &_AssetCleanDeleted_Response_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    11;
+
+  friend void swap(AssetCleanDeleted_Response& a, AssetCleanDeleted_Response& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(AssetCleanDeleted_Response* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(AssetCleanDeleted_Response* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  AssetCleanDeleted_Response* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<AssetCleanDeleted_Response>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const AssetCleanDeleted_Response& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const AssetCleanDeleted_Response& from) {
+    AssetCleanDeleted_Response::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(AssetCleanDeleted_Response* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.policy.AssetCleanDeleted_Response";
+  }
+  protected:
+  explicit AssetCleanDeleted_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kErrorFieldNumber = 2,
+    kDataFieldNumber = 3,
+    kStatusFieldNumber = 1,
+  };
+  // optional string error = 2;
+  bool has_error() const;
+  private:
+  bool _internal_has_error() const;
+  public:
+  void clear_error();
+  const std::string& error() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_error(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_error();
+  PROTOBUF_NODISCARD std::string* release_error();
+  void set_allocated_error(std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // optional string data = 3;
+  bool has_data() const;
+  private:
+  bool _internal_has_data() const;
+  public:
+  void clear_data();
+  const std::string& data() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_data(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_data();
+  PROTOBUF_NODISCARD std::string* release_data();
+  void set_allocated_data(std::string* data);
+  private:
+  const std::string& _internal_data() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_data(const std::string& value);
+  std::string* _internal_mutable_data();
+  public:
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  void clear_status();
+  ::com::wazuh::api::engine::ReturnStatus status() const;
+  void set_status(::com::wazuh::api::engine::ReturnStatus value);
+  private:
+  ::com::wazuh::api::engine::ReturnStatus _internal_status() const;
+  void _internal_set_status(::com::wazuh::api::engine::ReturnStatus value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.policy.AssetCleanDeleted_Response)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr data_;
+    int status_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_policy_2eproto;
+};
+// -------------------------------------------------------------------
+
 class DefaultParentGet_Request final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.DefaultParentGet_Request) */ {
  public:
@@ -1636,7 +2385,7 @@ class DefaultParentGet_Request final :
                &_DefaultParentGet_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    12;
 
   friend void swap(DefaultParentGet_Request& a, DefaultParentGet_Request& b) {
     a.Swap(&b);
@@ -1814,7 +2563,7 @@ class DefaultParentGet_Response final :
                &_DefaultParentGet_Response_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    13;
 
   friend void swap(DefaultParentGet_Response& a, DefaultParentGet_Response& b) {
     a.Swap(&b);
@@ -2009,7 +2758,7 @@ class DefaultParentPost_Request final :
                &_DefaultParentPost_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    14;
 
   friend void swap(DefaultParentPost_Request& a, DefaultParentPost_Request& b) {
     a.Swap(&b);
@@ -2159,6 +2908,195 @@ class DefaultParentPost_Request final :
 };
 // -------------------------------------------------------------------
 
+class DefaultParentPost_Response final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.DefaultParentPost_Response) */ {
+ public:
+  inline DefaultParentPost_Response() : DefaultParentPost_Response(nullptr) {}
+  ~DefaultParentPost_Response() override;
+  explicit PROTOBUF_CONSTEXPR DefaultParentPost_Response(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  DefaultParentPost_Response(const DefaultParentPost_Response& from);
+  DefaultParentPost_Response(DefaultParentPost_Response&& from) noexcept
+    : DefaultParentPost_Response() {
+    *this = ::std::move(from);
+  }
+
+  inline DefaultParentPost_Response& operator=(const DefaultParentPost_Response& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline DefaultParentPost_Response& operator=(DefaultParentPost_Response&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const DefaultParentPost_Response& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const DefaultParentPost_Response* internal_default_instance() {
+    return reinterpret_cast<const DefaultParentPost_Response*>(
+               &_DefaultParentPost_Response_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    15;
+
+  friend void swap(DefaultParentPost_Response& a, DefaultParentPost_Response& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(DefaultParentPost_Response* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(DefaultParentPost_Response* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  DefaultParentPost_Response* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<DefaultParentPost_Response>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const DefaultParentPost_Response& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const DefaultParentPost_Response& from) {
+    DefaultParentPost_Response::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(DefaultParentPost_Response* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.policy.DefaultParentPost_Response";
+  }
+  protected:
+  explicit DefaultParentPost_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kErrorFieldNumber = 2,
+    kWarningFieldNumber = 3,
+    kStatusFieldNumber = 1,
+  };
+  // optional string error = 2;
+  bool has_error() const;
+  private:
+  bool _internal_has_error() const;
+  public:
+  void clear_error();
+  const std::string& error() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_error(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_error();
+  PROTOBUF_NODISCARD std::string* release_error();
+  void set_allocated_error(std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // optional string warning = 3;
+  bool has_warning() const;
+  private:
+  bool _internal_has_warning() const;
+  public:
+  void clear_warning();
+  const std::string& warning() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_warning(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_warning();
+  PROTOBUF_NODISCARD std::string* release_warning();
+  void set_allocated_warning(std::string* warning);
+  private:
+  const std::string& _internal_warning() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_warning(const std::string& value);
+  std::string* _internal_mutable_warning();
+  public:
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  void clear_status();
+  ::com::wazuh::api::engine::ReturnStatus status() const;
+  void set_status(::com::wazuh::api::engine::ReturnStatus value);
+  private:
+  ::com::wazuh::api::engine::ReturnStatus _internal_status() const;
+  void _internal_set_status(::com::wazuh::api::engine::ReturnStatus value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.policy.DefaultParentPost_Response)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr warning_;
+    int status_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_policy_2eproto;
+};
+// -------------------------------------------------------------------
+
 class DefaultParentDelete_Request final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.DefaultParentDelete_Request) */ {
  public:
@@ -2207,7 +3145,7 @@ class DefaultParentDelete_Request final :
                &_DefaultParentDelete_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    16;
 
   friend void swap(DefaultParentDelete_Request& a, DefaultParentDelete_Request& b) {
     a.Swap(&b);
@@ -2357,6 +3295,195 @@ class DefaultParentDelete_Request final :
 };
 // -------------------------------------------------------------------
 
+class DefaultParentDelete_Response final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.DefaultParentDelete_Response) */ {
+ public:
+  inline DefaultParentDelete_Response() : DefaultParentDelete_Response(nullptr) {}
+  ~DefaultParentDelete_Response() override;
+  explicit PROTOBUF_CONSTEXPR DefaultParentDelete_Response(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  DefaultParentDelete_Response(const DefaultParentDelete_Response& from);
+  DefaultParentDelete_Response(DefaultParentDelete_Response&& from) noexcept
+    : DefaultParentDelete_Response() {
+    *this = ::std::move(from);
+  }
+
+  inline DefaultParentDelete_Response& operator=(const DefaultParentDelete_Response& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline DefaultParentDelete_Response& operator=(DefaultParentDelete_Response&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const DefaultParentDelete_Response& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const DefaultParentDelete_Response* internal_default_instance() {
+    return reinterpret_cast<const DefaultParentDelete_Response*>(
+               &_DefaultParentDelete_Response_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    17;
+
+  friend void swap(DefaultParentDelete_Response& a, DefaultParentDelete_Response& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(DefaultParentDelete_Response* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(DefaultParentDelete_Response* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  DefaultParentDelete_Response* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<DefaultParentDelete_Response>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const DefaultParentDelete_Response& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const DefaultParentDelete_Response& from) {
+    DefaultParentDelete_Response::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(DefaultParentDelete_Response* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "com.wazuh.api.engine.policy.DefaultParentDelete_Response";
+  }
+  protected:
+  explicit DefaultParentDelete_Response(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kErrorFieldNumber = 2,
+    kWarningFieldNumber = 3,
+    kStatusFieldNumber = 1,
+  };
+  // optional string error = 2;
+  bool has_error() const;
+  private:
+  bool _internal_has_error() const;
+  public:
+  void clear_error();
+  const std::string& error() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_error(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_error();
+  PROTOBUF_NODISCARD std::string* release_error();
+  void set_allocated_error(std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // optional string warning = 3;
+  bool has_warning() const;
+  private:
+  bool _internal_has_warning() const;
+  public:
+  void clear_warning();
+  const std::string& warning() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_warning(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_warning();
+  PROTOBUF_NODISCARD std::string* release_warning();
+  void set_allocated_warning(std::string* warning);
+  private:
+  const std::string& _internal_warning() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_warning(const std::string& value);
+  std::string* _internal_mutable_warning();
+  public:
+
+  // .com.wazuh.api.engine.ReturnStatus status = 1;
+  void clear_status();
+  ::com::wazuh::api::engine::ReturnStatus status() const;
+  void set_status(::com::wazuh::api::engine::ReturnStatus value);
+  private:
+  ::com::wazuh::api::engine::ReturnStatus _internal_status() const;
+  void _internal_set_status(::com::wazuh::api::engine::ReturnStatus value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.policy.DefaultParentDelete_Response)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr warning_;
+    int status_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_policy_2eproto;
+};
+// -------------------------------------------------------------------
+
 class PoliciesGet_Request final :
     public ::PROTOBUF_NAMESPACE_ID::internal::ZeroFieldsBase /* @@protoc_insertion_point(class_definition:com.wazuh.api.engine.policy.PoliciesGet_Request) */ {
  public:
@@ -2404,7 +3531,7 @@ class PoliciesGet_Request final :
                &_PoliciesGet_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    18;
 
   friend void swap(PoliciesGet_Request& a, PoliciesGet_Request& b) {
     a.Swap(&b);
@@ -2523,7 +3650,7 @@ class PoliciesGet_Response final :
                &_PoliciesGet_Response_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    19;
 
   friend void swap(PoliciesGet_Response& a, PoliciesGet_Response& b) {
     a.Swap(&b);
@@ -2718,7 +3845,7 @@ class NamespacesGet_Request final :
                &_NamespacesGet_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    14;
+    20;
 
   friend void swap(NamespacesGet_Request& a, NamespacesGet_Request& b) {
     a.Swap(&b);
@@ -2876,7 +4003,7 @@ class NamespacesGet_Response final :
                &_NamespacesGet_Response_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    15;
+    21;
 
   friend void swap(NamespacesGet_Response& a, NamespacesGet_Response& b) {
     a.Swap(&b);
@@ -3689,6 +4816,166 @@ inline void AssetPost_Request::set_allocated_namespace_(std::string* namespace_)
 
 // -------------------------------------------------------------------
 
+// AssetPost_Response
+
+// .com.wazuh.api.engine.ReturnStatus status = 1;
+inline void AssetPost_Response::clear_status() {
+  _impl_.status_ = 0;
+}
+inline ::com::wazuh::api::engine::ReturnStatus AssetPost_Response::_internal_status() const {
+  return static_cast< ::com::wazuh::api::engine::ReturnStatus >(_impl_.status_);
+}
+inline ::com::wazuh::api::engine::ReturnStatus AssetPost_Response::status() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetPost_Response.status)
+  return _internal_status();
+}
+inline void AssetPost_Response::_internal_set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  
+  _impl_.status_ = value;
+}
+inline void AssetPost_Response::set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  _internal_set_status(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetPost_Response.status)
+}
+
+// optional string error = 2;
+inline bool AssetPost_Response::_internal_has_error() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool AssetPost_Response::has_error() const {
+  return _internal_has_error();
+}
+inline void AssetPost_Response::clear_error() {
+  _impl_.error_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& AssetPost_Response::error() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetPost_Response.error)
+  return _internal_error();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void AssetPost_Response::set_error(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.error_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetPost_Response.error)
+}
+inline std::string* AssetPost_Response::mutable_error() {
+  std::string* _s = _internal_mutable_error();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.AssetPost_Response.error)
+  return _s;
+}
+inline const std::string& AssetPost_Response::_internal_error() const {
+  return _impl_.error_.Get();
+}
+inline void AssetPost_Response::_internal_set_error(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.error_.Set(value, GetArenaForAllocation());
+}
+inline std::string* AssetPost_Response::_internal_mutable_error() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.error_.Mutable(GetArenaForAllocation());
+}
+inline std::string* AssetPost_Response::release_error() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.AssetPost_Response.error)
+  if (!_internal_has_error()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.error_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void AssetPost_Response::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.error_.SetAllocated(error, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetPost_Response.error)
+}
+
+// optional string warning = 3;
+inline bool AssetPost_Response::_internal_has_warning() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool AssetPost_Response::has_warning() const {
+  return _internal_has_warning();
+}
+inline void AssetPost_Response::clear_warning() {
+  _impl_.warning_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline const std::string& AssetPost_Response::warning() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetPost_Response.warning)
+  return _internal_warning();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void AssetPost_Response::set_warning(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000002u;
+ _impl_.warning_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetPost_Response.warning)
+}
+inline std::string* AssetPost_Response::mutable_warning() {
+  std::string* _s = _internal_mutable_warning();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.AssetPost_Response.warning)
+  return _s;
+}
+inline const std::string& AssetPost_Response::_internal_warning() const {
+  return _impl_.warning_.Get();
+}
+inline void AssetPost_Response::_internal_set_warning(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.warning_.Set(value, GetArenaForAllocation());
+}
+inline std::string* AssetPost_Response::_internal_mutable_warning() {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  return _impl_.warning_.Mutable(GetArenaForAllocation());
+}
+inline std::string* AssetPost_Response::release_warning() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.AssetPost_Response.warning)
+  if (!_internal_has_warning()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  auto* p = _impl_.warning_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void AssetPost_Response::set_allocated_warning(std::string* warning) {
+  if (warning != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  _impl_.warning_.SetAllocated(warning, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetPost_Response.warning)
+}
+
+// -------------------------------------------------------------------
+
 // AssetDelete_Request
 
 // optional string policy = 1;
@@ -3893,6 +5180,166 @@ inline void AssetDelete_Request::set_allocated_namespace_(std::string* namespace
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetDelete_Request.namespace)
+}
+
+// -------------------------------------------------------------------
+
+// AssetDelete_Response
+
+// .com.wazuh.api.engine.ReturnStatus status = 1;
+inline void AssetDelete_Response::clear_status() {
+  _impl_.status_ = 0;
+}
+inline ::com::wazuh::api::engine::ReturnStatus AssetDelete_Response::_internal_status() const {
+  return static_cast< ::com::wazuh::api::engine::ReturnStatus >(_impl_.status_);
+}
+inline ::com::wazuh::api::engine::ReturnStatus AssetDelete_Response::status() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetDelete_Response.status)
+  return _internal_status();
+}
+inline void AssetDelete_Response::_internal_set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  
+  _impl_.status_ = value;
+}
+inline void AssetDelete_Response::set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  _internal_set_status(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetDelete_Response.status)
+}
+
+// optional string error = 2;
+inline bool AssetDelete_Response::_internal_has_error() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool AssetDelete_Response::has_error() const {
+  return _internal_has_error();
+}
+inline void AssetDelete_Response::clear_error() {
+  _impl_.error_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& AssetDelete_Response::error() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetDelete_Response.error)
+  return _internal_error();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void AssetDelete_Response::set_error(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.error_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetDelete_Response.error)
+}
+inline std::string* AssetDelete_Response::mutable_error() {
+  std::string* _s = _internal_mutable_error();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.AssetDelete_Response.error)
+  return _s;
+}
+inline const std::string& AssetDelete_Response::_internal_error() const {
+  return _impl_.error_.Get();
+}
+inline void AssetDelete_Response::_internal_set_error(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.error_.Set(value, GetArenaForAllocation());
+}
+inline std::string* AssetDelete_Response::_internal_mutable_error() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.error_.Mutable(GetArenaForAllocation());
+}
+inline std::string* AssetDelete_Response::release_error() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.AssetDelete_Response.error)
+  if (!_internal_has_error()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.error_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void AssetDelete_Response::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.error_.SetAllocated(error, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetDelete_Response.error)
+}
+
+// optional string warning = 3;
+inline bool AssetDelete_Response::_internal_has_warning() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool AssetDelete_Response::has_warning() const {
+  return _internal_has_warning();
+}
+inline void AssetDelete_Response::clear_warning() {
+  _impl_.warning_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline const std::string& AssetDelete_Response::warning() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetDelete_Response.warning)
+  return _internal_warning();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void AssetDelete_Response::set_warning(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000002u;
+ _impl_.warning_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetDelete_Response.warning)
+}
+inline std::string* AssetDelete_Response::mutable_warning() {
+  std::string* _s = _internal_mutable_warning();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.AssetDelete_Response.warning)
+  return _s;
+}
+inline const std::string& AssetDelete_Response::_internal_warning() const {
+  return _impl_.warning_.Get();
+}
+inline void AssetDelete_Response::_internal_set_warning(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.warning_.Set(value, GetArenaForAllocation());
+}
+inline std::string* AssetDelete_Response::_internal_mutable_warning() {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  return _impl_.warning_.Mutable(GetArenaForAllocation());
+}
+inline std::string* AssetDelete_Response::release_warning() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.AssetDelete_Response.warning)
+  if (!_internal_has_warning()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  auto* p = _impl_.warning_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void AssetDelete_Response::set_allocated_warning(std::string* warning) {
+  if (warning != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  _impl_.warning_.SetAllocated(warning, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetDelete_Response.warning)
 }
 
 // -------------------------------------------------------------------
@@ -4200,6 +5647,238 @@ inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
 AssetGet_Response::mutable_data() {
   // @@protoc_insertion_point(field_mutable_list:com.wazuh.api.engine.policy.AssetGet_Response.data)
   return &_impl_.data_;
+}
+
+// -------------------------------------------------------------------
+
+// AssetCleanDeleted_Request
+
+// optional string policy = 1;
+inline bool AssetCleanDeleted_Request::_internal_has_policy() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool AssetCleanDeleted_Request::has_policy() const {
+  return _internal_has_policy();
+}
+inline void AssetCleanDeleted_Request::clear_policy() {
+  _impl_.policy_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& AssetCleanDeleted_Request::policy() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetCleanDeleted_Request.policy)
+  return _internal_policy();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void AssetCleanDeleted_Request::set_policy(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.policy_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetCleanDeleted_Request.policy)
+}
+inline std::string* AssetCleanDeleted_Request::mutable_policy() {
+  std::string* _s = _internal_mutable_policy();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.AssetCleanDeleted_Request.policy)
+  return _s;
+}
+inline const std::string& AssetCleanDeleted_Request::_internal_policy() const {
+  return _impl_.policy_.Get();
+}
+inline void AssetCleanDeleted_Request::_internal_set_policy(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.policy_.Set(value, GetArenaForAllocation());
+}
+inline std::string* AssetCleanDeleted_Request::_internal_mutable_policy() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.policy_.Mutable(GetArenaForAllocation());
+}
+inline std::string* AssetCleanDeleted_Request::release_policy() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.AssetCleanDeleted_Request.policy)
+  if (!_internal_has_policy()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.policy_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.policy_.IsDefault()) {
+    _impl_.policy_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void AssetCleanDeleted_Request::set_allocated_policy(std::string* policy) {
+  if (policy != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.policy_.SetAllocated(policy, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.policy_.IsDefault()) {
+    _impl_.policy_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetCleanDeleted_Request.policy)
+}
+
+// -------------------------------------------------------------------
+
+// AssetCleanDeleted_Response
+
+// .com.wazuh.api.engine.ReturnStatus status = 1;
+inline void AssetCleanDeleted_Response::clear_status() {
+  _impl_.status_ = 0;
+}
+inline ::com::wazuh::api::engine::ReturnStatus AssetCleanDeleted_Response::_internal_status() const {
+  return static_cast< ::com::wazuh::api::engine::ReturnStatus >(_impl_.status_);
+}
+inline ::com::wazuh::api::engine::ReturnStatus AssetCleanDeleted_Response::status() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.status)
+  return _internal_status();
+}
+inline void AssetCleanDeleted_Response::_internal_set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  
+  _impl_.status_ = value;
+}
+inline void AssetCleanDeleted_Response::set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  _internal_set_status(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.status)
+}
+
+// optional string error = 2;
+inline bool AssetCleanDeleted_Response::_internal_has_error() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool AssetCleanDeleted_Response::has_error() const {
+  return _internal_has_error();
+}
+inline void AssetCleanDeleted_Response::clear_error() {
+  _impl_.error_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& AssetCleanDeleted_Response::error() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.error)
+  return _internal_error();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void AssetCleanDeleted_Response::set_error(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.error_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.error)
+}
+inline std::string* AssetCleanDeleted_Response::mutable_error() {
+  std::string* _s = _internal_mutable_error();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.error)
+  return _s;
+}
+inline const std::string& AssetCleanDeleted_Response::_internal_error() const {
+  return _impl_.error_.Get();
+}
+inline void AssetCleanDeleted_Response::_internal_set_error(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.error_.Set(value, GetArenaForAllocation());
+}
+inline std::string* AssetCleanDeleted_Response::_internal_mutable_error() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.error_.Mutable(GetArenaForAllocation());
+}
+inline std::string* AssetCleanDeleted_Response::release_error() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.error)
+  if (!_internal_has_error()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.error_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void AssetCleanDeleted_Response::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.error_.SetAllocated(error, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.error)
+}
+
+// optional string data = 3;
+inline bool AssetCleanDeleted_Response::_internal_has_data() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool AssetCleanDeleted_Response::has_data() const {
+  return _internal_has_data();
+}
+inline void AssetCleanDeleted_Response::clear_data() {
+  _impl_.data_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline const std::string& AssetCleanDeleted_Response::data() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.data)
+  return _internal_data();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void AssetCleanDeleted_Response::set_data(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000002u;
+ _impl_.data_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.data)
+}
+inline std::string* AssetCleanDeleted_Response::mutable_data() {
+  std::string* _s = _internal_mutable_data();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.data)
+  return _s;
+}
+inline const std::string& AssetCleanDeleted_Response::_internal_data() const {
+  return _impl_.data_.Get();
+}
+inline void AssetCleanDeleted_Response::_internal_set_data(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.data_.Set(value, GetArenaForAllocation());
+}
+inline std::string* AssetCleanDeleted_Response::_internal_mutable_data() {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  return _impl_.data_.Mutable(GetArenaForAllocation());
+}
+inline std::string* AssetCleanDeleted_Response::release_data() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.data)
+  if (!_internal_has_data()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  auto* p = _impl_.data_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.data_.IsDefault()) {
+    _impl_.data_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void AssetCleanDeleted_Response::set_allocated_data(std::string* data) {
+  if (data != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  _impl_.data_.SetAllocated(data, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.data_.IsDefault()) {
+    _impl_.data_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.AssetCleanDeleted_Response.data)
 }
 
 // -------------------------------------------------------------------
@@ -4719,6 +6398,166 @@ inline void DefaultParentPost_Request::set_allocated_parent(std::string* parent)
 
 // -------------------------------------------------------------------
 
+// DefaultParentPost_Response
+
+// .com.wazuh.api.engine.ReturnStatus status = 1;
+inline void DefaultParentPost_Response::clear_status() {
+  _impl_.status_ = 0;
+}
+inline ::com::wazuh::api::engine::ReturnStatus DefaultParentPost_Response::_internal_status() const {
+  return static_cast< ::com::wazuh::api::engine::ReturnStatus >(_impl_.status_);
+}
+inline ::com::wazuh::api::engine::ReturnStatus DefaultParentPost_Response::status() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.DefaultParentPost_Response.status)
+  return _internal_status();
+}
+inline void DefaultParentPost_Response::_internal_set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  
+  _impl_.status_ = value;
+}
+inline void DefaultParentPost_Response::set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  _internal_set_status(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.DefaultParentPost_Response.status)
+}
+
+// optional string error = 2;
+inline bool DefaultParentPost_Response::_internal_has_error() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool DefaultParentPost_Response::has_error() const {
+  return _internal_has_error();
+}
+inline void DefaultParentPost_Response::clear_error() {
+  _impl_.error_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& DefaultParentPost_Response::error() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.DefaultParentPost_Response.error)
+  return _internal_error();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void DefaultParentPost_Response::set_error(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.error_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.DefaultParentPost_Response.error)
+}
+inline std::string* DefaultParentPost_Response::mutable_error() {
+  std::string* _s = _internal_mutable_error();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.DefaultParentPost_Response.error)
+  return _s;
+}
+inline const std::string& DefaultParentPost_Response::_internal_error() const {
+  return _impl_.error_.Get();
+}
+inline void DefaultParentPost_Response::_internal_set_error(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.error_.Set(value, GetArenaForAllocation());
+}
+inline std::string* DefaultParentPost_Response::_internal_mutable_error() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.error_.Mutable(GetArenaForAllocation());
+}
+inline std::string* DefaultParentPost_Response::release_error() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.DefaultParentPost_Response.error)
+  if (!_internal_has_error()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.error_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void DefaultParentPost_Response::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.error_.SetAllocated(error, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.DefaultParentPost_Response.error)
+}
+
+// optional string warning = 3;
+inline bool DefaultParentPost_Response::_internal_has_warning() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool DefaultParentPost_Response::has_warning() const {
+  return _internal_has_warning();
+}
+inline void DefaultParentPost_Response::clear_warning() {
+  _impl_.warning_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline const std::string& DefaultParentPost_Response::warning() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.DefaultParentPost_Response.warning)
+  return _internal_warning();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void DefaultParentPost_Response::set_warning(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000002u;
+ _impl_.warning_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.DefaultParentPost_Response.warning)
+}
+inline std::string* DefaultParentPost_Response::mutable_warning() {
+  std::string* _s = _internal_mutable_warning();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.DefaultParentPost_Response.warning)
+  return _s;
+}
+inline const std::string& DefaultParentPost_Response::_internal_warning() const {
+  return _impl_.warning_.Get();
+}
+inline void DefaultParentPost_Response::_internal_set_warning(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.warning_.Set(value, GetArenaForAllocation());
+}
+inline std::string* DefaultParentPost_Response::_internal_mutable_warning() {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  return _impl_.warning_.Mutable(GetArenaForAllocation());
+}
+inline std::string* DefaultParentPost_Response::release_warning() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.DefaultParentPost_Response.warning)
+  if (!_internal_has_warning()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  auto* p = _impl_.warning_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void DefaultParentPost_Response::set_allocated_warning(std::string* warning) {
+  if (warning != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  _impl_.warning_.SetAllocated(warning, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.DefaultParentPost_Response.warning)
+}
+
+// -------------------------------------------------------------------
+
 // DefaultParentDelete_Request
 
 // optional string policy = 1;
@@ -4923,6 +6762,166 @@ inline void DefaultParentDelete_Request::set_allocated_parent(std::string* paren
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.DefaultParentDelete_Request.parent)
+}
+
+// -------------------------------------------------------------------
+
+// DefaultParentDelete_Response
+
+// .com.wazuh.api.engine.ReturnStatus status = 1;
+inline void DefaultParentDelete_Response::clear_status() {
+  _impl_.status_ = 0;
+}
+inline ::com::wazuh::api::engine::ReturnStatus DefaultParentDelete_Response::_internal_status() const {
+  return static_cast< ::com::wazuh::api::engine::ReturnStatus >(_impl_.status_);
+}
+inline ::com::wazuh::api::engine::ReturnStatus DefaultParentDelete_Response::status() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.DefaultParentDelete_Response.status)
+  return _internal_status();
+}
+inline void DefaultParentDelete_Response::_internal_set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  
+  _impl_.status_ = value;
+}
+inline void DefaultParentDelete_Response::set_status(::com::wazuh::api::engine::ReturnStatus value) {
+  _internal_set_status(value);
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.DefaultParentDelete_Response.status)
+}
+
+// optional string error = 2;
+inline bool DefaultParentDelete_Response::_internal_has_error() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
+}
+inline bool DefaultParentDelete_Response::has_error() const {
+  return _internal_has_error();
+}
+inline void DefaultParentDelete_Response::clear_error() {
+  _impl_.error_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const std::string& DefaultParentDelete_Response::error() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.DefaultParentDelete_Response.error)
+  return _internal_error();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void DefaultParentDelete_Response::set_error(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
+ _impl_.error_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.DefaultParentDelete_Response.error)
+}
+inline std::string* DefaultParentDelete_Response::mutable_error() {
+  std::string* _s = _internal_mutable_error();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.DefaultParentDelete_Response.error)
+  return _s;
+}
+inline const std::string& DefaultParentDelete_Response::_internal_error() const {
+  return _impl_.error_.Get();
+}
+inline void DefaultParentDelete_Response::_internal_set_error(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.error_.Set(value, GetArenaForAllocation());
+}
+inline std::string* DefaultParentDelete_Response::_internal_mutable_error() {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  return _impl_.error_.Mutable(GetArenaForAllocation());
+}
+inline std::string* DefaultParentDelete_Response::release_error() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.DefaultParentDelete_Response.error)
+  if (!_internal_has_error()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.error_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void DefaultParentDelete_Response::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  _impl_.error_.SetAllocated(error, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.error_.IsDefault()) {
+    _impl_.error_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.DefaultParentDelete_Response.error)
+}
+
+// optional string warning = 3;
+inline bool DefaultParentDelete_Response::_internal_has_warning() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool DefaultParentDelete_Response::has_warning() const {
+  return _internal_has_warning();
+}
+inline void DefaultParentDelete_Response::clear_warning() {
+  _impl_.warning_.ClearToEmpty();
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline const std::string& DefaultParentDelete_Response::warning() const {
+  // @@protoc_insertion_point(field_get:com.wazuh.api.engine.policy.DefaultParentDelete_Response.warning)
+  return _internal_warning();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void DefaultParentDelete_Response::set_warning(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000002u;
+ _impl_.warning_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.policy.DefaultParentDelete_Response.warning)
+}
+inline std::string* DefaultParentDelete_Response::mutable_warning() {
+  std::string* _s = _internal_mutable_warning();
+  // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.policy.DefaultParentDelete_Response.warning)
+  return _s;
+}
+inline const std::string& DefaultParentDelete_Response::_internal_warning() const {
+  return _impl_.warning_.Get();
+}
+inline void DefaultParentDelete_Response::_internal_set_warning(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.warning_.Set(value, GetArenaForAllocation());
+}
+inline std::string* DefaultParentDelete_Response::_internal_mutable_warning() {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  return _impl_.warning_.Mutable(GetArenaForAllocation());
+}
+inline std::string* DefaultParentDelete_Response::release_warning() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.policy.DefaultParentDelete_Response.warning)
+  if (!_internal_has_warning()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000002u;
+  auto* p = _impl_.warning_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
+}
+inline void DefaultParentDelete_Response::set_allocated_warning(std::string* warning) {
+  if (warning != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000002u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000002u;
+  }
+  _impl_.warning_.SetAllocated(warning, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.warning_.IsDefault()) {
+    _impl_.warning_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.policy.DefaultParentDelete_Response.warning)
 }
 
 // -------------------------------------------------------------------
@@ -5338,6 +7337,18 @@ NamespacesGet_Response::mutable_data() {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/engine/source/proto/src/policy.proto
+++ b/src/engine/source/proto/src/policy.proto
@@ -66,7 +66,12 @@ message AssetPost_Request
     optional string namespace = 3; // Namespace of the asset
 }
 
-// message AssetPost_Response -> Return a GenericStatus_Response
+message AssetPost_Response
+{
+    ReturnStatus status = 1;     // Status of the query
+    optional string error = 2;   // Error message if status is ERROR
+    optional string warning = 3; // Warning message if validation errors
+}
 
 /***************************************************
  * Delete an asset from a policy
@@ -80,7 +85,12 @@ message AssetDelete_Request
     optional string namespace = 3; // Namespace of the asset
 }
 
-// message AssetDelete_Response -> Return a GenericStatus_Response
+message AssetDelete_Response
+{
+    ReturnStatus status = 1;     // Status of the query
+    optional string error = 2;   // Error message if status is ERROR
+    optional string warning = 3; // Warning message if validation errors
+}
 
 /***************************************************
  * Get all assets of a namespace in a policy
@@ -98,6 +108,23 @@ message AssetGet_Response
     ReturnStatus status = 1;   // Status of the query
     optional string error = 2; // Error message if status is ERROR
     repeated string data = 3;  // List of assets
+}
+
+/***************************************************
+ * Delete assets from policy that are deleted from the catalog
+ *
+ * command: policy.asset/cleanDeleted
+ **************************************************/
+message AssetCleanDeleted_Request
+{
+    optional string policy = 1; // Policy name
+}
+
+message AssetCleanDeleted_Response
+{
+    ReturnStatus status = 1;   // Status of the query
+    optional string error = 2; // Error message if status is ERROR
+    optional string data = 3;  // Assets deleted and validation errors
 }
 
 /***************************************************
@@ -130,7 +157,12 @@ message DefaultParentPost_Request
     optional string parent = 3;    // Default parent of the namespace
 }
 
-// message DefaultParentPost_Response -> Return a GenericStatus_Response
+message DefaultParentPost_Response
+{
+    ReturnStatus status = 1;     // Status of the query
+    optional string error = 2;   // Error message if status is ERROR
+    optional string warning = 3; // Warning message if validation errors
+}
 
 /***************************************************
  * Delete default parent of a namespace in a policy
@@ -144,7 +176,12 @@ message DefaultParentDelete_Request
     optional string parent = 3;    // Default parent of the namespace
 }
 
-// message DefaultParentDelete_Response -> Return a GenericStatus_Response
+message DefaultParentDelete_Response
+{
+    ReturnStatus status = 1;     // Status of the query
+    optional string error = 2;   // Error message if status is ERROR
+    optional string warning = 3; // Warning message if validation errors
+}
 
 /***************************************************
  * Get all policies in the store

--- a/src/engine/test/helper_tests/engine_helper_test/src/runner/__main__.py
+++ b/src/engine/test/helper_tests/engine_helper_test/src/runner/__main__.py
@@ -456,8 +456,9 @@ def add_asset_to_policy(api_client: APIClient, asset: dict):
     request.policy = POLICY_NAME
     request.asset = asset["name"]
     request.namespace = NAMESPACE
-    response = send_recv(api_client, request, api_engine.GenericStatus_Response())
+    response = send_recv(api_client, request, api_policy.AssetPost_Response())
     assert response.status == api_engine.OK, f"{response.error}, Asset: {asset}"
+    assert len(response.warning) == 0, f"{response.warning}"
 
 
 def create_session(api_client: APIClient):
@@ -800,9 +801,11 @@ def main():
     api_client = APIClient(socket_path)
 
     from handler_engine_instance import up_down
+    print("Starting up_down engine")
     up_down_engine = up_down.UpDownEngine()
     up_down_engine.send_start_command()
 
+    print("running test cases")
     run_test_cases_executor(api_client, str(kvdb_path))
 
     up_down_engine.send_stop_command()

--- a/src/engine/test/integration_tests/policy/features/api.feature
+++ b/src/engine/test/integration_tests/policy/features/api.feature
@@ -85,7 +85,7 @@ Feature: Policy API Management
   Scenario: Set the non-exist default parent of a namespace
     Given I have a policy called "policy/wazuh/0"
     When I send a request to set the default parent called "default" in the namespace "wazuh"
-    Then I should receive a failed response indicating "Default parent 'default' in namespace 'wazuh' is neither a decoder or a rule"
+    Then I should receive a success response with a validation warning indicating "Saved invalid policy: Default parent 'default' in namespace 'wazuh' is neither a decoder or a rule"
 
   @exclude
   Scenario: Set the default parent of a namespace

--- a/src/engine/test/integration_tests/policy/steps/api_steps.py
+++ b/src/engine/test/integration_tests/policy/steps/api_steps.py
@@ -64,7 +64,7 @@ def add_integration_to_policy(integration_name: str, policy_name: str, namespace
     request.policy = policy_name
     request.asset = f"integration/{integration_name}/0"
     request.namespace = namespace
-    error, response = send_recv(request, api_engine.GenericStatus_Response())
+    error, response = send_recv(request, api_policy.AssetPost_Response())
     return response
 
 def remove_integration_to_policy(integration_name: str, policy_name: str, namespace: str):
@@ -72,7 +72,7 @@ def remove_integration_to_policy(integration_name: str, policy_name: str, namesp
     request.policy = policy_name
     request.asset = f"integration/{integration_name}/0"
     request.namespace = namespace
-    error, response = send_recv(request, api_engine.GenericStatus_Response())
+    error, response = send_recv(request, api_policy.AssetDelete_Response())
     return response
 
 def add_default_parent(default_parent_name: str, namespace: str):
@@ -80,7 +80,7 @@ def add_default_parent(default_parent_name: str, namespace: str):
     request.policy = "policy/wazuh/0"
     request.namespace = namespace
     request.parent = default_parent_name
-    error, response = send_recv(request, api_engine.GenericStatus_Response())
+    error, response = send_recv(request, api_policy.DefaultParentPost_Response())
     return response
 
 def get_default_parent(policy_name: str, namespace: str):
@@ -167,6 +167,11 @@ def step_impl(context, status: str, response: str):
         else:
             assert context.result.status == api_engine.ERROR, f"{context.result}"
             assert context.result.error == response, f"{context.result}"
+
+@then('I should receive a success response with a validation warning indicating "{response}"')
+def step_impl(context, response: str):
+    assert context.result.status == api_engine.OK, f"{context.result}"
+    assert context.result.warning == response, f"{context.result}"
 
 @then('I should receive a {status} response')
 def step_impl(context, status: str):

--- a/src/engine/test/integration_tests/router/steps/api_steps.py
+++ b/src/engine/test/integration_tests/router/steps/api_steps.py
@@ -47,14 +47,14 @@ def create_policy(policy_name: str):
 def delete_policy(policy_name: str):
     request = api_policy.StoreDelete_Request()
     request.policy = policy_name
-    error, response = send_recv(request, api_policy.PoliciesGet_Response())
+    error, response = send_recv(request, api_engine.GenericStatus_Response())
 
 def add_integration_to_policy(integration_name: str, policy_name: str):
     request = api_policy.AssetPost_Request()
     request.policy = policy_name
     request.asset = f"integration/{integration_name}/0"
     request.namespace = "system"
-    error, response = send_recv(request, api_engine.GenericStatus_Response())
+    error, response = send_recv(request, api_policy.AssetPost_Response())
     assert error is None, f"{error}"
 
 def policy_tear_down(policy_name: str, integration_name: str):

--- a/src/engine/test/integration_tests/tester/steps/api_steps.py
+++ b/src/engine/test/integration_tests/tester/steps/api_steps.py
@@ -49,14 +49,14 @@ def create_policy(policy_name: str):
 def delete_policy(policy_name: str):
     request = api_policy.StoreDelete_Request()
     request.policy = policy_name
-    error, response = send_recv(request, api_policy.PoliciesGet_Response())
+    error, response = send_recv(request, api_engine.GenericStatus_Response())
 
 def add_integration_to_policy(integration_name: str, policy_name: str):
     request = api_policy.AssetPost_Request()
     request.policy = policy_name
     request.asset = f"integration/{integration_name}/0"
     request.namespace = "system"
-    error, response = send_recv(request, api_engine.GenericStatus_Response())
+    error, response = send_recv(request, api_policy.AssetPost_Response())
     assert error is None, f"{error}"
 
 def policy_tear_down(policy_name: str, integration_name: str):

--- a/src/engine/tools/api-communication/src/api_communication/command.py
+++ b/src/engine/tools/api-communication/src/api_communication/command.py
@@ -103,6 +103,8 @@ def get_command(message: Message) -> Tuple[Optional[str], str]:
         return None, 'policy.policies/get'
     elif isinstance(message, policy.NamespacesGet_Request):
         return None, 'policy.namespaces/get'
+    elif isinstance(message, policy.AssetCleanDeleted_Request):
+        return None, 'policy.asset/cleanDeleted'
 
     # Router
     elif isinstance(message, router.RoutePost_Request):

--- a/src/engine/tools/api-communication/src/api_communication/proto/policy_pb2.py
+++ b/src/engine/tools/api-communication/src/api_communication/proto/policy_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 import api_communication.proto.engine_pb2 as _engine_pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cpolicy.proto\x12\x1b\x63om.wazuh.api.engine.policy\x1a\x0c\x65ngine.proto\"3\n\x11StorePost_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\t\n\x07_policy\"5\n\x13StoreDelete_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\t\n\x07_policy\"F\n\x10StoreGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x12\n\nnamespaces\x18\x02 \x03(\tB\t\n\x07_policy\"\x81\x01\n\x11StoreGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04\x64\x61ta\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\x07\n\x05_data\"w\n\x11\x41ssetPost_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05\x61sset\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x16\n\tnamespace\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x08\n\x06_assetB\x0c\n\n_namespace\"y\n\x13\x41ssetDelete_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05\x61sset\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x16\n\tnamespace\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x08\n\x06_assetB\x0c\n\n_namespace\"X\n\x10\x41ssetGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespace\"s\n\x11\x41ssetGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_error\"`\n\x18\x44\x65\x66\x61ultParentGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespace\"{\n\x19\x44\x65\x66\x61ultParentGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_error\"\x81\x01\n\x19\x44\x65\x66\x61ultParentPost_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x13\n\x06parent\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespaceB\t\n\x07_parent\"\x83\x01\n\x1b\x44\x65\x66\x61ultParentDelete_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x13\n\x06parent\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespaceB\t\n\x07_parent\"\x15\n\x13PoliciesGet_Request\"v\n\x14PoliciesGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_error\"7\n\x15NamespacesGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\t\n\x07_policy\"x\n\x16NamespacesGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_errorb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cpolicy.proto\x12\x1b\x63om.wazuh.api.engine.policy\x1a\x0c\x65ngine.proto\"3\n\x11StorePost_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\t\n\x07_policy\"5\n\x13StoreDelete_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\t\n\x07_policy\"F\n\x10StoreGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x12\n\nnamespaces\x18\x02 \x03(\tB\t\n\x07_policy\"\x81\x01\n\x11StoreGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04\x64\x61ta\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\x07\n\x05_data\"w\n\x11\x41ssetPost_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05\x61sset\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x16\n\tnamespace\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x08\n\x06_assetB\x0c\n\n_namespace\"\x88\x01\n\x12\x41ssetPost_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x07warning\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\n\n\x08_warning\"y\n\x13\x41ssetDelete_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05\x61sset\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x16\n\tnamespace\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x08\n\x06_assetB\x0c\n\n_namespace\"\x8a\x01\n\x14\x41ssetDelete_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x07warning\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\n\n\x08_warning\"X\n\x10\x41ssetGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespace\"s\n\x11\x41ssetGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_error\";\n\x19\x41ssetCleanDeleted_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\t\n\x07_policy\"\x8a\x01\n\x1a\x41ssetCleanDeleted_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04\x64\x61ta\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\x07\n\x05_data\"`\n\x18\x44\x65\x66\x61ultParentGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespace\"{\n\x19\x44\x65\x66\x61ultParentGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_error\"\x81\x01\n\x19\x44\x65\x66\x61ultParentPost_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x13\n\x06parent\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespaceB\t\n\x07_parent\"\x90\x01\n\x1a\x44\x65\x66\x61ultParentPost_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x07warning\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\n\n\x08_warning\"\x83\x01\n\x1b\x44\x65\x66\x61ultParentDelete_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x16\n\tnamespace\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x13\n\x06parent\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\t\n\x07_policyB\x0c\n\n_namespaceB\t\n\x07_parent\"\x92\x01\n\x1c\x44\x65\x66\x61ultParentDelete_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x07warning\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x08\n\x06_errorB\n\n\x08_warning\"\x15\n\x13PoliciesGet_Request\"v\n\x14PoliciesGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_error\"7\n\x15NamespacesGet_Request\x12\x13\n\x06policy\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\t\n\x07_policy\"x\n\x16NamespacesGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x0c\n\x04\x64\x61ta\x18\x03 \x03(\tB\x08\n\x06_errorb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'policy_pb2', globals())
@@ -31,26 +31,38 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _STOREGET_RESPONSE._serialized_end=369
   _ASSETPOST_REQUEST._serialized_start=371
   _ASSETPOST_REQUEST._serialized_end=490
-  _ASSETDELETE_REQUEST._serialized_start=492
-  _ASSETDELETE_REQUEST._serialized_end=613
-  _ASSETGET_REQUEST._serialized_start=615
-  _ASSETGET_REQUEST._serialized_end=703
-  _ASSETGET_RESPONSE._serialized_start=705
-  _ASSETGET_RESPONSE._serialized_end=820
-  _DEFAULTPARENTGET_REQUEST._serialized_start=822
-  _DEFAULTPARENTGET_REQUEST._serialized_end=918
-  _DEFAULTPARENTGET_RESPONSE._serialized_start=920
-  _DEFAULTPARENTGET_RESPONSE._serialized_end=1043
-  _DEFAULTPARENTPOST_REQUEST._serialized_start=1046
-  _DEFAULTPARENTPOST_REQUEST._serialized_end=1175
-  _DEFAULTPARENTDELETE_REQUEST._serialized_start=1178
-  _DEFAULTPARENTDELETE_REQUEST._serialized_end=1309
-  _POLICIESGET_REQUEST._serialized_start=1311
-  _POLICIESGET_REQUEST._serialized_end=1332
-  _POLICIESGET_RESPONSE._serialized_start=1334
-  _POLICIESGET_RESPONSE._serialized_end=1452
-  _NAMESPACESGET_REQUEST._serialized_start=1454
-  _NAMESPACESGET_REQUEST._serialized_end=1509
-  _NAMESPACESGET_RESPONSE._serialized_start=1511
-  _NAMESPACESGET_RESPONSE._serialized_end=1631
+  _ASSETPOST_RESPONSE._serialized_start=493
+  _ASSETPOST_RESPONSE._serialized_end=629
+  _ASSETDELETE_REQUEST._serialized_start=631
+  _ASSETDELETE_REQUEST._serialized_end=752
+  _ASSETDELETE_RESPONSE._serialized_start=755
+  _ASSETDELETE_RESPONSE._serialized_end=893
+  _ASSETGET_REQUEST._serialized_start=895
+  _ASSETGET_REQUEST._serialized_end=983
+  _ASSETGET_RESPONSE._serialized_start=985
+  _ASSETGET_RESPONSE._serialized_end=1100
+  _ASSETCLEANDELETED_REQUEST._serialized_start=1102
+  _ASSETCLEANDELETED_REQUEST._serialized_end=1161
+  _ASSETCLEANDELETED_RESPONSE._serialized_start=1164
+  _ASSETCLEANDELETED_RESPONSE._serialized_end=1302
+  _DEFAULTPARENTGET_REQUEST._serialized_start=1304
+  _DEFAULTPARENTGET_REQUEST._serialized_end=1400
+  _DEFAULTPARENTGET_RESPONSE._serialized_start=1402
+  _DEFAULTPARENTGET_RESPONSE._serialized_end=1525
+  _DEFAULTPARENTPOST_REQUEST._serialized_start=1528
+  _DEFAULTPARENTPOST_REQUEST._serialized_end=1657
+  _DEFAULTPARENTPOST_RESPONSE._serialized_start=1660
+  _DEFAULTPARENTPOST_RESPONSE._serialized_end=1804
+  _DEFAULTPARENTDELETE_REQUEST._serialized_start=1807
+  _DEFAULTPARENTDELETE_REQUEST._serialized_end=1938
+  _DEFAULTPARENTDELETE_RESPONSE._serialized_start=1941
+  _DEFAULTPARENTDELETE_RESPONSE._serialized_end=2087
+  _POLICIESGET_REQUEST._serialized_start=2089
+  _POLICIESGET_REQUEST._serialized_end=2110
+  _POLICIESGET_RESPONSE._serialized_start=2112
+  _POLICIESGET_RESPONSE._serialized_end=2230
+  _NAMESPACESGET_REQUEST._serialized_start=2232
+  _NAMESPACESGET_REQUEST._serialized_end=2287
+  _NAMESPACESGET_RESPONSE._serialized_start=2289
+  _NAMESPACESGET_RESPONSE._serialized_end=2409
 # @@protoc_insertion_point(module_scope)

--- a/src/engine/tools/api-communication/src/api_communication/proto/policy_pb2.pyi
+++ b/src/engine/tools/api-communication/src/api_communication/proto/policy_pb2.pyi
@@ -6,6 +6,22 @@ from typing import ClassVar as _ClassVar, Iterable as _Iterable, Optional as _Op
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
+class AssetCleanDeleted_Request(_message.Message):
+    __slots__ = ["policy"]
+    POLICY_FIELD_NUMBER: _ClassVar[int]
+    policy: str
+    def __init__(self, policy: _Optional[str] = ...) -> None: ...
+
+class AssetCleanDeleted_Response(_message.Message):
+    __slots__ = ["data", "error", "status"]
+    DATA_FIELD_NUMBER: _ClassVar[int]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    data: str
+    error: str
+    status: _engine_pb2.ReturnStatus
+    def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., data: _Optional[str] = ...) -> None: ...
+
 class AssetDelete_Request(_message.Message):
     __slots__ = ["asset", "namespace", "policy"]
     ASSET_FIELD_NUMBER: _ClassVar[int]
@@ -15,6 +31,16 @@ class AssetDelete_Request(_message.Message):
     namespace: str
     policy: str
     def __init__(self, policy: _Optional[str] = ..., asset: _Optional[str] = ..., namespace: _Optional[str] = ...) -> None: ...
+
+class AssetDelete_Response(_message.Message):
+    __slots__ = ["error", "status", "warning"]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    WARNING_FIELD_NUMBER: _ClassVar[int]
+    error: str
+    status: _engine_pb2.ReturnStatus
+    warning: str
+    def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., warning: _Optional[str] = ...) -> None: ...
 
 class AssetGet_Request(_message.Message):
     __slots__ = ["namespace", "policy"]
@@ -44,6 +70,16 @@ class AssetPost_Request(_message.Message):
     policy: str
     def __init__(self, policy: _Optional[str] = ..., asset: _Optional[str] = ..., namespace: _Optional[str] = ...) -> None: ...
 
+class AssetPost_Response(_message.Message):
+    __slots__ = ["error", "status", "warning"]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    WARNING_FIELD_NUMBER: _ClassVar[int]
+    error: str
+    status: _engine_pb2.ReturnStatus
+    warning: str
+    def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., warning: _Optional[str] = ...) -> None: ...
+
 class DefaultParentDelete_Request(_message.Message):
     __slots__ = ["namespace", "parent", "policy"]
     NAMESPACE_FIELD_NUMBER: _ClassVar[int]
@@ -53,6 +89,16 @@ class DefaultParentDelete_Request(_message.Message):
     parent: str
     policy: str
     def __init__(self, policy: _Optional[str] = ..., namespace: _Optional[str] = ..., parent: _Optional[str] = ...) -> None: ...
+
+class DefaultParentDelete_Response(_message.Message):
+    __slots__ = ["error", "status", "warning"]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    WARNING_FIELD_NUMBER: _ClassVar[int]
+    error: str
+    status: _engine_pb2.ReturnStatus
+    warning: str
+    def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., warning: _Optional[str] = ...) -> None: ...
 
 class DefaultParentGet_Request(_message.Message):
     __slots__ = ["namespace", "policy"]
@@ -81,6 +127,16 @@ class DefaultParentPost_Request(_message.Message):
     parent: str
     policy: str
     def __init__(self, policy: _Optional[str] = ..., namespace: _Optional[str] = ..., parent: _Optional[str] = ...) -> None: ...
+
+class DefaultParentPost_Response(_message.Message):
+    __slots__ = ["error", "status", "warning"]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    WARNING_FIELD_NUMBER: _ClassVar[int]
+    error: str
+    status: _engine_pb2.ReturnStatus
+    warning: str
+    def __init__(self, status: _Optional[_Union[_engine_pb2.ReturnStatus, str]] = ..., error: _Optional[str] = ..., warning: _Optional[str] = ...) -> None: ...
 
 class NamespacesGet_Request(_message.Message):
     __slots__ = ["policy"]


### PR DESCRIPTION
|Related issue|
|---|
| closes #24541 |

- A new method was added to remove deleted assets from a policy.
- Methods that modify the policy return a warning message with validation errors if any.