### PR TITLE
Backport fix from 4.9.1 to 4.9.0

### DIFF
--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -754,7 +754,7 @@ rm -fr %{buildroot}
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/centos/*
 %dir %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel
 %attr(750, root, root) %config(missingok) %{_localstatedir}/packages_files/manager_installation_scripts/etc/templates/config/rhel/*
-%attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/%{_vdfilename}
+%attr(750, wazuh, wazuh) %missingok %{_localstatedir}/tmp/%{_vdfilename}
 %dir %attr(750, root, wazuh) %{_localstatedir}/queue
 %attr(600, root, wazuh) %ghost %{_localstatedir}/queue/agents-timestamp
 %dir %attr(750, wazuh, wazuh) %{_localstatedir}/queue/agentless


### PR DESCRIPTION
|Related issue|
|---|
| #24963  |

## Description
This PR backports a fix that was introduced in 4.9.1 into 4.9.0:
- https://github.com/wazuh/wazuh/pull/24909

## Test
Thanks @pereyra-m for providing the package

### Install 4.8.1

```bash
$ sudo yum install ./wazuh-manager-4.8.1-1.x86_64.rpm 
Failed to set locale, defaulting to C.UTF-8
CentOS Linux 8 - AppStream                                                                                                                              5.8 kB/s | 4.3 kB     00:00    
CentOS Linux 8 - BaseOS                                                                                                                                 5.6 kB/s | 3.9 kB     00:00    
CentOS Linux 8 - Extras                                                                                                                                 2.1 kB/s | 1.5 kB     00:00    
CentOS Linux 8 - PowerTools                                                                                                                             5.8 kB/s | 4.3 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64                                                                                                          2.9 kB/s | 4.1 kB     00:01    
Dependencies resolved.
========================================================================================================================================================================================
 Package                                        Architecture                            Version                                     Repository                                     Size
========================================================================================================================================================================================
Installing:
 wazuh-manager                                  x86_64                                  4.8.1-1                                     @commandline                                  292 M

Transaction Summary
========================================================================================================================================================================================
Install  1 Package

Total size: 292 M
Installed size: 881 M
Is this ok [y/N]: Y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                1/1 
  Running scriptlet: wazuh-manager-4.8.1-1.x86_64                                                                                                                                   1/1 
  Installing       : wazuh-manager-4.8.1-1.x86_64                                                                                                                                   1/1 
  Running scriptlet: wazuh-manager-4.8.1-1.x86_64                                                                                                                                   1/1 
  Verifying        : wazuh-manager-4.8.1-1.x86_64                                                                                                                                   1/1 

Installed:
  wazuh-manager-4.8.1-1.x86_64                                                                                                                                                          

Complete!
```

Check content:
```bash
# md5sum vd_1.0.0_vd_4.8.0.tar.xz 
6c33f098b0e160ca47bb99fb99a2f950  vd_1.0.0_vd_4.8.0.tar.xz
```

### Upgrade to 4.9.0

```bash
$ sudo yum install ./wazuh-manager_4.9.0-0_x86_64_f534169.rpm 
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 0:03:36 ago on Tue Jul 30 18:47:48 2024.
Dependencies resolved.
========================================================================================================================================================================================
 Package                                        Architecture                            Version                                     Repository                                     Size
========================================================================================================================================================================================
Upgrading:
 wazuh-manager                                  x86_64                                  4.9.0-0                                     @commandline                                  300 M

Transaction Summary
========================================================================================================================================================================================
Upgrade  1 Package

Total size: 300 M
Is this ok [y/N]: Y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                1/1 
  Running scriptlet: wazuh-manager-4.9.0-0.x86_64                                                                                                                                   1/1 
  Running scriptlet: wazuh-manager-4.9.0-0.x86_64                                                                                                                                   1/2 
  Upgrading        : wazuh-manager-4.9.0-0.x86_64                                                                                                                                   1/2 
warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew

  Running scriptlet: wazuh-manager-4.9.0-0.x86_64                                                                                                                                   1/2 
  Running scriptlet: wazuh-manager-4.8.1-1.x86_64                                                                                                                                   2/2 
  Cleanup          : wazuh-manager-4.8.1-1.x86_64                                                                                                                                   2/2 
  Running scriptlet: wazuh-manager-4.8.1-1.x86_64                                                                                                                                   2/2 
  Running scriptlet: wazuh-manager-4.9.0-0.x86_64                                                                                                                                   2/2 
  Running scriptlet: wazuh-manager-4.8.1-1.x86_64                                                                                                                                   2/2 
  Verifying        : wazuh-manager-4.9.0-0.x86_64                                                                                                                                   1/2 
  Verifying        : wazuh-manager-4.8.1-1.x86_64                                                                                                                                   2/2 

Upgraded:
  wazuh-manager-4.9.0-0.x86_64                                                                                                                                                          

Complete!
```

Check content:
```bash
# md5sum vd_1.0.0_vd_4.8.0.tar.xz 
04f2224b5d735f6494c4711f3b10ae7b  vd_1.0.0_vd_4.8.0.tar.xz
```