### PR TITLE
Add Comms API `POST /commands/results` endpoint

### DIFF
--- a/apis/comms_api/core/commands.py
+++ b/apis/comms_api/core/commands.py
@@ -3,6 +3,7 @@ from typing import List
 
 from uuid6 import UUID
 
+from comms_api.models.commands import Result
 from wazuh.core.indexer import get_indexer_client
 from wazuh.core.indexer.models.commands import Command, Status
 
@@ -34,3 +35,15 @@ async def pull_commands(uuid: UUID) -> List[Command]:
             await indexer_client.commands.update(commands)
 
             return commands
+
+
+async def post_results(results: List[Result]) -> None:
+    """Post commands results to the indexer.
+
+    Parameters
+    ----------
+    results : List[Result]
+        Commands results.
+    """
+    async with get_indexer_client() as indexer_client:
+        await indexer_client.commands.update(results)

--- a/apis/comms_api/models/commands.py
+++ b/apis/comms_api/models/commands.py
@@ -1,9 +1,23 @@
 from typing import List
+from typing_extensions import Self
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
-from wazuh.core.indexer.models.commands import Command
+from wazuh.core.indexer.models.commands import Command, Result, Status
 
 
 class Commands(BaseModel):
     commands: List[Command]
+
+
+class CommandsResults(BaseModel):
+    results: List[Result]
+
+    @model_validator(mode='after')
+    def check_status(self) -> Self:
+        """Check that the result status is not pending or sent."""
+        for result in self.results:
+            if result.status not in (Status.COMPLETED, Status.FAILED):
+                raise ValueError(f"invalid status, it must be '{Status.COMPLETED}' or '{Status.FAILED}'")
+
+        return self

--- a/apis/comms_api/models/test/test_commands.py
+++ b/apis/comms_api/models/test/test_commands.py
@@ -1,0 +1,18 @@
+import pytest
+
+from comms_api.models.commands import CommandsResults
+from wazuh.core.indexer.models.commands import Result, Status
+
+
+async def test_check_status():
+    """Verify that the `check_status` model validator works as expected."""
+    results = [Result(id='id', status=Status.COMPLETED)]
+    CommandsResults(results=results)
+
+
+async def test_check_status_ko():
+    """Verify that the `check_status` model validator raises an exception on an invalid status."""
+    results = [Result(id='id', status=Status.SENT)]
+    with pytest.raises(ValueError):
+        CommandsResults(results=results)
+

--- a/apis/comms_api/routers/commands.py
+++ b/apis/comms_api/routers/commands.py
@@ -1,9 +1,10 @@
 from typing import Annotated
 
-from fastapi import Depends, status
+from fastapi import Depends, Response, status
+
 from comms_api.authentication.authentication import decode_token, JWTBearer
-from comms_api.core.commands import pull_commands
-from comms_api.models.commands import Commands
+from comms_api.core.commands import pull_commands, post_results
+from comms_api.models.commands import Commands, CommandsResults
 from comms_api.routers.exceptions import HTTPError
 from comms_api.routers.utils import timeout
 from wazuh.core.exception import WazuhCommsAPIError, WazuhResourceNotFound
@@ -35,5 +36,30 @@ async def get_commands(token: Annotated[str, Depends(JWTBearer())]) -> Commands:
     except WazuhCommsAPIError as exc:
         raise HTTPError(message=exc.message, code=exc.code, status_code=status.HTTP_403_FORBIDDEN)
     except WazuhResourceNotFound as exc:
-        raise HTTPError(message=str(exc), status_code=status.HTTP_404_NOT_FOUND)
+        raise HTTPError(message=exc.message, code=exc.code, status_code=status.HTTP_404_NOT_FOUND)
 
+
+@timeout(30)
+async def post_commands_results(results: CommandsResults) -> Response:
+    """Post commands results endpoint handler.
+
+    Parameters
+    ----------
+    token : str
+        JWT token.
+
+    Raises
+    ------
+    HTTPError
+        If there is any system or validation error.
+
+    Returns
+    -------
+    Response
+        HTTP OK empty response.
+    """
+    try:
+        await post_results(results.results)
+        return Response(status_code=status.HTTP_200_OK)
+    except WazuhResourceNotFound as exc:
+        raise HTTPError(message=exc.message, code=exc.code, status_code=status.HTTP_404_NOT_FOUND)

--- a/apis/comms_api/routers/commands.py
+++ b/apis/comms_api/routers/commands.py
@@ -45,8 +45,8 @@ async def post_commands_results(results: CommandsResults) -> Response:
 
     Parameters
     ----------
-    token : str
-        JWT token.
+    results : CommandsResults
+        Commands results.
 
     Raises
     ------

--- a/apis/comms_api/routers/exceptions.py
+++ b/apis/comms_api/routers/exceptions.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 
 class HTTPError(HTTPException):
@@ -73,9 +74,30 @@ async def exception_handler(request: Request, exc: Exception):
     Returns
     -------
     JSONResponse
-        JSON response containing an error description and code.
+        JSON response containing an error message and code.
     """
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         content={'message': f'{str(exc)}', 'code': status.HTTP_500_INTERNAL_SERVER_ERROR},
+    )
+
+
+async def starlette_http_exception_handler(request: Request, exc: StarletteHTTPException):
+    """Starlette HTTP exception handler.
+    
+    Parameters
+    ----------
+    request : Request
+        Client request.
+    exc : StarletteHTTPException
+        Starlette exception.
+    
+    Returns
+    -------
+    JSONResponse
+        JSON response containing an error message and code.
+    """
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={'message': exc.detail, 'code': exc.status_code},
     )

--- a/apis/comms_api/routers/exceptions.py
+++ b/apis/comms_api/routers/exceptions.py
@@ -35,6 +35,7 @@ async def http_error_handler(request: Request, exc: HTTPError) -> JSONResponse:
         content={'message': exc.message, 'code': exc.code},
     )
 
+
 async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """API request validation errors handler.
     
@@ -56,4 +57,25 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     return JSONResponse(
         status_code=status.HTTP_400_BAD_REQUEST,
         content={'message': f'{key} {message}', 'code': status.HTTP_400_BAD_REQUEST},
+    )
+
+
+async def exception_handler(request: Request, exc: Exception):
+    """API global errors handler.
+    
+    Parameters
+    ----------
+    request : Request
+        Client request.
+    exc : Exception
+        Base exception raised.
+    
+    Returns
+    -------
+    JSONResponse
+        JSON response containing an error description and code.
+    """
+    return JSONResponse(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        content={'message': f'{str(exc)}', 'code': status.HTTP_500_INTERNAL_SERVER_ERROR},
     )

--- a/apis/comms_api/routers/router.py
+++ b/apis/comms_api/routers/router.py
@@ -3,13 +3,14 @@ from fastapi.responses import Response
 
 from comms_api.authentication.authentication import JWTBearer
 from comms_api.routers.authentication import authentication
-from comms_api.routers.commands import get_commands
+from comms_api.routers.commands import get_commands, post_commands_results
 from comms_api.routers.events import post_stateful_events
 from comms_api.routers.files import get_files
 
 router = APIRouter(prefix='/api/v1')
 router.add_api_route('/authentication', authentication, methods=['POST'])
 router.add_api_route('/commands', get_commands, methods=['GET'])
+router.add_api_route('/commands/results', post_commands_results, dependencies=[Depends(JWTBearer())], methods=['POST'])
 router.add_api_route('/events/stateful', post_stateful_events, dependencies=[Depends(JWTBearer())], methods=['POST'])
 router.add_api_route('/files', get_files, methods=['GET'], dependencies=[Depends(JWTBearer())])
 

