### PR TITLE
Fix crash in Logcollector when rotating a log

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -578,8 +578,7 @@ void LogCollectorStart()
                         if (reload_file(current) == -1) {
                             minfo(FORGET_FILE, current->file);
                             os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                            EVP_MD_CTX_free(old_file_status->context);
-                            os_free(old_file_status);
+                            free_files_status_data(old_file_status);
                             w_logcollector_state_delete_file(current->file);
                             current->exists = 0;
                             current->ign++;
@@ -654,8 +653,7 @@ void LogCollectorStart()
                             if(current->exists==1){
                                 minfo(FORGET_FILE, current->file);
                                 os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                                EVP_MD_CTX_free(old_file_status->context);
-                                os_free(old_file_status);
+                                free_files_status_data(old_file_status);
                                 w_logcollector_state_delete_file(current->file);
                                 current->exists = 0;
                             }
@@ -711,8 +709,7 @@ void LogCollectorStart()
                         if(current->exists==1){
                             minfo(FORGET_FILE, current->file);
                             os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                            EVP_MD_CTX_free(old_file_status->context);
-                            os_free(old_file_status);
+                            free_files_status_data(old_file_status);
                             w_logcollector_state_delete_file(current->file);
                             current->exists = 0;
                         }
@@ -756,8 +753,7 @@ void LogCollectorStart()
                                current->file);
 
                         os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                        EVP_MD_CTX_free(old_file_status->context);
-                        os_free(old_file_status);
+                        free_files_status_data(old_file_status);
                         w_logcollector_state_delete_file(current->file);
 
                         fclose(current->fp);
@@ -791,8 +787,7 @@ void LogCollectorStart()
 
                         /* Get new file */
                         os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                        EVP_MD_CTX_free(old_file_status->context);
-                        os_free(old_file_status);
+                        free_files_status_data(old_file_status);
                         w_logcollector_state_delete_file(current->file);
 
                         fclose(current->fp);
@@ -887,8 +882,7 @@ void LogCollectorStart()
                         if (!PathFileExists(current->file)) {
 #endif
                             os_file_status_t * old_file_status = OSHash_Delete_ex(files_status, current->file);
-                            EVP_MD_CTX_free(old_file_status->context);
-                            os_free(old_file_status);
+                            free_files_status_data(old_file_status);
                             w_logcollector_state_delete_file(current->file);
 
                             if (Remove_Localfile(&(globs[j].gfiles), i, 1, 0,&globs[j])) {
@@ -1026,7 +1020,7 @@ int handle_file(int i, int j, __attribute__((unused)) int do_fseek, int do_log)
     /* We must be able to open the file, fseek and get the
      * time of change from it.
      */
-    
+
     /* TODO: Support text mode on Windows */
     lf->fp = wfopen(lf->file, "rb");
     if (!lf->fp) {
@@ -1115,7 +1109,7 @@ error:
 
 /* Reload file: open after close, and restore position */
 int reload_file(logreader * lf) {
-    
+
     /* TODO: Support text mode on Windows */
     lf->fp = wfopen(lf->file, "rb");
 


### PR DESCRIPTION
|Related issue|Regression|
|---|---|
|#25202|https://github.com/wazuh/wazuh/pull/22974|

The QA team has reported a crash in Logcollector, happened during automated tests.

## Bug trace

```
==1809963==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x55624bf073c5 bp 0x7ffdf1d57130 sp 0x7ffdf1d56950 T0)
==1809963==The signal is caused by a READ memory access.
==1809963==Hint: address points to the zero page.
    #0 0x55624bf073c5 in LogCollectorStart logcollector/logcollector.c:759
    #1 0x55624bf16c0c in main logcollector/main.c:195
    #2 0x7f754a0721c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #3 0x7f754a07228a in __libc_start_main_impl ../csu/libc-start.c:360
    #4 0x55624bef80d4 in _start (/var/ossec/bin/wazuh-logcollector+0x360d4) (BuildId: a972a7e2e94ec64845d822e0e969909977bc5111)
```

## Configuration

#### ossec.conf

```xml
<localfile>
  <log_format>syslog</log_format>
  <location>/root/test/logs/*.log</location>
</localfile>
```

#### local_internal_options.conf

```ini
logcollector.loop_timeout=1
logcollector.vcheck_files=5
```

## How to reproduce

Make Logcollector detect a rotated file twice in a row:

```bash
cd /root/test/logs
touch hello.log
sleep 6
touch hello.2 && mv hello.2 hello.log
sleep 6
touch hello.2 && mv hello.2 hello.log
```

## Proposed fix

Check that the file status structure is not null before trying to free the context: rely on the `free_files_status_data()` function.

## Tests

- [X] Unit tests for agent.

### Manual tests

- [X] Run Logcollector with AddressSanitizer.
- [X] **Focused test:** Rotate a file 10 times:
```bash
cd /root/test/logs

for i in {1..10}
do 
    touch hello.2 && mv hello.2 hello.log
    sleep 5
done
```
- [X] **Stress test:** Continuously create/write/delete 100 files:
```bash
cd /root/test/logs

while true
do 
    for i in {1..100}
    do 
        touch file$i.log
    done
    
    for i in {1..100}
    do
        echo "Hello" >> file$i.log
    done
    
    rm *.log
done
```

## Caveats

As part of the review of this PR, I'm asking @Nicogp and @TomasTurina for help in reviewing the `read_*.c` files and determine if calls to `EVP_MD_CTX_new()` may conflict with `w_get_hash_context()`, where such context may be overwritten.