### PR TITLE
CMakePresets for build types and workflows improves

### DIFF
--- a/.github/workflows/engine_health_test.yml
+++ b/.github/workflows/engine_health_test.yml
@@ -1,30 +1,38 @@
 name: Engine Health Test
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on pull request events but only for the engine base branch and with changes in the src/engine/ directory.
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
       - '.github/workflows/engine_health_test.yml'
 
-  # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      build_preset:
+        type: choice
+        description: 'Choose the CMake build preset'
+        required: false
+        default: 'release'
+        options:
+          - debug
+          - release
+          - relwithdebinfo
+          - minsize
 
 # Ensures only one instance of this workflow is running per PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  BUILD_TYPE: Release
+  BUILD_PRESET: ${{ github.event.inputs.build_preset || 'release' }}
   ENGINE_DIR: ${{github.workspace}}/src/engine
 
 jobs:
   build:
     name: Engine Health Test
 
-    # Runs only if the PR status is different to Draft
+    # Only runs if the PR status is different to Draft
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -44,7 +52,6 @@ jobs:
         python-version: 3.8
 
     - name: Install dependencies
-      # Install behave
       run: |
         pip install ${{env.ENGINE_DIR}}/tools/api-communication/
         pip install ${{env.ENGINE_DIR}}/test/integration_tests/it-utils/
@@ -58,20 +65,16 @@ jobs:
         vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
 
     - name: Configure CMake
-      # Configure the CMake build system with the specified build type
-      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
+      run: cmake --preset=${{env.BUILD_PRESET}} --no-warn-unused-cli -S ${{env.ENGINE_DIR}}
 
     - name: Build
-      # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j$(nproc)
+      run: cmake --build ${{env.ENGINE_DIR}}/build --target main -j$(nproc)
 
     - name: Setup environment
-      # Set Engine Configuration
       run: python3 ${{env.ENGINE_DIR}}/test/setupEnvironment.py -e /tmp/actions
 
     - name: Initial state
       run: python3 ${{env.ENGINE_DIR}}/test/health_test/initialState.py -e /tmp/actions
 
     - name: Health Test
-      # Run integration tests using behave
       run: python3 ${{env.ENGINE_DIR}}/test/health_test/run.py -e /tmp/actions

--- a/.github/workflows/engine_helper_functions_test.yml
+++ b/.github/workflows/engine_helper_functions_test.yml
@@ -1,30 +1,39 @@
 name: Engine Helper Functions Test
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on pull request events but only for the engine base branch and with changes in the src/engine/ directory.
+  # Triggers the workflow on pull request but only changes in the src/engine/ directory.
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
       - '.github/workflows/engine_helper_functions_test.yml'
 
-  # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      build_preset:
+        type: choice
+        description: 'Choose the CMake build preset'
+        required: false
+        default: 'release'
+        options:
+          - debug
+          - release
+          - relwithdebinfo
+          - minsize
 
 # Ensures only one instance of this workflow is running per PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  BUILD_TYPE: Release
+  BUILD_PRESET: ${{ github.event.inputs.build_preset || 'release' }}
   ENGINE_DIR: ${{github.workspace}}/src/engine
 
 jobs:
   build:
     name: Engine Helper Functions Test
 
-    # Runs only if the PR status is different to Draft
+    # Only runs if the PR status is different to Draft
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -56,16 +65,14 @@ jobs:
         vcpkgDirectory: '${{env.ENGINE_DIR}}/vcpkg'
         vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
         vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
-      # Configure the CMake build system with the specified build type
+
     - name: Configure CMake
-      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
+      run: cmake --preset=${{env.BUILD_PRESET}} --no-warn-unused-cli -S ${{env.ENGINE_DIR}}
 
     - name: Build
-      # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j$(nproc)
+      run: cmake --build ${{env.ENGINE_DIR}}/build --target main -j$(nproc)
 
     - name: Setup environment
-      # Set Engine Configuration
       run: python3 ${{env.ENGINE_DIR}}/test/setupEnvironment.py -e /tmp/actions
 
     - name: Initial state