--- a/apis/comms_api/routers/test/test_commands.py
+++ b/apis/comms_api/routers/test/test_commands.py
@@ -1,12 +1,14 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import status
+from pydantic import ValidationError
 
-from comms_api.models.commands import Commands
-from comms_api.routers.commands import get_commands
+from comms_api.models.commands import Commands, CommandsResults
+from comms_api.routers.commands import get_commands, post_commands_results
 from comms_api.routers.exceptions import HTTPError
-from wazuh.core.exception import WazuhCommsAPIError
-from wazuh.core.indexer.models.commands import Command, Status
+from wazuh.core.exception import WazuhCommsAPIError, WazuhResourceNotFound
+from wazuh.core.indexer.models.commands import Command, Result, Status
 
 COMMANDS = [Command(id='UB2jVpEBYSr9jxqDgXAD', status=Status.PENDING)]
 TOKEN = 'token'
@@ -27,10 +29,46 @@ async def test_get_commands(jwt_bearer_mock, decode_token_mock, pull_commands_mo
 
 @pytest.mark.asyncio
 @patch('comms_api.routers.commands.decode_token')
-async def test_get_commands_ko(decode_token_mock):
+@pytest.mark.parametrize('exception', [
+    WazuhCommsAPIError(2706),
+    WazuhResourceNotFound(2202),
+])
+async def test_get_commands_ko(decode_token_mock, exception):
     """Verify that the `get_commands` handler catches exceptions successfully."""
-    exception = WazuhCommsAPIError(2706)
-
     with patch('comms_api.routers.commands.pull_commands', MagicMock(side_effect=exception)):
         with pytest.raises(HTTPError, match=fr'{exception.code}: {exception.message}'):
             _ = await get_commands('')
+
+
+@pytest.mark.asyncio
+@patch('comms_api.routers.commands.post_results')
+async def test_post_commands_results(post_results_mock):
+    """Verify that the `post_commands_results` handler works as expected."""
+    results = [Result(id='id', status=Status.COMPLETED)]
+    body = CommandsResults(results=results)
+    response = await post_commands_results(body)
+
+    post_results_mock.assert_called_once_with(results)
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_post_commands_results_ko():
+    """Verify that the `post_commands_results` handler catches exceptions successfully."""
+    exception = WazuhResourceNotFound(2202)
+    results = [Result(id='id', status=Status.COMPLETED)]
+
+    with patch('comms_api.routers.commands.post_results', MagicMock(side_effect=exception)):
+        with pytest.raises(HTTPError) as exc:
+            _ = await post_commands_results(CommandsResults(results=results))
+
+    assert str(exc.value) == f'{exception.code}: {exception.message}'
+
+
+@pytest.mark.asyncio
+async def test_post_commands_results_body_ko():
+    """Verify that the `post_commands_results` request body validation works as expected."""
+    results = [Result(id='id', status=Status.SENT)]
+    with pytest.raises(ValidationError):
+        body = CommandsResults(results=results)
+        await post_commands_results(body)

--- a/apis/comms_api/routers/test/test_commands.py
+++ b/apis/comms_api/routers/test/test_commands.py
@@ -59,10 +59,8 @@ async def test_post_commands_results_ko():
     results = [Result(id='id', status=Status.COMPLETED)]
 
     with patch('comms_api.routers.commands.post_results', MagicMock(side_effect=exception)):
-        with pytest.raises(HTTPError) as exc:
+        with pytest.raises(HTTPError, match=fr'{exception.code}: {exception.message}'):
             _ = await post_commands_results(CommandsResults(results=results))
-
-    assert str(exc.value) == f'{exception.code}: {exception.message}'
 
 
 @pytest.mark.asyncio

--- a/apis/comms_api/routers/test/test_exceptions.py
+++ b/apis/comms_api/routers/test/test_exceptions.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import status
 from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from comms_api.routers.exceptions import HTTPError, http_error_handler, validation_exception_handler, exception_handler
+from comms_api.routers.exceptions import HTTPError, http_error_handler, validation_exception_handler, \
+    exception_handler, starlette_http_exception_handler
 
 
 @pytest.mark.asyncio
@@ -34,23 +36,42 @@ async def test_http_error_handler(message, code, status_code):
 ])
 async def test_validation_exception_handler(loc, msg, expected_msg):
     """Verify that the request validation exception handler works as expected."""
