### PR TITLE
Rework SCA for SUSE Linux Enterprise 15 SCA

### DIFF
--- a/ruleset/sca/sles/15/cis_sles15_linux.yml
+++ b/ruleset/sca/sles/15/cis_sles15_linux.yml
@@ -8,13 +8,13 @@
 # Foundation
 #
 # Based on:
-# CIS Benchmark for SUSE Linux Enterprise 15 v1.1.0 - 09-17-2021
+# CIS Benchmark for SUSE Linux Enterprise 15 v1.1.1 - 01-24-2022
 
 policy:
   id: "cis_sles15_linux"
   file: "cis_sles15_linux.yml"
-  name: "CIS SUSE Linux Enterprise 15 Benchmark v1.1.0"
-  description: "This document provides prescriptive guidance for establishing a secure configuration posture for SUSE Linux Enterprise 12 systems running on x86 and x64 platforms. This document was tested against SUSE Linux Enterprise Server 15 SP1."
+  name: "CIS SUSE Linux Enterprise 15 Benchmark v1.1.1"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for SUSE Linux Enterprise 15 systems running on x86 and x64 platforms. This document was tested against SUSE Linux Enterprise Server 15 SP1."
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
@@ -29,3876 +29,3630 @@ variables:
   $sshd_file: /etc/ssh/sshd_config
 
 checks:
-  # Section 1.1 - Filesystem Configuration
-
-  # 1.1.1.1 Ensure mounting of squashfs filesystems is disabled
+  # 1.1.1.1 Ensure mounting of squashfs filesystems is disabled. (Automated)
   - id: 21000
-    title: Ensure mounting of squashfs filesystems is disabled.
-    description: >
-      The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
-      small footprint systems (similar to cramfs ). A squashfs image can be used without having
-      to first decompress the image.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-      Example: vi /etc/modprobe.d/squashfs.conf
-      and add the following line:
-      install squashfs /bin/true
-
-      Run the following command to unload the squashfs module:
-      # modprobe -r squashfs
+    title: "Ensure mounting of squashfs filesystems is disabled."
+    description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems (similar to cramfs). A squashfs image can be used without having to first decompress the image."
+    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
+    impact: 'Disabling squashfs will prevent the use of snap. Snap is a package manager for Linux for installing Snap packages. "Snap" application packages of software are self-contained and work across a range of Linux distributions. This is unlike traditional Linux package management approaches, like APT or RPM, which require specifically adapted packages per Linux distribution on an application update and delay therefore application deployment from developers to their software''s end-user. Snaps themselves have no dependency on any external store ("App store"), can be obtained from any source and can be therefore used for upstream software deployment. When snaps are deployed on versions of Linux, the Ubuntu app store is used as default back-end, but other stores can be enabled as well.'
+    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/squashfs.conf and add the following line: install squashfs /bin/true Run the following command to unload the squashfs module: # modprobe -r squashfs."
     compliance:
       - cis: ["1.1.1.1"]
-      - cis_csc: ["5.1"]
-    condition: any
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
     rules:
-      - "c:modprobe -n -v squashfs -> r:install"
-      - "c:modprobe -n -v squashfs -> r:squashfs"
+      - "c:modprobe -n -v squashfs -> r:^install /bin/true"
+      - "not c:lsmod -> r:squashfs"
 
-  # 1.1.1.2 Ensure mounting of udf filesystems is disabled
+  # 1.1.1.2 Ensure mounting of udf filesystems is disabled. (Automated)
   - id: 21001