--- a/.github/workflows/engine_integration_test.yml
+++ b/.github/workflows/engine_integration_test.yml
@@ -2,23 +2,34 @@ name: Engine Integration Test
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on pull request events but only for the engine base branch and with changes in the src/engine/ directory.
+  # Triggers the workflow on pull request but only changes in the src/engine/ directory.
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
       - '.github/workflows/engine_integration_test.yml'
 
-  # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      build_preset:
+        type: choice
+        description: 'Choose the CMake build preset'
+        required: false
+        default: 'release'
+        options:
+          - debug
+          - release
+          - relwithdebinfo
+          - minsize
 
 # Ensures only one instance of this workflow is running per PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  BUILD_TYPE: Release
+  BUILD_PRESET: ${{ github.event.inputs.build_preset || 'release' }}
   ENGINE_DIR: ${{github.workspace}}/src/engine
+
 
 jobs:
   build:
@@ -59,20 +70,16 @@ jobs:
         vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
 
     - name: Configure CMake
-      # Configure the CMake build system with the specified build type
-      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
+      run: cmake --preset=${{env.BUILD_PRESET}} --no-warn-unused-cli -S ${{env.ENGINE_DIR}}
 
     - name: Build
-      # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target main -j$(nproc)
+      run: cmake --build ${{env.ENGINE_DIR}}/build --target main -j$(nproc)
 
     - name: Setup environment
-      # Set Engine Configuration
       run: python3 ${{env.ENGINE_DIR}}/test/setupEnvironment.py -e /tmp/actions
 
     - name: Initial state
       run: python3 ${{env.ENGINE_DIR}}/test/integration_tests/initialState.py -e /tmp/actions
 
     - name: Integration Test
-      # Run integration tests using behave
       run: python3 ${{env.ENGINE_DIR}}/test/integration_tests/run.py -e /tmp/actions

--- a/.github/workflows/engine_unit_test.yml
+++ b/.github/workflows/engine_unit_test.yml
@@ -1,23 +1,32 @@
 name: Engine Unit Test
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on pull request events but only for the engine base branch and with changes in the src/engine/ directory.
+  # Triggers the workflow on pull request but only changes in the src/engine/ directory.
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - 'src/engine/**'
       - '.github/workflows/engine_unit_test.yml'
 
-  # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      build_preset:
+        type: choice
+        description: 'Choose the CMake build preset'
+        required: false
+        default: 'release'
+        options:
+          - debug
+          - release
+          - relwithdebinfo
+          - minsize
 
 # Ensures only one instance of this workflow is running per PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  BUILD_TYPE: Release
+  BUILD_PRESET: ${{ github.event.inputs.build_preset || 'release' }}
   ENGINE_DIR: ${{github.workspace}}/src/engine
 
 jobs:
@@ -45,15 +54,14 @@ jobs:
         vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
         vcpkgJsonGlob: '${{env.ENGINE_DIR}}/vcpkg.json'
 
+
     - name: Configure CMake
-      # Configure the CMake build system with the specified build type
-      run: cmake --preset=default --no-warn-unused-cli -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -S ${{env.ENGINE_DIR}}
+      run: cmake --preset=${{env.BUILD_PRESET}} --no-warn-unused-cli -S ${{env.ENGINE_DIR}}
 
     - name: Build
-      # Build the specified target using CMake
-      run: cmake --build ${{env.ENGINE_DIR}}/build --config ${{env.BUILD_TYPE}} --target all -j$(nproc)
+      run: cmake --build ${{env.ENGINE_DIR}}/build --target all -j$(nproc)
 
     - name: Unit Test
       # Run unit tests using CTest
       working-directory: ${{env.ENGINE_DIR}}/build
-      run: ctest -C ${{env.BUILD_TYPE}} -T test --output-on-failure -j2
+      run: ctest -T test --output-on-failure -j$(nproc)

--- a/src/engine/CMakePresets.json
+++ b/src/engine/CMakePresets.json
@@ -2,10 +2,38 @@
   "version": 2,
   "configurePresets": [
     {
-      "name": "default",
+      "name": "debug",
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "release",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "relwithdebinfo",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "minsize",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       }
     }


### PR DESCRIPTION
|Related issue|
|---|
| closes #25188 |

## Description

This PR adds to the CMake preset the debug, release, relwithdebinfo and minsize compilations. 
On the other hand it fixes and improves the workflows, allowing to select the type of compilation for when you want to launch the workflow manually.