+    status_code = status.HTTP_400_BAD_REQUEST
     mock_req = MagicMock()
     mock_err = {'loc': loc, 'msg': msg}
     result = await validation_exception_handler(mock_req, RequestValidationError([mock_err]))
     body = json.loads(result.body)
 
-    assert result.status_code == status.HTTP_400_BAD_REQUEST
+    assert result.status_code == status_code
     assert body['message'] == expected_msg
-    assert body['code'] == status.HTTP_400_BAD_REQUEST
+    assert body['code'] == status_code
 
 
 @pytest.mark.asyncio
 async def test_exception_handler():
+    """Check that a base exception is handled corectly."""
     mock_req = MagicMock()
-    exc_message = 'message'
+    exc_message = 'error'
+    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     exc = Exception(exc_message)
     result = await exception_handler(mock_req, exc)
     body = json.loads(result.body)
 
-    assert result.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert result.status_code == status_code
     assert body['message'] == exc_message
+    assert body['code'] == status_code
+
+
+@pytest.mark.asyncio
+async def test_http_exception_handler():
+    """Check that a starlette HTTP exception is handled corectly."""
+    mock_req = MagicMock()
+    exc_message = 'Not Found'
+    status_code = status.HTTP_404_NOT_FOUND
+    exc = StarletteHTTPException(detail=exc_message, status_code=status_code)
+    result = await starlette_http_exception_handler(mock_req, exc)
+    body = json.loads(result.body)
+
+    assert result.status_code == status_code
+    assert body['message'] == exc_message
+    assert body['code'] == status_code

--- a/apis/comms_api/routers/test/test_exceptions.py
+++ b/apis/comms_api/routers/test/test_exceptions.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import status
 from fastapi.exceptions import RequestValidationError
 
-from comms_api.routers.exceptions import HTTPError, http_error_handler, validation_exception_handler
+from comms_api.routers.exceptions import HTTPError, http_error_handler, validation_exception_handler, exception_handler
 
 
 @pytest.mark.asyncio
@@ -42,3 +42,15 @@ async def test_validation_exception_handler(loc, msg, expected_msg):
     assert result.status_code == status.HTTP_400_BAD_REQUEST
     assert body['message'] == expected_msg
     assert body['code'] == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_exception_handler():
+    mock_req = MagicMock()
+    exc_message = 'message'
+    exc = Exception(exc_message)
+    result = await exception_handler(mock_req, exc)
+    body = json.loads(result.body)
+
+    assert result.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert body['message'] == exc_message

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -12,13 +12,14 @@ from brotli_asgi import BrotliMiddleware
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from gunicorn.app.base import BaseApplication
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from api.alogging import set_logging
 from api.configuration import generate_private_key, generate_self_signed_certificate
 from api.constants import COMMS_API_LOG_PATH
 from api.middlewares import SecureHeadersMiddleware
 from comms_api.routers.exceptions import HTTPError, http_error_handler, validation_exception_handler, \
-    exception_handler
+    exception_handler, starlette_http_exception_handler
 from comms_api.routers.router import router
 from comms_api.middlewares.logging import LoggingMiddleware
 from wazuh.core import common, pyDaemonModule, utils
@@ -36,6 +37,7 @@ def create_app() -> FastAPI:
     app.add_exception_handler(HTTPError, http_error_handler)
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
     app.add_exception_handler(Exception, exception_handler)
+    app.add_exception_handler(StarletteHTTPException, starlette_http_exception_handler)
     app.include_router(router)
     return app
 

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -17,7 +17,8 @@ from api.alogging import set_logging
 from api.configuration import generate_private_key, generate_self_signed_certificate
 from api.constants import COMMS_API_LOG_PATH
 from api.middlewares import SecureHeadersMiddleware
-from comms_api.routers.exceptions import HTTPError, http_error_handler, validation_exception_handler
+from comms_api.routers.exceptions import HTTPError, http_error_handler, validation_exception_handler, \
+    exception_handler
 from comms_api.routers.router import router
 from comms_api.middlewares.logging import LoggingMiddleware
 from wazuh.core import common, pyDaemonModule, utils
@@ -34,6 +35,7 @@ def create_app() -> FastAPI:
     app.add_middleware(LoggingMiddleware)
     app.add_exception_handler(HTTPError, http_error_handler)
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, exception_handler)
     app.include_router(router)
     return app
 

--- a/framework/wazuh/core/indexer/base.py
+++ b/framework/wazuh/core/indexer/base.py
@@ -27,6 +27,7 @@ class IndexerKey(str, Enum):
     BODY = 'body'
     TERMS = 'terms'
     CONFLICTS = 'conflicts'
+    ITEMS = 'items'
 
 
 class BaseIndex:

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -7,7 +7,7 @@ from .base import BaseIndex, IndexerKey, remove_empty_values
 from wazuh.core.exception import WazuhResourceNotFound
 from wazuh.core.indexer.models.commands import Command, Result, Status
 
-ID_KEY = 'id'
+DOC_ID_KEY = 'id'
 AGENT_ID_KEY = 'agent.id'
 STATUS_KEY = 'status'
 
@@ -71,8 +71,8 @@ class CommandsIndex(BaseIndex):
         for item in items:
             actions.append({IndexerKey.UPDATE: {IndexerKey._INDEX: self.INDEX, IndexerKey._ID: item.id}})
             item_dict = asdict(item, dict_factory=remove_empty_values)
-            # The ID field shouldn't be part of the document value
-            item_dict.pop(ID_KEY, None)
+            # The document ID shouldn't be part of the value
+            item_dict.pop(DOC_ID_KEY, None)
             actions.append({IndexerKey.DOC: item_dict})
 
         # TODO(25121): Create an internal library to build opensearch requests and parse responses

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -1,13 +1,13 @@
 from dataclasses import asdict
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from opensearchpy import NotFoundError
 from uuid6 import UUID
 
 from .base import BaseIndex, IndexerKey, remove_empty_values
-from wazuh.core.indexer.models.commands import Command, Status
 from wazuh.core.exception import WazuhResourceNotFound
+from wazuh.core.indexer.models.commands import Command, Result, Status
 
+ID_KEY = 'id'
 AGENT_ID_KEY = 'agent.id'
 STATUS_KEY = 'status'
 
@@ -54,13 +54,13 @@ class CommandsIndex(BaseIndex):
 
         return commands
 
-    async def update(self, commands: List[Command]) -> None:
+    async def update(self, items: List[Union[Command, Result]]) -> None:
         """Update commands.
         
         Parameters
         ----------
-        commands : List[Command]
-            List of commands to update.
+        items : List[Union[Command, Result]]
+            List of commands or results to update.
 
         Raises
         ------
@@ -68,12 +68,15 @@ class CommandsIndex(BaseIndex):
             If no document exists with the id provided.
         """
         actions = []
-        for command in commands:
-            actions.append({IndexerKey.UPDATE: {IndexerKey._INDEX: self.INDEX, IndexerKey._ID: command.id}})
-            command_dict = asdict(command, dict_factory=remove_empty_values)
-            actions.append({IndexerKey.DOC: command_dict})
+        for item in items:
+            actions.append({IndexerKey.UPDATE: {IndexerKey._INDEX: self.INDEX, IndexerKey._ID: item.id}})
+            item_dict = asdict(item, dict_factory=remove_empty_values)
+            # The ID field shouldn't be part of the document value
+            item_dict.pop(ID_KEY, None)
+            actions.append({IndexerKey.DOC: item_dict})
 
