### PR TITLE
Add framework Engine API client

### DIFF
--- a/framework/wazuh/core/engine/__init__.py
+++ b/framework/wazuh/core/engine/__init__.py
@@ -1,0 +1,56 @@
+from contextlib import asynccontextmanager
+from logging import getLogger
+from typing import AsyncIterator
+
+from httpx import AsyncClient, AsyncHTTPTransport, ConnectError, Timeout, TimeoutException, UnsupportedProtocol
+from wazuh.core.exception import WazuhEngineError
+
+logger = getLogger('wazuh')
+
+# TODO: use actual default path
+ENGINE_API_SOCKET_PATH = '/var/wazuh/queue/engine.sock'
+DEFAULT_RETRIES = 3
+DEFAULT_TIMEOUT = 0.5
+
+
+class Engine:
+    """Wazuh Engine API client."""
+
+    def __init__(
+        self,
+        socket_path: str = ENGINE_API_SOCKET_PATH,
+        retries: int = DEFAULT_RETRIES,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        transport = AsyncHTTPTransport(uds=socket_path, retries=retries)
+        self._client = AsyncClient(transport=transport, timeout=Timeout(timeout))
+
+        # Register Engine modules here
+
+    async def close(self) -> None:
+        """Close the Engine client."""
+        await self._client.aclose()
+
+
+@asynccontextmanager
+async def get_engine_client() -> AsyncIterator[Engine]:
+    """Create and return the engine client.
+
+    Returns
+    -------
+    AsyncIterator[Engine]
+        Engine client iterator.
+    """
+    # TODO: get class parameters from the configuration
+    client = Engine()
+
+    try:
+        yield client
+    except TimeoutException:
+        raise WazuhEngineError(2800)
+    except UnsupportedProtocol:
+        raise WazuhEngineError(2801)
+    except ConnectError:
+        raise WazuhEngineError(2802)
+    finally:
+        await client.close()

--- a/framework/wazuh/core/engine/base.py
+++ b/framework/wazuh/core/engine/base.py
@@ -1,0 +1,13 @@
+import logging
+
+from httpx import AsyncClient
+
+
+class BaseModule:
+    """Base class to interact with Engine modules."""
+
+    MODULE = None
+
+    def __init__(self, client: AsyncClient) -> None:
+        self._client = client
+        self._logger = logging.getLogger('wazuh')

--- a/framework/wazuh/core/engine/tests/test_base.py
+++ b/framework/wazuh/core/engine/tests/test_base.py
@@ -4,7 +4,7 @@ from wazuh.core.engine.base import BaseModule
 
 
 def test_base_module_init():
-    """Check the correct initalization of the `BaseModule` class."""
+    """Check the correct initialization of the `BaseModule` class."""
 
     client_mock = mock.MagicMock()
     instance = BaseModule(client=client_mock)

--- a/framework/wazuh/core/engine/tests/test_base.py
+++ b/framework/wazuh/core/engine/tests/test_base.py
@@ -1,0 +1,12 @@
+from unittest import mock
+
+from wazuh.core.engine.base import BaseModule
+
+
+def test_base_module_init():
+    """Check the correct initalization of the `BaseModule` class."""
+
+    client_mock = mock.MagicMock()
+    instance = BaseModule(client=client_mock)
+
+    assert instance._client == client_mock

--- a/framework/wazuh/core/engine/tests/test_init.py
+++ b/framework/wazuh/core/engine/tests/test_init.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+import pytest
+from httpx import AsyncClient, Timeout, TimeoutException
+from wazuh.core.engine import DEFAULT_RETRIES, DEFAULT_TIMEOUT, Engine, get_engine_client
+from wazuh.core.exception import WazuhEngineError
+
+
+@pytest.mark.parametrize(
+    'params',
+    [
+        {'retries': 3, 'timeout': 10},
+        {'retries': None, 'timeout': 15},
+        {'timeout': 0},
+        {},
+    ],
+)
+def test_engine_init(params: dict):
+    """Check the correct initalization of the `Engine` class."""
+    engine = Engine(socket_path='/test.sock', **params)
+
+    assert isinstance(engine._client, AsyncClient)
+    assert engine._client.is_closed == False
+
+    if 'retries' in params:
+        assert engine._client._transport._pool._retries == params['retries']
+    else:
+        assert engine._client._transport._pool._retries == DEFAULT_RETRIES
+
+    if 'timeout' in params:
+        assert engine._client.timeout == Timeout(params['timeout'])
+    else:
+        assert engine._client.timeout == Timeout(DEFAULT_TIMEOUT)
+
+
+@pytest.mark.asyncio
+async def test_close():
+    """Check the correct functionality of the `close` method."""
+    engine = Engine(socket_path='/test.sock', retries=5, timeout=10)
+    engine._client = mock.AsyncMock()
+    await engine.close()
+
+    engine._client.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_engine_client():
+    """Check the correct behavior of the `get_engine_client` function."""
+    async with get_engine_client() as engine:
+        assert engine._client.is_closed == False
+
+    assert engine._client.is_closed == True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('socket_path,error_number', [
+    ('http://timeout', 2800),
+    ('test', 2801),
+    ('http://invalid', 2802),
+])
+async def test_get_engine_client_ko(socket_path: str, error_number: int):
+    """Check that the `get_engine_client` returns a WazuhEngineError on an exception."""
+    with pytest.raises(WazuhEngineError, match=f'.*{error_number}.*'):
+        async with get_engine_client() as engine:
+            engine._client._transport._pool._retries = 0
+            engine._client.timeout = Timeout(None)
+
+            if error_number == 2800:
+                engine._client = mock.AsyncMock()
+                engine._client.get.side_effect = TimeoutException('')
+
+            _ = await engine._client.get(socket_path)

--- a/framework/wazuh/core/engine/tests/test_init.py
+++ b/framework/wazuh/core/engine/tests/test_init.py
@@ -16,11 +16,11 @@ from wazuh.core.exception import WazuhEngineError
     ],
 )
 def test_engine_init(params: dict):
