### PR TITLE
Replace nist_800_53_AC.7 with nist_800_53_AC.9 in 5 Rules

### DIFF
--- a/ruleset/rules/0580-win-security_rules.xml
+++ b/ruleset/rules/0580-win-security_rules.xml
@@ -78,7 +78,7 @@
     <field name="win.system.eventID">^528$|^540$|^673$|^4624$|^4769$</field>
     <description>Windows Logon Success</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.9,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
       <id>T1078</id>
     </mitre>
@@ -222,7 +222,7 @@
     <field name="win.eventdata.logonType">^2$</field>
     <description>Windows Workstation Logon Success</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.9,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
       <id>T1078</id>
     </mitre>
@@ -233,7 +233,7 @@
     <if_fts />
     <description>First time this user logged in this system</description>
     <options>no_full_log</options>
-    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.9,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
     <mitre>
       <id>T1078</id>
     </mitre>
@@ -1052,7 +1052,7 @@
     <field name="win.eventdata.subjectUserName">^LOCAL SERVICE|^NETWORK SERVICE|^ANONYMOUS LOGON</field>
     <description>Windows Logon Success (ignored)</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.9,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="60195" level="10">
@@ -1099,7 +1099,7 @@
     <field name="win.eventdata.logonType">^8$</field>
     <description>IIS NetworkCleartext Logon Success</description>
     <options>no_full_log</options>
-    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.9,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
   <rule id="60201" level="0">


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/external-devel-requests/issues/2428|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->
Regulatory compliance NIST 800-53 details are incorrect for rule ID 60106, 60118, 60119, 60194 and 60200.

S/N | Rule ID | Rule   Description | Change Applied
-- | -- | -- | --
1 | 60106 | Windows Logon Success | Replaced   nist_800_53_AC.7 with nist_800_53_AC.9
2 | 60118 | Windows Workstation   Logon Success | Replaced   nist_800_53_AC.7 with nist_800_53_AC.9
3 | 60119 | First time this user   logged in this system | Replaced   nist_800_53_AC.7 with nist_800_53_AC.9
4 | 60194 | Windows Logon Success   (ignored) | Replaced   nist_800_53_AC.7 with nist_800_53_AC.9
5 | 60200 | IIS NetworkCleartext   Logon Success | Replaced   nist_800_53_AC.7 with nist_800_53_AC.9