-        try:
-            await self._client.bulk(actions, self.INDEX)
-        except NotFoundError:
-            raise WazuhResourceNotFound(2202)
+        # TODO(25121): Create an internal library to build opensearch requests and parse responses
+        response = await self._client.bulk(actions, self.INDEX)
+        for item in response[IndexerKey.ITEMS]:
+            if item[IndexerKey.UPDATE][STATUS_KEY] == 404:
+                raise WazuhResourceNotFound(2202)

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -20,13 +20,33 @@ class Status(str, Enum):
 
 
 @dataclass
-class Command:
-    """Command data model."""
-    id: str = None # Document ID
-    args: List[str] = None
-    agent: CommandAgent = None
+class Document:
+    id: str = None
+
+
+@dataclass
+class Result(Document):
+    """Command result data model."""
+    # Cannot extend enumerations, custom validators are used to prevent agents 
+    # from uploading a result with a status other than completed or failed.
+    # https://docs.python.org/3/howto/enum.html#restricted-enum-subclassing
     status: Status = None
     info: str = None
+
+
+@dataclass
+class Agent:
+    """Agent data model in the context of commands."""
+    # TODO(25121): this should be a UUID, but pydantic supports up to v5 only.
+    # Related to https://github.com/python/cpython/issues/89083.
+    id: str
+
+
+@dataclass
+class Command(Result):
+    """Command data model."""
+    args: List[str] = None
+    agent: CommandAgent = None
 
     @classmethod
     def from_dict(cls, id: str, data: dict):

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -35,14 +35,6 @@ class Result(Document):
 
 
 @dataclass
-class Agent:
-    """Agent data model in the context of commands."""
-    # TODO(25121): this should be a UUID, but pydantic supports up to v5 only.
-    # Related to https://github.com/python/cpython/issues/89083.
-    id: str
-
-
-@dataclass
 class Command(Result):
     """Command data model."""
     args: List[str] = None

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -21,6 +21,7 @@ class Status(str, Enum):
 
 @dataclass
 class Document:
+    """OpenSearch document model."""
     id: str = None
 
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/24692 |

## Description

Implements the Communications API `POST /commands/results` endpoint.

## Tests

<details><summary>Indexing command</summary>

```console
root@wazuh-master:/# curl -X POST -H "Content-Type: application/json" -ku $INDEXER_USER:$INDEXER_PASSWORD http://wazuh-indexer:9200/commands/_doc -d '{"args": ["string"], "agent": {"id": "01912d07-b9b4-7528-bdad-15da902d651c"}, "status": "pending", "info": "string"}'
{"_index":"commands","_id":"EAg6a5EB2lsaOsbbzddv","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1}
```

</details>

<details><summary>Uploading its result</summary>

```console
root@wazuh-master:/# curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" -k https://0.0.0.0:27000/api/v1/commands/results -d '{"results": [{"id": "EAg6a5EB2lsaOsbbzddv", "status": "completed", "info": "Success"}]}'
...
< HTTP/1.1 200 OK
...
root@wazuh-master:/#
```

</details>

<details><summary>Verifying the command status and information was updated</summary>

```console
root@wazuh-master:/# curl -H "Content-Type: application/json" -ku $INDEXER_USER:$INDEXER_PASSWORD http://wazuh-indexer:9200/commands/_search -d '{"query": {"match": {"status": "completed"}}}'
{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":0.2876821,"hits":[{"_index":"commands","_id":"EAg6a5EB2lsaOsbbzddv","_score":0.2876821,"_source":{"args":["string"],"agent":{"id":"01912d07-b9b4-7528-bdad-15da902d651c"},"status":"completed","info":"Success"}}]}}
```

