### PR TITLE
Silence Errors 15027 and 15033 in Windows Eventchannel Monitoring

### DIFF
--- a/src/unit_tests/logcollector/test_read_win_event_channel.c
+++ b/src/unit_tests/logcollector/test_read_win_event_channel.c
@@ -72,7 +72,7 @@ void test_get_message_get_publisher_fail(void ** state) {
     assert_null(get_message(data->evt, data->provider_name, EvtFormatMessageEvent));
 }
 
-void test_get_message_get_size_fail(void ** state) {
+void test_get_message_result_true(void ** state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     expect_value(wrap_EvtOpenPublisherMetadata, Session, NULL);
@@ -84,13 +84,71 @@ void test_get_message_get_size_fail(void ** state) {
 
     will_return(wrap_EvtFormatMessage, strlen(data->message));
     will_return(wrap_EvtFormatMessage, TRUE);
-    will_return(wrap_GetLastError, ERROR_INSUFFICIENT_BUFFER);
-    expect_string(__wrap__merror, formatted_msg, "Could not EvtFormatMessage() to determine buffer size with flags (1) which returned (122)");
+    expect_string(__wrap__merror, formatted_msg, "Could not EvtFormatMessage() to determine buffer size with flags (1): unexpected result");
 
     will_return(wrap_EvtClose, TRUE);
 
     assert_null(get_message(data->evt, data->provider_name, EvtFormatMessageEvent));
+}
 
+void test_get_message_not_found(void ** state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_value(wrap_EvtOpenPublisherMetadata, Session, NULL);
+    expect_string(wrap_EvtOpenPublisherMetadata, PublisherId, data->provider_name);
+    expect_value(wrap_EvtOpenPublisherMetadata, LogFilePath, NULL);
+    expect_value(wrap_EvtOpenPublisherMetadata, Locale, 0);
+    expect_value(wrap_EvtOpenPublisherMetadata, Flags, 0);
+    will_return(wrap_EvtOpenPublisherMetadata, 1);
+
+    will_return(wrap_EvtFormatMessage, strlen(data->message));
+    will_return(wrap_EvtFormatMessage, FALSE);
+    will_return(wrap_GetLastError, ERROR_EVT_MESSAGE_NOT_FOUND);
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not EvtFormatMessage() to determine buffer size with flags (1) which returned (15027)");
+
+    will_return(wrap_EvtClose, TRUE);
+
+    assert_null(get_message(data->evt, data->provider_name, EvtFormatMessageEvent));
+}
+
+void test_get_message_locale_not_found(void ** state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_value(wrap_EvtOpenPublisherMetadata, Session, NULL);
+    expect_string(wrap_EvtOpenPublisherMetadata, PublisherId, data->provider_name);
+    expect_value(wrap_EvtOpenPublisherMetadata, LogFilePath, NULL);
+    expect_value(wrap_EvtOpenPublisherMetadata, Locale, 0);
+    expect_value(wrap_EvtOpenPublisherMetadata, Flags, 0);
+    will_return(wrap_EvtOpenPublisherMetadata, 1);
+
+    will_return(wrap_EvtFormatMessage, strlen(data->message));
+    will_return(wrap_EvtFormatMessage, FALSE);
+    will_return(wrap_GetLastError, ERROR_EVT_MESSAGE_LOCALE_NOT_FOUND);
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not EvtFormatMessage() to determine buffer size with flags (1) which returned (15033)");
+
+    will_return(wrap_EvtClose, TRUE);
+
+    assert_null(get_message(data->evt, data->provider_name, EvtFormatMessageEvent));
+}
+
+void test_get_message_error(void ** state) {
+    test_struct_t *data  = (test_struct_t *)*state;
+
+    expect_value(wrap_EvtOpenPublisherMetadata, Session, NULL);
+    expect_string(wrap_EvtOpenPublisherMetadata, PublisherId, data->provider_name);
+    expect_value(wrap_EvtOpenPublisherMetadata, LogFilePath, NULL);
+    expect_value(wrap_EvtOpenPublisherMetadata, Locale, 0);
+    expect_value(wrap_EvtOpenPublisherMetadata, Flags, 0);
+    will_return(wrap_EvtOpenPublisherMetadata, 1);
+
+    will_return(wrap_EvtFormatMessage, strlen(data->message));
+    will_return(wrap_EvtFormatMessage, FALSE);
+    will_return(wrap_GetLastError, 0);
+    expect_string(__wrap__merror, formatted_msg, "Could not EvtFormatMessage() to determine buffer size with flags (1) which returned (0)");
+
+    will_return(wrap_EvtClose, TRUE);
+
+    assert_null(get_message(data->evt, data->provider_name, EvtFormatMessageEvent));
 }
 
 void test_get_message_format_fail(void ** state) {
@@ -170,7 +228,10 @@ void test_get_message_success(void ** state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_get_message_get_publisher_fail, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_get_message_get_size_fail, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_message_result_true, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_message_not_found, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_message_locale_not_found, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_message_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_message_format_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_message_convert_string_fail, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_message_success, test_setup, test_teardown)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #24911 #3114|

## Description

This PR addresses issues related to specific error codes (15027 and 15033) encountered by the Wazuh agent for Windows when monitoring Eventchannel logs. The proposed solution silences these errors to reduce unnecessary noise in the logs while providing necessary debug information.

This change aims to improve the clarity and relevance of the logs generated by the Wazuh agent, helping users and developers focus on more critical issues while still providing visibility into specific non-critical errors through debug logs.

## Issues Fixed

- **Error 15027** (`ERROR_EVT_MESSAGE_NOT_FOUND`): This error occurs when the agent attempts to read an incomplete message. It has no impact, since the agent retries reading the message later: https://github.com/wazuh/wazuh/issues/4658#issuecomment-614884431.
- **Error 15033** (`ERROR_EVT_MESSAGE_LOCALE_NOT_FOUND`): This error occurs when the localized message resource for the specified locale cannot be found.

## Changes Made

- Updated the error handling code to silence errors 15027 and 15033.
- Both errors now produce a debug-1 log instead of an error log, making it easier to distinguish them from critical issues.

```
wazuh-agent[3284] read_win_event_channel.c:196 at get_message(): DEBUG: Could not EvtFormatMessage() to determine buffer size with flags (1) which returned (15027)
wazuh-agent[3284] read_win_event_channel.c:510 at send_channel_event(): DEBUG: Could not get message for (Application)
```

## Testing Performed

1. **Manual Testing:**
   - Inserted logs manually into the Application channel.
   - Verified that no errors appear in `ossec.log`.
   - Enabled debug mode on the agent and confirmed that such logs appear as debug-1.
```powershell
Write-EventLog -LogName Application -Source "Application" -EntryType Information -EventId 1000 -Message "This is a test log entry"
```
2. **Unit Tests:**
   - **Expected Case:** The first call should fail as it only provides the message size.
   - **Unexpected Case:** The first call returns success. This scenario should not occur.
   - **Error 15027:** Confirmed it prints a debug-1 log.
   - **Error 15033:** Confirmed it prints a debug-1 log.
   - **Other Errors:** Confirmed they print an error log.

