### PR TITLE
Allow multithread in indexerConnector

### DIFF
--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -41,8 +41,6 @@ class EXPORTED IndexerConnector final
      * @brief Initialized status.
      *
      */
-    std::atomic<bool> m_initialized {false};
-    std::thread m_initializeThread;
     std::condition_variable m_cv;
     std::mutex m_mutex;
     std::atomic<bool> m_stopping {false};
@@ -90,6 +88,8 @@ public:
      * @param config Indexer configuration, including database_path and servers.
      * @param logFunction Callback function to be called when trying to log a message.
      * @param timeout Server selector time interval.
+     * @param workingThreads Number of working threads used by the dispatcher. More than one results in an unordered
+     * processing.
      */
     explicit IndexerConnector(const nlohmann::json& config,
                               const std::function<void(const int,
@@ -99,7 +99,8 @@ public:
                                                        const std::string&,
                                                        const std::string&,
                                                        va_list)>& logFunction = {},
-                              const uint32_t& timeout = DEFAULT_INTERVAL);
+                              const uint32_t& timeout = DEFAULT_INTERVAL,
+                              const uint8_t workingThreads = 1);
 
     ~IndexerConnector();
 

--- a/src/shared_modules/utils/tests/threadEventDispatcher_test.cpp
+++ b/src/shared_modules/utils/tests/threadEventDispatcher_test.cpp
@@ -12,12 +12,16 @@
 #include "threadEventDispatcher_test.hpp"
 #include "threadEventDispatcher.hpp"
 
-void ThreadEventDispatcherTest::SetUp() {
-    // Not implemented
+auto constexpr TEST_DB = "test.db";
+
+void ThreadEventDispatcherTest::SetUp()
+{
+    std::filesystem::remove_all(TEST_DB);
 };
 
-void ThreadEventDispatcherTest::TearDown() {
-    // Not implemented
+void ThreadEventDispatcherTest::TearDown()
+{
+    std::filesystem::remove_all(TEST_DB);
 };
 
 constexpr auto BULK_SIZE {50};
@@ -48,7 +52,7 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestSingleThread)
                     promise.set_value();
                 }
             },
-            "test.db",
+            TEST_DB,
             BULK_SIZE);
 
         for (int i = 0; i < MESSAGES_TO_SEND; ++i)
@@ -71,7 +75,7 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThread)
         std::promise<void> promise;
         auto index {0};
 
-        ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>, NUM_THREADS> dispatcher(
+        ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>> dispatcher(
             [&counter, &index, &MESSAGES_TO_SEND, &promise](std::queue<std::string>& data)
             {
                 counter += data.size();
@@ -88,8 +92,10 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThread)
                     promise.set_value();
                 }
             },
-            "test.db",
-            BULK_SIZE);
+            TEST_DB,
+            BULK_SIZE,
+            UNLIMITED_QUEUE_SIZE,
+            NUM_THREADS);
 
         for (int i = 0; i < MESSAGES_TO_SEND; ++i)
         {
@@ -97,6 +103,132 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThread)
         }
         promise.get_future().wait_for(std::chrono::seconds(10));
         EXPECT_EQ(MESSAGES_TO_SEND, counter);
+    }
+}
+
+TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThreadDifferentTypeExceptions)
+{
+    const auto MESSAGES_TO_SEND {100};
+    const auto NUM_THREADS = 4;
+    std::vector<int> messagesProcessed;
+    std::mutex mutex;
+    std::atomic<size_t> counter {0};
+    std::promise<void> promise;
+    std::atomic<bool> fail {true};
+
+    TThreadEventDispatcher<rocksdb::Slice,
+                           rocksdb::PinnableSlice,
+                           std::function<void(std::queue<rocksdb::PinnableSlice>&)>>
+        dispatcher(
+            [&](std::queue<rocksdb::PinnableSlice>& data)
+            {
+                // We throw some exceptions to force the reinsertion
+                if (counter % 20 == 0 && fail)
+                {
+                    fail = false;
+                    throw std::runtime_error("Test exception: " + std::to_string(counter));
+                }
+                else
+                {
+                    fail = true;
+                }
+
+                counter += data.size();
+                while (!data.empty())
+                {
+                    auto& value = data.front();
+                    {
+                        std::lock_guard<std::mutex> lock(mutex);
+                        messagesProcessed.push_back(std::stoi(value.ToString()));
+                    }
+                    data.pop();
+                }
+
+                if (counter == MESSAGES_TO_SEND)
+                {
+                    promise.set_value();
+                }
+            },
+            TEST_DB,
+            10,
+            UNLIMITED_QUEUE_SIZE,
+            NUM_THREADS);
+
+    for (int i = 0; i < MESSAGES_TO_SEND; ++i)
+    {
+        dispatcher.push(std::to_string(i));
+    }
+    promise.get_future().wait_for(std::chrono::seconds(10));
+    EXPECT_EQ(MESSAGES_TO_SEND, counter);
+
+    // Check that all messages were processed
+    std::sort(messagesProcessed.begin(), messagesProcessed.end());
+    for (int i = 0; i < MESSAGES_TO_SEND; ++i)
+    {
+        EXPECT_EQ(i, messagesProcessed[i]);
+    }
+}
+
+TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThreadDifferentTypeMultiQueueExceptions)
+{
+    const auto MESSAGES_TO_SEND {100};
+    const auto NUM_THREADS = 4;
+    std::vector<int> messagesProcessed;
+    std::mutex mutex;
+    std::atomic<size_t> counter {0};
+    std::promise<void> promise;
+    std::atomic<bool> fail {true};
+
+    TThreadEventDispatcher<rocksdb::Slice,
+                           rocksdb::PinnableSlice,
+                           std::function<void(rocksdb::PinnableSlice&)>,
+                           RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>,
+                           Utils::TSafeMultiQueue<rocksdb::Slice,
+                                                  rocksdb::PinnableSlice,
+                                                  RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>>>
+        dispatcher(
+            [&](rocksdb::PinnableSlice& element)
+            {
+                // We throw some exceptions to force the reinsertion
+                if (counter % 20 == 0 && fail)
+                {
+                    fail = false;
+                    throw std::runtime_error("Test exception: " + std::to_string(counter));
+                }
+                else
+                {
+                    fail = true;
+                }
+
+                counter++;
+
+                {
+                    std::lock_guard<std::mutex> lock(mutex);
+                    messagesProcessed.push_back(std::stoi(element.ToString()));
+                }
+
+                if (counter == MESSAGES_TO_SEND)
+                {
+                    promise.set_value();
+                }
+            },
+            TEST_DB,
+            10,
+            UNLIMITED_QUEUE_SIZE,
+            NUM_THREADS);
+
+    for (int i = 0; i < MESSAGES_TO_SEND; ++i)
+    {
+        dispatcher.push("test_cf", std::to_string(i));
+    }
+    promise.get_future().wait_for(std::chrono::seconds(10));
+    EXPECT_EQ(MESSAGES_TO_SEND, counter);
+
+    // Check that all messages were processed
+    std::sort(messagesProcessed.begin(), messagesProcessed.end());
+    for (int i = 0; i < MESSAGES_TO_SEND; ++i)
+    {
+        EXPECT_EQ(i, messagesProcessed[i]);
     }
 }
 
@@ -110,7 +242,7 @@ TEST_F(ThreadEventDispatcherTest, CtorNoWorkerSingleThread)
         std::promise<void> promise;
         auto index {0};
 
-        ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>> dispatcher("test.db",
+        ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>> dispatcher(TEST_DB,
                                                                                                      BULK_SIZE);
 
         for (int i = 0; i < MESSAGES_TO_SEND; ++i)
@@ -173,7 +305,7 @@ TEST_F(ThreadEventDispatcherTest, CtorPopFeatureSingleThread)
                 promise.set_value();
             }
         },
-        "test.db",
+        TEST_DB,
         BULK_SIZE);
 
     for (int i = 0; i < MESSAGES_TO_SEND; ++i)

