### PR TITLE
Implementing generic translations

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -43,6 +43,9 @@ using namespace NSVulnerabilityScanner;
 constexpr auto DATABASE_PATH {"queue/vd/feed"};
 constexpr auto OFFSET_TRANSACTION_SIZE {1000};
 constexpr auto EMPTY_KEY {""};
+constexpr auto PRODUCT_PLACEHOLDER {"$(PRODUCTn)"};
+constexpr auto VENDOR_PLACEHOLDER {"$(VENDORn)"};
+constexpr auto VERSION_PLACEHOLDER {"$(VERSIONn)"};
 
 /**
  * @brief Scanning package data struct.
@@ -512,7 +515,7 @@ public:
 
         // Iterate over the Level 2 cache data
         m_translationL2Cache->forEach(
-            [&]([[maybe_unused]] const auto& key, const auto& cacheData)
+            [&]([[maybe_unused]] const auto& key, const auto& cacheData) -> bool
             {
                 /* Check conditions, return true to continue the loop, false to break it */
                 // - The target platform matches the provided OS platform
@@ -521,14 +524,23 @@ public:
                     return true;
                 }
                 // - The package name matches the product regex if present
+                std::smatch productExtractedGroups;
                 if (cacheData.productRegex.has_value() &&
-                    !std::regex_search(package.name, cacheData.productRegex.value()))
+                    !std::regex_search(package.name, productExtractedGroups, cacheData.productRegex.value()))
                 {
                     return true;
                 }
                 // - The vendor matches the vendor regex if present
+                std::smatch vendorExtractedGroups;
                 if (cacheData.vendorRegex.has_value() &&
-                    !std::regex_search(package.vendor, cacheData.vendorRegex.value()))
+                    !std::regex_search(package.vendor, vendorExtractedGroups, cacheData.vendorRegex.value()))
+                {
+                    return true;
+                }
+                // - The version matches the version regex if present
+                std::smatch versionExtractedGroups;
+                if (cacheData.versionRegex.has_value() &&
+                    !std::regex_search(package.version, versionExtractedGroups, cacheData.versionRegex.value()))
                 {
                     return true;
                 }
@@ -537,20 +549,33 @@ public:
                 for (const auto& translatedPackage : cacheData.translation)
                 {
                     TranslatedData translatedResult {.translatedProduct = translatedPackage.translatedProduct,
-                                                     .translatedVendor = translatedPackage.translatedVendor};
-                    // Search for version regex or use translated version
-                    std::smatch stringFound;
-                    if (cacheData.versionRegex.has_value() &&
-                        std::regex_search(package.name, stringFound, cacheData.versionRegex.value()) &&
-                        stringFound.size() > 0)
+                                                     .translatedVendor = translatedPackage.translatedVendor,
+                                                     .translatedVersion = translatedPackage.translatedVersion};
+
+                    auto placeHolderReplacement =
+                        [&translatedResult](const auto& extractedGroups, const auto& placeholder)
                     {
-                        // We only consider the first capture group
-                        translatedResult.translatedVersion = stringFound.str(1);
-                    }
-                    else
-                    {
-                        translatedResult.translatedVersion = translatedPackage.translatedVersion;
-                    }
+                        if (extractedGroups.size() > 0)
+                        {
+                            for (size_t i = 0; i < extractedGroups.size(); i++)
+                            {
+                                std::string placeHolderNumbered {placeholder};
+                                Utils::replaceFirst(placeHolderNumbered, "n", std::to_string(i));
+
+                                Utils::replaceAll(
+                                    translatedResult.translatedProduct, placeHolderNumbered, extractedGroups.str(i));
+                                Utils::replaceAll(
+                                    translatedResult.translatedVendor, placeHolderNumbered, extractedGroups.str(i));
+                                Utils::replaceAll(
+                                    translatedResult.translatedVersion, placeHolderNumbered, extractedGroups.str(i));
+                            }
+                        }
+                    };
+
+                    placeHolderReplacement(productExtractedGroups, PRODUCT_PLACEHOLDER);
+                    placeHolderReplacement(vendorExtractedGroups, VENDOR_PLACEHOLDER);
+                    placeHolderReplacement(versionExtractedGroups, VERSION_PLACEHOLDER);
+
                     translationResult.push_back(std::move(translatedResult));
                 }
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -98,33 +98,138 @@ const std::string VULNERABILITY_CANDIDATE_EXAMPLE = R"(
 ]
 )";
 
