### PR TITLE
fix: revert xml parser changes

### DIFF
--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -131,7 +131,7 @@ int DecodeWinevt(Eventinfo *lf){
         goto cleanup;
     }
 
-    w_strdup(json_received_event->valuestring, event);
+    event = cJSON_PrintUnformatted(json_received_event);
 
     if(event){
         if (OS_ReadXMLString(event, &xml) < 0){

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -286,27 +286,6 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
         cmp = '\0';
     }
 
-    // consume all the spaces, tabs or new line characters
-    while ((c = xml_getc_fun(_lxml->fp, _lxml)) != cmp) {
-        if (isspace(c)) {
-            continue;
-        } else {
-            break;
-        }
-    }
-
-    // check that the next character is '<'
-    if (c == cmp) {
-        retval = LEOF;
-        xml_error(_lxml, "XMLERR: Empty content.");
-        goto end;
-    }
-    else if (c != _R_CONFS) {
-        xml_error(_lxml, "XMLERR: Malformed XML does not start with '<'");
-        goto end;
-    }
-    _xml_ungetc(_R_CONFS, _lxml);
-
     while ((c = xml_getc_fun(_lxml->fp, _lxml)) != cmp) {
         if (c == '\\') {
             prevv *= -1;

--- a/src/unit_tests/analysisd/test_decoder_winevtchannel.c
+++ b/src/unit_tests/analysisd/test_decoder_winevtchannel.c
@@ -137,9 +137,8 @@ void test_winevt_failXML_parse(void ** state) {
     /********************** EVENT ***********************/
     // Get event
 
-    cJSON event = {0};
-    event.valuestring = strdup("test");
-    will_return(__wrap_cJSON_GetObjectItem, &event);
+    will_return(__wrap_cJSON_GetObjectItem, (cJSON *) 0x1);
+    will_return(__wrap_cJSON_PrintUnformatted, (char *) strdup("test"));
 
     // Fail read xml
     will_return(__wrap_OS_ReadXMLString, -1);
@@ -171,7 +170,6 @@ void test_winevt_failXML_parse(void ** state) {
 
     int ret = DecodeWinevt(lf);
     assert_int_equal(ret, SUCCESS_DECODE);
-    os_free(event.valuestring);
 }
 
 void test_winevt_dec_systemNode_ok(void ** state) {
@@ -184,10 +182,8 @@ void test_winevt_dec_systemNode_ok(void ** state) {
 
     /********************** EVENT ***********************/
     // Get event
-
-    cJSON event = {0};
-    event.valuestring = strdup("test");
-    will_return(__wrap_cJSON_GetObjectItem, &event);
+    will_return(__wrap_cJSON_GetObjectItem, (cJSON *) 0x1);
+    will_return(__wrap_cJSON_PrintUnformatted, (char *) strdup("test"));
 
     // Read xml ok
     will_return(__wrap_OS_ReadXMLString, 0);
@@ -372,7 +368,6 @@ void test_winevt_dec_systemNode_ok(void ** state) {
 
     int ret = DecodeWinevt(lf);
     assert_int_equal(ret, SUCCESS_DECODE);
-    os_free(event.valuestring);
 }
 
 void test_winevt_dec_eventDataNode_ok(void ** state) {
@@ -385,10 +380,8 @@ void test_winevt_dec_eventDataNode_ok(void ** state) {
 
     /********************** EVENT ***********************/
     // Get event
-
-    cJSON event = {0};
-    event.valuestring = strdup("test");
-    will_return(__wrap_cJSON_GetObjectItem, &event);
+    will_return(__wrap_cJSON_GetObjectItem, (cJSON *) 0x1);
+    will_return(__wrap_cJSON_PrintUnformatted, (char *) strdup("test"));
 
     // Read xml ok
     will_return(__wrap_OS_ReadXMLString, 0);
@@ -490,7 +483,6 @@ void test_winevt_dec_eventDataNode_ok(void ** state) {
 
     int ret = DecodeWinevt(lf);
     assert_int_equal(ret, SUCCESS_DECODE);
-    os_free(event.valuestring);
 }
 
 void test_winevt_dec_long_log_ok(void ** state) {
@@ -503,9 +495,8 @@ void test_winevt_dec_long_log_ok(void ** state) {
 
     /********************** EVENT ***********************/
     // Get event
-    cJSON event = {0};
-    event.valuestring = strdup("test");
-    will_return(__wrap_cJSON_GetObjectItem, &event);
+    will_return(__wrap_cJSON_GetObjectItem, (cJSON *) 0x1);
+    will_return(__wrap_cJSON_PrintUnformatted, (char *) strdup("test"));
 
     // Read xml ok
     will_return(__wrap_OS_ReadXMLString, 0);
@@ -574,7 +565,6 @@ void test_winevt_dec_long_log_ok(void ** state) {
 
     int ret = DecodeWinevt(lf);
     assert_int_equal(ret, SUCCESS_DECODE);
-    os_free(event.valuestring);
 }
 
 int main() {

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -1001,91 +1001,6 @@ void test_node_attribute_value_overflow(void **state) {
     assert_int_equal(data->xml.err_line, 1);
 }
 
-void test_os_readxml_non_empty_tag(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("<element-name>test</element-name>", data->xml_file_name, 256);
-
-    assert_int_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_int_equal(OS_RootElementExist(&data->xml, "element-name"), 1);
-}
-
-void test_os_readxml_non_empty_tag_space_at_start(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("  <element-name>test</element-name>", data->xml_file_name, 256);
-
-    assert_int_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_int_equal(OS_RootElementExist(&data->xml, "element-name"), 1);
-}
-
-void test_os_readxml_non_empty_tag_newline_at_start(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("\n<element-name>test</element-name>", data->xml_file_name, 256);
-
-    assert_int_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_int_equal(OS_RootElementExist(&data->xml, "element-name"), 1);
-}
-
-void test_os_readxml_non_empty_tag_tab_at_start(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("\t<element-name>test</element-name>", data->xml_file_name, 256);
-
-    assert_int_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_int_equal(OS_RootElementExist(&data->xml, "element-name"), 1);
-}
-
-void test_os_readxml_non_empty_tag_different_spaces_at_start(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("\t\n <element-name>test</element-name>", data->xml_file_name, 256);
-
-    assert_int_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_int_equal(OS_RootElementExist(&data->xml, "element-name"), 1);
-}
-
-void test_os_readxml_non_empty_tag_inside_quotes(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("\"<element-name>\"test\"</element-name>\"", data->xml_file_name, 256);
-
-    assert_int_not_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_string_equal(data->xml.err, "XMLERR: Malformed XML does not start with '<'");
-    assert_int_equal(data->xml.err_line, 1);
-}
-
-void test_os_readxml_xml_inside_non_json(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("{{\"field\":\"value\"},{<element-name>test</element-name>}}", data->xml_file_name, 256);
-
-    assert_int_not_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_string_equal(data->xml.err, "XMLERR: Malformed XML does not start with '<'");
-    assert_int_equal(data->xml.err_line, 1);
-}
-
-void test_os_readxml_random_string_with_valid_xml(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("\"field\"asidpoaisdpoa $$ :\"value\"},{<element-name>test</element-name>}}", data->xml_file_name, 256);
-
-    assert_int_not_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_string_equal(data->xml.err, "XMLERR: Malformed XML does not start with '<'");
-    assert_int_equal(data->xml.err_line, 1);
-}
-
-void test_os_readxml_empty_tag(void **state) {
-    test_struct_t *data  = (test_struct_t *)*state;
-
-    create_xml_file("<   >test</   >", data->xml_file_name, 256);
-
-    assert_int_not_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
-    assert_string_equal(data->xml.err, "XMLERR: Element '' not closed.");
-    assert_int_equal(data->xml.err_line, 1);
-}
-
 void test_node_attribute_value_truncate_overflow(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
@@ -1322,18 +1237,6 @@ int main(void) {
 
         // Truncate node attribute value inside XML overflow test
         cmocka_unit_test_setup_teardown(test_node_attribute_value_truncate_overflow, test_setup, test_teardown),
-
-        // OS_ReadXML tests
-        cmocka_unit_test_setup_teardown(test_os_readxml_non_empty_tag, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_non_empty_tag_space_at_start, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_non_empty_tag_newline_at_start, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_non_empty_tag_tab_at_start, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_non_empty_tag_different_spaces_at_start, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_non_empty_tag_inside_quotes, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_xml_inside_non_json, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_random_string_with_valid_xml, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_non_empty_tag, test_setup, test_teardown),
-        cmocka_unit_test_setup_teardown(test_os_readxml_empty_tag, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
|Related issue|
|---|
|#24966|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Revert the XML parser code to its previous implementation in 4.8.1.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Valgrind (memcheck and descriptor leaks check)



