### PR TITLE
Revert Unwanted Changes in `11334-dev-new-wazuh-engine` for Master Merge

### DIFF
--- a/.github/workflows/engine_health_test.yml
+++ b/.github/workflows/engine_health_test.yml
@@ -7,8 +7,6 @@ on:
     types:
       - ready_for_review
       - synchronize
-    branches:
-      - 11334-dev-new-wazuh-engine
     paths:
       - 'src/engine/**'
 

--- a/.github/workflows/engine_helper_functions_test.yml
+++ b/.github/workflows/engine_helper_functions_test.yml
@@ -7,8 +7,6 @@ on:
     types:
       - ready_for_review
       - synchronize
-    branches:
-      - 11334-dev-new-wazuh-engine
     paths:
       - 'src/engine/**'
 

--- a/.github/workflows/engine_integration_test.yml
+++ b/.github/workflows/engine_integration_test.yml
@@ -7,8 +7,6 @@ on:
     types:
       - ready_for_review
       - synchronize
-    branches:
-      - 11334-dev-new-wazuh-engine
     paths:
       - 'src/engine/**'
 

--- a/.github/workflows/engine_unit_test.yml
+++ b/.github/workflows/engine_unit_test.yml
@@ -7,8 +7,6 @@ on:
     types:
       - ready_for_review
       - synchronize
-    branches:
-      - 11334-dev-new-wazuh-engine
     paths:
       - 'src/engine/**'
 
@@ -53,4 +51,3 @@ jobs:
       # Run unit tests using CTest
       working-directory: ${{env.ENGINE_DIR}}/build
       run: ctest -C ${{env.BUILD_TYPE}} -T test --output-on-failure -j2
-

--- a/src/engine/test/integration_tests/geo/features/geo.feature
+++ b/src/engine/test/integration_tests/geo/features/geo.feature
@@ -47,7 +47,7 @@ Feature: Manage Geolocation Databases
         And the response should include "testdb-city.mmdb"
 
     Scenario: Remotely upsert a geolocation database
-        When I send a request to remotely upsert a database with path to "testdb-city.mmdb", type "city", db url "https://github.com/wazuh/wazuh/raw/11334-dev-new-wazuh-engine/src/engine/test/integration_tests/geo/data/base.mmdb" and hash url "https://github.com/wazuh/wazuh/raw/11334-dev-new-wazuh-engine/src/engine/test/integration_tests/geo/data/base.md5"
+        When I send a request to remotely upsert a database with path to "testdb-city.mmdb", type "city", db url "https://github.com/wazuh/wazuh/raw/master/src/engine/test/integration_tests/geo/data/base.mmdb" and hash url "https://github.com/wazuh/wazuh/raw/master/src/engine/test/integration_tests/geo/data/base.md5"
         Then the response should be a "success"
         And the database list "should" include "testdb-city.mmdb"
 
@@ -59,7 +59,7 @@ Feature: Manage Geolocation Databases
         Then the database list "should" include "testdb-city.mmdb"
 
     Scenario: Remotely added db persists after restart
-        When I send a request to remotely upsert a database with path to "testdb-city.mmdb", type "city", db url "https://github.com/wazuh/wazuh/raw/11334-dev-new-wazuh-engine/src/engine/test/integration_tests/geo/data/base.mmdb" and hash url "https://github.com/wazuh/wazuh/raw/11334-dev-new-wazuh-engine/src/engine/test/integration_tests/geo/data/base.md5"
+        When I send a request to remotely upsert a database with path to "testdb-city.mmdb", type "city", db url "https://github.com/wazuh/wazuh/raw/master/src/engine/test/integration_tests/geo/data/base.mmdb" and hash url "https://github.com/wazuh/wazuh/raw/master/src/engine/test/integration_tests/geo/data/base.md5"
         Then the response should be a "success"
         When I restart the engine
         Then the database list "should" include "testdb-city.mmdb"

--- a/src/engine/tools/vagrant/Vagrantfile
+++ b/src/engine/tools/vagrant/Vagrantfile
@@ -57,7 +57,7 @@ Vagrant.configure("2") do |config|
         echo "--- Downlading the engine from github ---"
         su vagrant -c "mkdir engine"
         cd engine