--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -41,6 +41,11 @@ public:
         , m_queue {std::make_unique<TSafeQueueType>(TQueueType(dbPath))}
         , m_numberOfThreads {numberOfThreads}
     {
+        if (m_numberOfThreads <= 0)
+        {
+            throw std::invalid_argument("Number of threads must be greater than 0.");
+        }
+
         m_threads.reserve(m_numberOfThreads);
 
         for (unsigned int i = 0; i < m_numberOfThreads; ++i)
@@ -59,6 +64,10 @@ public:
         , m_queue {std::make_unique<TSafeQueueType>(TQueueType(dbPath))}
         , m_numberOfThreads {numberOfThreads}
     {
+        if (m_numberOfThreads <= 0)
+        {
+            throw std::invalid_argument("Number of threads must be greater than 0.");
+        }
     }
 
     TThreadEventDispatcher& operator=(const TThreadEventDispatcher&) = delete;

--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -25,7 +25,6 @@
 template<typename T,
          typename U,
          typename Functor,
-         uint8_t TNumberOfThreads = 1,
          typename TQueueType = RocksDBQueue<T, U>,
          typename TSafeQueueType = Utils::TSafeQueue<T, U, RocksDBQueue<T, U>>>
 class TThreadEventDispatcher
@@ -34,37 +33,31 @@ public:
     explicit TThreadEventDispatcher(Functor functor,
                                     const std::string& dbPath,
                                     const uint64_t bulkSize = 1,
-                                    const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
+                                    const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE,
+                                    const uint8_t numberOfThreads = 1)
         : m_functor {std::move(functor)}
         , m_maxQueueSize {maxQueueSize}
         , m_bulkSize {bulkSize}
         , m_queue {std::make_unique<TSafeQueueType>(TQueueType(dbPath))}
+        , m_numberOfThreads {numberOfThreads}
     {
-        m_threads.reserve(TNumberOfThreads);
+        m_threads.reserve(m_numberOfThreads);
 
-        if constexpr (TNumberOfThreads == 1)
+        for (unsigned int i = 0; i < m_numberOfThreads; ++i)
         {
-            m_threads.push_back(std::thread {
-                &TThreadEventDispatcher<T, U, Functor, TNumberOfThreads, TQueueType, TSafeQueueType>::dispatch, this});
-        }
-        else
-        {
-            static_assert(isSameType, "T and U are not the same type");
-            for (unsigned int i = 0; i < TNumberOfThreads; ++i)
-            {
-                m_threads.push_back(std::thread {
-                    &TThreadEventDispatcher<T, U, Functor, TNumberOfThreads, TQueueType, TSafeQueueType>::dispatch,
-                    this});
-            }
+            m_threads.push_back(
+                std::thread {&TThreadEventDispatcher<T, U, Functor, TQueueType, TSafeQueueType>::dispatch, this});
         }
     }
 
     explicit TThreadEventDispatcher(const std::string& dbPath,
                                     const uint64_t bulkSize = 1,
-                                    const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
+                                    const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE,
+                                    const uint8_t numberOfThreads = 1)
         : m_maxQueueSize {maxQueueSize}
         , m_bulkSize {bulkSize}
         , m_queue {std::make_unique<TSafeQueueType>(TQueueType(dbPath))}
+        , m_numberOfThreads {numberOfThreads}
     {
     }
 
@@ -78,67 +71,43 @@ public:
     void startWorker(Functor functor)
     {
         m_functor = std::move(functor);
-        m_threads.reserve(TNumberOfThreads);
+        m_threads.reserve(m_numberOfThreads);
 
-        if constexpr (TNumberOfThreads == 1)
+        for (unsigned int i = 0; i < m_numberOfThreads; ++i)
         {
-            m_threads.push_back(std::thread {
-                &TThreadEventDispatcher<T, U, Functor, TNumberOfThreads, TQueueType, TSafeQueueType>::dispatch, this});
-        }
-        else
-        {
-            for (unsigned int i = 0; i < TNumberOfThreads; ++i)
-            {
-                m_threads.push_back(std::thread {
-                    &TThreadEventDispatcher<T, U, Functor, TNumberOfThreads, TQueueType, TSafeQueueType>::dispatch,
-                    this});
-            }
+            m_threads.push_back(
+                std::thread {&TThreadEventDispatcher<T, U, Functor, TQueueType, TSafeQueueType>::dispatch, this});
         }
     }
 
     void push(const T& value)
     {
-        if constexpr (!isTSafeMultiQueue)
+        // static assert to avoid compilation
+        static_assert(!isTSafeMultiQueue, "This method is not supported for this queue type");
+
+        if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue->size() < m_maxQueueSize))
         {
-            if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue->size() < m_maxQueueSize))
-            {
-                m_queue->push(value);
-            }
-        }
-        else
-        {
-            // static assert to avoid compilation
-            static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
+            m_queue->push(value);
         }
     }
 
     void push(std::string_view prefix, const T& value)
     {
-        if constexpr (isTSafeMultiQueue)
+        // static assert to avoid compilation
+        static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
+
+        if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue->size(prefix) < m_maxQueueSize))
         {
-            if (m_running && (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue->size(prefix) < m_maxQueueSize))
-            {
-                m_queue->push(prefix, value);
-            }
-        }
-        else
-        {
-            // static assert to avoid compilation
-            static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
+            m_queue->push(prefix, value);
         }
     }
 
     void clear(std::string_view prefix = "")
     {
-        if constexpr (isTSafeMultiQueue)
-        {
-            m_queue->clear(prefix);
-        }
-        else
-        {
-            // static assert to avoid compilation
-            static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
-        }
+        // static assert to avoid compilation
+        static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
+
+        m_queue->clear(prefix);
     }
 
     void cancel()
