### PR TITLE
Fix generate_package.sh script to use branch parameter correctly

### DIFF
--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -263,7 +263,8 @@ main() {
         set -x
     fi
 
-    if [ -z "${CUSTOM_CODE_VOL}" ]; then
+    # Add a default source only if neither the branch nor a custom code volume is defined.
+    if [ -z "${CUSTOM_CODE_VOL}" ] && [ -z "${BRANCH}" ]; then
         CUSTOM_CODE_VOL="-v $WAZUH_PATH:/wazuh-local-src:Z"
     fi
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25187|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In this PR we are including a small fix in the Linux package generation script to make the branch parameter work correctly. Until now the tests and the use of the workflows were done without problems because the local repository option was used, without the need to download again a branch. But it is a parameter that gives an option in case it is needed.

## Tests
- Tested in Ubuntu24 VM, with command:
```
root@ubuntu24:/home/vagrant/wazuh# packages/generate_package.sh -a amd64 --tag latest --system deb -t agent -s /tmp -j $(nproc) -r 0 -b bug/25187-generate-package-branch
...
Package wazuh-agent_4.9.0-0_amd64_b42d21432ad.deb added to /tmp.
```
- Tested package:
```
root@ubuntu24:/home/vagrant/wazuh# dpkg -i /tmp/wazuh-agent_4.9.0-0_amd64_b42d21432ad.deb
Selecting previously unselected package wazuh-agent.
(Reading database ... 106219 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.9.0-0_amd64_b42d21432ad.deb ...
Unpacking wazuh-agent (4.9.0-0) ...
Setting up wazuh-agent (4.9.0-0) ...
```