### PR TITLE
Fix SCA rule #33178

### DIFF
--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -3534,7 +3534,7 @@ checks:
       - nist_sp_800-53: ["IA-5 (1)"]
     condition: all
     rules:
-      - 'not f:/etc/passwd -> r:^\w+:x:'
+      - 'not f:/etc/passwd -> r:^[^:]*:x:'
 
   # 6.2.2 Ensure password fields are not empty. (Automated)
   - id: 33179


### PR DESCRIPTION
Fix SCA rule 33178 to make sure it does not mistakenly trigger when a username in /etc/passwd contains e.g. a '-'.  Currently triggers on usernames like systemd-network or www-data

|Related issue|
|---|
| #25103  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
change rule from `'not f:/etc/passwd -> r:^\w+:x:'` to `'not f:/etc/passwd -> r:^[^:]*:x:'`
See [current](https://regex101.com/r/oB2YhN/1) vs [fixed](https://regex101.com/r/LspGg5/1)
## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->
