### PR TITLE
Always restart agent after upgrade to read upgrade result

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -95,17 +95,12 @@ fi
 RESULT=$?
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Installation result = ${RESULT}" >> ./logs/upgrade.log
 
-# Start Agent if not already running
+# Restart Agent
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking for Wazuh Agent control script." >> ./logs/upgrade.log
 
 if [ -f "./bin/wazuh-control" ]; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking if Wazuh Agent is running." >> ./logs/upgrade.log
-    if ./bin/wazuh-control status >/dev/null 2>&1; then
-        echo "$(date +"%Y/%m/%d %H:%M:%S") - Wazuh Agent is already running." >> ./logs/upgrade.log
-    else
-        echo "$(date +"%Y/%m/%d %H:%M:%S") - Starting Wazuh Agent." >> ./logs/upgrade.log
-        ./bin/wazuh-control start >> ./logs/upgrade.log 2>&1
-    fi
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Restarting Wazuh Agent." >> ./logs/upgrade.log
+    ./bin/wazuh-control restart >> ./logs/upgrade.log 2>&1
 elif [ -f "./bin/ossec-control" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed: wazuh-control not found. Attempting to restart using ossec-control." >> ./logs/upgrade.log
     ./bin/ossec-control restart >> ./logs/upgrade.log 2>&1

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -47,7 +47,7 @@ if [[ "$OS" == "Darwin" ]]; then
 elif [[ "$OS" == "Linux" ]]; then
     if find ./var/upgrade/ -mindepth 1 -maxdepth 1 -type f -name "*.rpm" | read; then
         if command -v rpm >/dev/null 2>&1; then
-            rpm -Uvh ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
+            rpm -UFvh ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. RPM package found but rpm command not found." >> ./logs/upgrade.log
             echo -ne "2" > ./var/upgrade/upgrade_result


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24926|

## Description

It was identified that in some upgrade scenarios on Linux systems, the upgrade did not complete correctly. This is because the `upgrade_result` was not being read, as it is only read when the agent is restarted. By having the agent always restart after an upgrade, regardless of the outcome of the upgrade, this issue is resolved.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade