### PR TITLE
Add Comms API `POST /events/stateless` endpoint

### DIFF
--- a/apis/comms_api/core/events.py
+++ b/apis/comms_api/core/events.py
@@ -1,14 +1,16 @@
+from comms_api.models.events import StatelessEvents
+from wazuh.core.engine import get_engine_client
 from wazuh.core.indexer import get_indexer_client
-from wazuh.core.indexer.models.events import Events
+from wazuh.core.indexer.models.events import StatefulEvents
 
 
-async def create_stateful_events(events: Events) -> dict:
+async def create_stateful_events(events: StatefulEvents) -> dict:
     """Post new events to the indexer.
     
     Parameters
     ----------
-    events : Events
-        List of events.
+    events : StatefulEvents
+        Stateful events list.
     
     Returns
     -------
@@ -17,3 +19,15 @@ async def create_stateful_events(events: Events) -> dict:
     """
     async with get_indexer_client() as indexer_client:
         return await indexer_client.events.create(events)
+
+
+async def send_stateless_events(events: StatelessEvents) -> None:
+    """Send new events to the engine.
+    
+    Parameters
+    ----------
+    events : StatelessEvents
+        Stateless events list.
+    """
+    async with get_engine_client() as engine_client:
+        await engine_client.events.send(events.events)

--- a/apis/comms_api/core/events.py
+++ b/apis/comms_api/core/events.py
@@ -1,7 +1,6 @@
-from comms_api.models.events import StatelessEvents
+from comms_api.models.events import StatefulEvents, StatelessEvents
 from wazuh.core.engine import get_engine_client
 from wazuh.core.indexer import get_indexer_client
-from wazuh.core.indexer.models.events import StatefulEvents
 
 
 async def create_stateful_events(events: StatefulEvents) -> dict:

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -3,11 +3,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from comms_api.core.events import create_stateful_events, send_stateless_events
-from comms_api.models.events import StatelessEvents
-from wazuh.core.engine import Engine
+from comms_api.models.events import StatefulEvents, StatelessEvents
 from wazuh.core.engine.models.events import StatelessEvent
 from wazuh.core.indexer import Indexer
-from wazuh.core.indexer.models.events import StatefulEvents, SCAEvent
+from wazuh.core.indexer.models.events import SCAEvent
 
 INDEXER = Indexer(host='host', user='wazuh', password='wazuh')
 

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -1,10 +1,13 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from comms_api.core.events import create_stateful_events
+from comms_api.core.events import create_stateful_events, send_stateless_events
+from comms_api.models.events import StatelessEvents
+from wazuh.core.engine import Engine
+from wazuh.core.engine.models.events import StatelessEvent
 from wazuh.core.indexer import Indexer
-from wazuh.core.indexer.models.events import Events, SCAEvent
+from wazuh.core.indexer.models.events import StatefulEvents, SCAEvent
 
 INDEXER = Indexer(host='host', user='wazuh', password='wazuh')
 
@@ -13,8 +16,17 @@ INDEXER = Indexer(host='host', user='wazuh', password='wazuh')
 @patch('wazuh.core.indexer.create_indexer', return_value=INDEXER)
 @patch('wazuh.core.indexer.events.EventsIndex.create')
 async def test_create_stateful_events(events_create_mock, create_indexer_mock):
-    events = Events(events=[SCAEvent()])
+    events = StatefulEvents(events=[SCAEvent()])
     await create_stateful_events(events)
 
     create_indexer_mock.assert_called_once()
     events_create_mock.assert_called_once_with(events)
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.engine.events.EventsModule.send', new_callable=AsyncMock)
+async def test_send_stateless_events(events_send_mock):
+    events = StatelessEvents(events=[StatelessEvent(data='data')])
+    await send_stateless_events(events)
+
+    events_send_mock.assert_called_once_with(events.events)

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -16,6 +16,7 @@ INDEXER = Indexer(host='host', user='wazuh', password='wazuh')
 @patch('wazuh.core.indexer.create_indexer', return_value=INDEXER)
 @patch('wazuh.core.indexer.events.EventsIndex.create')
 async def test_create_stateful_events(events_create_mock, create_indexer_mock):
