### PR TITLE
Enable API to listening in double IP stack

### DIFF
--- a/api/api/configuration.py
+++ b/api/api/configuration.py
@@ -31,7 +31,7 @@ default_security_configuration = {
 }
 
 default_api_configuration = {
-    "host": "0.0.0.0",
+    "host": ["0.0.0.0", "::"],
     "port": 55000,
     "drop_privileges": True,
     "experimental_features": False,

--- a/api/api/configuration/api.yaml
+++ b/api/api/configuration/api.yaml
@@ -1,6 +1,6 @@
 # USE THIS FILE AS A TEMPLATE. UNCOMMENT LINES TO APPLY CUSTOM CONFIGURATION
 
-# host: 0.0.0.0
+# host: ['0.0.0.0', '::']
 # port: 55000
 
 # Advanced configuration

--- a/api/api/test/test_configuration.py
+++ b/api/api/test/test_configuration.py
@@ -11,7 +11,7 @@ import api.constants
 from api import configuration, api_exception
 
 custom_api_configuration = {
-    "host": "0.0.0.0",
+    "host": ["0.0.0.0", "::"],
     "port": 55000,
     "drop_privileges": True,
     "experimental_features": False,

--- a/api/api/validator.py
+++ b/api/api/validator.py
@@ -65,7 +65,7 @@ api_config_schema = {
     "type": "object",
     "additionalProperties": False,
     "properties": {
-        "host": {"type": "string"},
+        "host": {"type": "array", "items": {"type": "string"}},
         "port": {"type": "number"},
         "use_only_authd": {"type": "boolean"},  # Deprecated. To be removed on later versions
         "drop_privileges": {"type": "boolean"},

--- a/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
+++ b/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
@@ -1,4 +1,4 @@
-host: 0.0.0.0
+host: [0.0.0.0]
 port: 55000
 
 # Advanced configuration

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -859,7 +859,7 @@ stages:
           affected_items:
             - node_name: "master-node"
               node_api_config: &default_api_config
-                host: !anystr
+                host: !anylist
                 port: !anyint
                 https:
                   enabled: !anybool

--- a/tests/integration/test_api/conftest.py
+++ b/tests/integration/test_api/conftest.py
@@ -50,7 +50,7 @@ def wait_for_api_start(test_configuration: dict) -> None:
     """
     # Set the default values
     logs_format = 'plain'
-    host = '0.0.0.0'
+    host = ['0.0.0.0', '::']
     port = WAZUH_API_PORT
 
     # Check if specific values were set or set the defaults
@@ -59,7 +59,7 @@ def wait_for_api_start(test_configuration: dict) -> None:
             logs_configuration = test_configuration['blocks'].get('logs')
             # Set the default value if `format`` is not set
             logs_format = 'plain' if logs_configuration is None else logs_configuration.get('format', 'plain')
-            host = test_configuration['blocks'].get('host', '0.0.0.0')
+            host = test_configuration['blocks'].get('host', ['0.0.0.0', '::'])
             port = test_configuration['blocks'].get('port', WAZUH_API_PORT)
 
     file_to_monitor = WAZUH_API_JSON_LOG_FILE_PATH if logs_format == 'json' else WAZUH_API_LOG_FILE_PATH

--- a/tests/integration/test_api/test_config/test_host_port/data/test_cases/cases_host_port.yaml
+++ b/tests/integration/test_api/test_config/test_host_port/data/test_cases/cases_host_port.yaml
@@ -1,21 +1,21 @@
 - name: VALID_HOST_VALID_PORT
   description: Check if the connection can be established correctly by setting a valid host/port combination.
   configuration_parameters:
-    HOST: 0.0.0.0
+    HOST: [0.0.0.0]
     PORT: 55000
   metadata: null
 
 - name: INVALID_PORT_VALID_HOST
   description: Check if the connection can be established correctly by setting an invalid port and a valid host.
   configuration_parameters:
-    HOST: 0.0.0.0
+    HOST: [0.0.0.0]
     PORT: 55111
   metadata: null
 
 - name: INVALID_HOST_INVALID_PORT
   description: Check if the connection cannot be established correctly by setting an invalid host/port combination.
   configuration_parameters:
-    HOST: 123.45.6.78
+    HOST: [123.45.6.78]
     PORT: 55111
   metadata:
     expected_exception: connection
@@ -23,7 +23,7 @@
 - name: INVALID_HOST_VALID_PORT
   description: Check if the connection cannot be established correctly by setting an invalid host and a valid port.
   configuration_parameters:
-    HOST: 123.45.6.78
+    HOST: [123.45.6.78]
     PORT: 55000
   metadata:
     expected_exception: connection

--- a/tests/integration/test_api/test_config/test_host_port/test_host_port.py
+++ b/tests/integration/test_api/test_config/test_host_port/test_host_port.py
@@ -155,4 +155,4 @@ def test_host_port(test_configuration, test_metadata, add_configuration, truncat
     else:
         # Wait `timeout_before_exception` seconds to make sure that the exception is thrown
         with pytest.raises(requests.exceptions.ConnectionError):
-            login(host=host, port=port, timeout=timeout_before_exception)
+            login(host=host[0], port=port, timeout=timeout_before_exception)

--- a/tests/integration/test_api/test_config/test_logs/test_logs_format.py
+++ b/tests/integration/test_api/test_config/test_logs/test_logs_format.py
@@ -166,7 +166,7 @@ def test_logs_formats(test_configuration, test_metadata, add_configuration, trun
         else:
             json_file_monitor.start(callback=generate_callback(API_LOGIN_REQUEST_MSG, {
                     'user': WAZUH_API_USER,
-                    'host': '127.0.0.1',
+                    'host': '::1',
                     'login_route': LOGIN_ROUTE
                 })
             )
@@ -182,7 +182,7 @@ def test_logs_formats(test_configuration, test_metadata, add_configuration, trun
         else:
             plain_file_monitor.start(callback=generate_callback(API_LOGIN_REQUEST_MSG, {
                     'user': WAZUH_API_USER,
-                    'host': '127.0.0.1',
+                    'host': '::1',
                     'login_route': LOGIN_ROUTE
                 })
             )


### PR DESCRIPTION
|Related issue|
|---|
|#24981

## Description

This PR closes #24891. Enables the API to listen in both IP versions.


## Logs/Alerts example

* IPV4

```console
root@wazuh-master:/# curl -k -H  "Authorization: Bearer $TOKEN" https://127.0.0.1:55000/
{"data": {"title": "Wazuh API REST", "api_version": "4.9.1", "revision": 40910, "license_name": "GPL 2.0", "license_url": "https://github.com/wazuh/wazuh/blob/v4.9.1/LICENSE", "hostname": "wazuh-master", "timestamp": "2024-08-14T12:28:02Z"}, "error": 0}
```

* IPV6

```console
root@wazuh-master:/# curl -k -H  "Authorization: Bearer $TOKEN" 'https://[::1]:55000/'
{"data": {"title": "Wazuh API REST", "api_version": "4.9.1", "revision": 40910, "license_name": "GPL 2.0", "license_url": "https://github.com/wazuh/wazuh/blob/v4.9.1/LICENSE", "hostname": "wazuh-master", "timestamp": "2024-08-14T12:27:28Z"}, "error": 0}
```