-const std::string TRANSLATION_EXAMPLE = R"***(
-{
-    "target": [
-        "windows"
-    ],
-    "source":
+const std::vector<std::string> TRANSLATION_EXAMPLES = {{R"***(
     {
-        "vendor": "Microsoft Corporation",
-        "product": "^Microsoft ASP.NET Core ([0-9]\\.*[0-9]*\\.*[0-9]*)",
-        "version": "^Microsoft ASP.NET Core ([0-9]\\.*[0-9]*\\.*[0-9]*)"
-    },
-    "translation":
-    [
+        "target": [
+            "windows"
+        ],
+        "source":
         {
-            "vendor": "microsoft",
-            "product": "asp.net_core",
-            "version": ""
-        }
-    ],
-    "action":
-    [
-        "replace_vendor",
-        "set_version_if_product_matches",
-        "replace_product"
-    ]
-}
-)***";
+            "vendor": "Microsoft Corporation",
+            "product": "^Microsoft ASP.NET Core ([0-9]+\\.*[0-9]*\\.*[0-9]*)"
+        },
+        "translation":
+        [
+            {
+                "vendor": "microsoft",
+                "product": "asp.net_core",
+                "version": "$(PRODUCT1)"
+            }
+        ],
+        "action":
+        [
+            "replace_vendor",
+            "replace_product",
+            "set_version_if_product_matches"
+        ]
+    }
+    )***"},
+                                                       {R"***(
+    {
+        "target": [
+            "windows"
+        ],
+        "source":
+        {
+            "vendor": "^Microsoft Corporation",
+            "product": "^Microsoft Exchange Server ([0-9]{4}) .*Update ([0-9]+)"
+        },
+        "translation":
+        [
+            {
+                "vendor": "microsoft",
+                "product": "exchange_server_$(PRODUCT1)",
+                "version": "cumulative_update_$(PRODUCT2)"
+            }
+        ],
+        "action":
+        [
+            "replace_vendor",
+            "replace_product",
+            "set_version_if_product_matches"
+        ]
+    }
+    )***"},
+                                                       {R"***(
+    {
+        "target": [
+            "windows"
+        ],
+        "source":
+        {
+            "vendor": "^Oracle Corporation",
+            "product": "^Java (\\d+) Update (\\d+)"
+        },
+        "translation":
+        [
+            {
+                "vendor": "oracle",
+                "product": "jre",
+                "version": "1.$(PRODUCT1).0-update_$(PRODUCT2)"
+            }
+        ],
+        "action":
+        [
+            "replace_vendor",
+            "replace_product",
+            "set_version_if_product_matches"
+        ]
+    }
+    )***"},
+                                                       {R"***(
+    {
+        "target": [
+            "windows"
+        ],
+        "source":
+        {
+            "vendor": "Vendor ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)",
+            "product": "Product ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)",
+            "version": "Version ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)"
+        },
+        "translation":
+        [
+            {
+                "vendor": "vendor $(PRODUCT0) $(PRODUCT1) $(PRODUCT2) $(PRODUCT3) $(PRODUCT4) $(PRODUCT5) $(PRODUCT6) $(PRODUCT7) $(PRODUCT8) $(PRODUCT9) $(PRODUCT10)",
+                "product": "product $(VERSION0) $(VERSION1) $(VERSION2) $(VERSION3) $(VERSION4) $(VERSION5) $(VERSION6) $(VERSION7) $(VERSION8) $(VERSION9) $(VERSION10)",
+                "version": "version $(VENDOR0) $(VENDOR1) $(VENDOR2) $(VENDOR3) $(VENDOR4) $(VENDOR5) $(VENDOR6) $(VENDOR7) $(VENDOR8) $(VENDOR9) $(VENDOR10)"
+            }
+        ],
+        "action":
+        [
+            "replace_vendor",
+            "replace_product",
+            "set_version_if_product_matches"
+        ]
+    }
+    )***"},
+                                                       {R"***(
+    {
+        "target": [
+            "windows"
+        ],
+        "source":
+        {
+            "vendor": "Vendor test ([^ ]+) ([^ ]+) ([^ ]+)",
+            "product": "Product test ([^ ]+) ([^ ]+) ([^ ]+)",
+            "version": "Version test ([^ ]+) ([^ ]+) ([^ ]+) "
+        },
+        "translation":
+        [
+            {
+                "vendor": "vendor translated $(PRODUCT1) $(VENDOR2) $(VERSION3) $(VERSION4)",
+                "product": "product translated $(PRODUCT1) $(VENDOR2) $(VERSION3) $(VENDOR4)",
+                "version": "version translated $(PRODUCT1) $(VENDOR2) $(VERSION3) $(PRODUCT4)"
+            }
+        ],
+        "action":
+        [
+            "replace_vendor",
+            "replace_product",
+            "set_version_if_product_matches"
+        ]
+    }
+    )***"}};
 
 const std::string CNA_NAME {"cnaName"};
 const std::string PACKAGE_NAME {"libmagic-mgc"};
@@ -205,16 +310,21 @@ void DatabaseFeedManagerTest::SetUp()
     }
 
     // Populate DB
-    jsonData = nlohmann::json::parse(TRANSLATION_EXAMPLE);
-    assert(!jsonData.empty());
     assert(flatbuffers::LoadFile(TRANSLATION_FLATBUFFER_SCHEMA.c_str(), false, &schemaStr) == true);
     assert(parser.Parse(schemaStr.c_str()) == true);
-    assert(parser.Parse(jsonData.dump().c_str()) == true);
+    int translationIndex {0};
+    for (const auto& translationExample : TRANSLATION_EXAMPLES)
+    {
+        jsonData = nlohmann::json::parse(translationExample);
+        assert(!jsonData.empty());
 
-    buffer = parser.builder_.GetBufferPointer();
-    const rocksdb::Slice translation(reinterpret_cast<const char*>(buffer), parser.builder_.GetSize());
+        assert(parser.Parse(jsonData.dump().c_str()) == true);
 
-    rocksDBWrapper.put("TID-001", translation, TRANSLATIONS_COLUMN);
+        buffer = parser.builder_.GetBufferPointer();
+        const rocksdb::Slice translation(reinterpret_cast<const char*>(buffer), parser.builder_.GetSize());
+
+        rocksDBWrapper.put("TID-" + std::to_string(++translationIndex), translation, TRANSLATIONS_COLUMN);
+    }
     // TRANSLATIONS - END
 
     // Mock vendor map
@@ -1755,4 +1865,259 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, FileProcessingOffsetAndHashUpdat
     auto testLambda {[](const nlohmann::json& obj, Utils::IRocksDBWrapper* dbWrapper) {
     }};
     EXPECT_NO_THROW(spDatabaseFeedManager->processMessage(message, "topicName", testLambda));