-    """Check the correct initalization of the `Engine` class."""
+    """Check the correct initialization of the `Engine` class."""
     engine = Engine(socket_path='/test.sock', **params)
 
     assert isinstance(engine._client, AsyncClient)
-    assert engine._client.is_closed == False
+    assert not engine._client.is_closed
 
     if 'retries' in params:
         assert engine._client._transport._pool._retries == params['retries']
@@ -34,7 +34,7 @@ def test_engine_init(params: dict):
 
 
 @pytest.mark.asyncio
-async def test_close():
+async def test_engine_close():
     """Check the correct functionality of the `close` method."""
     engine = Engine(socket_path='/test.sock', retries=5, timeout=10)
     engine._client = mock.AsyncMock()
@@ -47,9 +47,9 @@ async def test_close():
 async def test_get_engine_client():
     """Check the correct behavior of the `get_engine_client` function."""
     async with get_engine_client() as engine:
-        assert engine._client.is_closed == False
+        assert not engine._client.is_closed
 
-    assert engine._client.is_closed == True
+    assert engine._client.is_closed
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -447,6 +447,11 @@ class WazuhException(Exception):
         2702: {'message': 'Ensure the certificates have the correct permissions'},
         2703: {'message': 'Wazuh comms API SSL error. Please, ensure the configuration is correct'},
 
+        # Engine API client
+        2800: {'message': 'The engine client connection timeout has been exceeded'},
+        2801: {'message': 'Invalid request URL scheme'},
+        2802: {'message': 'Invalid unix socket path'},
+
         # Cluster
         3000: 'Cluster',
         3001: 'Error creating zip file',
@@ -814,12 +819,22 @@ class WazuhHAPHelperError(WazuhClusterError):
     _default_type = "about:blank"
     _default_title = "HAProxy Helper Error"
 
+
 class WazuhCommsAPIError(WazuhInternalError):
     """
     This type of exception is raised inside the Agent comms API.
     """
     _default_type = "about:blank"
     _default_title = "Agent comms API Error"
+
+
+class WazuhEngineError(WazuhInternalError):
+    """
+    This type of exception is raised inside the engine.
+    """
+    _default_type = "about:blank"
+    _default_title = "Wazuh Engine Error"
+
 
 class WazuhIndexerError(WazuhInternalError):
     """


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/24646 |

## Description

Adds the `Engine` class to communicate to the Engine API via HTTP over Unix sockets.

## Tests

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/engine --disable-warnings
============================================================== test session starts ===============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 10 items                                                                                                                               

framework/wazuh/core/engine/tests/test_base.py .                                                                                           [ 10%]
framework/wazuh/core/engine/tests/test_init.py .........                                                                                   [100%]

=============================================================== 10 passed in 0.28s ===============================================================
```

</details>

<details><summary>Test using the Docker API as the server</summary>

> The Engine API is still unavailable, so I tested the class against the Docker API which uses the same protocols.

```console
(venv) gasti@gasti:~/work/wazuh$ /home/gasti/work/wazuh/venv/bin/python3 -m asyncio
asyncio REPL 3.10.14 (main, May  3 2024, 08:57:23) [GCC 12.2.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from wazuh.core.engine import Engine
>>> engine = Engine(socket_path='/var/run/docker.sock')
>>> response = await engine._client.get("http://docker/info")
>>> print(response)
<Response [200 OK]>
>>> print(response.json())
{'ID': '***', 'Containers': 0, 'ContainersRunning': 0, 'ContainersPaused': 0, 'ContainersStopped': 0, ...}
```

</details>