@@ -155,40 +124,26 @@ public:
 
     size_t size() const
     {
-        if constexpr (!isTSafeMultiQueue)
-        {
-            return m_queue->size();
-        }
-        else
-        {
-            static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
-        }
+        // static assert to avoid compilation
+        static_assert(!isTSafeMultiQueue, "This method is not supported for this queue type");
+
+        return m_queue->size();
     }
 
     size_t size(std::string_view prefix) const
     {
-        if constexpr (isTSafeMultiQueue)
-        {
-            return m_queue->size(prefix);
-        }
-        else
-        {
-            // static assert to avoid compilation
-            static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
-        }
+        // static assert to avoid compilation
+        static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
+
+        return m_queue->size(prefix);
     }
 
     void postpone(std::string_view prefix, const std::chrono::seconds& time) noexcept
     {
-        if constexpr (isTSafeMultiQueue)
-        {
-            m_queue->postpone(prefix, time);
-        }
-        else
-        {
-            // static assert to avoid compilation
-            static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
-        }
+        // static assert to avoid compilation
+        static_assert(isTSafeMultiQueue, "This method is not supported for this queue type");
+
+        m_queue->postpone(prefix, time);
     }
 
 private:
@@ -206,12 +161,6 @@ private:
     static constexpr bool isTSafeQueue = std::is_same_v<Utils::TSafeQueue<T, U, RocksDBQueue<T, U>>, TSafeQueueType>;
 
     /**
-     * @brief Check if the queue value are the same type. This is crucial for the `multiAndUnordered` method.
-     *
-     */
-    static constexpr bool isSameType = std::is_same_v<T, U>;
-
-    /**
      * @brief Dispatch function to handle queue processing based on the number of threads.
      *
      * This function enters a loop that runs while the dispatcher is active. Depending on the number of threads,
@@ -226,12 +175,12 @@ private:
         while (m_running)
         {
             // If only one thread is used, process the queue in a single-threaded, ordered manner
-            if constexpr (TNumberOfThreads == 1)
+            if (m_numberOfThreads == 1)
             {
                 singleAndOrdered();
             }
             // If multiple threads are used, process the queue in a multi-threaded, unordered manner
-            else
+            else if (m_numberOfThreads > 1)
             {
                 multiAndUnordered();
             }
@@ -289,14 +238,14 @@ private:
      */
     void multiAndUnordered()
     {
-        static_assert(isSameType, "T and U are not the same type");
-        std::queue<U> data; // Declare data outside the try block to ensure scope in catch block
+        // Declare data outside the try block to ensure scope in catch block
+        std::queue<U> data;
+        std::pair<U, std::string> dataPair;
         try
         {
             if constexpr (isTSafeQueue)
             {
                 data = m_queue->getBulkAndPop(m_bulkSize);
-                const auto size = data.size();
 
                 if (!data.empty())
                 {
@@ -305,11 +254,10 @@ private:
             }
             else if constexpr (isTSafeMultiQueue)
             {
-                auto dataPair = m_queue->front();
+                dataPair = m_queue->getAndPop();
                 if (!dataPair.second.empty())
                 {
                     m_functor(dataPair.first);
-                    m_queue->pop(dataPair.second);
                 }
             }
             else
@@ -332,12 +280,11 @@ private:
             }
             else if constexpr (isTSafeMultiQueue)
             {
-                while (!data.empty())
+                if (!dataPair.second.empty())
                 {
-                    m_queue->push(data.front());
-                    data.pop();
+                    m_queue->push(dataPair.second, dataPair.first);
                 }
-                std::cerr << "Dispatch handler error. Elements reinserted: " << ex.what() << "\n";
+                std::cerr << "Dispatch handler error. Element reinserted: " << ex.what() << "\n";
             }
         }
     }
@@ -360,9 +307,10 @@ private:
 
     const size_t m_maxQueueSize;
     const uint64_t m_bulkSize;
+    const uint8_t m_numberOfThreads;
 };
 
-template<typename Type, typename Functor, uint8_t NumberOfThreads = 1>
-using ThreadEventDispatcher = TThreadEventDispatcher<Type, Type, Functor, NumberOfThreads>;
+template<typename Type, typename Functor>
+using ThreadEventDispatcher = TThreadEventDispatcher<Type, Type, Functor>;
 
 #endif // _THREAD_EVENT_DISPATCHER_HPP


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25119|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR allows to select the number of threads that the `indexerConnector` will use during the processing of the elements in the internal queue.
For this goal, the threads parameter was moved from compile time to runtime at `threadEventDispatcher`.
Also:
- The limitation of using the same types `T` and `U` was removed for that class
- The multithread behavior was tested for the `safeQueue` and `safeMultiQueue`, including the reinsertion mechanism
- Some minor style improvements
- Some dangling references to a starting thread were removed

> [!NOTE]  
> The compilation in the `master` branch isn't working at this moment.
<!--
Add a clear description of how the problem has been solved.
-->


## Tests

The utils UT aren't present in any CI test. I've run them locally to confirm they pass

![2024-08-20_01-57](https://github.com/user-attachments/assets/ae22fd7c-1a8e-4bab-80bc-990c696d9b16)

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] QA templates contemplate the added capabilities

- [x] Added unit tests (for new features)