+}
+
+TEST_F(DatabaseFeedManagerTest, TestTranslationsRegexVersion)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto spIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTrap, shouldStop, mutex)};
+
+    PackageData packageData {
+        .name = "Microsoft ASP.NET Core 15.2.3", .vendor = "Microsoft Corporation", .version = "15.2.3.1516"};
+
+    auto translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+
+    EXPECT_EQ(translations.size(), 1);
+    EXPECT_EQ(translations[0].translatedProduct, "asp.net_core");
+    EXPECT_EQ(translations[0].translatedVendor, "microsoft");
+    EXPECT_EQ(translations[0].translatedVersion, "15.2.3");
+}
+
+TEST_F(DatabaseFeedManagerTest, TestTranslationsRegexVersionUpdate)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto spIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTrap, shouldStop, mutex)};
+
+    PackageData packageData {.name = "Microsoft Exchange Server 2016 Cumulative Update 22",
+                             .vendor = "Microsoft Corporation",
+                             .version = "15.1.2375.7"};
+
+    auto translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+
+    EXPECT_EQ(translations.size(), 1);
+    EXPECT_EQ(translations[0].translatedProduct, "exchange_server_2016");
+    EXPECT_EQ(translations[0].translatedVendor, "microsoft");
+    EXPECT_EQ(translations[0].translatedVersion, "cumulative_update_22");
+}
+
+TEST_F(DatabaseFeedManagerTest, TestTranslationsRegexVersionUpdateSameField)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto spIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTrap, shouldStop, mutex)};
+
+    PackageData packageData {
+        .name = "Java 8 Update 351 (64-bit)", .vendor = "Oracle Corporation", .version = "8.0.3510.10"};
+
+    auto translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+
+    EXPECT_EQ(translations.size(), 1);
+    EXPECT_EQ(translations[0].translatedProduct, "jre");
+    EXPECT_EQ(translations[0].translatedVendor, "oracle");
+    EXPECT_EQ(translations[0].translatedVersion, "1.8.0-update_351");
+}
+
+TEST_F(DatabaseFeedManagerTest, TestTranslationsRegexGeneric)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto spIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTrap, shouldStop, mutex)};
+
+    PackageData packageData {.name = "Product a b c d e f g h i j k l m n o p q r s t u v w x y z",
+                             .vendor = "Vendor A B C D E F G H I J K L M N O P Q R S T U V W X Y Z",
+                             .version = "Version 1 2 3 4 5 6 7 8 9 10"};
+
+    auto translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+
+    EXPECT_EQ(translations.size(), 1);
+    EXPECT_EQ(translations[0].translatedProduct, "product Version 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10");
+    EXPECT_EQ(translations[0].translatedVendor, "vendor Product a b c d e f g h i j a b c d e f g h i j");
+    EXPECT_EQ(translations[0].translatedVersion, "version Vendor A B C D E F G H I J A B C D E F G H I J");
+}
+
+TEST_F(DatabaseFeedManagerTest, TestTranslationsRegexMorePlaceHoldersThanExtractedGroups)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto spIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTrap, shouldStop, mutex)};
+
+    PackageData packageData {
+        .name = "Product test a b c d", .vendor = "Vendor test A B C D", .version = "Version test 1 2 3 4"};
+
+    auto translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+
+    EXPECT_EQ(translations.size(), 1);
+    EXPECT_EQ(translations[0].translatedProduct, "product translated a B 3 $(VENDOR4)");
+    EXPECT_EQ(translations[0].translatedVendor, "vendor translated a B 3 $(VERSION4)");
+    EXPECT_EQ(translations[0].translatedVersion, "version translated a B 3 $(PRODUCT4)");
+}
+
+TEST_F(DatabaseFeedManagerTest, TestTranslationsRegexAllRequired)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    auto spIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                              TrampolinePolicyManager,
+                                              TrampolineContentRegister,
+                                              TrampolineRouterSubscriber>>(spIndexerConnectorTrap, shouldStop, mutex)};
+
+    auto constexpr productMatch {"Product test a b c d"};
+    auto constexpr vendorMatch {"Vendor test A B C D"};
+    auto constexpr versionMatch {"Version test 1 2 3 4"};
+    auto constexpr productDontMatch {"Product that won't match"};
+    auto constexpr vendorDontMatch {"Vendor that won't match"};
+    auto constexpr versionDontMatch {"Version that won't match"};
+
+    PackageData packageData {.name = productDontMatch, .vendor = vendorDontMatch, .version = versionDontMatch};
+    auto translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 0);
+
+    packageData.name = productDontMatch;
+    packageData.vendor = vendorDontMatch;
+    packageData.version = versionMatch;
+    translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 0);
+
+    packageData.name = productDontMatch;
+    packageData.vendor = vendorMatch;
+    packageData.version = versionDontMatch;
+    translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 0);
+
+    packageData.name = productDontMatch;
+    packageData.vendor = vendorMatch;
+    packageData.version = versionMatch;
+    translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 0);
+
+    packageData.name = productMatch;
+    packageData.vendor = vendorDontMatch;
+    packageData.version = versionDontMatch;
+    translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 0);
+
+    packageData.name = productMatch;
+    packageData.vendor = vendorDontMatch;
+    packageData.version = versionMatch;
+    translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 0);
+
+    packageData.name = productMatch;
+    packageData.vendor = vendorMatch;
+    packageData.version = versionDontMatch;
+    translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 0);
+
+    packageData.name = productMatch;
+    packageData.vendor = vendorMatch;
+    packageData.version = versionMatch;
+    translations = spDatabaseFeedManager->getTranslationFromL2(packageData, "windows");
+    EXPECT_EQ(translations.size(), 1);
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #23656|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR extends the current translation capabilities allowing many capture groups for the fields name, vendor and version.

>[!WARNING]
> This is a breaking change

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Manual tests: the translations from the repository where added to the local test folder with a script

<details><summary>Translations script</summary>
<p>

```python
BIN_PATH = '/workspaces/wazuh/src/build/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/rocks_db_query_testtool'
DB_PATH = '/workspaces/wazuh/src/queue/vd/feed/'
FBS_PATH = '/workspaces/wazuh/src/wazuh_modules/vulnerability_scanner/schemas/packageTranslation.fbs'
COLUMN = 'translation'
import os

for root, dirs, files in os.walk("."):
    for name in dirs:
        with open(name + '/action.json', 'r') as f:
            print(name)
            data = f.read()
            data = data.strip().replace('\n', '')
            cmd = BIN_PATH + ' -d ' + DB_PATH + ' -f ' + FBS_PATH + ' -c ' + COLUMN + ' -k ' + name + ' -v \'' + data + '\''
            os.system(cmd)
```

</p>
</details> 

With the modified DB, the QA tests pass

```
root@fb659c773250:/workspaces/wazuh/src# GITHUB_WORKSPACE=/workspaces/wazuh/src python3 -m pytest -rA --html=report.html --self-contained-html -vvx wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py --log-cli-level=DEBUG

...

=================================================== short test summary info ====================================================
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log1]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log2]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log3]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log4]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log5]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log6]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log7]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log8]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log9]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log10]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log11]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log12]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log13]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log14]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log15]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log16]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log17]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log18]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log19]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log20]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log21]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log22]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log23]
PASSED wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log24]
SKIPPED [1] wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py:260: Test 000 is not required
=========================================== 24 passed, 1 skipped in 73.18s (0:01:13) ===========================================
```

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

- [x] Added unit tests (for new features)