+    """Check that the `create_stateful_events` function works as expected."""
     events = StatefulEvents(events=[SCAEvent()])
     await create_stateful_events(events)
 
@@ -26,6 +27,7 @@ async def test_create_stateful_events(events_create_mock, create_indexer_mock):
 @pytest.mark.asyncio
 @patch('wazuh.core.engine.events.EventsModule.send', new_callable=AsyncMock)
 async def test_send_stateless_events(events_send_mock):
+    """Check that the `send_stateless_events` function works as expected."""
     events = StatelessEvents(events=[StatelessEvent(data='data')])
     await send_stateless_events(events)
 

--- a/apis/comms_api/models/events.py
+++ b/apis/comms_api/models/events.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from pydantic import BaseModel
+
+from wazuh.core.engine.models.events import StatelessEvent
+
+
+class StatelessEvents(BaseModel):
+    events: List[StatelessEvent]

--- a/apis/comms_api/models/events.py
+++ b/apis/comms_api/models/events.py
@@ -3,6 +3,11 @@ from typing import List
 from pydantic import BaseModel
 
 from wazuh.core.engine.models.events import StatelessEvent
+from wazuh.core.indexer.models.events import StatefulEvent
+
+
+class StatefulEvents(BaseModel):
+    events: List[StatefulEvent]
 
 
 class StatelessEvents(BaseModel):

--- a/apis/comms_api/routers/commands.py
+++ b/apis/comms_api/routers/commands.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import Depends, Response, status
+from fastapi import APIRouter, Depends, Response, status
 
 from comms_api.authentication.authentication import decode_token, JWTBearer
 from comms_api.core.commands import pull_commands, post_results
@@ -63,3 +63,8 @@ async def post_commands_results(results: CommandsResults) -> Response:
         return Response(status_code=status.HTTP_200_OK)
     except WazuhResourceNotFound as exc:
         raise HTTPError(message=exc.message, code=exc.code, status_code=status.HTTP_404_NOT_FOUND)
+
+
+commands_router = APIRouter(prefix='/commands')
+commands_router.add_api_route('', get_commands, methods=['GET'])
+commands_router.add_api_route('/results', post_commands_results, dependencies=[Depends(JWTBearer())], methods=['POST'])

--- a/apis/comms_api/routers/events.py
+++ b/apis/comms_api/routers/events.py
@@ -3,11 +3,10 @@ from fastapi.responses import JSONResponse
 
 from comms_api.authentication.authentication import JWTBearer
 from comms_api.core.events import create_stateful_events, send_stateless_events
-from comms_api.models.events import StatelessEvents
+from comms_api.models.events import StatefulEvents, StatelessEvents
 from comms_api.routers.exceptions import HTTPError
 from comms_api.routers.utils import timeout
 from wazuh.core.exception import WazuhEngineError, WazuhError
-from wazuh.core.indexer.models.events import StatefulEvents
 
 
 @timeout(30)

--- a/apis/comms_api/routers/events.py
+++ b/apis/comms_api/routers/events.py
@@ -1,21 +1,22 @@
-from fastapi import status
+from fastapi import status, Response
 from fastapi.responses import JSONResponse
 
-from comms_api.core.events import create_stateful_events
+from comms_api.core.events import create_stateful_events, send_stateless_events
+from comms_api.models.events import StatelessEvents
 from comms_api.routers.exceptions import HTTPError
 from comms_api.routers.utils import timeout
-from wazuh.core.exception import WazuhError
-from wazuh.core.indexer.models.events import Events
+from wazuh.core.exception import WazuhEngineError, WazuhError
+from wazuh.core.indexer.models.events import StatefulEvents
 
 
 @timeout(30)
-async def post_stateful_events(events: Events) -> JSONResponse:
+async def post_stateful_events(events: StatefulEvents) -> JSONResponse:
     """Post stateful events handler.
 
     Parameters
     ----------
-    events : Events
-        List of events.
+    events : StatefulEvents
+        Stateful events list.
 
     Raises
     ------
@@ -32,3 +33,29 @@ async def post_stateful_events(events: Events) -> JSONResponse:
         return JSONResponse(response)
     except WazuhError as exc:
         raise HTTPError(message=exc.message, status_code=status.HTTP_400_BAD_REQUEST)
+
+
+@timeout(10)
+async def post_stateless_events(events: StatelessEvents) -> Response:
+    """Post stateless events handler.
+
+    Parameters
+    ----------
+    events : StatelessEvents
+        Stateless events list.
+
+    Raises
+    ------
+    HTTPError
+        If there is any error when communicating with the engine.
+
+    Returns
+    -------
+    Response
+        HTTP OK empty response.
+    """
+    try:
+        await send_stateless_events(events)
+        return Response(status_code=status.HTTP_200_OK)
+    except WazuhEngineError as exc:
+        raise HTTPError(message=exc.message, code=exc.code, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/apis/comms_api/routers/events.py
+++ b/apis/comms_api/routers/events.py
@@ -1,6 +1,7 @@
-from fastapi import status, Response
+from fastapi import APIRouter, Depends, status, Response
 from fastapi.responses import JSONResponse
 
+from comms_api.authentication.authentication import JWTBearer
 from comms_api.core.events import create_stateful_events, send_stateless_events
 from comms_api.models.events import StatelessEvents
 from comms_api.routers.exceptions import HTTPError
@@ -59,3 +60,8 @@ async def post_stateless_events(events: StatelessEvents) -> Response:
         return Response(status_code=status.HTTP_200_OK)
     except WazuhEngineError as exc:
         raise HTTPError(message=exc.message, code=exc.code, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+events_router = APIRouter(prefix='/events')
+events_router.add_api_route('/stateful', post_stateful_events, dependencies=[Depends(JWTBearer())], methods=['POST'])
+events_router.add_api_route('/stateless', post_stateless_events, dependencies=[Depends(JWTBearer())], methods=['POST'])

--- a/apis/comms_api/routers/router.py
+++ b/apis/comms_api/routers/router.py
@@ -4,7 +4,7 @@ from fastapi.responses import Response
 from comms_api.authentication.authentication import JWTBearer
 from comms_api.routers.authentication import authentication
 from comms_api.routers.commands import get_commands, post_commands_results
-from comms_api.routers.events import post_stateful_events
+from comms_api.routers.events import post_stateful_events, post_stateless_events
 from comms_api.routers.files import get_files
 
 router = APIRouter(prefix='/api/v1')
@@ -12,6 +12,7 @@ router.add_api_route('/authentication', authentication, methods=['POST'])
 router.add_api_route('/commands', get_commands, methods=['GET'])
 router.add_api_route('/commands/results', post_commands_results, dependencies=[Depends(JWTBearer())], methods=['POST'])
 router.add_api_route('/events/stateful', post_stateful_events, dependencies=[Depends(JWTBearer())], methods=['POST'])
+router.add_api_route('/events/stateless', post_stateless_events, dependencies=[Depends(JWTBearer())], methods=['POST'])
 router.add_api_route('/files', get_files, methods=['GET'], dependencies=[Depends(JWTBearer())])
 
 

--- a/apis/comms_api/routers/router.py
+++ b/apis/comms_api/routers/router.py
@@ -4,15 +4,14 @@ from fastapi.responses import Response
 from comms_api.authentication.authentication import JWTBearer
 from comms_api.routers.authentication import authentication
 from comms_api.routers.commands import get_commands, post_commands_results
-from comms_api.routers.events import post_stateful_events, post_stateless_events
+from comms_api.routers.events import events_router
 from comms_api.routers.files import get_files
 
 router = APIRouter(prefix='/api/v1')
 router.add_api_route('/authentication', authentication, methods=['POST'])
 router.add_api_route('/commands', get_commands, methods=['GET'])
 router.add_api_route('/commands/results', post_commands_results, dependencies=[Depends(JWTBearer())], methods=['POST'])
-router.add_api_route('/events/stateful', post_stateful_events, dependencies=[Depends(JWTBearer())], methods=['POST'])
-router.add_api_route('/events/stateless', post_stateless_events, dependencies=[Depends(JWTBearer())], methods=['POST'])
+router.include_router(events_router)
 router.add_api_route('/files', get_files, methods=['GET'], dependencies=[Depends(JWTBearer())])
 
 

--- a/apis/comms_api/routers/router.py
+++ b/apis/comms_api/routers/router.py
@@ -3,14 +3,13 @@ from fastapi.responses import Response
 
 from comms_api.authentication.authentication import JWTBearer
 from comms_api.routers.authentication import authentication
-from comms_api.routers.commands import get_commands, post_commands_results
+from comms_api.routers.commands import commands_router
 from comms_api.routers.events import events_router
 from comms_api.routers.files import get_files
 
 router = APIRouter(prefix='/api/v1')
 router.add_api_route('/authentication', authentication, methods=['POST'])
-router.add_api_route('/commands', get_commands, methods=['GET'])
-router.add_api_route('/commands/results', post_commands_results, dependencies=[Depends(JWTBearer())], methods=['POST'])
+router.include_router(commands_router)
 router.include_router(events_router)
 router.add_api_route('/files', get_files, methods=['GET'], dependencies=[Depends(JWTBearer())])
 

--- a/apis/comms_api/routers/test/test_events.py
+++ b/apis/comms_api/routers/test/test_events.py
@@ -48,7 +48,5 @@ async def test_post_stateless_events_ko():
     exception = WazuhEngineError(2802)
 
     with patch('comms_api.routers.events.send_stateless_events', MagicMock(side_effect=exception)):
-        with pytest.raises(HTTPError) as exc:
+        with pytest.raises(HTTPError, match=fr'{exception.code}: {exception.message}'):
             _ = await post_stateless_events('')
-
-    assert str(exc.value) == f'{exception.code}: {exception.message}'

--- a/apis/comms_api/routers/test/test_events.py
+++ b/apis/comms_api/routers/test/test_events.py
@@ -3,16 +3,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import status
 
-from comms_api.routers.events import post_stateful_events
+from comms_api.routers.events import post_stateful_events, post_stateless_events
 from comms_api.routers.exceptions import HTTPError
-from wazuh.core.exception import WazuhError
+from wazuh.core.exception import WazuhEngineError, WazuhError
 
 
 @pytest.mark.asyncio
 @patch('comms_api.routers.events.create_stateful_events', return_value={'foo': 'bar'})
 async def test_post_stateful_events(post_stateful_events_mock):
     """Verify that the `post_stateful_events` handler works as expected."""
-    events = ['test']
+    events = []
     response = await post_stateful_events(events)
 
     post_stateful_events_mock.assert_called_once_with(events)
@@ -29,3 +29,26 @@ async def test_post_stateful_events_ko():
     with patch('comms_api.routers.events.create_stateful_events', MagicMock(side_effect=exception)):
         with pytest.raises(HTTPError, match=fr'{code}: {exception.message}'):
             _ = await post_stateful_events('')
+
+
+@pytest.mark.asyncio
+@patch('comms_api.routers.events.send_stateless_events')
+async def test_post_stateless_events(send_stateless_events_mock):
+    """Verify that the `post_stateless_events` handler works as expected."""
+    events = []
+    response = await post_stateless_events(events)
+
+    send_stateless_events_mock.assert_called_once_with(events)
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_post_stateless_events_ko():
+    """Verify that the `post_stateless_events` handler catches exceptions successfully."""
+    exception = WazuhEngineError(2802)
+
+    with patch('comms_api.routers.events.send_stateless_events', MagicMock(side_effect=exception)):
+        with pytest.raises(HTTPError) as exc:
+            _ = await post_stateless_events('')
+
+    assert str(exc.value) == f'{exception.code}: {exception.message}'

--- a/framework/wazuh/core/engine/__init__.py
+++ b/framework/wazuh/core/engine/__init__.py
@@ -3,6 +3,8 @@ from logging import getLogger
 from typing import AsyncIterator
 
 from httpx import AsyncClient, AsyncHTTPTransport, ConnectError, Timeout, TimeoutException, UnsupportedProtocol
+
+from wazuh.core.engine.events import EventsModule
 from wazuh.core.exception import WazuhEngineError
 
 logger = getLogger('wazuh')
@@ -26,6 +28,7 @@ class Engine:
         self._client = AsyncClient(transport=transport, timeout=Timeout(timeout))
 
         # Register Engine modules here
+        self.events = EventsModule(client=self._client)
 
     async def close(self) -> None:
         """Close the Engine client."""

--- a/framework/wazuh/core/engine/events.py
+++ b/framework/wazuh/core/engine/events.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from wazuh.core.engine.base import BaseModule
+from wazuh.core.engine.models.events import StatelessEvent
+
+
+class EventsModule(BaseModule):
+    """Events module to send stateless events to the Engine."""
+
+    MODULE = 'events'
+
+    async def send(self, events: List[StatelessEvent]) -> None:
+        """Send events to the engine.
+        
+        Parameters
+        ----------
+        events : List[StatelessEvent]
+            Events list.
+        """
+        # TODO(25121): Send events to the engine once the API endpoint is available.

--- a/framework/wazuh/core/engine/models/events.py
+++ b/framework/wazuh/core/engine/models/events.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class StatelessEvent:
+    """Stateless event data model."""
+    # TODO(25121): Update fields once they're defined.
+    data: str

--- a/framework/wazuh/core/engine/tests/test_events.py
+++ b/framework/wazuh/core/engine/tests/test_events.py
@@ -18,6 +18,6 @@ class TestEventsModule:
         return self.module_class(client=client_mock)
 
     async def test_send(self, module_instance: EventsModule):
-        """Check the correct function of `send` method."""
+        """Check that the EventsModule `send` method works as expected."""
         events = [StatelessEvent(data='data')]
         await module_instance.send(events)

--- a/framework/wazuh/core/engine/tests/test_events.py
+++ b/framework/wazuh/core/engine/tests/test_events.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+import pytest
+
+from wazuh.core.engine.events import EventsModule
+from wazuh.core.engine.models.events import StatelessEvent
+
+
+class TestEventsModule:
+    module_class = EventsModule
+
+    @pytest.fixture
+    def client_mock(self) -> mock.AsyncMock:
+        return mock.AsyncMock()
+
+    @pytest.fixture
+    def module_instance(self, client_mock) -> EventsModule:
+        return self.module_class(client=client_mock)
+
+    async def test_send(self, module_instance: EventsModule):
+        """Check the correct function of `send` method."""
+        events = [StatelessEvent(data='data')]
+        await module_instance.send(events)

--- a/framework/wazuh/core/indexer/events.py
+++ b/framework/wazuh/core/indexer/events.py
@@ -1,13 +1,14 @@
 from dataclasses import asdict
+from typing import List
 
 from .base import BaseIndex
-from wazuh.core.indexer.models.events import StatefulEvents
+from wazuh.core.indexer.models.events import StatefulEvent
 
 
 class EventsIndex(BaseIndex):
     """Set of methods to interact with the stateful events indices."""
 
-    async def create(self, events: StatefulEvents) -> dict:
+    async def create(self, events: List[StatefulEvent]) -> dict:
         """Post new events to the indexer.
 
         Parameters

--- a/framework/wazuh/core/indexer/events.py
+++ b/framework/wazuh/core/indexer/events.py
@@ -1,13 +1,13 @@
 from dataclasses import asdict
 
 from .base import BaseIndex
-from wazuh.core.indexer.models.events import Events
+from wazuh.core.indexer.models.events import StatefulEvents
 
 
 class EventsIndex(BaseIndex):
     """Set of methods to interact with the stateful events indices."""
 
-    async def create(self, events: Events) -> dict:
+    async def create(self, events: StatefulEvents) -> dict:
         """Post new events to the indexer.
 
         Parameters

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -207,6 +207,5 @@ class VulnerabilityEvent(BaseModel):
         return VULNERABILITY_INDEX
 
 
-class StatefulEvents(BaseModel):
-    """Object holding a list of stateful events of any type."""
-    events: List[Union[FIMEvent, InventoryEvent, SCAEvent, VulnerabilityEvent]]
+# Stateful event type
+StatefulEvent = Union[FIMEvent, InventoryEvent, SCAEvent, VulnerabilityEvent]

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -207,6 +207,6 @@ class VulnerabilityEvent(BaseModel):
         return VULNERABILITY_INDEX
 
 
-class Events(BaseModel):
-    """Object holding a list of events of any type."""
+class StatefulEvents(BaseModel):
+    """Object holding a list of stateful events of any type."""
     events: List[Union[FIMEvent, InventoryEvent, SCAEvent, VulnerabilityEvent]]


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/24619 |

## Description

Implements the Communications API `POST /events/stateless` endpoint.

## Tests

<details><summary>Send stateless event</summary>

```console
root@wazuh-master:/# curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" -kv https://0.0.0.0:27000/api/v1/events/stateless -d '{"events": [{"data": "data"}]}
...
> POST /api/v1/events/stateless HTTP/1.1
> Host: 0.0.0.0:27000
> User-Agent: curl/7.81.0
> Accept: */*
> Authorization: Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTcyNDA4OTEwNywiZXhwIjoxNzI0MDkwMDA3LCJ1dWlkIjoiMDE5MTJkMDctYjliNC03NTI4LWJkYWQtMTVkYTkwMmQ2NTFjIn0.Gwn6BpETPLB6QjURlVs6T4L3nZAZKyLG7VXMCPrzEvyewGQ-OhIyjLFLrBQuEP6KEZfEn59_KrsB2WC4nRyODg
> Content-type: application/json
> Content-Length: 30
> 
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* TLSv1.2 (IN), TLS header, Supplemental data (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< date: Mon, 19 Aug 2024 17:39:05 GMT
< server: uvicorn
< content-length: 0
< server: Wazuh
< strict-transport-security: max-age=63072000; includeSubdomains
< x-frame-options: deny
< x-xss-protection: 0
< x-content-type-options: nosniff
< content-security-policy: none
< referrer-policy: no-referrer, strict-origin-when-cross-origin
< cache-control: no-store
< 
* Connection #0 to host 0.0.0.0 left intact
```

</details>


<details><summary>Comms API unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest apis/comms_api --disable-warnings
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis/comms_api
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 54 items                                                                                                                                                                          

apis/comms_api/authentication/test/test_authentication.py ......                                                                                                                      [ 11%]
apis/comms_api/core/test/test_commands.py ..                                                                                                                                          [ 14%]
apis/comms_api/core/test/test_events.py ..                                                                                                                                            [ 18%]
apis/comms_api/core/test/test_files.py ...                                                                                                                                            [ 24%]
apis/comms_api/middlewares/test/test_logging.py ..                                                                                                                                    [ 27%]
apis/comms_api/models/test/test_commands.py ..                                                                                                                                        [ 31%]
apis/comms_api/models/test/test_error.py ....                                                                                                                                         [ 38%]
apis/comms_api/routers/test/test_authentication.py ....                                                                                                                               [ 46%]
apis/comms_api/routers/test/test_commands.py ......                                                                                                                                   [ 57%]
apis/comms_api/routers/test/test_events.py ....                                                                                                                                       [ 64%]
apis/comms_api/routers/test/test_exceptions.py ......                                                                                                                                 [ 75%]
apis/comms_api/routers/test/test_files.py ........                                                                                                                                    [ 90%]
apis/comms_api/routers/test/test_utils.py .....                                                                                                                                       [100%]

============================================================================== 54 passed, 10 warnings in 1.56s ==============================================================================
```

</details>

<details><summary>Engine unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/engine/ --disable-warnings
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 11 items                                                                                                                                                                          

framework/wazuh/core/engine/tests/test_base.py .                                                                                                                                      [  9%]
framework/wazuh/core/engine/tests/test_events.py .                                                                                                                                    [ 18%]
framework/wazuh/core/engine/tests/test_init.py .........                                                                                                                              [100%]

==================================================================================== 11 passed in 0.30s =====================================================================================
```

</details>