### PR TITLE
Fixed docker file for build rpm package in arm64/aarch64

### DIFF
--- a/packages/rpms/arm64/agent/Dockerfile
+++ b/packages/rpms/arm64/agent/Dockerfile
@@ -1,5 +1,9 @@
 FROM arm64v8/centos:7
 
+# CentOS 7 is EOL, so we need to change the repositories to use the vault
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # Enable EPEL
 RUN yum install -y http://packages.wazuh.com/utils/pkg/epel-release-latest-7.noarch.rpm
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25137 |

## Description

CentOS 7 is EOL, so this PR change the repositories to use the vault.