-    title: Ensure mounting of udf filesystems is disabled.
-    description: >
-      The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and
-      ECMA-167 specifications. This is an open vendor filesystem type for data storage on a
-      broad range of media. This filesystem type is necessary to support writing DVDs and newer
-      optical disc formats.
-    rationale: >
-      Removing support for unneeded filesystem types reduces the local attack surface of the
-      system. If this filesystem type is not needed, disable it.
-    remediation: >
-      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-      Example: vi /etc/modprobe.d/udf.conf
-      and add the following line:
-      install udf /bin/true
-
-      Run the following command to unload the udf module:
-      # modprobe -r udf
+    title: "Ensure mounting of udf filesystems is disabled."
+    description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
+    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
+    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vi /etc/modprobe.d/udf.conf and add the following line: install udf /bin/true Run the following command to unload the udf module: # modprobe -r udf."
     compliance:
       - cis: ["1.1.1.2"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - "c:modprobe -n -v udf -> r:^install /bin/true"
+      - "not c:lsmod -> r:udf"
+
+  # 1.1.1.3 Ensure mounting of FAT filesystems is limited. (Automated)
+  - id: 21002
+    title: "Ensure mounting of FAT filesystems is limited."
+    description: "The FAT filesystem format is primarily used on older windows systems and portable USB drives or flash modules. It comes in three types FAT12, FAT16, and FAT32 all of which are supported by the vfat kernel module."
+    rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it. Notes: - The FAT filesystem format is used by UEFI systems for the EFI boot partition. Disabling the vfat module can prevent boot on UEFI systems. - FAT filesystems are often used on portable USB sticks and other flash media which are commonly used to transfer files between workstations, removing VFAT support may prevent the ability to transfer files in this way."
+    impact: "The FAT filesystem format is used by UEFI systems for the EFI boot partition. Disabling the vfat module can prevent boot on UEFI systems. FAT filesystems are often used on portable USB sticks and other flash media which are commonly used to transfer files between workstations, removing VFAT support may prevent the ability to transfer files in this way."
+    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf and add the following lines: Example: vim /etc/modprobe.d/fat.conf install fat /bin/true install vfat /bin/true install msdos /bin/true Run the following commands to unload the msdos, vfat, and fat modules: # modprobe -r msdos # modprobe -r vfat # modprobe -r fat."
+    compliance:
+      - cis: ["1.1.1.3"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - "c:modprobe -n -v fat -> r:^install /bin/true"
+      - "not c:lsmod -> r:fat"
+      - "c:modprobe -n -v vfat -> r:^install /bin/true"
+      - "not c:lsmod -> r:vfat"
+      - "c:modprobe -n -v msdos -> r:^install /bin/true"
+      - "not c:lsmod -> r:msdos"
+
+  # 1.1.2 Ensure /tmp is configured. (Automated)
+  - id: 21003
+    title: "Ensure /tmp is configured."
+    description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications. Notes: - If an entry for /tmp exists in /etc/fstab it will take precedence over entries in the tmp.mount file. - tmpfs can be resized using the size={size} parameter in /etc/fstab or on the Options line in the tmp.mount file. If we don't specify the size, it will be half the RAM. Resize tmpfs examples: - /etc/fstab tmpfs /tmp tmpfs rw,noexec,nodev,nosuid,size=2G 0 0 - tmp.mount [Mount] What=tmpfs Where=/tmp Type=tmpfs Options=mode=1777,strictatime,size=2G,noexec,nodev,nosuid."
+    rationale: "Making /tmp its own file system allows an administrator to set the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
+    impact: "Since the /tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. Running out of /tmp space is a problem regardless of what kind of filesystem lies under it, but in a default installation a disk-based /tmp will essentially have the whole disk available, as it only creates a single / partition. On the other hand, a RAM-based /tmp as with tmpfs will almost certainly be much smaller, which can lead to applications filling up the filesystem much more easily."
+    remediation: "Create or update an entry for /tmp in either /etc/fstab OR in a systemd tmp.mount file: If /etc/fstab is used: - Configure /etc/fstab as appropriate. Example: tmpfs /tmp tmpfs defaults,rw,nosuid,nodev,noexec,relatime 0 0 - Run the following command to remount /tmp # mount -o remount,noexec,nodev,nosuid /tmp OR If an explicit systemd target is used to mount /tmp: - Run the following command to create the file /etc/systemd/system/tmp.mount if it doesn't exist: # [ ! -f /etc/systemd/system/tmp.mount ] && cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ - Edit the file /etc/systemd/system/tmp.mount: Example tmp.mount file: # This file is part of systemd. # # systemd is free software; you can redistribute it and/or modify it # under the terms of the GNU Lesser General Public License as published by # the Free Software Foundation; either version 2.1 of the License, or # (at your option) any later version. [Unit] Description=Temporary Directory (/tmp) Documentation=man:hier(7) Documentation=https://www.freedesktop.org/wiki/Software/systemd/APIFileSystem s ConditionPathIsSymbolicLink=!/tmp DefaultDependencies=no Conflicts=umount.target Before=local-fs.target umount.target After=swap.target [Mount] What=tmpfs Where=/tmp Type=tmpfs Options=mode=1777,strictatime,nosuid,nodev,nosuid [Install] WantedBy=local-fs.target - Run the following command to reload the systemd daemon: # systemctl daemon-reload - Run the following command to unmask tmp.mount: # systemctl unmask tmp.mount - Run the following command to enable and start tmp.mount: # systemctl enable --now tmp.mount."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
+      - "https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/"
+    compliance:
+      - cis: ["1.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["13", "14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: any
     rules:
-      - "c:modprobe -n -v udf -> r:install"
-      - "c:modprobe -n -v udf -> r:udf"
+      - 'c:mount -> r:\s/tmp\s'
+      - 'f:/etc/fstab -> !r:^# && r:\s/tmp\s'
+      - "c: systemctl is-enabled tmp.mount -> r:^enabled"
 
-  # 1.1.1.3 Ensure mounting of FAT filesystems is limited - Not implemented
-  # 1.1.2 Ensure /tmp is configured - Not implemented
-
-  # 1.1.3 Ensure noexec option set on /tmp partition - Not implemented
-  - id: 21002
-    title: Ensure noexec option set on /tmp partition.
-    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
-    rationale: >
-      Since the /tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot run executable binaries from /tmp .
-    remediation: >
-      Edit the /etc/fstab file OR the /etc/systemd/system/localfs.target.wants/tmp.mount file:
-
-      IF /etc/fstab is used to mount /tmp
-      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp
-      partition. See the fstab(5) manual page for more information.
-      Run the following command to remount /tmp :
-
-      # mount -o remount,noexec /tmp
-
-      OR
-      IF systemd is used to mount /tmp:
-      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add noexec to the /tmp
-      mount options:
-
-      [Mount]
-      Options=mode=1777,strictatime,noexec,nodev,nosuid
-
-      Run the following command to restart the systemd daemon:
-      # systemctl daemon-reload
-
-      Run the following command to restart tmp.mount
-      # systemctl restart tmp.mount
+  # 1.1.3 Ensure noexec option set on /tmp partition. (Automated)
+  - id: 21004
+    title: "Ensure noexec option set on /tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
+    remediation: "Edit the /etc/fstab file OR the /etc/systemd/system/local- fs.target.wants/tmp.mount file: If /etc/fstab is used to mount /tmp Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp : # mount -o remount,noexec /tmp OR If an explicit systemd target is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add noexec to the /tmp mount options: [Mount] Options=mode=1777,strictatime,noexec,nodev,nosuid Run the following command to restart the systemd daemon: # systemctl daemon-reload Run the following command to restart tmp.mount # systemctl restart tmp.mount."
     compliance:
       - cis: ["1.1.3"]
-      - cis_csc: ["2.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/tmp\s && r:noexec'
+      - 'not c:mount -> r:\s/tmp\s && !r:noexec'
 
-  # 1.1.4 Ensure nodev option set on /tmp partition
-  - id: 21003
-    title: Ensure nodev option set on /tmp partition.
-    description: The nodev mount option specifies that the filesystem cannot contain special devices.
-    rationale: >
-      Since the /tmp filesystem is not intended to support devices, set this option to ensure that
-      users cannot attempt to create block or character special devices in /tmp .
-    remediation: >
-      Edit the /etc/fstab file OR the /etc/systemd/system/localfs.target.wants/tmp.mount file:
-      IF /etc/fstab is used to mount /tmp:
-      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp
-      partition. See the fstab(5) manual page for more information.
-      Run the following command to remount /tmp :
-      # mount -o remount,nodev /tmp
-      OR
-      IF systemd is used to mount /tmp:
-      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp
-      mount options:
-      [Mount]
-      Options=mode=1777,strictatime,noexec,nodev,nosuid
-      Run the following command to restart the systemd daemon:
-      # systemctl daemon-reload
-
-      Run the following command to restart tmp.mount
-      # systemctl restart tmp.mount
+  # 1.1.4 Ensure nodev option set on /tmp partition. (Automated)
+  - id: 21005
+    title: "Ensure nodev option set on /tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /tmp."
+    remediation: "Edit the /etc/fstab file OR the /etc/systemd/system/local- fs.target.wants/tmp.mount file: If /etc/fstab is used to mount /tmp: Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp : # mount -o remount,nodev /tmp OR If an explicit systemd target is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nodev to the /tmp mount options: [Mount] Options=mode=1777,strictatime,noexec,nodev,nosuid Run the following command to restart the systemd daemon: # systemctl daemon-reload Run the following command to restart tmp.mount # systemctl restart tmp.mount."
     compliance:
       - cis: ["1.1.4"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/tmp\s && r:nodev'
+      - 'not c:mount -> r:\s/tmp\s && !r:nodev'
 
-  # 1.1.5 Ensure nosuid option set on /tmp partition
-  - id: 21004
-    title: Ensure nosuid option set on /tmp partition.
-    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
-    rationale: >
-      Since the /tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot create setuid files in /tmp.
-    remediation: >
-      IF /etc/fstab is used to mount /tmp
-      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp
-      partition. See the fstab(5) manual page for more information.
-      Run the following command to remount /tmp :
-      # mount -o remount,nosuid /tmp
-
-      OR
-      IF systemd is used to mount /tmp:
-      Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp
-      mount options:
-      [Mount]
-      Options=mode=1777,strictatime,noexec,nodev,nosuid
-
-      Run the following command to restart the systemd daemon:
-      # systemctl daemon-reload
-
-      Run the following command to restart tmp.mount:
-      # systemctl restart tmp.mount
+  # 1.1.5 Ensure nosuid option set on /tmp partition. (Automated)
+  - id: 21006
+    title: "Ensure nosuid option set on /tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
+    remediation: "If /etc/fstab is used to mount /tmp Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /tmp : # mount -o remount,nosuid /tmp OR If an explicit systemd target is used to mount /tmp: Edit /etc/systemd/system/local-fs.target.wants/tmp.mount to add nosuid to the /tmp mount options: [Mount] Options=mode=1777,strictatime,noexec,nodev,nosuid Run the following command to restart the systemd daemon: # systemctl daemon-reload Run the following command to restart tmp.mount: # systemctl restart tmp.mount."
     compliance:
       - cis: ["1.1.5"]
-      - cis_csc: ["5.1", "13"]
-    condition: all
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
     rules:
-      - 'c:mount -> r:\s/tmp\s && r:nosuid'
+      - 'not c:mount -> r:\s/tmp\s && !r:nosuid'
 
-  # 1.1.6 Ensure /dev/shm is configured
-  - id: 21005
-    title: Ensure /dev/shm is configured.
-    description: >
-      /dev/shm is a traditional shared memory concept. One program will create a memory
-      portion, which other processes (if permitted) can access. If /dev/shm is not configured,
-      tmpfs will be mounted to /dev/shm by systemd.
-
-      Notes:
-        - An entry for /dev/shm in /etc/fstab will take precedence.
-        - tmpfs can be resized using the size={size} parameter in /etc/fstab. If we don't specify
-          the size, it will be half the RAM.
-
-      Resize tmpfs example:
-      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid,size=2G 0 0
-    rationale: >
-      Any user can upload and execute files inside the /dev/shm similar to the /tmp partition.
-      Configuring /dev/shm allows an administrator to set the noexec option on the mount,
-      making /dev/shm useless for an attacker to install executable code. It would also prevent an
-      attacker from establishing a hardlink to a system setuid program and wait for it to be
-      updated. Once the program was updated, the hardlink would be broken and the attacker
-      would have his own copy of the program. If the program happened to have a security
-      vulnerability, the attacker could continue to exploit the known flaw.
-    remediation: >
-      Edit /etc/fstab and add or edit the following line:
-      tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid 0 0
-
-      Run the following command to remount /dev/shm:
-      # mount -o remount,noexec,nodev,nosuid /dev/shm
+  # 1.1.6 Ensure /dev/shm is configured. (Automated)
+  - id: 21007
+    title: "Ensure /dev/shm is configured."
+    description: "/dev/shm is a traditional shared memory concept. One program will create a memory portion, which other processes (if permitted) can access. If /dev/shm is not configured, tmpfs will be mounted to /dev/shm by systemd. Notes: - An entry for /dev/shm in /etc/fstab will take precedence. - tmpfs can be resized using the size={size} parameter in /etc/fstab. If we don't specify the size, it will be half the RAM. Resize tmpfs example: tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid,size=2G 0 0."
+    rationale: "Any user can upload and execute files inside the /dev/shm similar to the /tmp partition. Configuring /dev/shm allows an administrator to set the noexec option on the mount, making /dev/shm useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+    remediation: "Edit /etc/fstab and add or edit the following line: tmpfs /dev/shm tmpfs defaults,noexec,nodev,nosuid 0 0 Run the following command to remount /dev/shm: # mount -o remount,noexec,nodev,nosuid /dev/shm."
     compliance:
       - cis: ["1.1.6"]
-      - cis_csc: ["5.1", "13"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\.+\s+/dev/shm\s+'
-      - 'f:/etc/fstab -> r:\.+\s+/dev/shm\s+'
+      - 'c:mount -> r:\s/dev/shm\s'
+      - 'f:/etc/fstab -> r:\s/dev/shm\s'
 
-  # 1.1.7 Ensure noexec option set on /dev/shm partition
-  - id: 21006
-    title: Ensure noexec option set on /dev/shm partition.
-    description: >
-      The noexec mount option specifies that the filesystem cannot contain executable binaries.
-      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
-      /etc/fstab to add mount options even though it is already being mounted on boot.
-    rationale: >
-      Setting this option on a file system prevents users from executing programs from shared
-      memory. This deters users from introducing potentially malicious software on the system.
-    remediation: >
-      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
-      /dev/shm partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /dev/shm:
-      # mount -o remount,noexec,nodev,nosuid /dev/shm
+  # 1.1.7 Ensure noexec option set on /dev/shm partition. (Automated)
+  - id: 21008
+    title: "Ensure noexec option set on /dev/shm partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries. Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to /etc/fstab to add mount options even though it is already being mounted on boot."
+    rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm: # mount -o remount,noexec,nodev,nosuid /dev/shm."
     compliance:
       - cis: ["1.1.7"]
-      - cis_csc: ["2.6", "13"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["2.6", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/dev/shm\s && r:noexec'
+      - 'not c:mount -> r:\s/dev/shm\s && !r:noexec'
 
-  # 1.1.8 Ensure nodev option set on /dev/shm partition - Not implemented
+  # 1.1.8 Ensure nodev option set on /dev/shm partition. (Automated)
+  - id: 21009
+    title: "Ensure nodev option set on /dev/shm partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices. Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to /etc/fstab to add mount options even though it is already being mounted on boot."
+    rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm: # mount -o remount,noexec,nodev,nosuid /dev/shm."
+    compliance:
+      - cis: ["1.1.8"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not c:mount -> r:\s/dev/shm\s && !r:nodev'
 
-  # 1.1.9 Ensure nosuid option set on /dev/shm partition
-  - id: 21007
-    title: Ensure nosuid option set on /dev/shm partition.
-    description: >
-      The nosuid mount option specifies that the filesystem cannot contain setuid files.
-      Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to
-      /etc/fstab to add mount options even though it is already being mounted on boot.
-    rationale: >
-      Setting this option on a file system prevents users from introducing privileged programs
-      onto the system and allowing non-root users to execute them.
-    remediation: >
-      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
-      /dev/shm partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /dev/shm:
-      # mount -o remount,noexec,nodev,nosuid /dev/shm
+  # 1.1.9 Ensure nosuid option set on /dev/shm partition. (Automated)
+  - id: 21010
+    title: "Ensure nosuid option set on /dev/shm partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files. Note: /dev/shm is mounted automatically by systemd. /dev/shm needs to be added to /etc/fstab to add mount options even though it is already being mounted on boot."
+    rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /dev/shm partition. See the fstab(5) manual page for more information. Run the following command to remount /dev/shm: # mount -o remount,noexec,nodev,nosuid /dev/shm."
     compliance:
       - cis: ["1.1.9"]
-      - cis_csc: ["5.1", "13"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/dev/shm\s && r:nosuid'
+      - 'not c:mount -> r:\s/dev/shm\s && !r:nosuid'
 
-  # 1.1.10 Ensure separate partition exists for /var
-  - id: 21008
-    title: Ensure separate partition exists for /var.
-    description: >
-      The /var directory is used by daemons and other system services to temporarily store
-      dynamic data. Some directories created by these processes may be world-writable.
-
-      Note: When modifying /var it is advisable to bring the system to emergency mode (so auditd
-      is not running), rename the existing directory, mount the new file system, and migrate the
-      data over before returning to multiuser mode.
-    rationale: >
-      Since the /var directory may contain world-writable files and directories, there is a risk of
-      resource exhaustion if it is not bound to a separate partition.
-    remediation: >
-      For new installations, during installation create a custom partition setup and specify a
-      separate partition for /var .
-      For systems that were previously installed, create a new partition and configure
-      /etc/fstab as appropriate.
+  # 1.1.10 Ensure separate partition exists for /var. (Automated)
+  - id: 21011
+    title: "Ensure separate partition exists for /var."
+    description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable. Note: When modifying /var it is advisable to bring the system to emergency mode (so auditd is not running), rename the existing directory, mount the new file system, and migrate the data over before returning to multiuser mode."
+    rationale: "Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion if it is not bound to a separate partition."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
     compliance:
       - cis: ["1.1.10"]
-      - cis_csc: ["5.1"]
-    references:
-      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
       - 'c:mount -> r:\s/var\s'
 
-  # 1.1.11 Ensure separate partition exists for /var/tmp
-  - id: 21009
-    title: Ensure separate partition exists for /var/tmp.
-    description: >
-      The /var/tmp directory is a world-writable directory used for temporary storage by all
-      users and some applications and is intended for temporary files that are preserved across
-      reboots.
-
-      Note: tmpfs should not be used for /var/tmp/. tmpfs is a temporary filesystem that resides in
-      memory and/or swap partition(s). Files in tmpfs are automatically cleared at each bootup.
-    rationale: >
-      Since the /var/tmp directory is intended to be world-writable, there is a risk of resource
-      exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own
-      file system allows an administrator to set the noexec option on the mount, making
-      /var/tmp useless for an attacker to install executable code. It would also prevent an
-      attacker from establishing a hardlink to a system setuid program and wait for it to be
-      updated. Once the program was updated, the hardlink would be broken and the attacker
-      would have his own copy of the program. If the program happened to have a security
-      vulnerability, the attacker could continue to exploit the known flaw.
-    remediation: >
-      For new installations, during installation create a custom partition setup and specify a
-      separate partition for /var/tmp .
-      For systems that were previously installed, create a new partition and configure
-      /etc/fstab as appropriate.
+  # 1.1.11 Ensure separate partition exists for /var/tmp. (Automated)
+  - id: 21012
+    title: "Ensure separate partition exists for /var/tmp."
+    description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications and is intended for temporary files that are preserved across reboots. Note: tmpfs should not be used for /var/tmp/. tmpfs is a temporary filesystem that resides in memory and/or swap partition(s). Files in tmpfs are automatically cleared at each bootup."
+    rationale: "Since the /var/tmp directory is intended to be world-writable, there is a risk of resource exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own file system allows an administrator to set the noexec option on the mount, making /var/tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hardlink to a system setuid program and wait for it to be updated. Once the program was updated, the hardlink would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/tmp . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
     compliance:
       - cis: ["1.1.11"]
-      - cis_csc: ["5.1", "13"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/var/tmp\s'
+      - "c:mount -> r:/var/tmp"
 
-  # 1.1.12 Ensure noexec option set on /var/tmp partition
-  - id: 21010
-    title: Ensure noexec option set on /var/tmp partition.
-    description: The noexec mount option specifies that the filesystem cannot contain executable binaries.
-    rationale: >
-      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot run executable binaries from /var/tmp .
-    remediation: >
-      Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /var/tmp :
-      # mount -o remount,noexec /var/tmp
+  # 1.1.12 Ensure noexec option set on /var/tmp partition. (Automated)
+  - id: 21013
+    title: "Ensure noexec option set on /var/tmp partition."
+    description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
+    remediation: "Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp : # mount -o remount,noexec /var/tmp."
     compliance:
       - cis: ["1.1.12"]
-      - cis_csc: ["2.6"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/var/tmp\s && r:noexec'
+      - "not c:mount -> r:/var/tmp && !r:noexec"
 
-  # 1.1.13 Ensure nodev option set on /var/tmp partition
-  - id: 21011
-    title: Ensure nodev option set on /var/tmp partition.
-    description: The nodev mount option specifies that the filesystem cannot contain special devices.
-    rationale: >
-      Since the /var/tmp filesystem is not intended to support devices, set this option to ensure
-      that users cannot attempt to create block or character special devices in /var/tmp .
-    remediation: >
-      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /var/tmp :
-      # mount -o remount,nodev /var/tmp
+  # 1.1.13 Ensure nodev option set on /var/tmp partition. (Automated)
+  - id: 21014
+    title: "Ensure nodev option set on /var/tmp partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices."
+    rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices in /var/tmp."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp : # mount -o remount,nodev /var/tmp."
     compliance:
       - cis: ["1.1.13"]
-      - cis_csc: ["5.1", "13"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s+/var/tmp\s+ && r:nodev'
+      - "not c:mount -> r:/var/tmp && !r:noexec"
 
-  # 1.1.14 Ensure nosuid option set on /var/tmp partition
-  - id: 21012
-    title: Ensure nosuid option set on /var/tmp partition.
-    description: The nosuid mount option specifies that the filesystem cannot contain setuid files.
-    rationale: >
-      Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-      ensure that users cannot create setuid files in /var/tmp
-    remediation: >
-      Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the
-      /var/tmp partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /var/tmp :
-      # mount -o remount,nosuid /var/tmp
+  # 1.1.14 Ensure nosuid option set on /var/tmp partition. (Automated)
+  - id: 21015
+    title: "Ensure nosuid option set on /var/tmp partition."
+    description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
+    rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
+    remediation: "Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for the /var/tmp partition. See the fstab(5) manual page for more information. Run the following command to remount /var/tmp : # mount -o remount,nosuid /var/tmp."
     compliance:
       - cis: ["1.1.14"]
-      - cis_csc: ["5.1", "13"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s+/var/tmp\s+ && r:nosuid'
+      - "not c:mount -> r:/var/tmp && !r:noexec"
 
-  # 1.1.15 Ensure separate partition exists for /var/log
-  - id: 21013
-    title: Ensure separate partition exists for /var/log.
-    description: The /var/log directory is used by system services to store log data.
-    rationale: >
-      There are two important reasons to ensure that system logs are stored on a separate
-      partition: protection against resource exhaustion (since logs can grow quite large) and
-      protection of audit data.
-
-      Note: When modifying /var/log it is advisable to bring the system to emergency mode (so
-      auditd is not running), rename the existing directory, mount the new file system, and migrate
-      the data over before returning to multiuser mode.
-    remediation: >
-      For new installations, during installation create a custom partition setup and specify a
-      separate partition for /var/log .
-      For systems that were previously installed, create a new partition and configure
-      /etc/fstab as appropriate.
+  # 1.1.15 Ensure separate partition exists for /var/log. (Automated)
+  - id: 21016
+    title: "Ensure separate partition exists for /var/log."
+    description: "The /var/log directory is used by system services to store log data."
+    rationale: "There are two important reasons to ensure that system logs are stored on a separate partition: protection against resource exhaustion (since logs can grow quite large) and protection of audit data. Note: When modifying /var/log it is advisable to bring the system to emergency mode (so auditd is not running), rename the existing directory, mount the new file system, and migrate the data over before returning to multiuser mode."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
     compliance:
       - cis: ["1.1.15"]
-      - cis_csc: ["6.4"]
-    references:
-      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+      - cis_csc_v8: ["4.1", "8.3"]
+      - cis_csc_v7: ["6.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["10.7", "11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["A1.1", "CC7.1", "CC8.1"]
     condition: all
     rules:
       - 'c:mount -> r:\s/var/log\s'
 
-  # 1.1.16 Ensure separate partition exists for /var/log/audit
-  - id: 21014
-    title: Ensure separate partition exists for /var/log/audit.
-    description: >
-      The auditing daemon, auditd , stores log data in the /var/log/audit directory.
-
-      Note: When modifying /var/log/audit it is advisable to bring the system to emergency mode
-      (so auditd is not running), rename the existing directory, mount the new file system, and
-      migrate the data over before returning to multiuser mode.
-    rationale: >
-      There are two important reasons to ensure that data gathered by auditd is stored on a
-      separate partition: protection against resource exhaustion (since the audit.log file can
-      grow quite large) and protection of audit data. The audit daemon calculates how much free
-      space is left and performs actions based on the results. If other processes (such as syslog )
-      consume space in the same partition as auditd , it may not perform as desired.
-    remediation: >
-      For new installations, during installation create a custom partition setup and specify a
-      separate partition for /var/log/audit .
-      For systems that were previously installed, create a new partition and configure
-      /etc/fstab as appropriate.
+  # 1.1.16 Ensure separate partition exists for /var/log/audit. (Automated)
+  - id: 21017
+    title: "Ensure separate partition exists for /var/log/audit."
+    description: "The auditing daemon, auditd , stores log data in the /var/log/audit directory. Note: When modifying /var/log/audit it is advisable to bring the system to emergency mode (so auditd is not running), rename the existing directory, mount the new file system, and migrate the data over before returning to multiuser mode."
+    rationale: "There are two important reasons to ensure that data gathered by auditd is stored on a separate partition: protection against resource exhaustion (since the audit.log file can grow quite large) and protection of audit data. The audit daemon calculates how much free space is left and performs actions based on the results. If other processes (such as syslog) consume space in the same partition as auditd , it may not perform as desired."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /var/log/audit . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
     compliance:
       - cis: ["1.1.16"]
-      - cis_csc: ["6.4"]
-    references:
-      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+      - cis_csc_v8: ["4.1", "8.3"]
+      - cis_csc_v7: ["6.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["10.7", "11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["A1.1", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/var/log/audit\s'
+      - "c:mount -> r:/var/log/audit"
 
-  # 1.1.17 Ensure separate partition exists for /home
-  - id: 21015
-    title: Ensure separate partition exists for /home.
-    description: The /home directory is used to support disk storage needs of local users.
-    rationale: >
-      If the system is intended to support local users, create a separate partition for the /home
-      directory to protect against resource exhaustion and restrict the type of files that can be
-      stored under /home .
-    remediation: >
-      For new installations, during installation create a custom partition setup and specify a
-      separate partition for /home .
-      For systems that were previously installed, create a new partition and configure
-      /etc/fstab as appropriate.
+  # 1.1.17 Ensure separate partition exists for /home. (Automated)
+  - id: 21018
+    title: "Ensure separate partition exists for /home."
+    description: "The /home directory is used to support disk storage needs of local users."
+    rationale: "If the system is intended to support local users, create a separate partition for the /home directory to protect against resource exhaustion and restrict the type of files that can be stored under /home."
+    impact: "Resizing filesystems is a common activity in cloud-hosted servers. Separate filesystem partitions may prevent successful resizing, or may require the installation of additional tools solely for the purpose of resizing operations. The use of these additional tools may introduce their own security considerations."
+    remediation: "For new installations, during installation create a custom partition setup and specify a separate partition for /home . For systems that were previously installed, create a new partition and configure /etc/fstab as appropriate."
+    references:
+      - "http://tldp.org/HOWTO/LVM-HOWTO/"
     compliance:
       - cis: ["1.1.17"]
-      - cis_csc: ["5.1", "13"]
-    references:
-      - AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
       - 'c:mount -> r:\s/home\s'
 
-  # 1.1.18 Ensure nodev option set on /home partition
-  - id: 21016
-    title: Ensure nodev option set on /home partition.
-    description: >
-      The nodev mount option specifies that the filesystem cannot contain special devices.
-      Note: The actions in this recommendation refer to the /home partition, which is the default
-      user partition. If you have created other user partitions, it is recommended that the
-      Remediation and Audit steps be applied to these partitions as well.
-    rationale: >
-      Since the user partitions are not intended to support devices, set this option to ensure that
-      users cannot attempt to create block or character special devices.
-    remediation: >
-      Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home
-      partition. See the fstab(5) manual page for more information.
-
-      Run the following command to remount /home/ with the nodev mount option:
-      # mount -o remount,nodev /home
+  # 1.1.18 Ensure nodev option set on /home partition. (Automated)
+  - id: 21019
+    title: "Ensure nodev option set on /home partition."
+    description: "The nodev mount option specifies that the filesystem cannot contain special devices. Note: The actions in this recommendation refer to the /home partition, which is the default user partition. If you have created other user partitions, it is recommended that the Remediation and Audit steps be applied to these partitions as well."
+    rationale: "Since the user partitions are not intended to support devices, set this option to ensure that users cannot attempt to create block or character special devices."
+    remediation: "Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the /home partition. See the fstab(5) manual page for more information. Run the following command to remount /home/ with the nodev mount option: # mount -o remount,nodev /home."
     compliance:
       - cis: ["1.1.18"]
-      - cis_csc: ["5.1", "13"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:mount -> r:\s/home\s && r:nodev'
+      - 'not c:mount -> r:\s/home\s && !r:nodev'
 
-  # 1.1.19 Ensure noexec option set on removable media partitions - Not implemented
-  # 1.1.20 Ensure nodev option set on removable media partitions - Not implemented
-  # 1.1.21 Ensure nosuid option set on removable media partitions - Not implemented
-  # 1.1.22 Ensure sticky bit is set on all world-writable directories - Not implemented
+  # 1.1.19 Ensure noexec option set on removable media partitions. (Manual) - Not Implemented
+  # 1.1.20 Ensure nodev option set on removable media partitions. (Manual) - Not Implemented
+  # 1.1.21 Ensure nosuid option set on removable media partitions. (Manual) - Not Implemented
+  # 1.1.22 Ensure sticky bit is set on all world-writable directories. (Automated) - Not Implemented
+  - id: 21020
+    title: "Ensure sticky bit is set on all world-writable directories."
+    description: "Setting the sticky bit on world writable directories prevents users from deleting or renaming files in that directory that are not owned by them."
+    rationale: "This feature prevents the ability to delete or rename files in world writable directories (such as /tmp) that are owned by another user."
+    remediation: "Run the following command to set the sticky bit on all world writable directories: # df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null | xargs -I '{}' chmod a+t '{}'."
+    compliance:
+      - cis: ["1.1.22"]
+      - cis_csc_v8: ["3.3", "4.1"]
+      - cis_csc_v7: ["5.1", "13"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6", "CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2", "7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.3.1", "1.5.1", "2.1.1", "2.2.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1", "CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'not c:sh -c "df --local -P 2> /dev/null | awk ''{if (NR!=1) print $6}'' | xargs -I ''{}'' find ''{}'' -xdev -type d \\( -perm -0002 -a ! -perm -1000 \\) 2>/dev/null" -> r:^/'
 
-  # 1.1.23 Disable Automounting
-  - id: 21017
-    title: Disable Automounting.
-    description: >
-      autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives.
-      Notes:
-        - Additional methods of disabling a service exist. Consult your distribution
-          documentation for appropriate methods.
-        - This control should align with the tolerance of the use of portable drives and optical
-          media in the organization.
-          - On a server requiring an admin to manually mount media can be part of
-            defense-in-depth to reduce the risk of unapproved software or information
-            being introduced or proprietary software or information being exfiltrated.
-          - If admins commonly use flash drives and Server access has sufficient physical
-            controls, requiring manual mounting may not increase security.
-    rationale: >
-      With automounting enabled anyone with physical access could attach a USB drive or disc
-      and have its contents available in system even if they lacked permissions to mount it
-      themselves.
-    remediation: >
-      Run the following command to mask autofs:
-      # systemctl --now mask autofs
+  # 1.1.23 Disable Automounting. (Automated)
+  - id: 21021
+    title: "Disable Automounting."
+    description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives. Notes: - Additional methods of disabling a service exist. Consult your distribution documentation for appropriate methods. - This control should align with the tolerance of the use of portable drives and optical media in the organization. o On a server requiring an admin to manually mount media can be part of defense-in-depth to reduce the risk of unapproved software or information being introduced or proprietary software or information being exfiltrated. If admins commonly use flash drives and Server access has sufficient physical controls, requiring manual mounting may not increase security. o."
+    rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
+    impact: "The use of portable hard drives is very common for workstation users. If your organization allows the use of portable storage or media on workstations and physical access controls to workstations is considered adequate there is little value add in turning off automounting."
+    remediation: "Run the following command to mask autofs: # systemctl --now mask autofs."
     compliance:
       - cis: ["1.1.23"]
-      - cis_csc: ["8.4", "8.5"]
-    condition: none
+      - cis_csc_v8: ["10.3"]
+      - cis_csc_v7: ["8.4", "8.5"]
+      - cmmc_v2.0: ["MP.L2-3.8.7"]
+      - hipaa: ["164.310(d)(1)"]
+      - iso_27001-2013: ["A.12.2.1"]
+    condition: all
     rules:
-      - "c:systemctl is-enabled autofs -> r:enabled"
+      - "not c:systemctl is-enabled autofs -> r:^enabled"
 
-  # 1.2.1 Ensure GPG keys are configured - Not implemented
-  # 1.2.2 Ensure package manager repositories are configured - Not implemented
-  # 1.2.3 Ensure gpgcheck is globally activated - Not implemented
+  # 1.2.1 Ensure GPG keys are configured. (Manual) - Not Implemented
+  # 1.2.2 Ensure package manager repositories are configured. (Manual) - Not Implemented
 
-  # 1.3.1 Ensure sudo is installed
-  - id: 21018
-    title: Ensure sudo is installed.
-    description: >
-      sudo allows a permitted user to execute a command as the superuser or another user, as
-      specified by the security policy. The invoking user's real (not effective) user ID is used to
-      determine the user name with which to query the security policy.
-    rationale: >
-      sudo supports a plugin architecture for security policies and input/output logging. Third
-      parties can develop and distribute their own policy and I/O logging plugins to work
-      seamlessly with the sudo front end. The default security policy is sudoers, which is
-      configured via the file /etc/sudoers.
+  # 1.2.3 Ensure gpgcheck is globally activated. (Automated)
+  - id: 21022
+    title: "Ensure gpgcheck is globally activated."
+    description: "The gpgcheck option, found in the main section of the /etc/zypp/zypp.conf and individual /etc/zypp/repos.d/*.repo files determine if an RPM package's signature is checked prior to its installation."
+    rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
+    remediation: "Edit /etc/zypp/zypp.conf and set 'gpgcheck=1' in the [main] section. Edit any failing files in /etc/zypp/repos.d/*.repo and set all instances of gpgcheck to 1."
+    compliance:
+      - cis: ["1.2.3"]
+      - cis_csc_v8: ["7.3"]
+      - cis_csc_v7: ["3.4"]
+      - cmmc_v2.0: ["SI.L1-3.14.1"]
+      - nist_sp_800-53: ["SI-2(2)"]
+      - pci_dss_v3.2.1: ["6.2"]
+      - soc_2: ["CC7.1"]
+    condition: all
+    rules:
+      - 'f:/etc/zypp/zypp.conf -> r:^gpgcheck\s*\t*=\s*\t*1'
+      - 'not d:/etc/zypp/repos.d/ -> r:\.+.repo -> n:^gpgcheck\s*\t*=\s*\t*(\d+) compare \!= 1'
 
-      The security policy determines what privileges, if any, a user has to run sudo. The policy
-      may require that users authenticate themselves with a password or another authentication
-      mechanism. If authentication is required, sudo will exit if the user's password is not
-      entered within a configurable time limit. This limit is policy-specific.
-    remediation: >
-      Run the following command to install sudo.
-      # zypper install sudo
+  # 1.3.1 Ensure sudo is installed. (Automated)
+  - id: 21023
+    title: "Ensure sudo is installed."
+    description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
+    rationale: "sudo supports a plugin architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plugins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
+    remediation: "Run the following command to install sudo. # zypper install sudo."
     compliance:
       - cis: ["1.3.1"]
-      - cis_csc: ["4"]
-    references:
-      - SUDO(8)
-    condition: none
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
     rules:
-      - "c:rpm -q sudo -> r:not installed"
+      - "c:rpm -q sudo -> r:sudo-"
 
-  # 1.3.2 Ensure sudo commands use pty
-  - id: 21019
-    title: Ensure sudo commands use pty.
-    description: >
-      sudo can be configured to run only from a pseudo-pty
-
-      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
-      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks for
-      parse errors. If the sudoers file is currently being edited you will receive a message to try
-      again later. The -f option allows you to tell visudo which file to edit.
-    rationale: >
-      Attackers can run a malicious program using sudo, which would again fork a background
-      process that remains even when the main program has finished executing.
-      This can be mitigated by configuring sudo to run other commands only from a pseudo-pty,
-      whether I/O logging is turned on or not.
-    remediation: >
-      Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
-      TO FILE> and add the following line:
-
-      Defaults use_pty
+  # 1.3.2 Ensure sudo commands use pty. (Automated)
+  - id: 21024
+    title: "Ensure sudo commands use pty."
+    description: "sudo can be configured to run only from a pseudo-pty Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks for parse errors. If the sudoers file is currently being edited you will receive a message to try again later. The -f option allows you to tell visudo which file to edit."
+    rationale: "Attackers can run a malicious program using sudo, which would again fork a background process that remains even when the main program has finished executing. This can be mitigated by configuring sudo to run other commands only from a pseudo-pty, whether I/O logging is turned on or not."
+    remediation: "Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Defaults use_pty."
     compliance:
       - cis: ["1.3.2"]
-      - cis_csc: ["4"]
-    references:
-      - SUDO(8)
-    condition: all
-    rules:
-      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+use_pty'
-
-  # 1.3.3 Ensure sudo log file exists
-  - id: 21020
-    title: Ensure sudo log file exists.
-    description: >
-      sudo can use a custom log file
-
-      Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
-      sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks
-      for parse errors. If the sudoers file is currently being edited you will receive a message to
-      try again later. The -f option allows you to tell visudo which file to edit.
-    rationale: A sudo log file simplifies auditing of sudo commands
-    remediation: >
-      edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH
-      TO FILE> and add the following line:
-      Defaults logfile="<PATH TO CUSTOM LOG FILE>"
-
-      Example
-      Defaults logfile="/var/log/sudo.log"
-    compliance:
-      - cis: ["1.3.3"]
-      - cis_csc: ["6.3"]
-    references:
-      - SUDO(8)
-      - VISUDO(8)
-    condition: all
-    rules:
-      - 'c:grep -REsih "^Defaults" /etc/sudoers /etc/sudoers.d -> r:^\wefaults\s+logfile="\.+"'
-
-  # 1.4.1 Ensure AIDE is installed
-  - id: 21021
-    title: Ensure AIDE is installed.
-    description: >
-      AIDE takes a snapshot of filesystem state including modification times, permissions, and
-      file hashes which can then be used to compare against the current state of the filesystem to
-      detect modifications to the system.
-
-      Note: The prelinking feature can interfere with AIDE because it alters binaries to speed up
-      their start up times. Run prelink -ua to restore the binaries to their prelinked state, thus
-      avoiding false positives from AIDE.
-    rationale: >
-      By monitoring the filesystem state compromised files can be detected to prevent or limit
-      the exposure of accidental or malicious misconfigurations or modified binaries.
-    remediation: >
-      Configure AIDE as appropriate for your environment. Consult the AIDE documentation for
-      options.
-      Run the following command to install AIDE:
-      # zypper install aide
-
-      Run the following commands to initialize AIDE:
-      # aide --init
-      # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
-    compliance:
-      - cis: ["1.4.1"]
-      - cis_csc: ["14.9"]
-    references:
-      - AIDE stable manual: http://aide.sourceforge.net/stable/manual.html
-    condition: none
-    rules:
-      - "c:rpm -q aide -> r:not installed"
-
-  # 1.4.2 Ensure filesystem integrity is regularly checked - Not implemented
-
-  # 1.5.1 Ensure bootloader password is set
-  - id: 21022
-    title: Ensure bootloader password is set.
-    description: >
-      Setting the boot loader password will require that anyone rebooting the system must enter
-      a password before being able to set command line boot parameters
-
-      Notes:
-        - This recommendation is designed around the grub2 bootloader, if LILO or another
-          bootloader is in use in your environment enact equivalent settings. Replace
-          `/boot/grub2/grub.cfg with the appropriate grub configuration file for your
-          environment
-        - The information can be placed in any /etc/grub.d file as long as that file is
-          incorporated into grub.cfg
-          - The superuser/user information and password should not be contained in the
-            /etc/grub.d/00_header file.
-          - A custom file, such as /etc/grub.d/40_custom should be used so it is not
-            overwritten should the Grub package be updated.
-    rationale: >
-      Requiring a boot password upon execution of the boot loader will prevent an unauthorized
-      user from entering boot parameters or changing the boot partition. This prevents users
-      from weakening security (e.g. turning off SELinux at boot time).
-    remediation: >
-      Create an encrypted password with grub2-mkpasswd-pbkdf2:
-        # grub2-mkpasswd-pbkdf2
-        Enter password: <password>
-        Reenter password: <password>
-        Your PBKDF2 is <encrypted-password>
-
-      Add the following into /etc/grub.d/40_custom
-        set superusers="<username>"
-        password_pbkdf2 <username> <encrypted-password>
-
-      Run the following command to update the grub2 configuration:
-        # grub2-mkconfig -o /boot/grub2/grub.cfg
-    compliance:
-      - cis: ["1.5.1"]
-      - cis_csc: ["5.1"]
-    references:
-      - https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-grub2.html
-    condition: all
-    rules:
-      - 'f:/boot/grub2/grub.cfg -> r:^\s*set superusers'
-      - 'f:/boot/grub2/grub.cfg -> r:^\s*password'
-
-  # 1.5.2 Ensure permissions on bootloader config are configured
-  - id: 21023
-    title: Ensure permissions on bootloader config are configured.
-    description: >
-      The grub configuration file contains information on boot settings and passwords for
-      unlocking boot options. The grub2 configuration is usually grub.cfg stored in
-      /boot/grub2/.
-
-      Notes:
-        - This recommendation is designed around the grub2 bootloader.
-        - If LILO or another bootloader is in use in your environment:
-          - Enact equivalent settings
-          - Replace /boot/grub2/grub.cfg and /boot/grub2/user.cfg with the
-            appropriate boot configuration files for your environment
-    rationale: >
-      Setting the permissions to read and write for root only prevents non-root users from
-      seeing the boot parameters or changing them. Non-root users who read the boot
-      parameters may be able to identify weaknesses in security upon boot and be able to exploit
-      them.
-    remediation: >
-      Run the following commands to set ownership and permissions on your grub
-      configuration:
-      # chown root:root /boot/grub2/grub.cfg
-      # chmod og-rwx /boot/grub2/grub.cfg
-    compliance:
-      - cis: ["1.5.2"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:stat -L /boot/grub2/grub.cfg -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  # 1.5.3 Ensure authentication required for single user mode
-  - id: 21024
-    title: Ensure authentication required for single user mode.
-    description: >
-      Single user mode (rescue mode) is used for recovery when the system detects an issue
-      during boot or by manual selection from the bootloader.
-    rationale: >
-      Requiring authentication in single user mode (rescue mode) prevents an unauthorized user
-      from rebooting the system into single user to gain root privileges without credentials.
-    remediation: >
-      Edit /usr/lib/systemd/system/rescue.service and add/modify the following line:
-      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
-
-      Edit /usr/lib/systemd/system/emergency.service and add/modify the following line:
-      ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency
-    compliance:
-      - cis: ["1.5.3"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'f:/usr/lib/systemd/system/rescue.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+rescue'
-      - 'f:/usr/lib/systemd/system/emergency.service -> r:^ExecStart=\.*/systemd/systemd-sulogin-shell\s+emergency'
-
-  # 1.6.1 Ensure core dumps are restricted
-  - id: 21025
-    title: Ensure core dumps are restricted.
-    description: >
-      A core dump is the memory of an executable program. It is generally used to determine
-      why a program aborted. It can also be used to glean confidential information from a core
-      file. The system provides the ability to set a soft limit for core dumps, but this can be
-      overridden by the user.
-    rationale: >
-      Setting a hard limit on core dumps prevents users from overriding the soft variable. If core
-      dumps are required, consider setting limits for user groups (see limits.conf(5) ). In
-      addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from
-      dumping core.
-    remediation: >
-      Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/*
-      file:
-      * hard core 0
-
-      Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      fs.suid_dumpable = 0
-
-      Run the following command to set the active kernel parameter:
-      # sysctl -w fs.suid_dumpable=0
-
-      If systemd-coredump is installed:
-      edit /etc/systemd/coredump.conf and add/modify the following lines:
-      Storage=none
-      ProcessSizeMax=0
-
-      Run the command:
-      systemctl daemon-reload
-    compliance:
-      - cis: ["1.6.1"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:grep -Rh ^*[[:space:]]*hard[[:space:]][[:space:]]*core[[:space:]][[:space:]]* /etc/security/limits.conf /etc/security/limits.d -> r:\s*\t*0$'
-      - 'c:sysctl fs.suid_dumpable -> r:\s0$'
-      - 'c:grep -Rh fs\.suid_dumpable /etc/sysctl.conf /etc/sysctl.d -> r:^\s*fs.suid_dumpable\s*=\s*0\s*$'
-
-  # 1.6.2 Ensure XD/NX support is enabled
-  - id: 21026
-    title: Ensure XD/NX support is enabled.
-    description: >
-      Recent processors in the x86 family support the ability to prevent code execution on a per
-      memory page basis. Generically and on AMD processors, this ability is called No Execute
-      (NX), while on Intel processors it is called Execute Disable (XD). This ability can help
-      prevent exploitation of buffer overflow vulnerabilities and should be activated whenever
-      possible. Extra steps must be taken to ensure that this protection is enabled, particularly on
-      32-bit x86 systems. Other processors, such as Itanium and POWER, have included such
-      support since inception and the standard kernel for those platforms supports the feature.
-    rationale: >
-      Enabling any feature that can protect against buffer overflow attacks enhances the security
-      of the system.
-
-      Note: Ensure your system supports the XD or NX bit and has PAE support before implementing
-      this recommendation as this may prevent it from booting if these are not supported by your
-      hardware.
-    remediation: >
-      On 32 bit systems install a kernel with PAE support, no installation is required on 64 bit
-      systems:
-      If necessary configure your bootloader to load the new kernel and reboot the system.
-      You may need to enable NX or XD support in your bios.
-    compliance:
-      - cis: ["1.6.2"]
-      - cis_csc: ["8.3"]
-    condition: all
-    rules:
-      - 'c:sh -c "journalctl | grep \"protection: active\"" -> r:\.*kernel: NX \(Execute Disable\) protection:\s*active'
-
-  # 1.6.3 Ensure address space layout randomization (ASLR) is enabled
-  - id: 21027
-    title: Ensure address space layout randomization (ASLR) is enabled.
-    description: >
-      Address space layout randomization (ASLR) is an exploit mitigation technique which
-      randomly arranges the address space of key data areas of a process.
-    rationale: >
-      Randomly placing virtual memory regions will make it difficult to write memory page
-      exploits as the memory placement will be consistently shifting.
-    remediation: >
-      Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      kernel.randomize_va_space = 2
-
-      Run the following command to set the active kernel parameter:
-      # sysctl -w kernel.randomize_va_space=2
-    compliance:
-      - cis: ["1.6.3"]
-      - cis_csc: ["8.3"]
-    condition: all
-    rules:
-      - 'c:grep -Rh ^kernel\.randomize_va_space /etc/sysctl.conf /etc/sysctl.d -> r:^\s*kernel.randomize_va_space\s*=\s*2$'
-      - 'c:sysctl kernel.randomize_va_space -> r:\s2$|\t2$'
-
-  # 1.6.4 Ensure prelink is disabled
-  - id: 21028
-    title: Ensure prelink is disabled.
-    description: >
-      prelinkis a program that modifies ELF shared libraries and ELF dynamically linked
-      binaries in such a way that the time needed for the dynamic linker to perform relocations
-      at startup significantly decreases.
-    rationale: >
-      The prelinking feature can interfere with the operation of AIDE, because it changes
-      binaries. Prelinking can also increase the vulnerability of the system if a malicious user is
-      able to compromise a common library such as libc.
-    remediation: >
-      Run the following command to restore binaries to normal:
-      # prelink -ua
-
-      Run the following command to uninstall prelink:
-      # zypper remove prelink
-    compliance:
-      - cis: ["1.6.4"]
-      - cis_csc: ["14.9"]
-    condition: all
-    rules:
-      - "c:rpm -q prelink -> r:not installed"
-
-  # 1.7.1.1 Ensure AppArmor is installed
-  - id: 21029
-    title: Ensure AppArmor is installed.
-    description: AppArmor provides Mandatory Access Controls.
-    rationale: >
-      Without a Mandatory Access Control system installed only the default Discretionary Access
-      Control system will be available.
-    remediation: >
-      Run the following command to install AppArmor:
-      # zypper install -t pattern apparmor
-    compliance:
-      - cis: ["1.7.1.1"]
-      - cis_csc: ["14.6"]
-    condition: none
-    rules:
-      - "c:rpm -q apparmor-docs -> r:not installed"
-      - "c:rpm -q apparmor-parser -> r:not installed"
-      - "c:rpm -q apparmor-profiles -> r:not installed"
-      - "c:rpm -q apparmor-utils -> r:not installed"
-      - "c:rpm -q libapparmor1 -> r:not installed"
-
-  # 1.7.1.2 Ensure AppArmor is enabled in the bootloader configuration - Not implemented
-  # 1.7.1.3 Ensure all AppArmor Profiles are in enforce or complain mode - Not implemented
-  # 1.7.1.4 Ensure all AppArmor Profiles are enforcing - Not implemented
-
-  # 1.8.1.1 Ensure message of the day is configured properly
-  - id: 21030
-    title: Ensure message of the day is configured properly.
-    description: >
-      The contents of the /etc/motd file are displayed to users after login and function as a
-      message of the day for authenticated users.
-
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/motd file with the appropriate contents according to your site policy, remove
-      any instances of \m , \r , \s , \v or references to the OS platform
-
-      OR
-
-      If the motd is not used, this file can be removed.
-      Run the following command to remove the motd file:
-      # rm /etc/motd
-    compliance:
-      - cis: ["1.8.1.1"]
-      - cis_csc: ["5.1"]
-    condition: none
-    rules:
-      - 'f:/etc/motd -> r:\\m'
-      - 'f:/etc/motd -> r:\\r'
-      - 'f:/etc/motd -> r:\\s'
-      - 'f:/etc/motd -> r:\\v'
-
-  # 1.8.1.2 Ensure local login warning banner is configured properly
-  - id: 21031
-    title: Ensure local login warning banner is configured properly.
-    description: >
-      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version - or the
-      operating system's name
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/issue file with the appropriate contents according to your site policy,
-      remove any instances of \m , \r , \s , \v or references to the OS platform
-      # echo "Authorized uses only. All activity may be monitored and reported." >
-      /etc/issue
-    compliance:
-      - cis: ["1.8.1.2"]
-      - cis_csc: ["5.1"]
-    condition: none
-    rules:
-      - 'f:/etc/issue -> r:\\m'
-      - 'f:/etc/issue -> r:\\r'
-      - 'f:/etc/issue -> r:\\s'
-      - 'f:/etc/issue -> r:\\v'
-
-  # 1.8.1.3 Ensure remote login warning banner is configured properly
-  - id: 21032
-    title: Ensure remote login warning banner is configured properly.
-    description: >
-      The contents of the /etc/issue.net file are displayed to users prior to login for remote
-      connections from configured services.
-      Unix-based systems have typically displayed information about the OS release and patch
-      level upon logging in to the system. This information can be useful to developers who are
-      developing software for a particular OS platform. If mingetty(8) supports the following
-      options, they display operating system information: \m - machine architecture \r -
-      operating system release \s - operating system name \v - operating system version
-    rationale: >
-      Warning messages inform users who are attempting to login to the system of their legal
-      status regarding the system and must include the name of the organization that owns the
-      system and any monitoring policies that are in place. Displaying OS and patch level
-      information in login banners also has the side effect of providing detailed system
-      information to attackers attempting to target specific exploits of a system. Authorized users
-      can easily get this information by running the " uname -a " command once they have logged
-      in.
-    remediation: >
-      Edit the /etc/issue.net file with the appropriate contents according to your site policy,
-      remove any instances of \m , \r , \s , \v or references to the OS platform
-      # echo "Authorized uses only. All activity may be monitored and reported." >
-      /etc/issue.net
-    compliance:
-      - cis: ["1.8.1.3"]
-      - cis_csc: ["5.1"]
-    condition: none
-    rules:
-      - 'f:/etc/issue.net -> r:\\m'
-      - 'f:/etc/issue.net -> r:\\r'
-      - 'f:/etc/issue.net -> r:\\s'
-      - 'f:/etc/issue.net -> r:\\v'
-
-  # 1.8.1.4 Ensure permissions on /etc/motd are configured
-  - id: 21033
-    title: Ensure permissions on /etc/motd are configured.
-    description: >
-      The contents of the /etc/motd file are displayed to users after login and function as a
-      message of the day for authenticated users.
-    rationale: >
-      If the /etc/motd file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/motd :
-      # chown root:root /etc/motd
-      # chmod u-x,go-wx /etc/motd
-    compliance:
-      - cis: ["1.8.1.4"]
-      - cis_csc: ["14.6"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/motd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  # 1.8.1.5 Ensure permissions on /etc/issue are configured
-  - id: 21034
-    title: Ensure permissions on /etc/issue are configured.
-    description: >
-      The contents of the /etc/issue file are displayed to users prior to login for local terminals.
-    rationale: >
-      If the /etc/issue file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/issue:
-      # chown root:root /etc/issue
-      # chmod u-x,go-wx /etc/issue
-    compliance:
-      - cis: ["1.8.1.5"]
-      - cis_csc: ["14.6"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/issue -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  # 1.8.1.6 Ensure permissions on /etc/issue.net are configured
-  - id: 21035
-    title: Ensure permissions on /etc/issue.net are configured.
-    description: >
-      The contents of the /etc/issue.net file are displayed to users prior to login for remote
-      connections from configured services.
-    rationale: >
-      If the /etc/issue.net file does not have the correct ownership it could be modified by
-      unauthorized users with incorrect or misleading information.
-    remediation: >
-      Run the following commands to set permissions on /etc/issue.net:
-      # chown root:root /etc/issue.net
-      # chmod u-x,go-wx /etc/issue.net
-    compliance:
-      - cis: ["1.8.1.6"]
-      - cis_csc: ["14.6"]
-    condition: all
-    rules:
-      - 'c:stat -L /etc/issue.net -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
-
-  # 1.9 Ensure updates, patches, and additional security software are installed - Not implemented
-  # 1.10 Ensure GDM is removed or login is configured - Not implemented
-
-  # 2.1.1 Ensure xinetd is not installed
-  - id: 21036
-    title: Ensure xinetd is not installed.
-    description: >
-      The eXtended InterNET Daemon ( xinetd ) is an open source super daemon that replaced
-      the original inetd daemon. The xinetd daemon listens for well known services and
-      dispatches the appropriate daemon to properly respond to service requests.
-    rationale: >
-      If there are no xinetd services required, it is recommended that the package be removed to
-      reduce the attack surface are of the system.
-
-      Note: If an xinetd service or services are required, ensure that any xinetd service not required
-      is stopped and disabled
-    remediation: >
-      Run the following command to remove xinetd:
-      # zypper remove xinetd
-    compliance:
-      - cis: ["2.1.1"]
-      - cis_csc: ["2.6", "9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q xinetd -> r:not installed"
-
-  # 2.2.1.1 Ensure time synchronization is in use - Not implemented
-  # 2.2.1.2 Ensure systemd-timesyncd is configured - Not implemented
-
-  # 2.2.1.3 Ensure chrony is configured
-  - id: 21037
-    title: Ensure chrony is configured.
-    description: >
-      chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to
-      synchronize system clocks across a variety of systems and use a source that is highly
-      accurate. More information on chrony can be found at: http://chrony.tuxfamily.org/.
-      chrony can be configured to be a client and/or a server.
-    rationale: >
-      If chrony is in use on the system proper configuration is vital to ensuring time
-      synchronization is working properly.
-
-      Note: This recommendation only applies if chrony is in use on the system. If another method of
-      time synchronization is in use on the system, this recommendation can be skipped.
-    remediation: >
-      Add or edit server or pool lines to /etc/chrony.conf as appropriate:
-      server <remote-server>
-
-      Add or edit the OPTIONS in /etc/sysconfig/chronyd to include '-u chrony':
-      OPTIONS="-u chrony"
-    compliance:
-      - cis: ["2.2.1.3"]
-      - cis_csc: ["6.1"]
-    condition: all
-    rules:
-      - 'f:/etc/chrony.conf -> r:^\s*server\s+\.+'
-      - 'f:/etc/sysconfig/chronyd -> r:^\s*OPTIONS\s*=\s*"-u\s*chrony"'
-
-  # 2.2.2 Ensure X11 Server components are not installed
-  - id: 21038
-    title: Ensure X11 Server components are not installed.
-    description: >
-      The X Window System provides a Graphical User Interface (GUI) where users can have
-      multiple windows in which to run programs and various add on. The X Windows system is
-      typically used on workstations where users login, but not on servers where users typically
-      do not login.
-    rationale: >
-      Unless your organization specifically requires graphical login access via X Windows,
-      remove it to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove the X Windows Server packages:
-      # zypper remove xorg-x11-server*
-    compliance:
-      - cis: ["2.2.2"]
-      - cis_csc: ["2.6"]
-    condition: none
-    rules:
-      - "c:rpm -qa -> r:^xorg-x11"
-
-  # 2.2.3 Ensure Avahi Server is not installed
-  - id: 21039
-    title: Ensure Avahi Server is not installed.
-    description: >
-      Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD
-      service discovery. Avahi allows programs to publish and discover services and hosts
-      running on a local network with no specific configuration. For example, a user can plug a
-      computer into a network and Avahi automatically finds printers to print to, files to look at
-      and people to talk to, as well as network services running on the machine.
-    rationale: >
-      Automatic discovery of network services is not normally required for system functionality.
-      It is recommended to remove this package to reduce the potential attack surface.
-    remediation: >
-      Run the following commands to stop, mask and remove avahi-autoipd and avahi:
-      # systemctl stop avahi-daemon.socket avahi-daemon.service
-      # zypper remove avahi-autoipd avahi
-    compliance:
-      - cis: ["2.2.3"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q avahi -> r:not installed"
-      - "c:rpm -q avahi-autoipd -> r:not installed"
-
-  # 2.2.4 Ensure CUPS is not installed
-  - id: 21040
-    title: Ensure CUPS is not installed.
-    description: >
-      The Common Unix Print System (CUPS) provides the ability to print to both local and
-      network printers. A system running CUPS can also accept print jobs from remote systems
-      and print them to local printers. It also provides a web based remote administration
-      capability.
-    rationale: >
-      If the system does not need to print jobs or accept print jobs from other systems, it is
-      recommended that CUPS be removed to reduce the potential attack surface.
-
-      Note: Removing CUPS will prevent printing from the system
-    remediation: >
-      Run the following command to remove cups:
-      # zypper remove cups
-    compliance:
-      - cis: ["2.2.4"]
-      - cis_csc: ["9.2"]
-    references:
-      - http://www.cups.org
-    condition: all
-    rules:
-      - "c:rpm -q cups -> r:not installed"
-
-  # 2.2.5 Ensure DHCP Server is not installed
-  - id: 21041
-    title: Ensure DHCP Server is not installed.
-    description: >
-      The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be
-      dynamically assigned IP addresses.
-    rationale: >
-      Unless a system is specifically set up to act as a DHCP server, it is recommended that the
-      dhcp package be removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove dhcp:
-      # zypper remove dhcp
-    compliance:
-      - cis: ["2.2.5"]
-      - cis_csc: ["9.2"]
-    references:
-      - dhcpd(8)
-    condition: all
-    rules:
-      - "c:rpm -q dhcp -> r:not installed"
-
-  # 2.2.6 Ensure LDAP server is not installed
-  - id: 21042
-    title: Ensure LDAP server is not installed
-    description: >
-      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
-      NIS/YP. It is a service that provides a method for looking up information from a central
-      database.
-    rationale: >
-      If the system will not need to act as an LDAP server, it is recommended that the software be
-      removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove openldap-servers:
-      # zypper remove openldap2
-    compliance:
-      - cis: ["2.2.6"]
-      - cis_csc: ["9.2"]
-    references:
-      - http://www.openldap.org
-    condition: all
-    rules:
-      - "c:rpm -q openldap2 -> r:not installed"
-
-  # 2.2.7 Ensure nfs-utils is not installed or the nfs-server service is masked - Not implemented
-  # 2.2.8 Ensure rpcbind is not installed or the rpcbind services are masked - Not implemented
-
-  # 2.2.9 Ensure DNS Server is not installed
-  - id: 21043
-    title: Ensure DNS Server is not installed.
-    description: >
-      The Domain Name System (DNS) is a hierarchical naming system that maps names to IP
-      addresses for computers, services and other resources connected to a network.
-    rationale: >
-      Unless a system is specifically designated to act as a DNS server, it is recommended that the
-      package be removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove bind:
-      # zypper remove bind
-    compliance:
-      - cis: ["2.2.9"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q bind -> r:not installed"
-
-  # 2.2.10 Ensure FTP Server is not installed
-  - id: 21044
-    title: Ensure FTP Server is not installed.
-    description: >
-      FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring
-      files between a server and clients over a network, especially where no authentication is
-      necessary (permits anonymous users to connect to a server).
-    rationale: >
-      FTP does not protect the confidentiality of data or authentication credentials. It is
-      recommended SFTP be used if file transfer is required. Unless there is a need to run the
-      system as a FTP server (for example, to allow anonymous downloads), it is recommended
-      that the package be removed to reduce the potential attack surface.
-
-      Note: Additional FTP servers also exist and should be removed if not required.
-    remediation: >
-      Run the following command to remove vsftpd:
-      # zypper remove vsftpd
-    compliance:
-      - cis: ["2.2.10"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q vsftpd -> r:not installed"
-
-  # 2.2.11 Ensure HTTP server is not installed
-  - id: 21045
-    title: Ensure HTTP server is not installed.
-    description: HTTP or web servers provide the ability to host web site content.
-    rationale: >
-      Unless there is a need to run the system as a web server, it is recommended that the
-      package be removed to reduce the potential attack surface.
-
-      Notes:
-        - Several http servers exist. apache, apache2, lighttpd, and nginx are example
-          packages that provide an HTTP server
-        - These and other packages should also be audited, and removed if not required
-    remediation: >
-      Run the following command to remove apache2:
-      # zypper remove apache2
-    compliance:
-      - cis: ["2.2.11"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q apache2 -> r:not installed"
-
-  # 2.2.12 Ensure IMAP and POP3 server is not installed
-  - id: 21046
-    title: Ensure IMAP and POP3 server is not installed.
-    description: dovecot is an open source IMAP and POP3 server for Linux based systems.
-    rationale: >
-      Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended
-      that the package be removed to reduce the potential attack surface.
-
-      Notes:
-        - Several IMAP/POP3 servers exist and can use other service names. courier-imap and
-          cyrus-imap are example services that provide a mail server.
-        - These and other services should also be audited and the packages removed if not
-          required.
-    remediation: >
-      Run the following command to remove dovecot:
-      # zypper remove dovecot
-    compliance:
-      - cis: ["2.2.12"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q dovecot -> r:not installed"
-
-  # 2.2.13 Ensure Samba is not installed
-  - id: 21047
-    title: Ensure Samba is not installed.
-    description: >
-      The Samba daemon allows system administrators to configure their Linux systems to share
-      file systems and directories with Windows desktops. Samba will advertise the file systems
-      and directories via the Server Message Block (SMB) protocol. Windows desktop users will
-      be able to mount these directories and file systems as letter drives on their systems.
-    rationale: >
-      If there is no need to mount directories and file systems to Windows systems, then this
-      package can be removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove samba:
-      # zypper remove samba
-    compliance:
-      - cis: ["2.2.13"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q samba -> r:not installed"
-
-  # 2.2.14 Ensure HTTP Proxy Server is not installed
-  - id: 21048
-    title: Ensure HTTP Proxy Server is not installed.
-    description: Squid is a standard proxy server used in many distributions and environments.
-    rationale: >
-      Unless a system is specifically set up to act as a proxy server, it is recommended that the
-      squid package be removed to reduce the potential attack surface.
-
-      Note: Several HTTP proxy servers exist. These should be checked and removed unless required.
-    remediation: >
-      Run the following command to remove the squid package:
-      # zypper remove squid
-    compliance:
-      - cis: ["2.2.14"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q squid -> r:not installed"
-
-  # 2.2.15 Ensure net-snmp is not installed
-  - id: 21049
-    title: Ensure net-snmp is not installed.
-    description: >
-      Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the
-      health and welfare of network equipment, computer equipment and devices like UPSs.
-        - Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157),
-          SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and
-          IPv6.
-        - Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was
-          dropped with the 4.0 release of the UCD-snmp package.
-        - The Simple Network Management Protocol (SNMP) server is used to listen for SNMP
-          commands from an SNMP management system, execute the commands or collect the
-          information and then send results back to the requesting system.
-    rationale: >
-      The SNMP server can communicate using SNMPv1, which transmits data in the clear and
-      does not require authentication to execute commands. SNMPv3 replaces the simple/clear
-      text password sharing used in SNMPv2 with more securely encoded parameters. If the the
-      SNMP service is not required, the net-snmp package should be removed to reduce the
-      attack surface of the system.
-
-      Note: If SNMP is required:
-        - The server should be configured for SNMP v3 only. User Authentication and Message
-          Encryption should be configured.
-        - If SNMP v2 is absolutely necessary, modify the community strings' values.
-    remediation: >
-      Run the following command to remove net-snmpd:
-      # zypper remove net-snmp
-    compliance:
-      - cis: ["2.2.15"]
-      - cis_csc: ["2.6", "9.2"]
-    condition: all
-    rules:
-      - "c:rpm -q net-snmp -> r:not installed"
-
-  # 2.2.16 Ensure mail transfer agent is configured for local-only mode
-  - id: 21050
-    title: Ensure mail transfer agent is configured for local-only mode.
-    description: >
-      Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming
-      mail and transfer the messages to the appropriate user or mail server. If the system is not
-      intended to be a mail server, it is recommended that the MTA be configured to only process
-      local mail.
-    rationale: >
-      The software for all Mail Transfer Agents is complex and most have a long history of
-      security issues. While it is important to ensure that the system can process local mail
-      messages, it is not necessary to have the MTA's daemon listening on a port unless the
-      server is intended to be a mail server that receives and processes mail from other systems.
-      Notes:
-        - This recommendation is designed around the postfix mail server.
-        - Depending on your environment you may have an alternative MTA installed such as
-          sendmail. If this is the case consult the documentation for your installed MTA to
-          configure the recommended state.
-    remediation: >
-      Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If
-      the line already exists, change it to look like the line below:
-      inet_interfaces = loopback-only
-
-      Run the folloing command to restart postfix:
-      # systemctl restart postfix
-    compliance:
-      - cis: ["2.2.16"]
-      - cis_csc: ["9.2"]
-    condition: all
-    rules:
-      - 'f:/etc/postfix/main.cf -> r:^\s*inet_interfaces\s*=\s*loopback-only'
-
-  # 2.2.17 Ensure rsync is not installed or the rsyncd service is masked
-  - id: 21051
-    title: Ensure rsync is not installed or the rsyncd service is masked.
-    description: The rsyncd service can be used to synchronize files between systems over network links.
-    rationale: >
-      Unless required, the rsync package should be removed to reduce the attack surface area of
-      the system.
-
-      The rsyncd service presents a security risk as it uses unencrypted protocols for
-      communication.
-
-      Note: If a required dependency exists for the rsync package, but the rsyncd service is not
-      required, the service should be masked.
-    remediation: >
-      Run the following command to remove the rsync package:
-      # zypper remove rsync
-
-      OR
-
-      Run the following command to mask the rsyncd service:
-      # systemctl --now mask rsyncd
-    compliance:
-      - cis: ["2.2.17"]
-      - cis_csc: ["9.2"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: any
     rules:
-      - "c:rpm -q rsync -> r:not installed"
-      - "c:systemctl is-enabled rsyncd -> r:^masked"
+      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*use_pty'
+      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*use_pty'
 
-  # 2.2.18 Ensure NIS server is not installed
+  # 1.3.3 Ensure sudo log file exists. (Automated)
+  - id: 21025
+    title: "Ensure sudo log file exists."
+    description: "sudo can use a custom log file Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks for parse errors. If the sudoers file is currently being edited you will receive a message to try again later. The -f option allows you to tell visudo which file to edit."
+    rationale: "A sudo log file simplifies auditing of sudo commands."
+    impact: "Editing the sudo configuration incorrectly can cause sudo to stop functioning."
+    remediation: 'edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo or visudo -f <PATH TO FILE> and add the following line: Defaults logfile="<PATH TO CUSTOM LOG FILE>" Example Defaults logfile="/var/log/sudo.log".'
+    compliance:
+      - cis: ["1.3.3"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: any
+    rules:
+      - 'f:/etc/sudoers -> r:^\s*\t*Defaults\s*\t*logfile='
+      - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
+
+  # 1.4.1 Ensure AIDE is installed. (Automated)
+  - id: 21026
+    title: "Ensure AIDE is installed."
+    description: "AIDE takes a snapshot of filesystem state including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system. Note: The prelinking feature can interfere with AIDE because it alters binaries to speed up their start up times. Run prelink -ua to restore the binaries to their prelinked state, thus avoiding false positives from AIDE."
+    rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
+    remediation: "Configure AIDE as appropriate for your environment. Consult the AIDE documentation for options. Run the following command to install AIDE: # zypper install aide Run the following commands to initialize AIDE: # aide --init # mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db."
+    compliance:
+      - cis: ["1.4.1"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AC-6(9)"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "c:rpm -q aide -> r:aide-"
+
+  # 1.4.2 Ensure filesystem integrity is regularly checked. (Automated)
+  - id: 21027
+    title: "Ensure filesystem integrity is regularly checked."
+    description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem. Note: The checking in this recommendation occurs every day at 5am. Alter the frequency and time of the checks in compliance with site policy."
+    rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
+    remediation: "If cron will be used to schedule and run aide check Run the following command: # crontab -u root -e Add the following line to the crontab: 0 5 * * * /usr/sbin/aide --check OR If aidecheck.service and aidecheck.timer will be used to schedule and run aide check: Create or edit the file /etc/systemd/system/aidecheck.service and add the following lines: [Unit] Description=Aide Check [Service] Type=simple ExecStart=/usr/sbin/aide --check [Install] WantedBy=multi-user.target Create or edit the file /etc/systemd/system/aidecheck.timer and add the following lines: [Unit] Description=Aide check every day at 5AM [Timer] OnCalendar=*-*-* 05:00:00 Unit=aidecheck.service [Install] WantedBy=multi-user.target Run the following commands: # chown root:root /etc/systemd/system/aidecheck.* # chmod 0644 /etc/systemd/system/aidecheck.* # systemctl daemon-reload # systemctl enable aidecheck.service # systemctl --now enable aidecheck.timer."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.service"
+      - "https://github.com/konstruktoid/hardening/blob/master/config/aidecheck.timer"
+    compliance:
+      - cis: ["1.4.2"]
+      - cis_csc_v8: ["3.14"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L2-3.1.7"]
+      - hipaa: ["164.312(b)", "164.312(c)(1)", "164.312(c)(2)"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AC-6(9)"]
+      - pci_dss_v3.2.1: ["10.2.1", "11.5"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled aidecheck.service -> r:enabled"
+      - "c:systemctl is-enabled aidecheck.timer -> r:enabled"
+      - "c:systemctl status aidecheck.timer -> r:enabled"
+
+  # 1.5.1 Ensure bootloader password is set. (Automated)
+  - id: 21028
+    title: "Ensure bootloader password is set."
+    description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters Notes: - This recommendation is designed around the grub2 bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings. Replace `/boot/grub2/grub.cfg with the appropriate grub configuration file for your environment - The information can be placed in any /etc/grub.d file as long as that file is incorporated into grub.cfg o The superuser/user information and password should not be contained in the /etc/grub.d/00_header file. o A custom file, such as /etc/grub.d/40_custom should be used so it is not overwritten should the Grub package be updated."
+    rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
+    impact: 'If password protection is enabled, only the designated superuser can edit a Grub 2 menu item by pressing "e" or access the GRUB 2 command line by pressing "c" If GRUB 2 is set up to boot automatically to a password-protected menu entry the user has no option to back out of the password prompt to select another menu entry. Holding the SHIFT key will not display the menu in this case. The user must enter the correct username and password. If unable, the configuration files will have to be edited via the LiveCD or other means to fix the problem - You can add --unrestricted to the menu entries to allow the system to boot without entering a password. Password will still be required to edit menu items.'
+    remediation: 'create an encrypted password with grub2-mkpasswd-pbkdf2: # grub2-mkpasswd-pbkdf2 Enter password: <password> Reenter password: <password> Your PBKDF2 is <encrypted-password> Add the following into /etc/grub.d/40_custom set superusers="<username>" password_pbkdf2 <username> <encrypted-password> Run the following command to update the grub2 configuration: # grub2-mkconfig -o /boot/grub2/grub.cfg.'
+    references:
+      - "https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-grub2.html"
+    compliance:
+      - cis: ["1.5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*\t*set superusers'
+      - 'f:/boot/grub2/grub.cfg -> r:^\s*\t*password'
+
+  # 1.5.2 Ensure permissions on bootloader config are configured. (Automated)
+  - id: 21029
+    title: "Ensure permissions on bootloader config are configured."
+    description: "The grub configuration file contains information on boot settings and passwords for unlocking boot options. The grub2 configuration is usually grub.cfg stored in /boot/grub2/. Notes: - This recommendation is designed around the grub2 bootloader. If LILO or another bootloader is in use in your environment: - o Enact equivalent settings o Replace /boot/grub2/grub.cfg and /boot/grub2/user.cfg with the appropriate boot configuration files for your environment."
+    rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
+    remediation: "Run the following commands to set ownership and permissions on your grub configuration: # chown root:root /boot/grub2/grub.cfg # chmod og-rwx /boot/grub2/grub.cfg."
+    compliance:
+      - cis: ["1.5.2"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'c:stat /boot/grub2/grub.cfg -> r:Access:\s*\(0\d00/-\w\w\w------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  # 1.5.3 Ensure authentication required for single user mode. (Automated)
+  - id: 21030
+    title: "Ensure authentication required for single user mode."
+    description: "Single user mode (rescue mode) is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
+    rationale: "Requiring authentication in single user mode (rescue mode) prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials."
+    remediation: "Edit /usr/lib/systemd/system/rescue.service and add/modify the following line: ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue Edit /usr/lib/systemd/system/emergency.service and add/modify the following line: ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency."
+    compliance:
+      - cis: ["1.5.3"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - "f:/usr/lib/systemd/system/rescue.service -> r: systemd-sulogin-shell"
+      - "f:/usr/lib/systemd/system/emergency.service -> r: systemd-sulogin-shell"
+
+  # 1.6.1 Ensure core dumps are restricted. (Automated) - Not Implmented
+  # 1.6.2 Ensure XD/NX support is enabled. (Automated) - Not Implemented
+
+  # 1.6.3 Ensure address space layout randomization (ASLR) is enabled. (Automated)
+  - id: 21031
+    title: "Ensure address space layout randomization (ASLR) is enabled."
+    description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
+    rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
+    remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: kernel.randomize_va_space = 2 Run the following command to set the active kernel parameter: # sysctl -w kernel.randomize_va_space=2."
+    compliance:
+      - cis: ["1.6.3"]
+      - cis_csc_v8: ["10.5"]
+      - cis_csc_v7: ["8.3"]
+      - nist_sp_800-53: ["SI-16"]
+      - pci_dss_v3.2.1: ["1.4"]
+      - soc_2: ["CC6.8"]
+    condition: any
+    rules:
+      - 'c:sysctl kernel.randomize_va_space -> r:^\s*kernel.randomize_va_space\s*=\s*2'
+      - 'f:/etc/sysctl.conf -> r:^\s*kernel.randomize_va_space\s*=\s*2'
+      - 'd:/etc/sysctl.d/ -> r:\.+ -> r:^\s*kernel.randomize_va_space\s*=\s*2'
+
+  # 1.6.4 Ensure prelink is disabled. (Automated)
+  - id: 21032
+    title: "Ensure prelink is disabled."
+    description: "prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases."
+    rationale: "The prelinking feature can interfere with the operation of AIDE, because it changes binaries. Prelinking can also increase the vulnerability of the system if a malicious user is able to compromise a common library such as libc."
+    remediation: "Run the following command to restore binaries to normal: # prelink -ua Run the following command to uninstall prelink: # zypper remove prelink."
+    compliance:
+      - cis: ["1.6.4"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["14.9"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - "c:rpm -q prelink -> r:package prelink is not installed"
+
+  # 1.7.1.1 Ensure AppArmor is installed. (Automated)
+  - id: 21033
+    title: "Ensure AppArmor is installed."
+    description: "AppArmor provides Mandatory Access Controls."
+    rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
+    remediation: "Run the following command to install AppArmor: # zypper install -t pattern apparmor."
+    compliance:
+      - cis: ["1.7.1.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - "c:rpm -q apparmor-docs -> r:apparmor-docs-"
+      - "c:rpm -q apparmor-parser -> r:apparmor-parser-"
+      - "c:rpm -q apparmor-profiles -> r:apparmor-profiles-"
+      - "c:rpm -q apparmor-utils -> r:apparmor-utils-"
+      - "c:rpm -q libapparmor1 -> r:libapparmor1-"
+
+  # 1.7.1.2 Ensure AppArmor is enabled in the bootloader configuration. (Automated)
+  - id: 21034
+    title: "Ensure AppArmor is enabled in the bootloader configuration."
+    description: "Configure AppArmor to be enabled at boot time and verify that it has not been overwritten by the bootloader boot parameters. Note: This recommendation is designed around the grub2 bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
+    rationale: "AppArmor must be enabled at boot time in your bootloader configuration to ensure that the controls it provides are not overridden."
+    remediation: 'Edit /etc/default/grub and add the apparmor=1 and security=apparmor parameters to the GRUB_CMDLINE_LINUX= line GRUB_CMDLINE_LINUX="apparmor=1 security=apparmor" Run the following command to update the grub2 configuration: # grub2-mkconfig -o /boot/grub2/grub.cfg.'
+    compliance:
+      - cis: ["1.7.1.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'not f:/boot/grub/grub.cfg -> r:^\s*linux && !r:apparmor=1'
+      - 'not f:/boot/grub/grub.cfg -> r:^\s*linux && !r:security=apparmor'
+
+  # 1.7.1.3 Ensure all AppArmor Profiles are in enforce or complain mode. (Automated)
+  - id: 21035
+    title: "Ensure all AppArmor Profiles are in enforce or complain mode."
+    description: "AppArmor profiles define what resources applications are able to access."
+    rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated."
+    remediation: "Run one of the following commands to set all profiles to either enforce OR complain mode - Run the following command to set all profiles to enforce mode: # aa-enforce /etc/apparmor.d/* - Run the following command to set all profiles to complain mode: # aa-complain /etc/apparmor.d/* Run the following command to list unconfined processes: # aa-unconfined Any unconfined processes may need to have a profile created or activated for them and then be restarted."
+    compliance:
+      - cis: ["1.7.1.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:apparmor_status -> n:^(\d+)\s+profiles\s+are\s+loaded compare > 0'
+      - "c:apparmor_status -> r:0 processes are unconfined"
+
+  # 1.7.1.4 Ensure all AppArmor Profiles are enforcing. (Automated)
+  - id: 21036
+    title: "Ensure all AppArmor Profiles are enforcing."
+    description: "AppArmor profiles define what resources applications are able to access."
+    rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that any policies that exist on the system are activated."
+    remediation: "Run the following command to set all profiles to enforce mode: # aa-enforce /etc/apparmor.d/* Run the following command to list unconfined processes: # aa-unconfined Any unconfined processes may need to have a profile created or activated for them and then be restarted."
+    compliance:
+      - cis: ["1.7.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:apparmor_status -> n:^(\d+)\s+profiles\s+are\s+loaded compare > 0'
+      - 'c:apparmor_status -> n:^(\d+)\s+profiles\s+are\s+in\s+enforce\s+mode compare > 0'
+      - 'c:apparmor_status -> r:^0\s*profiles\s+are\s+in\s+complain\s+mode'
+      - 'c:apparmor_status -> r:^0\s*processes\s+are\s+unconfined'
+
+  # 1.8.1.1 Ensure message of the day is configured properly. (Automated)
+  - id: 21037
+    title: "Ensure message of the day is configured properly."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version."
+    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
+    remediation: "Edit the /etc/motd file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform OR If the motd is not used, this file can be removed. Run the following command to remove the motd file: # rm /etc/motd."
+    compliance:
+      - cis: ["1.8.1.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: any
+    rules:
+      - 'not f:/etc/motd -> r:\\v|\\r|\\m|\\s'
+      - "not f:/etc/motd"
+
+  # 1.8.1.2 Ensure local login warning banner is configured properly. (Automated)
+  - id: 21038
+    title: "Ensure local login warning banner is configured properly."
+    description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version - or the operating system's name."
+    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
+    remediation: "Edit the /etc/issue file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue."
+    compliance:
+      - cis: ["1.8.1.2"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/issue -> r:\\v|\\r|\\m|\\s'
+
+  # 1.8.1.3 Ensure remote login warning banner is configured properly. (Automated)
+  - id: 21039
+    title: "Ensure remote login warning banner is configured properly."
+    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version."
+    rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
+    remediation: "Edit the /etc/issue.net file with the appropriate contents according to your site policy, remove any instances of \\m , \\r , \\s , \\v or references to the OS platform # echo \"Authorized uses only. All activity may be monitored and reported.\" > /etc/issue.net."
+    compliance:
+      - cis: ["1.8.1.3"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'not f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
+
+  # 1.8.1.4 Ensure permissions on /etc/motd are configured. (Automated)
+  - id: 21040
+    title: "Ensure permissions on /etc/motd are configured."
+    description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
+    rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/motd : # chown root:root /etc/motd # chmod u-x,go-wx /etc/motd."
+    compliance:
+      - cis: ["1.8.1.4"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  # 1.8.1.5 Ensure permissions on /etc/issue are configured. (Automated)
+  - id: 21041
+    title: "Ensure permissions on /etc/issue are configured."
+    description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
+    rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/issue: # chown root:root /etc/issue # chmod u-x,go-wx /etc/issue."
+    compliance:
+      - cis: ["1.8.1.5"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+  # 1.8.1.6 Ensure permissions on /etc/issue.net are configured. (Automated)
+  - id: 21042
+    title: "Ensure permissions on /etc/issue.net are configured."
+    description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
+    rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
+    remediation: "Run the following commands to set permissions on /etc/issue.net: # chown root:root /etc/issue.net # chmod u-x,go-wx /etc/issue.net."
+    compliance:
+      - cis: ["1.8.1.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:stat /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
+
+    # 1.9 Ensure updates, patches, and additional security software are installed. (Manual)- Not Implemented
+
+  # 1.10 Ensure GDM is removed or login is configured. (Automated)
+  - id: 21043
+    title: "Ensure GDM is removed or login is configured."
+    description: "The GNOME Display Manager (GDM) handles graphical login for GNOME based systems. Configuration of the GNOME desktop is managed with dconf. It is a hierarchically structured database or registry that allows users to modify their personal settings, and system administrators to set default or mandatory values for all users. Global dconf configuration parameters can be set in the /etc/dconf/db/ directory. This includes the configuration for GDM or locking certain configuration options for users."
+    rationale: "If a graphical login is not required, it should be removed to reduce the attack surface of the system. If a graphical login is required, last logged in user display should be disabled, and a warning banner should be configured. Displaying the last logged in user eliminates half of the Userid/Password equation that an unauthorized person would need to log on. Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Notes: - This recommendation is based on the gdm profile. If a different profile name is used on the system, update the gdm and gdm.d to <profilee_name> and <profile_name>.d - Additional options and sections may appear in the /etc/dconf/db/gdm.d/01-banner- - message and/or /etc/dconf/db/gdm.d/00-login-screen file. If a different GUI login service is in use and required on the system, consult your documentation to disable displaying the last logged on user and apply an equivalent banner."
+    remediation: "Run the following command to remove GDM # zypper remove gdm OR If GDM is required: Edit or create the gdm profile which contains the following lines: (This is typically /etc/dconf/profile/gdm) user-db:user system-db:gdm file-db:/usr/share/gdm/greeter-dconf-defaults Run the following Run to display a login banner: Note: the directory /etc/dconf/db/gdm.d/ may need to be created Edit or create a gdm keyfile for machine-wide settings: (This is typically /etc/dconf/db/gdm.d/01-banner-message) [org/gnome/login-screen] banner-message-enable=true banner-message-text='<banner message>' Example Banner Text: 'Authorized uses only. All activity may be monitored and reported.' Run the following to disable the user list: Edit or create a gdm keyfile for machine-wide settings in the directory /etc/dconf/db/gdm.d/ and add the following: (This is typically /etc/dconf/db/gdm.d/00- login-screen) [org/gnome/login-screen] # Do not show the user list disable-user-list=true Run the following command to update the system databases: # dconf update."
+    references:
+      - "https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-gui-desktop.html"
+      - "https://help.gnome.org/admin/system-admin-guide/stable"
+    compliance:
+      - cis: ["1.10"]
+      - cis_csc_v8: ["4.1", "4.8"]
+      - cis_csc_v7: ["2.6", "5.1"]
+    condition: any
+    rules:
+      - "c:rpm -q gdm -> r:package gdm is not installed"
+      - "f:/etc/dconf/profile/gdm"
+      - "f:/etc/dconf/profile/gdm -> r:user-db:user"
+      - "f:/etc/dconf/profile/gdm -> r:system-db:gdm"
+      - "f:/etc/dconf/profile/gdm -> r:file-db:/usr/share/gdm/greeter-dconf-defaults"
+      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-enable=true'
+      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-text='
+      - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:disable-user-list=true'
+
+  # 2.1.1 Ensure xinetd is not installed. (Automated)
+  - id: 21044
+    title: "Ensure xinetd is not installed."
+    description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
+    rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface are of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled."
+    remediation: "Run the following command to remove xinetd: # zypper remove xinetd."
+    compliance:
+      - cis: ["2.1.1"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q xinetd -> r:^package xinetd is not installed"
+
+  # 2.2.1.1 Ensure time synchronization is in use. (Automated)
+  - id: 21045
+    title: "Ensure time synchronization is in use."
+    description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Notes: - On systems where host based time synchronization is not available, verify that chrony is installed or systemd-timesyncd is enabled. - On systems where host based time synchronization is available consult your documentation and verify that host based synchronization is in use. If another method for time synchronization is being used, this section may be skipped. -."
+    rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
+    remediation: "On systems where host based time synchronization is not available, install chrony OR enable systemd-timesyncd: Run the following command to install chrony: # zypper install chrony OR Run the following command to enable systemd-timesyncd # systemctl enable systemd-timesyncd Note: On systems where host based time synchronization is available consult your virtualization software documentation and setup host based synchronization."
+    compliance:
+      - cis: ["2.2.1.1"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: any
+    rules:
+      - "c:rpm -q chrony -> r:^chrony-"
+      - "c:systemctl is-enabled systemd-timesyncd -> r:^enabled"
+
+  # 2.2.1.2 Ensure systemd-timesyncd is configured. (Manual)
+  - id: 21046
+    title: "Ensure systemd-timesyncd is configured."
+    description: 'systemd-timesyncd is a daemon that has been added for synchronizing the system clock across the network. The systemd-timesyncd daemon: Implements an SNTP client. - - Only implements a client side o Does not bother with the full NTP complexity o Only on querys time from one remote server, synchronizing the local clock to it - - runs with minimal privileges saves the current clock to disk every time a new NTP sync has been acquired o Uses this to correct the system clock early at bootup o to make sure that time monotonically progresses on these systems, even if it is not always correct - Requires a new system user and group "systemd-timesync" to be created on installation of systemd - Hooked up with networkd to only operate when network connectivity is available Notes: - The systemd-timesyncd service specifically implements only SNTP. This minimalistic service will set the system clock for large offsets or slowly adjust it for smaller deltas. More complex use cases are not covered by systemd-timesyncd. - This recommendation only applies if timesyncd is in use on the system.'
+    rationale: "Proper configuration is vital to ensuring time synchronization is working properly."
+    remediation: "Edit the file /etc/systemd/timesyncd.conf and add/modify the following lines: NTP=0.suse.pool.ntp.org 1.suse.pool.ntp.org #Servers listed should be In Accordance With Local Policy FallbackNTP=2.suse.pool.ntp.org 3.suse.pool.ntp.org #Servers listed should be In Accordance With Local Policy RootDistanceMax=1 #should be In Accordance With Local Policy Run the following commands to enable and start systemd-timesyncd: # systemctl --now enable systemd-timesyncd.service # timedatectl set-ntp true."
+    compliance:
+      - cis: ["2.2.1.2"]
+    condition: all
+    rules:
+      - "c:systemctl is-enabled systemd-timesyncd -> r:^enabled"
+      - "c:timedatectl status -> r:NTP enabled: yes"
+
+  # 2.2.1.3 Ensure chrony is configured. (Automated)
+  - id: 21047
+    title: "Ensure chrony is configured."
+    description: "chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at: http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
+    rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly. Note: This recommendation only applies if chrony is in use on the system. If another method of time synchronization is in use on the system, this recommendation can be skipped."
+    remediation: 'Add or edit server or pool lines to /etc/chrony.conf as appropriate: server <remote-server> Add or edit the OPTIONS in /etc/sysconfig/chronyd to include ''-u chrony'': OPTIONS="-u chrony".'
+    compliance:
+      - cis: ["2.2.1.3"]
+      - cis_csc_v8: ["8.4"]
+      - cis_csc_v7: ["6.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.7"]
+      - iso_27001-2013: ["A.12.4.4"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.4"]
+      - pci_dss_v4.0: ["10.6", "10.6.1", "10.6.2", "10.6.3"]
+      - soc_2: ["CC4.1", "CC5.2"]
+    condition: all
+    rules:
+      - "f:/etc/chrony.conf"
+      - 'f:/etc/chrony.conf -> r:^\s*\t*server|^\s*\t*pool'
+      - 'f:/etc/sysconfig/chronyd -> r:^\s*\t*OPTIONS\.*-u chrony'
+
+  # 2.2.2 Ensure X11 Server components are not installed. (Automated)
+  - id: 21048
+    title: "Ensure X11 Server components are not installed."
+    description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
+    rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
+    impact: 'Many Linux systems run applications which require a Java runtime. Some Linux Java packages have a dependency on specific X Windows xorg-x11-fonts. One workaround to avoid this dependency is to use the "headless" Java packages for your specific Java runtime.'
+    remediation: "Run the following command to remove the X Windows Server packages: # zypper remove xorg-x11-server*."
+    compliance:
+      - cis: ["2.2.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "not c:rpm -qa xorg-x11-server -> r:^xorg-x11-server-"
+
+  # 2.2.3 Ensure Avahi Server is not installed. (Automated)
+  - id: 21049
+    title: "Ensure Avahi Server is not installed."
+    description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
+    rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
+    remediation: "Run the following commands to stop, mask and remove avahi-autoipd and avahi: # systemctl stop avahi-daemon.socket avahi-daemon.service # zypper remove avahi-autoipd avahi."
+    compliance:
+      - cis: ["2.2.3"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q avahi-autoipd -> r:^package avahi-autoipd is not installed"
+      - "c:rpm -q avahi -> r:^package avahi is not installed"
+
+  # 2.2.4 Ensure CUPS is not installed. (Automated)
+  - id: 21050
+    title: "Ensure CUPS is not installed."
+    description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
+    rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface. Note: Removing CUPS will prevent printing from the system."
+    impact: "Disabling CUPS will prevent printing from the system, a common task for workstation systems."
+    remediation: "Run the following command to remove cups: # zypper remove cups."
+    references:
+      - "http://www.cups.org."
+    compliance:
+      - cis: ["2.2.4"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q cups -> r:package cups is not installed"
+
+  # 2.2.5 Ensure DHCP Server is not installed. (Automated)
+  - id: 21051
+    title: "Ensure DHCP Server is not installed."
+    description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
+    rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that the dhcp package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove dhcp: # zypper remove dhcp."
+    compliance:
+      - cis: ["2.2.5"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q dhcp -> r:^package dhcp is not installed"
+
+  # 2.2.6 Ensure LDAP server is not installed. (Automated)
   - id: 21052
-    title: Ensure NIS server is not installed.
-    description: >
-      The ypserv package provides the Network Information Service (NIS). This service, formally
-      known as Yellow Pages, is a client-server directory service protocol for distributing system
-      configuration files. The NIS server is a collection of programs that allow for the distribution
-      of configuration files.
-    rationale: >
-      The NIS service is inherently an insecure system that has been vulnerable to DOS attacks,
-      buffer overflows and has poor authentication for querying NIS maps. NIS generally has
-      been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is
-      recommended that the ypserv package be removed, and if required a more secure services
-      be used.
-    remediation: >
-      Run the following command to remove ypserv:
-      # zypper remove ypserv
+    title: "Ensure LDAP server is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP server, it is recommended that the software be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove openldap-servers: # zypper remove openldap2."
+    references:
+      - "http://www.openldap.org."
+    compliance:
+      - cis: ["2.2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q openldap2 -> r:^package openldap2 is not installed"
+
+  # 2.2.7 Ensure nfs-utils is not installed or the nfs-server service is masked. (Automated) - Not Implemented
+
+  # 2.2.8 Ensure rpcbind is not installed or the rpcbind services are masked. (Automated)
+  - id: 21053
+    title: "Ensure rpcbind is not installed or the rpcbind services are masked."
+    description: "The rpcbind utility maps RPC services to the ports on which they listen. RPC processes notify rpcbind when they start, registering the ports they are listening on and the RPC program numbers they expect to serve. The client system then contacts rpcbind on the server with a particular RPC program number. The rpcbind service redirects the client to the proper port number so it can communicate with the requested service Portmapper is an RPC service, which always listens on tcp and udp 111, and is used to map other RPC services (such as nfs, nlockmgr, quotad, mountd, etc.) to their corresponding port number on the server. When a remote host makes an RPC call to that server, it first consults with portmap to determine where the RPC server is listening."
+    rationale: "A small request (~82 bytes via UDP) sent to the Portmapper generates a large response (7x to 28x amplification), which makes it a suitable tool for DDoS attacks. If rpcbind is not required, it is recommended that the rpcbind package be removed to reduce the attack surface of the system. Note: many of the libvirt packages used by Enterprise Linux virtualization, and the nfs-utils package used for The Network File System (NFS) are dependent on the rpcbind package. If the rpcbind is required as a dependency, the services rpcbind.service and rpcbind.socket should be stopped and masked to reduce the attack surface of the system."
+    remediation: "Run the following command to remove nfs-utils: # zypper remove rpcbind OR If the rpcbind package is required as a dependency Run the following commands to stop and mask the rpcbind and rpcbind.socket services: # systemctl --now mask rpcbind # systemctl --now mask rpcbind.socket."
+    compliance:
+      - cis: ["2.2.8"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:rpm -q rpcbind -> r:^package rpcbind is not installed"
+      - "c:systemctl is-enabled rpcbind -> r:masked"
+      - "c:systemctl is-enabled rpcbind.socket -> r:masked"
+
+  # 2.2.9 Ensure DNS Server is not installed. (Automated)
+  - id: 21054
+    title: "Ensure DNS Server is not installed."
+    description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
+    rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove bind: # zypper remove bind."
+    compliance:
+      - cis: ["2.2.9"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q bind -> r:^package bind is not installed"
+
+  # 2.2.10 Ensure FTP Server is not installed. (Automated)
+  - id: 21055
+    title: "Ensure FTP Server is not installed."
+    description: "FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring files between a server and clients over a network, especially where no authentication is necessary (permits anonymous users to connect to a server)."
+    rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be removed to reduce the potential attack surface. Note: Additional FTP servers also exist and should be removed if not required."
+    remediation: "Run the following command to remove vsftpd: # zypper remove vsftpd."
+    compliance:
+      - cis: ["2.2.10"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q vsftpd -> r:^package vsftpd is not installed"
+
+  # 2.2.11 Ensure HTTP server is not installed. (Automated)
+  - id: 21056
+    title: "Ensure HTTP server is not installed."
+    description: "HTTP or web servers provide the ability to host web site content."
+    rationale: "Unless there is a need to run the system as a web server, it is recommended that the package be removed to reduce the potential attack surface. Notes: - Several http servers exist. apache, apache2, lighttpd, and nginx are example packages that provide an HTTP server - These and other packages should also be audited, and removed if not required."
+    remediation: "Run the following command to remove apache2: # zypper remove apache2."
+    compliance:
+      - cis: ["2.2.11"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q apache2 -> r:^package apache2 is not installed"
+
+  # 2.2.12 Ensure IMAP and POP3 server is not installed. (Automated)
+  - id: 21057
+    title: "Ensure IMAP and POP3 server is not installed."
+    description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
+    rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface. Notes: - Several IMAP/POP3 servers exist and can use other service names. courier-imap and cyrus-imap are example services that provide a mail server. - These and other services should also be audited and the packages removed if not required."
+    remediation: "Run the following command to remove dovecot: # zypper remove dovecot."
+    compliance:
+      - cis: ["2.2.12"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q dovecot -> r:^package dovecot is not installed"
+
+  # 2.2.13 Ensure Samba is not installed. (Automated)
+  - id: 21058
+    title: "Ensure Samba is not installed."
+    description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
+    rationale: "If there is no need to mount directories and file systems to Windows systems, then this package can be removed to reduce the potential attack surface."
+    remediation: "Run the following command to remove samba: # zypper remove samba."
+    compliance:
+      - cis: ["2.2.13"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q samba -> r:^package samba is not installed"
+
+  # 2.2.14 Ensure HTTP Proxy Server is not installed. (Automated)
+  - id: 21059
+    title: "Ensure HTTP Proxy Server is not installed."
+    description: "Squid is a standard proxy server used in many distributions and environments."
+    rationale: "Unless a system is specifically set up to act as a proxy server, it is recommended that the squid package be removed to reduce the potential attack surface. Note: Several HTTP proxy servers exist. These should be checked and removed unless required."
+    remediation: "Run the following command to remove the squid package: # zypper remove squid."
+    compliance:
+      - cis: ["2.2.14"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q squid -> r:^package squid is not installed"
+
+  # 2.2.15 Ensure net-snmp is not installed. (Automated)
+  - id: 21060
+    title: "Ensure net-snmp is not installed."
+    description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. - Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. - Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. - The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
+    rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values. -."
+    remediation: "Run the following command to remove net-snmpd: # zypper remove net-snmp."
+    compliance:
+      - cis: ["2.2.15"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q net-snmp -> r:^package net-snmp is not installed"
+
+  # 2.2.16 Ensure mail transfer agent is configured for local-only mode. (Automated)
+  - id: 21061
+    title: "Ensure mail transfer agent is configured for local-only mode."
+    description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
+    rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Notes: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as sendmail. If this is the case consult the documentation for your installed MTA to configure the recommended state."
+    remediation: "Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If the line already exists, change it to look like the line below: inet_interfaces = loopback-only Run the following command to restart postfix: # systemctl restart postfix."
+    compliance:
+      - cis: ["2.2.16"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: all
+    rules:
+      - 'not c:ss -lntu -> r:\.*:25\s* && !r:127.0.0.1:25\.*|::1:25\.*'
+
+  # 2.2.17 Ensure rsync is not installed or the rsyncd service is masked. (Automated)
+  - id: 21062
+    title: "Ensure rsync is not installed or the rsyncd service is masked."
+    description: "The rsyncd service can be used to synchronize files between systems over network links."
+    rationale: "Unless required, the rsync package should be removed to reduce the attack surface area of the system. The rsyncd service presents a security risk as it uses unencrypted protocols for communication. Note: If a required dependency exists for the rsync package, but the rsyncd service is not required, the service should be masked."
+    impact: "There are packages that are dependent on the rsync package. If the rsync package is removed, these packages will be removed as well. Before removing the rsync package, review any dependent packages to determine if they are required on the system. If a dependent package is required, mask the rsyncd service and leave the rsync package installed."
+    remediation: "Run the following command to remove the rsync package: # zypper remove rsync OR Run the following command to mask the rsyncd service: # systemctl --now mask rsyncd."
+    compliance:
+      - cis: ["2.2.17"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:rpm -q rsync -> r:package rsync is not installed"
+      - "c:systemctl is-enabled rsyncd -> r:masked"
+
+  # 2.2.18 Ensure NIS server is not installed. (Automated)
+  - id: 21063
+    title: "Ensure NIS server is not installed."
+    description: "The ypserv package provides the Network Information Service (NIS). This service, formally known as Yellow Pages, is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the ypserv package be removed, and if required a more secure services be used."
+    remediation: "Run the following command to remove ypserv: # zypper remove ypserv."
     compliance:
       - cis: ["2.2.18"]
-      - cis_csc: ["2.6", "9.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q ypserv -> r:not installed"
+      - "c:rpm -q ypserv -> r:^package ypserv is not installed"
 
-  # 2.2.19 Ensure telnet-server is not installed
-  - id: 21053
-    title: Ensure telnet-server is not installed.
-    description: >
-      The telnet package contains the telnet daemon, which accepts connections from users
-      from other systems via the telnet protocol.
-    rationale: >
-      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
-      medium could allow a user with access to sniff network traffic the ability to steal
-      credentials. The ssh package provides an encrypted session and stronger security.
-    remediation: >
-      Run the following command to remove the telnet-server package:
-      # zypper remove telnet
+  # 2.2.19 Ensure telnet-server is not installed. (Automated)
+  - id: 21064
+    title: "Ensure telnet-server is not installed."
+    description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
+    remediation: "Run the following command to remove the telnet-server package: # zypper remove telnet-server."
     compliance:
       - cis: ["2.2.19"]
-      - cis_csc: ["2.6", "9.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6", "9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2", "A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q telnet -> r:not installed"
+      - "c:rpm -q telnet-server -> r:^package telnet-server is not installed"
 
-  # 2.3.1 Ensure NIS Client is not installed
-  - id: 21054
-    title: Ensure NIS Client is not installed.
-    description: >
-      The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server
-      directory service protocol used to distribute system configuration files. The NIS client (
-      ypbind ) was used to bind a machine to an NIS server and receive the distributed
-      configuration files.
-    rationale: >
-      The NIS service is inherently an insecure system that has been vulnerable to DOS attacks,
-      buffer overflows and has poor authentication for querying NIS maps. NIS generally has
-      been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is
-      recommended that the service be removed.
-    remediation: >
-      Run the following command to remove the ypbind package:
-      # zypper remove ypbind
+  # 2.3.1 Ensure NIS Client is not installed. (Automated)
+  - id: 21065
+    title: "Ensure NIS Client is not installed."
+    description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind) was used to bind a machine to an NIS server and receive the distributed configuration files."
+    rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Run the following command to remove the ypbind package: # zypper remove ypbind."
     compliance:
       - cis: ["2.3.1"]
-      - cis_csc: ["2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q ypbind -> r:not installed"
+      - "c:rpm -q ypbind -> r:^package ypbind is not installed"
 
-  # 2.3.2 Ensure rsh client is not installed
-  - id: 21055
-    title: Ensure rsh client is not installed.
-    description: The rsh package contains the client commands for the rsh services.
-    rationale: >
-      These legacy clients contain numerous security exposures and have been replaced with the
-      more secure SSH package. Even if the server is removed, it is best to ensure the clients are
-      also removed to prevent users from inadvertently attempting to use these commands and
-      therefore exposing their credentials. Note that removing the rsh package removes the
-      clients for rsh , rcp and rlogin.
-    remediation: >
-      Run the following command to remove the rsh package:
-      # zypper remove rsh
+  # 2.3.2 Ensure rsh client is not installed. (Automated)
+  - id: 21066
+    title: "Ensure rsh client is not installed."
+    description: "The rsh package contains the client commands for the rsh services."
+    rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh , rcp and rlogin."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Run the following command to remove the rsh package: # zypper remove rsh."
     compliance:
       - cis: ["2.3.2"]
-      - cis_csc: ["2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q rsh -> r:not installed"
+      - "c:rpm -q rsh -> r:^package rsh is not installed"
 
-  # 2.3.3 Ensure talk client is not installed
-  - id: 21056
-    title: Ensure talk client is not installed.
-    description: >
-      The talk software makes it possible for users to send and receive messages across systems
-      through a terminal session. The talk client, which allows initialization of talk sessions, is
-      installed by default.
-    rationale: >
-      The software presents a security risk as it uses unencrypted protocols for communication.
-    remediation: >
-      Run the following command to remove the talk package:
-      # zypper remove talk
+  # 2.3.3 Ensure talk client is not installed. (Automated)
+  - id: 21067
+    title: "Ensure talk client is not installed."
+    description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
+    rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Run the following command to remove the talk package: # zypper remove talk."
     compliance:
       - cis: ["2.3.3"]
-      - cis_csc: ["2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q talk -> r:not installed"
+      - "c:rpm -q talk -> r:^package talk is not installed"
 
-  # 2.3.4 Ensure telnet client is not installed
-  - id: 21057
-    title: Ensure telnet client is not installed.
-    description: >
-      The telnet package contains the telnet client, which allows users to start connections to
-      other systems via the telnet protocol.
-    rationale: >
-      The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
-      medium could allow an unauthorized user to steal credentials. The ssh package provides
-      an encrypted session and stronger security and is included in most Linux distributions.
-    remediation: >
-      Run the following command to remove the telnet package:
-      # zypper remove telnet
+  # 2.3.4 Ensure telnet client is not installed. (Automated)
+  - id: 21068
+    title: "Ensure telnet client is not installed."
+    description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
+    rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
+    impact: "Many insecure service clients are used as troubleshooting tools and in testing environments. Uninstalling them can inhibit capability to test and troubleshoot. If they are required it is advisable to remove the clients after use to prevent accidental or intentional misuse."
+    remediation: "Run the following command to remove the telnet package: # zypper remove telnet."
     compliance:
       - cis: ["2.3.4"]
-      - cis_csc: ["2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q telnet -> r:not installed"
+      - "c:rpm -q telnet -> r:^package telnet is not installed"
 
-  # 2.3.5 Ensure LDAP client is not installed
-  - id: 21058
-    title: Ensure LDAP client is not installed.
-    description: >
-      The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for
-      NIS/YP. It is a service that provides a method for looking up information from a central
-      database.
-    rationale: >
-      If the system will not need to act as an LDAP client, it is recommended that the software be
-      removed to reduce the potential attack surface.
-    remediation: >
-      Run the following command to remove the openldap-clients package:
-      # zypper remove openldap2-clients
+  # 2.3.5 Ensure LDAP client is not installed. (Automated)
+  - id: 21069
+    title: "Ensure LDAP client is not installed."
+    description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
+    rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
+    impact: "Removing the LDAP client will prevent or inhibit using LDAP for authentication in your environment."
+    remediation: "Run the following command to remove the openldap-clients package: # zypper remove openldap2-clients."
     compliance:
       - cis: ["2.3.5"]
-      - cis_csc: ["2.6"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["2.6"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.12.5.1", "A.12.6.2"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q openldap2-clients -> r:not installed"
+      - "c:rpm -q openldap2-clients -> r:^package openldap2-clients is not installed"
 
-  # 2.4 Ensure nonessential services are removed or masked - Not implemented
-  # 3.1.1 Disable IPv6 - Not implemented
-  # 3.1.2 Ensure wireless interfaces are disabled - Not implemented
-  # 3.2.1 Ensure IP forwarding is disabled - Not implemented
+  # 2.4 Ensure nonessential services are removed or masked. (Manual) - Not Implemented
 
-  # 3.2.2 Ensure packet redirect sending is disabled
-  - id: 21059
-    title: Ensure packet redirect sending is disabled
-    description: >
-      ICMP Redirects are used to send routing information to other hosts. As a host itself does
-      not act as a router (in a host only configuration), there is no need to send redirects.
-    rationale: >
-      An attacker could use a compromised host to send invalid ICMP redirects to other router
-      devices in an attempt to corrupt routing and have users access a system set up by the
-      attacker as opposed to a valid system.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv4.conf.all.send_redirects = 0
-      net.ipv4.conf.default.send_redirects = 0
+  # 3.1.1 Disable IPv6. (Automated) - Not Implemented
+  # 3.1.2 Ensure wireless interfaces are disabled. (Manual) - Not Implemented
+  # 3.2.1 Ensure IP forwarding is disabled. (Automated) - Not Implemented
+  # 3.2.2 Ensure packet redirect sending is disabled. (Automated) - Not Implemented
+  # 3.3.1 Ensure source routed packets are not accepted. (Automated) - Not Implemented
+  # 3.3.2 Ensure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.3 Ensure secure ICMP redirects are not accepted. (Automated) - Not Implemented
+  # 3.3.4 Ensure suspicious packets are logged. (Automated) - Not Implemented
 
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv4.conf.all.send_redirects=0
-      # sysctl -w net.ipv4.conf.default.send_redirects=0
-      # sysctl -w net.ipv4.route.flush=1
-    compliance:
-      - cis: ["3.2.2"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.send_redirects -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
-      - 'c:sysctl net.ipv4.conf.default.send_redirects -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
-      - 'c:grep -Rh net\.ipv4\.conf\.all\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.send_redirects\s*=\s*0$'
-      - 'c:grep -Rh net\.ipv4\.conf\.default\.send_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.send_redirects\s*=\s*0$'
-
-  # 3.3.1 Ensure source routed packets are not accepted - Not implemented
-  # 3.3.2 Ensure ICMP redirects are not accepted - Not implemented
-
-  #3.3.3 Ensure secure ICMP redirects are not accepted
-  - id: 21060
-    title: Ensure secure ICMP redirects are not accepted.
-    description: >
-      Secure ICMP redirects are the same as ICMP redirects, except they come from gateways
-      listed on the default gateway list. It is assumed that these gateways are known to your
-      system, and that they are likely to be secure.
-    rationale: >
-      It is still possible for even known gateways to be compromised. Setting
-      net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table
-      updates by possibly compromised known gateways.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv4.conf.all.secure_redirects = 0
-      net.ipv4.conf.default.secure_redirects = 0
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv4.conf.all.secure_redirects=0
-      # sysctl -w net.ipv4.conf.default.secure_redirects=0
-      # sysctl -w net.ipv4.route.flush=1
-    compliance:
-      - cis: ["3.3.3"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.secure_redirects -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
-      - 'c:sysctl net.ipv4.conf.default.secure_redirects -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
-      - 'c:grep -Rh net\.ipv4\.conf\.all\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.secure_redirects\s*=\s*0$'
-      - 'c:grep -Rh net\.ipv4\.conf\.default\.secure_redirects /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.secure_redirects\s*=\s*0$'
-
-  # 3.3.4 Ensure suspicious packets are logged
-  - id: 21061
-    title: Ensure suspicious packets are logged.
-    description: >
-      When enabled, this feature logs packets with un-routable source addresses to the kernel
-      log.
-    rationale: >
-      Enabling this feature and logging these packets allows an administrator to investigate the
-      possibility that an attacker is sending spoofed packets to their system.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv4.conf.all.log_martians = 1
-      net.ipv4.conf.default.log_martians = 1
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv4.conf.all.log_martians=1
-      # sysctl -w net.ipv4.conf.default.log_martians=1
-      # sysctl -w net.ipv4.route.flush=1
-    compliance:
-      - cis: ["3.3.4"]
-      - cis_csc: ["6.2", "6.3"]
-    condition: all
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.log_martians -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
-      - 'c:sysctl net.ipv4.conf.default.log_martians -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
-      - 'c:grep -Rh net\.ipv4\.conf\.all\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.log_martians\s*=\s*1$'
-      - 'c:grep -Rh net\.ipv4\.conf\.default\.log_martians /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.log_martians\s*=\s*1$'
-
-  # 3.3.5 Ensure broadcast ICMP requests are ignored
-  - id: 21062
-    title: Ensure broadcast ICMP requests are ignored
-    description: >
-      Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all
-      ICMP echo and timestamp requests to broadcast and multicast addresses.
-    rationale: >
-      Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for
-      your network could be used to trick your host into starting (or participating) in a Smurf
-      attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast
-      messages with a spoofed source address. All hosts receiving this message and responding
-      would send echo-reply messages back to the spoofed address, which is probably not
-      routable. If many hosts respond to the packets, the amount of traffic on the network could
-      be significantly multiplied.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv4.icmp_echo_ignore_broadcasts = 1
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
-      # sysctl -w net.ipv4.route.flush=1
+  # 3.3.5 Ensure broadcast ICMP requests are ignored. (Automated)
+  - id: 21070
+    title: "Ensure broadcast ICMP requests are ignored."
+    description: "Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all ICMP echo and timestamp requests to broadcast and multicast addresses."
+    rationale: "Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for your network could be used to trick your host into starting (or participating) in a Smurf attack. A Smurf attack relies on an attacker sending large amounts of ICMP broadcast messages with a spoofed source address. All hosts receiving this message and responding would send echo-reply messages back to the spoofed address, which is probably not routable. If many hosts respond to the packets, the amount of traffic on the network could be significantly multiplied."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_echo_ignore_broadcasts = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1 # sysctl -w net.ipv4.route.flush=1."
     compliance:
       - cis: ["3.3.5"]
-      - cis_csc: ["5.1"]
-    condition: all
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: any
     rules:
       - 'c:sysctl net.ipv4.icmp_echo_ignore_broadcasts -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
-      - 'c:grep -Rh net\.ipv4\.icmp_echo_ignore_broadcasts /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'f:/etc/sysctl.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
+      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*1$'
 
-  # 3.3.6 Ensure bogus ICMP responses are ignored
-  - id: 21063
-    title: Ensure bogus ICMP responses are ignored.
-    description: >
-      Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus
-      responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from
-      filling up with useless log messages.
-    rationale: >
-      Some routers (and some attackers) will send responses that violate RFC-1122 and attempt
-      to fill up a log file system with many useless error messages.
-    remediation: >
-      Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv4.icmp_ignore_bogus_error_responses = 1
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
-      # sysctl -w net.ipv4.route.flush=1
+  # 3.3.6 Ensure bogus ICMP responses are ignored. (Automated)
+  - id: 21071
+    title: "Ensure bogus ICMP responses are ignored."
+    description: "Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from filling up with useless log messages."
+    rationale: "Some routers (and some attackers) will send responses that violate RFC-1122 and attempt to fill up a log file system with many useless error messages."
+    remediation: "Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.icmp_ignore_bogus_error_responses = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1 # sysctl -w net.ipv4.route.flush=1."
     compliance:
       - cis: ["3.3.6"]
-      - cis_csc: ["5.1"]
-    condition: all
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: any
     rules:
       - 'c:sysctl net.ipv4.icmp_ignore_bogus_error_responses -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
-      - 'c:grep -Rh net\.ipv4\.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'f:/etc/sysctl.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
+      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.icmp_ignore_bogus_error_responses\s*=\s*1$'
 
-  # 3.3.7 Ensure Reverse Path Filtering is enabled
-  - id: 21064
-    title: Ensure Reverse Path Filtering is enabled.
-    description: >
-      Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1 forces
-      the Linux kernel to utilize reverse path filtering on a received packet to determine if the
-      packet was valid. Essentially, with reverse path filtering, if the return packet does not go
-      out the same interface that the corresponding source packet came from, the packet is
-      dropped (and logged if log_martians is set).
-    rationale: >
-      Setting these flags is a good way to deter attackers from sending your system bogus
-      packets that cannot be responded to. One instance where this feature breaks down is if
-      asymmetrical routing is employed. This would occur when using dynamic routing protocols
-      (bgp, ospf, etc) on your system. If you are using asymmetrical routing on your system, you
-      will not be able to enable this feature without breaking the routing.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv4.conf.all.rp_filter = 1
-      net.ipv4.conf.default.rp_filter = 1
+  # 3.3.7 Ensure Reverse Path Filtering is enabled. (Automated) - Not Implemented
 
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv4.conf.all.rp_filter=1
-      # sysctl -w net.ipv4.conf.default.rp_filter=1
-      # sysctl -w net.ipv4.route.flush=1
-    compliance:
-      - cis: ["3.3.7"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:sysctl net.ipv4.conf.all.rp_filter -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
-      - 'c:sysctl net.ipv4.conf.default.rp_filter -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
-      - 'c:grep -Rh net\.ipv4\.conf\.all\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.all.rp_filter\s*=\s*1$'
-      - 'c:grep -Rh net\.ipv4\.conf\.default\.rp_filter /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.conf.default.rp_filter\s*=\s*1$'
-
-  # 3.3.8 Ensure TCP SYN Cookies is enabled
-  - id: 21065
-    title: Ensure TCP SYN Cookies is enabled
-    description: >
-      When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the
-      half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
-      cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
-      SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
-      encodes the source and destination IP address and port number and the time the packet
-      was sent. A legitimate connection would send the ACK packet of the three way handshake
-      with the specially crafted sequence number. This allows the system to verify that it has
-      received a valid response to a SYN cookie and allow the connection, even though there is no
-      corresponding SYN in the queue.
-    rationale: >
-      Attackers use SYN flood attacks to perform a denial of service attacked on a system by
-      sending many SYN packets without completing the three way handshake. This will quickly
-      use up slots in the kernel's half-open connection queue and prevent legitimate connections
-      from succeeding. SYN cookies allow the system to keep accepting valid connections, even if
-      under a denial of service attack.
-    remediation: >
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv4.tcp_syncookies = 1
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv4.tcp_syncookies=1
-      # sysctl -w net.ipv4.route.flush=1
+  # 3.3.8 Ensure TCP SYN Cookies is enabled. (Automated)
+  - id: 21072
+    title: "Ensure TCP SYN Cookies is enabled."
+    description: "When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that encodes the source and destination IP address and port number and the time the packet was sent. A legitimate connection would send the ACK packet of the three way handshake with the specially crafted sequence number. This allows the system to verify that it has received a valid response to a SYN cookie and allow the connection, even though there is no corresponding SYN in the queue."
+    rationale: "Attackers use SYN flood attacks to perform a denial of service attacked on a system by sending many SYN packets without completing the three-way handshake. This will quickly use up slots in the kernel's half-open connection queue and prevent legitimate connections from succeeding. SYN cookies allow the system to keep accepting valid connections, even if under a denial of service attack."
+    remediation: "Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file: net.ipv4.tcp_syncookies = 1 Run the following commands to set the active kernel parameters: # sysctl -w net.ipv4.tcp_syncookies=1 # sysctl -w net.ipv4.route.flush=1."
     compliance:
       - cis: ["3.3.8"]
-      - cis_csc: ["5.1"]
-    condition: all
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: any
     rules:
-      - 'c:grep -Rh net\.ipv4\.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
-      - 'c:/sbin/sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'c:sysctl net.ipv4.tcp_syncookies -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'f:/etc/sysctl.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
+      - 'd:->/etc/sysctl.d/ -> r:\.*.conf -> r:^net.ipv4.tcp_syncookies\s*=\s*1$'
 
-  # 3.3.9 Ensure IPv6 router advertisements are not accepted
-  - id: 21066
-    title: Ensure IPv6 router advertisements are not accepted
-    description: This setting disables the system's ability to accept IPv6 router advertisements.
-    rationale: >
-      It is recommended that systems do not accept router advertisements as they could be
-      tricked into routing traffic to compromised machines. Setting hard routes within the
-      system (usually a single default route to a trusted router) protects the system from bad
-      routes.
-    remediation: >
-      IF IPv6 is enabled:
+  # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated) - Not Implemented
 
-      Set the following parameters in /etc/sysctl.conf or a /etc/sysctl.d/* file:
-      net.ipv6.conf.all.accept_ra = 0
-      net.ipv6.conf.default.accept_ra = 0
-
-      Run the following commands to set the active kernel parameters:
-      # sysctl -w net.ipv6.conf.all.accept_ra=0
-      # sysctl -w net.ipv6.conf.default.accept_ra=0
-      # sysctl -w net.ipv6.route.flush=1
-    compliance:
-      - cis: ["3.3.9"]
-      - cis_csc: ["5.1"]
-    condition: all
-    rules:
-      - 'c:sysctl net.ipv6.conf.all.accept_ra -> r:\s*0$'
-      - 'c:sysctl net.ipv6.conf.default.accept_ra -> r:\s*0$'
-      - 'c:grep -Rh "net\.ipv6\.conf\.all\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.all.accept_ra\s*=\s*0'
-      - 'c:grep -Rh "net\.ipv6\.conf\.default\.accept_ra" /etc/sysctl.conf /etc/sysctl.d -> r:^\s*net.ipv6.conf.default.accept_ra\s*=\s*0'
-
-  # 3.4.1 Ensure DCCP is disabled
-  - id: 21067
-    title: Ensure DCCP is disabled
-    description: >
-      The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that
-      supports streaming media and telephony. DCCP provides a way to gain access to
-      congestion control, without having to do it at the application layer, but does not provide
-      insequence delivery.
-    rationale: >
-      If the protocol is not required, it is recommended that the drivers not be installed to reduce
-      the potential attack surface.
-    remediation: >
-      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-      Example: vim /etc/modprobe.d/dccp.conf
-      and add the following line:
-
-      install dccp /bin/true
+  # 3.4.1 Ensure DCCP is disabled. (Automated)
+  - id: 21073
+    title: "Ensure DCCP is disabled."
+    description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
+    rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
+    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vim /etc/modprobe.d/dccp.conf and add the following line: install dccp /bin/true."
     compliance:
       - cis: ["3.4.1"]
-      - cis_csc: ["9.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - 'c:grep -R dccp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+dccp\s+/bin/true'
+      - 'c:modprobe -n -v dccp -> r:install\s*\t*/bin/true'
+      - "not c:lsmod -> r:dccp"
 
-  # 3.4.2 Ensure SCTP is disabled
-  - id: 21068
-    title: Ensure SCTP is disabled
-    description: >
-      The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to
-      support message oriented communication, with several streams of messages in one
-      connection. It serves a similar function as TCP and UDP, incorporating features of both. It is
-      message-oriented like UDP, and ensures reliable in-sequence transport of messages with
-      congestion control like TCP.
-    rationale: >
-      If the protocol is not being used, it is recommended that kernel module not be loaded,
-      disabling the service to reduce the potential attack surface.
-    remediation: >
-      Edit or create a file in the /etc/modprobe.d/ directory ending in .conf
-      Example: vim /etc/modprobe.d/sctp.conf
-      and add the following line:
-
-      install sctp /bin/true
+  # 3.4.2 Ensure SCTP is disabled. (Automated)
+  - id: 21074
+    title: "Ensure SCTP is disabled."
+    description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
+    rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
+    remediation: "Edit or create a file in the /etc/modprobe.d/ directory ending in .conf Example: vim /etc/modprobe.d/sctp.conf and add the following line: install sctp /bin/true."
     compliance:
       - cis: ["3.4.2"]
-      - cis_csc: ["9.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - 'c:grep -R sctp /etc/modprobe.d -> r:^/etc/modprobe.d/\.+.conf:\s*install\s+sctp\s+/bin/true'
+      - 'c:modprobe -n -v sctp -> r:install\s*\t*/bin/true'
+      - "not c:lsmod -> r:sctp"
 
-  # 3.5.1.1 Ensure FirewallD is installed
-  - id: 21069
-    title: Ensure FirewallD is installed
-    description: >
-      firewalld is a firewall management tool for Linux operating systems. It provides firewall
-      features by acting as a front-end for the Linux kernel's netfilter framework via the iptables
-      backend or provides firewall features by acting as a front-end for the Linux kernel's
-      netfilter framework via the nftables utility.
-
-      FirewallD replaces iptables as the default firewall management tool. Use the firewalld
-      utility to configure a firewall for less complex firewalls. The utility is easy to use and covers
-      the typical use cases scenario. FirewallD supports both IPv4 and IPv6 networks and can
-      administer separate firewall zones with varying degrees of trust as defined in zone profiles.
-
-      Note: Starting in v0.6.0, FirewallD added support for acting as a front-end for the Linux
-      kernel's netfilter framework via the nftables userspace utility, acting as an alternative to the
-      nft command line program.
-    rationale: >
-      A firewall utility is required to configure the Linux kernel's netfilter framework via the
-      iptables or nftables back-end.
-
-      The Linux kernel's netfilter framework host-based firewall can protect against threats
-      originating from within a corporate network to include malicious mobile code and poorly
-      configured software on a host.
-
-      Note: Only one firewall utility should be installed and configured. FirewallD is dependent on
-      the iptables package.
-    remediation: >
-      Run the following command to install FirewallD and iptables:
-      # zypper install firewalld iptables
+  # 3.5.1.1 Ensure FirewallD is installed. (Automated)
+  - id: 21075
+    title: "Ensure FirewallD is installed."
+    description: "firewalld is a firewall management tool for Linux operating systems. It provides firewall features by acting as a front-end for the Linux kernel's netfilter framework via the iptables backend or provides firewall features by acting as a front-end for the Linux kernel's netfilter framework via the nftables utility. firewallD replaces iptables as the default firewall management tool. Use the firewalld utility to configure a firewall for less complex firewalls. The utility is easy to use and covers the typical use cases scenario. FirewallD supports both IPv4 and IPv6 networks and can administer separate firewall zones with varying degrees of trust as defined in zone profiles. Note: Starting in v0.6.0, FirewallD added support for acting as a front-end for the Linux kernel's netfilter framework via the nftables userspace utility, acting as an alternative to the nft command line program."
+    rationale: "A firewall utility is required to configure the Linux kernel's netfilter framework via the iptables or nftables back-end. The Linux kernel's netfilter framework host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured. FirewallD is dependent on the iptables package."
+    impact: "Changing firewall settings while connected over the network can result in being locked out of the system."
+    remediation: "Run the following command to install FirewallD and iptables: # zypper install firewalld iptables."
     compliance:
       - cis: ["3.5.1.1"]
-      - cis_csc: ["9.4"]
-    condition: none
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
     rules:
-      - "c:rpm -q firewalld -> r:not installed"
-      - "c:rpm -q iptables -> r:not installed"
+      - "c:rpm -q firewalld -> r:^firewalld-"
+      - "c:rpm -q iptables -> r:^iptables-"
 
-  # 3.5.1.2 Ensure nftables is not installed or stopped and masked - Not implemented
+  # 3.5.1.2 Ensure nftables is not installed or stopped and masked. (Automated)
+  - id: 21076
+    title: "Ensure nftables is not installed or stopped and masked."
+    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables. Notes: - Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as it's back-end by default. firewalld may be configured as the front-end to nftables. If this case, nftables should be stopped and masked instead of removed. -."
+    rationale: "Running both firewalld and nftables may lead to conflict."
+    remediation: "Run the following command to remove nftables: # zypper remove nftables OR Run the following command to stop and mask nftables: systemctl --now mask nftables."
+    compliance:
+      - cis: ["3.5.1.2"]
+      - cis_csc_v8: ["4.4", "4.8"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.1.6", "1.2.1", "1.3.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.1", "1.2.5", "1.4.1", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:rpm -q nftables -> r:^package nftables is not installed"
+      - "c:systemctl is-active nftables -> r:^inactive"
+      - "c:systemctl is-enabled nftables -> r:^masked"
 
-  # 3.5.1.3 Ensure firewalld service is enabled and running
-  - id: 21070
-    title: Ensure firewalld service is enabled and running
-    description: >
-      firewalld.service enables the enforcement of firewall rules configured through
-      firewalld
-    rationale: >
-      Ensure that the firewalld.service is enabled and running to enforce firewall rules
-      configured through firewalld
-    remediation: >
-      Run the following command to unmask firewalld
-      # systemctl unmask firewalld
-
-      Run the following command to enable and start firewalld
-      # systemctl --now enable firewalld
+  # 3.5.1.3 Ensure firewalld service is enabled and running. (Automated)
+  - id: 21077
+    title: "Ensure firewalld service is enabled and running."
+    description: "firewalld.service enables the enforcement of firewall rules configured through firewalld."
+    rationale: "Ensure that the firewalld.service is enabled and running to enforce firewall rules configured through firewalld."
+    impact: "Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following command to unmask firewalld # systemctl unmask firewalld Run the following command to enable and start firewalld # systemctl --now enable firewalld."
     compliance:
       - cis: ["3.5.1.3"]
-      - cis_csc: ["9.4"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
       - "c:systemctl is-enabled firewalld -> r:^enabled"
       - "c:firewall-cmd --state -> r:^running"
 
-  # 3.5.1.4 Ensure default zone is set - Not implemented
-  # 3.5.1.5 Ensure network interfaces are assigned to appropriate zone - Not implemented
-  # 3.5.1.6 Ensure unnecessary services and ports are not accepted - Not implemented
+  # 3.5.1.4 Ensure default zone is set. (Automated) - Not Implemented
+  # 3.5.1.5 Ensure network interfaces are assigned to appropriate zone. (Manual) - Not Implemented
 
-  # 3.5.2.1 Ensure nftables is installed
-  - id: 21071
-    title: Ensure nftables is installed
-    description: >
-      nftables provides a new in-kernel packet classification framework that is based on a
-      network-specific Virtual Machine (VM) and a new nft userspace command line tool.
-      nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure,
-      the connection tracking system, NAT, userspace queuing and logging subsystem.
-        Notes:
-          - nftables is available in Linux kernel 3.13 and newer.
-          - Only one firewall utility should be installed and configured.
-    rationale: >
-      nftables is a subsystem of the Linux kernel that can protect against threats originating from
-      within a corporate network to include malicious mobile code and poorly configured
-      software on a host.
-    remediation: >
-      Run the following command to install nftables
-      # zypper install nftables
+  # 3.5.1.6 Ensure unnecessary services and ports are not accepted. (Manual) - Not Implemented
+
+  # 3.5.2.1 Ensure nftables is installed. (Automated)
+  - id: 21078
+    title: "Ensure nftables is installed."
+    description: "nftables provides a new in-kernel packet classification framework that is based on a network-specific Virtual Machine (VM) and a new nft userspace command line tool. nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure, the connection tracking system, NAT, userspace queuing and logging subsystem. Notes: - nftables is available in Linux kernel 3.13 and newer. - Only one firewall utility should be installed and configured."
+    rationale: "nftables is a subsystem of the Linux kernel that can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host."
+    impact: "Changing firewall settings while connected over the network can result in being locked out of the system."
+    remediation: "Run the following command to install nftables # zypper install nftables."
     compliance:
       - cis: ["3.5.2.1"]
-      - cis_csc: ["9.4"]
-    condition: none
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
     rules:
-      - "c:rpm -q nftables -> r:not installed"
+      - "c:rpm -q nftables -> r:^nftables-"
 
-  # 3.5.2.2 Ensure firewalld is not installed or stopped and masked - Not implemented
-  # 3.5.2.3 Ensure iptables are flushed - Not implemented
+  # 3.5.2.2 Ensure firewalld is not installed or stopped and masked. (Automated) - Not Implemented
 
-  # 3.5.2.4 Ensure a table exists
-  - id: 21072
-    title: Ensure a table exists.
-    description: >
-      Tables hold chains. Each table only has one address family and only applies to packets of
-      this family. Tables can have one of five families.
-    rationale: >
-      nftables doesn't have any default tables. Without a table being build, nftables will not filter
-      network traffic.
-    remediation: >
-      Run the following command to create a table in nftables
-      # nft create table inet <table name>
+  # 3.5.2.3 Ensure iptables are flushed. (Manual) - Not Implemented
+
+  # 3.5.2.4 Ensure a table exists. (Automated)
+  - id: 21079
+    title: "Ensure a table exists."
+    description: "Tables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
+    rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
+    impact: "Adding rules to a running nftables can cause loss of connectivity to the system."
+    remediation: "Run the following command to create a table in nftables # nft create table inet <table name> Example: # nft create table inet filter."
     compliance:
       - cis: ["3.5.2.4"]
-      - cis_csc: ["9.4"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - 'c:nft list tables -> r:^table inet\s+\.+'
+      - 'c:nft list tables -> r:\w+'
 
-  # 3.5.2.5 Ensure base chains exist
-  - id: 21073
-    title: Ensure base chains exist.
-    description: >
-      Chains are containers for rules. They exist in two kinds, base chains and regular chains. A
-      base chain is an entry point for packets from the networking stack, a regular chain may be
-      used as jump target and is used for better rule organization.
-    rationale: >
-      If a base chain doesn't exist with a hook for input, forward, and delete, packets that would
-      flow through those chains will not be touched by nftables.
-    remediation: >
-      Run the following command to create the base chains:
-      # nft create chain inet <table name> <base chain name> { type filter hook
-      <(input|forward|output)> priority 0 \; }
+  # 3.5.2.5 Ensure base chains exist. (Automated)
+  - id: 21080
+    title: "Ensure base chains exist."
+    description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
+    rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
+    impact: "If configuring nftables over ssh, creating a base chain with a policy of drop will cause loss of connectivity. Ensure that a rule allowing ssh has been added to the base chain prior to setting the base chain's policy to drop."
+    remediation: "Run the following command to create the base chains: # nft create chain inet <table name> <base chain name> { type filter hook <(input|forward|output)> priority 0 \\; } Example: # nft create chain inet filter input { type filter hook input priority 0 \\; } # nft create chain inet filter forward { type filter hook forward priority 0 \\; } # nft create chain inet filter output { type filter hook output priority 0 \\; }."
     compliance:
       - cis: ["3.5.2.5"]
-      - cis_csc: ["9.4"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - 'c:nft list ruleset -> !r:^# && r:type hook input\s+\.+'
-      - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+'
-      - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+'
+      - "c:nft list ruleset -> r:hook input"
+      - "c:nft list ruleset -> r:hook forward"
+      - "c:nft list ruleset -> r:hook output"
 
-  # 3.5.2.6 Ensure loopback traffic is configured
-  # 3.5.2.7 Ensure outbound and established connections are configured
+  # 3.5.2.6 Ensure loopback traffic is configured. (Automated)
+  - id: 21081
+    title: "Ensure loopback traffic is configured."
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
+    remediation: "Run the following commands to implement the loopback rules: # nft add rule inet filter input iif lo accept # nft create rule inet filter input ip saddr 127.0.0.0/8 counter drop If IPv6 is enabled: Run the following command to implement the IPv6 loopback rules: # nft add rule inet filter input ip6 saddr ::1 counter drop."
+    compliance:
+      - cis: ["3.5.2.6"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/''" -> r:iif "lo" accept'
+      - 'c:sh -c "nft list ruleset | awk ''/hook input/,/}/''" -> r:ip saddr|ip6 saddr'
 
-  # 3.5.2.8 Ensure default deny firewall policy
-  - id: 21074
-    title: Ensure default deny firewall policy.
-    description: >
-      Base chain policy is the default verdict that will be applied to packets reaching the end of
-      the chain.
-    rationale: >
-      There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall
-      will accept any packet that is not configured to be denied and the packet will continue
-      transversing the network stack.
-      It is easier to white list acceptable usage than to black list unacceptable usage.
+  # 3.5.2.7 Ensure outbound and established connections are configured. (Manual) - Not Implemented
 
-      Note: Changing firewall settings while connected over network can result in being locked
-      out of the system.
-    remediation: >
-      Run the following command for the base chains with the input, forward, and output hooks
-      to implement a default DROP policy:
-      # nft chain <table family> <table name> <chain name> { policy drop \; }
-
-      Example:
-      # nft chain inet filter input { policy drop \; }
-      # nft chain inet filter forward { policy drop \; }
-      # nft chain inet filter output { policy drop \; }
+  # 3.5.2.8 Ensure default deny firewall policy. (Automated)
+  - id: 21082
+    title: "Ensure default deny firewall policy."
+    description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
+    rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue traversing the network stack. It is easier to allow acceptable usage than to block unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
+    impact: "If configuring nftables over ssh, creating a base chain with a policy of drop will cause loss of connectivity. Ensure that a rule allowing ssh has been added to the base chain prior to setting the base chain's policy to drop."
+    remediation: "Run the following command for the base chains with the input, forward, and output hooks to implement a default DROP policy: # nft chain <table family> <table name> <chain name> { policy drop \\; } Example: # nft chain inet filter input { policy drop \\; } # nft chain inet filter forward { policy drop \\; } # nft chain inet filter output { policy drop \\; }."
     compliance:
       - cis: ["3.5.2.8"]
-      - cis_csc: ["9.4"]
-    references:
-      - Manual Page nft
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - 'c:nft list ruleset -> !r:^# && r:type hook input\s+\.+policy\s+drop'
-      - 'c:nft list ruleset -> !r:^# && r:type hook forward\s+\.+policy\s+drop'
-      - 'c:nft list ruleset -> !r:^# && r:type hook output\s+\.+policy\s+drop'
+      - "c:nft list ruleset -> r:hook input && r:policy drop"
+      - "c:nft list ruleset -> r:hook forward && r:policy drop"
+      - "c:nft list ruleset -> r:hook output && r:policy drop"
 
-  # 3.5.2.9 Ensure nftables service is enabled
-  - id: 21075
-    title: Ensure nftables service is enabled
-    description: >
-      The nftables service allows for the loading of nftables rulesets during boot, or starting on
-      the nftables service
-    rationale: >
-      The nftables service restores the nftables rules from the rules files referenced in the
-      /etc/sysconfig/nftables.conf file during boot or the starting of the nftables service
-    remediation: >
-      Run the following command to enable the nftables service:
-      # systemctl enable nftables
+  # 3.5.2.9 Ensure nftables service is enabled. (Automated)
+  - id: 21083
+    title: "Ensure nftables service is enabled."
+    description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service."
+    rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/sysconfig/nftables.conf file during boot or the starting of the nftables service."
+    remediation: "Run the following command to enable the nftables service: # systemctl enable nftables."
     compliance:
       - cis: ["3.5.2.9"]
-      - cis_csc: ["9.4"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
       - "c:systemctl is-enabled nftables -> r:^enabled"
 
-  # 3.5.2.10 Ensure nftables rules are permanent - Not implemented
-  # 3.5.3.1.1 Ensure iptables package is installed - Not implemented
+  # 3.5.2.10 Ensure nftables rules are permanent. (Automated)
+  - id: 21084
+    title: "Ensure nftables rules are permanent."
+    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames. The nftables service reads the /etc/sysconfig/nftables.conf file for a nftables file or files to include in the nftables ruleset. A nftables ruleset containing the input, forward, and output base chains allow network traffic to be filtered."
+    rationale: "Changes made to nftables ruleset only affect the live system, you will also need to configure the nftables ruleset to apply on boot."
+    remediation: 'Edit the /etc/sysconfig/nftables.conf file and un-comment or add a line with include <Absolute path to nftables rules file> for each nftables file you want included in the nftables ruleset on boot Example: # vi /etc/sysconfig/nftables.conf Add the line: include "/etc/nftables/nftables.rules".'
+    compliance:
+      - cis: ["3.5.2.10"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "f:/etc/nftables.conf -> r:include *"
 
-  # 3.5.3.1.2 Ensure nftables is not installed - Not implemented
-  - id: 21076
-    title: Ensure nftables is not installed
-    description: >
-      nftables is a subsystem of the Linux kernel providing filtering and classification of network
-      packets/datagrams/frames and is the successor to iptables.
-    rationale: >
-      Running both iptables and nftables may lead to conflict.
-    remediation: >
-      Run the following command to remove nftables:
-      # zypper remove nftables
+  # 3.5.3.1.1 Ensure iptables package is installed. (Automated)
+  - id: 21085
+    title: "Ensure iptables package is installed."
+    description: "iptables is a utility program that allows a system administrator to configure the tables provided by the Linux kernel firewall, implemented as different Netfilter modules, and the chains and rules it stores. Different kernel modules and programs are used for different protocols; iptables applies to IPv4, ip6tables to IPv6, arptables to ARP, and ebtables to Ethernet frames."
+    rationale: "A method of configuring and maintaining firewall rules is necessary to configure a Host Based Firewall."
+    remediation: "Run the following command to install iptables # zypper install iptables."
+    compliance:
+      - cis: ["3.5.3.1.1"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:rpm -q iptables -> r:^iptables-"
+
+  # 3.5.3.1.2 Ensure nftables is not installed. (Automated)
+  - id: 21086
+    title: "Ensure nftables is not installed."
+    description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables."
+    rationale: "Running both iptables and nftables may lead to conflict."
+    remediation: "Run the following command to remove nftables: # zypper remove nftables."
     compliance:
       - cis: ["3.5.3.1.2"]
-      - cis_csc: ["9.4"]
+      - cis_csc_v8: ["4.4", "4.8"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.1.6", "1.2.1", "1.3.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.1", "1.2.5", "1.4.1", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "c:rpm -q nftables -> r:not installed"
+      - "c:rpm -q nftables -> r:^package nftables is not installed"
 
-  # 3.5.3.1.3 Ensure firewalld is not installed or stopped and masked - Not implemented
+  # 3.5.3.1.3 Ensure firewalld is not installed or stopped and masked. (Automated)
+  - id: 21087
+    title: "Ensure firewalld is not installed or stopped and masked."
+    description: 'firewalld (Dynamic Firewall Manager) provides a dynamically managed firewall with support for network/firewall "zones" to assign a level of trust to a network and its associated connections, interfaces or sources. It has support for IPv4, IPv6, Ethernet bridges and also for IPSet firewall settings. There is a separation of the runtime and permanent configuration options.'
+    rationale: "Running iptables.service and\\or ip6tables.service with firewalld.service may lead to conflict and unexpected results."
+    remediation: "Run the following command to remove firewalld # zypper remove firewalld OR Run the following command to stop and mask firewalld # systemctl --now mask firewalld."
+    compliance:
+      - cis: ["3.5.3.1.3"]
+      - cis_csc_v8: ["4.4", "4.8"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.1.6", "1.2.1", "1.3.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.1", "1.2.5", "1.4.1", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
+    condition: any
+    rules:
+      - "c:rpm -q firewalld -> r:^package firewalld is not installed"
+      - "not c:systemctl status firewalld -> r:active && r:running"
+      - "c:systemctl is-enabled firewalld -> r:^masked"
 
-  # 3.5.3.2.1 Ensure default deny firewall policy
-  - id: 21077
-    title: Ensure default deny firewall policy
-    description: >
-      A default deny all policy on connections ensures that any unconfigured network usage will
-      be rejected.
-    rationale: >
-      With a default accept policy the firewall will accept any packet that is not configured to be
-      denied. It is easier to white list acceptable usage than to black list unacceptable usage.
-
-      Note: Changing firewall settings while connected over network can result in being locked
-      out of the system.
-    remediation: >
-      Run the following commands to implement a default DROP policy:
-      # iptables -P INPUT DROP
-      # iptables -P OUTPUT DROP
-      # iptables -P FORWARD DROP
+  # 3.5.3.2.1 Ensure default deny firewall policy. (Automated)
+  - id: 21088
+    title: "Ensure default deny firewall policy."
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following commands to implement a default DROP policy: # iptables -P INPUT DROP # iptables -P OUTPUT DROP # iptables -P FORWARD DROP."
     compliance:
       - cis: ["3.5.3.2.1"]
-      - cis_csc: ["9.4"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - 'c:iptables -L -> r:^Chain INPUT \(policy DROP\)'
-      - 'c:iptables -L -> r:^Chain FORWARD \(policy DROP\)'
-      - 'c:iptables -L -> r:^Chain OUTPUT \(policy DROP\)'
+      - "c:iptables -L -> r:^Chain INPUT && r:policy DROP"
+      - "c:iptables -L -> r:^Chain FORWARD && r:policy DROP"
+      - "c:iptables -L -> r:^Chain OUTPUT && r:policy DROP"
 
-  # 3.5.3.2.2 Ensure loopback traffic is configured
-  - id: 21078
-    title: Ensure loopback traffic is configured
-    description: >
-      Configure the loopback interface to accept traffic. Configure all other interfaces to deny
-      traffic to the loopback network (127.0.0.0/8).
-    rationale: >
-      Loopback traffic is generated between processes on machine and is typically critical to
-      operation of the system. The loopback interface is the only place that loopback network
-      (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this
-      network as an anti-spoofing measure.
-
-      Note: Changing firewall settings while connected over network can result in being locked
-      out of the system.
-    remediation: >
-      Run the following commands to implement the loopback rules:
-      # iptables -A INPUT -i lo -j ACCEPT
-      # iptables -A OUTPUT -o lo -j ACCEPT
-      # iptables -A INPUT -s 127.0.0.0/8 -j DROP
+  # 3.5.3.2.2 Ensure loopback traffic is configured. (Automated)
+  - id: 21089
+    title: "Ensure loopback traffic is configured."
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure. Note: Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following commands to implement the loopback rules: # iptables -A INPUT -i lo -j ACCEPT # iptables -A OUTPUT -o lo -j ACCEPT # iptables -A INPUT -s 127.0.0.0/8 -j DROP."
     compliance:
       - cis: ["3.5.3.2.2"]
-      - cis_csc: ["9.4"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+lo\s+*\s+0.0.0.0/0\s+0.0.0.0/0'
-      - 'c:iptables -L INPUT -v -n -> r:^\s*\d+\s+\d+\s+DROP\s+all\s+--\s+*\s+*\s+127.0.0.0/8\s+0.0.0.0/0'
-      - 'c:iptables -L OUTPUT -v -n -> r:^\s*\d+\s+\d+\s+ACCEPT\s+all\s+--\s+*\s+lo\s+0.0.0.0/0\s+0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:\.*ACCEPT\.*all\.*lo\.**\.*0.0.0.0/0\.*0.0.0.0/0'
+      - 'c:iptables -L INPUT -v -n -> r:\.*DROP\.*all\.**\.**\.*127.0.0.0/8\.*0.0.0.0/0'
+      - 'c:iptables -L OUTPUT -v -n -> r:\.*ACCEPT\.*all\.**\.*lo\.*0.0.0.0/0\.*0.0.0.0/0'
 
-  # 3.5.3.2.3 Ensure outbound and established connections are configured - Not implemented
-  # 3.5.3.2.4 Ensure firewall rules exist for all open ports - Not implemented
-  # 3.5.3.3.1 Ensure IPv6 default deny firewall policy - Not implemented
-  # 3.5.3.3.2 Ensure IPv6 loopback traffic is configured - Not implemented
-  # 3.5.3.3.3 Ensure IPv6 outbound and established connections are configured - Not implemented
-  # 3.5.3.3.4 Ensure IPv6 firewall rules exist for all open ports - Not implemented
+  # 3.5.3.2.3 Ensure outbound and established connections are configured. (Manual) - Not Implemented
 
-  # 4.1.1.1 Ensure auditd is installed
-  - id: 21079
-    title: Ensure auditd is installed
-    description: >
-      auditd is the userspace component to the Linux Auditing System. It's responsible for
-      writing audit records to the disk
-    rationale: >
-      The capturing of system events provides system administrators with information to allow
-      them to determine if unauthorized access to their system is occurring.
-    remediation: >
-      Run the following command to Install auditd
-      # zypper install audit
+  # 3.5.3.2.4 Ensure firewall rules exist for all open ports. (Automated) - Not Implemented
+
+  # 3.5.3.3.1 Ensure IPv6 default deny firewall policy. (Automated)
+  - id: 21090
+    title: "Ensure IPv6 default deny firewall policy."
+    description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
+    rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following commands to implement a default DROP policy: # ip6tables -P INPUT DROP # ip6tables -P OUTPUT DROP # ip6tables -P FORWARD DROP."
+    compliance:
+      - cis: ["3.5.3.3.1"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - "c:ip6tables -L -> r:^Chain INPUT && r:policy DROP"
+      - "c:ip6tables -L -> r:^Chain FORWARD && r:policy DROP"
+      - "c:ip6tables -L -> r:^Chain OUTPUT && r:policy DROP"
+
+  # 3.5.3.3.2 Ensure IPv6 loopback traffic is configured. (Automated)
+  - id: 21091
+    title: "Ensure IPv6 loopback traffic is configured."
+    description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1)."
+    rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure. Note: Changing firewall settings while connected over network can result in being locked out of the system."
+    remediation: "Run the following commands to implement the loopback rules: # ip6tables -A INPUT -i lo -j ACCEPT # ip6tables -A OUTPUT -o lo -j ACCEPT # ip6tables -A INPUT -s ::1 -j DROP."
+    compliance:
+      - cis: ["3.5.3.3.2"]
+      - cis_csc_v8: ["4.4"]
+      - cis_csc_v7: ["9.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.20", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.1"]
+      - nist_sp_800-53: ["SC-7(5)"]
+      - pci_dss_v3.2.1: ["1.1.4", "1.3.1"]
+      - pci_dss_v4.0: ["1.2.1", "1.4.1"]
+      - soc_2: ["CC6.6"]
+    condition: all
+    rules:
+      - 'c:ip6tables -L INPUT -v -n -> r:ACCEPT\s*\t*all\s*\t*lo && r:\s*::/0'
+      - 'c:ip6tables -L INPUT -v -n -> r:DROP\s*\t*all\s*\t*lo && r:\s*::/0'
+      - 'c:ip6tables -L OUTPUT -v -n -> r:ACCEPT\s*\t*all\s*\t*lo && r:\s*::/0'
+
+  # 3.5.3.3.3 Ensure IPv6 outbound and established connections are configured. (Manual) - Not Implemented
+
+  # 3.5.3.3.4 Ensure IPv6 firewall rules exist for all open ports. (Manual) - Not Implemented
+
+  # 4.1.1.1 Ensure auditd is installed. (Automated)
+  - id: 21092
+    title: "Ensure auditd is installed."
+    description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to Install auditd # zypper install audit."
     compliance:
       - cis: ["4.1.1.1"]
-      - cis_csc: ["6.2", "6.3"]
-    condition: none
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
     rules:
-      - "c:rpm -q audit -> r:not installed"
+      - "c:rpm -q audit -> r:^audit-"
 
-  # 4.1.1.2 Ensure auditd service is enabled and running
-  - id: 21080
-    title: Ensure auditd service is enabled and running
-    description: Turn on the auditd daemon to record system events.
-    rationale: >
-      The capturing of system events provides system administrators with information to allow
-      them to determine if unauthorized access to their system is occurring.
-    remediation: >
-      Run the following command to enable and start auditd:
-      # systemctl --now enable auditd
+  # 4.1.1.2 Ensure auditd service is enabled and running. (Automated)
+  - id: 21093
+    title: "Ensure auditd service is enabled and running."
+    description: "Turn on the auditd daemon to record system events."
+    rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
+    remediation: "Run the following command to enable and start auditd: # systemctl --now enable auditd."
     compliance:
       - cis: ["4.1.1.2"]
-      - cis_csc: ["6.2", "6.3"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
     condition: all
     rules:
       - "c:systemctl is-enabled auditd -> r:^enabled"
-      - 'c:systemctl status auditd -> r:^\s*Active: active \(running\) since \.+'
+      - "c:systemctl status auditd -> r:active && r:running"
 
-  # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled - Not implemented
+  # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled. (Automated)
+  - id: 21094
+    title: "Ensure auditing for processes that start prior to auditd is enabled."
+    description: "Configure grub so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
+    rationale: "Audit events need to be captured on processes that start up prior to auditd , so that potential malicious activity cannot go undetected. Note: This recommendation is designed around the grub2 bootloader, if LILO or another bootloader is in use in your environment enact equivalent settings."
+    remediation: 'Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX: GRUB_CMDLINE_LINUX="audit=1" Run the following command to update the grub2 configuration: # grub2-mkconfig -o /boot/grub2/grub.cfg.'
+    compliance:
+      - cis: ["4.1.1.3"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
+    rules:
+      - "not f:/boot/grub2/grub.cfg -> !r:^# && r:linux && !r:audit=1"
 
-  # 4.1.2.1 Ensure audit log storage size is configured
-  - id: 21081
-    title: Ensure audit log storage size is configured.
-    description: >
-      Configure the maximum size of the audit log file. Once the log reaches the maximum size, it
-      will be rotated and a new log file will be started.
-
-      Notes:
-        - The max_log_file parameter is measured in megabytes.
-        - Other methods of log rotation may be appropriate based on site policy. One example is
-          time-based rotation strategies which don't have native support in auditd
-          configurations. Manual audit of custom configurations should be evaluated for
-          effectiveness and completeness.
-    rationale: >
-      It is important that an appropriate size is determined for log files so that they do not impact
-      the system and audit data is not lost.
-    remediation: >
-      Set the following parameter in /etc/audit/auditd.conf in accordance with site policy:
-      max_log_file = <MB>
+  # 4.1.2.1 Ensure audit log storage size is configured. (Automated)
+  - id: 21095
+    title: "Ensure audit log storage size is configured."
+    description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started. Notes: - The max_log_file parameter is measured in megabytes. - Other methods of log rotation may be appropriate based on site policy. One example is time-based rotation strategies which don't have native support in auditd configurations. Manual audit of custom configurations should be evaluated for effectiveness and completeness."
+    rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf in accordance with site policy: max_log_file = <MB>."
     compliance:
       - cis: ["4.1.2.1"]
-      - cis_csc: ["6.4"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
     condition: all
     rules:
-      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file\s*=\s*\d+'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file\s*\t*=\s*\t*\d+'
 
-  # 4.1.2.2 Ensure audit logs are not automatically deleted
-  - id: 21082
-    title: Ensure audit logs are not automatically deleted.
-    description: >
-      The max_log_file_action setting determines how to handle the audit log file reaching the
-      max file size. A value of keep_logs will rotate the logs but never delete old logs.
-    rationale: >
-      In high security contexts, the benefits of maintaining a long audit history exceed the cost of
-      storing the audit history.
-    remediation: >
-      Set the following parameter in /etc/audit/auditd.conf:
-      max_log_file_action = keep_logs
+  # 4.1.2.2 Ensure audit logs are not automatically deleted. (Automated)
+  - id: 21096
+    title: "Ensure audit logs are not automatically deleted."
+    description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
+    rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
+    remediation: "Set the following parameter in /etc/audit/auditd.conf: max_log_file_action = keep_logs."
     compliance:
       - cis: ["4.1.2.2"]
-      - cis_csc: ["6.2", "6.4"]
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.2", "6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
     condition: all
     rules:
-      - 'f:/etc/audit/auditd.conf -> r:^\s*max_log_file_action\s*=\s*keep_logs'
+      - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*\t*=\s*\t*keep_logs'
 
-  # 4.1.2.3 Ensure system is disabled when audit logs are full
-  - id: 21083
-    title: Ensure system is disabled when audit logs are full.
-    description: The auditd daemon can be configured to halt the system when the audit logs are full.
-    rationale: >
-      In high security contexts, the risk of detecting unauthorized access or nonrepudiation
-      exceeds the benefit of the system's availability.
-    remediation: >
-      Set the following parameters in /etc/audit/auditd.conf:
-      space_left_action = email
-      action_mail_acct = root
-      admin_space_left_action = halt
+  # 4.1.2.3 Ensure system is disabled when audit logs are full. (Automated)
+  - id: 21097
+    title: "Ensure system is disabled when audit logs are full."
+    description: "The auditd daemon can be configured to halt the system when the audit logs are full."
+    rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
+    remediation: "Set the following parameters in /etc/audit/auditd.conf: space_left_action = email action_mail_acct = root admin_space_left_action = halt."
     compliance:
       - cis: ["4.1.2.3"]
-      - cis_csc: ["6.2", "6.4"]
+      - cis_csc_v8: ["8.2", "8.3"]
+      - cis_csc_v7: ["6.2", "6.4"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3", "10.7"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["A1.1"]
     condition: all
     rules:
       - 'f:/etc/audit/auditd.conf -> r:^\s*space_left_action\s*=\s*email'
       - 'f:/etc/audit/auditd.conf -> r:^\s*action_mail_acct\s*=\s*root'
       - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt'
 
-  # 4.1.2.4 Ensure audit_backlog_limit is sufficient - Not implemented
-  # 4.1.3 Ensure events that modify date and time information are collected - Not implemented
+  # 4.1.2.4 Ensure audit_backlog_limit is sufficient. (Automated)
+  - id: 21098
+    title: "Ensure audit_backlog_limit is sufficient."
+    description: "The backlog limit has a default setting of 64."
+    rationale: "During boot if audit=1, then the backlog will hold 64 records. If more that 64 records are created during boot, auditd records will be lost and potential malicious activity could go undetected."
+    remediation: 'Edit /etc/default/grub and add audit_backlog_limit=<BACKLOG SIZE> to GRUB_CMDLINE_LINUX: Example: GRUB_CMDLINE_LINUX="audit_backlog_limit=8192" Run the following command to update the grub2 configuration: # grub2-mkconfig -o /boot/grub2/grub.cfg.'
+    compliance:
+      - cis: ["4.1.2.4"]
+      - cis_csc_v8: ["8.2", "8.3"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3", "10.7"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+      - soc_2: ["A1.1"]
+    condition: all
+    rules:
+      - 'not f:/boot/grub/grub.cfg -> r:^\s*\t*linux && !r:audit_backlog_limit'
 
-  # 4.1.4 Ensure events that modify user/group information are collected
-  - id: 21084
-    title: Ensure events that modify user/group information are collected.
-    description: >
-      Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or
-      /etc/security/opasswd (old passwords, based on remember parameter in the PAM
-      configuration) files. The parameters in this section will watch the files to see if they have
-      been opened for write or have had attribute changes (e.g. permissions) and tag them with
-      the identifier "identity" in the audit log file.
+  # 4.1.3 Ensure events that modify date and time information are collected. (Automated)
+  - id: 21099
+    title: "Ensure events that modify date and time information are collected."
+    description: 'Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or clock_settime (allows for the setting of several internal clocks and timers) system calls have been executed and always write an audit record to the /var/log/audit.log file upon exit, tagging the records with the identifier "time-change" Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
+    rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
+    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/time_change.rules and add the following lines: -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change -a always,exit -F arch=b32 -S clock_settime -k time-change -w /etc/localtime -p wa -k time-change For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/time_change.rules and add the following lines: -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change -a always,exit -F arch=b64 -S clock_settime -k time-change -a always,exit -F arch=b32 -S clock_settime -k time-change -w /etc/localtime -p wa -k time-change."
+    compliance:
+      - cis: ["4.1.3"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:adjtimex && r:settimeofday|settimeofday -S stime && r:-k time-change|key=time-change'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32|-F arch=b64 && r:-S && r:clock_settime && r:-k time-change|key=time-change'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change|key=time-change'
+      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:adjtimex && r:settimeofday|settimeofday -S stime && r:-k time-change|key=time-change"
+      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32|-F arch=b64 && r:-S && r:clock_settime && r:-k time-change|key=time-change"
+      - "c:auditctl -l -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change|key=time-change"
 
-      Note: Reloading the auditd config to set active settings may require a system reboot.
-    rationale: >
-      Unexpected changes to these files could be an indication that the system has been
-      compromised and that an unauthorized user is attempting to hide their activities or
-      compromise additional accounts.
-    remediation: >
-      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
-      Example: vi /etc/audit/rules.d/identity.rules
-      and add the following lines:
-
-      -w /etc/group -p wa -k identity
-      -w /etc/passwd -p wa -k identity
-      -w /etc/gshadow -p wa -k identity
-      -w /etc/shadow -p wa -k identity
-      -w /etc/security/opasswd -p wa -k identity
+  # 4.1.4 Ensure events that modify user/group information are collected. (Automated)
+  - id: 21100
+    title: "Ensure events that modify user/group information are collected."
+    description: 'Record events affecting the group , passwd (user IDs), shadow and gshadow (passwords) or /etc/security/opasswd (old passwords, based on remember parameter in the PAM configuration) files. The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file. Note: Reloading the auditd config to set active settings may require a system reboot.'
+    rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/identity.rules and add the following lines: -w /etc/group -p wa -k identity -w /etc/passwd -p wa -k identity -w /etc/shadow -p wa -k identity -w /etc/security/opasswd -p wa -k identity."
     compliance:
       - cis: ["4.1.4"]
-      - cis_csc: ["4.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:grep -R identity /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/group\s+-p\s+wa\s+-k\s+identity'
-      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/passwd\s+-p\s+wa\s+-k\s+identity'
-      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/gshadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/shadow\s+-p\s+wa\s+-k\s+identity'
-      - 'c:sh -c "auditctl -l | grep identity" -> r:^\s*-w\s+/etc/security/opasswd\s+-p\s+wa\s+-k\s+identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/group && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/passwd && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/gshadow && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity|key=identity'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity|key=identity'
+      - "c:auditctl -l -> r:^-w && r:/etc/group && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/passwd && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/gshadow && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/shadow && r:-p wa && r:-k identity|key=identity"
+      - "c:auditctl -l -> r:^-w && r:/etc/security/opasswd && r:-p wa && r:-k identity|key=identity"
 
-  # 4.1.5 Ensure events that modify the system's network environment are collected - Not implemented
+  # 4.1.5 Ensure events that modify the system's network environment are collected. (Automated)
+  - id: 21101
+    title: "Ensure events that modify the system's network environment are collected."
+    description: "Record changes to network environment files or system calls. The below parameters monitor the sethostname (set the systems host name) or setdomainname (set the systems domainname) system calls, and write an audit event on system call exit. The other parameters monitor the /etc/issue and /etc/issue.net files (messages displayed pre-login), /etc/hosts (file containing host names and associated IP addresses) and /etc/sysconfig/network (directory containing network interface scripts and configurations) files. Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot."
+    rationale: 'Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes in the file that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records will be tagged with the identifier "system-locale.".'
+    remediation: "_If /etc/issue is not a symlink to /run/issue and the issue generator is not being used to create a volatile banner file: For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/system_locale.rules and add the following lines: -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale -w /etc/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/sysconfig/network -p wa -k system-locale For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/system_locale.rules and add the following lines: -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale -w /etc/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/sysconfig/network -p wa -k system-locale If the issue generator service is enabled then /etc/issue is a symlink and /run/issue should be monitored instead: For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/system_locale.rules and add the following lines: -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale -w /run/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/sysconfig/network -p wa -k system-locale For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/system_locale.rules and add the following lines: -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale -w /run/issue -p wa -k system-locale -w /etc/issue.net -p wa -k system-locale -w /etc/hosts -p wa -k system-locale -w /etc/sysconfig/network -p wa -k system-locale."
+    compliance:
+      - cis: ["4.1.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5", "6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2", "A.12.4.1"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:exit,always|always,exit && r:-F arch=b64|-F arch=b32 && r:-S && r:sethostname && r:setdomainname && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale|key=system-locale'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sysconfig/network && r:-p wa && r:-k system-locale|key=system-locale'
+      - "c:auditctl -l -> r:^-a && r:exit,always|always,exit && r:-F arch=b64|-F arch=b32 && r:-S && r:sethostname && r:setdomainname && r:-k system-locale|-F key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/issue && r:-p wa && r:-k system-locale|key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/issue.net && r:-p wa && r:-k system-locale|key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/hosts && r:-p wa && r:-k system-locale|key=system-locale"
+      - "c:auditctl -l -> r:^-w && r:/etc/sysconfig/network && r:-p wa && r:-k system-locale|key=system-locale"
 
-  # 4.1.6 Ensure events that modify the system's Mandatory Access Controls are collected
-  - id: 21085
-    title: Ensure events that modify the system's Mandatory Access Controls are collected.
-    description: >
-      Monitor SELinux mandatory access controls. The parameters below monitor any write
-      access (potential additional, deletion or modification of files in the directory) or attribute
-      changes to the /etc/selinux/ and /usr/share/selinux/ directories.
-
-      Notes:
-        - If a different Mandatory Access Control method is used, changes to the corresponding
-          directories should be audited.
-        - Reloading the auditd config to set active settings requires the auditd service to be
-          restarted, and may require a system reboot.
-    rationale: >
-      Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate
-      that an unauthorized user is attempting to modify access controls and change security
-      contexts, leading to a compromise of the system.
-    remediation: >
-      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
-      Example: vi /etc/audit/rules.d/MAC_policy.rules
-      and add the following lines:
-
-      -w /etc/selinux/ -p wa -k MAC-policy
-      -w /usr/share/selinux/ -p wa -k MAC-policy
+  # 4.1.6 Ensure events that modify the system's Mandatory Access Controls are collected. (Automated)
+  - id: 21102
+    title: "Ensure events that modify the system's Mandatory Access Controls are collected."
+    description: "Monitor SELinux mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux/ and /usr/share/selinux/ directories. Notes: - If a different Mandatory Access Control method is used, changes to the corresponding directories should be audited. - Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot."
+    rationale: "Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/MAC_policy.rules and add the following lines: -w /etc/selinux/ -p wa -k MAC-policy -w /usr/share/selinux/ -p wa -k MAC-policy."
     compliance:
       - cis: ["4.1.6"]
-      - cis_csc: ["5.5"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.5"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.1.2"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'c:grep -R MAC-policy /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:grep -R MAC-policy /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:sh -c "auditctl -l | grep MAC-policy" -> r:^\s*-w\s+/etc/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
-      - 'c:sh -c "auditctl -l | grep MAC-policy" -> r:^\s*-w\s+/usr/share/selinux/\s+-p\s+wa\s+-k\s+MAC-policy'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/selinux && r:-p wa && r:-k MAC-policy|key=MAC-policy'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/usr/share/selinux && r:-p wa && r:-k MAC-policy|key=MAC-policy'
+      - "c:auditctl -l -> r:^-w && r:/etc/selinux && r:-p wa && r:-k MAC-policy|key=MAC-policy"
+      - "c:auditctl -l -> r:^-w && r:/usr/share/selinux && r:-p wa && r:-k MAC-policy|key=MAC-policy"
 
-  # 4.1.7 Ensure login and logout events are collected
-  - id: 21086
-    title: Ensure login and logout events are collected.
-    description: >
-      Monitor login and logout events. The parameters below track changes to files associated
-      with login/logout events.
-        - The file /var/log/faillog tracks failed events from login.
-        - The file /var/log/lastlog maintain records of the last time a user successfully
-          logged in.
-        - The file /var/log/tallylog maintains records of failures via the pam_tally2
-          module
-      Note: Reloading the auditd config to set active settings requires the auditd service to be
-      restarted, and may require a system reboot.
-    rationale: >
-      Monitoring login/logout events could provide a system administrator with information
-      associated with brute force attacks against user logins.
-    remediation: >
-      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
-      Example: vi /etc/audit/rules.d/logins.rules
-      and add the following lines:
-
-      -w /var/log/faillog -p wa -k logins
-      -w /var/log/lastlog -p wa -k logins
-      -w /var/log/tallylog -p wa -k logins
+  # 4.1.7 Ensure login and logout events are collected. (Automated)
+  - id: 21103
+    title: "Ensure login and logout events are collected."
+    description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. - The file /var/log/faillog tracks failed events from login. - The file /var/log/lastlog maintain records of the last time a user successfully logged in. - The file /var/log/tallylog maintains records of failures via the pam_tally2 module Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot."
+    rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/logins.rules and add the following lines: -w /var/log/faillog -p wa -k logins -w /var/log/lastlog -p wa -k logins -w /var/log/tallylog -p wa -k logins."
     compliance:
       - cis: ["4.1.7"]
-      - cis_csc: ["4.9", "16.11", "16.13"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:grep -R logins /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:sh -c "auditctl -l | grep logins" -> r:^\s*-w\s+/var/log/faillog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:sh -c "auditctl -l | grep logins" -> r:^\s*-w\s+/var/log/lastlog\s+-p\s+wa\s+-k\s+logins'
-      - 'c:sh -c "auditctl -l | grep logins" -> r:^\s*-w\s+/var/log/tallylog\s+-p\s+wa\s+-k\s+logins'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins|key=logins'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/run/faillock && r:-p wa && r:-k logins|key=logins'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/tallylog && r:-p wa && r:-k logins|key=logins'
+      - "c:auditctl -l -> r:^-w && r:/var/log/lastlog && r:-p wa && r:-k logins|key=logins"
+      - "c:auditctl -l -> r:^-w && r:/var/run/faillock && r:-p wa && r:-k logins|key=logins"
+      - "c:auditctl -l -> r:^-w && r:/var/log/tallylog && r:-p wa && r:-k logins|key=logins"
 
-  # 4.1.8 Ensure session initiation information is collected
-  - id: 21087
-    title: Ensure session initiation information is collected.
-    description: >
-      Monitor session initiation events. The parameters in this section track changes to the files
-      associated with session events. The file /var/run/utmp tracks all currently logged in users.
-      All audit records will be tagged with the identifier "session." The /var/log/wtmp file tracks
-      logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed
-      login attempts and can be read by entering the command /usr/bin/last -f
-      /var/log/btmp . All audit records will be tagged with the identifier "logins."
-
-      Notes:
-        - The last command can be used to read /var/log/wtmp (last with no parameters)
-          and /var/run/utmp (last -f /var/run/utmp)
-        - Reloading the auditd config to set active settings requires the auditd service to be
-          restarted, and may require a system reboot.
-    rationale: >
-      Monitoring these files for changes could alert a system administrator to logins occurring at
-      unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when
-      they do not normally log in).
-    remediation: >
-      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
-      Example: vi /etc/audit/rules.d/session.rules
-      and add the following lines:
-
-      -w /var/run/utmp -p wa -k session
-      -w /var/log/wtmp -p wa -k logins
-      -w /var/log/btmp -p wa -k logins
+  # 4.1.8 Ensure session initiation information is collected. (Automated)
+  - id: 21104
+    title: "Ensure session initiation information is collected."
+    description: 'Monitor session initiation events. The parameters in this section track changes to the files associated with session events. The file /var/run/utmp tracks all currently logged in users. All audit records will be tagged with the identifier "session." The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. The file /var/log/btmp keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp. All audit records will be tagged with the identifier "logins." Notes: - The last command can be used to read /var/log/wtmp (last with no parameters) and /var/run/utmp (last -f /var/run/utmp) - Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
+    rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/session.rules and add the following lines: -w /var/run/utmp -p wa -k session -w /var/log/wtmp -p wa -k logins -w /var/log/btmp -p wa -k logins."
     compliance:
       - cis: ["4.1.8"]
-      - cis_csc: ["4.9", "16.11", "16.13"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.9", "16.11", "16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.8.1.3", "A.9.4.2"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
-      - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:grep -RE "(session|logins)" /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:sh -c "auditctl -l | grep -E \"(session|logins)\"" -> r:^\s*-w\s+/var/run/utmp\s+-p\s+wa\s+-k\s+session'
-      - 'c:sh -c "auditctl -l | grep -E \"(session|logins)\"" -> r:^\s*-w\s+/var/log/wtmp\s+-p\s+wa\s+-k\s+logins'
-      - 'c:sh -c "auditctl -l | grep -E \"(session|logins)\"" -> r:^\s*-w\s+/var/log/btmp\s+-p\s+wa\s+-k\s+logins'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/run/utmp && r:-p wa && r:-k session|key=session'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k session|key=session'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k session|key=session'
+      - "c:auditctl -l -> r:^-w && r:/var/run/utmp && r:-p wa && r:-k session|key=session"
+      - "c:auditctl -l -> r:^-w && r:/var/log/wtmp && r:-p wa && r:-k session|key=session"
+      - "c:auditctl -l -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k session|key=session"
 
-  # 4.1.9 Ensure discretionary access control permission modification events are collected - Not implemented
-  # 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected - Not implemented
-  # 4.1.11 Ensure use of privileged commands is collected - Not implemented
-  # 4.1.12 Ensure successful file system mounts are collected - Not implemented
-  # 4.1.13 Ensure file deletion events by users are collected - Not implemented
+  # 4.1.9 Ensure discretionary access control permission modification events are collected. (Automated) - Not Implemented
+  # 4.1.10 Ensure unsuccessful unauthorized file access attempts are collected. (Automated) - Not Implemented
+  # 4.1.11 Ensure use of privileged commands is collected. (Automated) - Not Implemented
 
-  # 4.1.14 Ensure changes to system administration scope (sudoers) is collected
-  - id: 21088
-    title: Ensure changes to system administration scope (sudoers) is collected
-    description: >
-      Monitor scope changes for system administrators. If the system has been properly
-      configured to force system administrators to log in as themselves first and then use the
-      sudo command to execute privileged commands, it is possible to monitor changes in scope.
-      The file /etc/sudoers or a file in the /etc/sudoers.d directory will be written to when the
-      file or its attributes have changed.
+  # 4.1.12 Ensure successful file system mounts are collected. (Automated)
+  - id: 21105
+    title: "Ensure successful file system mounts are collected."
+    description: "Monitor the use of the mount system call. The mount (and umount) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user Notes: - Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run the following command: - # awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs - If your systems' UID_MIN is not 1000, replace audit>=1000 with audit>=<UID_MIN for your system> in the Audit and Remediation procedures. - This tracks successful and unsuccessful mount commands. - File system mounts do not have to come from external media and this action still does not verify write (e.g. CD ROMS). - Reloading the auditd config to set active settings may require a system reboot."
+    rationale: "It is highly unusual for a non-privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
+    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/mounts.rules and add the following lines: -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/mounts.rules and add the following lines: -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts."
+    compliance:
+      - cis: ["4.1.12"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b32|-F arch=b64 && r:-S mount && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k mounts|key=mounts'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32|-F arch=b64 && r:-S mount && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k mounts|key=mounts'
 
-      Notes: Reloading the auditd config to set active settings may require a system reboot.
-    rationale: >
-      Changes in the /etc/sudoers file, or a file in the /etc/sudoers.d/ directory can indicate
-      that an unauthorized change has been made to scope of system administrator activity.
-    remediation: >
-      Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules
-      Example: vi /etc/audit/rules.d/scope.rules
-      and add the following lines:
+  # 4.1.13 Ensure file deletion events by users are collected. (Automated)
+  - id: 21106
+    title: "Ensure file deletion events by users are collected."
+    description: "Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for following system calls and tags them with the identifier \"delete\": - unlink - remove a file - unlinkat - remove a file attribute - rename - rename a file - renameat - rename a file attribute Notes: - Systems may have been customized to change the default UID_MIN. To confirm the UID_MIN for your system, run the following command: - # awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs - If your systems' UID_MIN is not 1000, replace audit>=1000 with audit>=<UID_MIN for your system> in the Audit and Remediation procedures. - At a minimum, configure the audit system to collect file deletion events for all users and root. - Reloading the auditd config to set active settings may require a system reboot."
+    rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
+    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/deletion.rules and add the following lines: -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/deletion.rules and add the following lines: -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete."
+    compliance:
+      - cis: ["4.1.13"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["6.2", "13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k delete|key=delete'
+      - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k delete|key=delete'
 
-      -w /etc/sudoers -p wa -k scope
-      -w /etc/sudoers.d/ -p wa -k scope
+  # 4.1.14 Ensure changes to system administration scope (sudoers) is collected. (Automated)
+  - id: 21107
+    title: "Ensure changes to system administration scope (sudoers) is collected."
+    description: "Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers or a file in the /etc/sudoers.d directory will be written to when the file or its attributes have changed. Notes: Reloading the auditd config to set active settings may require a system reboot."
+    rationale: "Changes in the /etc/sudoers file, or a file in the /etc/sudoers.d/ directory can indicate that an unauthorized change has been made to scope of system administrator activity."
+    remediation: "Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/scope.rules and add the following lines: -w /etc/sudoers -p wa -k scope -w /etc/sudoers.d/ -p wa -k scope."
     compliance:
       - cis: ["4.1.14"]
-      - cis_csc: ["4.8"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["4.8"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.12.4.3"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'c:grep -R scope /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
-      - 'c:grep -R scope /etc/audit/rules.d/ -> r:^/etc/audit/rules.d/\.+.rules:\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
-      - 'c:sh -c "auditctl -l | grep scope" -> r:^\s*-w\s+/etc/sudoers\s+-p\s+wa\s+-k\s+scope'
-      - 'c:sh -c "auditctl -l | grep scope" -> r:^\s*-w\s+/etc/sudoers.d/\s+-p\s+wa\s+-k\s+scope'
+      - "d:/etc/audit/rules.d"
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope|key=\\s*\t*scope'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/etc/sudoers.d && r:-p wa && r:-k scope|key=\\s*\t*scope'
+      - 'c:auditctl -l -> r:^-w && r:/etc/sudoers && r:-p wa && r:-k scope|key=\\s*\t*scope'
+      - 'c:auditctl -l -> r:^-w && r:/etc/sudoers.d && r:-p wa && r:-k scope|key=\\s*\t*scope'
 
-  # 4.1.15 Ensure system administrator actions (sudolog) are collected - Not implemented
-  # 4.1.16 Ensure kernel module loading and unloading is collected - Not implemented
+  # 4.1.15 Ensure system administrator actions (sudolog) are collected. (Automated) - Not Implemented
 
-  # 4.1.17 Ensure the audit configuration is immutable
-  - id: 21089
-    title: Ensure the audit configuration is immutable.
-    description: >
-      Set system audit so that audit rules cannot be modified with auditctl . Setting the flag "-e
-      2" forces audit to be put in immutable mode. Audit changes can only be made on system
-      reboot.
+  # 4.1.16 Ensure kernel module loading and unloading is collected. (Automated)
+  - id: 21108
+    title: "Ensure kernel module loading and unloading is collected."
+    description: 'Monitor the loading and unloading of kernel modules. The programs insmod (install a kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated program to load and unload modules, as well as some other features) control loading and unloading of modules. The init_module (load a module) and delete_module (delete a module) system calls control loading and unloading of modules. Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of "modules". Note: Reloading the auditd config to set active settings requires the auditd service to be restarted, and may require a system reboot.'
+    rationale: "Monitoring the use of insmod , rmmod and modprobe could provide system administrators with evidence that an unauthorized user loaded or unloaded a kernel module, possibly compromising the security of the system. Monitoring of the init_module and delete_module system calls would reflect an unauthorized user attempting to use a different program to load and unload modules."
+    remediation: "For 32 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/modules.rules and add the following lines: -w /sbin/insmod -p x -k modules -w /sbin/rmmod -p x -k modules -w /sbin/modprobe -p x -k modules -a always,exit -F arch=b32 -S init_module -S delete_module -k modules For 64 bit systems Edit or create a file in the /etc/audit/rules.d/ directory ending in .rules Example: vi /etc/audit/rules.d/modules.rules and add the following lines: -w /sbin/insmod -p x -k modules -w /sbin/rmmod -p x -k modules -w /sbin/modprobe -p x -k modules -a always,exit -F arch=b64 -S init_module -S delete_module -k modules."
+    compliance:
+      - cis: ["4.1.16"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
+    rules:
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:delete_module && r:-k modules|-F key=modules'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/sbin/insmod && r:-p x && r:-k modules|-F key=modules'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/sbin/rmmod && r:-p x && r:-k modules|-F key=modules'
+      - 'd:/etc/audit/rules.d -> r:\.+.rules$ -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules|-F key=modules'
+      - "c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b64|-F arch=b32 && r:-S && r:init_module && r:delete_module && r:-k modules|-F key=modules"
+      - "c:auditctl -l -> r:^-w && r:/sbin/insmod && r:-p x && r:-k modules|-F key=modules"
+      - "c:auditctl -l -> r:^-w && r:/sbin/rmmod && r:-p x && r:-k modules|-F key=modules"
+      - "c:auditctl -l -> r:^-w && r:/sbin/modprobe && r:-p x && r:-k modules|-F key=modules"
 
-      Note: This setting will require the system to be rebooted to update the active auditd
-      configuration settings.
-    rationale: >
-      In immutable mode, unauthorized users cannot execute changes to the audit system to
-      potentially hide malicious activity and then put the audit rules back. Users would most
-      likely notice a system reboot and that could alert administrators of an attempt to make
-      unauthorized audit changes.
-    remediation: >
-      Edit or create the file /etc/audit/rules.d/99-finalize.rules and add the following line
-      at the end of the file:
-
-      -e 2
+  # 4.1.17 Ensure the audit configuration is immutable. (Automated)
+  - id: 21109
+    title: "Ensure the audit configuration is immutable."
+    description: 'Set system audit so that audit rules cannot be modified with auditctl. Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made on system reboot. Note: This setting will require the system to be rebooted to update the active auditd configuration settings.'
+    rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
+    remediation: "Edit or create the file /etc/audit/rules.d/99-finalize.rules and add the following line at the end of the file: -e 2."
     compliance:
       - cis: ["4.1.17"]
-      - cis_csc: ["6.2", "6.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:sh -c "grep -R \"^\s*[^#]\" /etc/audit/rules.d/ | tail -1" -> r:^/etc/audit/rules.d/\.+.rules:\s*-e\s+2\s*$'
+      - "d:/etc/audit"
+      - "d:/etc/audit/rules.d -> r:^99-finalize.rules$"
+      - 'd:/etc/audit/rules.d -> r:^99-finalize.rules$ -> r:^\s*\t*-e 2$'
 
-  # 4.2.1.1 Ensure rsyslog is installed
-  - id: 21090
-    title: Ensure rsyslog is installed.
-    description: >
-      The rsyslog software is a recommended replacement to the original syslogd daemon.
-      rsyslog provides improvements over syslogd, including:
-        - connection-oriented (i.e. TCP) transmission of logs
-        - The option to log to database formats
-        - Encryption of log data en route to a central logging server
-    rationale: >
-      The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission
-      of logs, the option to log to database formats, and the encryption of log data en route to a
-      central logging server) justify installing and configuring the package.
-    remediation: >
-      Run the following command to install rsyslog:
-      # zypper install rsyslog
+  # 4.2.1.1 Ensure rsyslog is installed. (Automated)
+  - id: 21110
+    title: "Ensure rsyslog is installed."
+    description: "The rsyslog software is a recommended replacement to the original syslogd daemon. rsyslog provides improvements over syslogd, including: connection-oriented (i.e. TCP) transmission of logs - - The option to log to database formats - Encryption of log data en route to a central logging server."
+    rationale: "The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
+    remediation: "Run the following command to install rsyslog: # zypper install rsyslog."
     compliance:
       - cis: ["4.2.1.1"]
-      - cis_csc: ["6.2", "6.3"]
-    condition: none
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
+    condition: all
     rules:
-      - "c:rpm -q rsyslog -> r:not installed"
+      - "c:rpm -q rsyslog -> r:^rsyslog-"
 
-  # 4.2.1.2 Ensure rsyslog Service is enabled and running
-  - id: 21091
-    title: Ensure rsyslog Service is enabled and running.
-    description: rsyslog needs to be enabled and running to perform logging
-    rationale: >
-      If the rsyslog service is not activated the system may default to the syslogd service or lack
-      logging instead.
-    remediation: >
-      Run the following command to enable and start rsyslog:
-      # systemctl --now enable rsyslog
+  # 4.2.1.2 Ensure rsyslog Service is enabled and running. (Automated)
+  - id: 21111
+    title: "Ensure rsyslog Service is enabled and running."
+    description: "rsyslog needs to be enabled and running to perform logging."
+    rationale: "If the rsyslog service is not activated the system may default to the syslogd service or lack logging instead."
+    remediation: "Run the following command to enable and start rsyslog: # systemctl --now enable rsyslog."
     compliance:
       - cis: ["4.2.1.2"]
-      - cis_csc: ["6.2", "6.3"]
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
     condition: all
     rules:
       - "c:systemctl is-enabled rsyslog -> r:^enabled"
-      - 'c:systemctl status rsyslog -> r:^\s*Active: active \(running\) since \.+'
+      - "c:systemctl status rsyslog -> r:active && r:running"
 
-  # 4.2.1.3 Ensure rsyslog default file permissions configured
-  - id: 21092
-    title: Ensure rsyslog default file permissions configured.
-    description: >
-      rsyslog will create logfiles that do not already exist on the system. This setting controls
-      what permissions will be applied to these newly created files.
-      The $FileCreateMode parameter specifies the file creation mode with which rsyslogd
-      creates new files. If not specified, the value 0644 is used.
-      Notes:
-        - The value given must always be a 4-digit octal number, with the initial digit being
-          zero.
-        - This setting can be overridden by a less restrictive setting in any file ending in .conf in
-          the /etc/rsyslog.d/ directory
-    rationale: >
-      It is important to ensure that log files have the correct permissions to ensure that sensitive
-      data is archived and protected.
-    remediation: >
-      Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to
-      0640 or more restrictive:
-
-      $FileCreateMode 0640
+  # 4.2.1.3 Ensure rsyslog default file permissions configured. (Automated)
+  - id: 21112
+    title: "Ensure rsyslog default file permissions configured."
+    description: "rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files. The $FileCreateMode parameter specifies the file creation mode with which rsyslogd creates new files. If not specified, the value 0644 is used. Notes: - The value given must always be a 4-digit octal number, with the initial digit being zero. - This setting can be overridden by a less restrictive setting in any file ending in .conf in the /etc/rsyslog.d/ directory."
+    rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
+    remediation: "Edit the /etc/rsyslog.conf and /etc/rsyslog.d/*.conf files and set $FileCreateMode to 0640 or more restrictive: $FileCreateMode 0640."
     compliance:
       - cis: ["4.2.1.3"]
-      - cis_csc: ["5.1"]
-    references:
-      - See the rsyslog.conf(5) man page for more information.
-    condition: all
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: any
     rules:
-      - 'c:grep -Rh ^\$FileCreateMode /etc/rsyslog.conf /etc/rsyslog.d/ -> r:^\$FileCreateMode\s+0640'
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d/ -> r:\.*.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0 && r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d00'
 
-  # 4.2.1.4 Ensure logging is configured - Not implemented
-  # 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host - Not implemented
-  # 4.2.1.6 Ensure remote rsyslog messages are only accepted on designated log hosts - Not implemented
+  # 4.2.1.4 Ensure logging is configured. (Manual) - Not Implemented
+  # 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host. (Automated) - Not Implemented
+  # 4.2.1.6 Ensure remote rsyslog messages are only accepted on designated log hosts. (Manual) - Not Implemented
 
-  # 4.2.2.1 Ensure journald is configured to send logs to rsyslog
-  - id: 21093
-    title: Ensure journald is configured to send logs to rsyslog.
-    description: >
-      Data from journald may be stored in volatile memory or persisted locally on the server.
-      Utilities exist to accept remote export of journald logs, however, use of the rsyslog service
-      provides a consistent means of log collection and export.
-
-      Notes:
-        - This recommendation assumes that recommendation 4.2.1.5, "Ensure rsyslog is
-          configured to send logs to a remote log host" has been implemented.
-        - The main configuration file /etc/systemd/journald.conf is read before any of the
-          custom *.conf files. If there are custom configs present, they override the main
-          configuration parameters
-        - As noted in the journald man pages: journald logs may be exported to rsyslog either
-          through the process mentioned here, or through a facility like systemdjournald.service. There are trade-offs involved in each implementation, where
-          ForwardToSyslog will immediately capture all events (and forward to an external log
-          server, if properly configured), but may not capture all boot-up activities. Mechanisms
-          such as systemd-journald.service, on the other hand, will record bootup events, but
-          may delay sending the information to rsyslog, leading to the potential for log
-          manipulation prior to export. Be aware of the limitations of all tools employed to
-          secure a system.
-    rationale: >
-      Storing log data on a remote host protects log integrity from local attacks. If an attacker
-      gains root access on the local system, they could tamper with or remove log data that is
-      stored on the local system.
-    remediation: >
-      Edit the /etc/systemd/journald.conf file and add the following line:
-      ForwardToSyslog=yes
+  # 4.2.2.1 Ensure journald is configured to send logs to rsyslog. (Automated)
+  - id: 21113
+    title: "Ensure journald is configured to send logs to rsyslog."
+    description: 'Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the rsyslog service provides a consistent means of log collection and export. Notes: - This recommendation assumes that recommendation 4.2.1.5, "Ensure rsyslog is configured to send logs to a remote log host" has been implemented. - The main configuration file /etc/systemd/journald.conf is read before any of the custom *.conf files. If there are custom configs present, they override the main configuration parameters - As noted in the journald man pages: journald logs may be exported to rsyslog either through the process mentioned here, or through a facility like systemd-journald.service. There are trade-offs involved in each implementation, where ForwardToSyslog will immediately capture all events (and forward to an external log server, if properly configured), but may not capture all boot-up activities. Mechanisms such as systemd-journald.service, on the other hand, will record bootup events, but may delay sending the information to rsyslog, leading to the potential for log manipulation prior to export. Be aware of the limitations of all tools employed to secure a system.'
+    rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
+    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: ForwardToSyslog=yes."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf"
     compliance:
       - cis: ["4.2.2.1"]
-      - cis_csc: ["6.5"]
-    references:
-      - https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf
+      - cis_csc_v8: ["8.9"]
+      - cis_csc_v7: ["6.5"]
+      - nist_sp_800-53: ["AU-6(3)"]
+      - pci_dss_v3.2.1: ["10.5.3", "10.5.4"]
+      - pci_dss_v4.0: ["10.3.3"]
+      - soc_2: ["PL1.4"]
     condition: all
     rules:
-      - "f:/etc/systemd/journald.conf -> r:^ForwardToSyslog=yes"
+      - 'f:/etc/systemd/journald.conf -> r:^\s*\t*ForwardToSyslog\s*=\s*yes'
 
-  # 4.2.2.2 Ensure journald is configured to compress large log files
-  - id: 21094
-    title: Ensure journald is configured to compress large log files.
-    description: >
-      The journald system includes the capability of compressing overly large files to avoid filling
-      up the system with logs or making the log's size unmanageable.
-
-      Note: The main configuration file /etc/systemd/journald.conf is read before any of the
-      custom *.conf files. If there are custom configs present, they override the main configuration
-      parameters
-    rationale: >
-      Uncompressed large files may unexpectedly fill a filesystem leading to resource
-      unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem
-      impacts.
-    remediation: >
-      Edit the /etc/systemd/journald.conf file and add the following line:
-      Compress=yes
+  # 4.2.2.2 Ensure journald is configured to compress large log files. (Automated)
+  - id: 21114
+    title: "Ensure journald is configured to compress large log files."
+    description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the log's size unmanageable. Note: The main configuration file /etc/systemd/journald.conf is read before any of the custom *.conf files. If there are custom configs present, they override the main configuration parameters."
+    rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
+    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Compress=yes."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf"
     compliance:
       - cis: ["4.2.2.2"]
-      - cis_csc: ["6.4"]
-    references:
-      - https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf
+      - cis_csc_v8: ["8.3"]
+      - cis_csc_v7: ["6.4"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - pci_dss_v3.2.1: ["10.7"]
+      - soc_2: ["A1.1"]
     condition: all
     rules:
       - "f:/etc/systemd/journald.conf -> r:^Compress=yes"
 
-  # 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk
-  - id: 21095
-    title: Ensure journald is configured to write logfiles to persistent disk.
-    description: >
-      Data from journald may be stored in volatile memory or persisted locally on the server.
-      Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the
-      server they are protected from loss.
-
-      Note: The main configuration file /etc/systemd/journald.conf is read before any of the
-      custom *.conf files. If there are custom configs present, they override the main configuration
-      parameters
-    rationale: >
-      Writing log data to disk will provide the ability to forensically reconstruct events which
-      may have impacted the operations or security of a system even after a system crash or
-      reboot.
-    remediation: >
-      Edit the /etc/systemd/journald.conf file and add the following line:
-      Storage=persistent
+  # 4.2.2.3 Ensure journald is configured to write logfiles to persistent disk. (Automated)
+  - id: 21115
+    title: "Ensure journald is configured to write logfiles to persistent disk."
+    description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss. Note: The main configuration file /etc/systemd/journald.conf is read before any of the custom *.conf files. If there are custom configs present, they override the main configuration parameters."
+    rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
+    remediation: "Edit the /etc/systemd/journald.conf file and add the following line: Storage=persistent."
+    references:
+      - "https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf"
     compliance:
       - cis: ["4.2.2.3"]
-      - cis_csc: ["6.2", "6.3"]
-    references:
-      - https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#etcsystemdjournaldconf
+      - cis_csc_v8: ["8.2"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-7"]
+      - pci_dss_v3.2.1: ["10.2", "10.3"]
+      - pci_dss_v4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
     condition: all
     rules:
       - "f:/etc/systemd/journald.conf -> r:^Storage=persistent"
 
-  # 4.2.3 Ensure permissions on all logfiles are configured - Not implemented
-  # 4.2.4 Ensure logrotate is configured - Not implemented
+  # 4.2.3 Ensure permissions on all logfiles are configured. (Automated) - Not Implemented
+  # 4.2.4 Ensure logrotate is configured. (Manual) - Not Implemented
 
-  # 5.1.1 Ensure cron daemon is enabled and running
-  - id: 21096
-    title: Ensure cron daemon is enabled and running
-    description: The cron daemon is used to execute batch jobs on the system.
-    rationale: >
-      While there may not be user jobs that need to be run on the system, the system does have
-      maintenance jobs that may include security monitoring that have to run. If another method
-      for scheduling tasks is not being used, cron is used to execute them, and needs to be
-      enabled and running.
-    remediation: >
-      Run the following command to enable and start cron:
-      # systemctl --now enable cron
-
-      OR
-
-      Run the following command to remove cron:
-      # zypper remove cronie
+  # 5.1.1 Ensure cron daemon is enabled and running. (Automated)
+  - id: 21116
+    title: "Ensure cron daemon is enabled and running."
+    description: "The cron daemon is used to execute batch jobs on the system."
+    rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run. If another method for scheduling tasks is not being used, cron is used to execute them, and needs to be enabled and running."
+    remediation: "Run the following command to enable and start cron: # systemctl --now enable cron."
     compliance:
       - cis: ["5.1.1"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - "c:systemctl is-enabled cron -> r:^enabled"
-      - 'c:systemctl status cron -> r:^\s*Active: active \(running\) since \.+'
+      - "c:systemctl is-enabled crond -> r:^enabled"
+      - "c:systemctl status crond -> r:active && r:running"
 
-  # 5.1.2 Ensure permissions on /etc/crontab are configured
-  - id: 21097
-    title: Ensure permissions on /etc/crontab are configured.
-    description: >
-      The /etc/crontab file is used by cron to control its own jobs. The commands in this item
-      make sure that root is the user and group owner of the file and that only the owner can
-      access the file.
-    rationale: >
-      This file contains information on what system jobs are run by cron. Write access to these
-      files could provide unprivileged users with the ability to elevate their privileges. Read
-      access to these files could provide users with the ability to gain insight on system jobs that
-      run on the system and could provide them a way to gain unauthorized privileged access.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/crontab:
-      # chown root:root /etc/crontab
-      # chmod u-x,og-rwx /etc/crontab
-
-      OR
-
-      Run the following command to remove cron:
-      # zypper remove cronie
+  # 5.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
+  - id: 21117
+    title: "Ensure permissions on /etc/crontab are configured."
+    description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
+    rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
+    remediation: "Run the following commands to set ownership and permissions on /etc/crontab: # chown root:root /etc/crontab # chmod u-x,og-rwx /etc/crontab OR Run the following command to remove cron: # zypper remove cronie."
     compliance:
       - cis: ["5.1.2"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/crontab -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/crontab" -> r:600\s*\t*-rw------- && r:0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.3 Ensure permissions on /etc/cron.hourly are configured
-  - id: 21098
-    title: Ensure permissions on /etc/cron.hourly are configured.
-    description: >
-      This directory contains system cron jobs that need to run on an hourly basis. The files in
-      this directory cannot be manipulated by the crontab command, but are instead edited by
-      system administrators using a text editor. The commands below restrict read/write and
-      search access to user and group root, preventing regular users from accessing this
-      directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on the /etc/cron.hourly/
-      directory:
-      # chown root:root /etc/cron.hourly/
-      # chmod og-rwx /etc/cron.hourly/
-
-      OR
-
-      Run the following command to remove cron
-      # zypper remove cronie
+  # 5.1.3 Ensure permissions on /etc/cron.hourly are configured. (Automated)
+  - id: 21118
+    title: "Ensure permissions on /etc/cron.hourly are configured."
+    description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on the /etc/cron.hourly/ directory: # chown root:root /etc/cron.hourly/ # chmod og-rwx /etc/cron.hourly/ OR Run the following command to remove cron # zypper remove cronie."
     compliance:
       - cis: ["5.1.3"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/cron.hourly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.hourly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.4 Ensure permissions on /etc/cron.daily are configured
-  - id: 21099
-    title: Ensure permissions on /etc/cron.daily are configured.
-    description: >
-      The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis.
-      The files in this directory cannot be manipulated by the crontab command, but are instead
-      edited by system administrators using a text editor. The commands below restrict
-      read/write and search access to user and group root, preventing regular users from
-      accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.daily
-      directory:
-      # chown root:root /etc/cron.daily
-      # chmod og-rwx /etc/cron.daily
-
-      OR
-
-      Run the following command to remove cron:
-      # zypper remove cronie
+  # 5.1.4 Ensure permissions on /etc/cron.daily are configured. (Automated)
+  - id: 21119
+    title: "Ensure permissions on /etc/cron.daily are configured."
+    description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.daily directory: # chown root:root /etc/cron.daily # chmod og-rwx /etc/cron.daily OR Run the following command to remove cron: # zypper remove cronie."
     compliance:
       - cis: ["5.1.4"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/cron.daily/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.daily/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.5 Ensure permissions on /etc/cron.weekly are configured
-  - id: 21100
-    title: Ensure permissions on /etc/cron.weekly are configured.
-    description: >
-      The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly
-      basis. The files in this directory cannot be manipulated by the crontab command, but are
-      instead edited by system administrators using a text editor. The commands below restrict
-      read/write and search access to user and group root, preventing regular users from
-      accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
+  # 5.1.5 Ensure permissions on /etc/cron.weekly are configured. (Automated)
+  - id: 21120
+    title: "Ensure permissions on /etc/cron.weekly are configured."
+    description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.weekly/ directory: # chown root:root /etc/cron.weekly/ # chmod og-rwx /etc/cron.weekly/ OR Run the following command to remove cron: # zypper remove cronie."
     compliance:
       - cis: ["5.1.5"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/cron.weekly -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.weekly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.6 Ensure permissions on /etc/cron.monthly are configured
-  - id: 21101
-    title: Ensure permissions on /etc/cron.monthly are configured.
-    description: >
-      The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly
-      basis. The files in this directory cannot be manipulated by the crontab command, but are
-      instead edited by system administrators using a text editor. The commands below restrict
-      read/write and search access to user and group root, preventing regular users from
-      accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.monthly
-      directory:
-      # chown root:root /etc/cron.monthly
-      # chmod og-rwx /etc/cron.monthly
-
-      OR
-
-      Run the following command to remove cron:
-      # zypper remove cronie
+  # 5.1.6 Ensure permissions on /etc/cron.monthly are configured. (Automated)
+  - id: 21121
+    title: "Ensure permissions on /etc/cron.monthly are configured."
+    description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.monthly directory: # chown root:root /etc/cron.monthly # chmod og-rwx /etc/cron.monthly OR Run the following command to remove cron: # zypper remove cronie."
     compliance:
       - cis: ["5.1.6"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/cron.monthly/ -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.monthly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.7 Ensure permissions on /etc/cron.d are configured
-  - id: 21102
-    title: Ensure permissions on /etc/cron.d are configured.
-    description: >
-      The /etc/cron.d/ directory contains system cron jobs that need to run in a similar manner
-      to the hourly, daily weekly and monthly jobs from /etc/crontab , but require more
-      granular control as to when they run. The files in this directory cannot be manipulated by
-      the crontab command, but are instead edited by system administrators using a text editor.
-      The commands below restrict read/write and search access to user and group root,
-      preventing regular users from accessing this directory.
-    rationale: >
-      Granting write access to this directory for non-privileged users could provide them the
-      means for gaining unauthorized elevated privileges. Granting read access to this directory
-      could give an unprivileged user insight in how to gain elevated privileges or circumvent
-      auditing controls.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/cron.d directory:
-      # chown root:root /etc/cron.d
-      # chmod og-rwx /etc/cron.d
-
-      OR
-
-      Run the following command to remove cron:
-      # zypper remove cronie
+  # 5.1.7 Ensure permissions on /etc/cron.d are configured. (Automated)
+  - id: 21122
+    title: "Ensure permissions on /etc/cron.d are configured."
+    description: "The /etc/cron.d/ directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab , but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
+    rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
+    remediation: "Run the following commands to set ownership and permissions on /etc/cron.d directory: # chown root:root /etc/cron.d # chmod og-rwx /etc/cron.d OR Run the following command to remove cron: # zypper remove cronie."
     compliance:
       - cis: ["5.1.7"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/cron.d -> r:^Access:\s*\(0700/drwx------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.d/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.8 Ensure cron is restricted to authorized users
-  - id: 21103
-    title: Ensure cron is restricted to authorized users.
-    description: >
-      If cron is installed in the system, configure /etc/cron.allow to allow specific users to use
-      these services. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any
-      user not specifically defined in those files is allowed to use cron. By removing the file, only
-      users in /etc/cron.allow are allowed to use cron.
-
-      Note: Even though a given user is not listed in cron.allow, cron jobs can still be run as that
-      user. The cron.allow file only controls administrative access to the crontab command for
-      scheduling and modifying cron jobs.
-    rationale: >
-      On many systems, only the system administrator is authorized to schedule cron jobs. Using
-      the cron.allow file to control who can run cron jobs enforces this policy. It is easier to
-      manage an allow list than a deny list. In a deny list, you could potentially add a user ID to
-      the system and forget to add it to the deny files.
-    remediation: >
-      Run the following command to remove /etc/cron.deny:
-      # rm /etc/cron.deny
-
-      Run the following command to create /etc/cron.allow
-      # touch /etc/cron.allow
-
-      Run the following commands to set the owner and permissions on /etc/cron.allow:
-      # chown root:root /etc/cron.allow
-      # chmod u-x,og-rwx /etc/cron.allow
-
-      OR
-
-      Run the following command to remove cron
-      # zypper remove cronie
+  # 5.1.8 Ensure cron is restricted to authorized users. (Automated)
+  - id: 21123
+    title: "Ensure cron is restricted to authorized users."
+    description: "If cron is installed in the system, configure /etc/cron.allow to allow specific users to use these services. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any user not specifically defined in those files is allowed to use cron. By removing the file, only users in /etc/cron.allow are allowed to use cron. Note: Even though a given user is not listed in cron.allow, cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
+    rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Run the following command to remove /etc/cron.deny: # rm /etc/cron.deny Run the following command to create /etc/cron.allow # touch /etc/cron.allow Run the following commands to set the owner and permissions on /etc/cron.allow: # chown root:root /etc/cron.allow # chmod u-x,og-rwx /etc/cron.allow OR Run the following command to remove cron # zypper remove cronie."
     compliance:
       - cis: ["5.1.8"]
-      - cis_csc: ["16"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["16"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - "not f:/etc/cron.deny"
-      - 'c:stat -L /etc/cron.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.allow -> r:600\s*\t*-rw-------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.1.9 Ensure at is restricted to authorized users
-  - id: 21104
-    title: Ensure at is restricted to authorized users.
-    description: >
-      If at is installed in the system, configure /etc/at.allow to allow specific users to use these
-      services. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not
-      specifically defined in those files is allowed to use at. By removing the file, only users in
-      /etc/at.allow are allowed to use at.
-
-      Note: Even though a given user is not listed in at.allow, at jobs can still be run as that user.
-      The at.allow file only controls administrative access to the at command for scheduling and
-      modifying at jobs.
-    rationale: >
-      On many systems, only the system administrator is authorized to schedule at jobs. Using
-      the at.allow file to control who can run at jobs enforces this policy. It is easier to manage
-      an allow list than a deny list. In a deny list, you could potentially add a user ID to the system
-      and forget to add it to the deny files.
-    remediation: >
-      Run the following command to remove /etc/at.deny:
-      # rm /etc/at.deny
-
-      Run the following command to create /etc/at.allow
-      # touch /etc/at.allow
-
-      Run the following commands to set the owner and permissions on /etc/at.allow:
-      # chown root:root /etc/at.allow
-      # chmod u-x,og-rwx /etc/at.allow
-
-      OR
-
-      Run the following command to remove at:
-      # zypper remove at
+  # 5.1.9 Ensure at is restricted to authorized users. (Automated)
+  - id: 21124
+    title: "Ensure at is restricted to authorized users."
+    description: "If at is installed in the system, configure /etc/at.allow to allow specific users to use these services. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not specifically defined in those files is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Even though a given user is not listed in at.allow, at jobs can still be run as that user. The at.allow file only controls administrative access to the at command for scheduling and modifying at jobs."
+    rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
+    remediation: "Run the following command to remove /etc/at.deny: # rm /etc/at.deny Run the following command to create /etc/at.allow # touch /etc/at.allow Run the following commands to set the owner and permissions on /etc/at.allow: # chown root:root /etc/at.allow # chmod u-x,og-rwx /etc/at.allow OR Run the following command to remove at: # zypper remove at."
     compliance:
       - cis: ["5.1.9"]
-      - cis_csc: ["16"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["16"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
       - "not f:/etc/at.deny"
-      - 'c:stat -L /etc/at.allow -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/at.allow -> r:600\s*\t*-rw-------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured
-  - id: 21114
-    title: Ensure permissions on /etc/ssh/sshd_config are configured
-    description: >
-      The /etc/ssh/sshd_config file contains configuration specifications for sshd. The
-      command below sets the owner and group of the file to root.
-    rationale: >
-      The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by nonprivileged users.
-    remediation: >
-      Run the following commands to set ownership and permissions on /etc/ssh/sshd_config:
-
-      # chown root:root /etc/ssh/sshd_config
-      # chmod og-rwx /etc/ssh/sshd_config
+  # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured. (Automated)
+  - id: 21125
+    title: "Ensure permissions on /etc/ssh/sshd_config are configured."
+    description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
+    rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
+    remediation: "Run the following commands to set ownership and permissions on /etc/ssh/sshd_config: # chown root:root /etc/ssh/sshd_config # chmod og-rwx /etc/ssh/sshd_config."
     compliance:
       - cis: ["5.2.1"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/ssh/sshd_config -> r:^Access:\s*\(0600/-rw-------\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/ssh/sshd_config" -> r:600\s*\t*-rw------- && r:0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.2.2 Ensure permissions on SSH private host key files are configured - Not implemented
-  # 5.2.3 Ensure permissions on SSH public host key files are configured - Not implemented
+  # 5.2.2 Ensure permissions on SSH private host key files are configured. (Automated)
+  - id: 21126
+    title: "Ensure permissions on SSH private host key files are configured."
+    description: "An SSH private key is one of two files used in SSH public key authentication. In this authentication method, The possession of the private key is proof of identity. Only a private key that corresponds to a public key will be able to authenticate successfully. The private keys need to be stored and handled carefully, and no copies of the private key should be distributed."
+    rationale: "If an unauthorized user obtains the private SSH host key file, the host could be impersonated."
+    remediation: "Run the following commands to set permissions, ownership, and group on the private SSH host key files: # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chmod u-x,g-wx,o- rwx {} \\; # find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -exec chown root:ssh_keys {} \\;."
+    compliance:
+      - cis: ["5.2.2"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/ssh/ssh_host_rsa_key" -> r:600\s*\t*-rw------- && r:0\s*\t*root\s*\t*0\s*\t*root'
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/ssh/ssh_host_ecdsa_key" -> r:600\s*\t*-rw------- && r:0\s*\t*root\s*\t*0\s*\t*root'
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/ssh/ssh_host_ed25519_key" -> r:600\s*\t*-rw------- && r:0\s*\t*root\s*\t*0\s*\t*root'
 
-  # 5.2.4 Ensure SSH access is limited
-  - id: 21115
-    title: Ensure SSH access is limited.
-    description: >
-      There are several options available to limit which users and group can access the system
-      via SSH. It is recommended that at least one of the following options be leveraged:
-        - AllowUsers:
-          - The AllowUsers variable gives the system administrator the option of
-            allowing specific users to ssh into the system. The list consists of space
-            separated user names. Numeric user IDs are not recognized with this
-            variable. If a system administrator wants to restrict user access further by
-            only allowing the allowed users to log in from a particular host, the entry can
-            be specified in the form of user@host.
-        - AllowGroups:
-          - The AllowGroups variable gives the system administrator the option of
-            allowing specific groups of users to ssh into the system. The list consists of
-            space separated group names. Numeric group IDs are not recognized with
-            this variable.
-        - DenyUsers:
-          - The DenyUsers variable gives the system administrator the option of denying
-            specific users to ssh into the system. The list consists of space separated user
-            names. Numeric user IDs are not recognized with this variable. If a system
-            administrator wants to restrict user access further by specifically denying a
-            user's access from a particular host, the entry can be specified in the form of
-            user@host.
-        - DenyGroups:
-          - The DenyGroups variable gives the system administrator the option of
-            denying specific groups of users to ssh into the system. The list consists of
-            space separated group names. Numeric group IDs are not recognized with
-            this variable.
-    rationale: >
-      Restricting which users can remotely access the system via SSH will help ensure that only
-      authorized users access the system.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows:
-      AllowUsers <userlist>
+  # 5.2.3 Ensure permissions on SSH public host key files are configured. (Automated)
+  - id: 21127
+    title: "Ensure permissions on SSH public host key files are configured."
+    description: "An SSH public key is one of two files used in SSH public key authentication. In this authentication method, a public key is a key that can be used for verifying digital signatures generated using a corresponding private key. Only a public key that corresponds to a private key will be able to authenticate successfully."
+    rationale: "If a public host key file is modified by an unauthorized user, the SSH service may be compromised."
+    remediation: "Run the following commands to set permissions and ownership on the SSH host public key files # find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chmod u-x,go- wx {} \\; #find /etc/ssh -xdev -type f -name 'ssh_host_*_key.pub' -exec chown root:root {} \\;."
+    compliance:
+      - cis: ["5.2.3"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/ssh/ssh_host_rsa_key.pub" -> r:644\s*\t*-rw-r--r-- && r:0\s*\t*root\s*\t*0\s*\t*root'
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/ssh/ssh_host_ecdsa_key.pub" -> r:644\s*\t*-rw-r--r-- && r:0\s*\t*root\s*\t*0\s*\t*root'
+      - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/ssh/ssh_host_ed25519_key.pub" -> r:644\s*\t*-rw-r--r-- && r:0\s*\t*root\s*\t*0\s*\t*root'
 
-      OR
-      AllowGroups <grouplist>
-
-      OR
-      DenyUsers <userlist>
-
-      OR
-      DenyGroups <grouplist>
+  # 5.2.4 Ensure SSH access is limited. (Automated)
+  - id: 21128
+    title: "Ensure SSH access is limited."
+    description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: - AllowUsers: o The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. - AllowGroups: o The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. - DenyUsers: o The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. - DenyGroups: o The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
+    rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows: AllowUsers <userlist> OR AllowGroups <grouplist> OR DenyUsers <userlist> OR DenyGroups <grouplist>."
     compliance:
       - cis: ["5.2.4"]
-      - cis_csc: ["4.3"]
-    condition: any
+      - cis_csc_v8: ["3.3", "5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "MP.L2-3.8.2", "SC.L2-3.13.3"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6", "AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1", "CC6.3"]
+    condition: all
     rules:
-      - 'c:sshd -T -> r:^\s*allowusers\s+\S+'
-      - 'c:sshd -T -> r:^\s*allowgroups\s+\S+'
-      - 'c:sshd -T -> r:^\s*denyusers\s+\S+'
-      - 'c:sshd -T -> r:^\s*denygroups\s+\S+'
+      - 'c:sshd -T -> r:^\s*AllowUsers\s+\w+|^\s*AllowGroups\s+\w+|^\s*DenyUsers\s+\w+|^\s*DenyGroups\s+\w+'
+      - 'f:/etc/ssh/sshd_config -> r:^\s*AllowUsers\s+\w+|^\s*AllowGroups\s+\w+|^\s*DenyUsers\s+\w+|^\s*DenyGroups\s+\w+'
 
-  # 5.2.5 Ensure SSH LogLevel is appropriate
-  - id: 21116
-    title: Ensure SSH LogLevel is appropriate.
-    description: >
-      INFO level is the basic level that only records login activity of SSH users. In many situations,
-      such as Incident Response, it is important to determine when a particular user was active
-      on a system. The logout record can eliminate those users who disconnected, which helps
-      narrow the field.
-
-      VERBOSE level specifies that login and logout activity as well as the key fingerprint for any
-      SSH key used for login will be logged. This information is important for SSH key
-      management, especially in legacy environments.
-    rationale: >
-      SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically
-      not recommended other than strictly for debugging SSH communications since it provides
-      so much data that it is difficult to identify important security information.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      LogLevel VERBOSE
-      OR
-      LogLevel INFO
+  # 5.2.5 Ensure SSH LogLevel is appropriate. (Automated)
+  - id: 21129
+    title: "Ensure SSH LogLevel is appropriate."
+    description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
+    rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LogLevel VERBOSE OR LogLevel INFO."
     compliance:
       - cis: ["5.2.5"]
-      - cis_csc: ["6.2", "6.3"]
-    references:
-      - https://www.ssh.com/ssh/sshd_config/
-    condition: any
+      - cis_csc_v8: ["8.2", "8.5"]
+      - cis_csc_v7: ["6.2", "6.3"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - hipaa: ["164.312(b)"]
+      - iso_27001-2013: ["A.12.4.1"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
+    condition: all
     rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*VERBOSE'
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:LogLevel\s*\t*INFO'
+      - 'c:sshd -T -> r:^\s*LogLevel\s+INFO|^\s*LogLevel\s*VERBOSE'
 
-  # 5.2.6 Ensure SSH X11 forwarding is disabled
-  - id: 21117
-    title: Ensure SSH X11 forwarding is disabled.
-    description: >
-      The X11Forwarding parameter provides the ability to tunnel X11 traffic through the
-      connection to enable remote graphic connections.
-    rationale: >
-      Disable X11 forwarding unless there is an operational requirement to use X11 applications
-      directly. There is a small risk that the remote X11 servers of users who are logged in via
-      SSH with X11 forwarding could be compromised by other users on the X11 server. Note
-      that even if X11 forwarding is disabled, users can always install their own forwarders.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      X11Forwarding no
+  # 5.2.6 Ensure SSH X11 forwarding is disabled. (Automated)
+  - id: 21130
+    title: "Ensure SSH X11 forwarding is disabled."
+    description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
+    rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: X11Forwarding no."
     compliance:
       - cis: ["5.2.6"]
-      - cis_csc: ["9.2"]
+      - cis_csc_v8: ["4.8"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
+      - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
+      - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^\s*x11forwarding\s+no'
+      - 'c:sshd -T -> r:^\s*X11Forwarding\s+no'
 
-  # 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less
-  - id: 21118
-    title: Ensure SSH MaxAuthTries is set to 4 or less.
-    description: >
-      The MaxAuthTries parameter specifies the maximum number of authentication attempts
-      permitted per connection. When the login failure count reaches half the number, error
-      messages will be written to the syslog file detailing the login failure.
-    rationale: >
-      Setting the MaxAuthTries parameter to a low number will minimize the risk of successful
-      brute force attacks to the SSH server. While the recommended setting is 4, set the number
-      based on site policy.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      MaxAuthTries 4
+  # 5.2.7 Ensure SSH MaxAuthTries is set to 4 or less. (Automated)
+  - id: 21131
+    title: "Ensure SSH MaxAuthTries is set to 4 or less."
+    description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
+    rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxAuthTries 4."
     compliance:
       - cis: ["5.2.7"]
-      - cis_csc: ["16.13"]
+      - cis_csc_v8: ["8.5"]
+      - cis_csc_v7: ["16.13"]
+      - cmmc_v2.0: ["AU.L2-3.3.1"]
+      - nist_sp_800-53: ["AU-3(1)", "AU-7"]
+      - pci_dss_v3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
+      - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
+      - soc_2: ["CC5.2", "CC7.2"]
     condition: all
     rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
+      - 'c:sshd -T -> n:^MaxAuthTries\s*\t*(\d+) compare <= 4'
 
-  # 5.2.8 Ensure SSH IgnoreRhosts is enabled
-  - id: 21119
-    title: Ensure SSH IgnoreRhosts is enabled.
-    description: >
-      The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in
-      RhostsRSAAuthentication or HostbasedAuthentication.
-    rationale: Setting this parameter forces users to enter a password when authenticating with ssh.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      IgnoreRhosts yes
+  # 5.2.8 Ensure SSH IgnoreRhosts is enabled. (Automated)
+  - id: 21132
+    title: "Ensure SSH IgnoreRhosts is enabled."
+    description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
+    rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: IgnoreRhosts yes."
     compliance:
       - cis: ["5.2.8"]
-      - cis_csc: ["9.2"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:IgnoreRhosts\s*\t*yes'
+      - 'c:sshd -T -> r:^\s*IgnoreRhosts\s+yes'
 
-  # 5.2.9 Ensure SSH HostbasedAuthentication is disabled
-  - id: 21120
-    title: Ensure SSH HostbasedAuthentication is disabled.
-    description: >
-      The HostbasedAuthentication parameter specifies if authentication is allowed through
-      trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public
-      key client host authentication. This option only applies to SSH Protocol Version 2.
-    rationale: >
-      Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf,
-      disabling the ability to use .rhosts files in SSH provides an additional layer of protection.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      HostbasedAuthentication no
+  # 5.2.9 Ensure SSH HostbasedAuthentication is disabled. (Automated)
+  - id: 21133
+    title: "Ensure SSH HostbasedAuthentication is disabled."
+    description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
+    rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: HostbasedAuthentication no."
     compliance:
       - cis: ["5.2.9"]
-      - cis_csc: ["16.3"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:HostbasedAuthentication\s*\t*no'
+      - 'c:sshd -T -> r:^\s*HostbasedAuthentication\s+no'
 
-  # 5.2.10 Ensure SSH root login is disabled
-  - id: 21121
-    title: Ensure SSH root login is disabled.
-    description: >
-      The PermitRootLogin parameter specifies if the root user can log in using ssh. The default
-      is no.
-    rationale: >
-      Disallowing root logins over SSH requires system admins to authenticate using their own
-      individual account, then escalating to root via sudo or su. This in turn limits opportunity for
-      non-repudiation and provides a clear audit trail in the event of a security incident.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      PermitRootLogin no
+  # 5.2.10 Ensure SSH root login is disabled. (Automated)
+  - id: 21134
+    title: "Ensure SSH root login is disabled."
+    description: "The PermitRootLogin parameter specifies if the root user can log in using ssh. The default is no."
+    rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitRootLogin no."
     compliance:
       - cis: ["5.2.10"]
-      - cis_csc: ["4.3"]
+      - cis_csc_v8: ["5.4"]
+      - cis_csc_v7: ["4.3"]
+      - cmmc_v2.0: ["AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "SC.L2-3.13.3"]
+      - iso_27001-2013: ["A.9.2.3"]
+      - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - soc_2: ["CC6.1", "CC6.3"]
     condition: all
     rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitRootLogin\s*\t*no'
+      - 'c:sshd -T -> r:^\s*PermitRootLogin\s+no'
 
-  # 5.2.11 Ensure SSH PermitEmptyPasswords is disabled
-  - id: 21122
-    title: Ensure SSH PermitEmptyPasswords is disabled.
-    description: >
-      The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts
-      with empty password strings.
-    rationale: >
-      Disallowing remote shell access to accounts that have an empty password reduces the
-      probability of unauthorized access to the system
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      PermitEmptyPasswords no
+  # 5.2.11 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
+  - id: 21135
+    title: "Ensure SSH PermitEmptyPasswords is disabled."
+    description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
+    rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitEmptyPasswords no."
     compliance:
       - cis: ["5.2.11"]
-      - cis_csc: ["16.3"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.3"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'f:$sshd_file -> !r:^\s*\t*# && r:PermitEmptyPasswords\s*\t*no'
+      - 'c:sshd -T -> r:^\s*PermitEmptyPasswords\s+no'
 
-  # 5.2.12 Ensure SSH PermitUserEnvironment is disabled
-  - id: 21123
-    title: Ensure SSH PermitUserEnvironment is disabled.
-    description: >
-      The PermitUserEnvironment option allows users to present environment options to the
-      ssh daemon.
-    rationale: >
-      Permitting users the ability to set environment variables through the SSH daemon could
-      potentially allow users to bypass security controls (e.g. setting an execution path that has
-      ssh executing a Trojan’s programs)
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      PermitUserEnvironment no
+  # 5.2.12 Ensure SSH PermitUserEnvironment is disabled. (Automated)
+  - id: 21136
+    title: "Ensure SSH PermitUserEnvironment is disabled."
+    description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
+    rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing a Trojan's programs)."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: PermitUserEnvironment no."
     compliance:
       - cis: ["5.2.12"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^\s*permituserenvironment\s+no'
+      - 'c:sshd -T -> r:^\s*PermitUserEnvironment\s+no'
 
-  # 5.2.13 Ensure only strong Ciphers are used
-  - id: 21124
-    title: Ensure only strong Ciphers are used.
-    description: >
-      This variable limits the ciphers that SSH can use during communication.
-      Notes:
-        - Some organizations may have stricter requirements for approved ciphers. Ensure that
-          ciphers used are in compliance with site policy
-        - The only "strong" ciphers currently FIPS 140-2 compliant are: aes256-ctr,aes192-
-          ctr,aes128-ctr
-        - CVE-2013-4548 referenced bellow applies to OpenSSH versions 6.2 and 6.3. If running
-          these versions of Open SSH, Please upgrade to version 6.4 or later to fix the
-          vulnerability, or disable AES-GCM in the server configuration
-
-      The Following are the supported ciphers in openSSH 7.9:
-      3des-cbc
-      aes128-cbc
-      aes192-cbc
-      aes256-cbc
-      aes128-ctr
-      aes192-ctr
-      aes256-ctr
-      aes128-gcm@openssh.com
-      aes256-gcm@openssh.com
-      chacha20-poly1305@openssh.com
-    rationale: >
-      Weak ciphers that are used for authentication to the cryptographic module cannot be relied
-      upon to provide confidentiality or integrity, and system data may be compromised.
-        - The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of
-          approximately four billion blocks, which makes it easier for remote attackers to
-          obtain cleartext data via a birthday attack against a long-duration encrypted session,
-          aka a "Sweet32" attack
-        - The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly
-          combine state data with key data during the initialization phase, which makes it
-          easier for remote attackers to conduct plaintext-recovery attacks against the initial
-          bytes of a stream by sniffing network traffic that occasionally relies on keys affected
-          by the Invariance Weakness, and then using a brute-force approach involving LSB
-          values, aka the "Bar Mitzvah" issue
-        - The passwords used during an SSH session encrypted with RC4 can be recovered by
-          an attacker who is able to capture and replay the session
-        - Error handling in the SSH protocol; Client and Server, when using a block cipher
-          algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote
-          attackers to recover certain plaintext data from an arbitrary block of ciphertext in
-          an SSH session via unknown vectors
-        - The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher
-          is used, does not properly initialize memory for a MAC context data structure, which
-          allows remote authenticated users to bypass intended ForceCommand and loginshell restrictions via packet data that provides a crafted callback address
-    remediation: >
-      Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma
-      separated list of the site approved ciphers
-
-      Example:
-      Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-
-      gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+  # 5.2.13 Ensure only strong Ciphers are used. (Automated)
+  - id: 21137
+    title: "Ensure only strong Ciphers are used."
+    description: 'This variable limits the ciphers that SSH can use during communication. Notes: - Some organizations may have stricter requirements for approved ciphers. Ensure that ciphers used are in compliance with site policy - The only "strong" ciphers currently FIPS 140-2 compliant are: aes256-ctr,aes192- ctr,aes128-ctr - CVE-2013-4548 referenced bellow applies to OpenSSH versions 6.2 and 6.3. If running these versions of Open SSH, Please upgrade to version 6.4 or later to fix the vulnerability, or disable AES-GCM in the server configuration The Following are the supported ciphers in openSSH 7.9: 3des-cbc aes128-cbc aes192-cbc aes256-cbc aes128-ctr aes192-ctr aes256-ctr aes128-gcm@openssh.com aes256-gcm@openssh.com chacha20-poly1305@openssh.com.'
+    rationale: 'Weak ciphers that are used for authentication to the cryptographic module cannot be relied upon to provide confidentiality or integrity, and system data may be compromised. - The DES, Triple DES, and Blowfish ciphers, as used in SSH, have a birthday bound of approximately four billion blocks, which makes it easier for remote attackers to obtain cleartext data via a birthday attack against a long-duration encrypted session, aka a "Sweet32" attack - The RC4 algorithm, as used in the TLS protocol and SSL protocol, does not properly combine state data with key data during the initialization phase, which makes it easier for remote attackers to conduct plaintext-recovery attacks against the initial bytes of a stream by sniffing network traffic that occasionally relies on keys affected by the Invariance Weakness, and then using a brute-force approach involving LSB values, aka the "Bar Mitzvah" issue - The passwords used during an SSH session encrypted with RC4 can be recovered by an attacker who is able to capture and replay the session - Error handling in the SSH protocol; Client and Server, when using a block cipher algorithm in Cipher Block Chaining (CBC) mode, makes it easier for remote attackers to recover certain plaintext data from an arbitrary block of ciphertext in an SSH session via unknown vectors - The mm_newkeys_from_blob function in monitor_wrap.c, when an AES-GCM cipher is used, does not properly initialize memory for a MAC context data structure, which allows remote authenticated users to bypass intended ForceCommand and login-shell restrictions via packet data that provides a crafted callback address.'
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the Ciphers line to contain a comma separated list of the site approved ciphers Example: Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128- gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr."
+    references:
+      - "https://nvd.nist.gov/vuln/detail/CVE-2016-2183"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2015-2808"
+      - "https://www.kb.cert.org/vuls/id/565052"
+      - "https://www.openssh.com/txt/cbc.adv"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2008-5161"
+      - "https://nvd.nist.gov/vuln/detail/CVE-2013-4548"
     compliance:
       - cis: ["5.2.13"]
-      - cis_csc: ["14.4"]
-    references:
-      - https://nvd.nist.gov/vuln/detail/CVE-2016-2183
-      - https://nvd.nist.gov/vuln/detail/CVE-2015-2808
-      - https://www.kb.cert.org/vuls/id/565052
-      - https://www.openssh.com/txt/cbc.adv
-      - https://nvd.nist.gov/vuln/detail/CVE-2008-5161
-      - https://nvd.nist.gov/vuln/detail/CVE-2013-4548
-      - https://www.kb.cert.org/vuls/id/565052
-      - https://www.openssh.com/txt/cbc.adv
-      - SSHD_CONFIG(5)
-    condition: none
+      - cis_csc_v8: ["3.10"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.13", "AC.L2-3.1.17", "IA.L2-3.5.10", "SC.L2-3.13.11", "SC.L2-3.13.15", "SC.L2-3.13.8"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(1)", "164.312(e)(2)(i)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - nist_sp_800-53: ["AC-17(2)", "SC-8", "SC-8(1)"]
+      - pci_dss_v3.2.1: ["2.1.1", "4.1", "4.1.1", "8.2.1"]
+      - pci_dss_v4.0: ["2.2.7", "4.1.1", "4.2.1", "4.2.1.2", "4.2.2", "8.3.2"]
+    condition: all
     rules:
-      - 'c:sshd -T -> r:^ciphers\s+ && r:3des-cbc'
-      - 'c:sshd -T -> r:^ciphers\s+ && r:aes128-cbc'
-      - 'c:sshd -T -> r:^ciphers\s+ && r:aes192-cbc'
-      - 'c:sshd -T -> r:^ciphers\s+ && r:aes256-cbc'
+      - "not c:sshd -T -> r:ciphers && r:3des-cbc|aes128-cbc|aes192-cbc|aes256-cbc"
 
-  # 5.2.14 Ensure only strong MAC algorithms are used
-  - id: 21125
-    title: Ensure only strong MAC algorithms are used.
-    description: >
-      This variable limits the types of MAC algorithms that SSH can use during communication.
-      Notes:
-        - Some organizations may have stricter requirements for approved MACs. Ensure that
-          MACs used are in compliance with site policy
-        - The only "strong" MACs currently FIPS 140-2 approved are hmac-sha2-256 and hmacsha2-512
-
-      The Supported MACs are:
-      hmac-md5
-      hmac-md5-96
-      hmac-sha1
-      hmac-sha1-96
-      hmac-sha2-256
-      hmac-sha2-512
-      umac-64@openssh.com
-      umac-128@openssh.com
-      hmac-md5-etm@openssh.com
-      hmac-md5-96-etm@openssh.com
-      hmac-sha1-etm@openssh.com
-      hmac-sha1-96-etm@openssh.com
-      hmac-sha2-256-etm@openssh.com
-      hmac-sha2-512-etm@openssh.com
-      umac-64-etm@openssh.com
-      umac-128-etm@openssh.com
-    rationale: >
-      MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase
-      exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of
-      attention as a weak spot that can be exploited with expanded computing power. An
-      attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the
-      SSH tunnel and capture credentials and information
-    remediation: >
-      Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma
-      separated list of the site approved MACs
-
-      Example:
-      MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-
-      512,hmac-sha2-256
+  # 5.2.14 Ensure only strong MAC algorithms are used. (Automated)
+  - id: 21138
+    title: "Ensure only strong MAC algorithms are used."
+    description: 'This variable limits the types of MAC algorithms that SSH can use during communication. Notes: - Some organizations may have stricter requirements for approved MACs. Ensure that MACs used are in compliance with site policy - The only "strong" MACs currently FIPS 140-2 approved are hmac-sha2-256 and hmac-sha2-512 The Supported MACs are: hmac-md5 hmac-md5-96 hmac-sha1 hmac-sha1-96 hmac-sha2-256 hmac-sha2-512 umac-64@openssh.com umac-128@openssh.com hmac-md5-etm@openssh.com hmac-md5-96-etm@openssh.com hmac-sha1-etm@openssh.com hmac-sha1-96-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512-etm@openssh.com umac-64-etm@openssh.com umac-128-etm@openssh.com.'
+    rationale: "MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information."
+    remediation: "Edit the /etc/ssh/sshd_config file and add/modify the MACs line to contain a comma separated list of the site approved MACs Example: MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2- 512,hmac-sha2-256."
+    references:
+      - "http://www.mitls.org/pages/attacks/SLOTH"
     compliance:
       - cis: ["5.2.14"]
-      - cis_csc: ["14.4", "16.5"]
-    references:
-      - http://www.mitls.org/pages/attacks/SLOTH
-      - SSHD_CONFIG(5)
-    condition: none
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["14.4", "16.5"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
     rules:
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96'
-      - 'c:sshd -T -> r:^macs\s+ && r:umac-64@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:umac-128@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-etm@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-md5-96-etm@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-ripemd160-etm@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-etm@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:hmac-sha1-96-etm@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:umac-64-etm@openssh.com'
-      - 'c:sshd -T -> r:^macs\s+ && r:umac-128-etm@openssh.com'
+      - "not c:sshd -T -> r:MACs && r:hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1|hmac-sha1-96|umac-64@openssh.com|umac-128@openssh.com|hmac-md5-etm@openssh.com|hmac-md5-96-etm@openssh.com|hmac-ripemd160-etm@openssh.com|hmac-sha1-etm@openssh.com|hmac-sha1-96-etm@openssh.com|umac-64-etm@openssh.com|umac-128-etm@openssh.com"
 
-  # 5.2.15 Ensure only strong Key Exchange algorithms are used
-  - id: 21126
-    title: Ensure only strong Key Exchange algorithms are used.
-    description: >
-      Key exchange is any method in cryptography by which cryptographic keys are exchanged
-      between two parties, allowing use of a cryptographic algorithm. If the sender and receiver
-      wish to exchange encrypted messages, each must be equipped to encrypt messages to be
-      sent and decrypt messages received
-
-      Notes:
-      Kex algorithms have a higher preference the earlier they appear in the list
-        - Some organizations may have stricter requirements for approved Key exchange
-          algorithms. Ensure that Key exchange algorithms used are in compliance with site
-          policy.
-        - The only Key Exchange Algorithms currently FIPS 140-2 approved are: ecdh-sha2-
-          nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchangesha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffiehellman-group14-sha256
-
-      The Key Exchange algorithms supported by OpenSSH 7.9 are:
-      curve25519-sha256
-      curve25519-sha256@libssh.org
-      diffie-hellman-group1-sha1
-      diffie-hellman-group14-sha1
-      diffie-hellman-group14-sha256
-      diffie-hellman-group16-sha512
-      diffie-hellman-group18-sha512
-      diffie-hellman-group-exchange-sha1
-      diffie-hellman-group-exchange-sha256
-      ecdh-sha2-nistp256
-      ecdh-sha2-nistp384
-      ecdh-sha2-nistp521
-    rationale: >
-      Key exchange methods that are considered weak should be removed. A key exchange
-      method may be weak because too few bits are used, or the hashing algorithm is considered
-      too weak. Using weak algorithms could expose connections to man-in-the-middle attacks
-    remediation: >
-      Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma
-      separated list of the site approved key exchange algorithms
-
-      Example
-      KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellmangroup14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-
-      sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffiehellman-group-exchange-sha256
+  # 5.2.15 Ensure only strong Key Exchange algorithms are used. (Automated)
+  - id: 21139
+    title: "Ensure only strong Key Exchange algorithms are used."
+    description: "Key exchange is any method in cryptography by which cryptographic keys are exchanged between two parties, allowing use of a cryptographic algorithm. If the sender and receiver wish to exchange encrypted messages, each must be equipped to encrypt messages to be sent and decrypt messages received Notes: Kex algorithms have a higher preference the earlier they appear in the list - Some organizations may have stricter requirements for approved Key exchange algorithms. Ensure that Key exchange algorithms used are in compliance with site policy. - The only Key Exchange Algorithms currently FIPS 140-2 approved are: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256 The Key Exchange algorithms supported by OpenSSH 7.9 are: curve25519-sha256 curve25519-sha256@libssh.org diffie-hellman-group1-sha1 diffie-hellman-group14-sha1 diffie-hellman-group14-sha256 diffie-hellman-group16-sha512 diffie-hellman-group18-sha512 diffie-hellman-group-exchange-sha1 diffie-hellman-group-exchange-sha256 ecdh-sha2-nistp256 ecdh-sha2-nistp384 ecdh-sha2-nistp521."
+    rationale: "Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks."
+    remediation: "Edit the /etc/ssh/sshd_config file add/modify the KexAlgorithms line to contain a comma separated list of the site approved key exchange algorithms Example KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman- group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18- sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie- hellman-group-exchange-sha256."
     compliance:
       - cis: ["5.2.15"]
-      - cis_csc: ["14.4"]
-    condition: none
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["14.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.10.1.1", "A.13.1.1"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
     rules:
-      - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group1-sha1'
-      - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group14-sha1'
-      - 'c:sshd -T -> r:^kexalgorithms\s+ && r:diffie-hellman-group-exchange-sha1'
+      - "not c:sshd -T -> r:kexalgorithms && r:diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1"
 
-  # 5.2.16 Ensure SSH Idle Timeout Interval is configured
-  - id: 21127
-    title: Ensure SSH Idle Timeout Interval is configured
-    description: >
-      The two options ClientAliveInterval and ClientAliveCountMax control the timeout of
-      ssh sessions.
-        - ClientAliveInterval sets a timeout interval in seconds after which if no data has
-          been received from the client, sshd will send a message through the encrypted
-          channel to request a response from the client. The default is 0, indicating that these
-          messages will not be sent to the client.
-        - ClientAliveCountMax sets the number of client alive messages which may be sent
-          without sshd receiving any messages back from the client. If this threshold is
-          reached while client alive messages are being sent, sshd will disconnect the client,
-          terminating the session. The default value is 3.
-            - The client alive messages are sent through the encrypted channel
-            - Setting ClientAliveCountMax to 0 disables connection termination
-
-      Example: If the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is
-      set to 3, the client ssh session will be terminated after 45 seconds of idle time.
-    rationale: >
-      Having no timeout value associated with a connection could allow an unauthorized user
-      access to another user's ssh session (e.g. user walks away from their computer and doesn't
-      lock the screen). Setting a timeout value reduces this risk.
-       The recommended ClientAliveInterval setting is 300 seconds (5 minutes)
-       The recommended ClientAliveCountMax setting is 3
-       The ssh session would send three keep alive messages at 5 minute intervals. If no
-      response is received after the third keep alive message, the ssh session would be
-      terminated after 15 minutes.
-    remediation: >
-      Having no timeout value associated with a connection could allow an unauthorized user
-      access to another user's ssh session (e.g. user walks away from their computer and doesn't
-      lock the screen). Setting a timeout value reduces this risk.
-        - The recommended ClientAliveInterval setting is 300 seconds (5 minutes)
-        - The recommended ClientAliveCountMax setting is 3
-        - The ssh session would send three keep alive messages at 5 minute intervals. If no
-          response is received after the third keep alive message, the ssh session would be
-          terminated after 15 minutes.
+  # 5.2.16 Ensure SSH Idle Timeout Interval is configured. (Automated)
+  - id: 21140
+    title: "Ensure SSH Idle Timeout Interval is configured."
+    description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. - ClientAliveInterval sets a timeout interval in seconds after which if no data has been received from the client, sshd will send a message through the encrypted channel to request a response from the client. The default is 0, indicating that these messages will not be sent to the client. - ClientAliveCountMax sets the number of client alive messages which may be sent without sshd receiving any messages back from the client. If this threshold is reached while client alive messages are being sent, sshd will disconnect the client, terminating the session. The default value is 3. o The client alive messages are sent through the encrypted channel o Setting ClientAliveCountMax to 0 disables connection termination Example: If the ClientAliveInterval is set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be terminated after 45 seconds of idle time."
+    rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value reduces this risk. - The recommended ClientAliveInterval setting is 300 seconds (5 minutes) - The recommended ClientAliveCountMax setting is 3 - The ssh session would send three keep alive messages at 5 minute intervals. If no response is received after the third keep alive message, the ssh session would be terminated after 15 minutes."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameters according to site policy. This should include ClientAliveInterval between 1 and 300 and ClientAliveCountMax of 3 or less: ClientAliveInterval 300 ClientAliveCountMax 3."
+    references:
+      - "https://man.openbsd.org/sshd_config"
     compliance:
       - cis: ["5.2.16"]
-      - cis_csc: ["16.11"]
-    references:
-      - https://man.openbsd.org/sshd_config
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.11"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare >= 1'
-      - 'c:sshd -T -> n:^clientaliveinterval\s+(\d+) compare <= 300'
-      - 'c:sshd -T -> n:^ClientAliveCountMax\s+(\d+) compare <= 3'
+      - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare >= 1'
+      - 'c:sshd -T -> n:ClientAliveInterval\s*\t*(\d+) compare <= 300'
+      - 'c:sshd -T -> n:clientalivecountmax\s*\t*(\d+) compare >= 1'
+      - 'c:sshd -T -> n:clientalivecountmax\s*\t*(\d+) compare <= 3'
 
-  # 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less
-  - id: 21128
-    title: Ensure SSH LoginGraceTime is set to one minute or less.
-    description: >
-      The LoginGraceTime parameter specifies the time allowed for successful authentication to
-      the SSH server. The longer the Grace period is the more open unauthenticated connections
-      can exist. Like other session controls in this session the Grace Period should be limited to
-      appropriate organizational limits to ensure the service is available for needed access.
-    rationale: >
-      Setting the LoginGraceTime parameter to a low number will minimize the risk of successful
-      brute force attacks to the SSH server. It will also limit the number of concurrent
-      unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set
-      the number based on site policy.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-      LoginGraceTime 60
+  # 5.2.17 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
+  - id: 21141
+    title: "Ensure SSH LoginGraceTime is set to one minute or less."
+    description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
+    rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: LoginGraceTime 60."
     compliance:
       - cis: ["5.2.17"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare >= 1'
-      - 'c:sshd -T -> n:^logingracetime\s+(\d+) compare <= 60'
+      - 'c:sshd -T -> n:logingracetime\s*\t*(\d+) compare <= 60 && n:LoginGraceTime\s*\t*(\d+) compare >= 1'
 
-  # 5.2.18 Ensure SSH warning banner is configured
-  - id: 21129
-    title: Ensure SSH warning banner is configured.
-    description: >
-      The Banner parameter specifies a file whose contents must be sent to the remote user
-      before authentication is permitted. By default, no banner is displayed.
-    rationale: >
-      Banners are used to warn connecting users of the particular site's policy regarding
-      connection. Presenting a warning message prior to the normal user login may assist the
-      prosecution of trespassers on the computer system.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-
-      Banner /etc/issue.net
+  # 5.2.18 Ensure SSH warning banner is configured. (Automated)
+  - id: 21142
+    title: "Ensure SSH warning banner is configured."
+    description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
+    rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: Banner /etc/issue.net."
     compliance:
       - cis: ["5.2.18"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^banner\s+/etc/issue.net'
+      - 'c:sshd -T -> r:^\s*banner\s*\t*/etc/issue.net'
 
-  # 5.2.19 Ensure SSH PAM is enabled
-  - id: 21130
-    title: Ensure SSH PAM is enabled.
-    description: >
-      UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will
-      enable PAM authentication using ChallengeResponseAuthentication and
-      PasswordAuthentication in addition to PAM account and session module processing for all
-      authentication types
-    rationale: >
-      When usePAM is set to yes, PAM runs through account and session types properly. This is
-      important if you want to restrict access to services based off of IP, time or other factors of
-      the account. Additionally, you can make sure users inherit certain environment variables
-      on login or disallow access to the server
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-
-      UsePAM yes
+  # 5.2.19 Ensure SSH PAM is enabled. (Automated)
+  - id: 21143
+    title: "Ensure SSH PAM is enabled."
+    description: 'UsePAM Enables the Pluggable Authentication Module interface. If set to "yes" this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication in addition to PAM account and session module processing for all authentication types.'
+    rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
+    impact: "If UsePAM is enabled, you will not be able to run sshd(8) as a non-root user."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: UsePAM yes."
     compliance:
       - cis: ["5.2.19"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^usepam\s+yes'
+      - 'c:sshd -T -> r:^\s*usepam\s+yes'
 
-  # 5.2.20 Ensure SSH AllowTcpForwarding is disabled
-  - id: 21131
-    title: Ensure SSH AllowTcpForwarding is disabled.
-    description: >
-      SSH port forwarding is a mechanism in SSH for tunneling application ports from the client
-      to the server, or servers to clients. It can be used for adding encryption to legacy
-      applications, going through firewalls, and some system administrators and IT professionals
-      use it for opening backdoors into the internal network from their home machines
-    rationale: >
-      Leaving port forwarding enabled can expose the organization to security risks and backdoors.
-
-      SSH connections are protected with strong encryption. This makes their contents invisible
-      to most deployed network monitoring and traffic filtering solutions. This invisibility carries
-      considerable risk potential if it is used for malicious purposes such as data exfiltration.
-      Cybercriminals or malware could exploit SSH to hide their unauthorized communications,
-      or to exfiltrate stolen data from the target network
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-
-      AllowTcpForwarding no
+  # 5.2.20 Ensure SSH AllowTcpForwarding is disabled. (Automated)
+  - id: 21144
+    title: "Ensure SSH AllowTcpForwarding is disabled."
+    description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
+    rationale: "Leaving port forwarding enabled can expose the organization to security risks and back-doors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
+    impact: "SSH tunnels are widely used in many corporate environments that employ mainframe systems as their application backends. In those environments the applications themselves may have very limited native support for security. By utilizing tunneling, compliance with SOX, HIPAA, PCI-DSS, and other standards can be achieved without having to modify the applications."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: AllowTcpForwarding no."
+    references:
+      - "https://www.ssh.com/ssh/tunneling/example"
     compliance:
       - cis: ["5.2.20"]
-      - cis_csc: ["9.2"]
-    references:
-      - https://www.ssh.com/ssh/tunneling/example
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["9.2"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.13.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^allowtcpforwarding\s+no'
+      - 'c:sshd -T -> r:^\s*AllowTcpForwarding\s+no'
 
-  # 5.2.21 Ensure SSH MaxStartups is configured
-  - id: 21132
-    title: Ensure SSH MaxStartups is configured.
-    description: >
-      The MaxStartups parameter specifies the maximum number of concurrent unauthenticated
-      connections to the SSH daemon.
-    rationale: >
-      To protect a system from denial of service due to a large number of pending authentication
-      connection attempts, use the rate limiting function of MaxStartups to protect availability of
-      sshd logins and prevent overwhelming the daemon.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-
-      maxstartups 10:30:60
+  # 5.2.21 Ensure SSH MaxStartups is configured. (Automated)
+  - id: 21145
+    title: "Ensure SSH MaxStartups is configured."
+    description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
+    rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: maxstartups 10:30:60."
     compliance:
       - cis: ["5.2.21"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> r:^maxstartups\s+10:30:60\s*$'
+      - 'c:sshd -T -> r:^\s*maxstartups\s+10:30:60'
 
-  # 5.2.22 Ensure SSH MaxSessions is limited
-  - id: 21133
-    title: Ensure SSH MaxSessions is limited.
-    description: >
-      The MaxSessions parameter specifies the maximum number of open sessions permitted
-      from a given connection.
-    rationale: >
-      To protect a system from denial of service due to a large number of concurrent sessions,
-      use the rate limiting function of MaxSessions to protect availability of sshd logins and
-      prevent overwhelming the daemon.
-    remediation: >
-      Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-
-      MaxSessions 10
+  # 5.2.22 Ensure SSH MaxSessions is limited. (Automated)
+  - id: 21146
+    title: "Ensure SSH MaxSessions is limited."
+    description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
+    rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
+    remediation: "Edit the /etc/ssh/sshd_config file to set the parameter as follows: MaxSessions 10."
     compliance:
       - cis: ["5.2.22"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sshd -T -> n:^maxsessions\s+(\d+) compare <= 10'
+      - 'c:sshd -T -> n:^\s*maxsessions\s+(\d+) compare <= 10'
 
-  # 5.3.1 Ensure password creation requirements are configured - Not implemented
-  # 5.3.2 Ensure lockout for failed password attempts is configured - Not implemented
+  # 5.3.1 Ensure password creation requirements are configured. (Automated)
+  - id: 21147
+    title: "Ensure password creation requirements are configured."
+    description: "The pam_cracklib.so module checks the strength of passwords. It performs checks including ensuring a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following are definitions of the pam_cracklib.so options: - retry=3 - Allow 3 tries before sending back a failure. - minlen=14 - password must be 14 characters or more - dcredit=-1 - provide at least one digit - ucredit=-1 - provide at least one uppercase character - ocredit=-1 - provide at least one special character - lcredit=-1 - provide at least one lowercase character Additional module options may be set. This recommendation only covers: - minlen= - dcredit= - ucredit= - ocredit= - lcredit= NOTES: The settings shown above are one possible policy. If local site policy requires stricter settings, alter these values to conform to your organization's password policies."
+    rationale: "Strong passwords and limited attempts before locking an account protect systems from being hacked through brute force methods."
+    remediation: "Run the following command: # pam-config -a --cracklib-minlen=14 --cracklib-retry=3 --cracklib-lcredit=-1 --cracklib-ucredit=-1 --cracklib-dcredit=-1 --cracklib-ocredit=-1 --cracklib OR Edit the /etc/pam.d/common-password file to include the appropriate options for pam_cracklib.so and to conform to site policy: password requisite pam_cracklib.so retry=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1."
+    references:
+      - "https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-security-"
+    compliance:
+      - cis: ["5.3.1"]
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/common-password -> !r:^\s*# && r:password && r:requisite|required && r:pam_cracklib.so && n:minlen\s*=\s*(\d+) compare >= 14'
+      - 'f:/etc/pam.d/common-password -> !r:^\s*# && r:password && r:requisite|required && r:pam_cracklib.so && r:dcredit\s*=\s*-1 && r:ucredit\s*=\s*-1 && r:ocredit\s*=\s*-1 && r:lcredit\s*=\s*-1'
 
-  # 5.3.3 Ensure password reuse is limited
-  - id: 21134
-    title: Ensure password reuse is limited.
-    description: >
-      The /etc/security/opasswd file stores the users' old passwords and can be checked to
-      ensure that users are not recycling recent passwords.
+  # 5.3.2 Ensure lockout for failed password attempts is configured. (Automated)
+  - id: 21148
+    title: "Ensure lockout for failed password attempts is configured."
+    description: 'Lock out users after n unsuccessful consecutive login attempts. These settings are commonly configured with the pam_faillock.so module. Some environments may continue using the pam_tally2.so module, where this older method may simplify automation in mixed environments. Set the lockout number in deny= to the policy in effect at your site. unlock_time=_n_ is the number of seconds the account remains locked after the number of attempts configured in deny=_n_ has been met. Notes: - Additional module options may be set, recommendation only covers those listed here. If you want to require the administrator to unlock accounts, leave off the unlock_time - option - The default location for attempted accesses is recorded in /var/log/tallylog - Use of the "audit" keyword may log credentials in the case of user error during authentication. This risk should be evaluated in the context of the site policies of your organization. - You may also lock out root, this should be considered carefully due to the ability to have this setting lock all access to the system o As an option on the same line: o auth required pam_tally2.so deny=5 even_deny_root unlock_time=900 o To define a different lockout time for root: o auth required pam_tally2.so deny=5 root_unlock_time=120 unlock_time=900 - If a user has been locked out because they have reached the maximum consecutive failure count defined by deny= in the pam_tally2.so module, the user can be unlocked by issuing following command. This command sets the failed count to 0, effectively unlocking the user. - # pam_tally2 -u <username> --reset.'
+    rationale: "Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
+    remediation: "Modify the deny= and unlock_time= parameters to conform to local site policy, Not to be greater than deny=5: Edit the file /etc/pam.d/login and add the following line: auth required pam_tally2.so deny=5 onerr=fail unlock_time=900 Note: The ordering on the lines is important. The additional line needs to below the line auth required pam_env.so and above all password validation lines. Example: auth required pam_env.so auth required pam_tally2.so deny=5 onerr=fail unlock_time=900 auth sufficient pam_unix.so nullok try_first_pass auth required pam_deny.so Edit the /etc/pam.d/common-account file and add the following pam_tally2.so line: account required pam_tally2.so."
+    compliance:
+      - cis: ["5.3.2"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.7"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.9.2.6"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/login -> !r:^\s*\t*# && r:auth && r:required|requisite && r:pam_tally2.so && n:deny\s*\t*=\s*\t*(\d+) compare <= 5 && r:onerr\s*\t*=\s*\t*fail && r:unlock_time='
+      - 'f:/etc/pam.d/login -> !r:^\s*\t*# && r:auth && r:required|requisite && r:pam_unix.so && r:try_first_pass'
+      - 'f:/etc/pam.d/common-account -> !r:^\s*\t*# && r:account && r:required|requisite && r:pam_tally2.so'
 
-      Notes:
-      - Additional module options may be set, recommendation only covers those listed here.
-      - This setting only applies to local accounts.
-      - This option is configured with the remember=n module option in /etc/pam.d/commonpassword
-    rationale: >
-      Forcing users not to reuse their past passwords make it less likely that an attacker will be
-      able to guess the password.
-    remediation: >
-      Run the following command:
-      # pam-config -a --pwhistory --pwhistory-remember=5
-
-      OR
-
-      Edit the file /etc/pam.d/common-password to include the remember= option and conform to
-      site policy as shown:
-      password required pam_pwhistory.so remember=5
+  # 5.3.3 Ensure password reuse is limited. (Automated)
+  - id: 21149
+    title: "Ensure password reuse is limited."
+    description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords. Notes: - Additional module options may be set, recommendation only covers those listed here. - This setting only applies to local accounts. - This option is configured with the remember=n module option in /etc/pam.d/common- password."
+    rationale: "Forcing users not to reuse their past passwords make it less likely that an attacker will be able to guess the password."
+    remediation: "Run the following command: # pam-config -a --pwhistory --pwhistory-remember=5 OR Edit the file /etc/pam.d/common-password to include the remember= option and conform to site policy as shown: password required pam_pwhistory.so remember=5."
     compliance:
       - cis: ["5.3.3"]
-      - cis_csc: ["16"]
-    condition: any
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["16"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
     rules:
-      - 'f:/etc/pam.d/common-password -> n:^\s*password\t+requisite\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
-      - 'f:/etc/pam.d/common-password -> n:^\s*password\t+required\t+pam_pwhistory\.so\t+remember\s*=\s*(\d+) compare >= 5'
+      - 'f:/etc/pam.d/common-password -> !r:^\s*\t*# && r:password && r:required|requisite && r:pam_pwhistory.so && n:deny\s*\t*=\s*\t*(\d+) compare >= 5'
 
-  # 5.4.1.1 Ensure password hashing algorithm is SHA-512
-  - id: 21135
-    title: Ensure password hashing algorithm is SHA-512.
-    description: >
-      Login passwords are hashed and stored in the /etc/shadow file.
-
-      Note: These changes only apply to accounts configured on the local system.
-    rationale: >
-      The SHA-512 algorithm provides much stronger hashing than MD5, thus providing
-      additional protection to the system by increasing the level of effort for an attacker to
-      successfully determine passwords.
-    remediation: >
-      Edit the /etc/login.defs file and modify ENCRYPT_METHOD to SHA512:
-      ENCRYPT_METHOD sha512
-
-      Notes:
-        - Any system accounts that need to be expired should be carefully done separately by the
-          system administrator to prevent any potential problems
-        - If it is determined that the password algorithm being used is not SHA-512, once it is
-          changed, it is recommended that all user ID's be immediately expired and forced to
-          change their passwords on next login, In accordance with local site policies
-        - To accomplish this, the following command can be used
-          # awk -F: '( $3<'"$(awk '/^\s*UID_MIN/{print $2}' /etc/login.defs)"' &&
-          $1 != "nfsnobody" ) { print $1 }' /etc/passwd | xargs -n 1 chage -d 0
+  # 5.4.1.1 Ensure password hashing algorithm is SHA-512. (Automated)
+  - id: 21150
+    title: "Ensure password hashing algorithm is SHA-512."
+    description: "Login passwords are hashed and stored in the /etc/shadow file. Note: These changes only apply to accounts configured on the local system."
+    rationale: "The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords."
+    remediation: "Edit the /etc/login.defs file and modify ENCRYPT_METHOD to SHA512: ENCRYPT_METHOD sha512 Notes: - - - Any system accounts that need to be expired should be carefully done separately by the system administrator to prevent any potential problems If it is determined that the password algorithm being used is not SHA-512, once it is changed, it is recommended that all user ID's be immediately expired and forced to change their passwords on next login, In accordance with local site policies To accomplish this, the following command can be used # awk -F: '( $3<'\"$(awk '/^\\s*UID_MIN/{print $2}' /etc/login.defs)\"' && $1 != \"nfsnobody\" ) { print $1 }' /etc/passwd | xargs -n 1 chage -d 0."
     compliance:
       - cis: ["5.4.1.1"]
-      - cis_csc: ["16.4"]
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["16.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.10.1.1"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
     condition: all
     rules:
-      - 'f:/etc/login.defs -> r:^\s*ENCRYPT_METHOD\s+SHA512'
+      - 'f:/etc/login.defs -> r:ENCRYPT_METHOD\s*\t*SHA512'
 
-  # 5.4.1.2 Ensure password expiration is 365 days or less - Not implemented
-  # 5.4.1.3 Ensure minimum days between password changes is configured - Not implemented
-  # 5.4.1.4 Ensure password expiration warning days is 7 or more - Not implemented
-  # 5.4.1.5 Ensure inactive password lock is 30 days or less - Not implemented
-  # 5.4.1.6 Ensure all users last password change date is in the past - Not implemented
-  # 5.4.2 Ensure system accounts are secured - Not implemented
+  # 5.4.1.2 Ensure password expiration is 365 days or less. (Automated)
+  - id: 21151
+    title: "Ensure password expiration is 365 days or less."
+    description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days. Notes: - A value of -1 will disable password expiration. - The password expiration must be greater than the minimum days between password changes or users will be unable to change their password."
+    rationale: "The window of opportunity for an attacker to leverage compromised credentials via a brute force attack, using already compromised credentials, or gaining the credentials by other means, can be limited by the age of the password. Therefore, reducing the maximum age of a password can also reduce an attacker's window of opportunity. Requiring passwords to be changed helps to mitigate the risk posed by the poor security practice of passwords being used for multiple accounts, and poorly implemented off-boarding and change of responsibility policies. This should not be considered a replacement for proper implementation of these policies and practices. Note: If it is believed that a user's password may have been compromised, the user's account should be locked immediately. Local policy should be followed to ensure the secure update of their password."
+    remediation: "Set the PASS_MAX_DAYS parameter to conform to site policy in /etc/login.defs : PASS_MAX_DAYS 365 Modify user parameters for all users with a password set to match: # chage --maxdays 365 <user>."
+    compliance:
+      - cis: ["5.4.1.2"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MAX_DAYS\s*\t*(\d+) compare <= 365'
+      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:\d+:(\d+): compare > 365'
 
-  # 5.4.3 Ensure default group for the root account is GID 0
-  - id: 21136
-    title: Ensure default group for the root account is GID 0
-    description: >
-      The usermod command can be used to specify which group the root user belongs to. This
-      affects permissions of files that are created by the root user.
-    rationale: >
-      Using GID 0 for the root account helps prevent root -owned files from accidentally
-      becoming accessible to non-privileged users.
-    remediation: >
-      Run the following command to set the root user default group to GID 0 :
-      # usermod -g 0 root
+  # 5.4.1.3 Ensure minimum days between password changes is configured. (Automated)
+  - id: 21152
+    title: "Ensure minimum days between password changes is configured."
+    description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 1 or more days."
+    rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
+    remediation: "Set the PASS_MIN_DAYS parameter to 1 in /etc/login.defs : PASS_MIN_DAYS 1 Modify user parameters for all users with a password set to match: # chage --mindays 1 <user>."
+    compliance:
+      - cis: ["5.4.1.3"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_MIN_DAYS\s*\t*(\d+) compare >= 1'
+      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare < 1'
+
+  # 5.4.1.4 Ensure password expiration warning days is 7 or more. (Automated)
+  - id: 21153
+    title: "Ensure password expiration warning days is 7 or more."
+    description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
+    rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
+    remediation: "Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs : PASS_WARN_AGE 7 Modify user parameters for all users with a password set to match: # chage --warndays 7 <user>."
+    compliance:
+      - cis: ["5.4.1.4"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'f:/etc/login.defs -> n:^\s*\t*PASS_WARN_AGE\s*\t*(\d+) compare >= 7'
+      - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:\d+:\d+:(\d+): compare < 7'
+
+  # 5.4.1.5 Ensure inactive password lock is 30 days or less. (Automated)
+  - id: 21154
+    title: "Ensure inactive password lock is 30 days or less."
+    description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled. Note: A value of -1 would disable this setting."
+    rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
+    remediation: "Run the following command to set the default password inactivity period to 30 days: # useradd -D -f 30 Modify user parameters for all users with a password set to match: # chage --inactive 30 <user>."
+    compliance:
+      - cis: ["5.4.1.5"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.9"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - "not c:useradd -D -> r:^INACTIVE=-1"
+      - 'c:useradd -D -> n:^INACTIVE=(\d+) compare <= 30'
+      - 'not f:/etc/shadow -> n:^\w+:\w+:\w+:\w+:\w+:\w+:(\d+): compare > 30'
+      - 'not f:/etc/shadow -> r:^\w+:\w+:\w+:\w+:\w+:\w+:-1:'
+
+  # 5.4.1.6 Ensure all users last password change date is in the past. (Automated) - Not Implemented
+  # 5.4.2 Ensure system accounts are secured. (Automated) - Not Implemented
+
+  # 5.4.3 Ensure default group for the root account is GID 0. (Automated)
+  - id: 21155
+    title: "Ensure default group for the root account is GID 0."
+    description: "The usermod command can be used to specify which group the root user belongs to. This affects permissions of files that are created by the root user."
+    rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
+    remediation: "Run the following command to set the root user default group to GID 0 : # usermod -g 0 root."
     compliance:
       - cis: ["5.4.3"]
-      - cis_csc: ["5.1"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'f:/etc/passwd -> r:^root:\S+:\S+:0:'
+      - 'f:/etc/passwd -> !r:^\s*\t*# && r:root:\w+:\w+:0:'
 
-  # 5.4.4 Ensure default user shell timeout is configured - Not implemented
-  # 5.4.5 Ensure default user umask is configured - Not implemented
-  # 5.5 Ensure root login is restricted to system console - Not implemented
-  # 5.6 Ensure access to the su command is restricted - Not implemented
-  # 6.1.1 Audit system file permissions
+  # 5.4.4 Ensure default user shell timeout is configured. (Automated) - Not Implemented
+  # 5.4.5 Ensure default user umask is configured. (Automated) - Not Implemented
+  # 5.5 Ensure root login is restricted to system console. (Manual) - Not Implemented
 
-  # 6.1.2 Ensure permissions on /etc/passwd are configured
-  - id: 21137
-    title: Ensure permissions on /etc/passwd are configured.
-    description: >
-      The /etc/passwd file contains user account information that is used by many system
-      utilities and therefore must be readable for these utilities to operate.
-    rationale: >
-      It is critical to ensure that the /etc/passwd file is protected from unauthorized write
-      access. Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following commands to set owner, group, and permissions on /etc/passwd:
+  # 5.6 Ensure access to the su command is restricted. (Automated)
+  - id: 21156
+    title: "Ensure access to the su command is restricted."
+    description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
+    rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
+    remediation: "Create an empty group that will be specified for use of the su command. The group should be named according to site policy. Example # groupadd sugroup Add the following line to the /etc/pam.d/su file, specifying the empty group: auth required pam_wheel.so use_uid group=sugroup."
+    compliance:
+      - cis: ["5.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
+    condition: all
+    rules:
+      - 'f:/etc/pam.d/su -> !r:^\s*\t*# && r:auth && r:required && r:pam_wheel.so && r:use_uid && r:group=\w+'
 
-      # chown root:root /etc/passwd
-      # chmod u-x,g-wx,o-wx /etc/passwd
+  # 6.1.1 Audit system file permissions. (Manual) - Not Implemented
+
+  # 6.1.2 Ensure permissions on /etc/passwd are configured. (Automated)
+  - id: 21157
+    title: "Ensure permissions on /etc/passwd are configured."
+    description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
+    rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to set owner, group, and permissions on /etc/passwd: # chown root:root /etc/passwd # chmod u-x,g-wx,o-wx /etc/passwd."
     compliance:
       - cis: ["6.1.2"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/passwd -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.3 Ensure permissions on /etc/shadow are configured
-  - id: 21138
-    title: Ensure permissions on /etc/shadow are configured.
-    description: >
-      The /etc/shadow file is used to store the information about user accounts that is critical to
-      the security of those accounts, such as the hashed password and other security
-      information.
-    rationale: >
-      If attackers can gain read access to the /etc/shadow file, they can easily run a password
-      cracking program against the hashed password to break it. Other security information that
-      is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the
-      user accounts.
-    remediation: >
-      Run the following commands to set owner, group, and permissions on /etc/shadow:
-
-      # chown root:root /etc/shadow
-      # chmod u-x,g-wx,o-rwx /etc/shadow
+  # 6.1.3 Ensure permissions on /etc/shadow are configured. (Automated)
+  - id: 21158
+    title: "Ensure permissions on /etc/shadow are configured."
+    description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
+    remediation: "Run the following commands to set owner, group, and permissions on /etc/shadow: # chown root:root /etc/shadow # chmod u-x,g-wx,o-rwx /etc/shadow."
     compliance:
       - cis: ["6.1.3"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow -> r:0 root (\d+) shadow && r:644|640|604|600|400|500'
 
-  # 6.1.4 Ensure permissions on /etc/group are configured
-  - id: 21139
-    title: Ensure permissions on /etc/group are configured.
-    description: >
-      The /etc/group file contains a list of all the valid groups defined in the system. The
-      command below allows read/write access for root and read access for everyone else.
-    rationale: >
-      The /etc/group file needs to be protected from unauthorized changes by non-privileged
-      users, but needs to be readable as this information is used with many non-privileged
-      programs.
-    remediation: >
-      Run the following commands to set owner, group, and permissions on /etc/group :
-
-      # chown root:root /etc/group
-      # chmod u-x,g-wx,o-wx /etc/group
+  # 6.1.4 Ensure permissions on /etc/group are configured. (Automated)
+  - id: 21159
+    title: "Ensure permissions on /etc/group are configured."
+    description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
+    rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
+    remediation: "Run the following commands to set owner, group, and permissions on /etc/group : # chown root:root /etc/group # chmod u-x,g-wx,o-wx /etc/group."
     compliance:
       - cis: ["6.1.4"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/group -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/group -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.5 Ensure permissions on /etc/passwd- are configured
-  - id: 21140
-    title: Ensure permissions on /etc/passwd- are configured.
-    description: The /etc/passwd- file contains backup user account information.
-    rationale: >
-      It is critical to ensure that the /etc/passwd- file is protected from unauthorized access.
-      Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following commands to set owner, group, and permissions on /etc/passwd- :
-
-      # chown root:root /etc/passwd-
-      # chmod u-x,go-wx /etc/passwd
+  # 6.1.5 Ensure permissions on /etc/passwd- are configured. (Automated)
+  - id: 21160
+    title: "Ensure permissions on /etc/passwd- are configured."
+    description: "The /etc/passwd- file contains backup user account information."
+    rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to set owner, group, and permissions on /etc/passwd- : # chown root:root /etc/passwd- # chmod u-x,go-wx /etc/passwd-."
     compliance:
       - cis: ["6.1.5"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/passwd -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/passwd- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.6 Ensure permissions on /etc/shadow- are configured
-  - id: 21141
-    title: Ensure permissions on /etc/shadow- are configured
-    description: >
-      The /etc/shadow- file is used to store backup information about user accounts that is
-      critical to the security of those accounts, such as the hashed password and other security
-      information.
-    rationale: >
-      It is critical to ensure that the /etc/shadow- file is protected from unauthorized access.
-      Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following commands to set owner, group, and permissions on /etc/shadow-:
-
-      # chown root:shadow /etc/shadow-
-      # chmod u-x,g-wx,o-rwx /etc/shadow
+  # 6.1.6 Ensure permissions on /etc/shadow- are configured. (Automated)
+  - id: 21161
+    title: "Ensure permissions on /etc/shadow- are configured."
+    description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
+    rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to set owner, group, and permissions on /etc/shadow-: # chown root:shadow /etc/shadow- # chmod u-x,g-wx,o-rwx /etc/shadow-."
     compliance:
       - cis: ["6.1.6"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*15/\s*shadow\)'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow- -> r:0 root (\d+) shadow && r:644|640|604|600|400|500'
 
-  # 6.1.7 Ensure permissions on /etc/group- are configured
-  - id: 21142
-    title: Ensure permissions on /etc/group- are configured.
-    description: The /etc/group- file contains a backup list of all the valid groups defined in the system.
-    rationale: >
-      It is critical to ensure that the /etc/group- file is protected from unauthorized access.
-      Although it is protected by default, the file permissions could be changed either
-      inadvertently or through malicious actions.
-    remediation: >
-      Run the following commands to set owner, group, and permissions on /etc/group-:
-
-      # chown root:root /etc/group-
-      # chmod u-x,go-wx /etc/group-
+  # 6.1.7 Ensure permissions on /etc/group- are configured. (Automated)
+  - id: 21162
+    title: "Ensure permissions on /etc/group- are configured."
+    description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
+    rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
+    remediation: "Run the following commands to set owner, group, and permissions on /etc/group-: # chown root:root /etc/group- # chmod u-x,go-wx /etc/group-."
     compliance:
       - cis: ["6.1.7"]
-      - cis_csc: ["14.6"]
+      - cis_csc_v8: ["3.3"]
+      - cis_csc_v7: ["14.6"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
+      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
+      - iso_27001-2013: ["A.9.1.1"]
+      - nist_sp_800-53: ["AC-5", "AC-6"]
+      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
+      - pci_dss_v4.0: ["1.3.1", "7.1"]
+      - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -L /etc/group- -> r:^Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*0/\s*root\)\s*Gid:\s*\(\s*0/\s*root\)'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/group- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.8 Ensure no world writable files exist - Not implemented
-  # 6.1.9 Ensure no unowned files or directories exist - Not implemented
-  # 6.1.10 Ensure no ungrouped files or directories exist - Not implemented
-  # 6.1.11 Audit SUID executables - Not implemented
-  # 6.1.12 Audit SGID executables - Not implemented
+  # 6.1.8 Ensure no world writable files exist. (Automated) - Not Implemented
+  # 6.1.9 Ensure no unowned files or directories exist. (Automated) - Not Implemented
+  # 6.1.10 Ensure no ungrouped files or directories exist. (Automated) - Not Implemented
+  # 6.1.11 Audit SUID executables. (Manual) - Not Implemented
+  # 6.1.12 Audit SGID executables. (Manual) - Not Implemented
 
-  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords
-  - id: 21143
-    title: Ensure accounts in /etc/passwd use shadowed passwords.
-    description: >
-      Local accounts can uses shadowed passwords. With shadowed passwords, The passwords
-      are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash.
-      Accounts with a shadowed password have an x in the second field in /etc/passwd.
-    rationale: >
-      The /etc/passwd file also contains information like user ID's and group ID's that are used
-      by many system programs. Therefore, the /etc/passwd file must remain world readable. In
-      spite of encoding the password with a randomly-generated one-way hash function, an
-      attacker could still break the system if they got access to the /etc/passwd file. This can be
-      mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd
-      file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write.
-      This helps mitigate the risk of an attacker gaining access to the encoded passwords with
-      which to perform a dictionary attack.
-
-      Notes:
-        - All accounts must have passwords or be locked to prevent the account from being used
-          by an unauthorized user.
-        - A user account with an empty second field in /etc/passwd allows the account to be
-          logged into by providing only the username.
-    remediation: >
-      If any accounts in the /etc/passwd file do not have a single x in the password field, run the
-      following command to set these accounts to use shadowed passwords:
-
-      # sed -e 's/^\([a-zA-Z0-9_]*\):[^:]*:/\1:x:/' -i /etc/passwd
-
-      Investigate to determine if the account is logged in and what it is being used for, to
-      determine if it needs to be forced off.
+  # 6.2.1 Ensure accounts in /etc/passwd use shadowed passwords. (Automated)
+  - id: 21163
+    title: "Ensure accounts in /etc/passwd use shadowed passwords."
+    description: "Local accounts can uses shadowed passwords. With shadowed passwords, The passwords are saved in shadow password file, /etc/shadow, encrypted by a salted one-way hash. Accounts with a shadowed password have an x in the second field in /etc/passwd."
+    rationale: "The /etc/passwd file also contains information like user ID's and group ID's that are used by many system programs. Therefore, the /etc/passwd file must remain world readable. In spite of encoding the password with a randomly-generated one-way hash function, an attacker could still break the system if they got access to the /etc/passwd file. This can be mitigated by using shadowed passwords, thus moving the passwords in the /etc/passwd file to /etc/shadow. The /etc/shadow file is set so only root will be able to read and write. This helps mitigate the risk of an attacker gaining access to the encoded passwords with which to perform a dictionary attack. Notes: - All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user. - A user account with an empty second field in /etc/passwd allows the account to be logged into by providing only the username."
+    remediation: "If any accounts in the /etc/passwd file do not have a single x in the password field, run the following command to set these accounts to use shadowed passwords: # sed -e 's/^\\([a-zA-Z0-9_]*\\):[^:]*:/\\1:x:/' -i /etc/passwd Investigate to determine if the account is logged in and what it is being used for, to determine if it needs to be forced off."
     compliance:
       - cis: ["6.2.1"]
-      - cis_csc: ["4.4"]
-    condition: none
+      - cis_csc_v8: ["3.11"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
+      - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - nist_sp_800-53: ["SC-28", "SC-28(1)"]
+      - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
+      - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
+      - soc_2: ["CC6.1"]
+    condition: all
     rules:
-      - 'f:/etc/passwd -> !r:^\.+:x:'
+      - 'not f:/etc/passwd -> !r:^\w+:x:'
 
-  # 6.2.2 Ensure /etc/shadow password fields are not empty
-  - id: 21144
-    title: Ensure /etc/shadow password fields are not empty.
-    description: >
-      An account with an empty password field means that anybody may log in as that user
-      without providing a password.
-    rationale: >
-      All accounts must have passwords or be locked to prevent the account from being used by
-      an unauthorized user.
-    remediation: >
-      If any accounts in the /etc/shadow file do not have a password, run the following command
-      to lock the account until it can be determined why it does not have a password:
-
-      # passwd -l <username>
-
-      Also, check to see if the account is logged in and investigate what it is being used for to
-      determine if it needs to be forced off.
+  # 6.2.2 Ensure /etc/shadow password fields are not empty. (Automated)
+  - id: 21164
+    title: "Ensure /etc/shadow password fields are not empty."
+    description: "An account with an empty password field means that anybody may log in as that user without providing a password."
+    rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
+    remediation: "If any accounts in the /etc/shadow file do not have a password, run the following command to lock the account until it can be determined why it does not have a password: # passwd -l <username> Also, check to see if the account is logged in and investigate what it is being used for to determine if it needs to be forced off."
     compliance:
       - cis: ["6.2.2"]
-      - cis_csc: ["4.4"]
-    condition: none
+      - cis_csc_v8: ["5.2"]
+      - cis_csc_v7: ["4.4"]
+      - cmmc_v2.0: ["IA.L2-3.5.7"]
+      - iso_27001-2013: ["A.9.4.3"]
+      - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
+      - soc_2: ["CC6.1"]
+    condition: all
     rules:
-      - "c:grep -E ^[^:]+:: /etc/shadow -> r:::"
+      - 'not f:/etc/shadow -> r:^\w+::'
 
-  # 6.2.3 Ensure root is the only UID 0 account
-  - id: 21145
-    title: Ensure root is the only UID 0 account.
-    description: Any account with UID 0 has superuser privileges on the system.
-    rationale: >
-      This access must be limited to only the default root account and only from the system
-      console. Administrative access must be through an unprivileged account using an approved
-      mechanism as noted in Item 5.6 Ensure access to the su command is restricted.
-    remediation: >
-      Remove any users other than root with UID 0 or assign them a new UID if appropriate.
+  # 6.2.3 Ensure root is the only UID 0 account. (Automated)
+  - id: 21165
+    title: "Ensure root is the only UID 0 account."
+    description: "Any account with UID 0 has superuser privileges on the system."
+    rationale: "This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in Item 5.6 Ensure access to the su command is restricted."
+    remediation: "Remove any users other than root with UID 0 or assign them a new UID if appropriate."
     compliance:
       - cis: ["6.2.3"]
-      - cis_csc: ["5.1"]
-    condition: none
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
     rules:
-      - 'f:/etc/passwd -> !r:^\s*\t*# && !r:^\s*\t*root: && r:^\w+:\w+:0:'
-# 6.2.4 Ensure root PATH Integrity - Not implemented
-# 6.2.5 Ensure all users' home directories exist - Not implemented
-# 6.2.6 Ensure users' home directories permissions are 750 or more restrictive - Not implemented
-# 6.2.7 Ensure users own their home directories - Not implemented
-# 6.2.8 Ensure users' dot files are not group or world writable - Not implemented
-# 6.2.9 6.2.9 Ensure no users have .forward files - Not implemented
-# 6.2.10 Ensure no users have .netrc files - Not implemented
-# 6.2.11 Ensure users' .netrc Files are not group or world accessible - Not implemented
-# 6.2.12 Ensure no users have .rhosts files - Not implemented
-# 6.2.13 Ensure all groups in /etc/passwd exist in /etc/group - Not implemented
-# 6.2.14 Ensure no duplicate UIDs exist - Not implemented
-# 6.2.15 Ensure no duplicate GIDs exist - Not implemented
-# 6.2.16 Ensure no duplicate user names exist - Not implemented
-# 6.2.17 Ensure no duplicate group names exist - Not implemented
-# 6.2.18 Ensure shadow group is empty - Not implemented
+      - 'not f:/etc/passwd -> !r:^\s*\t*# && !r:^root: && r:^\w+:\w+:0:'
+
+  # 6.2.4 Ensure root PATH Integrity. (Automated) - Not Implemented
+  # 6.2.5 Ensure all users' home directories exist. (Automated) - Not Implemented
+  # 6.2.6 Ensure users' home directories permissions are 750 or more restrictive. (Automated) - Not Implemented
+  # 6.2.7 Ensure users own their home directories. (Automated) - Not Implemented
+  # 6.2.8 Ensure users' dot files are not group or world writable. (Automated) - Not Implemented
+  # 6.2.9 Ensure no users have .forward files. (Automated) - Not Implemented
+  # 6.2.10 Ensure no users have .netrc files. (Automated) - Not Implemented
+  # 6.2.11 Ensure users' .netrc Files are not group or world accessible. (Automated) - Not Implemented
+  # 6.2.12 Ensure no users have .rhosts files. (Automated) - Not Implemented
+  # 6.2.13 Ensure all groups in /etc/passwd exist in /etc/group. (Automated) - Not Implemented
+  # 6.2.14 Ensure no duplicate UIDs exist. (Automated) - Not Implemented
+  # 6.2.15 Ensure no duplicate GIDs exist. (Automated) - Not Implemented
+  # 6.2.16 Ensure no duplicate user names exist. (Automated) - Not Implemented
+  # 6.2.17 Ensure no duplicate group names exist. (Automated)
+
+  # 6.2.18 Ensure shadow group is empty. (Automated)
+  - id: 21166
+    title: "Ensure shadow group is empty."
+    description: "The shadow group allows system programs which require access the ability to read the /etc/shadow file. No users should be assigned to the shadow group."
+    rationale: "Any users assigned to the shadow group would be granted read access to the /etc/shadow file. If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed passwords to break them. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert additional user accounts."
+    remediation: "Remove all users from the shadow group, and change the primary group of any users with shadow as their primary group."
+    compliance:
+      - cis: ["6.2.18"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["5.1"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - 'f:/etc/group -> r:shadow:\w*:\d+:$'


### PR DESCRIPTION
| Component | Action type           | Main Issue 
| --- | --- | ---
| SCA       | Rework |  #18306


## Main tasks

- [x] Use the latest CIS benchmark PDF from https://downloads.cisecurity.org/#/ -  CIS SUSE Linux Enterprise 15 Benchmark v1.1.1
- [x] Verify IDs numbers.
- [x] Verify texts are correct: Title, Description, Rationale and Remediation.
- [x] Verify Compliance: CIS, CIS_CSC.
- [x] Verify condtion and rules:
  - [x] To Pass.
  - [x] To Fail.

## Checks
### Syntax and semantic

- [x] a) ID of each policy must be contiguous.
- [x] b) The order and format set in [Documentation](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html) must be respected.
- [x] c) YML must be valid to avoid errors.

### Content

- [x] a) Compare each check with its analogue from CIS Benchmark.
- [x] b) Try to maintain each rule as similar as possible with the `Audit` section from the CIS check.
- [x] c) Check that the commands provide the expected output.
- [x] d) When a failure is discovered, check similar policies to avoid repetition of the issue.

### Unit testing

- [x] a) Output from `ossec.log` after the SCA scan and a raw output of the result of the checks.
<details><summary>Tests results</summary>
<p>

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

```
2023/11/03 20:33:53 sca[22891] wm_sca.c:2598 at wm_sca_send_summary(): DEBUG: Sending summary event for file: 'cis_sles15_linux.yml'
2023/11/03 20:33:53 sca[22891] wm_sca.c:271 at wm_sca_send_alert(): DEBUG: Sending event: {"type":"summary","scan_id":2057074577,"name":"CIS SUSE Linux Enterprise 15 Benchmark v1.1.1","policy_id":"cis_sles15_linux","file":"cis_sles15_linux.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for SUSE Linux Enterprise 15 systems running on x86 and x64 platforms. This document was tested against SUSE Linux Enterprise Server 15 SP1.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":73,"failed":84,"invalid":12,"total_checks":169,"score":46.4968147277832,"start_time":1699043626,"end_time":1699043630,"hash":"9f193a571f070d6194d47afa9b563e11dac8897a1d218c7843bb282d6a71ac2b","hash_file":"f602b87ec68463fd7546242abe5fdee6d9d8f8cf13aad98a7270f806eeed05d6","first_scan":1}
```
</p>
</details>

### Deployment

- [x] a) If the policy it's new, it must be added to the `sca.files` templates.
- [x] b) If the OS has many supported SCA policies, a policy must be set as default policy. ([as example](https://github.com/wazuh/wazuh/blob/master/etc/templates/config/centos/sca.files))