### PR TITLE
Fix/25225 backport fix when remoted fails to read a message

### DIFF
--- a/src/remoted/netbuffer.c
+++ b/src/remoted/netbuffer.c
@@ -110,7 +110,7 @@ int nb_recv(netbuffer_t * buffer, int sock) {
 
     if (i > 0) {
         if (i < sockbuf->data_len) {
-            memcpy(sockbuf->data, sockbuf->data + i, sockbuf->data_len - i);
+            memmove(sockbuf->data, sockbuf->data + i, sockbuf->data_len - i);
         }
 
         sockbuf->data_len -= i;

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -79,7 +79,7 @@ list(APPEND remoted_names "test_netbuffer")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,wnet_order -Wl,--wrap,wnotify_modify \
                             -Wl,--wrap,bqueue_push -Wl,--wrap,bqueue_peek -Wl,--wrap,bqueue_drop -Wl,--wrap,bqueue_clear -Wl,--wrap,sleep \
                             -Wl,--wrap,send -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,fcntl -Wl,--wrap,getpid \
-                            -Wl,--wrap,bqueue_used -Wl,--wrap,rem_inc_send_discarded")
+                            -Wl,--wrap,bqueue_used -Wl,--wrap,rem_inc_send_discarded -Wl,--wrap,recv -Wl,--wrap,rem_msgpush")
 
 list(APPEND remoted_names "test_sendmsg")
 list(APPEND remoted_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,OS_IsAllowedID -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25225|

## Description

This PR is to backport to `4.8.2` the fix that was developed here:
- https://github.com/wazuh/wazuh/pull/21595

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] AddressSanitizer