-        su vagrant -c "git clone --branch 11334-dev-new-wazuh-engine  https://github.com/wazuh/wazuh.git"
+        su vagrant -c "git clone --branch master  https://github.com/wazuh/wazuh.git"
         # Make symbolic link to the engine folder
         su vagrant -c "cd && ln -s engine/wazuh/src/engine/ project"
         cd wazuh/src/engine

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -383,6 +383,7 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
     DWORD count = 0;
     int result = 0;
     wchar_t *wprovider_name = NULL;
+    char *msg_sent = NULL;
     char *provider_name = NULL;
     char *msg_from_prov = NULL;
     char *xml_event = NULL;
@@ -390,6 +391,8 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
     char *end_prov = NULL;
     char *find_prov = NULL;
     size_t num;
+
+    cJSON *event_json = cJSON_CreateObject();
 
     os_malloc(OS_MAXSTR, provider_name);
 
@@ -468,13 +471,19 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
                 "Could not get message for (%s)",
                 channel->evt_log);
         }
+        else {
+            cJSON_AddStringToObject(event_json, "Message", msg_from_prov);
+        }
     }
 
     win_format_event_string(xml_event);
 
-    w_logcollector_state_update_file(channel->evt_log, strlen(xml_event));
+    cJSON_AddStringToObject(event_json, "Event", xml_event);
+    msg_sent = cJSON_PrintUnformatted(event_json);
 
-    if (SendMSG(logr_queue, xml_event, "EventChannel", WIN_EVT_MQ) < 0) {
+    w_logcollector_state_update_file(channel->evt_log, strlen(msg_sent));
+
+    if (SendMSG(logr_queue, msg_sent, "EventChannel", WIN_EVT_MQ) < 0) {
         merror(QUEUE_SEND);
         w_logcollector_state_update_target(channel->evt_log, "agent", true);
     } else {
@@ -488,9 +497,11 @@ void send_channel_event(EVT_HANDLE evt, os_channel *channel)
 cleanup:
     os_free(msg_from_prov);
     os_free(xml_event);
+    os_free(msg_sent);
     os_free(properties_values);
     os_free(provider_name);
     os_free(wprovider_name);
+    cJSON_Delete(event_json);
 
     return;
 }

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -46,11 +46,6 @@
   </localfile>
 
   <localfile>
-    <location>Microsoft-Windows-Sysmon/Operational</location>
-    <log_format>eventchannel</log_format>
-  </localfile>
-
-  <localfile>
     <location>active-response\active-responses.log</location>
     <log_format>syslog</log_format>
   </localfile>


### PR DESCRIPTION
|Related issue|
|---|
| Closes #24922 |

### Purpose of the Pull Request
This PR addresses the necessary reversions and updates in the `11334-dev-new-wazuh-engine` branch to ensure a clean and consistent integration into the master branch. The focus is on maintaining compatibility and functionality by removing specific configurations and changes that were not intended to be part of the master production environment.

### Major Changes
- **Reversion of Windows Configuration:** Removed an inadvertently added localfile configuration for Microsoft Windows-Sysmon from the `ossec.conf` file to align with the intended settings for production.
- **Reversion of `read_json` Function Changes:** Reverted the modifications made to the `read_json` function, which was a previously discarded approach, to restore its original functionality.
- **Reversion of Logcollector Event Channel Configuration:** Reverted changes to the Logcollector's event channel handling to ensure events are sent as JSON, aligning with standard operational procedures.
- **Update the integration test**: Update the feature file of the integration test of wazuh-engine
- **Update vagrant**: Update the vagrant master branch.

### GitHub Actions Updates
Updated the GitHub Actions workflows to trigger on activity in the master branch rather than the `11334-dev-new-wazuh-engine` branch, ensuring that CI processes reflect changes affecting production:

- Engine Health Test
- Engine Helper Functions Test
- Engine Integration Test
- Engine Unit Test

### Justification for Reversions
These changes ensure that the master branch remains stable and functional by discarding experimental or developmental configurations that do not align with Wazuh's operational requirements. The revisions have been thoroughly tested to confirm their efficacy and to ensure that they do not introduce regressions.

### Checklist of Tasks Completed
- [x] Removed specific Windows localfile configuration from `ossec.conf`.
- [x] Reverted `read_json` changes to its prior state.
- [x] Restored original Logcollector event channel behavior.
- [x] Updated GitHub Actions to trigger for the master branch activities.

