### PR TITLE
New framework Indexer client

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -1,5 +1,8 @@
 anyio==4.1.0
+aiohttp==3.9.5
+aiosignal==1.3.1
 asgiref==3.7.2
+async-timeout==4.0.3
 attrs==23.1.0
 azure-common==1.1.25
 azure-core==1.30.2
@@ -22,6 +25,7 @@ defusedxml==0.6.0
 docker==7.1.0
 docker-pycreds==0.4.0
 docutils==0.15.2
+Events==0.5
 exceptiongroup==1.2.0
 frozenlist==1.2.0
 future==0.18.3
@@ -57,6 +61,7 @@ mypy-extensions==0.4.3
 numpy==1.26.0
 openapi-schema-validator==0.6.2
 openapi-spec-validator==0.7.1
+opensearch-py==2.6.0
 packaging==20.9
 pathable==0.4.3
 pathlib==1.0.1

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -437,6 +437,9 @@ class WazuhException(Exception):
         # External services
         2100: {'message': 'Error in CTI service request'},
 
+        # Indexer
+        2200: {'message': 'Could not initialize Indexer connection'},
+
         # Cluster
         3000: 'Cluster',
         3001: 'Error creating zip file',
@@ -803,6 +806,14 @@ class WazuhHAPHelperError(WazuhClusterError):
     """
     _default_type = "about:blank"
     _default_title = "HAProxy Helper Error"
+
+
+class WazuhIndexerError(WazuhInternalError):
+    """
+    This type of exception is raised inside the indexer.
+    """
+    _default_type = "about:blank"
+    _default_title = "Wazuh Indexer Error"
 
 
 class WazuhError(WazuhException):

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -439,6 +439,7 @@ class WazuhException(Exception):
 
         # Indexer
         2200: {'message': 'Could not connect to the indexer'},
+        2201: {'message': 'Indexer credentials not provided'},
 
         # Cluster
         3000: 'Cluster',

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -438,7 +438,7 @@ class WazuhException(Exception):
         2100: {'message': 'Error in CTI service request'},
 
         # Indexer
-        2200: {'message': 'Could not initialize Indexer connection'},
+        2200: {'message': 'Could not connect to the indexer'},
 
         # Cluster
         3000: 'Cluster',

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -1,0 +1,96 @@
+import os
+
+from core.exception import WazuhIndexerError
+from opensearchpy import AsyncOpenSearch
+
+HOST_KEY = 'host'
+PORT_KEY = 'port'
+
+# This constants are temporary
+INDEXER_HOST = os.environ.get('WAZUH_INDEXER_HOST' 'wazuh-indexer')
+INDEXER_PORT = os.environ.get('WAZUH_INDEXER_PORT', 9200)
+INDEXER_USER = os.environ.get('WAZUH_INDEXER_USER', 'admin')
+INDEXER_PASSWORD = os.environ.get('WAZUH_INDEXER_PASSWORD', 'SecretPassword1%')
+
+
+class Indexer:
+    """Interface to connect with Wazuh Indexer."""
+
+    def __init__(
+        self,
+        host: str = INDEXER_HOST,
+        user: str = INDEXER_USER,
+        password: str = INDEXER_PASSWORD,
+        port: int = INDEXER_PORT,
+        use_ssl: bool = True,
+        verify_certs: bool = True,
+    ) -> None:
+        self.host = host
+        self.user = user
+        self.password = password
+        self.port = port
+        self.use_ssl = use_ssl
+        self.verify_certs = verify_certs
+
+        self._client = self._get_opensearch_client()
+
+        # Register index clients here
+
+    def _get_opensearch_client(self) -> AsyncOpenSearch:
+        """Get the a new instance of the opensearch client.
+
+        Returns
+        -------
+        AsyncOpenSearch
+            The created instance.
+        """
+        self._client = AsyncOpenSearch(
+            hosts=[{HOST_KEY: self.host, PORT_KEY: self.port}],
+            http_compress=True,
+            http_auth=(self.user, self.password),
+            use_ssl=self.use_ssl,
+            verify_certs=self.verify_certs,
+        )
+
+    async def initiazlize(self):
+        """Initialize the Wazuh Indexer connection.
+
+        Raises
+        ------
+        WazuhIndexerError
+            In case of errors communicating with the Wazuh Indexer.
+        """
+        if not (await self._client.ping()):
+            raise WazuhIndexerError(2200)
+
+
+async def create_indexer(
+    host: str = INDEXER_HOST,
+    user: str = INDEXER_USER,
+    password: str = INDEXER_PASSWORD,
+    port: int = INDEXER_PORT,
+    **kwargs,
+) -> Indexer:
+    """Create and initialize the Indexer.
+
+    Parameters
+    ----------
+    host : str, optional
+        Location of the Wazuh Indexer, by default INDEXER_HOST
+    user : str, optional
+        User of the Wazuh Indexer to authenticate with, by default INDEXER_USER
+    password : str, optional
+        Password of the Wazuh Indexer to authenticate with, by default INDEXER_PASSWORD
+    port : int, optional
+        Port of the Wazuh Indexer to connect with, by default INDEXER_PORT
+
+    Returns
+    -------
+    Indexer
+        The new Indexer instance.
+    """
+
+    indexer = Indexer(host, user, password, port, **kwargs)
+    await indexer.initiazlize()
+
+    return indexer

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -23,6 +23,7 @@ class Indexer:
         port: int = 9200,
         use_ssl: bool = True,
         verify_certs: bool = True,
+        ca_certs: str = ''
     ) -> None:
         self.host = host
         self.user = user
@@ -30,6 +31,7 @@ class Indexer:
         self.port = port
         self.use_ssl = use_ssl
         self.verify_certs = verify_certs
+        self.ca_certs = ca_certs
 
         self._client = self._get_opensearch_client()
 
@@ -49,6 +51,7 @@ class Indexer:
             http_auth=(self.user, self.password),
             use_ssl=self.use_ssl,
             verify_certs=self.verify_certs,
+            ca_certs=self.ca_certs
         )
 
     async def initiazlize(self):

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -1,13 +1,18 @@
 import os
+import random
+from asyncio import sleep
+from logging import getLogger
 
-from core.exception import WazuhIndexerError
 from opensearchpy import AsyncOpenSearch
+from wazuh.core.exception import WazuhIndexerError
+
+logger = getLogger('wazuh')
 
 HOST_KEY = 'host'
 PORT_KEY = 'port'
 
 # This constants are temporary
-INDEXER_HOST = os.environ.get('WAZUH_INDEXER_HOST' 'wazuh-indexer')
+INDEXER_HOST = os.environ.get('WAZUH_INDEXER_HOST', 'wazuh-indexer')
 INDEXER_PORT = os.environ.get('WAZUH_INDEXER_PORT', 9200)
 INDEXER_USER = os.environ.get('WAZUH_INDEXER_USER', 'admin')
 INDEXER_PASSWORD = os.environ.get('WAZUH_INDEXER_PASSWORD', 'SecretPassword1%')
@@ -44,7 +49,7 @@ class Indexer:
         AsyncOpenSearch
             The created instance.
         """
