### PR TITLE
Update 0915-win-powershell_rules.xml

### DIFF
--- a/ruleset/rules/0915-win-powershell_rules.xml
+++ b/ruleset/rules/0915-win-powershell_rules.xml
@@ -6,7 +6,7 @@
   Powershell Rules 91801 - 92000
 -->
 
-<group name="windows, powershell,">
+<group name="windows,powershell,">
 
   <!-- Powershell Operational grouping -->
   <rule id="91801" level="0">


### PR DESCRIPTION
fix space in group name

|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25229|

## Description

Fix issue when trying to filter rule.group by powershell

## Configuration options
N/A

## Logs/Alerts example

```
    "groups": [
      "windows",
      " powershell"
    ],
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors