### PR TITLE
Hide undesired messages in the package generation script

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -1,5 +1,5 @@
-run-name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }} ${{ inputs.is_stage && '- is stage' || '' }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.debug && '- debug' || '' }} ${{ inputs.id }}
-name: Build Wazuh manager
+run-name: Package - Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }} ${{ inputs.is_stage && '- is stage' || '' }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.debug && '- debug' || '' }} ${{ inputs.id }}
+name: Package - Build Wazuh manager
 
 on:
   workflow_dispatch:

--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -120,7 +120,7 @@ jobs:
         working-directory: packages
         run: |
           REVISION=${{ inputs.revision }}
-          FLAGS="-t manager -s /tmp --dont-build-docker -j $(nproc) "
+          FLAGS="--verbose -t manager -s /tmp --dont-build-docker -j $(nproc) "
           if [ -z "$REVISION" ]; then FLAGS+="-r 0 "; else FLAGS+="-r $REVISION "; fi
           if [ "${{ inputs.is_stage }}" == "true" ]; then FLAGS+="--is_stage "; fi
           if [ "${{ inputs.checksum }}" == "true" ]; then FLAGS+="--checksum "; fi

--- a/.github/workflows/packages-build-multiple-managers.yml
+++ b/.github/workflows/packages-build-multiple-managers.yml
@@ -1,4 +1,4 @@
-name: Build multiple Wazuh Manager Packages - DEB|RPM - amd64|x86_64
+name: Package - Build multiple Wazuh Manager Packages - DEB|RPM - amd64|x86_64
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -1,5 +1,5 @@
-run-name: Build Filebeat module ${{ inputs.revision }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.id }}
-name: Build Filebeat module
+run-name: Package - Build Filebeat module ${{ inputs.revision }} ${{ inputs.checksum && '- checksum' || '' }} ${{ inputs.id }}
+name: Package - Build Filebeat module
 
 on:
   workflow_dispatch:

--- a/packages/build.sh
+++ b/packages/build.sh
@@ -81,7 +81,9 @@ build_dir="/build_wazuh"
 
 source helper_function.sh
 
-set -x
+if [ -n "${WAZUH_VERBOSE}" ]; then
+  set -x
+fi
 
 # Download source code if it is not shared from the local host
 if [ ! -d "/wazuh-local-src" ] ; then

--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -8,7 +8,7 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
-set -ex
+set -e
 CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 WAZUH_PATH="$(cd $CURRENT_PATH/..; pwd -P)"
 ARCHITECTURE="amd64"
@@ -94,6 +94,7 @@ build_pkg() {
         -e INSTALLATION_PATH="${INSTALLATION_PATH}" \
         -e IS_STAGE="${IS_STAGE}" \
         -e WAZUH_BRANCH="${BRANCH}" \
+        -e WAZUH_VERBOSE="${VERBOSE}" \
         ${CUSTOM_CODE_VOL} \
         ${CONTAINER_NAME}:${DOCKER_TAG} \
         ${REVISION} ${JOBS} ${DEBUG} \
@@ -131,6 +132,7 @@ help() {
     echo "    --system                   [Optional] Select Package OS [rpm, deb]. By default is 'deb'."
     echo "    --src                      [Optional] Generate the source package in the destination directory."
     echo "    --future                   [Optional] Build test future package x.30.0 Used for development purposes."
+    echo "    --verbose                  [Optional] Print commands and their arguments as they are executed."
     echo "    -h, --help                 Show this help."
     echo
     exit $1
@@ -248,10 +250,18 @@ main() {
             SYSTEM="$2"
             shift 2
             ;;
+        "--verbose")
+            VERBOSE="yes"
+            shift 1
+            ;;
         *)
             help 1
         esac
     done
+
+    if [ -n "${VERBOSE}" ]; then
+        set -x
+    fi
 
     if [ -z "${CUSTOM_CODE_VOL}" ]; then
         CUSTOM_CODE_VOL="-v $WAZUH_PATH:/wazuh-local-src:Z"

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 # Program to build and package OSX wazuh-agent
 # Wazuh package generator
 # Copyright (C) 2015, Wazuh Inc.


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24676|

## Description

The script was displaying debug information for all commands, which resulted in excessive output, including when simply checking the help message. This information was more detailed than necessary and could obscure important details.

**Note:** This PR also adds the prefix **Package - ** to the **name** and **run_name** fields for the following workflows:

packages-build-manager
packages-build-multiple-managers
packages-filebeat

## Tests

- No verbose
![image](https://github.com/user-attachments/assets/92627850-8a95-4c3f-b42e-e9b64e1ef5e2)

- Verbose
![image](https://github.com/user-attachments/assets/5d21251a-8e50-4cb3-93fd-c8f103f2ad6a)

- Make the Wazuh manager workflow verbose.
run: https://github.com/wazuh/wazuh/actions/runs/10146646933/job/28055195219
![image](https://github.com/user-attachments/assets/7c0c70bf-8ac1-4002-af7c-0f50d608559e)
