### PR TITLE
Fix Integration Test Failure for Analysisd - Tier 2 in 4.9.0-Alpha3

### DIFF
--- a/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_rare_socket_responses.py
+++ b/tests/integration/test_analysisd/test_all_syscheckd_configurations/test_check_rare_socket_responses.py
@@ -82,8 +82,9 @@ receiver_sockets, monitored_sockets = None, None  # Set in the fixtures
 
 # Test function.
 @pytest.mark.parametrize('test_metadata', test_metadata, ids=test_cases_ids)
-def test_validate_rare_socket_responses(test_metadata, configure_local_internal_options, configure_sockets_environment_module,
-                                        connect_to_sockets_module, wait_for_analysisd_startup):
+def test_validate_rare_socket_responses(
+    test_metadata, configure_local_internal_options, configure_sockets_environment_module,
+        connect_to_sockets_module, wait_for_analysisd_startup):
     '''
     description: Validate each response from the 'wazuh-analysisd' daemon socket
                  to the 'wazuh-db' daemon socket using rare 'syscheck' events
@@ -131,11 +132,12 @@ def test_validate_rare_socket_responses(test_metadata, configure_local_internal_
 
     # Start monitor
     receiver_sockets[0].send(test_metadata['input'])
-    monitored_sockets[0].start(callback=callback, timeout=session_parameters.default_timeout)
+    monitored_sockets[0].start(callback=callback, timeout=session_parameters.default_timeout, encoding='utf-8')
 
     # Check that expected message appears
     for actual, expected in zip(monitored_sockets[0].callback_result, callback(test_metadata['output'])):
         try:
-            assert json.loads(actual) == json.loads(expected), 'Failed test case stage: {}'.format(test_metadata['stage'])
+            assert json.loads(actual) == json.loads(
+                expected), 'Failed test case stage: {}'.format(test_metadata['stage'])
         except json.decoder.JSONDecodeError:
             assert actual == expected, 'Failed test case stage: {}'.format(test_metadata['stage'])


### PR DESCRIPTION
|Related issue|
|---|
|#24949|

### Summary

This pull request addresses the issue of failed integration tests for `Analysisd` - Tier 2 in the `4.9.0-Alpha3` release. The integration tests, particularly `test_check_rare_socket_responses`, encountered numerous errors due to incorrect character encoding during byte decoding. The failures were traced to the use of `'latin-1'` encoding instead of `'utf-8'`, leading to mismatched and incorrectly represented characters in the test outputs.

### Changes

- **Updated Character Encoding**: Modified the decoding process to use `'utf-8'` encoding instead of the default `'latin-1'`. This change ensures that characters are properly interpreted and matches the expected output in integration tests.
  
  - **Issue Description**:
    - The integration tests failed with multiple errors related to character encoding discrepancies, as observed in various test cases like `Added`, `Modified`, and `Deleted`.
    - Examples of failed assertions showed that characters were misrepresented (e.g., `'/testdir0/ï¿½ï¿½å\x9a£ï¿½'` vs. `'/testdir0/��嚣�'`).

  - **Solution Implemented**:
    - The decoding of bytes received  was corrected to use `'utf-8'`, ensuring that character strings are accurately represented and match the expected values.

- **Test Results**:
  - After applying the encoding fix, the previously failing test cases should pass successfully, confirming that the correct character encoding resolves the issues.

This PR fixes the encoding issue that caused the integration test failures, aligning the test outputs with expected values and improving overall test reliability.