</details>

<details><summary>Try to upload an invalid result</summary>

```console
root@wazuh-master:/# curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" -k https://0.0.0.0:27000/api/v1/commands/results -d '{"results": [{"id": "EAg6a5EB2lsaOsbbzddv", "status": "pending", "info": "Success"}]}'
{"message":"body value error, invalid status, it must be 'completed' or 'failed'","code":400}
```

</details>

<details><summary>Trying to update a command that does not exist</summary>

```console
root@wazuh-master:/# curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" -k https://0.0.0.0:27000/api/v1/commands/results -d '{"results": [{"id": "doc", "stat
us": "failed", "info": "Error"}]}'
{"message":"Command does not exist","code":2202}
```

</details>

<details><summary>API logs</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-comms-apid -f
2024/08/19 14:58:28 INFO: Starting API in foreground
2024/08/19 14:58:36 INFO: GET http://wazuh-indexer:9200/ [status:200 request:0.006s]
2024/08/19 14:58:36 INFO: GET http://wazuh-indexer:9200/agents/_doc/01912d07-b9b4-7528-bdad-15da902d651c [status:200 request:0.013s]
2024/08/19 14:58:36 INFO: POST http://wazuh-indexer:9200/agents/_update/01912d07-b9b4-7528-bdad-15da902d651c [status:200 request:0.065s]
2024/08/19 14:58:36 WARNING: Closing the indexer client session.
2024/08/19 14:58:36 INFO: "POST /api/v1/authentication" with parameters {} and body {"uuid": "01912d07-b9b4-7528-bdad-15da902d651c", "key": "***"} done in 0.123s: 200
2024/08/19 15:00:56 INFO: GET http://wazuh-indexer:9200/ [status:200 request:0.004s]
2024/08/19 15:00:57 INFO: POST http://wazuh-indexer:9200/commands/_bulk [status:200 request:0.045s]
2024/08/19 15:00:57 WARNING: Closing the indexer client session.
2024/08/19 15:00:57 INFO: (01912d07-b9b4-7528-bdad-15da902d651c) "POST /api/v1/commands/results" with parameters {} and body {"results": [{"id": "EAg6a5EB2lsaOsbbzddv", "status": "completed", "info": "Success"}]} done in 0.055s: 200
2024/08/19 15:03:07 INFO: (01912d07-b9b4-7528-bdad-15da902d651c) "POST /api/v1/commands/results" with parameters {} and body {"results": [{"id": "EAg6a5EB2lsaOsbbzddv", "status": "pending", "info": "Success"}]} done in 0.001s: 400
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest apis/comms_api/ --disable-warnings
======================================== test session starts ========================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis/comms_api
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 51 items                                                                                  

apis/comms_api/authentication/test/test_authentication.py ......                              [ 11%]
apis/comms_api/core/test/test_commands.py ..                                                  [ 15%]
apis/comms_api/core/test/test_events.py .                                                     [ 17%]
apis/comms_api/core/test/test_files.py ...                                                    [ 23%]
apis/comms_api/middlewares/test/test_logging.py ..                                            [ 27%]
apis/comms_api/models/test/test_commands.py ..                                                [ 31%]
apis/comms_api/models/test/test_error.py ....                                                 [ 39%]
apis/comms_api/routers/test/test_authentication.py ....                                       [ 47%]
apis/comms_api/routers/test/test_commands.py ......                                           [ 58%]
apis/comms_api/routers/test/test_events.py ..                                                 [ 62%]
apis/comms_api/routers/test/test_exceptions.py ......                                         [ 74%]
apis/comms_api/routers/test/test_files.py ........                                            [ 90%]
apis/comms_api/routers/test/test_utils.py .....                                               [100%]

================================== 51 passed, 10 warnings in 1.52s ==================================
```

</details>
