### PR TITLE
Fix crash during agent shutdown

### DIFF
--- a/src/wazuh_modules/wm_syscollector.c
+++ b/src/wazuh_modules/wm_syscollector.c
@@ -256,12 +256,12 @@ void* wm_sys_main(wm_sys_t *sys) {
         close(queue_fd);
         queue_fd = 0;
     }
-    so_free_library(syscollector_module);
+
 #ifndef CLIENT
     so_free_library(router_module_ptr);
     router_module_ptr = NULL;
 #endif // CLIENT
-    syscollector_module = NULL;
+
     mtinfo(WM_SYS_LOGTAG, "Module finished.");
     w_mutex_lock(&sys_stop_mutex);
     w_cond_signal(&sys_stop_condition);


### PR DESCRIPTION
|Related issue|
|---|
|Partially fixes #24376|


This pull request addresses a crash that occurs during the agent shutdown when both FIM and Syscollector are enabled. The crash happens because `syscollector.dll` is unloaded while FIM may still attempt to write logs, causing the agent to access an invalid callback.

## Fix

The proposed fix prevents the agent from unloading `syscollector.dll` during shutdown. This ensures that any remaining logging operations by FIM do not access invalid memory, preventing the crash.

## Tests

We conducted the following tests based on the observed facts:

1. Enabled `debug=2` to make the error more easily reproducible.
2. Verified that the crash no longer occurs when both FIM and Syscollector are enabled.

Due to the complexity of reproducing this race condition reliably, writing an automated test for this scenario is challenging.