### PR TITLE
Rework SCA Policy for Apple macOS 13.0 Ventura

### DIFF
--- a/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
+++ b/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
@@ -1,6 +1,4 @@
-# Security Configuration Assessment
-# CIS Checks for Apple macOS 13.x Ventura
-# Copyright (C) 2023, Wazuh Inc.
+# Copyright (C) 2015, Wazuh Inc.
 #
 # This program is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public
@@ -8,19 +6,19 @@
 # Foundation
 #
 # Based on:
-# SCA policy for Apple macOS 13.x Ventura based on Center for Internet Security Apple macOS 13.x Ventura Benchmark v1.0.0 - 11-14-2022
+# Center for Internet Security Mac0S 13 Ventura Benchmark v1.1.0 - 07-24-2023
 
 policy:
-  id: "cis_macOS_13"
-  file: "cis_apple_macOS_13.x.yml"
-  name: "CIS Apple macOS 13.0 Ventura Benchmark v1.0.0"
-  description: "This document provides prescriptive guidance for establishing a secure configuration posture for Apple macOS 13.x. This guide was tested against Apple macOS 13.x."
+  id: "cis_macOS_13.0_Ventura.yml"
+  file: "cis_macOS_13.0_Ventura.yml"
+  name: "CIS_Apple_macOS_13.0_Ventura_Benchmark_v1.1.0"
+  description: "This document provides prescriptive guidance for establishing a secure configuration posture for MacOS 13 Ventura systems."
   references:
     - https://www.cisecurity.org/cis-benchmarks/
 
 requirements:
-  title: "Check Apple macOS version."
-  description: "Requirements for running the SCA scan against Apple macOS 13.x Ventura."
+  title: "Check MacOS 13 Ventura platform."
+  description: "Requirements for running the policy against MacOS 13 Ventura."
   condition: any
   rules:
     - 'c:sw_vers -> r:^ProductVersion:\t*\s*13\p'
@@ -32,33 +30,15 @@ checks:
   # 1 Install Updates, Patches and Additional Security Software
   ##########################################################################
 
-  # 1.1 Ensure All Apple-provided Software Is Current. (Automated)
-  - id: 31000
-    title: "Ensure All Apple-provided Software Is Current."
-    description: 'Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update. Software updates should be run at minimum every 30 days. Run the following command to verify when software update was previously run: $ /usr/bin/sudo defaults read /Library/Preferences/com.apple.SoftwareUpdate | grep -e LastFullSuccessfulDate. The response should be in the last 30 days (Example): LastFullSuccessfulDate = "2020-07-30 12:45:25 +0000";.'
-    rationale: "It is important that these updates be applied in a timely manner to prevent unauthorized persons from exploiting the identified vulnerabilities."
-    impact: "Missing patches can lead to more exploit opportunities."
-    remediation: "Graphical Method: Perform the following to install all available software updates: 1. Open System Settings 2. Select General 3. Select Software Update 4. Select Update All Terminal Method: Run the following command to verify what packages need to be installed: $ /usr/bin/sudo /usr/sbin/softwareupdate -l The output will include the following: Software Update found the following new or updated software: Run the following command to install all the packages that need to be updated: $ /usr/bin/sudo /usr/sbin/softwareupdate -i -a -R Or run the following command to install individual packages: $ /usr/bin/sudo /usr/sbin/softwareupdate -i '<package name>' example: $ /usr/bin/sudo /usr/sbin/softwareupdate -l Software Update Tool Finding available software Software Update found the following new or updated software: * iTunesX-12.8.2 iTunes (12.8.2), 273614K [recommended] $ /usr/bin/sudo /usr/sbin/softwareupdate -i 'iTunesX-12.8.2' Software Update Tool Downloaded iTunes Installing iTunes Done with iTunes Done."
-    compliance:
-      - cis: ["1.1"]
-      - cis_csc_v8: ["7.3", "7.4"]
-      - cis_csc_v7: ["3.4", "3.5"]
-      - cmmc_v2.0: ["SI.L1-3.14.1"]
-      - mitre_techniques: ["T1017", "T1019", "T1031", "T1034", "T1038", "T1044", "T1053", "T1068", "T1072", "T1073", "T1075", "T1076", "T1078", "T1081", "T1088", "T1100", "T1103", "T1114", "T1137", "T1138", "T1145", "T1161", "T1176", "T1189", "T1190", "T1195", "T1210", "T1211", "T1212", "T1213", "T1214", "T1482", "T1484", "T1495", "T1505", "T1525", "T1527", "T1528", "T1530"]
-      - nist_sp_800-53: ["SI-2(2)"]
-      - pci_dss_v3.2.1: ["6.2"]
-      - soc_2: ["CC7.1"]
-    condition: all
-    rules:
-      - "c:softwareupdate -l -> r:No new software available."
+  # 1.1 Ensure All Apple-provided Software Is Current (Automated) - Not Implemented
 
   # 1.2 Ensure Auto Update Is Enabled. (Automated)
-  - id: 31001
+  - id: 30000
     title: "Ensure Auto Update Is Enabled."
     description: 'Auto Update verifies that your system has the newest security patches and software updates. If "Automatically check for updates" is not selected, background updates for new malware definition files from Apple for XProtect and Gatekeeper will not occur. http://macops.ca/os-x-admins-your-clients-are-not-getting-background-security-updates/ https://derflounder.wordpress.com/2014/12/17/forcing-xprotect-blacklist-updates-on-mavericks-and-yosemite/.'
     rationale: "It is important that a system has the newest updates applied so as to prevent unauthorized persons from exploiting identified vulnerabilities."
     impact: "Without automatic update, updates may not be made in a timely manner and the system will be exposed to additional risk."
-    remediation: "Graphical Method: Perform the steps following to enable the system to automatically check for updates: 1. Open System Settings 2. Select General 3. Select Software Update 4. Select the i 5. Set Check for updates to enabled 6. Select Done Terminal Method: Run the following command to enable auto update: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool true Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.SoftwareUpdate 2. The key to include is AutomaticCheckEnabled 3. The key must be set to <true/>."
+    remediation: "Graphical Method: Perform the following steps to enable the system to automatically check for updates: 1. Open System Settings 2. Select General 3. Select Software Update 4. Select the i 5. Set Check for updates to enabled 6. Select Done Terminal Method: Run the following command to enable auto update: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool true Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.SoftwareUpdate 2. The key to include is AutomaticCheckEnabled 3. The key must be set to <true/>."
     compliance:
       - cis: ["1.2"]
       - cis_csc_v8: ["7.3", "7.4"]
@@ -67,14 +47,13 @@ checks:
       - nist_sp_800-53: ["SI-2(2)"]
       - pci_dss_v3.2.1: ["6.2"]
       - soc_2: ["CC7.1"]
-      - mitre_techniques: ["T1103", "T1017", "T1138", "T1189", "T1190", "T1212", "T1211", "T1068", "T1210", "T1495", "T1137", "T1075", "T1195", "T1019", "T1072", "T1100", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticCheckEnabled'')" -> r:^1$'
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticCheckEnabled'')" -> r:\.+'
 
   # 1.3 Ensure Download New Updates When Available Is Enabled. (Automated)
-  - id: 31002
+  - id: 30001
     title: "Ensure Download New Updates When Available Is Enabled."
     description: 'In the GUI, both "Install macOS updates" and "Install app updates from the App Store" are dependent on whether "Download new updates when available" is selected.'
     rationale: "It is important that a system has the newest updates downloaded so that they can be applied."
@@ -88,14 +67,13 @@ checks:
       - nist_sp_800-53: ["SI-2(2)"]
       - pci_dss_v3.2.1: ["6.2"]
       - soc_2: ["CC7.1"]
-      - mitre_techniques: ["T1103", "T1017", "T1138", "T1189", "T1190", "T1212", "T1211", "T1068", "T1210", "T1495", "T1137", "T1075", "T1195", "T1019", "T1072", "T1100", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticDownload'')" -> r:^1$'
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticDownload'')" -> r:\.+'
 
   # 1.4 Ensure Install of macOS Updates Is Enabled. (Automated)
-  - id: 31003
+  - id: 30002
     title: "Ensure Install of macOS Updates Is Enabled."
     description: "Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off simply to allow the administrator to contact users in order to verify installation. A dependable, repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off."
     rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited."
@@ -109,14 +87,13 @@ checks:
       - nist_sp_800-53: ["SI-2(2)"]
       - pci_dss_v3.2.1: ["6.2"]
       - soc_2: ["CC7.1"]
-      - mitre_techniques: ["T1103", "T1017", "T1138", "T1189", "T1190", "T1212", "T1211", "T1068", "T1210", "T1495", "T1137", "T1075", "T1195", "T1019", "T1072", "T1100", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticallyInstallMacOSUpdates'')" -> r:^1$'
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''AutomaticallyInstallMacOSUpdates'')" -> r:\.+'
 
   # 1.5 Ensure Install Application Updates from the App Store Is Enabled. (Automated)
-  - id: 31004
+  - id: 30003
     title: "Ensure Install Application Updates from the App Store Is Enabled."
     description: "Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or administrator privileges for end users."
     rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited."
@@ -130,23 +107,22 @@ checks:
       - nist_sp_800-53: ["SI-2(2)"]
       - pci_dss_v3.2.1: ["6.2"]
       - soc_2: ["CC7.1"]
-      - mitre_techniques: ["T1103", "T1017", "T1138", "T1189", "T1190", "T1212", "T1211", "T1068", "T1210", "T1495", "T1137", "T1075", "T1195", "T1019", "T1072", "T1100", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: all
     rules:
       - "c:defaults read /Library/Preferences/com.apple.commerce AutoUpdate -> r:^1$"
 
   # 1.6 Ensure Install Security Responses and System Files Is Enabled. (Automated)
-  - id: 31005
+  - id: 30004
     title: "Ensure Install Security Responses and System Files Is Enabled."
-    description: "Ensure that system and security updates are installed after they are available from Apple. This setting enables definition updates for XProtect and Gatekeeper. With this setting in place, new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights."
+    description: "Ensure that system and security updates are installed after they are available from Apple. This setting enables definition updates for XProtect and Gatekeeper. With this setting in place, new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights. Apple has introduced a security feature that allows for smaller downloads and the installation of security updates when a reboot is not required. This feature is only available when the last regular update has already been applied. This feature emphasizes that a Mac must be up-to-date on patches so that Apple's security tools can be used to quickly patch when a rapid response is necessary."
     rationale: "Patches need to be applied in a timely manner to reduce the risk of vulnerabilities being exploited."
     impact: "Unpatched software may be exploited."
     remediation: "Graphical Method: Perform the following steps to enable system data files and security updates to install automatically: 1. Open System Settings 2. Select General 3. Select Software Update 4. Select the i 5. Set Install Security Responses and System files to enabled 6. Select Done Terminal Method: Run the following commands to enable automatic checking of system data files and security updates: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.SoftwareUpdate 2. The key to include is ConfigDataInstall 3. The key must be set to <true/> 4. The key to also include is CriticalUpdateInstall 5. The key must be set to <true/>."
     references:
-      - https://eclecticlight.co/2021/10/27/silently-updated-security-data-files-in-monterey/
-      - https://support.apple.com/en-us/HT202491
-      - https://support.apple.com/guide/security/protecting-against-malware-sec469d47bd8/web
-      - https://support.apple.com/guide/deployment/rapid-security-responses-dep93ff7ea78/1/web/1.0
+      - "https://eclecticlight.co/2021/10/27/silently-updated-security-data-files-in-"
+      - "https://support.apple.com/en-us/HT202491"
+      - "https://support.apple.com/guide/security/protecting-against-malware-"
+      - "https://support.apple.com/guide/deployment/rapid-security-responses-"
     compliance:
       - cis: ["1.6"]
       - cis_csc_v8: ["7.3", "7.4", "7.7"]
@@ -156,21 +132,20 @@ checks:
       - pci_dss_v3.2.1: ["6.2"]
       - pci_dss_v4.0: ["11.3.1", "11.3.2", "11.3.2.1"]
       - soc_2: ["CC7.1"]
-      - mitre_techniques: ["T1103", "T1017", "T1138", "T1189", "T1190", "T1212", "T1211", "T1068", "T1210", "T1495", "T1137", "T1075", "T1195", "T1019", "T1072", "T1100", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''ConfigDataInstall'')" && c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''CriticalUpdateInstall'')" -> r:^1$'
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''ConfigDataInstall'')" && c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.SoftwareUpdate'').objectForKey(''CriticalUpdateInstall'')" -> r:\.+'
 
   # 1.7 Ensure Software Update Deferment Is Less Than or Equal to 30 Days. (Automated)
-  - id: 31006
+  - id: 30005
     title: "Ensure Software Update Deferment Is Less Than or Equal to 30 Days."
     description: "Apple provides the capability to manage software updates on Apple devices through mobile device management. Part of those capabilities permit organizations to defer software updates and allow for testing. Many organizations have specialized software and configurations that may be negatively impacted by Apple updates. If software updates are deferred, they should not be deferred for more than 30 days. This control only verifies that deferred software updates are not deferred for more than 30 days."
     rationale: "Apple software updates almost always include security updates. Attackers evaluate updates to create exploit code in order to attack unpatched systems. The longer a system remains unpatched, the greater an exploit possibility exists in which there are publicly reported vulnerabilities."
     impact: "Some organizations may need more than 30 days to evaluate the impact of software updates."
     remediation: "Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.applicationaccess 2. The key to include is enforcedSoftwareUpdateDelay 3. The key must be set to <integer><1-30></integer>."
     references:
-      - https://support.apple.com/guide/deployment/manage-software-updates-depc4c80847a/web
+      - "https://support.apple.com/guide/deployment/manage-software-updates-"
     compliance:
       - cis: ["1.7"]
       - cis_csc_v8: ["7.3", "7.4"]
@@ -179,26 +154,19 @@ checks:
       - nist_sp_800-53: ["SI-2(2)"]
       - pci_dss_v3.2.1: ["6.2"]
       - soc_2: ["CC7.1"]
-      - mitre_techniques: ["T1103", "T1017", "T1138", "T1189", "T1190", "T1212", "T1211", "T1068", "T1210", "T1495", "T1137", "T1075", "T1195", "T1019", "T1072", "T1100", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: any
     rules:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.applicationaccess'').objectForKey(''enforcedSoftwareUpdateDelay'')" -> n:^(\d+)$ compare <= 30'
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.applicationaccess'').objectForKey(''enforcedSoftwareUpdateDelay'')" -> r:\.+'
 
-  ############################################################
-  # 2 System Settings
-  ############################################################
-
-  # 2.1 Apple ID
-  # 2.1.1 iCloud
-  # 2.1.1.1 Audit iCloud Keychain (Manual) - Not implemented
-  # 2.1.1.2 Audit iCloud Drive (Manual) - Not implemented
-  # 2.1.1.3 Ensure iCloud Drive Document and Desktop Sync Is Disabled (Automated) - Not Implemented
-  # 2.1.2 Audit App Store Password Settings (Manual) - Not implemented
-  # 2.2 Network
+  # 2.1.1.1 Audit iCloud Keychain. (Manual) - Not Implemented
+  # 2.1.1.2 Audit iCloud Drive. (Manual) - Not Implemented
+  # 2.1.1.3 Ensure iCloud Drive Document and Desktop Sync Is Disabled. (Automated) - Not Implemented
+  # 2.1.1.4 Audit Security Keys Used With AppleIDs. (Manual) - Not Implemented
+  # 2.1.2 Audit App Store Password Settings. (Manual) - Not Implemented
 
   # 2.2.1 Ensure Firewall Is Enabled. (Automated)
-  - id: 31007
+  - id: 30006
     title: "Ensure Firewall Is Enabled."
     description: "A firewall is a piece of software that blocks unwanted incoming connections to a system. Apple has posted general documentation about the application firewall:."
     rationale: "A firewall minimizes the threat of unauthorized users gaining access to your system while connected to a network or the Internet."
@@ -214,7 +182,6 @@ checks:
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L1-3.1.20", "AU.L2-3.3.5", "AU.L2-3.3.6", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "SC.L1-3.13.1", "SC.L2-3.13.6", "SI.L2-3.14.3", "SI.L2-3.14.7"]
       - hipaa: ["164.312(b)"]
       - iso_27001-2013: ["A.13.1.1", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["AU-6(1)", "AU-7", "CM-7(1)", "CM-9", "IR-4(1)", "SA-10", "SC-7(5)", "SI-4(2)", "SI-4(5)"]
       - pci_dss_v3.2.1: ["1.1.4", "1.4", "10.5.3", "10.6.1", "11.5", "2.2"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "10.7", "10.7.1", "10.7.2", "10.7.3", "11.5", "2.1.1", "2.2.1"]
@@ -225,12 +192,12 @@ checks:
       - "c:defaults read /Library/Preferences/com.apple.security.firewall EnableFirewall -> r:^1$|^2$|^true$"
 
   # 2.2.2 Ensure Firewall Stealth Mode Is Enabled. (Automated)
-  - id: 31008
+  - id: 30007
     title: "Ensure Firewall Stealth Mode Is Enabled."
     description: "While in Stealth mode, the computer will not respond to unsolicited probes, dropping that traffic."
     rationale: "Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet."
     impact: "Traditional network discovery tools like ping will not succeed. Other network tools that measure activity and approved applications will work as expected. This control aligns with the primary macOS use case of a laptop that is often connected to untrusted networks where host segregation may be non-existent. In that use case, hiding from the other inmates is likely more than desirable. In use cases where use is only on trusted LANs with static IP addresses, stealth mode may not be desirable."
-    remediation: "Graphical Method: Perform the following steps to enable firewall stealth mode: 1. Open System Settings 2. Select Network 3. Select Firewall 4. Select Options... 5. Set Enabled stealth mode to enabled Terminal Method: Run the following command to enable stealth mode: $ /usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on Stealth mode enabled Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.security.firewall 2. The key to include is EnableStealthMode 3. The key must be set to <true/> Note: This key must be set in the same configuration profile with EnableFirewall set to <true/>. If it is set in its own configuration profile, it will fail."
+    remediation: "Graphical Method: Perform the following steps to enable firewall stealth mode: 1. Open System Settings 2. Select Network 3. Select Firewall 4. Select Options... 5. Set Enabled stealth mode to enabled Terminal Method: Run the following command to enable stealth mode: $ /usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw -- setstealthmode on Stealth mode enabled Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.security.firewall 2. The key to include is EnableStealthMode 3. The key must be set to <true/> Note: This key must be set in the same configuration profile with EnableFirewall set to <true/>. If it is set in its own configuration profile, it will fail."
     references:
       - "http://support.apple.com/en-us/HT201642"
     compliance:
@@ -239,7 +206,6 @@ checks:
       - cis_csc_v7: ["5.1", "9.4"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L1-3.1.20", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L1-3.13.1", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10", "SC-7(5)"]
       - pci_dss_v3.2.1: ["1.1.4", "1.1.6", "1.2.1", "1.4", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -249,14 +215,11 @@ checks:
       - "c:defaults read /Library/Preferences/com.apple.alf stealthenabled -> r:^1$|^2$"
       - "c:defaults read /Library/Preferences/com.apple.security.firewall EnableStealthMode -> r:^1$|^2$|^true$"
 
-  # 2.3 General
-  # 2.3.1 AirDrop & Handoff
-  # 2.3.1.1 Ensure AirDrop Is Disabled (Automated) - Not Implemented
-  # 2.3.1.2 Ensure AirPlay Receiver Is Disabled (Automated) - Not Implemented
-  # 2.3.2 Date & Time
+  # 2.3.1.1 Ensure AirDrop Is Disabled When Not Actively Transferring Files. (Automated) - Not Implemented
+  # 2.3.1.2 Ensure AirPlay Receiver Is Disabled. (Automated) - Not Implemented
 
   # 2.3.2.1 Ensure Set Time and Date Automatically Is Enabled. (Automated)
-  - id: 31009
+  - id: 30008
     title: "Ensure Set Time and Date Automatically Is Enabled."
     description: "Correct date and time settings are required for authentication protocols, file creation, modification dates, and log entries. Note: If your organization has internal time servers, enter them here. Enterprise mobile devices may need to use a mix of internal and external time servers. If multiple servers are required, use the Date & Time System Preference with each server separated by a space. Additional Note: The default Apple time server is time.apple.com. Variations include time.euro.apple.com. While it is certainly more efficient to use internal time servers, there is no reason to block access to global Apple time servers or to add a time.apple.com alias to internal DNS records. There are no reports that Apple gathers any information from NTP synchronization, as the computers already phone home to Apple for Apple services including iCloud use and software updates. Best practice is to allow DNS resolution to an authoritative time service for time.apple.com, preferably to connect to Apple servers, but local servers are acceptable as well."
     rationale: "Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes. This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features."
@@ -277,7 +240,7 @@ checks:
       - 'c:/usr/sbin/systemsetup -getusingnetworktime -> r:Network Time:\s*\t*On'
 
   # 2.3.2.2 Ensure Time Is Set Within Appropriate Limits. (Automated)
-  - id: 31010
+  - id: 30009
     title: "Ensure Time Is Set Within Appropriate Limits."
     description: "Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries. Ensure that time on the computer is within acceptable limits. Truly accurate time is measured within milliseconds. For this audit, a drift under four and a half minutes passes the control check. Since Kerberos is one of the important features of macOS integration into Directory systems, the guidance here is to warn you before there could be an impact to operations. From the perspective of accurate time, this check is not strict, so it may be too great for your organization. Your organization can adjust to a smaller offset value as needed. If there are consistent drift issues on the OS, some of the most common drift issues should be investigated: - The chosen time server is not reachable based on network firewall rules on the current network - The computer is offline often and the battery drains, and the network is not immediately available - The chosen time server is a special internal or non-public time server that does not provide a reliable time source Note: ntpdate has been deprecated with 10.14. sntp replaces that command."
     rationale: "Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes. This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features. Audit check is for more than 4 minutes and 30 seconds ahead or behind."
@@ -297,10 +260,8 @@ checks:
     rules:
       - "c:systemsetup -getnetworktimeserver -> r:Network Time Server:"
 
-  # 2.3.3 Sharing
-
   # 2.3.3.1 Ensure DVD or CD Sharing Is Disabled. (Automated)
-  - id: 31011
+  - id: 30010
     title: "Ensure DVD or CD Sharing Is Disabled."
     description: "DVD or CD Sharing allows users to remotely access the system's optical drive. While Apple does not ship Macs with built-in optical drives any longer, external optical drives are still recognized when they are connected. In testing, the sharing of an external optical drive persists when a drive is reconnected."
     rationale: "Disabling DVD or CD Sharing minimizes the risk of an attacker using the optical drive as a vector for attack and exposure of sensitive data."
@@ -312,7 +273,6 @@ checks:
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -322,21 +282,20 @@ checks:
       - 'c:sh -c "launchctl list | grep -c com.apple.ODSAgent" -> r:^0$'
 
   # 2.3.3.2 Ensure Screen Sharing Is Disabled. (Automated)
-  - id: 31012
+  - id: 30011
     title: "Ensure Screen Sharing Is Disabled."
-    description: "Screen Sharing allows a computer to connect to another computer on a network and display the computer's screen. While sharing the computer's screen, the user can control what happens on that computer, such as opening documents or applications, opening, moving, or closing windows, and even shutting down the computer. While mature administration and management does not use graphical connections for standard maintenance, most help desks have capabilities to assist users in performing their work when they have technical issues and need support. Help desks use graphical remote tools to understand what the user sees and assist them so they can get back to work. For MacOS, some of these remote capabilities can use Apple's OS tools. Control is therefore not meant to prohibit the use of a just-in-time graphical view from authorized personnel with authentication controls. Sharing should not be enabled except in narrow windows when help desk support is required."
+    description: "Screen Sharing allows a computer to connect to another computer on a network and display the computer's screen. While sharing the computer's screen, the user can control what happens on that computer, such as opening documents or applications, opening, moving, or closing windows, and even shutting down the computer. While mature administration and management does not use graphical connections for standard maintenance, most help desks have capabilities to assist users in performing their work when they have technical issues and need support. Help desks use graphical remote tools to understand what the user sees and assist them so they can get back to work. For MacOS, some of these remote capabilities can use Apple's OS tools. Control is therefore not meant to prohibit the use of a just-in-time graphical view from authorized personnel with authentication controls. Sharing should not be enabled except in narrow windows when help desk support is required. Screen Sharing on macOS can allow the use of the insecure VNC protocol. VNC is a clear text protocol that should not be used on macOS."
     rationale: "Disabling Screen Sharing mitigates the risk of remote connections being made without the user of the console knowing that they are sharing the computer."
     impact: "Help desks may require the periodic use of a graphical connection mechanism to assist users. Any support that relies on native MacOS components will not work unless a scripted solution to enable and disable sharing as neccessary."
     remediation: "Graphical Method: Perform the following steps to disable Screen Sharing: 1. Open System Settings 2. Select General 3. Select Sharing 4. Set Screen Sharing to disabled Terminal Method: Run the following command to turn off Screen Sharing: $ /usr/bin/sudo /bin/launchctl disable system/com.apple.screensharing."
     references:
-      - https://support.apple.com/guide/mac-help/turn-screen-sharing-on-or-off-mh11848/mac
+      - "https://support.apple.com/guide/mac-help/turn-screen-sharing-on-or-off-"
     compliance:
       - cis: ["2.3.3.2"]
       - cis_csc_v8: ["4.1", "4.8"]
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -346,9 +305,9 @@ checks:
       - 'c:sh -c "launchctl list | grep -c com.apple.screensharing" -> r:^0$'
 
   # 2.3.3.3 Ensure File Sharing Is Disabled. (Automated)
-  - id: 31013
+  - id: 30012
     title: "Ensure File Sharing Is Disabled."
-    description: "File sharing from a user workstation creates additional risks, such as: - Open ports are created that can be probed and attacked - Passwords are attached to user accounts for access that may be exposed and endanger other parts of the organizational environment, including directory accounts Increased complexity makes security more difficult and may expose additional attack vectors - Apple's File Sharing uses the Server Message Block (SMB) protocol to share to other computers that can mount SMB shares. This includes other macOS computers. Apple warns that SMB sharing stored passwords is less secure, and anyone with system access can gain access to the password for that account. When sharing with SMB, each user accessing the Mac must have SMB enabled. Storing passwords, especially copies of valid directory passwords, decrease security for the directory account and should not be used."
+    description: "File sharing from a user workstation creates additional risks, such as: - Open ports are created that can be probed and attacked - Passwords are attached to user accounts for access that may be exposed and endanger other parts of the organizational environment, including directory accounts Increased complexity makes security more difficult and may expose additional attack vectors - Apple's File Sharing uses the Server Message Block (SMB) protocol to share to other computers that can mount SMB shares. This includes other macOS computers. Apple warns that SMB sharing stored passwords is less secure, and anyone with system access can gain access to the password for that account. When sharing with SMB, each user accessing the Mac must have SMB enabled. Storing passwords, especially copies of valid directory passwords, decreases security for the directory account and should not be used."
     rationale: "By disabling File Sharing, the remote attack surface and risk of unauthorized access to files stored on the system is reduced."
     impact: "File Sharing can be used to share documents with other users, but hardened servers should be used rather than user endpoints. Turning on File Sharing increases the visibility and attack surface of a system unnecessarily."
     remediation: "Graphical Method: Perform the following steps to disable File Sharing: 1. Open System Settings 2. Select General 3. Select Sharing 4. Set File Sharing to disabled Terminal Method: Run the following command to disable File Sharing: $ /usr/bin/sudo /bin/launchctl disable system/com.apple.smbd."
@@ -358,7 +317,6 @@ checks:
       - cis_csc_v7: ["4.3", "5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.3", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3", "A.9.2.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["AC-6(2)", "AC-6(5)", "CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5", "7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -368,7 +326,7 @@ checks:
       - 'c:sh -c "launchctl list | grep -c com.apple.smbd" -> r:^0$'
 
   # 2.3.3.4 Ensure Printer Sharing Is Disabled. (Automated)
-  - id: 31014
+  - id: 30013
     title: "Ensure Printer Sharing Is Disabled."
     description: "By enabling Printer Sharing, the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead."
     rationale: "Disabling Printer Sharing mitigates the risk of attackers attempting to exploit the print server to gain access to the system."
@@ -379,7 +337,6 @@ checks:
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -389,11 +346,11 @@ checks:
       - 'c:sh -c "cupsctl | grep _share_printers | cut -d ''='' -f2" -> r:^0$'
 
   # 2.3.3.5 Ensure Remote Login Is Disabled. (Automated)
-  - id: 31015
+  - id: 30014
     title: "Ensure Remote Login Is Disabled."
     description: "Remote Login allows an interactive terminal connection to a computer."
     rationale: "Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to posix servers, the scope of the benchmark is for Apple macOS clients, not servers. macOS does have an IP-based firewall available (pf, ipfw has been deprecated) that is not enabled or configured. There are more details and links in the Network sub-section. macOS no longer has TCP Wrappers support built in and does not have strong Brute-Force password guessing mitigations, or frequent patching of openssh by Apple. Since most macOS computers are mobile workstations, managing IP-based firewall rules on mobile devices can be very resource intensive. All of these factors can be parts of running a hardened SSH server."
-    impact: "The SSH server built into macOS should not be enabled on a standard user computer, particularly one that changes locations and IP addresses. A standard user that runs local applications, including email, web browser, and productivity tools, should not use the same device as a server. There are Enterprise management toolsets that do utilize SSH. If they are in use, the computer should be locked down to only respond to known, trusted IP addresses and appropriate administrator service accounts. For macOS computers that are being used for specialized functions, there are several options to harden the SSH server to protect against unauthorized access including brute force attacks. There are some basic criteria that need to be considered: - Do not open an SSH server to the internet without controls in place to mitigate SSH brute force attacks. This is particularly important for systems bound to Directory environments. It is great to have controls in place to protect the system, but if they trigger after the user is already locked out of their account, they are not optimal. If authorization happens after authentication, directory accounts for users that don't even use the system can be locked out. - Do not use SSH key pairs when there is no insight to the security on the client system that will authenticate into the server with a private key. If an attacker gets access to the remote system and can find the key, they may not need a password or a key logger to access the SSH server. - Detailed instructions on hardening an SSH server, if needed, are available in the CIS Linux Benchmarks, but it is beyond the scope of this benchmark."
+    impact: "The SSH server built into macOS should not be enabled on a standard user computer, particularly one that changes locations and IP addresses. A standard user that runs local applications, including email, web browser, and productivity tools, should not use the same device as a server. There are Enterprise management toolsets that do utilize SSH. If they are in use, the computer should be locked down to only respond to known, trusted IP addresses and appropriate administrator service accounts. For macOS computers that are being used for specialized functions, there are several options to harden the SSH server to protect against unauthorized access, including brute force attacks. There are some basic criteria that need to be considered: - Do not open an SSH server to the internet without controls in place to mitigate SSH brute force attacks. This is particularly important for systems bound to Directory environments. It is great to have controls in place to protect the system, but if they trigger after the user is already locked out of their account, they are not optimal. If authorization happens after authentication, directory accounts for users that don't even use the system can be locked out. - Do not use SSH key pairs when there is no insight to the security on the client system that will authenticate into the server with a private key. If an attacker gets access to the remote system and can find the key, they may not need a password or a key logger to access the SSH server. - Detailed instructions on hardening an SSH server, if needed, are available in the CIS Linux Benchmarks, but it is beyond the scope of this benchmark."
     remediation: "Perform the following to disable Remote Login: Graphical Method: Perform the following steps to disable Remote Login: 1. Open System Settings 2. Select General 3. Select Sharing 4. Set Remote Login to disabled Terminal Method: Run the following command to disable Remote Login: $ /usr/bin/sudo /usr/sbin/systemsetup -setremotelogin off Do you really want to turn remote login off? If you do, you will lose this connection and can only turn it back on locally at the server (yes/no)? Entering yes will disable remote login."
     compliance:
       - cis: ["2.3.3.5"]
@@ -401,7 +358,6 @@ checks:
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -411,7 +367,7 @@ checks:
       - 'c:systemsetup -getremotelogin -> r:Remote Login:\s*\t*Off'
 
   # 2.3.3.6 Ensure Remote Management Is Disabled. (Automated)
-  - id: 31016
+  - id: 30015
     title: "Ensure Remote Management Is Disabled."
     description: "Remote Management is the client portion of Apple Remote Desktop (ARD). Remote Management can be used by remote administrators to view the current screen, install software, report on, and generally manage client Macs. The screen sharing options in Remote Management are identical to those in the Screen Sharing section. In fact, only one of the two can be configured. If Remote Management is used, refer to the Screen Sharing section above on issues regard screen sharing. Remote Management should only be enabled when a Directory is in place to manage the accounts with access. Computers will be available on port 5900 on a macOS System and could accept connections from untrusted hosts depending on the configuration, which is a major concern for mobile systems. As with other sharing options, an open port even for authorized management functions can be attacked, and both unauthorized access and Denial-of-Service vulnerabilities could be exploited. If remote management is required, the pf firewall should restrict access only to known, trusted management consoles. Remote management should not be used across the Internet without the use of a VPN tunnel."
     rationale: "Remote Management should only be enabled on trusted networks with strong user controls present in a Directory system. Mobile devices without strict controls are vulnerable to exploit and monitoring."
@@ -423,7 +379,6 @@ checks:
       - cis_csc_v7: ["4.3", "9.2", "14.3"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.5", "AC.L2-3.1.6", "AC.L2-3.1.7", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.3", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.1", "A.13.1.3", "A.9.2.3"]
-      - mitre_techniques: ["T1003", "T1015", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1133", "T1134", "T1136", "T1169", "T1175", "T1176", "T1184", "T1190", "T1200", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - nist_sp_800-53: ["AC-6(2)", "AC-6(5)", "CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5", "7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -433,7 +388,7 @@ checks:
       - "not p:/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent"
 
   # 2.3.3.7 Ensure Remote Apple Events Is Disabled. (Automated)
-  - id: 31017
+  - id: 30016
     title: "Ensure Remote Apple Events Is Disabled."
     description: "Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer."
     rationale: "Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system."
@@ -445,7 +400,6 @@ checks:
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -455,7 +409,7 @@ checks:
       - 'c:systemsetup -getremoteappleevents -> r:Remote Apple Events:\s*\t*Off'
 
   # 2.3.3.8 Ensure Internet Sharing Is Disabled. (Automated)
-  - id: 31018
+  - id: 30017
     title: "Ensure Internet Sharing Is Disabled."
     description: "Internet Sharing uses the open source natd process to share an internet connection with other computers and devices on a local network. This allows the Mac to function as a router and share the connection to other, possibly unauthorized, devices."
     rationale: "Disabling Internet Sharing reduces the remote attack surface of the system."
@@ -467,7 +421,6 @@ checks:
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -478,22 +431,21 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.MCX'').objectForKey(''forceInternetSharingOff'')" -> r:^true$'
 
   # 2.3.3.9 Ensure Content Caching Is Disabled. (Automated)
-  - id: 31019
+  - id: 30018
     title: "Ensure Content Caching Is Disabled."
-    description: "Starting with 10.13 (macOS High Sierra), Apple introduced a service to make it easier to deploy data from Apple, including software updates, where there are bandwidth constraints to the Internet and fewer constraints or greater bandwidth exist on the local subnet. This capability can be very valuable for organizations that have throttled and possibly metered Internet connections. In heterogeneous enterprise networks with multiple subnets, the effectiveness of this capability would be determined by how many Macs were on each subnet at the time new, large updates were made available upstream. This capability requires the use of mac OS clients as P2P nodes for updated Apple content. Unless there is a business requirement to manage operational Internet connectivity and bandwidth user endpoints should not store content and act as a cluster to provision data. Content types supported by Content Caching in macOS."
-    rationale: "The main use case for Mac computers is as mobile user endpoints. P2P sharing services should not be enabled on laptops that are using untrusted networks. Content Caching can allow a computer to be a server for local nodes on an untrusted network. While there are certainly logical controls that could be used to mitigate risk, they add to the management complexity. Since the value of the service is in specific use cases organizations with the use case described above can accept risk as necessary."
+    description: "Starting with 10.13 (macOS High Sierra), Apple introduced a service to make it easier to deploy data from Apple, including software updates, where there are bandwidth constraints to the Internet and fewer constraints or greater bandwidth exist on the local subnet. This capability can be very valuable for organizations that have throttled and possibly metered Internet connections. In heterogeneous enterprise networks with multiple subnets, the effectiveness of this capability would be determined by how many Macs were on each subnet at the time new, large updates were made available upstream. This capability requires the use of mac OS clients as P2P nodes for updated Apple content. Unless there is a business requirement to manage operational Internet connectivity and bandwidth, user endpoints should not store content and act as a cluster to provision data. Content types supported by Content Caching in macOS."
+    rationale: "The main use case for Mac computers is as mobile user endpoints. P2P sharing services should not be enabled on laptops that are using untrusted networks. Content Caching can allow a computer to be a server for local nodes on an untrusted network. While there are certainly logical controls that could be used to mitigate risk, they add to the management complexity. Since the value of the service is in specific use cases, organizations with the use case described above can accept risk as necessary."
     impact: "This setting will adversely affect bandwidth usage between local subnets and the Internet."
     remediation: "Graphical Method: Perform the following steps to disable Content Caching: 1. Open System Settings 2. Select General 3. Select Sharing 4. Set Content Caching to disabled Terminal Method: Run the following command to disable Content Caching: $ /usr/bin/sudo /usr/bin/AssetCacheManagerUtil deactivate The output will include Content caching deactivated Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.applicationaccess 2. The key to include is allowContentCaching 3. The key must be set to <false/>."
     references:
-      - https://support.apple.com/guide/mac-help/about-content-caching-mchl9388ba1b/
-      - https://support.apple.com/guide/mac-help/set-up-content-caching-on-mac-mchl3b6c3720/
+      - "https://support.apple.com/guide/mac-help/about-content-caching-mchl9388ba1b/"
+      - "https://support.apple.com/guide/mac-help/set-up-content-caching-on-mac-"
     compliance:
       - cis: ["2.3.3.9"]
       - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
       - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1051", "T1076", "T1133", "T1200"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
@@ -502,25 +454,23 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.AssetCache'').objectForKey(''Activated'')" -> r:^0$'
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.applicationaccess'').objectForKey(''allowContentCaching'')" -> r:^0$|^true$'
 
-  # 2.3.3.10 Ensure Media Sharing Is Disabled (Automated) - Not implemented
-  # 2.3.3.11 Ensure Bluetooth Sharing Is Disabled (Automated) - Not implemented
-  # 2.3.3.12 Ensure Computer Name Does Not Contain PII or Protected Organizational Information (Manual) - Not implemented
-  # 2.3.4 Time Machine
+  # 2.3.3.10 Ensure Media Sharing Is Disabled. (Automated) - Not Implemented
+  # 2.3.3.11 Ensure Bluetooth Sharing Is Disabled. (Automated) - Not Implemented
+  # 2.3.3.12 Ensure Computer Name Does Not Contain PII or Protected Organizational Information. (Manual) - Not Implemented
 
   # 2.3.4.1 Ensure Backup Automatically is Enabled If Time Machine Is Enabled. (Automated)
-  - id: 31020
+  - id: 30019
     title: "Ensure Backup Automatically is Enabled If Time Machine Is Enabled."
-    description: 'Backup solutions are only effective if the backups run on a regular basis. The time to check for backups is before the hard drive fails or the computer goes missing. In order to simplify the user experience so that backups are more likely to occur, Time Machine should be on and set to Back Up Automatically whenever the target volume is available. Operational staff should ensure that backups complete on a regular basis and the backups are tested to ensure that file restoration from backup is possible when needed. Backup dates are available even when the target volume is not available in the Time Machine plist. SnapshotDates = ( "2012-08-20 12:10:22 +0000", "2013-02-03 23:43:22 +0000", "2014-02-19 21:37:21 +0000", "2015-02-22 13:07:25 +0000", "2016-08-20 14:07:14 +0000" When the backup volume is connected to the computer more extensive information is available through tmutil. See man tmutil.'
+    description: 'Backup solutions are only effective if the backups run on a regular basis. The time to check for backups is before the hard drive fails or the computer goes missing. In order to simplify the user experience so that backups are more likely to occur, Time Machine should be on and set to Back Up Automatically whenever the target volume is available. Operational staff should ensure that backups complete on a regular basis and the backups are tested to ensure that file restoration from backup is possible when needed. Backup dates are available even when the target volume is not available in the Time Machine plist. SnapshotDates = ( "2012-08-20 12:10:22 +0000", "2013-02-03 23:43:22 +0000", "2014-02-19 21:37:21 +0000", "2015-02-22 13:07:25 +0000", "2016-08-20 14:07:14 +0000" When the backup volume is connected to the computer, more extensive information is available through tmutil. See man tmutil.'
     rationale: "Backups should automatically run whenever the backup drive is available."
     impact: "The backup will run periodically in the background and could have user impact while running."
-    remediation: "Graphical Method: Perform the following steps to enable Time Machine automatic backup: 1. Open System Settings 2. Select General 3. Select Time Machine 4. Select Options... 5. Set Back up frequency to Automatically <every hour/every day/every week> Terminal Method: Run the following command to enable automatic backups if Time Machine is enabled: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -bool true Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.TimeMachine 2. The key to include is Forced 3. The key must be set to: <array> <dict> <key>mcx_preference_settings</key> <dict> <key>AutoBackup</key> <true/> </dict> </dict> </array>."
+    remediation: "Graphical Method: Perform the following steps to enable Time Machine automatic backup: 1. Open System Settings 2. Select General 3. Select Time Machine 4. Select Options... 5. Set Back up frequency to Automatically <every hour/every day/every week> Terminal Method: Run the following command to enable automatic backups if Time Machine is enabled: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -bool true Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.MCX.TimeMachine 2. The key to include is AutoBackup 3. The key must be set to."
     compliance:
       - cis: ["2.3.4.1"]
       - cis_csc_v8: ["11.2"]
       - cis_csc_v7: ["10.1"]
       - hipaa: ["164.308(a)(7)(ii)(A)"]
       - iso_27001-2013: ["A.12.3.1"]
-      - mitre_techniques: ["T1485", "T1486", "T1487", "T1488", "T1490", "T1491"]
       - pci_dss_v3.2.1: ["12.10.1"]
     condition: any
     rules:
@@ -528,11 +478,11 @@ checks:
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.TimeMachine'').objectForKey(''LastDestinationID'')" -> r:^\.+$'
 
   # 2.3.4.2 Ensure Time Machine Volumes Are Encrypted If Time Machine Is Enabled. (Automated)
-  - id: 31021
+  - id: 30020
     title: "Ensure Time Machine Volumes Are Encrypted If Time Machine Is Enabled."
-    description: "One of the most important security tools for data protection on macOS is FileVault. With encryption in place it makes it difficult for an outside party to access your data if they get physical possession of the computer. One very large weakness in data protection with FileVault is the level of protection on backup volumes. If the internal drive is encrypted but the external backup volume that goes home in the same laptop bag is not it is self-defeating. Apple tries to make this mistake easily avoided by providing a checkbox to enable encryption when setting-up a Time Machine backup. Using this option does require some password management, particularly if a large drive is used with multiple computers. A unique complex password to unlock the drive can be stored in keychains on multiple systems for ease of use. While some portable drives may contain non-sensitive data and encryption may make interoperability with other systems difficult backup volumes should be protected just like boot volumes."
+    description: "One of the most important security tools for data protection on macOS is FileVault. With encryption in place, it makes it difficult for an outside party to access your data if they get physical possession of the computer. One very large weakness in data protection with FileVault is the level of protection on backup volumes. If the internal drive is encrypted but the external backup volume that goes home in the same laptop bag is not, it is self-defeating. Apple tries to make this mistake easily avoided by providing a checkbox to enable encryption when setting up a Time Machine backup. Using this option does require some password management, particularly if a large drive is used with multiple computers. A unique, complex password to unlock the drive can be stored in keychains on multiple systems for ease of use. While some portable drives may contain non-sensitive data and encryption may make interoperability with other systems difficult, backup volumes should be protected just like boot volumes."
     rationale: "Backup volumes need to be encrypted."
-    remediation: "Graphical Method: Perform the following steps to enable encryption on the Time Machine drive: 1. Open System Settings 2. Select General 3. Select Time Machine 4. Select the unencrypted drive 5. Select - to forget that drive as a destination 6. Select + to add a different drive as the destination 7. Select Set Up Disk... 8. Set Encrypt Backup to enabled 9. Enter a password in the New Password and the same password in the Re-enter Password fields 10. A password hint is required, but it is recommended that you do not use any identifying information for the password Note: In macOS 12.0 Monterey and previous, the existing Time Machine drive could have encryption added without formatting it. This is no longer possible in macOS 13.0 Ventura. If you with to keep previous backups from the unencrypted volume, you will need to manually move those files over to the new encrypted drive."
+    remediation: "Graphical Method: Perform the following steps to enable encryption on the Time Machine drive: 1. Open System Settings 2. Select General 3. Select Time Machine 4. Select the unencrypted drive 5. Select - to forget that drive as a destination 6. Select + to add a different drive as the destination 7. Select Set Up Disk... 8. Set Encrypt Backup to enabled 9. Enter a password in the New Password and the same password in the Re-enter Password fields 10. A password hint is required, but it is recommended that you do not use any identifying information for the password Note: In macOS 12.0 Monterey and previous, the existing Time Machine drive could have encryption added without formatting it. This is no longer possible in macOS 13.0 Ventura. If you wish to keep previous backups from the unencrypted volume, you will need to manually move those files over to the new encrypted drive."
     compliance:
       - cis: ["2.3.4.2"]
       - cis_csc_v8: ["3.6", "3.11", "11.3"]
@@ -540,7 +490,6 @@ checks:
       - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "MP.L2-3.8.9", "SC.L2-3.13.11", "SC.L2-3.13.16"]
       - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
       - iso_27001-2013: ["A.10.1.1", "A.12.3.1", "A.6.2.1"]
-      - mitre_techniques: ["T1040", "T1070", "T1072", "T1114", "T1119", "T1145", "T1208", "T1485", "T1486", "T1487", "T1488", "T1490", "T1491", "T1492", "T1493", "T1527", "T1530"]
       - nist_sp_800-53: ["CP-9(8)", "SC-28", "SC-28(1)"]
       - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1", "9.5", "9.5.1"]
       - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
@@ -549,18 +498,14 @@ checks:
     rules:
       - 'c: sh -c "defaults read /Library/Preferences/com.apple.TimeMachine.plist | grep -c NotEncrypted" -> r:^0$'
 
-  # 2.4 Control Center
-  # 2.4.1 Ensure Show Wi-Fi status in Menu Bar Is Enabled (Automated) - Not implemented
-  # 2.4.2 Ensure Show Bluetooth Status in Menu Bar Is Enabled (Automated) - Not implemented
-  # 2.5 Siri & Spotlight
-  # 2.5.1 Audit Siri Settings (Manual) - Not Implemented
-  # 2.6 Privacy & Security
-  # 2.6.1 Location Services
+  # 2.4.1 Ensure Show Wi-Fi status in Menu Bar Is Enabled. (Automated) - Not Implemented
+  # 2.4.2 Ensure Show Bluetooth Status in Menu Bar Is Enabled. (Automated) - Not Implemented
+  # 2.5.1 Audit Siri Settings. (Manual) - Not Implemented
 
   # 2.6.1.1 Ensure Location Services Is Enabled. (Automated)
-  - id: 31022
+  - id: 30021
     title: "Ensure Location Services Is Enabled."
-    description: "macOS uses location information gathered through local Wi-Fi networks to enable applications to supply relevant information to users. With the operating system verifying the location, users do not need to change the time or the time zone. The computer will change them based on the user's location. They do not need to specify their location for weather or travel times, and they will receive alerts on travel times to meetings and appointment where location information is supplied. Location Services simplify some processes with mobile computers, such as asset management and time or log management. There are some use cases where it is important that the computer not be able to report its exact location. While the general use case is to enable Location Services, it should not be allowed if the physical location of the computer and the user should not be public knowledge."
+    description: "macOS uses location information gathered through local Wi-Fi networks to enable applications to supply relevant information to users. With the operating system verifying the location, users do not need to change the time or the time zone. The computer will change them based on the user's location. They do not need to specify their location for weather or travel times, and they will receive alerts on travel times to meetings and appointments where location information is supplied. Location Services simplify some processes with mobile computers, such as asset management and time or log management. There are some use cases where it is important that the computer not be able to report its exact location. While the general use case is to enable Location Services, it should not be allowed if the physical location of the computer and the user should not be public knowledge."
     rationale: "Location Services are helpful in most use cases and can simplify log and time management where computers change time zones."
     remediation: "Graphical Method: Perform the following steps to enable Location Services: 1. Open System Settings 2. Select Privacy & Security 3. Select Location Services 4. Set Location Services to enabled Terminal Method: Run the following command to enable Location Services: $ /usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.locationd.plist If the com.apple.locationd.plist outputs 0, run the following command to also ensure Location Services is running: $ /usr/bin/sudo /usr/bin/defaults write /var/db/locationd/Library/Preferences/ByHost/com.apple.locationd LocationServicesEnabled -bool false $ /usr/bin/sudo /bin/launchctl kickstart -k system/com.apple.locationd Note: In some use cases, organizations may not want Location Services running. To disable Location Services, System Integrity Protection must be disabled."
     references:
@@ -571,7 +516,6 @@ checks:
       - cis_csc_v7: ["5.1"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -582,19 +526,18 @@ checks:
       - 'c:sudo -u _locationd /usr/bin/osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.locationd'').objectForKey(''LocationServicesEnabled'')" -> r:^1$'
 
   # 2.6.1.2 Ensure Location Services Is in the Menu Bar. (Automated)
-  - id: 31023
+  - id: 30022
     title: "Ensure Location Services Is in the Menu Bar."
-    description: "This setting provides the user to understand the current status of Location Services and which applications are using it."
-    rationale: 'Apple has fully integrated location services into macOS. Where the computer is currently located is used for Timezones, weather, travel times, geolocation, "Find my Mac" and advertising services. This benchmark recommends that location services are enabled for most users. Many users may have occasions when they do not want to share their current locations, some users may need to rarely share their locations. The immediate availability of Location Services in the menu bar provides easy access to the current status, which applications are using the service and a quick shortcut to making changes. This setting provides better user control in managing user privacy.'
+    description: "This setting provides the user an understanding of the current status of Location Services and which applications are using it."
+    rationale: 'Apple has fully integrated location services into macOS. Where the computer is currently located is used for Timezones, weather, travel times, geolocation, "Find my Mac," and advertising services. This benchmark recommends that location services are enabled for most users. Many users may have occasions when they do not want to share their current locations, and some users may need to rarely share their locations. The immediate availability of Location Services in the menu bar provides easy access to the current status, which applications are using the service, and a quick shortcut to making changes. This setting provides better user control in managing user privacy.'
     impact: "Users may be provided visibility to a setting they cannot control if organizations control Location Services globally by policy."
-    remediation: "Graphical Method: Perform the following steps to set whether the location services icon is in the menu bar: 1. Open System Settings 2. Select Privacy & Security 3. Select Location Services 4. Select Details... 5. Set Show location icon in menu bar when System Services request your location to your organization's parameters Terminal Method: Run the following commands to set the option of the location services icon being in the menu bar: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -bool <true/false>."
+    remediation: "Graphical Method: Perform the following steps to set whether the location services icon is in the menu bar: 1. Open System Settings 2. Select Privacy & Security 3. Select Location Services 4. Select Details... 5. Set Show location icon in menu bar when System Services request your location to enabled Terminal Method: Run the following commands to set the option of the location services icon being in the menu bar: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -bool true."
     compliance:
       - cis: ["2.6.1.2"]
       - cis_csc_v8: ["4.1", "4.8"]
       - cis_csc_v7: ["5.1"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -603,12 +546,12 @@ checks:
     rules:
       - "c:defaults read /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -> r:^1$|^true$"
 
-  # 2.6.1.3 Audit Location Services Access (Manual) - Not Implemented
-  # 2.6.2 Ensure Sending Diagnostic and Usage Data to Apple Is Disabled (Automated) - Not implemented
-  # 2.6.3 Ensure Limit Ad Tracking Is Enabled (Automated) - Not implemented
+  # 2.6.1.3 Audit Location Services Access. (Manual) - Not Implemented
+  # 2.6.2 Ensure Sending Diagnostic and Usage Data to Apple Is Disabled. (Automated) - Not Implemented
+  # 2.6.3 Ensure Limit Ad Tracking Is Enabled. (Automated) - Not Implemented
 
   # 2.6.4 Ensure Gatekeeper Is Enabled. (Automated)
-  - id: 31024
+  - id: 30023
     title: "Ensure Gatekeeper Is Enabled."
     description: "Gatekeeper is Apple's application that utilizes allowlisting to restrict downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization. In an update to Gatekeeper in macOS 13 Ventura, Gatekeeper checks every application on every launch, not just quarantined apps."
     rationale: "Disallowing unsigned software will reduce the risk of unauthorized or malicious applications from running on the system."
@@ -620,7 +563,6 @@ checks:
       - cmmc_v2.0: ["SI.L1-3.14.2", "SI.L1-3.14.4"]
       - hipaa: ["164.308(a)(5)(ii)(B)"]
       - iso_27001-2013: ["A.12.2.1"]
-      - mitre_techniques: ["T1017", "T1019", "T1027", "T1045", "T1068", "T1072", "T1073", "T1075", "T1091", "T1100", "T1103", "T1137", "T1138", "T1189", "T1190", "T1193", "T1194", "T1195", "T1200", "T1210", "T1211", "T1212", "T1215", "T1221", "T1495"]
       - nist_sp_800-53: ["SI-16"]
       - pci_dss_v3.2.1: ["1.4", "11.4", "5.1", "5.1.1", "5.2"]
       - pci_dss_v4.0: ["5.1.1", "5.2.1", "5.2.2", "5.3.1", "5.3.2"]
@@ -630,16 +572,16 @@ checks:
       - "c:spctl --status -> r:^assessments enabled"
 
   # 2.6.5 Ensure FileVault Is Enabled. (Automated)
-  - id: 31025
+  - id: 30024
     title: "Ensure FileVault Is Enabled."
     description: "FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it. FileVault should be used with a saved escrow key to ensure that the owner can decrypt their data if the password is lost. FileVault may also be enabled using command line using the fdesetup command. To use this functionality, consult the Der Flounder blog for more details (see link below under References)."
     rationale: "Encrypting sensitive data minimizes the likelihood of unauthorized users gaining access to it."
     impact: "Mounting a FileVault encrypted volume from an alternate boot source will require a valid password to decrypt it."
     remediation: "Graphical Method: Perform the following steps to enable FileVault: 1. Open System Settings 2. Select Security & Privacy 3. Select Turn On... Note: This will allow you to create a recovery key for FileVault. Keep the key saved securely in case it is needed at a later date. Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.MCX 2. The key to include is dontAllowFDEDisable 3. The key must be set to <true/> Note: This profile is required to pass the audit."
     references:
-      - https://derflounder.wordpress.com/2015/02/02/managing-yosemites-filevault-2-with-fdesetup/
-      - https://derflounder.wordpress.com/2019/01/15/unlock-or-decrypt-your-filevault-encrypted-boot-drive-from-the-command-line-on-macos-mojave/
-      - https://derflounder.wordpress.com/2021/10/29/use-of-filevault-institutional-recovery-keys-no-longer-recommended-by-apple/
+      - "https://derflounder.wordpress.com/2015/02/02/managing-yosemites-filevault-2-"
+      - "https://derflounder.wordpress.com/2019/01/15/unlock-or-decrypt-your-filevault-"
+      - "https://derflounder.wordpress.com/2021/10/29/use-of-filevault-institutional-"
     compliance:
       - cis: ["2.6.5"]
       - cis_csc_v8: ["3.6", "3.11"]
@@ -647,7 +589,6 @@ checks:
       - cmmc_v2.0: ["AC.L2-3.1.19", "IA.L2-3.5.10", "MP.L2-3.8.1", "SC.L2-3.13.11", "SC.L2-3.13.16"]
       - hipaa: ["164.312(a)(2)(iv)", "164.312(e)(2)(ii)"]
       - iso_27001-2013: ["A.10.1.1", "A.6.2.1"]
-      - mitre_techniques: ["T1040", "T1070", "T1072", "T1114", "T1119", "T1145", "T1208", "T1492", "T1493", "T1527", "T1530"]
       - nist_sp_800-53: ["SC-28", "SC-28(1)"]
       - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
       - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
@@ -657,12 +598,13 @@ checks:
       - "c:fdesetup status -> r:^FileVault is On"
       - 'c:osascript -l JavaScript -e "osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.MCX'').objectForKey(''dontAllowFDEDisable'')" -> r:^0$'
 
-  # 2.6.6 Audit Lockdown Mode (Manual) - Not Implemented
-  # 2.6.7 Ensure an Administrator Password Is Required to Access System-Wide Preferences. (Manual)
-  - id: 31026
+  # 2.6.6 Audit Lockdown Mode. (Manual) - Not Implemented
+
+  # 2.6.7 Ensure an Administrator Password Is Required to Access System-Wide Preferences. (Automated)
+  - id: 30025
     title: "Ensure an Administrator Password Is Required to Access System-Wide Preferences."
     description: "System Preferences controls system and user settings on a macOS Computer. System Preferences allows the user to tailor their experience on the computer as well as allowing the System Administrator to configure global security settings. Some of the settings should only be altered by the person responsible for the computer."
-    rationale: "By requiring a password to unlock system-wide System Preferences, the risk is mitigated of a user changing configurations that affect the entire system and requires an admin user to re-authenticate to make changes."
+    rationale: "By requiring a password to unlock system-wide System Preferences, the risk of a user changing configurations that affect the entire system is mitigated and requires an admin user to re-authenticate to make changes."
     impact: "Users will need to enter their password to unlock some additional preference panes that are unlocked by default like Network, Startup and Printers & Scanners."
     remediation: "Graphical Method: Perform the following steps to verify that an administrator password is required to access system-wide preferences: 1. Open System Settings 2. Select Privacy & Security 3. Select Advanced 4. Set Require an administrator password to access system-wide settings to enabled. Terminal Method: The authorizationdb settings cannot be written to directly, so the plist must be exported out to temporary file. Changes can be made to the temporary plist, then imported back into the authorizationdb settings. Run the following commands to enable that an administrator password is required to access system-wide preferences: $ /usr/bin/sudo /usr/bin/security authorizationdb read system.preferences > /tmp/system.preferences.plist YES (0) $ /usr/bin/sudo /usr/bin/defaults write /tmp/system.preferences.plist shared -bool false $ /usr/bin/sudo /usr/bin/security authorizationdb write system.preferences < /tmp/system.preferences.plist YES (0)."
     compliance:
@@ -671,7 +613,6 @@ checks:
       - cis_csc_v7: ["5.1"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
       - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["11.5", "2.2"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
@@ -680,26 +621,45 @@ checks:
     rules:
       - "c:security authorizationdb read system.preferences | grep -A1 shared -> r:>false<"
 
-  # 2.7 Desktop & Dock
-  # 2.7.1 Ensure Screen Saver Corners Are Secure (Automated) - Not implemented
-  # 2.8 Displays
-  # 2.8.1 Audit Universal Control Settings (Manual) - Not Implemented
-  # 2.9 Battery (Energy Saver)
+  # 2.7.1 Ensure Screen Saver Corners Are Secure. (Automated) - Not Implemented
+  # 2.8.1 Audit Universal Control Settings. (Manual) - Not Implemented
+  # 2.9.1.1 Ensure the OS Is Not Active When Resuming from Standby (Intel). (Automated) - Not - Implemented
+  # 2.9.1.2 Ensure the OS Is Not Active When Resuming from Sleep and Display Sleep (Apple Silicon). (Automated) Not - Implemented
 
-  # 2.9.1 Ensure Power Nap Is Disabled for Intel Macs. (Automated)
-  - id: 31027
+  # 2.9.1.3 Ensure FileVault is Locked on Sleep. (Automated)
+  - id: 30026
+    title: "Ensure FileVault is Locked on Sleep."
+    description: "Full Disk Encryption (FDE) is a Data-at-Rest (DAR) solution. It ensures that when the data on the drive is not in use it is full encrypted, but it can be decrypted (unlocked) as needed. When a Mac sleeps, the encryption keys remain in memory so that the drive is encrypted but unlocked. There are attacks available to interact with the OS and data on the unlocked drive. FileVault volumes should be locked when not in use to resist attack."
+    rationale: "The purpose of DAR is to ensure data is encrypted while at rest. If the volume is always unlocked it is not sufficient."
+    impact: "The laptop will require a user to log in with their username and password, not TouchID, into the OS after the FileVault key is destroyed."
+    remediation: "Terminal Method: Run the following command to ensure FileVault keys are set to be destroyed on standby: $ /usr/bin/sudo /usr/bin/pmset -a destroyfvkeyonstandby 1."
+    compliance:
+      - cis: ["2.9.1.3"]
+      - cis_csc_v8: ["4.1"]
+      - cis_csc_v7: ["16.11"]
+      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
+      - iso_27001-2013: ["A.8.1.3"]
+      - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
+      - pci_dss_v3.2.1: ["11.5", "2.2"]
+      - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
+      - soc_2: ["CC7.1", "CC8.1"]
+    condition: all
+    rules:
+      - "c:pmset -b -g -> r:^DestroyFVKeyOnStandby 1"
+
+  # 2.9.2 Ensure Power Nap Is Disabled for Intel Macs. (Automated)
+  - id: 30027
     title: "Ensure Power Nap Is Disabled for Intel Macs."
     description: "Power Nap allows the system to stay in low power mode, especially while on battery power, and periodically connect to previously known networks with stored credentials for user applications to phone home and get updates. This capability requires FileVault to remain unlocked and the use of previously joined networks to be risk accepted based on the SSID without user input. This control has been updated to check the status on both battery and AC Power. The presence of an electrical outlet does not completely correlate with logical and physical security of the device or available networks."
     rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access. The use of Power Nap adds to the risk of compromised physical and logical security. The user should be able to decrypt FileVault and have the applications download what is required when the computer is actively used. The control to prevent computer sleep has been retired for this version of the Benchmark. Forcing the computer to stay on and use energy in case a management push is needed is contrary to most current management processes. Only keep computers unslept if after hours pushes are required on closed LANs."
     impact: "Power Nap exists for unattended user application updates like email and social media clients. With Power Nap disabled, the computer will not wake and reconnect to known wireless SSIDs intermittently when slept."
     remediation: "Graphical Method: Perform the following steps to disable Power Nap: Desktop Instructions: 1. Open System Settings 2. Select Energy Saver 3. Set Power Nap to disabled 4. Select UPS (if applicable) 5. Set Power Nap to disabled Laptop Instructions: 1. Open System Settings 2. Select Battery 3. Select Power Adapter (for laptops only) 4. Set Power Nap to disabled 5. Select Battery 6. Set Power Nap to disabled 7. Select UPS (if applicable) 8. Set Power Nap to disabled Terminal Method: Run the following command to disable Power Nap: $ /usr/bin/sudo /usr/bin/pmset -a powernap 0."
     compliance:
-      - cis: ["2.9.1"]
+      - cis: ["2.9.2"]
       - cis_csc_v8: ["4.1", "4.8"]
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -708,20 +668,19 @@ checks:
     rules:
       - 'not c:sh -c "pmset -g custom" -> r:powernap\s*\t*1'
 
-  # 2.9.2 Ensure Wake for Network Access Is Disabled. (Automated)
-  - id: 31028
+  # 2.9.3 Ensure Wake for Network Access Is Disabled. (Automated)
+  - id: 30028
     title: "Ensure Wake for Network Access Is Disabled."
     description: "This feature allows the computer to take action when the user is not present and the computer is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks. This macOS feature is meant to allow the computer to resume activity as needed regardless of physical security controls. This feature allows other users to be able to access your computer's shared resources, such as shared printers or Apple Music playlists, even when your computer is in sleep mode. In a closed network when only authorized devices could wake a computer, it could be valuable to wake computers in order to do management push activity. Where mobile workstations and agents exist, the device will more likely check in to receive updates when already awake. Mobile devices should not be listening for signals on any unmanaged network or where untrusted devices exist that could send wake signals."
     rationale: "Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access."
     impact: "Management programs like Apple Remote Desktop Administrator use wake-on-LAN to connect with computers. If turned off, such management programs will not be able to wake a computer over the LAN. If the wake-on-LAN feature is needed, do not turn off this feature. The control to prevent computer sleep has been retired for this version of the Benchmark. Forcing the computer to stay on and use energy in case a management push is needed is contrary to most current management processes. Only keep computers unslept if after hours pushes are required on closed LANs."
     remediation: "Graphical Method: Perform the following steps to disable Wake for network access: Desktop Instructions: 1. Open System Settings 2. Select Energy Saver 3. Set Wake for network access to disabled Laptop Instructions: 1. Open System Settings 2. Select Battery 3. Select Options... 4. Set Wake for network access to Never Terminal Method: Run the following command to disable Wake for network access: $ /usr/bin/sudo /usr/bin/pmset -a womp 0 Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.MCX 2. The key to include is com.apple.EnergySaver.desktop.ACPower 3. The key must be set to: <dict> <key>Wake On LAN</key> <integer>0</integer> <key>Wake On Modem Ring</key> <integer>0</integer> </dict> 4. The key to also include is com.apple.EnergySaver.portable.ACPower 5. The key must be set to: <dict> <key>Wake On LAN</key> <integer>0</integer> <key>Wake On Modem Ring</key> <integer>0</integer> </dict> 6. The key to also include is com.apple.EnergySaver.portable.BatteryPower 7. The key must be set to: <dict> <key>Wake On LAN</key> <integer>0</integer> <key>Wake On Modem Ring</key> <integer>0</integer> </dict> Note: Both Wake on LAN and Wake on Modem Ring need to be set. Only setting Wake On LAN will allow the profile to install but not set any settings. This profile will only apply the setting at installation and is not sticky."
     compliance:
-      - cis: ["2.9.2"]
+      - cis: ["2.9.3"]
       - cis_csc_v8: ["4.8"]
       - cis_csc_v7: ["9.2"]
       - cmmc_v2.0: ["CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3"]
-      - mitre_techniques: ["T1015", "T1051", "T1076", "T1133", "T1200"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
@@ -731,25 +690,23 @@ checks:
       - 'not c:sh -c "profiles -P -o stdout | grep ''Wake On LAN''" -> n:=\s*(\d) compare != 0'
       - 'not c:sh -c "profiles -P -o stdout | grep ''Wake On Modem Ring''" -> n:=\s*(\d) compare != 0'
 
-  # 2.9.3 Ensure the OS is not Activate When Resuming from Sleep (Automated) - Not Implemented
-  # 2.10 Lock Screen
-  # 2.10.1 Ensure an Inactivity Interval of 20 Minutes Or Less for the Screen Saver Is Enabled (Automated) - Not implemented
-  # 2.10.2 Ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled. (Automated)
-  - id: 31029
-    title: "Ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled."
+  # 2.10.1 Ensure an Inactivity Interval of 20 Minutes Or Less for the Screen Saver Is Enabled. (Automated) - Not Implemented
+
+  # 2.10.2 Ensure Require Password After Screen Saver Begins or Display Is Turned Off Is Enabled for 5 Seconds or Immediately. (Automated)
+  - id: 30029
+    title: "Ensure Require Password After Screen Saver Begins or Display Is Turned Off Is Enabled for 5 Seconds or Immediately."
     description: "Sleep and screen saver modes are low power modes that reduce electrical consumption while the system is not in use."
     rationale: "Prompting for a password when waking from sleep or screen saver mode mitigates the threat of an unauthorized person gaining access to a system in the user's absence."
-    impact: "Without a screenlock in place anyone with physical access to the computer would be logged in and able to use the active user's session."
+    impact: "Without a screenlock in place, anyone with physical access to the computer would be logged in and able to use the active user's session."
     remediation: "Graphical Method: Perform the following steps to enable a password for unlock after a screen saver begins or after sleep: 1. Open System Settings 2. Select Lock Screen 3. Set Require password after screensaver begins or display is turned off to either After 0 seconds or After 5 seconds Terminal Method: Run the following command to require a password to unlock the computer after the screen saver engages or the computer sleeps: $ /usr/bin/sudo /usr/sbin/sysadminctl -screenLock immediate -password <administrator password> or $ /usr/bin/sudo /usr/sbin/sysadminctl -screenLock 5 seconds -password <administrator password> Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.screensaver 2. The key to include is askForPassword 3. The key must be set to <true/> 4. The key to also include is askForPasswordDelay 5. The key must be set to <integer><0,5></integer>."
     references:
-      - "https://blog.kolide.com/screensaver-security-on-macos-10-13-is-broken-a385726e2ae2"
-      - "https://github.com/rtrouton/profiles/blob/master/SetDefaultScreensaver/SetDefaultScreensaver.mobileconfig"
+      - "https://blog.kolide.com/screensaver-security-on-macos-10-13-is-broken-"
+      - "https://github.com/rtrouton/profiles/blob/master/SetDefaultScreensaver/SetDefaul"
     compliance:
       - cis: ["2.10.2"]
       - cis_csc_v8: ["4.7"]
       - cis_csc_v7: ["4.2"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1003", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1134", "T1136", "T1169", "T1175", "T1184", "T1190", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - pci_dss_v3.2.1: ["2.1", "2.1.1"]
       - pci_dss_v4.0: ["2.2.2", "2.3.1"]
       - soc_2: ["CC6.3"]
@@ -759,7 +716,7 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.screensaver'').objectForKey(''askForPasswordDelay'')" -> n:^(\d+)$ compare <= 5'
 
   # 2.10.3 Ensure a Custom Message for the Login Screen Is Enabled. (Automated)
-  - id: 31030
+  - id: 30030
     title: "Ensure a Custom Message for the Login Screen Is Enabled."
     description: "An access warning informs the user that the system is reserved for authorized use only, and that the use of the system may be monitored."
     rationale: "An access warning may reduce a casual attacker's tendency to target the system. Access warnings may also aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status, acceptable use policy, and authorization requirements."
@@ -771,7 +728,6 @@ checks:
       - cis_csc_v7: ["5.1"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
       - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["11.5", "2.2"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
@@ -781,7 +737,7 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''LoginwindowText'')" -> r:^\.+$'
 
   # 2.10.4 Ensure Login Window Displays as Name and Password Is Enabled. (Automated)
-  - id: 31031
+  - id: 30031
     title: "Ensure Login Window Displays as Name and Password Is Enabled."
     description: "The login window prompts a user for his/her credentials, verifies their authorization level, and then allows or denies the user access to the system."
     rationale: "Prompting the user to enter both their username and password makes it twice as hard for unauthorized users to gain access to the system since they must discover two attributes."
@@ -792,7 +748,6 @@ checks:
       - cis_csc_v7: ["5.1"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
       - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["11.5", "2.2"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
@@ -802,7 +757,7 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''SHOWFULLNAME'')" -> r:^1$|^true$'
 
   # 2.10.5 Ensure Show Password Hints Is Disabled. (Automated)
-  - id: 31032
+  - id: 30032
     title: "Ensure Show Password Hints Is Disabled."
     description: "Password hints are user-created text displayed when an incorrect password is used for an account."
     rationale: "Password hints make it easier for unauthorized persons to gain access to systems by displaying information provided by the user to assist in remembering the password. This info could include the password itself or other information that might be readily discerned with basic knowledge of the end user."
@@ -814,7 +769,6 @@ checks:
       - cis_csc_v7: ["5.1"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7"]
       - iso_27001-2013: ["A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["11.5", "2.2"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
@@ -824,9 +778,8 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''RetriesUntilHint'')" -> r:^0$'
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''RetriesUntilHint'')" -> r:\w+'
 
-  # 2.11 Touch ID & Password (Login Password)
   # 2.11.1 Ensure Users' Accounts Do Not Have a Password Hint. (Automated)
-  - id: 31033
+  - id: 30033
     title: "Ensure Users' Accounts Do Not Have a Password Hint."
     description: "Password hints help the user recall their passwords for various systems and/or accounts. In most cases, password hints are simple and closely related to the user's password."
     rationale: "Password hints that are closely related to the user's password are a security vulnerability, especially in the social media age. Unauthorized users are more likely to guess a user's password if there is a password hint. The password hint is very susceptible to social engineering attacks and information exposure on social media networks."
@@ -837,23 +790,21 @@ checks:
       - cis_csc_v7: ["4.4"]
       - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1003", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1134", "T1136", "T1169", "T1175", "T1184", "T1190", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
     condition: none
     rules:
       - 'not c:dscl . -list /Users hint -> r:^\w*$'
 
-  # 2.11.2 Audit Touch ID and Wallet & Apple Pay Settings (Manual) - Not Implemented
-  # 2.12 Users & Groups
+  # 2.11.2 Audit Touch ID. (Manual) - Not Implemented
 
   # 2.12.1 Ensure Guest Account Is Disabled. (Automated)
-  - id: 31034
+  - id: 30034
     title: "Ensure Guest Account Is Disabled."
     description: "The guest account allows users access to the system without having to create an account or password. Guest users are unable to make setting changes and cannot remotely login to the system. All files, caches, and passwords created by the guest user are deleted upon logging out."
     rationale: "Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system."
     impact: "A guest user can use that access to find out additional information about the system and might be able to use privilege escalation vulnerabilities to establish greater access."
-    remediation: "Graphical Method: Perform the following steps to disable guest account availability: 1. Open System Settings 2. Select Users & Groups 3. Select the i next to the Guest User 4. Set Allow guests to log in to this computer to disabled Terminal Method: Run the following command to disable the guest account: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool false Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.MCX 2. The key to include is DisableGuestAccount 3. The key must be set to <true/>."
+    remediation: "Graphical Method: Perform the following steps to disable guest account availability: 1. Open System Settings 2. Select Users & Groups 3. Select the i next to the Guest User 4. Set Allow guests to log in to this computer to disabled Terminal Method: Run the following command to disable the guest account: $ /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool false Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.MCX 2. The key to include is DisableGuestAccount 3. The key must be set to <true/> 4. The key to include is EnableGuestAccount 5. The key must be set to <false/>."
     compliance:
       - cis: ["2.12.1"]
       - cis_csc_v8: ["5.2", "6.2", "6.8"]
@@ -861,7 +812,6 @@ checks:
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.4", "AC.L2-3.1.5", "IA.L2-3.5.7", "SC.L2-3.13.3"]
       - hipaa: ["164.308(a)(3)(ii)(B)", "164.308(a)(3)(ii)(C)", "164.308(a)(4)(i)", "164.308(a)(4)(ii)(C)"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1003", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1134", "T1136", "T1169", "T1175", "T1184", "T1190", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - nist_sp_800-53: ["AC-2(1)", "AC-5", "AC-6", "AC-6(1)", "AC-6(7)", "AU-9(4)"]
       - pci_dss_v3.2.1: ["8.1.3"]
       - pci_dss_v4.0: ["10.3.1", "2.2.2", "7.1", "7.1.1", "7.2", "7.2.1", "7.2.2", "7.2.4", "7.2.6", "7.3", "7.3.1", "7.3.2", "8.2.4", "8.2.5", "8.3.5", "8.3.6", "8.6.3"]
@@ -872,10 +822,10 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''GuestEnabled'')" -> r:^0$'
 
   # 2.12.2 Ensure Guest Access to Shared Folders Is Disabled. (Automated)
-  - id: 31035
+  - id: 30035
     title: "Ensure Guest Access to Shared Folders Is Disabled."
     description: "Allowing guests to connect to shared folders enables users to access selected shared folders and their contents from different computers on a network."
-    rationale: "Not allowing guests to connect to shared folders mitigates the risk of an untrusted user doing basic reconnaissance and possibly use privilege escalation attacks to take control of the system."
+    rationale: "Not allowing guests to connect to shared folders mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system."
     impact: "Unauthorized users could access shared files on the system."
     remediation: "Graphical Method: Perform the following steps to no longer allow guest user access to shared folders: 1. Open System Settings 2. Select Users & Groups 3. Select the i next to the Guest User 4. Set Allow guests to connect to shared folders to disabled Terminal Method: Run the following commands to verify that shared folders are not accessible to guest users: $ /usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess off."
     compliance:
@@ -885,7 +835,6 @@ checks:
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
       - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
       - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1004", "T1015", "T1021", "T1023", "T1031", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1050", "T1051", "T1053", "T1054", "T1070", "T1072", "T1073", "T1075", "T1076", "T1078", "T1080", "T1081", "T1084", "T1089", "T1096", "T1097", "T1133", "T1134", "T1145", "T1146", "T1150", "T1152", "T1156", "T1157", "T1159", "T1160", "T1162", "T1163", "T1165", "T1168", "T1169", "T1184", "T1185", "T1196", "T1197", "T1198", "T1200", "T1209", "T1213", "T1484", "T1489", "T1492", "T1494", "T1501", "T1504", "T1528", "T1530", "T1537", "T1538"]
       - nist_sp_800-53: ["AC-5", "AC-6"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_v4.0: ["1.3.1", "7.1"]
@@ -895,7 +844,7 @@ checks:
       - "c:sysadminctl -smbGuestAccess status -> r:SMB guest access disabled"
 
   # 2.12.3 Ensure Automatic Login Is Disabled. (Automated)
-  - id: 31036
+  - id: 30036
     title: "Ensure Automatic Login Is Disabled."
     description: "The automatic login feature saves a user's system access credentials and bypasses the login screen. Instead, the system automatically loads to the user's desktop screen."
     rationale: "Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system."
@@ -906,7 +855,6 @@ checks:
       - cis_csc_v8: ["4.7"]
       - cis_csc_v7: ["4.2"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1003", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1134", "T1136", "T1169", "T1175", "T1184", "T1190", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - pci_dss_v3.2.1: ["2.1", "2.1.1"]
       - pci_dss_v4.0: ["2.2.2", "2.3.1"]
       - soc_2: ["CC6.3"]
@@ -915,16 +863,13 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''com.apple.login.mcx.DisableAutoLoginClient'')" -> r:^1$'
       - 'not c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.loginwindow'').objectForKey(''autoLoginUser'')" -> r:^\.+$'
 
-  # 2.13 Passwords
-  # 2.13.1 Audit Passwords System Preference Setting (Manual) - Not implemented
-  # 2.14 Notifications
-  # 2.14.1 Audit Notification & Focus Settings (Manual) - Not implemented
-  ##########################################################################
-  # 3 Logging and Auditing
-  ##########################################################################
+  # 2.13.1 Audit Passwords System Preference Setting. (Manual) - Not Implemented
+  # 2.14.1 Audit Game Center Settings. (Manual) - Not Implemented
+  # 2.15.1 Audit Notification & Focus Settings. (Manual) - Not Implemented
+  # 2.16.1 Audit Wallet & Apple Pay Settings. (Manual) - Not Implemented
 
   # 3.1 Ensure Security Auditing Is Enabled. (Automated)
-  - id: 31037
+  - id: 30037
     title: "Ensure Security Auditing Is Enabled."
     description: "macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log."
     rationale: "Logs generated by auditd may be useful when investigating a security incident as they may help reveal the vulnerable application and the actions taken by a malicious actor."
@@ -940,23 +885,22 @@ checks:
       - pci_dss_v3.2.1: ["10.1", "10.2", "10.2.2", "10.2.4", "10.2.5", "10.3"]
       - pci_dss_v4.0: ["10.2", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2", "9.4.5"]
       - soc_2: ["CC5.2", "CC7.2"]
-      - mitre_techniques: ["T1110", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028", "T1156", "T1146", "T1196", "T1081", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1145", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209"]
     condition: all
     rules:
       - "c:launchctl list -> r:com.apple.auditd"
 
   # 3.2 Ensure Security Auditing Flags For User-Attributable Events Are Configured Per Local Organizational Requirements. (Automated)
-  - id: 31038
+  - id: 30038
     title: "Ensure Security Auditing Flags For User-Attributable Events Are Configured Per Local Organizational Requirements."
     description: "Auditing is the capture and maintenance of information about security-related events. Auditable events often depend on differing organizational requirements."
     rationale: "Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred, have begun, or are about to begin. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Depending on the governing authority, organizations can have vastly different auditing requirements. In this control we have selected a minimal set of audit flags that should be a part of any organizational requirements. The flags selected below may not adequately meet organizational requirements for users of this benchmark. The auditing checks for the flags proposed here will not impact additional flags that are selected."
     remediation: "Terminal Method: Perform the following to set the required Security Auditing Flags: Edit the /etc/security/audit_control file and add -fm, ad, -ex, aa, -fr, lo, and -fw to flags. You can also substitute -all for -fm, -ex, -fr, and -fw."
     references:
-      - https://derflounder.wordpress.com/2012/01/30/openbsm-auditing-on-mac-os-x/
-      - https://csrc.nist.gov/CSRC/media/Publications/sp/800-179/rev-1/draft/documents/sp800-179r1-draft.pdf
-      - https://www.scip.ch/en/?labs.20150108
-      - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171r2.pdf
-      - https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-the-Federal-Governments-Investigative-and-Remediation-Capabilities-Related-to-Cybersecurity-Incidents.pdf
+      - "https://derflounder.wordpress.com/2012/01/30/openbsm-auditing-on-mac-os-x/"
+      - "https://csrc.nist.gov/CSRC/media/Publications/sp/800-179/rev-"
+      - "https://www.scip.ch/en/?labs.20150108"
+      - "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171r2.pdf"
+      - "https://www.whitehouse.gov/wp-content/uploads/2021/08/M-21-31-Improving-"
     compliance:
       - cis: ["3.2"]
       - cis_csc_v8: ["3.14", "8.2", "8.5"]
@@ -974,7 +918,7 @@ checks:
       - "f:/etc/security/audit_control -> r:^flags && r:-all && r:ad && r:aa && r:lo"
 
   # 3.3 Ensure install.log Is Retained for 365 or More Days and No Maximum Size. (Automated)
-  - id: 31039
+  - id: 30039
     title: "Ensure install.log Is Retained for 365 or More Days and No Maximum Size."
     description: 'macOS writes information pertaining to system-related events to the file /var/log/install.log and has a configurable retention policy for this file. The default logging setting limits the file size of the logs and the maximum size for all logs. The default allows for an errant application to fill the log files and does not enforce sufficient log retention. The Benchmark recommends a value based on standard use cases. The value should align with local requirements within the organization. The default value has an "all_max" file limitation, no reference to a minimum retention, and a less precise rotation argument. The all_max flag control will remove old log entries based only on the size of the log files. Log size can vary widely depending on how verbose installing applications are in their log entries. The decision here is to ensure that logs go back a year, and depending on the applications a size restriction could compromise the ability to store a full year. While this Benchmark is not scoring for a rotation flag, the default rotation is sequential rather than using a timestamp. Auditors may prefer timestamps in order to simply review specific dates where event information is desired. Please review the File Rotation section in the man page for more information. man asl.conf - The maximum file size limitation string should be removed "all_max=" - An organization appropriate retention should be added "ttl=" - The rotation should be set with timestamps "rotate=utc" or "rotate=local".'
     rationale: "Archiving and retaining install.log for at least a year is beneficial in the event of an incident as it will allow the user to view the various changes to the system along with the date and time they occurred."
@@ -996,7 +940,7 @@ checks:
       - 'not f:/etc/asl/com.apple.install -> r:^\s*all_max='
 
   # 3.4 Ensure Security Auditing Retention Is Enabled. (Automated)
-  - id: 31040
+  - id: 30040
     title: "Ensure Security Auditing Retention Is Enabled."
     description: "The macOS audit capability contains important information to investigate security or operational issues. This resource is only completely useful if it is retained long enough to allow technical staff to find the root cause of anomalies in the records. Retention can be set to respect both size and longevity. To retain as much as possible under a certain size, the recommendation is to use the following: expire-after:60d OR 5G This recomendation is based on minimum storage for review and investigation. When a third party tool is in use to allow remote logging or the store and forwarding of logs, this local storage requirement is not required."
     rationale: "The audit records need to be retained long enough to be reviewed as necessary."
@@ -1023,16 +967,12 @@ checks:
       - 'f:/etc/security/audit_control -> n:^expire-after:\s*\d+\w OR (\d+)m compare => 5120'
       - 'f:/etc/security/audit_control -> n:^expire-after:\s*\d+\w OR (\d+)g compare => 5'
 
-  # 3.5 Ensure Access to Audit Records Is Controlled (Automated) - Not implemented
-  # 3.6 Ensure Firewall Logging Is Enabled and Configured (Automated) - Not implemented
-  # 3.7 Audit Software Inventory (Manual) - Not Implemented
-
-  ##########################################################################
-  # 4 Network Configurations
-  ##########################################################################
+  # 3.5 Ensure Access to Audit Records Is Controlled. (Automated) - Not Implemented
+  # 3.6 Ensure Firewall Logging Is Enabled and Configured. (Automated) - Not Implemented
+  # 3.7 Audit Software Inventory. (Manual) - Not Implemented
 
   # 4.1 Ensure Bonjour Advertising Services Is Disabled. (Automated)
-  - id: 31041
+  - id: 30041
     title: "Ensure Bonjour Advertising Services Is Disabled."
     description: "Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled."
     rationale: 'Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour''s multicast DNS feature to discover a vulnerable or poorly-configured service or additional information to aid a targeted attack. Implementing this control disables the continuous broadcasting of "I''m here!" messages. Typical end-user endpoints should not have to advertise services to other computers. This setting does not stop the computer from sending out service discovery messages when looking for services on an internal subnet, if the computer is looking for a printer or server and using service discovery. To block all Bonjour traffic except to approved devices, the pf or other firewall would be needed.'
@@ -1044,7 +984,6 @@ checks:
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -1054,21 +993,21 @@ checks:
       - 'c:osascript -l JavaScript -e "$.NSUserDefaults.alloc.initWithSuiteName(''com.apple.mDNSResponder'').objectForKey(''NoMulticastAdvertisements'')" -> r:^1$'
 
   # 4.2 Ensure HTTP Server Is Disabled. (Automated)
-  - id: 31042
+  - id: 30042
     title: "Ensure HTTP Server Is Disabled."
     description: "macOS used to have a graphical front-end to the embedded Apache web server in the Operating System. Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer. Personal web sharing from a user endpoint has long been considered questionable, and Apple has removed that capability from the GUI. Apache, however, is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end-user computer. Web sharing should only be done through hardened web servers and appropriate cloud services."
     rationale: "Web serving should not be done from a user desktop. Dedicated webservers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer."
     impact: "The web server is both a point of attack for the system and a means for unauthorized file transfers."
-    remediation: "Terminal Method: Run the following command to disable the HTTP server services: $ sudo /usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist."
+    remediation: "Terminal Method: Run the following command to disable the HTTP server services: $ /usr/bin/sudo /usr/sbin/apachectl stop $ /usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist."
     references:
-      - https://www.stigviewer.com/stig/apple_macos_11_big_sur/2021-06-16/finding/V-230793
+      - "https://www.stigviewer.com/stig/apple_macos_11_big_sur/2021-06-16/finding/V-"
+      - "https://httpd.apache.org/security/vulnerabilities_24.html"
     compliance:
       - cis: ["4.2"]
       - cis_csc_v8: ["4.1", "4.8"]
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -1078,19 +1017,18 @@ checks:
       - "not c:launchctl list -> r:org.apache.httpd"
 
   # 4.3 Ensure NFS Server Is Disabled. (Automated)
-  - id: 31043
+  - id: 30043
     title: "Ensure NFS Server Is Disabled."
     description: "macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable, and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end-user computer. The etc/exports file contains the list of NFS shared directories. If the file exists, it is likely that NFS sharing has been enabled in the past or may be available periodically. As an additional check, the audit verifies that there is no /etc/exports file."
     rationale: "File serving should not be done from a user desktop. Dedicated servers should be used. Open ports make it easier to exploit the computer."
     impact: "The nfs server is both a point of attack for the system and a means for unauthorized file transfers."
-    remediation: "Terminal Method: Run the following command to disable the nfsd fileserver services: $ /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd Remove the exported Directory listing. $ /usr/bin/sudo /bin/rm /etc/exports."
+    remediation: "Terminal Method: Run the following command to disable the nfsd fileserver services: $ /usr/bin/sudo /sbin/nfsd stop $ /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd Remove the exported Directory listing. $ /usr/bin/sudo /bin/rm /etc/exports."
     compliance:
       - cis: ["4.3"]
       - cis_csc_v8: ["4.1", "4.8"]
       - cis_csc_v7: ["5.1", "9.2"]
       - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "CM.L2-3.4.1", "CM.L2-3.4.2", "CM.L2-3.4.6", "CM.L2-3.4.7", "CM.L2-3.4.8", "SC.L2-3.13.6"]
       - iso_27001-2013: ["A.13.1.3", "A.14.2.5", "A.8.1.3"]
-      - mitre_techniques: ["T1003", "T1011", "T1015", "T1017", "T1019", "T1028", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1051", "T1053", "T1054", "T1055", "T1058", "T1067", "T1070", "T1072", "T1073", "T1075", "T1076", "T1077", "T1078", "T1080", "T1081", "T1084", "T1086", "T1087", "T1088", "T1089", "T1092", "T1096", "T1097", "T1098", "T1100", "T1110", "T1112", "T1130", "T1133", "T1134", "T1136", "T1137", "T1138", "T1139", "T1142", "T1145", "T1146", "T1147", "T1148", "T1150", "T1156", "T1157", "T1165", "T1166", "T1169", "T1173", "T1174", "T1175", "T1176", "T1177", "T1178", "T1184", "T1187", "T1190", "T1196", "T1197", "T1198", "T1199", "T1200", "T1201", "T1206", "T1208", "T1209", "T1210", "T1214", "T1215", "T1218", "T1485", "T1486", "T1487", "T1488", "T1489", "T1490", "T1491", "T1492", "T1494", "T1495", "T1501", "T1503", "T1504", "T1505", "T1506", "T1525", "T1530", "T1535", "T1537", "T1539"]
       - nist_sp_800-53: ["CM-7(1)", "CM-9", "SA-10"]
       - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "11.5", "2.2", "2.2.2", "2.2.5"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.5", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1", "2.2.4", "6.4.1"]
@@ -1100,45 +1038,18 @@ checks:
       - "not c:launchctl list -> r:com.apple.nfsd"
       - "not f:/etc/exports"
 
-  ##########################################################################
-  # 5 System Access, Authentication and Authorization
-  ##########################################################################
-
-  # 5.1 File System Permissions and Access Controls
-  - id: 31044
-    title: "Ensure Home Folders Are Secure."
-    description: 'By default, macOS allows all valid users into the top level of every other user''s home folder and restricts access to the Apple default folders within. Another user on the same system can see you have a "Documents" folder but cannot see inside it. This configuration does work for personal file sharing but can expose user files to standard accounts on the system. The best parallel for Enterprise environments is that everyone who has a Dropbox account can see everything that is at the top level but can''t see your pictures. Similarly with macOS, users can see into every new Directory that is created because of the default permissions. Home folders should be restricted to access only by the user. Sharing should be used on dedicated servers or cloud instances that are managing access controls. Some environments may encounter problems if execute rights are removed as well as read and write. Either no access or execute only for group or others is acceptable.'
-    rationale: "Allowing all users to view the top level of all networked users' home folder may not be desirable since it may lead to the revelation of sensitive information."
-    impact: 'If implemented, users will not be able to use the "Public" folders in other users'' home folders. "Public" folders with appropriate permissions would need to be set up in the /Shared folder.'
-    remediation: "Terminal Method: For each user, run the following command to secure all home folders: $ /usr/bin/sudo /bin/chmod -R og-rwx /Users/<username> Alternately, run the following command if there needs to be executable access for a home folder: $ /usr/bin/sudo /bin/chmod -R og-rw /Users/<username> example: $ /usr/bin/sudo /bin/chmod -R og-rw /Users/thirduser/ $ /usr/bin/sudo /bin/chmod -R og-rwx /Users/fourthuser/ # /bin/ls -l /Users/ total 0 drwxr-xr-x+ 12 Guest _guest 384 24 Jul 13:42 Guest drwxrwxrwt 4 root wheel 128 22 Jul 11:00 Shared drwx--x--x+ 18 firstuser staff 576 10 Aug 14:36 firstuser drwx--x--x+ 15 seconduser staff 480 10 Aug 09:16 seconduser drwx--x--x+ 11 thirduser staff 352 10 Aug 14:53 thirduser drwx------+ 11 fourthuser staff 352 10 Aug 14:53 fourthuser."
-    compliance:
-      - cis: ["5.1.1"]
-      - cis_csc_v8: ["3.3"]
-      - cis_csc_v7: ["14.6"]
-      - cmmc_v2.0: ["AC.L1-3.1.1", "AC.L1-3.1.2", "AC.L2-3.1.3", "AC.L2-3.1.5", "MP.L2-3.8.2"]
-      - hipaa: ["164.308(a)(3)(i)", "164.308(a)(3)(ii)(A)", "164.312(a)(1)"]
-      - iso_27001-2013: ["A.9.1.1"]
-      - mitre_techniques: ["T1004", "T1015", "T1021", "T1023", "T1031", "T1034", "T1035", "T1036", "T1037", "T1044", "T1047", "T1050", "T1051", "T1053", "T1054", "T1070", "T1072", "T1073", "T1075", "T1076", "T1078", "T1080", "T1081", "T1084", "T1089", "T1096", "T1097", "T1133", "T1134", "T1145", "T1146", "T1150", "T1152", "T1156", "T1157", "T1159", "T1160", "T1162", "T1163", "T1165", "T1168", "T1169", "T1184", "T1185", "T1196", "T1197", "T1198", "T1200", "T1209", "T1213", "T1484", "T1489", "T1492", "T1494", "T1501", "T1504", "T1528", "T1530", "T1537", "T1538"]
-      - nist_sp_800-53: ["AC-5", "AC-6"]
-      - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
-      - pci_dss_v4.0: ["1.3.1", "7.1"]
-      - soc_2: ["CC5.2", "CC6.1"]
-    condition: any
-    rules:
-      - 'not c:sh -c "ls -l /Users | grep -v total" -> !r:^drwx------ && !r:^drwx--x--x'
-
   # 5.1.1 Ensure Home Folders Are Secure. (Automated) - Not Implemented
 
   # 5.1.2 Ensure System Integrity Protection Status (SIP) Is Enabled. (Automated)
-  - id: 31045
+  - id: 30044
     title: "Ensure System Integrity Protection Status (SIP) Is Enabled."
     description: "System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan. System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID."
     rationale: "Running without System Integrity Protection on a production system runs the risk of the modification of system binaries or code injection of system processes that would otherwise be protected by SIP."
     impact: "System binaries and processes could become compromised."
-    remediation: "Terminal Method: Perform the following steps to enable System Integrity Protection: 1. Reboot into the Recovery Partition (reboot and hold down Command + R) 2. Select Utilities 3. Select Terminal 4. Run the following command: $ /usr/bin/sudo /usr/bin/csrutil enable Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect. 5. Reboot the computer Note: You should research why the system had SIP disabled. It might be a better option to erase the Mac and reinstall the operating system. That is at your discretion. Note: You cannot enable System Integrity Protection from the booted operating system. If the remediation is attempted in the booted OS and not the Recovery Partition the output will give the error csrutil: failed to modify system integrity configuration. This tool needs to be executed from the Recovery OS."
+    remediation: "Terminal Method: Perform the following steps to enable System Integrity Protection: 1. Reboot into the Recovery Partition (reboot and hold down Command () + R) 2. Select Utilities 3. Select Terminal 4. Run the following command: $ /usr/bin/sudo /usr/bin/csrutil enable Successfully enabled System Integrity Protection. Please restart the machine for the changes to take effect. 5. Reboot the computer Note: You should research why the system had SIP disabled. It might be a better option to erase the Mac and reinstall the operating system. That is at your discretion. Note: You cannot enable System Integrity Protection from the booted operating system. If the remediation is attempted in the booted OS and not the Recovery Partition the output will give the error csrutil: failed to modify system integrity configuration. This tool needs to be executed from the Recovery OS."
     references:
-      - https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection
-      - https://support.apple.com/en-us/HT204899
+      - "https://developer.apple.com/documentation/security/disabling_and_enabling_syst"
+      - "https://support.apple.com/en-us/HT204899"
     compliance:
       - cis: ["5.1.2"]
       - cis_csc_v8: ["2.3", "2.6", "10.5"]
@@ -1149,23 +1060,22 @@ checks:
       - pci_dss_v3.2.1: ["1.4"]
       - pci_dss_v4.0: ["1.2.5", "12.3.4", "2.2.4"]
       - soc_2: ["CC5.2", "CC6.8", "CC7.1"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
     condition: all
     rules:
       - "c:csrutil status -> r:^System Integrity Protection status: enabled."
 
   # 5.1.3 Ensure Apple Mobile File Integrity (AMFI) Is Enabled. (Automated)
-  - id: 31046
+  - id: 30045
     title: "Ensure Apple Mobile File Integrity (AMFI) Is Enabled."
     description: "Apple Mobile File Integrity (AMFI) was first released in macOS 10.12. The daemon and service block attempts to run unsigned code. AMFI uses lanchd, code signatures, certificates, entitlements, and provisioning profiles to create a filtered entitlement dictionary for an app. AMFI is the macOS kernel module that enforces code-signing and library validation."
     rationale: "Apple Mobile File Integrity validates that application code is validated."
     impact: "Applications could be compromised with malicious code."
     remediation: 'Terminal Method: Run the following command to enable the Apple Mobile File Integrity service: $ /usr/bin/sudo /usr/sbin/nvram boot-args="".'
     references:
-      - https://eclecticlight.co/2018/12/29/amfi-checking-file-integrity-on-your-mac/
-      - https://github.com/usnistgov/macos_security/issues/39
-      - https://github.com/usnistgov/macos_security/issues/40
-      - https://www.naut.ca/blog/2020/11/13/forbidden-commands-to-liberate-macos/
+      - "https://eclecticlight.co/2018/12/29/amfi-checking-file-integrity-on-your-mac/"
+      - "https://github.com/usnistgov/macos_security/issues/39"
+      - "https://github.com/usnistgov/macos_security/issues/40"
+      - "https://www.naut.ca/blog/2020/11/13/forbidden-commands-to-liberate-macos/"
     compliance:
       - cis: ["5.1.3"]
       - cis_csc_v8: ["2.3", "2.6"]
@@ -1175,23 +1085,22 @@ checks:
       - nist_sp_800-53: ["CM-10", "CM-7(1)", "CM-7(2)", "CM-8(3)"]
       - pci_dss_v4.0: ["1.2.5", "12.3.4", "2.2.4"]
       - soc_2: ["CC5.2", "CC7.1"]
-      - mitre_techniques: ["T1191", "T1092", "T1175", "T1173", "T1519", "T1052", "T1210", "T1133", "T1118", "T1171", "T1170", "T1046", "T1137", "T1086", "T1164", "T1121", "T1076", "T1091", "T1180", "T1064", "T1184", "T1221", "T1127", "T1028"]
     condition: all
     rules:
       - "not c:nvram -p -> r:amfi_get_out_of_my_way=1"
 
   # 5.1.4 Ensure Sealed System Volume (SSV) Is Enabled. (Automated)
-  - id: 31047
+  - id: 30046
     title: "Ensure Sealed System Volume (SSV) Is Enabled."
     description: "Sealed System Volume is a security feature introduced in macOS 11.0 Big Sur. During system installation, a SHA-256 cryptographic hash is calculated for all immutable system files and stored in a Merkle tree which itself is hashed as the Seal. Both are stored in the metadata of the snapshot created of the System volume. The seal is verified by the boot loader at startup. macOS will not boot if system files have been tampered with. If validation fails, the user will be instructed to reinstall the operating system. During read operations for files located in the Sealed System Volume, a hash is calculated and compared to the value stored in the Merkle tree."
     rationale: "Running without Sealed System Volume on a production system could run the risk of Apple software that integrates directly with macOS being modified."
     impact: "Apple Software that integrates with the operating system could become compromised."
     remediation: "If SSV has been disabled, assume that the operating system has been compromised. Back up any files, and do a clean install to a known good Operating System."
     references:
-      - https://developer.apple.com/news/?id=3xpv8r2m
-      - https://eclecticlight.co/2020/11/30/is-big-surs-system-volume-sealed/
-      - https://eclecticlight.co/2020/06/25/big-surs-signed-system-volume-added-security-protection/
-      - https://support.apple.com/guide/security/signed-system-volume-security-secd698747c9/web
+      - "https://developer.apple.com/news/?id=3xpv8r2m"
+      - "https://eclecticlight.co/2020/11/30/is-big-surs-system-volume-sealed/"
+      - "https://eclecticlight.co/2020/06/25/big-surs-signed-system-volume-added-"
+      - "https://support.apple.com/guide/security/signed-system-volume-security-"
     compliance:
       - cis: ["5.1.4"]
       - cis_csc_v8: ["3.6", "3.11"]
@@ -1203,26 +1112,23 @@ checks:
       - pci_dss_v3.2.1: ["3.4", "3.4.1", "8.2.1"]
       - pci_dss_v4.0: ["3.1.1", "3.3.2", "3.3.3", "3.5.1", "3.5.1.2", "3.5.1.3", "8.3.2"]
       - soc_2: ["CC6.1"]
-      - mitre_techniques: ["T1527", "T1119", "T1530", "T1114", "T1070", "T1208", "T1040", "T1145", "T1492", "T1493", "T1072"]
     condition: all
     rules:
       - "c:csrutil authenticated-root status -> r:^Authenticated Root status: enabled"
 
-  # 5.1.5 Ensure Appropriate Permissions Are Enabled for System Wide Applications (Automated) - Not implemented
-  # 5.1.6 Ensure No World Writable Files Exist in the System Folder (Automated) - Not implemented
-  # 5.1.7 Ensure No World Writable Files Exist in the Library Folder (Automated) - Not implemented
-
-  # 5.2 Password Management
+  # 5.1.5 Ensure Appropriate Permissions Are Enabled for System Wide Applications. (Automated) - Not Implemented
+  # 5.1.6 Ensure No World Writable Folders Exist in the System Folder. (Automated) - Not Implemented
+  # 5.1.7 Ensure No World Writable Folders Exist in the Library Folder. (Automated) - Not Implemented
 
   # 5.2.1 Ensure Password Account Lockout Threshold Is Configured. (Automated)
-  - id: 31048
+  - id: 30047
     title: "Ensure Password Account Lockout Threshold Is Configured."
     description: "The account lockout threshold specifies the amount of times a user can enter an incorrect password before a lockout will occur. Ensure that a lockout threshold is part of the password policy on the computer."
     rationale: "The account lockout feature mitigates brute-force password attacks on the system."
     impact: "The number of incorrect log on attempts should be reasonably small to minimize the possibility of a successful password attack, while allowing for honest errors made during a normal user log on. The locked account will auto-unlock after a few minutes when bad password attempts stop. The computer will accept the still-valid password if remembered or recovered."
-    remediation: 'Terminal Method: Run the following command to set the maximum number of failed login attempts to less than or equal to 5: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy \"maxFailedLoginAttempts=<value=<5>\" Note: When the account lockout threshold is set with pwpolicy, it will also set a reset value to policyAttributeMinutesUntilFailedAuthenticationReset that defaults to 1 minute. You can change this value with the command: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy \"policyAttributeMinutesUntilFailedAuthenticationReset=<value in minutes>\" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy \"maxFailedLoginAttempts=5\" /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy \"policyAttributeMinutesUntilFailedAuthenticationReset=10\" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is maxFailedAttempts 3. The key must be set to <integer><value<=5></integer> Note: When setting the lockout threshold with a mobile configuration profile there is no default reset to the lockout. To set the reset value use the key autoEnableInSeconds and set the key to <integer><value in seconds></integer>. Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
+    remediation: 'Terminal Method: Run the following command to set the maximum number of failed login attempts to less than or equal to 5: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxFailedLoginAttempts=<value<5>" Note: When the account lockout threshold is set with pwpolicy, it will also set a reset value to policyAttributeMinutesUntilFailedAuthenticationReset that defaults to 1 minute. You can change this value with the command: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "policyAttributeMinutesUntilFailedAuthenticationReset=<value in minutes>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxFailedLoginAttempts=5" /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "policyAttributeMinutesUntilFailedAuthenticationReset=10" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is maxFailedAttempts 3. The key must be set to <integer><value<5></integer> Note: When setting the lockout threshold with a mobile configuration profile, there is no default reset to the lockout. To set the reset value, use the key autoEnableInSeconds and set the key to <integer><value in seconds></integer>. Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
     references:
-      - CIS Password Policy - https://workbench.cisecurity.org/communities/113
+      - "https://workbench.cisecurity.org/communities/113"
     compliance:
       - cis: ["5.2.1"]
       - cis_csc_v8: ["6.2"]
@@ -1234,18 +1140,17 @@ checks:
       - pci_dss_v3.2.1: ["8.1.3"]
       - pci_dss_v4.0: ["8.2.4", "8.2.5"]
       - soc_2: ["CC6.2", "CC6.3"]
-      - mitre_techniques: ["T1134", "T1197", "T1538", "T1530", "T1213", "T1089", "T1157", "T1044", "T1484", "T1054", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1031", "T1050", "T1075", "T1097", "T1034", "T1163", "T1076", "T1021", "T1053", "T1489", "T1051", "T1023", "T1165", "T1528", "T1501", "T1072", "T1537", "T1078", "T1047", "T1084", "T1004"]
     condition: all
     rules:
       - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:maxFailedLoginAttempts=(\d+) compare < 6'
 
   # 5.2.2 Ensure Password Minimum Length Is Configured. (Automated)
-  - id: 31049
+  - id: 30048
     title: "Ensure Password Minimum Length Is Configured."
     description: "A minimum password length is the fewest number of characters a password can contain to meet a system's requirements. Ensure that a minimum of a 15-character password is part of the password policy on the computer. Where the confidentiality of encrypted information in FileVault is more of a concern, requiring a longer password or passphrase may be sufficient rather than imposing additional complexity requirements that may be self-defeating."
     rationale: "Information systems that are not protected with strong password schemes including passwords of minimum length provide a greater opportunity for attackers to crack the password and gain access to the system."
     impact: "Short passwords can be easily attacked."
-    remediation: 'Terminal Method: Run the following command to set the password length to greater than or equal to 15: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy \"minChars=<value>=15>\" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy \"minChars=15\" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is minLength 3. The key must be set to <integer><value>=15></integer> Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
+    remediation: 'Terminal Method: Run the following command to set the password length to greater than or equal to 15: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "minChars=<value>15>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "minChars=15" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is minLength 3. The key must be set to <integer><value>15></integer> Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
     compliance:
       - cis: ["5.2.2"]
       - cis_csc_v8: ["5.2"]
@@ -1254,25 +1159,23 @@ checks:
       - iso_27001-2013: ["A.9.4.3"]
       - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
     condition: all
     rules:
       - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:minChars=(\d+) compare > 14'
 
   # 5.2.3 Ensure Complex Password Must Contain Alphabetic Characters Is Configured. (Manual)
-  - id: 31050
+  - id: 30049
     title: "Ensure Complex Password Must Contain Alphabetic Characters Is Configured."
     description: "Complex passwords contain one character from each of the following classes: English uppercase letters, English lowercase letters, Westernized Arabic numerals, and non-alphanumeric characters. Ensure that an Alphabetic character is part of the password policy on the computer."
     rationale: "The more complex a password, the more resistant it will be against persons seeking unauthorized access to a system."
     impact: "Password policy should be in effect to reduce the risk of exposed services being compromised easily through dictionary attacks or other social engineering attempts."
-    remediation: 'Terminal Method: Run the following command to set the that passwords must contain at least one letter: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy - setaccountpolicies "requiresAlpha=<value>=1>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresAlpha=1" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is requireAlphanumeric 3. The key must be set to <true/> Note: This profile sets a requirement of both an alphabetical and a numeric character. Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
+    remediation: 'Terminal Method: Run the following command to set the that passwords must contain at least one letter: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy - setaccountpolicies "requiresAlpha=<value>1>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresAlpha=1" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is requireAlphanumeric 3. The key must be set to <true/> Note: This profile sets a requirement of both an alphabetical and a numeric character. Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
     compliance:
       - cis: ["5.2.3"]
       - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
       - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1003", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1134", "T1136", "T1169", "T1175", "T1184", "T1190", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
     condition: any
@@ -1281,19 +1184,18 @@ checks:
       - 'c:sh  -c "pwpolicy -getaccountpolicies | grep -A1 minimumLetters " -> n:>(\d+)< compare >= 1'
 
   # 5.2.4 Ensure Complex Password Must Contain Numeric Character Is Configured. (Manual)
-  - id: 31051
+  - id: 30050
     title: "Ensure Complex Password Must Contain Numeric Character Is Configured."
     description: "Complex passwords contain one character from each of the following classes: English uppercase letters, English lowercase letters, Westernized Arabic numerals, and non-alphanumeric characters. Ensure that a number or numeric value is part of the password policy on the computer."
     rationale: "The more complex a password, the more resistant it will be against persons seeking unauthorized access to a system."
     impact: "Password policy should be in effect to reduce the risk of exposed services being compromised easily through dictionary attacks or other social engineering attempts."
-    remediation: 'Terminal Method: Run the following command to set passwords to require at least one number: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy - setaccountpolicies "requiresNumeric=<value>=1>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresNumeric=2" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is requireAlphanumeric 3. The key must be set to <true/> Note: This profile sets a requirement of both an alphabetical and a numeric character. Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
+    remediation: 'Terminal Method: Run the following command to set passwords to require at least one number: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy - setaccountpolicies "requiresNumeric=<value>1>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresNumeric=2" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is requireAlphanumeric 3. The key must be set to <true/> Note: This profile sets a requirement of both an alphabetical and a numeric character. Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
     compliance:
       - cis: ["5.2.4"]
       - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
       - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1003", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1134", "T1136", "T1169", "T1175", "T1184", "T1190", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
     condition: any
@@ -1301,22 +1203,21 @@ checks:
       - "c:pwpolicy -getaccountpolicies -> r:Contain at least one number and one alphabetic character."
       - 'c:sh  -c "pwpolicy -getaccountpolicies | grep -A1 minimumNumericCharacters " -> n:>(\d+)< compare >= 1'
 
-  # 5.2.5 Ensure Complex Password Must Contain Special Character Is Configured (Manual) - Not Implemented
+  # 5.2.5 Ensure Complex Password Must Contain Special Character Is Configured. (Manual) - Not Implemented
 
-  # 5.2.6 Ensure Complex Password Must Contain Uppercase and Lowercase Characters Is Configured (Manual)
-  - id: 31052
+  # 5.2.6 Ensure Complex Password Must Contain Uppercase and Lowercase Characters Is Configured. (Manual)
+  - id: 30051
     title: "Ensure Complex Password Must Contain Uppercase and Lowercase Characters Is Configured."
     description: "Complex passwords contain one character from each of the following classes: English uppercase letters, English lowercase letters, Westernized Arabic numerals, and non-alphanumeric characters. Ensure that both uppercase and lowercase letters are part of the password policy on the computer."
     rationale: "The more complex a password, the more resistant it will be against persons seeking unauthorized access to a system."
     impact: "Password policy should be in effect to reduce the risk of exposed services being compromised easily through dictionary attacks or other social engineering attempts."
-    remediation: 'Terminal Method: Run the following command to set passwords to require at upper and lower case letter: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresMixedCase=<value>=1>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresMixedCase=1".'
+    remediation: 'Terminal Method: Run the following command to set passwords to require at upper and lower case letter: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresMixedCase=<value>1>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresMixedCase=1".'
     compliance:
       - cis: ["5.2.6"]
       - cis_csc_v8: ["5.2"]
       - cis_csc_v7: ["4.4"]
       - cmmc_v2.0: ["IA.L2-3.5.7"]
       - iso_27001-2013: ["A.9.4.3"]
-      - mitre_techniques: ["T1003", "T1017", "T1019", "T1028", "T1035", "T1047", "T1051", "T1053", "T1055", "T1067", "T1072", "T1075", "T1076", "T1077", "T1078", "T1084", "T1086", "T1088", "T1097", "T1098", "T1100", "T1134", "T1136", "T1169", "T1175", "T1184", "T1190", "T1206", "T1208", "T1210", "T1214", "T1215", "T1218", "T1495", "T1501", "T1505", "T1525"]
       - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
     condition: any
@@ -1324,12 +1225,12 @@ checks:
       - 'c:sh  -c "pwpolicy -getaccountpolicies | grep -A1 minimumMixedCaseCharacters " -> n:>(\d+)< compare >= 1'
 
   # 5.2.7 Ensure Password Age Is Configured. (Automated)
-  - id: 31053
+  - id: 30052
     title: "Ensure Password Age Is Configured."
     description: "Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users should reset passwords periodically. This control uses 365 days as the acceptable value. Some organizations may be more or less restrictive. This control mainly exists to mitigate against password reuse of the macOS account password in other realms that may be more prone to compromise. Attackers take advantage of exposed information to attack other accounts."
     rationale: "Passwords should be changed periodically to reduce exposure."
     impact: "Required password changes will lead to some locked computers requiring admin assistance."
-    remediation: 'Terminal Method: Run the following command to require that passwords expire after at most 365 days: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxMinutesUntilChangePassword=<value<=525600>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxMinutesUntilChangePassword=43200" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is maxPINAgeInDays 3. The key must be set to <integer><value>=365></integer> Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
+    remediation: 'Terminal Method: Run the following command to require that passwords expire after at most 365 days: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxMinutesUntilChangePassword=<value<525600>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxMinutesUntilChangePassword=43200" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is maxPINAgeInDays 3. The key must be set to <integer><value>365></integer> Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
     compliance:
       - cis: ["5.2.7"]
       - cis_csc_v8: ["5.3"]
@@ -1338,18 +1239,17 @@ checks:
       - nist_sp_800-53: ["AC-2(3)"]
       - pci_dss_v3.2.1: ["8.1.4"]
       - pci_dss_v4.0: ["8.3.7"]
-      - mitre_techniques: ["T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078", "T1134", "T1197", "T1538", "T1089", "T1157", "T1054", "T1159", "T1160", "T1152", "T1168", "T1162", "T1185", "T1050", "T1075", "T1097", "T1163", "T1021", "T1489", "T1051", "T1023", "T1165", "T1501", "T1072", "T1537", "T1047", "T1084", "T1004"]
     condition: all
     rules:
       - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:maxMinutesUntilChangePassword=(\d+) compare < 525601'
 
   # 5.2.8 Ensure Password History Is Configured. (Automated)
-  - id: 31054
+  - id: 30053
     title: "Ensure Password History Is Configured."
     description: "Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 15. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak."
     rationale: "Old passwords should not be reused."
     impact: "Required password changes will lead to some locked computers requiring admin assistance."
-    remediation: 'Terminal Method: Run the following command to require that the password must to be different from at least the last 15 passwords: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "usingHistory=<value>=15>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "usingHistory=15" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is pinHistory 3. The key must be set to <integer><value>=15></integer> Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
+    remediation: 'Terminal Method: Run the following command to require that the password must to be different from at least the last 15 passwords: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "usingHistory=<value>15>" example: $ /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "usingHistory=15" Profile Method: Create or edit a configuration profile with the following information: 1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 2. The key to include is pinHistory 3. The key must be set to <integer><value>15></integer> Note: The profile method is the preferred method for setting password policy since - setglobalpolicy in pwpolicy is deprecated and will likely be removed in a future macOS release.'
     compliance:
       - cis: ["5.2.8"]
       - cis_csc_v8: ["5.2"]
@@ -1358,18 +1258,15 @@ checks:
       - iso_27001-2013: ["A.9.4.3"]
       - pci_dss_v4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
-      - mitre_techniques: ["T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1501", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
     condition: all
     rules:
       - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:usingHistory=(\d+) compare > 14'
 
-  # 5.3 Encryption
-
-  # 5.3.1 Ensure all user storage APFS volumes are encrypted (Manual) - Not Implemented
-  # 5.3.2 Ensure all user storage CoreStorage volumes are encrypted (Manual) - Not Implemented
+  # 5.3.1 Ensure all user storage APFS volumes are encrypted. (Manual) - Not Implemented
+  # 5.3.2 Ensure all user storage CoreStorage volumes are encrypted. (Manual) - Not Implemented
 
   # 5.4 Ensure the Sudo Timeout Period Is Set to Zero. (Automated)
-  - id: 31055
+  - id: 30054
     title: "Ensure the Sudo Timeout Period Is Set to Zero."
     description: "The sudo command allows the user to run programs as the root user. Working as the root user allows the user an extremely high level of configurability within the system. This control, along with the control to use a separate timestamp for each tty, limits the window where an unauthorized user, process, or attacker could utilize legitimate credentials that are valid for longer than required."
     rationale: "The sudo command stays logged in as the root user for five minutes before timing out and re-requesting a password. This five-minute window should be eliminated since it leaves the system extremely vulnerable. This is especially true if an exploit were to gain access to the system, since they would be able to make changes as a root user."
@@ -1381,42 +1278,40 @@ checks:
       - cis_csc_v7: ["16.11"]
       - cmmc_v2.0: ["AC.L2-3.1.10", "AC.L2-3.1.11"]
       - hipaa: ["164.312(a)(2)(iii)"]
-      - nist_sp_800-53: ["AC-11", "AC-11(1)", "AC-12", "AC-2(5)"]
       - iso_27001-2013: ["A.8.1.3"]
+      - nist_sp_800-53: ["AC-11", "AC-11(1)", "AC-12", "AC-2(5)"]
       - pci_dss_v3.2.1: ["8.1.8"]
       - pci_dss_v4.0: ["8.2.8"]
-      - mitre_techniques: ["T1110", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: all
     rules:
       - "c:sudo -V -> r:Authentication timestamp timeout: 0.0 minutes"
       - "c:stat /etc/sudoers.d -> r:root wheel"
 
   # 5.5 Ensure a Separate Timestamp Is Enabled for Each User/tty Combo. (Automated)
-  - id: 31056
+  - id: 30055
     title: "Ensure a Separate Timestamp Is Enabled for Each User/tty Combo."
     description: "Using tty tickets ensures that a user must enter the sudo password in each Terminal session. With sudo versions 1.8 and higher, introduced in 10.12, the default value is to have tty tickets for each interface so that root access is limited to a specific terminal. The default configuration can be overwritten or not configured correctly on earlier versions of macOS."
     rationale: "In combination with removing the sudo timeout grace period, a further mitigation should be in place to reduce the possibility of a background process using elevated rights when a user elevates to root in an explicit context or tty. Additional mitigation should be in place to reduce the risk of privilege escalation of background processes."
     impact: "This control should have no user impact. Developers or installers may have issues if background processes are spawned with different interfaces than where sudo was executed."
     remediation: "Terminal Method: Run the following command to edit the sudo settings: $ /usr/bin/sudo /usr/sbin/visudo -f /etc/sudoers.d/<configuration file name> example: $ /usr/bin/sudo /usr/sbin/visudo -f /etc/sudoers.d/10_cissudoconfiguration Note: Unlike other Unix and/or Linux distros, macOS will ignore configuration files in the sudoers.d folder that contain a . so do not add a file extension to the configuration file. Add the line Defaults timestamp_type=tty to the configuration file. Note: The Defaults timestamp_type=tty line can be added to an existing configuration file or a new one. That will depend on your organization's preference and works either way."
     references:
-      - https://github.com/jorangreef/sudo-prompt/issues/33
+      - "https://github.com/jorangreef/sudo-prompt/issues/33"
     compliance:
       - cis: ["5.5"]
       - cis_csc_v8: ["4.3"]
       - cis_csc_v7: ["16.11"]
       - cmmc_v2.0: ["AC.L2-3.1.10", "AC.L2-3.1.11"]
       - hipaa: ["164.312(a)(2)(iii)"]
-      - nist_sp_800-53: ["AC-11", "AC-11(1)", "AC-12", "AC-2(5)"]
       - iso_27001-2013: ["A.8.1.3"]
+      - nist_sp_800-53: ["AC-11", "AC-11(1)", "AC-12", "AC-2(5)"]
       - pci_dss_v3.2.1: ["8.1.8"]
       - pci_dss_v4.0: ["8.2.8"]
-      - mitre_techniques: ["T1110", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: all
     rules:
       - "c:sudo -V -> r:Type of authentication timestamp record: tty"
 
   # 5.6 Ensure the "root" Account Is Disabled. (Automated)
-  - id: 31057
+  - id: 30056
     title: 'Ensure the "root" Account Is Disabled.'
     description: "The root account is a superuser account that has access privileges to perform any actions and read/write to any file on the computer. With some versions of Linux, the system administrator may commonly use the root account to perform administrative functions."
     rationale: "Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using the sudo command allows users to perform functions as a root user while limiting and password protecting the access privileges. By default the root account is not enabled on a macOS computer. An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell)."
@@ -1431,45 +1326,43 @@ checks:
       - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
       - pci_dss_v3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - soc_2: ["CC6.1", "CC6.3"]
-      - mitre_techniques: ["T1176", "T1501", "T1134", "T1098", "T1017", "T1067", "T1088", "T1175", "T1136", "T1003", "T1214", "T1190", "T1210", "T1495", "T1525", "T1208", "T1215", "T1075", "T1097", "T1086", "T1055", "T1076", "T1053", "T1505", "T1035", "T1051", "T1218", "T1184", "T1169", "T1206", "T1019", "T1072", "T1078", "T1100", "T1077", "T1047", "T1084", "T1028"]
     condition: all
     rules:
       - "c:dscl . -read /Users/root AuthenticationAuthority -> r:^No such key: AuthenticationAuthority"
 
   # 5.7 Ensure an Administrator Account Cannot Login to Another User's Active and Locked Session. (Automated)
-  - id: 31058
+  - id: 30057
     title: "Ensure an Administrator Account Cannot Login to Another User's Active and Locked Session."
     description: "macOS has a privilege that can be granted to any user that will allow that user to unlock active user's sessions."
     rationale: "Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents unauthorized persons from viewing potentially sensitive and/or personal information."
     impact: "While Fast user switching is a workaround for some lab environments, especially where there is even less of an expectation of privacy, this setting change may impact some maintenance workflows."
     remediation: "Terminal Method: Run the following command to disable a user logging into another user's active and/or locked session: $ /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver use-login-window-ui YES (0)."
     references:
-      - https://derflounder.wordpress.com/2014/02/16/managing-the-authorization-database-in-os-x-mavericks/
-      - https://www.jamf.com/jamf-nation/discussions/18195/system-login-screensaver
+      - "https://derflounder.wordpress.com/2014/02/16/managing-the-authorization-"
+      - "https://www.jamf.com/jamf-nation/discussions/18195/system-login-screensaver"
     compliance:
       - cis: ["5.7"]
       - cis_csc_v8: ["4.3"]
       - cis_csc_v7: ["16.11"]
       - cmmc_v2.0: ["AC.L2-3.1.10", "AC.L2-3.1.11"]
       - hipaa: ["164.312(a)(2)(iii)"]
-      - nist_sp_800-53: ["AC-11", "AC-11(1)", "AC-12", "AC-2(5)"]
       - iso_27001-2013: ["A.8.1.3"]
+      - nist_sp_800-53: ["AC-11", "AC-11(1)", "AC-12", "AC-2(5)"]
       - pci_dss_v3.2.1: ["8.1.8"]
       - pci_dss_v4.0: ["8.2.8"]
-      - mitre_techniques: ["T1110", "T1527", "T1176", "T1088", "T1081", "T1214", "T1530", "T1213", "T1038", "T1073", "T1482", "T1114", "T1044", "T1484", "T1525", "T1161", "T1031", "T1034", "T1145", "T1076", "T1053", "T1505", "T1528", "T1078"]
     condition: all
     rules:
       - "c:security authorizationdb read system.login.screensaver -> r:use-login-window-ui"
 
   # 5.8 Ensure a Login Window Banner Exists. (Automated)
-  - id: 31059
+  - id: 30058
     title: "Ensure a Login Window Banner Exists."
     description: "A Login window banner warning informs the user that the system is reserved for authorized use only. It enforces an acknowledgment by the user that they have been informed of the use policy in the banner if required. The system recognizes either the .txt and the .rtf formats."
     rationale: "An access warning may reduce a casual attacker's tendency to target the system. Access warnings may also aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status, acceptable use policy, and authorization requirements."
     impact: "Users will have to click on the window with the Login text before logging into the computer."
     remediation: "Terminal Method: Run the following commands to create or edit the login window text and set the proper permissions: Edit (or create) a PolicyBanner.txt or PolicyBanner.rtf file, in the /Library/Security/ folder, to include the required login window banner text. Perform the following to set permissions on the policy banner file: $ /usr/bin/sudo /usr/sbin/chown o+r /Library/Security/PolicyBanner.txt $ /usr/bin/sudo /usr/sbin/chown o+r /Library/Security/PolicyBanner.rtf Note: If your organization uses an .rtfd file to set the policy banner, run $ /usr/bin/sudo /usr/sbin/chown -R o+rx /Library/Security/PolicyBanner.rtfd to update the permissions."
     references:
-      - https://support.apple.com/en-au/HT202277
+      - "https://support.apple.com/en-au/HT202277"
     compliance:
       - cis: ["5.8"]
       - cis_csc_v8: ["4.1"]
@@ -1480,16 +1373,15 @@ checks:
       - pci_dss_v3.2.1: ["11.5", "2.2"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
       - soc_2: ["CC7.1", "CC8.1"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
     condition: all
     rules:
       - "d:/Library/Security -> r:^PolicyBanner"
       - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
 
-  # 5.9 Ensure Legacy EFI Is Valid and Updating (Automated) - Not implemented
+  # 5.9 Ensure Legacy EFI Is Valid and Updating. (Automated) - Not Implemented
 
   # 5.10 Ensure the Guest Home Folder Does Not Exist. (Automated)
-  - id: 31060
+  - id: 30059
     title: "Ensure the Guest Home Folder Does Not Exist."
     description: "In the previous two controls, the guest account login has been disabled and sharing to guests has been disabled, as well. There is no need for the legacy Guest home folder to remain in the file system. When normal user accounts are removed, you have the option to archive it, leave it in place, or delete. In the case of the guest folder, the folder remains in place without a GUI option to remove it. If at some point in the future a Guest account is needed, it will be re-created. The presence of the Guest home folder can cause automated audits to fail when looking for compliant settings within all User folders, as well. Rather than ignoring the folder's continued existence, it is best removed."
     rationale: "The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately."
@@ -1505,33 +1397,18 @@ checks:
       - pci_dss_v3.2.1: ["11.5", "2.2"]
       - pci_dss_v4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
       - soc_2: ["CC7.1", "CC8.1"]
-      - mitre_techniques: ["T1110", "T1003", "T1081", "T1097", "T1178", "T1072", "T1067", "T1495", "T1019", "T1177", "T1485", "T1486", "T1491", "T1488", "T1487", "T1490", "T1146", "T1148", "T1015", "T1133", "T1200", "T1076", "T1051", "T1176", "T1501", "T1087", "T1098", "T1139", "T1197", "T1092", "T1136", "T1011", "T1147", "T1130", "T1174", "T1053", "T1166", "T1206", "T1503", "T1214", "T1187", "T1208", "T1142", "T1075", "T1201", "T1145", "T1184", "T1537", "T1078", "T1077", "T1134", "T1017", "T1088", "T1175", "T1190", "T1210", "T1525", "T1215", "T1086", "T1055", "T1505", "T1035", "T1218", "T1169", "T1100", "T1047", "T1084", "T1028", "T1156", "T1196", "T1530", "T1089", "T1073", "T1157", "T1054", "T1070", "T1037", "T1036", "T1096", "T1034", "T1150", "T1504", "T1494", "T1489", "T1198", "T1165", "T1492", "T1080", "T1209", "T1112", "T1058", "T1173", "T1137", "T1539", "T1535", "T1506", "T1138", "T1044", "T1199"]
     condition: all
     rules:
       - "not d:/Users/Guest"
 
-  ##########################################################################
-  # 6 Applications
-  ##########################################################################
+  # 6.1.1 Ensure Show All Filename Extensions Setting is Enabled. (Automated) - Not Implemented
+  # 6.2.1 Ensure Protect Mail Activity in Mail Is Enabled. (Manual) - Not Implemented
+  # 6.3.1 Ensure Automatic Opening of Safe Files in Safari Is Disabled. (Automated) - Not Implemented
+  # 6.3.2 Audit History and Remove History Items. (Manual) - Not Implemented
+  # 6.3.3 Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled. (Automated) - Not Implemented
+  # 6.3.4 Ensure Prevent Cross-site Tracking in Safari Is Enabled. (Automated) - Not Implemented
+  # 6.3.5 Audit Hide IP Address in Safari Setting. (Manual) - Not Implemented
+  # 6.3.6 Ensure Advertising Privacy Protection in Safari Is Enabled. (Automated) - Not Implemented
+  # 6.3.7 Ensure Show Full Website Address in Safari Is Enabled. (Automated) - Not Implemented
 
-  # 6.1 Finder
-
-  # 6.1.1 Ensure Show All Filename Extensions Setting is Enabled (Automated) - Not implemented
-
-  # 6.2 Mail
-
-  # 6.2.1 Ensure Protect Mail Activity in Mail Is Enabled (Manual) - Not Implemented
-
-  # 6.3 Safari
-
-  # 6.3.1 Ensure Automatic Opening of Safe Files in Safari Is Disabled (Automated) - Not implemented
-  # 6.3.2 Audit History and Remove History Items (Manual) - Not implemented
-  # 6.3.3 Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled (Automated) - Not implemented
-  # 6.3.4 Ensure Prevent Cross-site Tracking in Safari Is Enabled (Automated) - Not implemented
-  # 6.3.5 Audit Hide IP Address in Safari Setting (Manual) - Not implemented
-  # 6.3.6 Ensure Advertising Privacy Protection in Safari Is Enabled (Automated) - Not implemented
-  # 6.3.7 Ensure Show Full Website Address in Safari Is Enabled (Automated) - Not implemented
-
-  # 6.4 Terminal
-
-  # 6.4.1 Ensure Secure Keyboard Entry Terminal.app Is Enabled (Automated) - Not implemented
+  # 6.4.1 Ensure Secure Keyboard Entry Terminal.app Is Enabled. (Automated) - Not Implemented


### PR DESCRIPTION
|Related issue|
|---|
|#17319|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR aims to rework the SCA policy for macOS Ventura following the latest available CIS benchmark.
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

#### Analysisd (server or local)
analysisd.debug=2

#### Auth daemon debug (server)
authd.debug=0

#### Exec daemon debug (server, local, or Unix agent)
execd.debug=0

#### Monitor daemon debug (server, local, or Unix agent)
monitord.debug=0

#### Log collector (server, local or Unix agent)
logcollector.debug=0

#### Integrator daemon debug (server, local, or Unix agent)
integrator.debug=0

#### Unix agentd
agent.debug=2

## Tests
### Unit testing

- [x] a) Output from `ossec.log` after the SCA scan and a raw output of the result of the checks.
#### Tests results
```
2023/11/02 02:22:08 sca[24467] wm_sca.c:493 at wm_sca_read_files(): DEBUG: Calculating hash for scanned results.
2023/11/02 02:22:08 sca[24467] wm_sca.c:2817 at wm_sca_hash_integrity(): DEBUG: Concatenating check results:
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30000; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30001; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30002; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30003; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30004; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30005; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30006; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30007; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30008; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30009; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30010; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30011; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30012; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30013; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30014; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30015; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30016; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30017; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30018; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30019; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30020; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30021; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30022; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30023; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30024; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30025; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30026; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30027; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30028; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30029; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30030; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30031; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30032; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30033; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30034; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30035; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30036; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30037; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30038; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30039; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30040; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30041; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30042; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30043; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30044; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30045; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30046; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30047; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30048; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30049; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30050; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30051; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30052; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30053; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30054; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30055; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30056; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30057; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30058; Result: 'passed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30059; Result: 'failed'
2023/11/02 02:22:08 sca[24467] wm_sca.c:2820 at wm_sca_hash_integrity(): DEBUG: ID: 30060; Result: 'passed'
2023/11/02 02:22:11 sca[24467] wm_sca.c:2450 at wm_sca_send_summary(): DEBUG: Sending summary event for file: 'cis_macOS_13.0_Ventura.yml'
2023/11/02 02:22:11 sca[24467] wm_sca.c:270 at wm_sca_send_alert(): DEBUG: Sending event: {"type":"summary","scan_id":1672210278,"name":"CIS_Apple_macOS_13.0_Ventura_Benchmark_v1.1.0","policy_id":"cis_macOS_13.0_Ventura.yml","file":"cis_macOS_13.0_Ventura.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for MacOS 13 Ventura systems.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":34,"failed":27,"invalid":0,"total_checks":61,"score":55.737705230712891,"start_time":1698916913,"end_time":1698916928,"hash":"995d5e77d695bf417df4d60f7e34d19b881853a1d03b90a2fe7a9b643cdf4b68","hash_file":"3dec3105d06639923deae5b7db1118d429f093aeafb867a48700abd12a99f9e9","first_scan":1}
```