### PR TITLE
Fix handling of single quotes in FIM and Syscollector

### DIFF
--- a/src/data_provider/src/network/networkLinuxWrapper.h
+++ b/src/data_provider/src/network/networkLinuxWrapper.h
@@ -274,7 +274,7 @@ class NetworkLinuxInterface final : public INetworkInterfaceWrapper
                     {
                         line = Utils::rightTrim(line);
                         Utils::replaceAll(line, "\t", " ");
-                        Utils::replaceAll(line, "  ", " ");
+                        line = Utils::trimRepeated(line, ' ');
                         const auto fields { Utils::split(line, ' ') };
 
                         if (GatewayFileFields::Size == fields.size() &&
@@ -477,7 +477,7 @@ class NetworkLinuxInterface final : public INetworkInterfaceWrapper
                     {
                         line = Utils::trim(line);
                         Utils::replaceAll(line, "\t", " ");
-                        Utils::replaceAll(line, "  ", " ");
+                        line = Utils::trimRepeated(line, ' ');
                         Utils::replaceAll(line, ": ", " ");
                         const auto fields { Utils::split(line, ' ') };
 

--- a/src/data_provider/src/network/networkSolarisWrapper.hpp
+++ b/src/data_provider/src/network/networkSolarisWrapper.hpp
@@ -194,7 +194,7 @@ class NetworkSolarisInterface final : public INetworkInterfaceWrapper
 
                 for (auto line : lines)
                 {
-                    Utils::replaceAll(line, "  ", " ");
+                    line = Utils::trimRepeated(line, ' ');
                     const auto fields { Utils::split(line, ' ') };
 
                     if (fields.size() == ROUTING_SIZE_FIELDS && fields.front().compare("default") == 0)
@@ -296,7 +296,7 @@ class NetworkSolarisInterface final : public INetworkInterfaceWrapper
                     for (auto& line : lines)
                     {
                         Utils::replaceAll(line, "\t", " ");
-                        Utils::replaceAll(line, "  ", " ");
+                        line = Utils::trimRepeated(line, ' ');
                         auto fields { Utils::split(line, ' ') };
 
                         value = std::stoi(fields.back(), &valueSize);
@@ -352,7 +352,7 @@ class NetworkSolarisInterface final : public INetworkInterfaceWrapper
                 for (auto line : lines)
                 {
                     Utils::replaceAll(line, "\t", "");
-                    Utils::replaceAll(line, "  ", " ");
+                    line = Utils::trimRepeated(line, ' ');
 
                     if (headers.size() == 0)
                     {

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -531,7 +531,7 @@ nlohmann::json SysInfo::getPorts() const
                 {
                     row = Utils::trim(row);
                     Utils::replaceAll(row, "\t", " ");
-                    Utils::replaceAll(row, "  ", " ");
+                    row = Utils::trimRepeated(row, ' ');
                     std::make_unique<PortImpl>(std::make_shared<LinuxPortWrapper>(portType.first, row))->buildPortData(port);
                     inodes.push_back(port.at("inode"));
                     ports.push_back(std::move(port));

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -127,7 +127,7 @@ public:
                                 {
                                     // Remove the tabs and double spaces.
                                     Utils::replaceAll(response, "\t", " ");
-                                    Utils::replaceAll(response, "  ", " ");
+                                    response = Utils::trimRepeated(response, ' ');
                                     // Split the response by rows.
                                     const auto rows {Utils::split(response, '\n')};
 

--- a/src/shared_modules/rsync/src/rsyncImplementation.cpp
+++ b/src/shared_modules/rsync/src/rsyncImplementation.cpp
@@ -256,8 +256,13 @@ size_t RSyncImplementation::getRangeCount(const std::shared_ptr<DBSyncWrapper>& 
     };
 
     auto rowFilter { querySelect.at("row_filter").get_ref<const std::string&>() } ;
-    Utils::replaceFirst(rowFilter, "?", syncData.begin);
-    Utils::replaceFirst(rowFilter, "?", syncData.end);
+    auto beginSanitized = syncData.begin;
+    auto endSanitized = syncData.end;
+
+    Utils::replaceAll(beginSanitized, "'", "''");
+    Utils::replaceAll(endSanitized, "'", "''");
+    Utils::replaceFirst(rowFilter, "?", beginSanitized);
+    Utils::replaceFirst(rowFilter, "?", endSanitized);
 
     queryParam["row_filter"] = rowFilter;
     queryParam["column_list"] = querySelect.at("column_list");
@@ -315,8 +320,13 @@ void RSyncImplementation::fillChecksum(const std::shared_ptr<DBSyncWrapper>& spD
     };
 
     auto rowFilter { querySelect.at("row_filter").get_ref<const std::string&>() } ;
-    Utils::replaceFirst(rowFilter, "?", begin);
-    Utils::replaceFirst(rowFilter, "?", end);
+    auto beginSanitized = begin;
+    auto endSanitized = end;
+
+    Utils::replaceAll(beginSanitized, "'", "''");
+    Utils::replaceAll(endSanitized, "'", "''");
+    Utils::replaceFirst(rowFilter, "?", beginSanitized);
+    Utils::replaceFirst(rowFilter, "?", endSanitized);
 
     auto& queryParam { selectData["query"] };
     queryParam["row_filter"] = rowFilter;
@@ -355,7 +365,10 @@ nlohmann::json RSyncImplementation::getRowData(const std::shared_ptr<DBSyncWrapp
         // Register sync flow
         querySelect = jsonSyncConfiguration.at("row_data_query_json");
         rowFilter = querySelect.at("row_filter").get_ref<const std::string&>();
-        Utils::replaceFirst(rowFilter, "?", index);
+
+        auto indexSanitized = index;
+        Utils::replaceAll(indexSanitized, "'", "''");
+        Utils::replaceFirst(rowFilter, "?", indexSanitized);
     }
     else
     {

--- a/src/shared_modules/rsync/tests/interface/rsync_test.cpp
+++ b/src/shared_modules/rsync/tests/interface/rsync_test.cpp
@@ -26,7 +26,7 @@ constexpr auto SQL_STMT_INFO
     PRAGMA foreign_keys=OFF;
     BEGIN TRANSACTION;
     CREATE TABLE entry_path (path TEXT NOT NULL, inode_id INTEGER, mode INTEGER, last_event INTEGER, entry_type INTEGER, scanned INTEGER, options INTEGER, checksum TEXT NOT NULL, PRIMARY KEY(path));
-    INSERT INTO entry_path VALUES('/boot/grub2/fonts/unicode.pf2',1,0,1596489273,0,1,131583,'96482cde495f716fcd66a71a601fbb905c13b426');
+    INSERT INTO entry_path VALUES('/boot/grub2/font''s/unicode.pf2',1,0,1596489273,0,1,131583,'96482cde495f716fcd66a71a601fbb905c13b426');
     INSERT INTO entry_path VALUES('/boot/grub2/grubenv',2,0,1596489273,0,1,131583,'e041159610c7ec18490345af13f7f49371b56893');
     INSERT INTO entry_path VALUES('/boot/grub2/i386-pc/datehook.mod',3,0,1596489273,0,1,131583,'f83bc87319566e270fcece2fae4910bc18fe7355');
     INSERT INTO entry_path VALUES('/boot/grub2/i386-pc/gcry_whirlpool.mod',4,0,1596489273,0,1,131583,'d59ffd58d107b9398ff5a809097f056b903b3c3e');
@@ -358,7 +358,7 @@ TEST_F(RSyncTest, startSyncIntegrityGlobal)
 
     const auto expectedResult1
     {
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2")"
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/font's/unicode.pf2")"
     };
 
     const auto expectedResult2
@@ -472,11 +472,11 @@ TEST_F(RSyncTest, RegisterAndPush)
     ASSERT_NE(nullptr, handle_rsync);
 
     auto expectedGlobalResponse =
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/font's/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto expectedResult1
     {
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/fonts/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/font's/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"
     };
 
     const auto expectedResult2
@@ -486,7 +486,7 @@ TEST_F(RSyncTest, RegisterAndPush)
 
     const auto expectedResult3
     {
-        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/fonts/unicode.pf2","scanned":1},"index":"/boot/grub2/fonts/unicode.pf2","timestamp":1596489273},"type":"state"})"
+        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/font's/unicode.pf2","scanned":1},"index":"/boot/grub2/font's/unicode.pf2","timestamp":1596489273},"type":"state"})"
     };
 
     const auto expectedResult4
@@ -571,13 +571,13 @@ TEST_F(RSyncTest, RegisterAndPush)
     const std::unique_ptr<cJSON, CJsonSmartDeleter> spStartConfigStmt{ cJSON_Parse(START_CONFIG_STMT_PATH) };
     ASSERT_EQ(0, rsync_start_sync(handle_rsync, handle_dbsync, spStartConfigStmt.get(), callbackDataDiff));
 
-    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_EQ(0, rsync_push_message(handle_rsync, reinterpret_cast<const void*>(buffer1.data()), buffer1.size()));
 
-    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/fonts/unicode.pf2","id":1})"};
+    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/font's/unicode.pf2","id":1})"};
     ASSERT_EQ(0, rsync_push_message(handle_rsync, reinterpret_cast<const void*>(buffer2.data()), buffer2.size()));
 
-    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_EQ(0, rsync_push_message(handle_rsync, reinterpret_cast<const void*>(buffer3.data()), buffer3.size()));
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -593,7 +593,7 @@ TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
     ASSERT_NE(nullptr, handle_rsync);
 
     auto expectedGlobalResponse =
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/font's/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto registerConfigStmt
     {
@@ -650,14 +650,14 @@ TEST_F(RSyncTest, RegisterIncorrectQueryAndPush)
     const std::unique_ptr<cJSON, CJsonSmartDeleter> spStartConfigStmt{ cJSON_Parse(START_CONFIG_STMT_PATH) };
     ASSERT_EQ(0, rsync_start_sync(handle_rsync, handle_dbsync, spStartConfigStmt.get(), callbackDataDiff));
 
-    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
 
     ASSERT_EQ(0, rsync_push_message(handle_rsync, reinterpret_cast<const void*>(buffer1.data()), buffer1.size()));
 
-    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/fonts/unicode.pf2","id":1})"};
+    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/font's/unicode.pf2","id":1})"};
     ASSERT_EQ(0, rsync_push_message(handle_rsync, reinterpret_cast<const void*>(buffer2.data()), buffer2.size()));
 
-    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_EQ(0, rsync_push_message(handle_rsync, reinterpret_cast<const void*>(buffer3.data()), buffer3.size()));
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -673,11 +673,11 @@ TEST_F(RSyncTest, RegisterAndPushCPP)
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
 
     auto expectedGlobalResponse =
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/font's/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto expectedResult1
     {
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/fonts/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/font's/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"
     };
 
     const auto expectedResult2
@@ -687,7 +687,7 @@ TEST_F(RSyncTest, RegisterAndPushCPP)
 
     const auto expectedResult3
     {
-        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/fonts/unicode.pf2","scanned":1},"index":"/boot/grub2/fonts/unicode.pf2","timestamp":1596489273},"type":"state"})"
+        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/font's/unicode.pf2","scanned":1},"index":"/boot/grub2/font's/unicode.pf2","timestamp":1596489273},"type":"state"})"
     };
 
     const auto expectedResult4
@@ -784,14 +784,14 @@ TEST_F(RSyncTest, RegisterAndPushCPP)
 
     EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
 
-    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
 
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
 
-    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/fonts/unicode.pf2","id":1})"};
+    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/font's/unicode.pf2","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer2.begin(), buffer2.end() }));
 
-    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -968,7 +968,7 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInode)
 
     const auto expectedResult3
     {
-        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/fonts/unicode.pf2","scanned":1},"index":1,"timestamp":1596489273},"type":"state"})"
+        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/font's/unicode.pf2","scanned":1},"index":1,"timestamp":1596489273},"type":"state"})"
     };
 
     const auto expectedResult4
@@ -1142,13 +1142,13 @@ TEST_F(RSyncTest, RegisterAndPushWithoutStartCPP)
 
     ASSERT_NO_THROW(remoteSync->registerSyncID("test_id", dbSync->handle(), nlohmann::json::parse(registerConfigStmt), callbackData));
 
-    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer1{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
 
-    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/fonts/unicode.pf2","id":1})"};
+    std::string buffer2{R"(test_id checksum_fail {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/font's/unicode.pf2","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer2.begin(), buffer2.end() }));
 
-    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -1166,7 +1166,7 @@ TEST_F(RSyncTest, RegisterAndPushWithNewerIDCPP)
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
 
     auto expectedGlobalResponse =
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/font's/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto registerConfigStmt
     {
@@ -1236,7 +1236,7 @@ TEST_F(RSyncTest, RegisterAndPushWithNewerIDCPP)
     };
 
     auto expectedResult1 =
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/fonts/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"_json;
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/font's/unicode.pf2","checksum":"acfe3a5baf97f842838c13b32e7e61a11e144e64","end":"/boot/grub2/grubenv","id":1,"tail":"/boot/grub2/i386-pc/datehook.mod"},"type":"integrity_check_left"})"_json;
 
     auto expectedResult2 =
         R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/datehook.mod","checksum":"891333533a9c7d989b92928d200ed8402fe67813","end":"/boot/grub2/i386-pc/gzio.mod","id":1},"type":"integrity_check_right"})"_json;
@@ -1255,7 +1255,7 @@ TEST_F(RSyncTest, RegisterAndPushWithNewerIDCPP)
     EXPECT_CALL(wrapper, callbackMock(expectedResult2.dump())).Times(1);
 
     std::string buffer1 {R"(test_id checksum_fail )"};
-    auto buffer1Json = R"({"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod"})"_json;
+    auto buffer1Json = R"({"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod"})"_json;
     buffer1Json["id"] = syncId;
     buffer1 += buffer1Json.dump();
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer1.begin(), buffer1.end() }));
@@ -1276,7 +1276,7 @@ TEST_F(RSyncTest, RegisterAndPushCPPByInodePartialNODataRange)
 
     const auto expectedResult1
     {
-        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/fonts/unicode.pf2","scanned":1},"index":1,"timestamp":1596489273},"type":"state"})"
+        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/font's/unicode.pf2","scanned":1},"index":1,"timestamp":1596489273},"type":"state"})"
     };
 
     const auto expectedResult2
@@ -1439,7 +1439,7 @@ TEST_F(RSyncTest, RegisterAndPushShutdownCPP)
     EXPECT_NO_THROW(remoteSync = std::make_unique<RemoteSync>());
 
     auto expectedGlobalResponse =
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/font's/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto registerConfigStmt
     {
@@ -1506,7 +1506,7 @@ TEST_F(RSyncTest, RegisterAndPushShutdownCPP)
 
     EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
 
-    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -1526,11 +1526,11 @@ TEST_F(RSyncTest, RegisterAndPushWithDoubleHandleDisconnect)
     EXPECT_NO_THROW(remoteSyncToDelete = std::make_unique<RemoteSync>());
 
     auto expectedGlobalResponse =
-        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/fonts/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
+        R"({"component":"test_id","data":{"begin":"/boot/grub2/i386-pc/gzio.mod","checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709","end":"/boot/grub2/font's/unicode.pf2","id":1696450039},"type":"integrity_check_global"})"_json;
 
     const auto expectedResult1
     {
-        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/fonts/unicode.pf2","scanned":1},"index":"/boot/grub2/fonts/unicode.pf2","timestamp":1596489273},"type":"state"})"
+        R"({"component":"test_id","data":{"attributes":{"checksum":"96482cde495f716fcd66a71a601fbb905c13b426","entry_type":0,"inode_id":1,"last_event":1596489273,"mode":0,"options":131583,"path":"/boot/grub2/font's/unicode.pf2","scanned":1},"index":"/boot/grub2/font's/unicode.pf2","timestamp":1596489273},"type":"state"})"
     };
 
     const auto expectedResult2
@@ -1670,7 +1670,7 @@ TEST_F(RSyncTest, RegisterAndPushWithDoubleHandleDisconnect)
 
     EXPECT_NO_THROW(remoteSync->startSync(dbSync->handle(), nlohmann::json::parse(START_CONFIG_STMT_PATH), callbackDataDiff));
 
-    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/fonts/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
+    std::string buffer3{R"(test_id no_data {"begin":"/boot/grub2/font's/unicode.pf2","end":"/boot/grub2/i386-pc/gzio.mod","id":1})"};
     ASSERT_NO_THROW(remoteSync->pushMessage({ buffer3.begin(), buffer3.end() }));
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -1762,7 +1762,7 @@ TEST_F(RSyncTest, RegisterAndPushCPPWithDeletedElement)
             {
                  "begin":"/boot/grub2/i386-pc/gzio.mod",
                  "checksum":"da39a3ee5e6b4b0d3255bfef95601890afd80709",
-                 "end":"/boot/grub2/fonts/unicode.pf2",
+                 "end":"/boot/grub2/font's/unicode.pf2",
                  "id":1696450039
             },
             "type":"integrity_check_global"
@@ -1840,4 +1840,3 @@ TEST_F(RSyncTest, RegisterAndPushCPPWithDeletedElement)
     std::this_thread::sleep_for(std::chrono::seconds(1));
     remoteSync.reset();
 }
-

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -132,6 +132,21 @@ namespace Utils
         return leftTrim(rightTrim(str, args), args);
     }
 
+    static std::string trimRepeated(const std::string& str, char c = ' ')
+    {
+        auto haystack = str;
+        auto needle = std::string(2, c);
+        auto pos = haystack.find(needle);
+
+        while (std::string::npos != pos)
+        {
+            haystack.replace(pos, 2, 1, c);
+            pos = haystack.find(needle);
+        }
+
+        return haystack;
+    }
+
     static std::vector<std::string> split(const std::string& str, const char delimiter)
     {
         std::vector<std::string> tokens;

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -75,7 +75,7 @@ namespace Utils
         while (std::string::npos != pos)
         {
             data.replace(pos, toSearch.size(), toReplace);
-            pos = data.find(toSearch, pos);
+            pos = data.find(toSearch, pos + toReplace.size());
         }
 
         return ret;

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -278,9 +278,8 @@ UBUNTU_CODENAME=jammy\n");
 TEST_F(StringUtilsTest, CheckMultiReplacement)
 {
     std::string string_base {"hello         world"};
-    const auto retVal {Utils::replaceAll(string_base, "  ", " ")};
-    EXPECT_EQ(string_base, "hello world");
-    EXPECT_TRUE(retVal);
+    const auto retVal {Utils::trimRepeated(string_base, ' ')};
+    EXPECT_EQ(retVal, "hello world");
 }
 
 TEST_F(StringUtilsTest, substrOnFirstOccurrenceCorrect)

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -33,6 +33,30 @@ TEST_F(StringUtilsTest, CheckNotReplacement)
     EXPECT_FALSE(retVal);
 }
 
+TEST_F(StringUtilsTest, CheckUnchanged)
+{
+    std::string string_base {"hello_world"};
+    const auto retVal {Utils::replaceAll(string_base, "_", "_")};
+    EXPECT_EQ(string_base, "hello_world");
+    EXPECT_TRUE(retVal);
+}
+
+TEST_F(StringUtilsTest, CheckQuoteEscape)
+{
+    std::string string_base {"hello'world"};
+    const auto retVal {Utils::replaceAll(string_base, "'", "''")};
+    EXPECT_EQ(string_base, "hello''world");
+    EXPECT_TRUE(retVal);
+}
+
+TEST_F(StringUtilsTest, CheckUnquoteEscape)
+{
+    std::string string_base {"hello''world"};
+    const auto retVal {Utils::replaceAll(string_base, "''", "'")};
+    EXPECT_EQ(string_base, "hello'world");
+    EXPECT_TRUE(retVal);
+}
+
 TEST_F(StringUtilsTest, SplitEmptyString)
 {
     auto splitTextVector {Utils::split("", '.')};
@@ -588,4 +612,3 @@ TEST_F(StringUtilsTest, haveUpperCaseCharacters)
     EXPECT_FALSE(Utils::haveUpperCaseCharacters("test"));
     EXPECT_FALSE(Utils::haveUpperCaseCharacters(""));
 }
-

--- a/src/syscheckd/src/db/src/fimDB.cpp
+++ b/src/syscheckd/src/db/src/fimDB.cpp
@@ -36,12 +36,22 @@ void FIMDB::sync()
     if (!m_stopping)
     {
         m_loggingFunction(LOG_DEBUG, "Executing FIM sync.");
-        FIMDBCreator<OS_TYPE>::sync(m_rsyncHandler,
-                                    m_dbsyncHandler->handle(),
-                                    m_syncFileMessageFunction,
-                                    m_syncRegistryMessageFunction,
-                                    m_syncRegistryEnabled);
-        m_loggingFunction(LOG_DEBUG, "Finished FIM sync.");
+
+        try
+        {
+            FIMDBCreator<OS_TYPE>::sync(m_rsyncHandler,
+                                        m_dbsyncHandler->handle(),
+                                        m_syncFileMessageFunction,
+                                        m_syncRegistryMessageFunction,
+                                        m_syncRegistryEnabled);
+
+            m_loggingFunction(LOG_DEBUG, "Finished FIM sync.");
+        }
+        catch (const std::exception& e)
+        {
+            auto message = std::string("Cannot sync database:") + e.what();
+            m_loggingFunction(LOG_ERROR, message);
+        }
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#24376|

## Summary

This pull request addresses a bug in the RSync component when handling data with single quotes. This issue affects both the FIM and Syscollector modules. 

## Changes Made

- **String Sanitization:** We have written code to sanitize strings in the database by escaping apostrophes.
- **Helper Bug Fix:** We have fixed a bug in the helper for replacing strings, which previously did not support substrings of different lengths before and after replacement.
- **Exception Handling:** We have implemented exception handling for this case in FIM to prevent future occurrences.

## Testing

- **Unit Tests:** Extended unit tests to cover the new changes.
- **Component Tests:** Extended tests for the RSync component.
- **Manual Testing:** Verified that the issue no longer reproduces in FIM.