### PR TITLE
Use VCPKG dependencies for the engine compilation.

### DIFF
--- a/.github/workflows/engine_health_test.yml
+++ b/.github/workflows/engine_health_test.yml
@@ -50,13 +50,20 @@ jobs:
         pip install ${{env.ENGINE_DIR}}/test/integration_tests/it-utils/
         pip install ${{env.ENGINE_DIR}}/tools/engine-suite/
 
+    - name: Setup VCPKG
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{env.ENGINE_DIR}}/vcpkg'
+        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+        vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
+
     - name: Configure CMake
       # Configure the CMake build system with the specified build type
-      run: cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}} -B ${{env.ENGINE_DIR}}/build
+      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
 
     - name: Build
       # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j2
+      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j$(nproc)
 
     - name: Setup environment
       # Set Engine Configuration

--- a/.github/workflows/engine_helper_functions_test.yml
+++ b/.github/workflows/engine_helper_functions_test.yml
@@ -50,13 +50,19 @@ jobs:
         pip install ${{env.ENGINE_DIR}}/tools/engine-suite/
         pip install ${{env.ENGINE_DIR}}/test/helper_tests/engine_helper_test
 
-    - name: Configure CMake
+    - name: Setup VCPKG
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{env.ENGINE_DIR}}/vcpkg'
+        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+        vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
       # Configure the CMake build system with the specified build type
-      run: cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}} -B ${{env.ENGINE_DIR}}/build
+    - name: Configure CMake
+      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
 
     - name: Build
       # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j2
+      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j$(nproc)
 
     - name: Setup environment
       # Set Engine Configuration

--- a/.github/workflows/engine_integration_test.yml
+++ b/.github/workflows/engine_integration_test.yml
@@ -51,13 +51,20 @@ jobs:
         pip install ${{env.ENGINE_DIR}}/tools/engine-suite/
         pip install behave
 
+    - name: Setup VCPKG
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{env.ENGINE_DIR}}/vcpkg'
+        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+        vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
+
     - name: Configure CMake
       # Configure the CMake build system with the specified build type
-      run: cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}} -B ${{env.ENGINE_DIR}}/build
+      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
 
     - name: Build
       # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j2
+      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j$(nproc)
 
     - name: Setup environment
       # Set Engine Configuration

--- a/.github/workflows/engine_unit_test.yml
+++ b/.github/workflows/engine_unit_test.yml
@@ -38,13 +38,20 @@ jobs:
       with:
         key: ${{ github.workflow }}-${{ runner.os }}
 
+    - name: Setup VCPKG
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{env.ENGINE_DIR}}/vcpkg'
+        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+        vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
+
     - name: Configure CMake
       # Configure the CMake build system with the specified build type
-      run: cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}} -B ${{env.ENGINE_DIR}}/build
+      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
 
     - name: Build
       # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target all -j2
+      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target all -j$(nproc)
 
     - name: Unit Test
       # Run unit tests using CTest

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Minimum 3.14 required by googletest discover tests
-# Todo find wich component is not working properly until 3.24 version
-cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+# Todo find wich component is not working properly until 3.22.1 version
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 # Set c++17
 set(CMAKE_CXX_STANDARD 17)
@@ -108,56 +108,63 @@ include(${CPM_DOWNLOAD_LOCATION})
 ####################################################################################################
 include(cmake/CPM.cmake)
 
-# Concurrent Queue
-CPMAddPackage(
-  NAME CameronQueue
-  GITHUB_REPOSITORY cameron314/concurrentqueue
-  GIT_TAG v1.0.3
-  VERSION 1.0.3
-  EXCLUDE_FROM_ALL YES
-)
-
-CPMAddPackage(
-  NAME RxCpp
-  GITHUB_REPOSITORY ReactiveX/RxCpp
-  GIT_TAG v4.1.1
-  VERSION 4.1.1
-  EXCLUDE_FROM_ALL YES
-)
-
-CPMAddPackage(
-  NAME CLI11
-  GITHUB_REPOSITORY CLIUtils/CLI11
-  GIT_TAG v2.2.0
-  VERSION 2.2.0
-  DOWNLOAD_ONLY YES
-)
+function(find_and_create_imported_target package_name target_name)
+    find_package(${package_name} CONFIG REQUIRED)
+    if (${package_name}_FOUND)
+        if (NOT TARGET ${target_name})
+            add_library(${target_name} INTERFACE IMPORTED)
+            set_target_properties(${target_name} PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${${package_name}_INCLUDE_DIRS}")
+            message(STATUS "Created imported target ${target_name}")
+        else()
+            message(STATUS "Target ${target_name} already exists")
+        endif()
+    else()
+        message(FATAL_ERROR "${package_name} not found!")
+    endif()
+endfunction()
 
 # Build test
 if(ENGINE_BUILD_TEST)
 enable_testing()
-CPMAddPackage(
-    NAME googletest
-    GITHUB_REPOSITORY google/googletest
-    GIT_TAG release-1.11.0
-    VERSION 1.11.0
-    OPTIONS
-    "INSTALL_GTEST OFF"
-    EXCLUDE_FROM_ALL YES
-)
+find_and_create_imported_target("GTest" "GTest::gtest")
+find_and_create_imported_target("GTest" "GTest::gtest_main")
+find_and_create_imported_target("GTest" "GTest::gmock")
+find_and_create_imported_target("GTest" "GTest::gmock_main")
 include(GoogleTest)
 endif(ENGINE_BUILD_TEST)
+
+find_and_create_imported_target("RapidJSON" "RapidJSON::RapidJSON")
+find_and_create_imported_target("rxcpp" "RxCpp::RxCpp")
+# yaml-cpp::yaml-cpp vs yaml-cpp #FIXME 70 stars on github
+find_and_create_imported_target("yaml-cpp" "yaml-cpp::yaml-cpp")
+find_and_create_imported_target("spdlog" "spdlog::spdlog")
+find_and_create_imported_target("fmt" "fmt::fmt-header-only")
+find_and_create_imported_target("RocksDB" "RocksDB::rocksdb")
+find_and_create_imported_target("Taskflow" "Taskflow::Taskflow")
+find_and_create_imported_target("unofficial-concurrentqueue" "unofficial-concurrentqueue::concurrentqueue")
+find_and_create_imported_target("CLI11" "CLI11::CLI11")
+find_and_create_imported_target("re2" "re2::re2")
+find_and_create_imported_target("CURL" "CURL::libcurl")
+find_and_create_imported_target("maxminddb" "maxminddb::maxminddb")
+find_and_create_imported_target("benchmark" "benchmark::benchmark")
+find_and_create_imported_target("pugixml" "pugixml::pugixml")
+
+find_and_create_imported_target("libuv" "libuv::libuv")
+find_and_create_imported_target("uvw" "uvw::uvw")
+
+find_and_create_imported_target("opentelemetry-cpp" "opentelemetry-cpp::api")
+find_and_create_imported_target("opentelemetry-cpp" "opentelemetry-cpp::sdk")
+find_and_create_imported_target("opentelemetry-cpp" "opentelemetry-cpp::logs")
+find_and_create_imported_target("opentelemetry-cpp" "opentelemetry-cpp::metrics")
+
+find_and_create_imported_target("Protobuf" "protobuf::libprotobuf")
 
 ####################################################################################################
 # Targets
 ####################################################################################################
 # Build main
 add_executable(main ${ENGINE_SOURCE_DIR}/main.cpp)
-
-target_include_directories(main
-    PRIVATE
-    ${CLI11_SOURCE_DIR}/include
-)
 
 add_subdirectory(${ENGINE_SOURCE_DIR}/base)
 add_subdirectory(${ENGINE_SOURCE_DIR}/sockiface)
@@ -184,25 +191,8 @@ add_subdirectory(${ENGINE_SOURCE_DIR}/metrics)
 add_subdirectory(${ENGINE_SOURCE_DIR}/geo)
 add_subdirectory(${ENGINE_SOURCE_DIR}/queue)
 
-
 #TODO isolate rxcpp
-target_link_libraries(main base cmds api)
-
-# Build test
-if(ENGINE_BUILD_TEST)
-# Add googletest as CPM dependency
-CPMAddPackage(
-    NAME googletest
-    GITHUB_REPOSITORY google/googletest
-    GIT_TAG release-1.11.0
-    VERSION 1.11.0
-    OPTIONS
-    "INSTALL_GTEST OFF"
-    EXCLUDE_FROM_ALL YES
-)
-
-include(GoogleTest)
-endif(ENGINE_BUILD_TEST)
+target_link_libraries(main base cmds api CLI11::CLI11)
 
 # Build benchmark
 if(ENGINE_BUILD_BENCHMARK)

--- a/src/engine/CMakePresets.json
+++ b/src/engine/CMakePresets.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
+}

--- a/src/engine/CMakePresets.json
+++ b/src/engine/CMakePresets.json
@@ -3,7 +3,7 @@
   "configurePresets": [
     {
       "name": "default",
-      "generator": "Ninja",
+      "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"

--- a/src/engine/benchmark/CMakeLists.txt
+++ b/src/engine/benchmark/CMakeLists.txt
@@ -1,14 +1,4 @@
 # Add google benchmark as CPM dependency
-include(../cmake/CPM.cmake)
-CPMAddPackage(
-  NAME benchmark
-  GITHUB_REPOSITORY google/benchmark
-  VERSION 1.6.1
-  OPTIONS
-   "BENCHMARK_ENABLE_TESTING Off"
-  EXCLUDE_FROM_ALL YES
-)
-
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Release"
         AND NOT CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     message(WARNING

--- a/src/engine/benchmark/regex/CMakeLists.txt
+++ b/src/engine/benchmark/regex/CMakeLists.txt
@@ -1,15 +1,7 @@
-# dependencies
-CPMAddPackage(
-  NAME RE2
-  GITHUB_REPOSITORY google/re2
-  GIT_TAG 2022-02-01
-  VERSION release 2022-02-01
-)
-
 # Configuration regex test
 add_executable(regex_bench
   regex_bench.cpp
 )
 
 # Build benchmarks
-target_link_libraries(regex_bench benchmark::benchmark_main re2)
+target_link_libraries(regex_bench benchmark::benchmark_main re2::re2)

--- a/src/engine/source/api/CMakeLists.txt
+++ b/src/engine/source/api/CMakeLists.txt
@@ -8,7 +8,7 @@ set(IFACE_DIR ${CMAKE_CURRENT_LIST_DIR}/interface)
 # ###################################################################################################
 add_library(api_iapi INTERFACE)
 target_include_directories(api_iapi INTERFACE ${IFACE_DIR})
-target_link_libraries(api_iapi INTERFACE fmt base store::istore)
+target_link_libraries(api_iapi INTERFACE base store::istore)
 add_library(api::iapi ALIAS api_iapi)
 
 add_library(api STATIC
@@ -44,7 +44,6 @@ target_include_directories(api
 target_link_libraries(api
     base
     eMessages
-    fmt
     kvdb::ikvdb
     metrics
     router::irouter
@@ -69,7 +68,7 @@ if(ENGINE_BUILD_TEST)
   # Mocks
   add_library(api_mocks INTERFACE)
   target_include_directories(api_mocks INTERFACE ${TEST_MOCK_DIR})
-  target_link_libraries(api_mocks INTERFACE gmock api::iapi)
+  target_link_libraries(api_mocks INTERFACE GTest::gmock api::iapi)
   add_library(api::mocks ALIAS api_mocks)
 
   add_executable(api_utest
@@ -91,7 +90,7 @@ if(ENGINE_BUILD_TEST)
   )
 
   target_link_libraries(api_utest
-    gtest_main
+    GTest::gtest_main
     base
     base::test
     api

--- a/src/engine/source/base/CMakeLists.txt
+++ b/src/engine/source/base/CMakeLists.txt
@@ -1,37 +1,4 @@
 ####################################################################################################
-# logging
-####################################################################################################
-CPMAddPackage(
-  NAME fmt
-  GITHUB_REPOSITORY fmtlib/fmt
-  GIT_TAG "8.1.1"
-  OPTIONS "FMT_HEADER_ONLY ON"
-)
-
-CPMAddPackage(
-  NAME spdlog
-  GITHUB_REPOSITORY gabime/spdlog
-  GIT_TAG "v1.11.0"
-  OPTIONS "SPDLOG_FMT_EXTERNAL_HO ON"
-)
-
-add_dependencies(spdlog fmt)
-
-####################################################################################################
-# json
-####################################################################################################
-CPMAddPackage(
-    NAME rapidjson
-    GITHUB_REPOSITORY Tencent/rapidjson
-    GIT_TAG 8261c1ddf43f10de00fd8c9a67811d1486b2c784 # Latest master commit from 21/03/2022
-    OPTIONS
-    "RAPIDJSON_BUILD_DOC OFF"
-    "RAPIDJSON_BUILD_EXAMPLES OFF"
-    "RAPIDJSON_BUILD_TESTS OFF"
-    DOWNLOAD_ONLY YES
-    )
-
-####################################################################################################
 # BASE
 ####################################################################################################
 # Defs
@@ -50,8 +17,6 @@ add_library(base STATIC
 target_include_directories(base
     PUBLIC
     ${INC_DIR}
-    ${spdlog_SOURCE_DIR}/include
-    ${rapidjson_SOURCE_DIR}/include
 
     PRIVATE
     ${INC_DIR}/base
@@ -59,10 +24,8 @@ target_include_directories(base
 )
 target_link_libraries(base
     PUBLIC
-    fmt
-
-    PRIVATE
-    spdlog
+    fmt::fmt-header-only
+    spdlog::spdlog
 )
 
 # Tests
@@ -104,7 +67,7 @@ target_link_libraries(base_utest
 
     PRIVATE
     base
-    gtest_main
+    GTest::gtest_main
 )
 gtest_discover_tests(base_utest)
 
@@ -120,7 +83,7 @@ target_include_directories(base_logger_utest
 target_link_libraries(base_logger_utest
     PRIVATE
     base
-    gtest_main
+    GTest::gtest_main
 )
 gtest_discover_tests(base_logger_utest)
 

--- a/src/engine/source/bk/CMakeLists.txt
+++ b/src/engine/source/bk/CMakeLists.txt
@@ -1,26 +1,3 @@
-# Dependencies
-CPMAddPackage(
-  NAME taskflow
-  GITHUB_REPOSITORY taskflow/taskflow
-  GIT_TAG v3.6.0
-  VERSION 3.6.0
-  EXCLUDE_FROM_ALL YES
-  OPTIONS
-    "TF_BUILD_TESTS OFF"
-    "TF_BUILD_EXAMPLES OFF"
-)
-
-CPMAddPackage(
-    NAME RxCpp
-    GITHUB_REPOSITORY ReactiveX/RxCpp
-    GIT_TAG v4.1.1
-    VERSION 4.1.1
-    OPTIONS
-    "RXCPP_DISABLE_TESTS_AND_EXAMPLES"
-    EXCLUDE_FROM_ALL YES
-    DOWNLOAD_ONLY
-)
-
 # Defs
 set(IFACE_DIR ${CMAKE_CURRENT_LIST_DIR}/interface)
 set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
@@ -79,14 +56,14 @@ set(COMPONENT_SRC_DIR ${TEST_SRC_DIR}/component)
 ## Mocks
 add_library(bk_mocks INTERFACE)
 target_include_directories(bk_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(bk_mocks INTERFACE gmock bk::ibk)
+target_link_libraries(bk_mocks INTERFACE GTest::gmock bk::ibk)
 add_library(bk::mocks ALIAS bk_mocks)
 
 ## Backend component test
 add_executable(bk_ctest
     ${COMPONENT_SRC_DIR}/bk_test.cpp
 )
-target_link_libraries(bk_ctest gtest_main bk::taskf bk::rx bk::mocks)
+target_link_libraries(bk_ctest GTest::gtest_main bk::taskf bk::rx bk::mocks)
 gtest_discover_tests(bk_ctest)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -160,7 +160,7 @@ add_executable(builder_utest
 target_include_directories(builder_utest PRIVATE ${BUILDER_PRI_INCS} ${TEST_SRC_DIR} ${UNIT_SRC_DIR})
 target_link_libraries(builder_utest
     PUBLIC
-    gtest_main
+    GTest::gtest_main
 
     PRIVATE
     builder

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -15,16 +15,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_compile_definitions(RE2_ON_VALGRIND)
 endif()
 
-CPMAddPackage(
-  NAME RE2
-  GITHUB_REPOSITORY google/re2
-  GIT_TAG 2022-02-01
-  VERSION release 2022-02-01
-  EXCLUDE_FROM_ALL YES
-  OPTIONS
-    "RE2_BUILD_TESTING OFF"
-)
-
 ## Lib
 SET(BUILDER_PUB_INCS
     ${INC_DIR}
@@ -86,7 +76,7 @@ target_link_libraries(builder
     logpar
 
     PRIVATE
-    re2
+    re2::re2
     logicexpr
     date::date
 )
@@ -102,7 +92,7 @@ set(COMPONENT_SRC_DIR ${TEST_SRC_DIR}/component)
 ## Mocks
 add_library(builder_mocks INTERFACE)
 target_include_directories(builder_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(builder_mocks INTERFACE gmock builder::ibuilder)
+target_link_libraries(builder_mocks INTERFACE GTest::gmock builder::ibuilder)
 add_library(builder::mocks ALIAS builder_mocks)
 
 ## Component test
@@ -110,7 +100,7 @@ add_executable(builder_ctest
     ${COMPONENT_SRC_DIR}/builder_test.cpp
     ${COMPONENT_SRC_DIR}/validator_test.cpp
 )
-target_link_libraries(builder_ctest PRIVATE builder gtest_main schemf::mocks store::mocks defs::mocks sockiface::mocks base::test)
+target_link_libraries(builder_ctest PRIVATE builder GTest::gtest_main schemf::mocks store::mocks defs::mocks sockiface::mocks base::test)
 gtest_discover_tests(builder_ctest)
 
 ## Unit tests

--- a/src/engine/source/cmds/CMakeLists.txt
+++ b/src/engine/source/cmds/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(cmds
     router::router
     store
     api
-    uv_a
+    libuv::uv_a
     kvdb
     conf::cliconf
     conf::iconf
@@ -39,10 +39,8 @@ target_link_libraries(cmds
 target_include_directories(cmds
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${uvw_SOURCE_DIR}/src/ # TODO For the each client shared the client
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src
-    ${CLI11_SOURCE_DIR}/include
 )
 
 # Tests
@@ -59,13 +57,13 @@ target_include_directories(cmds_utest
     PRIVATE
     ${TEST_SRC_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/src
-    ${CLI11_SOURCE_DIR}/include
 )
 target_link_libraries(cmds_utest
     PRIVATE
-    gtest_main
+    GTest::gtest_main
     cmds
     base
+    CLI11::CLI11
 )
 gtest_discover_tests(cmds_utest)
 

--- a/src/engine/source/cmds/include/cmds/apiclnt/client.hpp
+++ b/src/engine/source/cmds/include/cmds/apiclnt/client.hpp
@@ -7,11 +7,11 @@
 #include <variant>
 #include <vector>
 
-#include <uvw/pipe.hpp>
-#include <uvw/timer.hpp>
+#include <uvw/pipe.h>
+#include <uvw/timer.h>
 
-#include <base/utils/wazuhProtocol/wazuhProtocol.hpp>
 #include <base/error.hpp>
+#include <base/utils/wazuhProtocol/wazuhProtocol.hpp>
 
 #include <cmds/apiExcept.hpp>
 
@@ -117,14 +117,10 @@ public:
             {
                 error = "Connection closed by server";
                 gracefullEnd(handle);
-
             });
 
-        clientHandle->once<uvw::CloseEvent>(
-            [gracefullEnd](const uvw::CloseEvent&, uvw::PipeHandle& handle)
-            {
-                gracefullEnd(handle);
-            });
+        clientHandle->once<uvw::CloseEvent>([gracefullEnd](const uvw::CloseEvent&, uvw::PipeHandle& handle)
+                                            { gracefullEnd(handle); });
 
         timer->on<uvw::TimerEvent>(
             [wClientHandle, gracefullEnd, &error](const uvw::TimerEvent&, uvw::TimerHandle& timerRef)
@@ -144,11 +140,7 @@ public:
                 error = errorUvw.what();
             });
 
-        timer->on<uvw::CloseEvent>(
-            [](const uvw::CloseEvent&, uvw::TimerHandle& timer)
-            {
-            });
-
+        timer->on<uvw::CloseEvent>([](const uvw::CloseEvent&, uvw::TimerHandle& timer) {});
 
         // Stablish connection
         clientHandle->connect(m_socketPath);

--- a/src/engine/source/conf/CMakeLists.txt
+++ b/src/engine/source/conf/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(conf_cliconf STATIC
 target_include_directories(conf_cliconf
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/include
-    ${CLI11_SOURCE_DIR}/include
 )
 target_link_libraries(conf_cliconf base)
 add_library(conf::cliconf ALIAS conf_cliconf)
@@ -25,7 +24,7 @@ set(UNIT_SRC_DIR ${TEST_SRC_DIR}/unit)
 add_executable(cliconf_utest
     ${UNIT_SRC_DIR}/cliconf_test.cpp
 )
-target_link_libraries(cliconf_utest gtest_main conf::cliconf)
+target_link_libraries(cliconf_utest GTest::gtest_main conf::cliconf CLI11::CLI11)
 gtest_discover_tests(cliconf_utest)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/defs/CMakeLists.txt
+++ b/src/engine/source/defs/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(defs_utest
   PRIVATE
   defs::mocks
   defs
-  gtest_main
+  GTest::gtest_main
 )
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/geo/CMakeLists.txt
+++ b/src/engine/source/geo/CMakeLists.txt
@@ -15,11 +15,19 @@ set(SRCS
 )
 set(PRIVATE_LINKS
     CURL::libcurl
+    maxminddb::maxminddb
 )
 set(PUBLIC_LINKS
     geo::igeo
     store::istore
 )
+
+# Patch the maxminddb target
+set_target_properties(maxminddb::maxminddb 
+  PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ""
+)
+
 add_library(geo
       ${SRCS}
 )
@@ -37,9 +45,6 @@ target_link_libraries(geo
 
     PRIVATE
     ${PRIVATE_LINKS}
-
-    INTERFACE
-    maxminddb::maxminddb
 )
 
 # Tests

--- a/src/engine/source/geo/CMakeLists.txt
+++ b/src/engine/source/geo/CMakeLists.txt
@@ -8,21 +8,12 @@ target_include_directories(geo_igeo INTERFACE ${IFACE_DIR})
 target_link_libraries(geo_igeo INTERFACE base)
 add_library(geo::igeo ALIAS geo_igeo)
 
-CPMAddPackage(
-    NAME libmaxminddb
-    GITHUB_REPOSITORY maxmind/libmaxminddb
-    GIT_TAG 1.9.1
-    OPTIONS
-    "BUILD_SHARED_LIBS OFF"
-    "BUILD_TESTING OFF"
-)
 set(SRCS
     ${SRC_DIR}/manager.cpp
     ${SRC_DIR}/downloader.cpp
     ${SRC_DIR}/locator.cpp
 )
 set(PRIVATE_LINKS
-    maxminddb::maxminddb
     CURL::libcurl
 )
 set(PUBLIC_LINKS
@@ -46,6 +37,9 @@ target_link_libraries(geo
 
     PRIVATE
     ${PRIVATE_LINKS}
+
+    INTERFACE
+    maxminddb::maxminddb
 )
 
 # Tests
@@ -75,6 +69,7 @@ target_include_directories(geo_utest
 )
 target_link_libraries(geo_utest
     PRIVATE
+    geo
     geo::mocks # Ensure it compiles
     ${PRIVATE_LINKS}
     ${PUBLIC_LINKS}

--- a/src/engine/source/geo/CMakeLists.txt
+++ b/src/engine/source/geo/CMakeLists.txt
@@ -73,7 +73,7 @@ target_link_libraries(geo_utest
     geo::mocks # Ensure it compiles
     ${PRIVATE_LINKS}
     ${PUBLIC_LINKS}
-    gtest_main
+    GTest::gtest_main
     store::mocks
 )
 target_compile_definitions(geo_utest PRIVATE MMDB_PATH_TEST="${MMDB_PATH_TEST}")
@@ -81,7 +81,7 @@ target_compile_definitions(geo_utest PRIVATE MMDB_PATH_TEST="${MMDB_PATH_TEST}")
 add_executable(geo_ctest
     ${COMPONENT_SRC_DIR}/manager_test.cpp
 )
-target_link_libraries(geo_ctest PRIVATE geo gtest_main store::mocks)
+target_link_libraries(geo_ctest PRIVATE geo GTest::gtest_main store::mocks)
 target_compile_definitions(geo_ctest PRIVATE MMDB_PATH_TEST="${MMDB_PATH_TEST}")
 gtest_discover_tests(geo_ctest)
 

--- a/src/engine/source/hlp/CMakeLists.txt
+++ b/src/engine/source/hlp/CMakeLists.txt
@@ -1,15 +1,5 @@
 
 CPMAddPackage(
-        NAME CURL
-        GITHUB_REPOSITORY curl/curl
-        GIT_TAG curl-7_83_1
-        VERSION 7.83_1
-        EXCLUDE_FROM_ALL YES
-        GIT_SHALLOW TRUE
-        DOWNLOAD_ONLY
-)
-
-CPMAddPackage(
         NAME date
         # Live at head
         # https://github.com/HowardHinnant/date/issues/828#issuecomment-2184283807
@@ -22,13 +12,6 @@ CPMAddPackage(
         GITHUB_REPOSITORY fastfloat/fast_float
         VERSION 3.8.0
         GIT_SHALLOW TRUE
-)
-
-CPMAddPackage(
-  NAME pugixml
-  GITHUB_REPOSITORY zeux/pugixml
-  GIT_TAG v1.12.1
-  VERSION 1.12.1
 )
 
 # https://github.com/HowardHinnant/date/wiki/FAQ#why-is-a-failing
@@ -103,7 +86,7 @@ add_executable(hlp_utest
   ${UNIT_SRC_DIR}/dsv_csv_test.cpp
 )
 
-target_link_libraries(hlp_utest PRIVATE hlp gtest_main)
+target_link_libraries(hlp_utest PRIVATE hlp GTest::gtest_main)
 gtest_discover_tests(hlp_utest)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/kvdb/CMakeLists.txt
+++ b/src/engine/source/kvdb/CMakeLists.txt
@@ -9,24 +9,6 @@ target_include_directories(kvdb_ikvdb INTERFACE ${IFACE_DIR})
 target_link_libraries(kvdb_ikvdb INTERFACE base)
 add_library(kvdb::ikvdb ALIAS kvdb_ikvdb)
 
-## Deps
-CPMAddPackage(
-  NAME rocksdb
-  GITHUB_REPOSITORY facebook/rocksdb
-  GIT_TAG v8.3.2
-  VERSION 8.3.2
-  OPTIONS
-    "WITH_GFLAGS OFF"
-    "WITH_TESTS OFF"
-    "WITH_BENCHMARK_TOOLS OFF"
-    "WITH_TOOLS OFF"
-    "WITH_FOLLY_DISTRIBUTED_MUTEX OFF"
-    "USE_RTTI 1"
-    "FAIL_ON_WARNINGS ON"
-    "ROCKSDB_BUILD_SHARED FALSE"
-    "CMAKE_DISABLE_FIND_PACKAGE_gtest TRUE"
-)
-
 ## Kvdb
 add_library(kvdb STATIC
     ${SRC_DIR}/kvdbManager.cpp
@@ -46,7 +28,7 @@ target_include_directories(kvdb
 target_link_libraries(kvdb
     PRIVATE
     metrics
-    rocksdb
+    RocksDB::rocksdb
     base
     PUBLIC
     kvdb::ikvdb
@@ -63,14 +45,14 @@ set(COMPONENT_SRC_DIR ${TEST_SRC_DIR}/component)
 ## Mocks
 add_library(kvdb_mocks INTERFACE)
 target_include_directories(kvdb_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(kvdb_mocks INTERFACE gmock kvdb::ikvdb)
+target_link_libraries(kvdb_mocks INTERFACE GTest::gmock kvdb::ikvdb)
 add_library(kvdb::mocks ALIAS kvdb_mocks)
 
 # Unit test
 add_executable(kvdb_utest
     ${UNIT_SRC_DIR}/kvdb_test.cpp
 )
-target_link_libraries(kvdb_utest gtest_main kvdb kvdb::mocks)
+target_link_libraries(kvdb_utest GTest::gtest_main kvdb kvdb::mocks)
 gtest_discover_tests(kvdb_utest)
 
 # Component test
@@ -83,7 +65,7 @@ target_include_directories(kvdb_ctest
     PRIVATE
     ${TEST_SRC_DIR}) #TODO Remove after implemente metrics mock (Only here for fake metrics)
 
-target_link_libraries(kvdb_ctest gtest_main metrics kvdb)
+target_link_libraries(kvdb_ctest GTest::gtest_main metrics kvdb)
 gtest_discover_tests(kvdb_ctest)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/logicexpr/CMakeLists.txt
+++ b/src/engine/source/logicexpr/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(logicexpr_test
     ${TEST_SRC_DIR}/evaluator_test.cpp
     ${TEST_SRC_DIR}/logicexpr_test.cpp
 )
-target_link_libraries(logicexpr_test logicexpr gtest_main)
+target_link_libraries(logicexpr_test logicexpr GTest::gtest_main)
 gtest_discover_tests(logicexpr_test)
 
 

--- a/src/engine/source/logpar/CMakeLists.txt
+++ b/src/engine/source/logpar/CMakeLists.txt
@@ -10,7 +10,7 @@ PUBLIC
 PRIVATE
   include/logpar
 )
-target_link_libraries(logpar PUBLIC hlp fmt base schemf::ischema parsec)
+target_link_libraries(logpar PUBLIC hlp base schemf::ischema parsec)
 
 # Tests
 if(ENGINE_BUILD_TEST)
@@ -20,6 +20,6 @@ set(UNIT_SRC_DIR ${TEST_SRC_DIR}/unit)
 add_executable(logpar_utest
     ${UNIT_SRC_DIR}/logpar_test.cpp
 )
-target_link_libraries(logpar_utest PRIVATE logpar gtest_main schemf::mocks)
+target_link_libraries(logpar_utest PRIVATE logpar GTest::gtest_main schemf::mocks)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/metrics/CMakeLists.txt
+++ b/src/engine/source/metrics/CMakeLists.txt
@@ -1,20 +1,6 @@
 set(ENGINE_METRICS_SOURCE_DIR ${ENGINE_SOURCE_DIR}/metrics/src)
 set(ENGINE_METRICS_INCLUDE_DIR ${ENGINE_SOURCE_DIR}/metrics/include)
 
-####################################################################################################
-# Dependencies
-####################################################################################################
-CPMAddPackage(
-    NAME opentelemetry
-    GITHUB_REPOSITORY open-telemetry/opentelemetry-cpp
-    GIT_TAG v1.8.2
-    VERSION 1.8.2
-    EXCLUDE_FROM_ALL YES
-    OPTIONS
-        "BUILD_TESTING OFF"
-        "WITH_ZIPKIN ON" # TODO: Add build option and link zipkin to it. Define OT modules policy.
-)
-
 add_compile_definitions ( ONLY_C_LOCALE=1 )
 
 ####################################################################################################
@@ -27,12 +13,13 @@ ${ENGINE_METRICS_SOURCE_DIR}/dataHubExporter.cpp
 ${ENGINE_METRICS_SOURCE_DIR}/metricsScope.cpp
 )
 
-target_link_libraries(metrics PUBLIC
-opentelemetry_api
-opentelemetry_sdk
-opentelemetry_exporter_ostream_metrics
-opentelemetry_resources
-PRIVATE base)
+target_link_libraries(metrics PRIVATE
+  base
+  opentelemetry-cpp::api
+  opentelemetry-cpp::metrics
+  opentelemetry-cpp::sdk
+  opentelemetry-cpp::logs
+)
 
 target_include_directories(metrics PUBLIC
 ${ENGINE_METRICS_INCLUDE_DIR}
@@ -53,12 +40,12 @@ add_executable(metrics_utest
 # Mocks
 add_library(metrics_mocks INTERFACE)
 target_include_directories(metrics_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(metrics_mocks INTERFACE gmock)
+target_link_libraries(metrics_mocks INTERFACE GTest::gmock)
 add_library(metrics::mocks ALIAS metrics_mocks)
 
 target_include_directories(metrics_utest INTERFACE ${TEST_MOCK_DIR})
 
 # TODO: Replace test_mocks with the metrics executable when you have the test folder available.
-target_link_libraries(metrics_utest gtest_main gmock base metrics)
+target_link_libraries(metrics_utest GTest::gtest_main GTest::gmock base metrics)
 gtest_discover_tests(metrics_utest)
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/mmdb/CMakeLists.txt
+++ b/src/engine/source/mmdb/CMakeLists.txt
@@ -3,18 +3,6 @@ set(IFACE_DIR ${CMAKE_CURRENT_LIST_DIR}/interface)
 set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(INC_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
 
-####################################################################################################
-# Dependencies -- assuming cpm is available
-####################################################################################################
-CPMAddPackage(
-    NAME libmaxminddb
-    GITHUB_REPOSITORY maxmind/libmaxminddb
-    GIT_TAG 1.9.1
-    OPTIONS
-    "BUILD_SHARED_LIBS OFF"
-    "BUILD_TESTING OFF"
-)
-
 # Interface
 add_library(mmdb_immdb INTERFACE)
 target_include_directories(mmdb_immdb INTERFACE ${IFACE_DIR})
@@ -57,7 +45,7 @@ if(ENGINE_BUILD_TEST)
     # Mocks
     add_library(mmdb_mocks INTERFACE)
     target_include_directories(mmdb_mocks INTERFACE ${TEST_MOCK_DIR})
-    target_link_libraries(mmdb_mocks INTERFACE gmock mmdb::immdb)
+    target_link_libraries(mmdb_mocks INTERFACE Gtest::gmock mmdb::immdb)
     add_library(mmdb::mocks ALIAS mmdb_mocks)
 
     # mmdb component test
@@ -69,7 +57,7 @@ if(ENGINE_BUILD_TEST)
     target_include_directories(mmdb_ctest PRIVATE ${SRC_DIR})
     target_link_libraries(mmdb_ctest
         PUBLIC
-        gtest_main
+        GTest::gtest_main
         base
         mmdb::mmdb
 
@@ -87,7 +75,7 @@ if(ENGINE_BUILD_TEST)
     target_include_directories(mmdb_utest PRIVATE ${SRC_DIR})
     target_link_libraries(mmdb_utest
         PUBLIC
-        gtest_main
+        GTest::gtest_main
         mmdb::mmdb
 
         PRIVATE

--- a/src/engine/source/parsec/CMakeLists.txt
+++ b/src/engine/source/parsec/CMakeLists.txt
@@ -13,7 +13,7 @@ set(TEST_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/test/src)
 add_executable(parsec_test
     ${TEST_SRC_DIR}/parsec_test.cpp
 )
-target_link_libraries(parsec_test parsec gtest_main)
+target_link_libraries(parsec_test parsec GTest::gtest_main)
 gtest_discover_tests(parsec_test)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/proto/CMakeLists.txt
+++ b/src/engine/source/proto/CMakeLists.txt
@@ -2,27 +2,6 @@ set(ENGINE_EMESSAGES_INCLUDE_DIR ${ENGINE_SOURCE_DIR}/proto/include)
 set(GENERATE_PROTOBUF_SCRIPT ${ENGINE_SOURCE_DIR}/proto/generateCode.sh)
 
 # ###################################################################################################
-# Dependencies
-# ###################################################################################################
-# Add google protobuf
-CPMAddPackage(
-  NAME protobuf
-  GITHUB_REPOSITORY google/protobuf
-  GIT_TAG v21.12
-  VERSION 21.12
-  EXCLUDE_FROM_ALL YES
-  # Disable test
-  OPTIONS "protobuf_BUILD_TESTS OFF"
-  # Disable install
-  OPTIONS "protobuf_BUILD_PROTOC_BINARIES OFF"
-  OPTIONS "protobuf_BUILD_PROTOBUF_LITE OFF"
-  OPTIONS "protobuf_BUILD_SHARED_LIBS OFF"
-  OPTIONS "protobuf_BUILD_STATIC_LIBS ON"
-  OPTIONS "protobuf_MSVC_STATIC_RUNTIME OFF"
-  OPTIONS "protobuf_WITH_ZLIB OFF"
-)
-
-# ###################################################################################################
 # Sources - Includes
 # ###################################################################################################
 file(GLOB EMESSAGE_AUTO_SOURCES "${ENGINE_EMESSAGES_INCLUDE_DIR}/eMessages/*.cc")

--- a/src/engine/source/queue/CMakeLists.txt
+++ b/src/engine/source/queue/CMakeLists.txt
@@ -1,12 +1,3 @@
-# Concurrent Queue
-CPMAddPackage(
-  NAME CameronQueue
-  GITHUB_REPOSITORY cameron314/concurrentqueue
-  GIT_TAG v1.0.3
-  VERSION 1.0.3
-  EXCLUDE_FROM_ALL YES
-)
-
 # Defs
 set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(INC_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -16,7 +7,7 @@ set(TEST_DIR ${CMAKE_CURRENT_LIST_DIR}/test)
 # # Interface
 add_library(queue_iqueue INTERFACE)
 target_include_directories(queue_iqueue INTERFACE ${IFACE_DIR})
-target_link_libraries(queue_iqueue INTERFACE fmt base)
+target_link_libraries(queue_iqueue INTERFACE base)
 add_library(queue::iqueue ALIAS queue_iqueue)
 
 # # Queue
@@ -34,6 +25,7 @@ target_link_libraries(queue
   PUBLIC
   base # Only for the loggin
   queue::iqueue
+  unofficial-concurrentqueue::concurrentqueue
 
   # metrics::imetrics
   metrics
@@ -49,7 +41,7 @@ if(ENGINE_BUILD_TEST)
   # Mocks
   add_library(queue_mocks INTERFACE)
   target_include_directories(queue_mocks INTERFACE ${TEST_MOCK_DIR})
-  target_link_libraries(queue_mocks INTERFACE gmock queue)
+  target_link_libraries(queue_mocks INTERFACE GTest::gmock queue)
   add_library(queue::mocks ALIAS queue_mocks)
 
   # Component test
@@ -57,8 +49,8 @@ if(ENGINE_BUILD_TEST)
     ${TEST_SRC_COMPONENT_DIR}/queue_test.cpp
   )
 
-  target_link_libraries(queue_ctest 
-    gtest_main
+  target_link_libraries(queue_ctest
+    GTest::gtest_main
     base
     queue
     #metrics::mocks)

--- a/src/engine/source/queue/include/queue/concurrentQueue.hpp
+++ b/src/engine/source/queue/include/queue/concurrentQueue.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <type_traits>
 
-#include <blockingconcurrentqueue.h>
+#include <concurrentqueue/blockingconcurrentqueue.h>
 #include <queue/iqueue.hpp>
 
 #include <base/logging.hpp>

--- a/src/engine/source/rbac/CMakeLists.txt
+++ b/src/engine/source/rbac/CMakeLists.txt
@@ -27,7 +27,7 @@ set(TEST_MOCK_DIR ${CMAKE_CURRENT_LIST_DIR}/test/mocks)
 add_library(rbac_mocks INTERFACE)
 
 target_include_directories(rbac_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(rbac_mocks INTERFACE gmock rbac::irbac)
+target_link_libraries(rbac_mocks INTERFACE GTest::gmock rbac::irbac)
 add_library(rbac::mocks ALIAS rbac_mocks)
 
 add_executable(rbac_test
@@ -41,7 +41,7 @@ target_include_directories(rbac_test
     ${TEST_SRC_DIR}
 )
 
-target_link_libraries(rbac_test gtest_main base rbac store::mocks)
+target_link_libraries(rbac_test GTest::gtest_main base rbac store::mocks)
 gtest_discover_tests(rbac_test)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/router/CMakeLists.txt
+++ b/src/engine/source/router/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ENGINE_BUILD_TEST)
     # Mocks
     add_library(router_mocks INTERFACE)
     target_include_directories(router_mocks INTERFACE ${TEST_MOCK_DIR})
-    target_link_libraries(router_mocks INTERFACE gmock router::irouter)
+    target_link_libraries(router_mocks INTERFACE GTest::gmock router::irouter)
     add_library(router::mocks ALIAS router_mocks)
 
     # Router component test
@@ -62,7 +62,7 @@ if(ENGINE_BUILD_TEST)
     )
     target_include_directories(router_ctest PRIVATE ${SRC_DIR})
     target_link_libraries(router_ctest
-        gtest_main
+        GTest::gtest_main
         base
         router::router
         builder::mocks
@@ -84,7 +84,7 @@ if(ENGINE_BUILD_TEST)
     )
     target_include_directories(router_utest PRIVATE ${SRC_DIR})
     target_link_libraries(router_utest
-        gtest_main
+        GTest::gtest_main
         base
         router::router
         # router::mocks # Todo delete

--- a/src/engine/source/schemf/CMakeLists.txt
+++ b/src/engine/source/schemf/CMakeLists.txt
@@ -33,20 +33,20 @@ set(COMPONENT_SRC_DIR ${TEST_SRC_DIR}/component)
 
 add_library(schemf_mocks INTERFACE)
 target_include_directories(schemf_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(schemf_mocks INTERFACE gmock schemf::ischema)
+target_link_libraries(schemf_mocks INTERFACE GTest::gmock schemf::ischema)
 add_library(schemf::mocks ALIAS schemf_mocks)
 
 add_executable(schemf_utest
     ${UNIT_SRC_DIR}/field_test.cpp
 )
-target_link_libraries(schemf_utest PRIVATE schemf gtest_main)
+target_link_libraries(schemf_utest PRIVATE schemf GTest::gtest_main)
 gtest_discover_tests(schemf_utest)
 
 add_executable(schemf_ctest
     ${COMPONENT_SRC_DIR}/schema_test.cpp
     ${COMPONENT_SRC_DIR}/validator_test.cpp
 )
-target_link_libraries(schemf_ctest PRIVATE schemf gtest_main schemf::mocks base::test)
+target_link_libraries(schemf_ctest PRIVATE schemf GTest::gtest_main schemf::mocks base::test)
 gtest_discover_tests(schemf_ctest)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/server/CMakeLists.txt
+++ b/src/engine/source/server/CMakeLists.txt
@@ -2,34 +2,6 @@ set(ENGINE_SERVER_SOURCE_DIR ${ENGINE_SOURCE_DIR}/server/src)
 set(ENGINE_SERVER_INCLUDE_DIR ${ENGINE_SOURCE_DIR}/server/include)
 
 ####################################################################################################
-# Dependencies
-####################################################################################################
-CPMAddPackage(
-  NAME libuv
-  GITHUB_REPOSITORY libuv/libuv
-  GIT_TAG v1.34.2
-  VERSION 1.34.2
-  OPTIONS
-      "BUILD_SHARED_LIBS ON"
-      "BUILD_TESTS OFF"
-      "BUILD_EXAMPLES OFF"
-  EXCLUDE_FROM_ALL YES
-)
-# wazuh/src/engine/build/_deps/libuv-src/src/unix/core.c:1211: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
-
-CPMAddPackage(
-  NAME uvw
-  GITHUB_REPOSITORY skypjack/uvw
-  GIT_TAG v2.3.1_libuv-v1.34
-  VERSION 2.3.1
-  OPTIONS
-      "BUILD_UVW_LIBS OFF"
-      "BUILD_DOCS OFF"
-      "BUILD_TESTING OFF"
-  EXCLUDE_FROM_ALL YES
-)
-
-####################################################################################################
 # Sources - Includes
 ####################################################################################################
 add_library(server STATIC
@@ -41,8 +13,7 @@ add_library(server STATIC
     ${ENGINE_SERVER_SOURCE_DIR}/protocolHandlers/wStream.cpp
 )
 
-#TODO do this better
-target_link_libraries(server base uv_a api queue metrics)
+target_link_libraries(server base libuv::uv_a api queue metrics)
 
 target_include_directories(server
     PUBLIC
@@ -68,7 +39,7 @@ target_include_directories(server_utest
     ${uvw_SOURCE_DIR}/src/
 )
 
-target_link_libraries(server_utest PRIVATE gtest_main server uv_a)
+target_link_libraries(server_utest PRIVATE GTest::gtest_main server libuv::uv_a)
 gtest_discover_tests(server_utest)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/server/include/server/engineServer.hpp
+++ b/src/engine/source/server/include/server/engineServer.hpp
@@ -6,7 +6,7 @@
 #include <string>
 
 #include <uvw.hpp>
-#include <uvw/async.hpp>
+#include <uvw/async.h>
 
 #include <server/endpoint.hpp>
 
@@ -35,9 +35,9 @@ class EngineServer
     };
 
 private:
-    std::shared_ptr<uvw::Loop> m_loop; ///< The main loop of the application.
-    Status m_status; ///< The status of the server.
-    std::shared_ptr<uvw::AsyncHandle> m_stopHandle; ///< The handle used to stop the server.
+    std::shared_ptr<uvw::Loop> m_loop;                                      ///< The main loop of the application.
+    Status m_status;                                                        ///< The status of the server.
+    std::shared_ptr<uvw::AsyncHandle> m_stopHandle;                         ///< The handle used to stop the server.
     std::unordered_map<std::string, std::shared_ptr<Endpoint>> m_endpoints; ///< The endpoints of the server.
 
     void stop();
@@ -75,9 +75,8 @@ public:
      * server.
      */
     void request_stop();
-
 };
 
-} // namespace server
+} // namespace engineserver
 
 #endif // _SERVER_SERVER_H

--- a/src/engine/source/server/test/src/unit/unixDatagram_test.cpp
+++ b/src/engine/source/server/test/src/unit/unixDatagram_test.cpp
@@ -225,7 +225,9 @@ TEST_F(UnixDatagramTest, taskQueueSizeTestAndOverflow)
                 LOG_INFO("Unblock the worker id: {}", idstr);
             }
             processedMessages++;
-            LOG_INFO("Processing message [{}]: {}", processedMessages, data.substr(0, 100).c_str());
+            LOG_INFO("Processing message [{}]: {}",
+                     static_cast<std::size_t>(processedMessages),
+                     data.substr(0, 100).c_str());
         },
         std::make_shared<FakeMetricScope>(),
         std::make_shared<FakeMetricScope>(),
@@ -266,7 +268,9 @@ TEST_F(UnixDatagramTest, taskQueueSizeTestAndOverflow)
             for (std::size_t i = 0; i < numMessagesToSend; ++i)
             {
                 std::string message = "Message " + std::to_string(i);
-                LOG_INFO("Sending message [{}]: {}", sendedMessages, message.substr(0, 100).c_str());
+                LOG_INFO("Sending message [{}]: {}",
+                         static_cast<std::size_t>(sendedMessages),
+                         message.substr(0, 100).c_str());
                 sendUnixDatagram(clientFD, message);
                 sendedMessages++;
             }
@@ -370,7 +374,9 @@ TEST_F(UnixDatagramTest, StopWhenBufferIsFull)
                 LOG_INFO("Unblock the worker id: {}", idstr);
             }
             processedMessages++;
-            LOG_INFO("Processing message [{}]: {}", processedMessages, data.substr(0, 100).c_str());
+            LOG_INFO("Processing message [{}]: {}",
+                     static_cast<std::size_t>(processedMessages),
+                     data.substr(0, 100).c_str());
         },
         std::make_shared<FakeMetricScope>(),
         std::make_shared<FakeMetricScope>(),
@@ -403,7 +409,7 @@ TEST_F(UnixDatagramTest, StopWhenBufferIsFull)
     for (std::size_t i = 0; i < taskQueueSize; ++i)
     {
         std::string message = "Message " + std::to_string(i);
-        LOG_INFO("Sending message [{}]: {}", sendedMessages, message.substr(0, 100).c_str());
+        LOG_INFO("Sending message [{}]: {}", static_cast<std::size_t>(sendedMessages), message.substr(0, 100).c_str());
         sendUnixDatagram(clientFD, message);
         sendedMessages++;
     }

--- a/src/engine/source/sockiface/CMakeLists.txt
+++ b/src/engine/source/sockiface/CMakeLists.txt
@@ -28,7 +28,7 @@ set(TEST_MOCK_DIR ${CMAKE_CURRENT_LIST_DIR}/test/mocks)
 
 add_library(sockiface_mocks INTERFACE)
 target_include_directories(sockiface_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(sockiface_mocks INTERFACE gmock sockiface::isock)
+target_link_libraries(sockiface_mocks INTERFACE GTest::gmock sockiface::isock)
 add_library(sockiface::mocks ALIAS sockiface_mocks)
 
 add_executable(sockiface_test
@@ -44,6 +44,6 @@ target_include_directories(sockiface_test
     ${TEST_SRC_DIR}/testAuxiliar/
 )
 
-target_link_libraries(sockiface_test gtest_main base sockiface)
+target_link_libraries(sockiface_test GTest::gtest_main base sockiface)
 gtest_discover_tests(sockiface_test)
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/store/CMakeLists.txt
+++ b/src/engine/source/store/CMakeLists.txt
@@ -8,7 +8,7 @@ set(DRIVER_DIR ${CMAKE_CURRENT_LIST_DIR}/drivers)
 ## Interface
 add_library(store_istore INTERFACE)
 target_include_directories(store_istore INTERFACE ${IFACE_DIR})
-target_link_libraries(store_istore INTERFACE fmt base)
+target_link_libraries(store_istore INTERFACE base)
 add_library(store::istore ALIAS store_istore)
 
 ## File driver
@@ -43,14 +43,14 @@ set(COMPONENT_SRC_DIR ${TEST_SRC_DIR}/component)
 ## Mocks
 add_library(store_mocks INTERFACE)
 target_include_directories(store_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(store_mocks INTERFACE gmock store::istore)
+target_link_libraries(store_mocks INTERFACE GTest::gmock store::istore)
 add_library(store::mocks ALIAS store_mocks)
 
 ## File driver tests
 add_executable(store_fileDriver_unit_test
     ${UNIT_SRC_DIR}/fileDriver_test.cpp
 )
-target_link_libraries(store_fileDriver_unit_test gtest_main store::fileDriver)
+target_link_libraries(store_fileDriver_unit_test GTest::gtest_main store::fileDriver)
 gtest_discover_tests(store_fileDriver_unit_test)
 
 # TODO FIX THIS CMAKE (Separe unit tests from component tests)
@@ -58,13 +58,13 @@ gtest_discover_tests(store_fileDriver_unit_test)
 add_executable(store_ctest
     ${COMPONENT_SRC_DIR}/store_test.cpp
 )
-target_link_libraries(store_ctest gtest_main store::fileDriver store)
+target_link_libraries(store_ctest GTest::gtest_main store::fileDriver store)
 gtest_discover_tests(store_ctest)
 
 add_executable(store_utest
     ${UNIT_SRC_DIR}/store_test.cpp
 )
-target_link_libraries(store_utest gtest_main store::mocks store)
+target_link_libraries(store_utest GTest::gtest_main store::mocks store)
 gtest_discover_tests(store_utest)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/wdb/CMakeLists.txt
+++ b/src/engine/source/wdb/CMakeLists.txt
@@ -27,12 +27,12 @@ set(TEST_MOCK_DIR ${CMAKE_CURRENT_LIST_DIR}/test/mocks)
 add_executable(wdb_test
     ${TEST_SRC_DIR}/wdb_test.cpp
 )
-target_link_libraries(wdb_test gtest_main base wdb sockiface::mocks)
+target_link_libraries(wdb_test GTest::gtest_main base wdb sockiface::mocks)
 gtest_discover_tests(wdb_test)
 
 add_library(wdb_mocks INTERFACE)
 target_include_directories(wdb_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(wdb_mocks INTERFACE gmock wdb::iwdb)
+target_link_libraries(wdb_mocks INTERFACE GTest::gmock wdb::iwdb)
 add_library(wdb::mocks ALIAS wdb_mocks)
 
 endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/yml/CMakeLists.txt
+++ b/src/engine/source/yml/CMakeLists.txt
@@ -1,26 +1,11 @@
 # ###################################################################################################
-# Dependencies
-# ###################################################################################################
-# yaml-cpp::yaml-cpp vs yaml-cpp #FIXME 70 stars on github
-CPMAddPackage(
-    NAME yaml-cpp
-    GITHUB_REPOSITORY jbeder/yaml-cpp
-    GIT_TAG yaml-cpp-0.7.0
-    VERSION 0.7.0
-    OPTIONS
-    "YAML_BUILD_SHARED_LIBS OFF"
-    "YAML_CPP_BUILD_TESTS OFF"
-    EXCLUDE_FROM_ALL YES
-)
-
-# ###################################################################################################
 # Sources - Includes
 # ###################################################################################################
 add_library(yml STATIC
     ${CMAKE_CURRENT_LIST_DIR}/src/yml.cpp
 )
 
-target_link_libraries(yml yaml-cpp base)
+target_link_libraries(yml yaml-cpp::yaml-cpp base)
 
 target_include_directories(yml PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/include
@@ -34,7 +19,7 @@ set(UNIT_SRC_DIR ${TEST_SRC_DIR}/unit)
 add_executable(yml_utest
     ${UNIT_SRC_DIR}/yml_test.cpp
 )
-target_link_libraries(yml_utest PRIVATE gtest_main base yml)
+target_link_libraries(yml_utest PRIVATE GTest::gtest_main base yml)
 gtest_discover_tests(yml_utest)
 
 set(TEST_FILE "${UNIT_SRC_DIR}/testFile.yml")

--- a/src/engine/vcpkg-configuration.json
+++ b/src/engine/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "136a0d8b8c4584e07e5b394d69e492f679d81737",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/src/engine/vcpkg.json
+++ b/src/engine/vcpkg.json
@@ -40,7 +40,7 @@
       },
       {
           "name": "cli11",
-          "version": "2.4.2#0"
+          "version": "2.2.0#0"
       },
       {
           "name": "concurrentqueue",

--- a/src/engine/vcpkg.json
+++ b/src/engine/vcpkg.json
@@ -1,0 +1,106 @@
+{
+  "dependencies": [
+    "benchmark",
+    "cli11",
+    "concurrentqueue",
+    "curl",
+    "date",
+    "fmt",
+    "gtest",
+    "libmaxminddb",
+    "opentelemetry-cpp",
+    "protobuf",
+    "pugixml",
+    "rapidjson",
+    "re2",
+    "rocksdb",
+    "rxcpp",
+    "spdlog",
+    "taskflow",
+    "uvw",
+    "yaml-cpp",
+    "libuv"
+  ],
+  "overrides":[
+      {
+          "name": "libuv",
+          "version": "1.48.0#0"
+      },
+      {
+          "name": "spdlog",
+          "version": "1.14.1#0"
+      },
+      {
+          "name": "gtest",
+          "version": "1.15.0#0"
+      },
+      {
+          "name": "benchmark",
+          "version": "1.8.5#0"
+      },
+      {
+          "name": "cli11",
+          "version": "2.4.2#0"
+      },
+      {
+          "name": "concurrentqueue",
+          "version": "1.0.4#0"
+      },
+      {
+          "name": "curl",
+          "version": "8.9.1#0"
+      },
+      {
+          "name": "libmaxminddb",
+          "version": "1.9.1#0"
+      },
+      {
+          "name": "yaml-cpp",
+          "version": "0.8.0#0"
+      },
+      {
+          "name": "uvw",
+          "version": "2.12.1#2"
+      },
+      {
+          "name": "opentelemetry-cpp",
+          "version": "1.8.3#6"
+      },
+      {
+          "name": "protobuf",
+          "version": "3.21.12#4"
+      },
+      {
+          "name": "date",
+          "version": "2024-05-14#0"
+      },
+      {
+          "name": "pugixml",
+          "version": "1.14#0"
+      },
+      {
+          "name": "rapidjson",
+          "version": "2023-07-17#1"
+      },
+      {
+          "name": "re2",
+          "version": "2024-06-01#0"
+      },
+      {
+          "name": "rocksdb",
+          "version": "9.2.1#0"
+      },
+      {
+          "name": "rxcpp",
+          "version": "4.1.1#1"
+      },
+      {
+          "name": "taskflow",
+          "version": "3.7.0#0"
+      },
+      {
+          "name": "fmt",
+          "version": "8.1.1#2"
+      }
+  ]
+}


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25073|

This PR aims to use VCPKG as a package manager in the engine project as start point.

Basically:
- Fix the GH actions test execution.
- Add cmake helper function to add cmake targets
- Modify cmakelist file to use the new targets.
- Remove the major part of CPMAdd... calls.