### PR TITLE
Enhance Connection between `wazuh-analysisd` and `wazuh-db`

### DIFF
--- a/src/analysisd/mitre.c
+++ b/src/analysisd/mitre.c
@@ -61,6 +61,14 @@ int mitre_load() {
     os_calloc(OS_SIZE_6144 + 1, sizeof(char), wazuhdb_query);
     os_calloc(OS_MAXSTR, sizeof(char), response);
 
+    /* Connect to wdb */
+    sock = wdbc_connect_with_attempts(5);
+    if (sock < 0) {
+        merror("Unable to connect to Wazuh-DB for Mitre matrix information.");
+        result = -1;
+        goto end;
+    }
+
     /* Getting technique ID and name from Mitre's database in Wazuh-DB  */
     snprintf(wazuhdb_query, OS_SIZE_6144, SQL_GET_ALL_TECHNIQUES, MAX_TECHNIQUES_REQUEST, offset);
     techniques_json = wdbc_query_parse_json(&sock, wazuhdb_query, response, OS_MAXSTR);

--- a/src/headers/wazuhdb_op.h
+++ b/src/headers/wazuhdb_op.h
@@ -31,6 +31,7 @@ typedef enum wdbc_result {
 extern const char* WDBC_RESULT[];
 
 int wdbc_connect();
+int wdbc_connect_with_attempts(int max_attempts);
 int wdbc_query(const int sock, const char *query, char *response, const int len);
 int wdbc_query_ex(int *sock, const char *query, char *response, const int len);
 int wdbc_parse_result(char *result, char **payload);

--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -18,15 +18,25 @@
  * @return Socket descriptor or -1 if error.
  */
 int wdbc_connect() {
+    return wdbc_connect_with_attempts(3);
+}
 
-    int attempts;
+/**
+ * @brief Connects to Wazuh-DB socket with a maximum number of attempts.
+ *
+ * @param max_attempts Maximum number of attempts to connect.
+ * @return int Socket descriptor or -1 if error.
+ */
+int wdbc_connect_with_attempts(int max_attempts) {
+
+    assert(max_attempts > 0);
     int wdb_socket = -1;
     char sockname[PATH_MAX + 1];
 
     strcpy(sockname, WDB_LOCAL_SOCK);
 
 
-    for (attempts = 1; attempts <= 3 && (wdb_socket = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_SIZE_6144)) < 0; attempts++) {
+    for (int attempts = 1; attempts <= max_attempts && (wdb_socket = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_SIZE_6144)) < 0; attempts++) {
         switch (errno) {
         case ENOENT:
             minfo("Cannot find '%s'. Waiting %d seconds to reconnect.", sockname, attempts);

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -64,7 +64,8 @@ list(APPEND analysisd_names "test_labels")
 list(APPEND analysisd_flags "-Wl,--wrap,wdb_get_agent_labels")
 
 list(APPEND analysisd_names "test_mitre")
-list(APPEND analysisd_flags "-Wl,--wrap,wdbc_query_ex -Wl,--wrap,wdbc_query_parse_json ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
+list(APPEND analysisd_flags "-Wl,--wrap,wdbc_connect_with_attempts -Wl,--wrap,wdbc_query_ex \
+                             -Wl,--wrap,wdbc_query_parse_json ${HASH_OP_WRAPPERS} ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND analysisd_names "test_rules")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_mwarn -Wl,--wrap,_merror -Wl,--wrap,_os_analysisd_add_logmsg \

--- a/src/unit_tests/analysisd/test_mitre.c
+++ b/src/unit_tests/analysisd/test_mitre.c
@@ -57,11 +57,10 @@ void test_queryid_error_socket(void **state)
     int ret;
     cJSON * id_array = NULL;
 
-    will_return(__wrap_wdbc_query_parse_json, -2);
-    will_return(__wrap_wdbc_query_parse_json, id_array);
+    will_return(__wrap_wdbc_connect_with_attempts, -2);
 
-    expect_string(__wrap__merror, formatted_msg, "Unable to connect to socket 'queue/db/wdb'");
-    expect_string(__wrap__merror, formatted_msg, "Response from the Mitre database cannot be parsed.");
+
+    expect_string(__wrap__merror, formatted_msg, "Unable to connect to Wazuh-DB for Mitre matrix information.");
     expect_string(__wrap__merror, formatted_msg, "Mitre matrix information could not be loaded.");
 
     ret = mitre_load();
@@ -75,6 +74,7 @@ void test_queryid_no_response(void **state)
     int ret;
     cJSON * id_array = NULL;
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     will_return(__wrap_wdbc_query_parse_json, -1);
     will_return(__wrap_wdbc_query_parse_json, id_array);
 
@@ -94,6 +94,8 @@ void test_queryid_bad_response(void **state)
     cJSON * id_array = NULL;
 
     char *response_ids = "err not found";
+
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     will_return(__wrap_wdbc_query_parse_json, 1);
     will_return(__wrap_wdbc_query_parse_json, response_ids);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -113,6 +115,7 @@ void test_queryid_error_parse(void **state)
     int ret;
     cJSON * id_array = cJSON_Parse("[{\"id\":}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
 
@@ -130,6 +133,7 @@ void test_queryid_empty_array(void **state)
     int ret;
     cJSON * id_array = cJSON_Parse("[ ]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
 
@@ -145,6 +149,7 @@ void test_queryid_error_parse_technique_id(void **state) {
     int ret;
     cJSON * id_array = cJSON_Parse("[{\"ids\":\"technique-0001\"},{\"ids\":\"technique-0002\"}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
 
@@ -166,6 +171,7 @@ void test_queryid_error_parse_technique_name(void **state) {
     int ret;
     cJSON * id_array = cJSON_Parse("[{\"id\":\"technique-0001\"},{\"id\":\"technique-0002\"}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
 
@@ -187,6 +193,7 @@ void test_queryid_error_parse_technique_external_id(void **state) {
     int ret;
     cJSON * id_array = cJSON_Parse("[{\"id\":\"technique-0001\",\"name\":\"Technique1\"},{\"id\":\"technique-0002\",\"name\":\"Technique2\"}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
 
@@ -210,6 +217,7 @@ void test_querytactics_error_socket(void **state) {
     cJSON * id_array = cJSON_Parse("[{\"id\":\"technique-0001\",\"name\":\"Technique1\",\"external_id\":\"T1001\"},{\"id\":\"technique-0002\",\"name\":\"Technique2\",\"external_id\":\"T1002\"}]");
     cJSON * tactic_array = NULL;
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -238,6 +246,7 @@ void test_querytactics_no_response(void **state) {
     cJSON * id_array = cJSON_Parse("[{\"id\":\"technique-0001\",\"name\":\"Technique1\",\"external_id\":\"T1001\"},{\"id\":\"technique-0002\",\"name\":\"Technique2\",\"external_id\":\"T1002\"}]");
     cJSON * tactic_array = NULL;
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -267,6 +276,7 @@ void test_querytactics_bad_response(void **state) {
     cJSON * tactic_array = NULL;
     char * response_tactics = "err not found";
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -296,6 +306,7 @@ void test_querytactics_error_parse(void **state) {
     cJSON * id_array = cJSON_Parse("[{\"id\":\"technique-0001\",\"name\":\"Technique1\",\"external_id\":\"T1001\"},{\"id\":\"technique-0002\",\"name\":\"Technique2\",\"external_id\":\"T1002\"}]");
     cJSON * tactic_array = cJSON_Parse("[{\"phase_name\":}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -323,6 +334,7 @@ void test_querytactics_empty_array(void **state) {
     cJSON * id_array = cJSON_Parse("[{\"id\":\"technique-0001\",\"name\":\"Technique1\",\"external_id\":\"T1001\"},{\"id\":\"technique-0002\",\"name\":\"Technique2\",\"external_id\":\"T1002\"}]");
     cJSON * tactic_array = cJSON_Parse("[ ]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -350,6 +362,7 @@ void test_querytactics_error_parse_tactics(void **state) {
     cJSON * id_array = cJSON_Parse("[{\"id\":\"technique-0001\",\"name\":\"Technique1\",\"external_id\":\"T1001\"},{\"id\":\"technique-0002\",\"name\":\"Technique2\",\"external_id\":\"T1002\"}]");
     cJSON * tactic_array = cJSON_Parse("[{\"phase\":\"Discovery\"}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -378,6 +391,7 @@ void test_queryname_error_socket(void **state) {
     cJSON * tactic_array = cJSON_Parse("[{\"tactic_id\":\"tactic-0001\"}]");
     cJSON * tactic_info_array = NULL;
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -411,6 +425,7 @@ void test_queryname_no_response(void **state) {
     cJSON * tactic_array = cJSON_Parse("[{\"tactic_id\":\"tactic-0001\"}]");
     cJSON * tactic_info_array = NULL;
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -445,6 +460,7 @@ void test_queryname_bad_response(void **state) {
     cJSON * tactic_info_array = NULL;
     char * response_tactics = "err not found";
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -479,6 +495,7 @@ void test_queryname_error_parse(void **state) {
     cJSON * tactic_array = cJSON_Parse("[{\"tactic_id\":\"tactic-0001\"}]");
     cJSON * tactic_info_array = cJSON_Parse("[{\"info\":}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -511,6 +528,7 @@ void test_queryname_error_parse_technique_name(void **state) {
     cJSON * tactic_array = cJSON_Parse("[{\"tactic_id\":\"tactic-0001\"}]");
     cJSON * tactic_info_array = cJSON_Parse("[{\"info\":\"Tactic1\"}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -543,6 +561,7 @@ void test_queryname_error_parse_technique_external_id(void **state) {
     cJSON * tactic_array = cJSON_Parse("[{\"tactic_id\":\"tactic-0001\"}]");
     cJSON * tactic_info_array = cJSON_Parse("[{\"name\":\"Tactic1\"}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -575,6 +594,7 @@ void test_query_tactics_error_filling_technique(void **state) {
     cJSON * tactic_array = cJSON_Parse("[{\"tactic_id\":\"tactic-0001\"}]");
     cJSON * tactic_info_array = cJSON_Parse("[{\"name\":\"Tactic1\",\"external_id\":\"TA001\"}]");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);
@@ -612,6 +632,7 @@ void test_query_tactics_success(void **state) {
     cJSON * tactic_info_array = cJSON_Parse("[{\"name\":\"Tactic1\",\"external_id\":\"TA001\"}]");
     cJSON * technique_last = cJSON_Parse(" ");
 
+    will_return(__wrap_wdbc_connect_with_attempts, 1);
     /* Mitre's techniques IDs query */
     will_return(__wrap_wdbc_query_parse_json, 0);
     will_return(__wrap_wdbc_query_parse_json, id_array);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -179,6 +179,14 @@ void __wrap_wdbi_update_completion(__attribute__((unused))wdb_t * wdb,
     check_expected(manager_checksum);
 }
 
+int __wrap_wdbc_connect_with_attempts(__attribute__((unused)) int max_attempts) {
+
+    if (max_attempts <= 0) {
+        fail_msg("Attempts must be greater than 0.");
+    }
+    return mock();
+}
+
 cJSON* __wrap_wdbc_query_parse_json(__attribute__((unused)) int *sock,
                                     __attribute__((unused)) const char *query,
                                     char *response,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -57,6 +57,8 @@ int __wrap_wdbi_query_checksum(wdb_t *wdb, wdb_component_t component, const char
 
 int __wrap_wdbi_query_clear(wdb_t *wdb, wdb_component_t component, const char *payload);
 
+int __wrap_wdbc_connect_with_attempts(int max_attempts);
+
 cJSON* __wrap_wdbc_query_parse_json(int *sock, const char *query, char *response, const int len);
 
 wdbc_result __wrap_wdbc_query_parse(int *sock, const char *query, char *response, const int len, char** payload);


### PR DESCRIPTION
|Related issue|
|---|
| closes #24679 |


### Problem Description
During tests conducted on a CentOS 7 system, as reported in https://github.com/wazuh/wazuh/issues/24679, an intermittent error was observed wherein `wazuh-analysisd` failed to connect to `wazuh-db`. This sporadic issue was primarily noticed in environments with limited CPU resources, indicating a timing issue rather than a persistent fault.

### Errors Reported
The error manifested sporadically during the initialization phase:
```
05:42:56  2024/07/15 08:39:57 wazuh-analysisd: ERROR: Unable to connect to socket 'queue/db/wdb'.
```

### Solution Implemented
To mitigate this issue, the `wdbc_connect_with_attempts` function was introduced within the `shared` module. This enhancement allows configurable retry attempts for establishing a connection to `wazuh-db`. The default retry count has been increased from 3 to 5 in `wazuh-analysisd`, providing additional robustness during slower startup times.

### Changes Made
- **Function Addition:** Added `wdbc_connect_with_attempts` in the `shared` module to better manage connection retries.
- **Integration in `wazuh-analysisd`:** Updated `wazuh-analysisd` to utilize the new function with an increased retry limit.
- **Unit Tests:** Updated unit tests.

### Impact
This update is expected to reduce initialization errors related to `wazuh-db` connection timeouts on systems with high CPU load or slow startup conditions. It aims to improve the reliability of the Wazuh manager under constrained resource conditions.

### Testing
- **Environment Testing:** The changes were tested under conditions where `wazuh-db` initialization delays were simulated, confirming that the increased retry attempts successfully mitigate the connection issue.
- **Unit Testing:** Revised unit tests validate the new connection logic and ensure that the adjustments perform as expected without introducing regressions.



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors