### PR TITLE
Adapt azure wodle to new lib versions

### DIFF
--- a/wodles/azure/azure_services/storage.py
+++ b/wodles/azure/azure_services/storage.py
@@ -135,7 +135,6 @@ def get_blobs(
     json_file: bool,  # CHECKME
     json_inline: bool,  # CHECKME
     blob_extension: str,
-    next_marker: str = None,
     prefix: str = None,
 ):
     """Get the blobs from a container and send their content.
@@ -154,8 +153,6 @@ def get_blobs(
         Value to compare with the blobs last modified times.
     md5_hash : str
         md5 value used to search the container in the file containing the dates.
-    next_marker : str
-        Token used as a marker to continue from previous iteration.
     prefix : str, optional
         Prefix value to search blobs that match with it.
 

--- a/wodles/azure/tests/azure_services/test_storage.py
+++ b/wodles/azure/tests/azure_services/test_storage.py
@@ -324,14 +324,12 @@ def test_get_blobs(
     service_client.get_container_client.return_value = container_client
 
     container_name = 'container'
-    marker = 'marker'
     md5_hash = 'hash'
     tag = 'tag'
     get_blobs(
         container_name=container_name,
         service_client=service_client,
         md5_hash=md5_hash,
-        next_marker=marker,
         min_datetime=parse(min_date),
         max_datetime=parse(max_date),
         desired_datetime=parse(desired_date),
@@ -390,13 +388,11 @@ def test_that_empty_blobs_are_omitted(mock_logging):
     service_client.get_container_client.return_value = container_client
 
     container_name = 'container'
-    marker = 'marker'
     md5_hash = 'hash'
     get_blobs(
         container_name=container_name,
         service_client=service_client,
         md5_hash=md5_hash,
-        next_marker=marker,
         min_datetime=parse(PRESENT_DATE),
         max_datetime=parse(FUTURE_DATE),
         desired_datetime=parse(FUTURE_DATE),


### PR DESCRIPTION
|Related issue|
|---|
| #24061 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This issue closes #24061. Adapts the azure wodle to the new libs version introduced in #24129.

## Tests

```python
(framework) ➜  wazuh git:(bug/24061-adapt-new-azure-lib-version) ✗ PYTHONPATH=$WAZUH_REPO/api:$WAZUH_REPO/framework python -m pytest wodles/azure/tests/
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/nstefani/git/wazuh/wodles
configfile: pytest.ini
plugins: aiohttp-1.0.4, asyncio-0.18.1, tavern-1.23.5, trio-0.8.0, html-2.1.1, metadata-3.1.1
asyncio: mode=auto
collected 148 items

wodles/azure/tests/test_azure_utils.py ...................................................                                                                                                                    [ 34%]
wodles/azure/tests/azure_services/test_analytics.py ..................                                                                                                                                        [ 46%]
wodles/azure/tests/azure_services/test_graph.py ............                                                                                                                                                  [ 54%]
wodles/azure/tests/azure_services/test_storage.py ...........................                                                                                                                                 [ 72%]
wodles/azure/tests/db/test_db_utils.py .........                                                                                                                                                              [ 79%]
wodles/azure/tests/db/test_orm.py ...............................                                                                                                                                             [100%]

================================================================================================ 148 passed in 1.30s ================================================================================================
```

## Logs/Alerts example

```bash
root@wazuh-master:/var/ossec# wpy wodles/azure/azure-logs.py --storage --storage_auth_path /var/ossec/wodles/azure/storage.credentials --container "frameworktestcontainer" --blobs "*" --storage_tag azure-activity --storage_time_offset 30d --debug 1
```

<details><summary>Module output</summary>
<p>

```bash
2024/07/18 19:53:49 azure: INFO: Checking database integrity
2024/07/18 19:53:49 azure: INFO: Database integrity check finished
2024/07/18 19:53:49 azure: INFO: Azure Storage starting.
2024/07/18 19:53:49 azure: INFO: Storage: Authenticating.
2024/07/18 19:53:49 azure: INFO: Request URL: 'https://frameworkteststorage.blob.core.windows.net/frameworktestcontainer?restype=REDACTED'
Request method: 'GET'
Request headers:
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'azsdk-python-storage-blob/12.19.1 Python/3.10.13 (Linux-6.9.3-76060903-generic-x86_64-with-glibc2.35)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '73968e42-453f-11ef-9749-0242ac140002'
    'Authorization': 'REDACTED'
No body was attached to the request
2024/07/18 19:53:51 azure: INFO: Response status: 200
Response headers:
    'Content-Length': '0'
    'Last-Modified': 'Wed, 20 Oct 2021 07:47:27 GMT'
    'ETag': '"0x8D9939DDD0A61EA"'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': 'c78158ff-201e-0026-264c-d9e0ef000000'
    'x-ms-client-request-id': '73968e42-453f-11ef-9749-0242ac140002'
    'x-ms-version': 'REDACTED'
    'x-ms-lease-status': 'REDACTED'
    'x-ms-lease-state': 'REDACTED'
    'x-ms-has-immutability-policy': 'REDACTED'
    'x-ms-has-legal-hold': 'REDACTED'
    'x-ms-immutable-storage-with-versioning-enabled': 'REDACTED'
    'x-ms-default-encryption-scope': 'REDACTED'
    'x-ms-deny-encryption-scope-override': 'REDACTED'
    'Date': 'Thu, 18 Jul 2024 19:53:49 GMT'
2024/07/18 19:53:51 azure: INFO: Storage: Getting the specified containers: frameworktestcontainer
2024/07/18 19:53:51 azure: INFO: Storage: Authenticated.
2024/07/18 19:53:51 azure: INFO: 82e049b81fa6eb88ebf85f1677785f2b was not found in the database for storage. Adding it.
2024/07/18 19:53:51 azure: INFO: Storage: Getting blobs from container frameworktestcontainer.
2024/07/18 19:53:51 azure: INFO: Storage: The search starts from the date: 2024-06-18 19:53:51.040625+00:00 for blobs in container: "frameworktestcontainer" and prefix: "/"
2024/07/18 19:53:51 azure: INFO: Request URL: 'https://frameworkteststorage.blob.core.windows.net/frameworktestcontainer?restype=REDACTED&comp=REDACTED'
Request method: 'GET'
Request headers:
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'azsdk-python-storage-blob/12.19.1 Python/3.10.13 (Linux-6.9.3-76060903-generic-x86_64-with-glibc2.35)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '746e42e2-453f-11ef-9749-0242ac140002'
    'Authorization': 'REDACTED'
No body was attached to the request
2024/07/18 19:53:51 azure: INFO: Response status: 200
Response headers:
    'Transfer-Encoding': 'chunked'
    'Content-Type': 'application/xml'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': 'c78159e5-201e-0026-634c-d9e0ef000000'
    'x-ms-client-request-id': '746e42e2-453f-11ef-9749-0242ac140002'
    'x-ms-version': 'REDACTED'
    'Date': 'Thu, 18 Jul 2024 19:53:50 GMT'
2024/07/18 19:53:51 azure: INFO: Storage: Skipping blob 1701245986-27d77755-7658-4e6f-b4e0-efb90b977c90.2.log due to being already processed
2024/07/18 19:53:51 azure: INFO: Storage: Skipping blob PT1H.3.json due to being already processed
2024/07/18 19:53:51 azure: INFO: Storage: Skipping blob PT1H.json due to being already processed
2024/07/18 19:53:51 azure: INFO: Storage: Skipping blob opensearch.yml.txt due to being already processed
2024/07/18 19:53:51 azure: INFO: Getting data from blob sample.inline
2024/07/18 19:53:51 azure: INFO: Request URL: 'https://frameworkteststorage.blob.core.windows.net/frameworktestcontainer/sample.inline'
Request method: 'GET'
Request headers:
    'x-ms-range': 'REDACTED'
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'azsdk-python-storage-blob/12.19.1 Python/3.10.13 (Linux-6.9.3-76060903-generic-x86_64-with-glibc2.35)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '74c43440-453f-11ef-9749-0242ac140002'
    'Authorization': 'REDACTED'
No body was attached to the request
2024/07/18 19:53:51 azure: INFO: Response status: 206
Response headers:
    'Content-Length': '311'
    'Content-Type': 'application/octet-stream'
    'Content-Range': 'REDACTED'
    'Last-Modified': 'Mon, 15 Jul 2024 20:34:22 GMT'
    'Accept-Ranges': 'REDACTED'
    'ETag': '"0x8DCA50D82EC4098"'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': 'c7815baa-201e-0026-654c-d9e0ef000000'
    'x-ms-client-request-id': '74c43440-453f-11ef-9749-0242ac140002'
    'x-ms-version': 'REDACTED'
    'x-ms-creation-time': 'REDACTED'
    'x-ms-blob-content-md5': 'REDACTED'
    'x-ms-lease-status': 'REDACTED'
    'x-ms-lease-state': 'REDACTED'
    'x-ms-blob-type': 'REDACTED'
    'x-ms-copy-id': 'REDACTED'
    'x-ms-copy-source': 'REDACTED'
    'x-ms-copy-status': 'REDACTED'
    'x-ms-copy-progress': 'REDACTED'
    'x-ms-copy-completion-time': 'REDACTED'
    'x-ms-server-encrypted': 'REDACTED'
    'Date': 'Thu, 18 Jul 2024 19:53:50 GMT'
2024/07/18 19:53:51 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:51 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:51 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:51 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:51 azure: INFO: Getting data from blob sample.json
2024/07/18 19:53:51 azure: INFO: Request URL: 'https://frameworkteststorage.blob.core.windows.net/frameworktestcontainer/sample.json'
Request method: 'GET'
Request headers:
    'x-ms-range': 'REDACTED'
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'azsdk-python-storage-blob/12.19.1 Python/3.10.13 (Linux-6.9.3-76060903-generic-x86_64-with-glibc2.35)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '74f3dec0-453f-11ef-9749-0242ac140002'
    'Authorization': 'REDACTED'
No body was attached to the request
2024/07/18 19:53:52 azure: INFO: Response status: 206
Response headers:
    'Content-Length': '247'
    'Content-Type': 'application/json'
    'Content-Range': 'REDACTED'
    'Last-Modified': 'Wed, 17 Jul 2024 21:12:57 GMT'
    'Accept-Ranges': 'REDACTED'
    'ETag': '"0x8DCA6A53B73DF5B"'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': 'c7815c8e-201e-0026-1e4c-d9e0ef000000'
    'x-ms-client-request-id': '74f3dec0-453f-11ef-9749-0242ac140002'
    'x-ms-version': 'REDACTED'
    'x-ms-creation-time': 'REDACTED'
    'x-ms-blob-content-md5': 'REDACTED'
    'x-ms-lease-status': 'REDACTED'
    'x-ms-lease-state': 'REDACTED'
    'x-ms-blob-type': 'REDACTED'
    'x-ms-copy-id': 'REDACTED'
    'x-ms-copy-source': 'REDACTED'
    'x-ms-copy-status': 'REDACTED'
    'x-ms-copy-progress': 'REDACTED'
    'x-ms-copy-completion-time': 'REDACTED'
    'x-ms-server-encrypted': 'REDACTED'
    'Date': 'Thu, 18 Jul 2024 19:53:51 GMT'
2024/07/18 19:53:52 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:52 azure: INFO: Storage: Skipping blob sample.txt due to being already processed
2024/07/18 19:53:52 azure: INFO: Storage: Skipping blob test_folder/sample.inline due to being already processed
2024/07/18 19:53:52 azure: INFO: Storage: Skipping blob test_folder/sample.json due to being already processed
2024/07/18 19:53:52 azure: INFO: Storage: Skipping blob test_folder/sample.txt due to being already processed
2024/07/18 19:53:52 azure: INFO: Storage: Skipping blob test_prefix/inside_prefix/sample.inline due to being already processed
2024/07/18 19:53:52 azure: INFO: Getting data from blob test_prefix/sample.inline
2024/07/18 19:53:52 azure: INFO: Request URL: 'https://frameworkteststorage.blob.core.windows.net/frameworktestcontainer/test_prefix/sample.inline'
Request method: 'GET'
Request headers:
    'x-ms-range': 'REDACTED'
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'azsdk-python-storage-blob/12.19.1 Python/3.10.13 (Linux-6.9.3-76060903-generic-x86_64-with-glibc2.35)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '75226ec0-453f-11ef-9749-0242ac140002'
    'Authorization': 'REDACTED'
No body was attached to the request
2024/07/18 19:53:52 azure: INFO: Response status: 206
Response headers:
    'Content-Length': '233'
    'Content-Type': 'application/octet-stream'
    'Content-Range': 'REDACTED'
    'Last-Modified': 'Wed, 17 Jul 2024 21:19:35 GMT'
    'Accept-Ranges': 'REDACTED'
    'ETag': '"0x8DCA6A62863E71E"'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': 'c7815d8b-201e-0026-6b4c-d9e0ef000000'
    'x-ms-client-request-id': '75226ec0-453f-11ef-9749-0242ac140002'
    'x-ms-version': 'REDACTED'
    'x-ms-creation-time': 'REDACTED'
    'x-ms-blob-content-md5': 'REDACTED'
    'x-ms-lease-status': 'REDACTED'
    'x-ms-lease-state': 'REDACTED'
    'x-ms-blob-type': 'REDACTED'
    'x-ms-copy-id': 'REDACTED'
    'x-ms-copy-source': 'REDACTED'
    'x-ms-copy-status': 'REDACTED'
    'x-ms-copy-progress': 'REDACTED'
    'x-ms-copy-completion-time': 'REDACTED'
    'x-ms-server-encrypted': 'REDACTED'
    'Date': 'Thu, 18 Jul 2024 19:53:51 GMT'
2024/07/18 19:53:52 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:52 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:52 azure: INFO: Storage: Sending event by socket.
2024/07/18 19:53:52 azure: INFO: Storage: End
```


</p>
</details> 