-        self._client = AsyncOpenSearch(
+        return AsyncOpenSearch(
             hosts=[{HOST_KEY: self.host, PORT_KEY: self.port}],
             http_compress=True,
             http_auth=(self.user, self.password),
@@ -63,15 +68,21 @@ class Indexer:
         if not (await self._client.ping()):
             raise WazuhIndexerError(2200)
 
+    async def close(self):
+        """Close the Wazuh Indexer client."""
+        await self._client.close()
+
 
 async def create_indexer(
     host: str = INDEXER_HOST,
     user: str = INDEXER_USER,
     password: str = INDEXER_PASSWORD,
     port: int = INDEXER_PORT,
+    retries: int = 5,
+    backoff_in_seconds: int = 1,
     **kwargs,
 ) -> Indexer:
-    """Create and initialize the Indexer.
+    """Create and initialize the Indexer instance implementing a retry with backoff machanism.
 
     Parameters
     ----------
@@ -83,6 +94,10 @@ async def create_indexer(
         Password of the Wazuh Indexer to authenticate with, by default INDEXER_PASSWORD
     port : int, optional
         Port of the Wazuh Indexer to connect with, by default INDEXER_PORT
+    retries : int, optional
+        Number of retries, by default 5.
+    backoff_in_seconds : int, optional
+        Base seconds to wait, by default 1.
 
     Returns
     -------
@@ -91,6 +106,18 @@ async def create_indexer(
     """
 
     indexer = Indexer(host, user, password, port, **kwargs)
-    await indexer.initiazlize()
+    retries_count = 0
+    while True:
+        try:
+            await indexer.initiazlize()
+            return indexer
+        except WazuhIndexerError:
+            if retries_count == retries:
+                await indexer.close()
+                raise
 
-    return indexer
+            wait = backoff_in_seconds * 2**retries_count + random.uniform(0, 1)
+            logger.warning('Cannot initialize the indexer client.')
+            logger.info(f'Sleeping {wait}s until next try.')
+            await sleep(wait)
+            retries_count += 1

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -23,7 +23,7 @@ class Indexer:
         port: int = 9200,
         use_ssl: bool = True,
         verify_certs: bool = True,
-        ca_certs: str = ''
+        ca_certs: str = '',
     ) -> None:
         self.host = host
         self.user = user
@@ -51,10 +51,10 @@ class Indexer:
             http_auth=(self.user, self.password),
             use_ssl=self.use_ssl,
             verify_certs=self.verify_certs,
-            ca_certs=self.ca_certs
+            ca_certs=self.ca_certs,
         )
 
-    async def initiazlize(self):
+    async def initialize(self):
         """Initialize the Wazuh Indexer connection.
 
         Raises
@@ -79,15 +79,15 @@ async def create_indexer(
     backoff_in_seconds: int = 1,
     **kwargs,
 ) -> Indexer:
-    """Create and initialize the Indexer instance implementing a retry with backoff machanism.
+    """Create and initialize the Indexer instance implementing a retry with backoff mechanism.
 
     Parameters
     ----------
-    host : str, optional
+    host : str
         Location of the Wazuh Indexer.
-    user : str, optional
+    user : str
         User of the Wazuh Indexer to authenticate with.
-    password : str, optional
+    password : str
         Password of the Wazuh Indexer to authenticate with.
     port : int, optional
         Port of the Wazuh Indexer to connect with, by default 9200
@@ -106,7 +106,7 @@ async def create_indexer(
     retries_count = 0
     while True:
         try:
-            await indexer.initiazlize()
+            await indexer.initialize()
             return indexer
         except WazuhIndexerError:
             if retries_count == retries:

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -11,22 +11,16 @@ logger = getLogger('wazuh')
 HOST_KEY = 'host'
 PORT_KEY = 'port'
 
-# This constants are temporary
-INDEXER_HOST = os.environ.get('WAZUH_INDEXER_HOST', 'wazuh-indexer')
-INDEXER_PORT = os.environ.get('WAZUH_INDEXER_PORT', 9200)
-INDEXER_USER = os.environ.get('WAZUH_INDEXER_USER', 'admin')
-INDEXER_PASSWORD = os.environ.get('WAZUH_INDEXER_PASSWORD', 'SecretPassword1%')
-
 
 class Indexer:
     """Interface to connect with Wazuh Indexer."""
 
     def __init__(
         self,
-        host: str = INDEXER_HOST,
-        user: str = INDEXER_USER,
-        password: str = INDEXER_PASSWORD,
-        port: int = INDEXER_PORT,
+        host: str,
+        user: str,
+        password: str,
+        port: int = 9200,
         use_ssl: bool = True,
         verify_certs: bool = True,
     ) -> None:
@@ -74,10 +68,10 @@ class Indexer:
 
 
 async def create_indexer(
-    host: str = INDEXER_HOST,
-    user: str = INDEXER_USER,
-    password: str = INDEXER_PASSWORD,
-    port: int = INDEXER_PORT,
+    host: str,
+    user: str,
+    password: str,
+    port: int = 9200,
     retries: int = 5,
     backoff_in_seconds: int = 1,
     **kwargs,
@@ -87,13 +81,13 @@ async def create_indexer(
     Parameters
     ----------
     host : str, optional
-        Location of the Wazuh Indexer, by default INDEXER_HOST
+        Location of the Wazuh Indexer.
     user : str, optional
-        User of the Wazuh Indexer to authenticate with, by default INDEXER_USER
+        User of the Wazuh Indexer to authenticate with.
     password : str, optional
-        Password of the Wazuh Indexer to authenticate with, by default INDEXER_PASSWORD
+        Password of the Wazuh Indexer to authenticate with.
     port : int, optional
-        Port of the Wazuh Indexer to connect with, by default INDEXER_PORT
+        Port of the Wazuh Indexer to connect with, by default 9200
     retries : int, optional
         Number of retries, by default 5.
     backoff_in_seconds : int, optional

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -38,7 +38,7 @@ class Indexer:
         # Register index clients here
 
     def _get_opensearch_client(self) -> AsyncOpenSearch:
-        """Get the a new instance of the opensearch client.
+        """Get a new OpenSearch client instance.
 
         Returns
         -------
@@ -54,8 +54,8 @@ class Indexer:
             ca_certs=self.ca_certs,
         )
 
-    async def initialize(self):
-        """Initialize the Wazuh Indexer connection.
+    async def connect(self) -> None:
+        """Connect to the Wazuh Indexer.
 
         Raises
         ------
@@ -65,8 +65,9 @@ class Indexer:
         if not (await self._client.ping()):
             raise WazuhIndexerError(2200)
 
-    async def close(self):
+    async def close(self) -> None:
         """Close the Wazuh Indexer client."""
+        logger.warning('Closing the indexer client session.')
         await self._client.close()
 
 
@@ -106,7 +107,7 @@ async def create_indexer(
     retries_count = 0
     while True:
         try:
-            await indexer.initialize()
+            await indexer.connect()
             return indexer
         except WazuhIndexerError:
             if retries_count == retries:

--- a/framework/wazuh/core/indexer/base.py
+++ b/framework/wazuh/core/indexer/base.py
@@ -1,0 +1,13 @@
+import logging
+
+from opensearchpy import AsyncOpenSearch
+
+
+class BaseIndex:
+    """Base class to interact with indexes."""
+
+    INDEX = None
+
+    def __init__(self, client: AsyncOpenSearch) -> None:
+        self._client = client
+        self._logger = logging.getLogger('wazuh')

--- a/framework/wazuh/core/indexer/tests/test_base.py
+++ b/framework/wazuh/core/indexer/tests/test_base.py
@@ -1,0 +1,12 @@
+from unittest import mock
+
+from wazuh.core.indexer.base import BaseIndex
+
+
+def test_base_index_init():
+    """Check the correct initalization of the `BaseIndex` class."""
+
+    client_mock = mock.MagicMock()
+    instance = BaseIndex(client=client_mock)
+
+    assert instance._client == client_mock

--- a/framework/wazuh/core/indexer/tests/test_init.py
+++ b/framework/wazuh/core/indexer/tests/test_init.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+import pytest
+from opensearchpy import AsyncOpenSearch
+from wazuh.core.exception import WazuhIndexerError
+from wazuh.core.indexer import Indexer, create_indexer
+
+
+@pytest.fixture
+def indexer_instance() -> Indexer:
+    return Indexer(host='test', user='user_test', password='password_test')
+
+
+@pytest.fixture
+def indexer_instance_with_mocked_client(indexer_instance) -> Indexer:
+    indexer_instance._client = mock.AsyncMock()
+    return indexer_instance
+
+
+class TestIndexer:
+    def test_indexer_init(self, indexer_instance):
+        """Check the correct initalization of the `Indexer` class."""
+
+        assert isinstance(indexer_instance._client, AsyncOpenSearch)
+
+    async def test_initialize(self, indexer_instance_with_mocked_client):
+        """Check the correct function of `initialize` method."""
+
+        indexer_instance_with_mocked_client._client.ping.return_value = True
+        await indexer_instance_with_mocked_client.initialize()
+
+        indexer_instance_with_mocked_client._client.ping.assert_called_once()
+
+    async def test_initialize_ko(self, indexer_instance_with_mocked_client):
+        """Check the correct raise of `initialize` method."""
+
+        indexer_instance_with_mocked_client._client.ping.return_value = False
+
+        with pytest.raises(WazuhIndexerError, match='.*2200.*'):
+            await indexer_instance_with_mocked_client.initialize()
+
+    async def test_close(self, indexer_instance_with_mocked_client):
+        """Check the correct function of `close` method."""
+
+        await indexer_instance_with_mocked_client.close()
+
+        indexer_instance_with_mocked_client._client.close.assert_called_once()
+
+
+@mock.patch('wazuh.core.indexer.Indexer', autospec=True)
+async def test_create_indexer(indexer_mock: mock.AsyncMock):
+    """Check the correct function of `create_index`."""
+
+    host = 'test'
+    user = 'user_test'
+    password = 'password_test'
+
+    instance_mock = await create_indexer(host=host, user=user, password=password)
+    indexer_mock.assert_called_once_with(host=host, user=user, password=password, port=9200)
+    instance_mock.initialize.assert_called_once()
+
+
+@pytest.mark.parametrize('retries', [2, 4])
+@mock.patch('wazuh.core.indexer.Indexer', autospec=True)
+async def test_create_indexer_ko(indexer_mock: mock.AsyncMock, retries: int):
+    """Check the correct raise of `create_index`."""
+
+    host = 'test'
+    user = 'user_test'
+    password = 'password_test'
+
+    instance_mock = mock.AsyncMock()
+    instance_mock.initialize.side_effect = WazuhIndexerError(2200)
+    indexer_mock.return_value = instance_mock
+
+    with mock.patch('wazuh.core.indexer.sleep') as sleep_mock:
+        with pytest.raises(WazuhIndexerError, match='.*2200.*'):
+            instance_mock = await create_indexer(host=host, user=user, password=password, retries=retries)
+
+        assert instance_mock.initialize.call_count == retries + 1
+        instance_mock.close.assert_called_once()
+        assert sleep_mock.call_count == retries


### PR DESCRIPTION
|Related issue|
|---|
| #24615|

## Description

This PR closes #24615. Implements the base client to interact with the Indexer component.

## Configuration options

With the script below is possible to test the connection.

<details><summary>init_indexer.py</summary>
<p>

```python
import asyncio
import os

from framework.wazuh.core.indexer import create_indexer

INDEXER_HOST = os.environ.get('WAZUH_INDEXER_HOST', 'wazuh-indexer')
INDEXER_PORT = os.environ.get('WAZUH_INDEXER_PORT', 9200)
INDEXER_USER = os.environ.get('WAZUH_INDEXER_USER', 'admin')
INDEXER_PASSWORD = os.environ.get('WAZUH_INDEXER_PASSWORD', 'SecretPassword1%')

async def main():
    client = await create_indexer(host=INDEXER_HOST, user=INDEXER_USER, password=INDEXER_PASSWORD, use_ssl=False)
    await client.close()


if __name__ == '__main__':
    asyncio.run(main())
```

</p>
</details> 

## Logs/Alerts example

### Succesful connection to the Indexer

```bash
(framework) ➜  wazuh git:(enhancement/24615-framework-indexer-client) ✗ WAZUH_INDEXER_HOST=127.0.0.1 python init_indexer.py
```

### Unsuccesful connection to the Indexer

```bash
(framework) ➜  wazuh git:(enhancement/24615-framework-indexer-client) ✗ python init_indexer.py
Cannot initialize the indexer client.
Cannot initialize the indexer client.
Cannot initialize the indexer client.
Cannot initialize the indexer client.
Cannot initialize the indexer client.
Traceback (most recent call last):
  File "/home/nstefani/git/wazuh/init_indexer.py", line 18, in <module>
    asyncio.run(main())
  File "/home/nstefani/.pyenv/versions/3.10.13/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/nstefani/.pyenv/versions/3.10.13/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/nstefani/git/wazuh/init_indexer.py", line 13, in main
    client = await create_indexer(host=INDEXER_HOST, user=INDEXER_USER, password=INDEXER_PASSWORD, use_ssl=False)
  File "/home/nstefani/git/wazuh/framework/wazuh/core/indexer/__init__.py", line 109, in create_indexer
    await indexer.initialize()
  File "/home/nstefani/git/wazuh/framework/wazuh/core/indexer/__init__.py", line 66, in initialize
    raise WazuhIndexerError(2200)
wazuh.core.exception.WazuhIndexerError: Error 2200 - Could not initialize Indexer connection
```

## Tests

```bash
(framework) ➜  wazuh git:(enhancement/24615-framework-indexer-client) ✗ PYTHONPATH=$WAZUH_REPO/api:$WAZUH_REPO/framework python -m pytest framework/wazuh/core/indexer
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/nstefani/git/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.8.0, anyio-4.1.0, html-2.1.1, metadata-3.1.1, cov-4.1.0
asyncio: mode=auto
collected 8 items

framework/wazuh/core/indexer/tests/test_base.py .                                                                                                                                                             [ 12%]
framework/wazuh/core/indexer/tests/test_init.py .......                                                                                                                                                       [100%]

================================================================================================= 8 passed in 0.30s =================================================================================================
```