### PR TITLE
Allow longer user/group entries in FIM

### DIFF
--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -563,7 +563,7 @@ char *get_user(int uid) {
     int errno;
 
     bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
-    if (bufsize == -1) {
+    if (bufsize < 16384) {
         bufsize = 16384;
     }
 
@@ -600,7 +600,7 @@ char *get_group(int gid) {
     int bufsize;
 
     bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
-    if (bufsize == -1) {
+    if (bufsize < 16384) {
         bufsize = 16384;
     }
 

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -581,7 +581,7 @@ char *get_user(int uid) {
             mdebug2("User with uid '%d' not found.\n", uid);
         }
         else {
-            mdebug2("Failed getting user_name (%d): '%s'\n", errno, strerror(errno));
+            mdebug2("Failed getting user_name for uid %d: (%d): '%s'\n", uid, errno, strerror(errno));
         }
     } else {
         os_strdup(pwd.pw_name, user_name);
@@ -612,7 +612,7 @@ char *get_group(int gid) {
         if (errno == 0) {
             mdebug2("Group with gid '%d' not found.\n", gid);
         } else {
-            mdebug2("Failed getting group_name (%d): '%s'\n", errno, strerror(errno));
+            mdebug2("Failed getting group_name for gid %d: (%d): '%s'\n", gid, errno, strerror(errno));
         }
     } else {
         os_strdup(grp.gr_name, group_name);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25115|

While the system logic for searching for a user or group by name uses a large buffer size, FIM searches for items by ID using an OS-based buffer size (1 KiB), which may be insufficient if an item contains special characters, or if a group contains many users. This might prevent FIM from retrieving the user/group for a file, given the UID/GID, and produce this log:

> syscheck_op.c:615 at get_group(): DEBUG: Failed getting group_name (34): 'Numerical result out of range'

This change sets the minimum buffer size to 16 KiB, which can be extended to whatever the OS sets (if larger).

## Changes applied

1. Minimum buffer size of 16 KiB for searching for user or group names by their ID.
2. Change debug-2 logs to include the UID or GID that could not be found.
3. Unit tests for the above changes.

## Manual testing

### Files

<details><summary>Dockerfile</summary>

```Dockerfile
FROM ubuntu:20.04
ARG BRANCH=4.9.1
ARG MANAGER=172.28.54.78
WORKDIR /root
SHELL ["/bin/bash", "-c"]

RUN <<EOF
set -i
apt-get update
DEBIAN_FRONTEND=noninteractive apt-get install -y gcc cmake make g++ curl git procps net-tools
EOF

RUN <<EOF
set -i
GNAME="doynq1.yeyesbhhzfobyx"
GID=815162123

addgroup --gid $GID --force-badname "$GNAME"

for i in {ctewbwhhf,zdshcf.sicfgp,iejfja.hsogw,nupcq.fjsecoseju,kyzukdw.jyhacncowvvu,vgjjbs.ezrlbtk,ytgugrtf.wqmugujlzm,ddpqgjegpmr,kh.cloazhqgwr,alq.pqbytzcirr,gxvebq,ydk.gsgpyakmuk,jnp_dzl_iyrws.srvfnz,ek.ooqdkzsuzc,caorzhl.owja,ee.timirheoyh,hfvhopyqbacvqi,rympvsiph.uokgttuobg,ibdndbycecnn,zc.dmkoumncjp,sjionlybrzqd,es.yvyobvityd,abngip.ahedpqu,gviv.vblwqwojbb,vsluwzstxtyry,szdysbud.rnqjonuoyj,po.olxzygrzjd,ezjsdir.lumcvdn,roozhcj.zmhbqppa,cwa.rwvpgctvpx,lfbmsktez24,qxuzk.adakhcqhap,rrnvpfjgjypj,iutwr,qyv.ojutdkysap,svidezwlvv,vjfjw.uazcmy,zqwupx.ggumezwtmot,xnwhjprxxbdetxj,qd.fewixlqfcn,grwpdyndn.icuphkderj,rcktjm.umvqfagxvw,lrarzg.zmzgewmfzp,ccekh.dgcmbnhpnw,ktqvcjook.smrdiqnajp,bdlc.vxzcwirmof,zohzxo_yahrbpkjs,rosuqajecw,cpa,wlfbgfsbq,ftacsrjxl,nfyxfnjqtr,iacc.rlninth,nsmkxqvhvo,xqthlztphhca.tuxonnf,jvqpyxnwo.psznngzovk,dcidt.cawppkb,isxiww.muamrytnpt,qqmlej.rwmddihbgf,feumvto.rhkzze,an.nhrdh.gyttldffw,tn.agfjdi.cfkhxzxce,lh.rajira,rs.xedcsjer,mr.lvaqsov.mxyn,wr.uanesy.bmymxa,qkco.chgfzibvhx,om.ardynlwole,iqefbiuf,tphwql.urmvoreowu,okf.zhsmyiubtn,ybgtipd.ysidyjhtka,bacpmeclodpuxxdqf,xdewxigird,oteuluyj.mczgruhfiz,zcfymkuq.qhamoj,kytpdlao,wunellsbizpxn}
do
    adduser --disabled-password --force-badname --gecos "" "$i"
    adduser "$i" "$GNAME"
done

touch hello.txt
chgrp "$GNAME" hello.txt
EOF

RUN <<EOF
set -i
git clone --depth 1 -b "$BRANCH" https://github.com/wazuh/wazuh.git
USER_LANGUAGE="en" USER_NO_STOP="y" USER_INSTALL_TYPE="agent" USER_DIR="/var/ossec" USER_AGENT_SERVER_IP="$MANAGER" USER_ENABLE_SYSCHECK="y" USER_ENABLE_ROOTCHECK="y" USER_ENABLE_ACTIVE_RESPONSE="y" USER_CA_STORE="n" USER_UPDATE="y" wazuh/install.sh
rm -r wazuh
EOF

ADD client.keys /var/ossec/etc/client.keys
ADD ossec.conf /var/ossec/etc/ossec.conf
```

</details>

<details><summary>ossec.conf</summary>

```xml
<!--
  Wazuh - Agent - Default configuration for ubuntu 20.04
  More info at: https://documentation.wazuh.com
  Mailing list: https://groups.google.com/forum/#!forum/wazuh
-->

<ossec_config>
  <client>
    <server>
      <address>172.28.54.78</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
    <config-profile>ubuntu, ubuntu20, ubuntu20.04</config-profile>
    <notify_time>10</notify_time>
    <time-reconnect>60</time-reconnect>
    <auto_restart>no</auto_restart>
    <crypto_method>aes</crypto_method>
  </client>

  <client_buffer>
    <!-- Agent buffer options -->
    <disabled>no</disabled>
    <queue_size>5000</queue_size>
    <events_per_second>500</events_per_second>
  </client_buffer>

  <!-- File integrity monitoring -->
  <syscheck>
    <disabled>no</disabled>

    <!-- Frequency that syscheck is executed default every 12 hours -->
    <frequency>43200</frequency>

    <scan_on_start>yes</scan_on_start>

    <!-- Directories to check  (perform all possible verifications) -->
    <directories>/root</directories>

    <!-- Files/directories to ignore -->
    <ignore>/etc/mtab</ignore>
    <ignore>/etc/hosts.deny</ignore>
    <ignore>/etc/mail/statistics</ignore>
    <ignore>/etc/random-seed</ignore>
    <ignore>/etc/random.seed</ignore>
    <ignore>/etc/adjtime</ignore>
    <ignore>/etc/httpd/logs</ignore>
    <ignore>/etc/utmpx</ignore>
    <ignore>/etc/wtmpx</ignore>
    <ignore>/etc/cups/certs</ignore>
    <ignore>/etc/dumpdates</ignore>
    <ignore>/etc/svc/volatile</ignore>

    <!-- File types to ignore -->
    <ignore type="sregex">.log$|.swp$</ignore>

    <!-- Check the file, but never compute the diff -->
    <nodiff>/etc/ssl/private.key</nodiff>

    <skip_nfs>yes</skip_nfs>
    <skip_dev>yes</skip_dev>
    <skip_proc>yes</skip_proc>
    <skip_sys>yes</skip_sys>

    <!-- Nice value for Syscheck process -->
    <process_priority>10</process_priority>

    <!-- Maximum output throughput -->
    <max_eps>50</max_eps>

    <!-- Database synchronization settings -->
    <synchronization>
      <enabled>yes</enabled>
      <interval>5m</interval>
      <max_eps>10</max_eps>
    </synchronization>
  </syscheck>

  <!-- Active response -->
  <active-response>
    <disabled>no</disabled>
    <ca_store>etc/wpk_root.pem</ca_store>
    <ca_verification>yes</ca_verification>
  </active-response>

  <!-- Choose between "plain", "json", or "plain,json" for the format of internal logs -->
  <logging>
    <log_format>plain</log_format>
  </logging>

</ossec_config>
```

</details>

> [!TIP]
> Remember to change the correct manager address at _ossec.conf_.

`client.keys`: You can either pre-enroll an agent or leave it empty.

### 🔴 Unfixed branch

```shell
docker build -t poc-gid:4.9.1 .
docker run -it poc-gid:4.9.1 bash
```

```shell

/var/ossec/bin/wazuh-agentd
/var/ossec/bin/wazuh-syscheckd -dd

grep get_group /var/ossec/logs/ossec.log
```

> 2024/08/13 11:40:11 wazuh-syscheckd[21] syscheck_op.c:615 at get_group(): DEBUG: Failed getting group_name (34): 'Numerical result out of range'

```shell
grep hello.txt /var/ossec/logs/ossec.log
```

> 2024/08/13 11:40:11 wazuh-syscheckd[21] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"attributes":{"attributes":"","checksum":"1cb3e511618fbc8fbc63744b406d851c135b9531","gid":"815162123","group_name":"","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":437300,"mtime":1723549050,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"index":"/root/hello.txt","timestamp":1723549211},"type":"state"}

> [!NOTE]
> Member `group_name` is empty. :-1:

### 🟢 Fixed branch

```shell
docker build --build-arg=BRANCH=fix/25115-fim-group-buffer -t poc-gid:fixed .
docker run -it poc-gid:fixed bash
```

```shell

/var/ossec/bin/wazuh-agentd
/var/ossec/bin/wazuh-syscheckd -dd

grep get_group /var/ossec/logs/ossec.log
```

> (No logs)

```shell
grep hello.txt /var/ossec/logs/ossec.log
```

> 2024/08/13 11:46:26 wazuh-syscheckd[45] run_check.c:113 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"attributes":{"attributes":"","checksum":"e56ad0efb97274b1d62c96ae503cba33aaa91610","gid":"815162123","group_name":"doynq1.yeyesbhhzfobyx","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":483389,"mtime":1723549209,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"index":"/root/hello.txt","timestamp":1723549586},"type":"state"}

> [!NOTE]
> Member `group_name` is filled this time. :+1: