### PR TITLE
Improve monitoring class

### DIFF
--- a/.github/workflows/rtr_syscollector.yml
+++ b/.github/workflows/rtr_syscollector.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: "Install dependencies"
         uses: ./.github/actions/install_build_deps
         with:

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -14,6 +14,8 @@ jobs:
         target: ['agent', 'server']
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -39,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -66,6 +70,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: |
           brew install llvm@14

--- a/.github/workflows/ubuntu-syscollector-tests.yml
+++ b/.github/workflows/ubuntu-syscollector-tests.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |

--- a/src/data_provider/src/packages/packageLinuxParserSnap.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserSnap.cpp
@@ -14,7 +14,7 @@
 
 void getSnapInfo(std::function<void(nlohmann::json&)> callback)
 {
-    const auto onSuccess = [&](const std::string& result)
+    const auto onSuccess = [&](const std::string & result)
     {
         auto feed = nlohmann::json::parse(result, nullptr, false).at("result");
 
@@ -34,13 +34,15 @@ void getSnapInfo(std::function<void(nlohmann::json&)> callback)
         }
     };
 
-    const auto onError = [&](const std::string& result, const long responseCode)
+    const auto onError = [&](const std::string & result, const long responseCode)
     {
         std::cerr << "Error retrieving packages using snap unix-socket (" << responseCode << ") " << result << "\n";
     };
 
+    const auto url = HttpUnixSocketURL("/run/snapd.socket", "http://localhost/v2/snaps");
+
     UNIXSocketRequest::instance().get(
-        RequestParameters {.url = HttpUnixSocketURL("/run/snapd.socket", "http://localhost/v2/snaps")},
+        RequestParameters {.url = url},
         PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
         ConfigurationParameters {});
 }

--- a/src/shared_modules/content_manager/src/components/APIDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/APIDownloader.hpp
@@ -81,8 +81,9 @@ private:
             }};
 
         // Run the request. Save the file on disk.
-        m_urlRequest.download(
-            HttpURL(m_url), m_fullFilePath, onError, {}, {}, m_context->spUpdaterBaseContext->httpUserAgent);
+        m_urlRequest.download(RequestParameters {.url = HttpURL(m_url)},
+                              PostRequestParameters {.onError = onError, .outputFile = m_fullFilePath},
+                              ConfigurationParameters {.userAgent = m_context->spUpdaterBaseContext->httpUserAgent});
     }
 
     std::string m_url {};                         ///< URL of the API to connect to.

--- a/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/CtiDownloader.hpp
@@ -212,19 +212,16 @@ protected:
         unsigned int sleepTime {0};
         unsigned int retryAttempt;
         auto lastErrorType {CtiErrorType::NO_ERROR};
-        auto& stopCondition {m_spUpdaterContext->spUpdaterBaseContext->spStopCondition};
+        auto const& stopCondition {m_spUpdaterContext->spUpdaterBaseContext->spStopCondition};
 
         while (!stopCondition->waitFor(std::chrono::seconds(sleepTime)))
         {
             try
             {
-                m_urlRequest.get(HttpURL(URL + queryParameters),
-                                 onSuccess,
-                                 onError,
-                                 outputFilepath,
-                                 DEFAULT_HEADERS,
-                                 {},
-                                 m_spUpdaterContext->spUpdaterBaseContext->httpUserAgent);
+                m_urlRequest.get(
+                    RequestParameters {.url = HttpURL(URL + queryParameters)},
+                    PostRequestParameters {.onSuccess = onSuccess, .onError = onError, .outputFile = outputFilepath},
+                    ConfigurationParameters {.userAgent = m_spUpdaterContext->spUpdaterBaseContext->httpUserAgent});
                 return;
             }
             catch (const cti_server_error& e)

--- a/src/shared_modules/content_manager/src/components/fileDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/fileDownloader.hpp
@@ -71,7 +71,9 @@ private:
         // Download and store file.
         logDebug2(WM_CONTENTUPDATER, "Downloading file from '%s'", url.string().c_str());
         HTTPRequest::instance().download(
-            HttpURL(url), outputFilePath, onError, {}, {}, context.spUpdaterBaseContext->httpUserAgent);
+            RequestParameters {.url = HttpURL(url)},
+            PostRequestParameters {.onError = onError, .outputFile = outputFilePath},
+            ConfigurationParameters {.userAgent = context.spUpdaterBaseContext->httpUserAgent});
 
         // Just process the new file if the hash is different from the last one.
         auto downloadFileHash {Utils::asciiToHex(Utils::hashFile(outputFilePath))};

--- a/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/offlineDownloader.hpp
@@ -96,7 +96,9 @@ private:
                   "Downloading file from '%s' into '%s'",
                   inputFileURL.string().c_str(),
                   outputFilepath.string().c_str());
-        m_urlRequest.download(HttpURL(inputFileURL), outputFilepath, onError, {}, {}, userAgent);
+        m_urlRequest.download(RequestParameters {.url = HttpURL(inputFileURL)},
+                              PostRequestParameters {.onError = onError, .outputFile = outputFilepath},
+                              ConfigurationParameters {.userAgent = userAgent});
         return returnCode;
     }
 

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -383,9 +383,9 @@ TEST_F(ActionTest, HashOnDemandUpdate)
     putData["hash"] = std::move(fileHash);
     putData["topicName"] = topicName;
     UNIXSocketRequest::instance().put(
-            RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, putUrl), .data = putData},
-            PostRequestParameters {},
-            ConfigurationParameters {});
+        RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, putUrl), .data = putData},
+        PostRequestParameters {},
+        ConfigurationParameters {});
 
     // Trigger two more downloads that will be skipped.
     EXPECT_CALL(*spMockRouterProvider, send(::testing::_)).Times(0);

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -383,7 +383,9 @@ TEST_F(ActionTest, HashOnDemandUpdate)
     putData["hash"] = std::move(fileHash);
     putData["topicName"] = topicName;
     UNIXSocketRequest::instance().put(
-        HttpUnixSocketURL(ONDEMAND_SOCK, std::move(putUrl)), std::move(putData), [](auto) {});
+            RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, putUrl), .data = putData},
+            PostRequestParameters {},
+            ConfigurationParameters {});
 
     // Trigger two more downloads that will be skipped.
     EXPECT_CALL(*spMockRouterProvider, send(::testing::_)).Times(0);

--- a/src/shared_modules/indexer_connector/qa/test_efficacy_log.py
+++ b/src/shared_modules/indexer_connector/qa/test_efficacy_log.py
@@ -44,7 +44,7 @@ def test_opensearch_health(opensearch):
     url = 'http://localhost:9200/_cluster/health'
     response = requests.get(url)
     assert response.status_code == 200
-    assert response.json()['status'] == 'green'
+    assert response.json()['status'] == 'green' or response.json()['status'] == 'yellow'
 
 def test_initialize_indexer_connector(opensearch):
     os.chdir(Path(__file__).parent.parent.parent.parent)

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -287,7 +287,7 @@ void IndexerConnector::diff(const nlohmann::json& responseJson,
 
         HTTPRequest::instance().post(
             RequestParameters {.url = HttpURL(url), .data = bulkData, .secureCommunication = secureCommunication},
-            PostRequestParameters {.onError = onError},
+            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
             ConfigurationParameters {});
     }
 }

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -74,6 +74,84 @@ class Monitoring final
     std::atomic<bool> m_stop {false};
     uint32_t m_interval {INTERVAL};
 
+    /**
+     * @brief Checks the health of a server.
+     *
+     * @note It sends a request to the \p serverAddress and update the serverStatus (true if the server is
+     * available, false otherwise). The \p authentication object is used to provide secure communication.
+     *
+     * @param serverAddress
+     * @param authentication
+     */
+    void healthCheck(const std::string& serverAddress, const SecureCommunication& authentication)
+    {
+        auto& serverStatus = m_servers[serverAddress];
+
+        // On success callback
+        const auto onSuccess = [&serverStatus](std::string response)
+        {
+            // Remove the tabs and double spaces.
+            Utils::replaceAll(response, "\t", " ");
+            response = Utils::trimRepeated(response, ' ');
+
+            // Split the response by rows.
+            const auto rows {Utils::split(response, '\n')};
+
+            // Check if the response has the expected number of rows.
+            if (HealthCheckRows::SIZE == rows.size())
+            {
+                // Split the data row by spaces.
+                const auto fields {Utils::split(rows.at(HealthCheckRows::DATA), ' ')};
+
+                // Check if the response has the expected number of columns and if the status is green.
+                if (fields.size() == HealthCheckColumns::SIZE &&
+                    fields.at(HealthCheckColumns::STATUS).compare("green") == 0)
+                {
+                    serverStatus = true;
+                }
+                else
+                {
+                    serverStatus = false;
+                }
+            }
+            else
+            {
+                serverStatus = false; // LCOV_EXCL_LINE
+            }
+        };
+
+        // On error callback
+        const auto onError = [&serverStatus](const std::string& /*error*/, const long /*statusCode*/)
+        {
+            serverStatus = false;
+        };
+
+        // Get the health of the server.
+        HTTPRequest::instance().get(HttpURL(serverAddress + "/_cat/health?v"),
+                                    onSuccess,
+                                    onError,
+                                    "",
+                                    {"Accept-Charset: utf-8"},
+                                    authentication);
+    }
+
+    /**
+     * @brief Initializes the status of the servers.
+     * 
+     * @param serverAddresses Servers to be monitored.
+     * @param secureCommunication Object that provides secure communication.
+     */
+    void initialize(const std::vector<std::string>& serverAddresses, const SecureCommunication& secureCommunication)
+    {
+        std::scoped_lock lock(m_mutex);
+
+        // Initialize the status of the servers
+        for (const auto& serverAddress : serverAddresses)
+        {
+            healthCheck(serverAddress, secureCommunication);
+        }
+    }
+
 public:
     ~Monitoring()
     {
@@ -90,87 +168,32 @@ public:
      *
      * @param serverAddresses Servers to be monitored.
      * @param interval Interval for monitoring.
-     * @param secureCommunication Object that provides secure communication.
+     * @param authentication Object that provides secure communication.
      */
     explicit Monitoring(const std::vector<std::string>& serverAddresses,
                         const uint32_t interval = INTERVAL,
                         const SecureCommunication& secureCommunication = {})
         : m_interval(interval)
     {
-        /**
-         * @brief Health check function
-         *
-         * @note It sends a request to the \p serverAddress and update the \p serverStatus (true if the server is
-         * available, false otherwise).
-         */
-        const auto healthCheck = [this, secureCommunication](const std::string& serverAddress, bool& serverStatus)
-        {
-            // Get the health of the server.
-            HTTPRequest::instance().get(
-                HttpURL(serverAddress + "/_cat/health?v"),
-                [&](std::string response)
-                {
-                    // Remove the tabs and double spaces.
-                    Utils::replaceAll(response, "\t", " ");
-                    response = Utils::trimRepeated(response, ' ');
-                    // Split the response by rows.
-                    const auto rows {Utils::split(response, '\n')};
-
-                    // Check if the response has the expected number of rows.
-                    if (HealthCheckRows::SIZE == rows.size())
-                    {
-                        // Split the data row by spaces.
-                        const auto fields {Utils::split(rows.at(HealthCheckRows::DATA), ' ')};
-
-                        // Check if the response has the expected number of columns and if the status is
-                        // green.
-                        if (fields.size() == HealthCheckColumns::SIZE &&
-                            fields.at(HealthCheckColumns::STATUS).compare("green") == 0)
-                        {
-                            serverStatus = true;
-                        }
-                        else
-                        {
-                            serverStatus = false;
-                        }
-                    }
-                    else
-                    {
-                        serverStatus = false; // LCOV_EXCL_LINE
-                    }
-                },
-                [&](const std::string& error, const long /*statusCode*/) { serverStatus = false; },
-                "",
-                {"Accept-Charset: utf-8"},
-                secureCommunication);
-        };
-
-        {
-            // Initialize the status of the servers
-            std::scoped_lock lock(m_mutex);
-            for (const auto& serverAddress : serverAddresses)
-            {
-                healthCheck(serverAddress, m_servers[serverAddress]);
-            }
-        }
+        initialize(serverAddresses, secureCommunication);
 
         // Start the thread, that will check the health of the servers.
         m_thread = std::thread(
-            [this, secureCommunication, healthCheck]()
+            [this, &secureCommunication]()
             {
                 while (!m_stop)
                 {
                     // Wait for the interval.
-                    std::unique_lock<std::mutex> lock(m_mutex);
+                    std::unique_lock lock(m_mutex);
                     m_condition.wait_for(lock, std::chrono::seconds(m_interval), [this]() { return m_stop.load(); });
 
                     // If the thread is not stopped, check the health of the servers.
                     if (!m_stop)
                     {
                         // Check the health of the servers.
-                        for (auto& [serverAddress, serverStatus] : m_servers)
+                        for (const auto& [serverAddress, _] : m_servers)
                         {
-                            healthCheck(serverAddress, serverStatus);
+                            healthCheck(serverAddress, secureCommunication);
                         }
                     }
                 }
@@ -186,8 +209,7 @@ public:
      */
     bool isAvailable(const std::string& serverAddress)
     {
-        // Check if the server is available.
-        std::lock_guard<std::mutex> lock(m_mutex);
+        std::scoped_lock lock(m_mutex);
         return m_servers.at(serverAddress);
     }
 };

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -128,12 +128,10 @@ class Monitoring final
         };
 
         // Get the health of the server.
-        HTTPRequest::instance().get(HttpURL(serverAddress + "/_cat/health?v"),
-                                    onSuccess,
-                                    onError,
-                                    "",
-                                    {"Accept-Charset: utf-8"},
-                                    authentication);
+        HTTPRequest::instance().get(
+            RequestParameters {.url = HttpURL(serverAddress + "/_cat/health?v"), .secureCommunication = authentication},
+            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
+            ConfigurationParameters {});
     }
 
     /**

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -24,7 +24,6 @@
 #include <thread>
 #include <vector>
 
-
 // 60 seconds interval for monitoring
 constexpr auto INTERVAL = 60u;
 

--- a/src/shared_modules/indexer_connector/src/monitoring.hpp
+++ b/src/shared_modules/indexer_connector/src/monitoring.hpp
@@ -24,7 +24,6 @@
 #include <thread>
 #include <vector>
 
-constexpr auto MONITORING_NAME {"monitoring"};
 
 // 60 seconds interval for monitoring
 constexpr auto INTERVAL = 60u;

--- a/src/shared_modules/indexer_connector/src/serverSelector.hpp
+++ b/src/shared_modules/indexer_connector/src/serverSelector.hpp
@@ -35,14 +35,14 @@ public:
      *
      * @param values Servers to be selected.
      * @param timeout Timeout for monitoring.
-     * @param secureCommunication Object that provides secure communication.
+     * @param authentication Object that provides secure communication.
      */
     explicit ServerSelector(const std::vector<std::string>& values,
                             const uint32_t timeout = INTERVAL,
-                            const SecureCommunication& secureCommunication = {})
+                            const SecureCommunication& authentication = {})
         : RoundRobinSelector<std::string>(values)
     {
-        m_monitoring = std::make_shared<Monitoring>(values, timeout, secureCommunication);
+        m_monitoring = std::make_shared<Monitoring>(values, timeout, authentication);
     }
 
     /**

--- a/src/shared_modules/indexer_connector/src/serverSelector.hpp
+++ b/src/shared_modules/indexer_connector/src/serverSelector.hpp
@@ -25,7 +25,7 @@
 class ServerSelector final : private RoundRobinSelector<std::string>
 {
 private:
-    std::shared_ptr<Monitoring> monitoring;
+    std::shared_ptr<Monitoring> m_monitoring;
 
 public:
     ~ServerSelector() = default;
@@ -42,7 +42,7 @@ public:
                             const SecureCommunication& secureCommunication = {})
         : RoundRobinSelector<std::string>(values)
     {
-        monitoring = std::make_shared<Monitoring>(values, timeout, secureCommunication);
+        m_monitoring = std::make_shared<Monitoring>(values, timeout, secureCommunication);
     }
 
     /**
@@ -55,7 +55,7 @@ public:
         auto initialValue {RoundRobinSelector<std::string>::getNext()};
         auto retValue {initialValue};
 
-        while (!monitoring->isAvailable(retValue))
+        while (!m_monitoring->isAvailable(retValue))
         {
             retValue = RoundRobinSelector<std::string>::getNext();
             if (retValue.compare(initialValue) == 0)

--- a/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
+++ b/src/shared_modules/indexer_connector/tests/component/fakeIndexer.hpp
@@ -12,6 +12,7 @@
 #ifndef _FAKE_INDEXER_HPP
 #define _FAKE_INDEXER_HPP
 
+#include "json.hpp"
 #include <external/cpp-httplib/httplib.h>
 #include <functional>
 #include <sstream>
@@ -128,17 +129,29 @@ public:
     void run()
     {
         // Endpoint where the health status is returned.
-        m_server.Get(
-            "/_cat/health",
-            [this](const httplib::Request& req, httplib::Response& res)
-            {
-                std::ignore = req;
-                std::stringstream ss;
-                ss << "epoch      timestamp cluster            status node.total node.data discovered_cluster_manager "
-                      "shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent\n";
-                ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
-                res.set_content(ss.str(), "text/plain");
-            });
+        m_server.Get("/_cat/health",
+                     [this](const httplib::Request& req, httplib::Response& res)
+                     {
+                         const auto response = nlohmann::json::array({{{"epoch", "1726271464"},
+                                                                       {"timestamp", "23:51:04"},
+                                                                       {"cluster", "wazuh-cluster"},
+                                                                       {"status", m_health},
+                                                                       {"node.total", "1"},
+                                                                       {"node.data", "1"},
+                                                                       {"discovered_cluster_manager", "true"},
+                                                                       {"shards", "166"},
+                                                                       {"pri", "166"},
+                                                                       {"relo", "0"},
+                                                                       {"init", "0"},
+                                                                       {"unassign", "0"},
+                                                                       {"pending_tasks", "0"},
+                                                                       {"max_task_wait_time", "-"},
+                                                                       {"active_shards_percent", "100.0%"}}});
+
+                         std::stringstream ss;
+                         ss << response.dump();
+                         res.set_content(ss.str(), "application/json");
+                     });
 
         // Endpoint where the index is initialized.
         m_server.Put("/" + m_indexName,

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -30,6 +30,7 @@ private:
     std::string m_host;
     std::string m_health;
     int m_port;
+    uint16_t m_forcedDelay;
 
 public:
     /**
@@ -38,12 +39,14 @@ public:
      * @param host host of the fake OpenSearch server.
      * @param port port of the fake OpenSearch server
      * @param health health status of the fake OpenSearch server.
+     * @param forcedDelay forced delay in milliseconds (default 0). This is used to simulate a slow server.
      */
-    FakeOpenSearchServer(std::string host, int port, std::string health)
+    FakeOpenSearchServer(std::string host, int port, std::string health, uint16_t forcedDelay = 0)
         : m_thread(&FakeOpenSearchServer::run, this)
         , m_host(std::move(host))
         , m_health(std::move(health))
         , m_port(port)
+        , m_forcedDelay(forcedDelay)
     {
         // Wait until server is ready
         while (!m_server.is_running())
@@ -74,6 +77,9 @@ public:
             "/_cat/health",
             [this](const httplib::Request& req, httplib::Response& res)
             {
+                // Simulate a slow server
+                std::this_thread::sleep_for(std::chrono::milliseconds(m_forcedDelay));
+
                 std::stringstream ss;
                 ss << "epoch      timestamp cluster            status node.total node.data discovered_cluster_manager "
                       "shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent\n";

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -73,19 +73,32 @@ public:
      */
     void run()
     {
-        m_server.Get(
-            "/_cat/health",
-            [this](const httplib::Request& req, httplib::Response& res)
-            {
-                // Simulate a slow server
-                std::this_thread::sleep_for(std::chrono::milliseconds(m_forcedDelay));
+        m_server.Get("/_cat/health",
+                     [this](const httplib::Request& req, httplib::Response& res)
+                     {
+                         // Simulate a slow server
+                         std::this_thread::sleep_for(std::chrono::milliseconds(m_forcedDelay));
 
-                std::stringstream ss;
-                ss << "epoch      timestamp cluster            status node.total node.data discovered_cluster_manager "
-                      "shards pri relo init unassign pending_tasks max_task_wait_time active_shards_percent\n";
-                ss << "1694645550 22:52:30 opensearch-cluster " << m_health << " 2 2 true 14 7 0 0 0 0 - 100.0%\n";
-                res.set_content(ss.str(), "text/plain");
-            });
+                         const auto response = nlohmann::json::array({{{"epoch", "1726271464"},
+                                                                       {"timestamp", "23:51:04"},
+                                                                       {"cluster", "wazuh-cluster"},
+                                                                       {"status", m_health},
+                                                                       {"node.total", "1"},
+                                                                       {"node.data", "1"},
+                                                                       {"discovered_cluster_manager", "true"},
+                                                                       {"shards", "166"},
+                                                                       {"pri", "166"},
+                                                                       {"relo", "0"},
+                                                                       {"init", "0"},
+                                                                       {"unassign", "0"},
+                                                                       {"pending_tasks", "0"},
+                                                                       {"max_task_wait_time", "-"},
+                                                                       {"active_shards_percent", "100.0%"}}});
+
+                         std::stringstream ss;
+                         ss << response.dump();
+                         res.set_content(ss.str(), "application/json");
+                     });
         m_server.set_keep_alive_max_count(1);
         m_server.listen(m_host.c_str(), m_port);
     }

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -16,7 +16,7 @@
 #include <thread>
 
 // Healt check interval for the servers
-constexpr auto MONITORING_HEALTH_CHECK_INTERVAL {5u};
+constexpr auto MONITORING_HEALTH_CHECK_INTERVAL {1u};
 
 /**
  * @brief Test instantiation and check the availability of valid servers.
@@ -27,6 +27,7 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
     const auto hostGreenServer {m_servers.at(0)};
     const auto hostRedServer {m_servers.at(1)};
     const auto hostYellowServer {m_servers.at(2)};
+    const auto hostGreenServerWithDelay {m_servers.at(3)};
 
     EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers, MONITORING_HEALTH_CHECK_INTERVAL));
 
@@ -34,6 +35,7 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
     EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
     EXPECT_FALSE(m_monitoring->isAvailable(hostYellowServer));
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));
@@ -46,6 +48,28 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
 
     // It's false because the yellow server isn't available
     EXPECT_FALSE(m_monitoring->isAvailable(hostYellowServer));
+
+    // It's true because the green server is available
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));
+}
+
+/**
+ * @brief Test a slow server.
+ *
+ */
+TEST_F(MonitoringTest, TestSlowServer)
+{
+    const auto hostGreenServerWithDelay {m_servers.at(3)};
+
+    EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers, MONITORING_HEALTH_CHECK_INTERVAL));
+
+    // It's true because the green server is available
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));
+
+    // Wait for the first health check to finish + the delay of the server
+    std::this_thread::sleep_for(std::chrono::milliseconds(MONITORING_HEALTH_CHECK_INTERVAL * 1000 + 110));
+
+    EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));
 }
 
 /**

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -73,8 +73,8 @@ TEST_F(MonitoringTest, TestInvalidServer)
 
     EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers, MONITORING_HEALTH_CHECK_INTERVAL));
 
-    // All servers are available the first time
-    EXPECT_TRUE(m_monitoring->isAvailable(invalidServer));
+    // All servers have their corresponding status the first time
+    EXPECT_FALSE(m_monitoring->isAvailable(invalidServer));
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));
@@ -95,9 +95,9 @@ TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
 
     EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers, MONITORING_HEALTH_CHECK_INTERVAL));
 
-    // All servers are available the first time
+    // All servers have their corresponding status the first time
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
-    EXPECT_TRUE(m_monitoring->isAvailable(hostRedServer));
+    EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -26,12 +26,14 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
 {
     const auto hostGreenServer {m_servers.at(0)};
     const auto hostRedServer {m_servers.at(1)};
+    const auto hostYellowServer {m_servers.at(2)};
 
     EXPECT_NO_THROW(m_monitoring = std::make_shared<Monitoring>(m_servers, MONITORING_HEALTH_CHECK_INTERVAL));
 
-    // All servers are available the first time.
+    // All servers have their corresponding status the first time
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
-    EXPECT_TRUE(m_monitoring->isAvailable(hostRedServer));
+    EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
+    EXPECT_FALSE(m_monitoring->isAvailable(hostYellowServer));
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));
@@ -41,6 +43,9 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
 
     // It's false because the red server isn't available
     EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
+
+    // It's false because the yellow server isn't available
+    EXPECT_FALSE(m_monitoring->isAvailable(hostYellowServer));
 }
 
 /**

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -34,7 +34,7 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
     // All servers have their corresponding status the first time
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServer));
     EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
-    EXPECT_FALSE(m_monitoring->isAvailable(hostYellowServer));
+    EXPECT_TRUE(m_monitoring->isAvailable(hostYellowServer));
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));
 
     // Interval to check the health of the servers
@@ -47,7 +47,7 @@ TEST_F(MonitoringTest, TestInstantiationWithValidServers)
     EXPECT_FALSE(m_monitoring->isAvailable(hostRedServer));
 
     // It's false because the yellow server isn't available
-    EXPECT_FALSE(m_monitoring->isAvailable(hostYellowServer));
+    EXPECT_TRUE(m_monitoring->isAvailable(hostYellowServer));
 
     // It's true because the green server is available
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -67,7 +67,7 @@ TEST_F(MonitoringTest, TestSlowServer)
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));
 
     // Wait for the first health check to finish + the delay of the server
-    std::this_thread::sleep_for(std::chrono::milliseconds(MONITORING_HEALTH_CHECK_INTERVAL * 1000 + 110));
+    std::this_thread::sleep_for(std::chrono::milliseconds(MONITORING_HEALTH_CHECK_INTERVAL * 1000 * 2));
 
     EXPECT_TRUE(m_monitoring->isAvailable(hostGreenServerWithDelay));
 }

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
@@ -34,6 +34,9 @@ protected:
     inline static std::unique_ptr<FakeOpenSearchServer>
         m_fakeOpenSearchYellowServer; ///< pointer to FakeOpenSearchServer class
 
+    inline static std::unique_ptr<FakeOpenSearchServer>
+        m_fakeOpenSearchGreenServerWithDelay; ///< pointer to FakeOpenSearchServer class
+
     std::shared_ptr<Monitoring> m_monitoring; ///< pointer to Monitoring class
 
     std::vector<std::string> m_servers; ///< Servers
@@ -50,6 +53,8 @@ protected:
         m_servers.emplace_back("http://localhost:9210");
         // Register the host and port of the yellow server
         m_servers.emplace_back("http://localhost:9211");
+        // Register the host and port of the server with delay
+        m_servers.emplace_back("http://localhost:9212");
     }
 
     /**
@@ -74,6 +79,12 @@ protected:
         {
             m_fakeOpenSearchYellowServer = std::make_unique<FakeOpenSearchServer>(host, 9211, "yellow");
         }
+
+        if (!m_fakeOpenSearchGreenServerWithDelay)
+        {
+            // Create a server with a delay of 100 milliseconds
+            m_fakeOpenSearchGreenServerWithDelay = std::make_unique<FakeOpenSearchServer>(host, 9212, "green", 100);
+        }
     }
 
     /**
@@ -85,6 +96,7 @@ protected:
         m_fakeOpenSearchGreenServer.reset();
         m_fakeOpenSearchRedServer.reset();
         m_fakeOpenSearchYellowServer.reset();
+        m_fakeOpenSearchGreenServerWithDelay.reset();
     }
 };
 

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.hpp
@@ -31,6 +31,9 @@ protected:
     inline static std::unique_ptr<FakeOpenSearchServer>
         m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
 
+    inline static std::unique_ptr<FakeOpenSearchServer>
+        m_fakeOpenSearchYellowServer; ///< pointer to FakeOpenSearchServer class
+
     std::shared_ptr<Monitoring> m_monitoring; ///< pointer to Monitoring class
 
     std::vector<std::string> m_servers; ///< Servers
@@ -45,6 +48,8 @@ protected:
         m_servers.emplace_back("http://localhost:9209");
         // Register the host and port of the red server
         m_servers.emplace_back("http://localhost:9210");
+        // Register the host and port of the yellow server
+        m_servers.emplace_back("http://localhost:9211");
     }
 
     /**
@@ -64,6 +69,11 @@ protected:
         {
             m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>(host, 9210, "red");
         }
+
+        if (!m_fakeOpenSearchYellowServer)
+        {
+            m_fakeOpenSearchYellowServer = std::make_unique<FakeOpenSearchServer>(host, 9211, "yellow");
+        }
     }
 
     /**
@@ -74,6 +84,7 @@ protected:
     {
         m_fakeOpenSearchGreenServer.reset();
         m_fakeOpenSearchRedServer.reset();
+        m_fakeOpenSearchYellowServer.reset();
     }
 };
 

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -47,19 +47,18 @@ TEST_F(ServerSelectorTest, TestInstantiationWithoutServers)
 TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
 {
     const auto hostGreenServer {m_servers.at(0)};
-    const auto hostRedServer {m_servers.at(1)};
 
     std::string nextServer;
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers, SERVER_SELECTOR_HEALTH_CHECK_INTERVAL));
 
-    // It doesn't throw an exception because all servers are available before health check
+    // It doesn't throw an exception because the green server is available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't throw an exception because all servers are available before health check
+    // It doesn't throw an exception because the green server is available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
-    EXPECT_EQ(nextServer, hostRedServer);
+    EXPECT_EQ(nextServer, hostGreenServer);
 }
 
 /**
@@ -69,7 +68,6 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
 TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
 {
     const auto hostGreenServer {m_servers.at(0)};
-    const auto hostRedServer {m_servers.at(1)};
 
     std::string nextServer;
 
@@ -79,18 +77,18 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't throw an exception because all servers are available before health check
+    // It doesn't throw an exception because the green server is available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
-    EXPECT_EQ(nextServer, hostRedServer);
+    EXPECT_EQ(nextServer, hostGreenServer);
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(SERVER_SELECTOR_HEALTH_CHECK_INTERVAL + 5));
 
-    // next server will be the green because it's available
+    // Next server will be the green because it's available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // next server will be the green because the red server isn't available
+    // Next server will be the green because the red server isn't available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 }
@@ -102,20 +100,15 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
 TEST_F(ServerSelectorTest, TestGextNextWhenThereAreNoAvailableServers)
 {
     const auto hostRedServer {m_servers.at(1)};
+    const auto hostYellowServer {m_servers.at(2)};
 
     m_servers.clear();
     m_servers.emplace_back(hostRedServer);
+    m_servers.emplace_back(hostYellowServer);
 
     std::string nextServer;
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers, SERVER_SELECTOR_HEALTH_CHECK_INTERVAL));
-
-    // It doesn't throw an exception because all servers are available before health check
-    EXPECT_NO_THROW(nextServer = m_selector->getNext());
-    EXPECT_EQ(nextServer, hostRedServer);
-
-    // Interval to check the health of the servers
-    std::this_thread::sleep_for(std::chrono::seconds(SERVER_SELECTOR_HEALTH_CHECK_INTERVAL + 5));
 
     // It throws an exception because there are no available servers
     EXPECT_THROW(nextServer = m_selector->getNext(), std::runtime_error);

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.cpp
@@ -47,18 +47,19 @@ TEST_F(ServerSelectorTest, TestInstantiationWithoutServers)
 TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
 {
     const auto hostGreenServer {m_servers.at(0)};
+    const auto hostYellowServer {m_servers.at(2)};
 
     std::string nextServer;
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers, SERVER_SELECTOR_HEALTH_CHECK_INTERVAL));
 
-    // It doesn't throw an exception because the green server is available
+    // It doesn't throw an exception because the green and yellow servers are available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't throw an exception because the green server is available
+    // It doesn't throw an exception because the green and yellow servers are available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
-    EXPECT_EQ(nextServer, hostGreenServer);
+    EXPECT_EQ(nextServer, hostYellowServer);
 }
 
 /**
@@ -68,29 +69,30 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeHealthCheck)
 TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
 {
     const auto hostGreenServer {m_servers.at(0)};
+    const auto hostYellowServer {m_servers.at(2)};
 
     std::string nextServer;
 
     EXPECT_NO_THROW(m_selector = std::make_shared<ServerSelector>(m_servers, SERVER_SELECTOR_HEALTH_CHECK_INTERVAL));
 
-    // It doesn't throw an exception because all servers are available before health check
+    // It doesn't throw an exception because yellow and green servers are available before health check
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // It doesn't throw an exception because the green server is available
+    // It doesn't throw an exception because the green and yellow servers are available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
-    EXPECT_EQ(nextServer, hostGreenServer);
+    EXPECT_EQ(nextServer, hostYellowServer);
 
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(SERVER_SELECTOR_HEALTH_CHECK_INTERVAL + 5));
 
-    // Next server will be the green because it's available
+    // Next server will be the green because is the next available server
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
     EXPECT_EQ(nextServer, hostGreenServer);
 
-    // Next server will be the green because the red server isn't available
+    // Next server will be the yellow because the red server isn't available
     EXPECT_NO_THROW(nextServer = m_selector->getNext());
-    EXPECT_EQ(nextServer, hostGreenServer);
+    EXPECT_EQ(nextServer, hostYellowServer);
 }
 
 /**
@@ -100,11 +102,9 @@ TEST_F(ServerSelectorTest, TestGetNextBeforeAndAfterHealthCheck)
 TEST_F(ServerSelectorTest, TestGextNextWhenThereAreNoAvailableServers)
 {
     const auto hostRedServer {m_servers.at(1)};
-    const auto hostYellowServer {m_servers.at(2)};
 
     m_servers.clear();
     m_servers.emplace_back(hostRedServer);
-    m_servers.emplace_back(hostYellowServer);
 
     std::string nextServer;
 

--- a/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/serverSelector_test.hpp
@@ -30,6 +30,9 @@ protected:
     inline static std::unique_ptr<FakeOpenSearchServer>
         m_fakeOpenSearchRedServer; ///< pointer to FakeOpenSearchServer class
 
+    inline static std::unique_ptr<FakeOpenSearchServer>
+        m_fakeOpenSearchYellowServer; ///< pointer to FakeOpenSearchServer class
+
     std::shared_ptr<ServerSelector> m_selector; ///< pointer to Selector class
 
     std::vector<std::string> m_servers; ///< Servers
@@ -44,6 +47,8 @@ protected:
         m_servers.emplace_back("http://localhost:9209");
         // Register the host and port of the red server
         m_servers.emplace_back("http://localhost:9210");
+        // Register the host and port of the yellow server
+        m_servers.emplace_back("http://localhost:9211");
     }
 
     /**
@@ -63,6 +68,11 @@ protected:
         {
             m_fakeOpenSearchRedServer = std::make_unique<FakeOpenSearchServer>(host, 9210, "red");
         }
+
+        if (!m_fakeOpenSearchYellowServer)
+        {
+            m_fakeOpenSearchYellowServer = std::make_unique<FakeOpenSearchServer>(host, 9211, "yellow");
+        }
     }
 
     /**
@@ -73,6 +83,7 @@ protected:
     {
         m_fakeOpenSearchGreenServer.reset();
         m_fakeOpenSearchRedServer.reset();
+        m_fakeOpenSearchYellowServer.reset();
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -356,15 +356,16 @@ public:
                 {
                     logError(WM_VULNSCAN_LOGTAG, "Error updating feed: %s, trying to re-download the feed.", e.what());
 
+                    const auto onError = [](const std::string& msg, const long responseCode)
+                    {
+                        logError(WM_VULNSCAN_LOGTAG, "%s: %ld.", msg.c_str(), responseCode);
+                    };
+
                     const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
-                    TUNIXSocketRequest::instance().get(
-                        HttpUnixSocketURL(ONDEMAND_SOCK, url),
-                        []([[maybe_unused]] const std::string&)
-                        {
-                            // Not used
-                        },
-                        [](const std::string& msg, const long responseCode)
-                        { logError(WM_VULNSCAN_LOGTAG, "%s: %ld.", msg.c_str(), responseCode); });
+
+                    TUNIXSocketRequest::instance().get(RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, url)},
+                                                       PostRequestParameters {.onError = onError},
+                                                       ConfigurationParameters {});
                 }
             });
 
@@ -792,14 +793,16 @@ private:
 
         // Exclude from coverage because need to be tested in integration tests.
         // LCOV_EXCL_START
+
+        const auto onError = [](const std::string& msg, const long responseCode)
+        {
+            throw std::runtime_error("Error updating offset: " + msg + " - " + std::to_string(responseCode));
+        };
+
         TUNIXSocketRequest::instance().put(
-            HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"),
-            data,
-            []([[maybe_unused]] const std::string&)
-            {
-                // Not used
-            },
-            [](const std::string& msg, const long) { throw std::runtime_error("Error updating offset: " + msg); });
+            RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"), .data = data},
+            PostRequestParameters {.onError = onError},
+            ConfigurationParameters {});
         // LCOV_EXCL_STOP
     }
 
@@ -819,12 +822,15 @@ private:
 
         // Exclude from coverage because need to be tested in integration tests.
         // LCOV_EXCL_START
+        const auto onError = [](const std::string& msg, const long responseCode)
+        {
+            throw std::runtime_error("Error updating file hash: " + msg + " - " + std::to_string(responseCode));
+        };
+
         TUNIXSocketRequest::instance().put(
-            HttpUnixSocketURL(ONDEMAND_SOCK, URL),
-            std::move(data),
-            [](const std::string& msg) {},
-            [](const std::string& msg, const long responseCode)
-            { throw std::runtime_error("Error updating file hash: " + msg); });
+            RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, URL), .data = std::move(data)},
+            PostRequestParameters {.onError = onError},
+            ConfigurationParameters {});
         // LCOV_EXCL_STOP
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -361,9 +361,10 @@ public:
                         logError(WM_VULNSCAN_LOGTAG, "%s: %ld.", msg.c_str(), responseCode);
                     };
 
-                    const std::string url = "http://localhost/ondemand/" + topicName + "?offset=0";
+                    const auto url =
+                        HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/ondemand/" + topicName + "?offset=0");
 
-                    TUNIXSocketRequest::instance().get(RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, url)},
+                    TUNIXSocketRequest::instance().get(RequestParameters {.url = url},
                                                        PostRequestParameters {.onError = onError},
                                                        ConfigurationParameters {});
                 }
@@ -799,10 +800,11 @@ private:
             throw std::runtime_error("Error updating offset: " + msg + " - " + std::to_string(responseCode));
         };
 
-        TUNIXSocketRequest::instance().put(
-            RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset"), .data = data},
-            PostRequestParameters {.onError = onError},
-            ConfigurationParameters {});
+        const auto url = HttpUnixSocketURL(ONDEMAND_SOCK, "http://localhost/offset");
+
+        TUNIXSocketRequest::instance().put(RequestParameters {.url = url, .data = data},
+                                           PostRequestParameters {.onError = onError},
+                                           ConfigurationParameters {});
         // LCOV_EXCL_STOP
     }
 
@@ -827,10 +829,11 @@ private:
             throw std::runtime_error("Error updating file hash: " + msg + " - " + std::to_string(responseCode));
         };
 
-        TUNIXSocketRequest::instance().put(
-            RequestParameters {.url = HttpUnixSocketURL(ONDEMAND_SOCK, URL), .data = std::move(data)},
-            PostRequestParameters {.onError = onError},
-            ConfigurationParameters {});
+        const auto url = HttpUnixSocketURL(ONDEMAND_SOCK, URL);
+
+        TUNIXSocketRequest::instance().put(RequestParameters {.url = url, .data = std::move(data)},
+                                           PostRequestParameters {.onError = onError},
+                                           ConfigurationParameters {});
         // LCOV_EXCL_STOP
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockUnixSocketRequest.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockUnixSocketRequest.hpp
@@ -31,10 +31,9 @@ public:
      */
     MOCK_METHOD(void,
                 put,
-                (const HttpUnixSocketURL& url,
-                 const nlohmann::json& data,
-                 const std::function<void(const std::string&)>& successCallback,
-                 const std::function<void(const std::string&, const long)>& errorCallback),
+                (RequestParameters requestParameters,
+                 PostRequestParameters postRequestParameters,
+                 ConfigurationParameters configurationParameters),
                 (const));
 
     /**
@@ -42,9 +41,9 @@ public:
      */
     MOCK_METHOD(void,
                 get,
-                (const HttpUnixSocketURL& url,
-                 const std::function<void(const std::string&)>& successCallback,
-                 const std::function<void(const std::string&, const long)>& errorCallback),
+                (RequestParameters requestParameters,
+                 PostRequestParameters postRequestParameters,
+                 ConfigurationParameters configurationParameters),
                 (const));
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -852,7 +852,7 @@ void databaseFeedManagerTestGracefulShutdown()
     int putCalls = gracefullShutdownElements / OFFSET_TRANSACTION_SIZE +
                    (gracefullShutdownElements % OFFSET_TRANSACTION_SIZE ? 1 : 0);
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _)).Times(putCalls);
+    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _)).Times(putCalls);
 
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
@@ -1206,9 +1206,15 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataSuccess)
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _))
+    PostRequestParameters postRequestParams;
+    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _))
         .Times(1)
-        .WillOnce(::testing::InvokeArgument<2>(std::string {"ok"}));
+        .WillOnce(::testing::Invoke(
+            [&](RequestParameters, PostRequestParameters postRequestParams, ConfigurationParameters)
+            {
+                // Simulate the success callback
+                postRequestParams.onSuccess(std::string {"ok"});
+            }));
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
     auto spDatabaseFeedManager {
@@ -1231,9 +1237,15 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataSuccessBut
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _))
+    PostRequestParameters postRequestParams;
+    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _))
         .Times(1)
-        .WillOnce(::testing::InvokeArgument<3>(std::string {"Error"}, 400));
+        .WillOnce(::testing::Invoke(
+            [&](RequestParameters, PostRequestParameters postRequestParams, ConfigurationParameters)
+            {
+                // Simulate the success callback
+                postRequestParams.onError(std::string {"Error"}, 400);
+            }));
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
     auto spDatabaseFeedManager {
@@ -1406,7 +1418,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestRawFileWithDataSuccess)
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _, _)).Times(1);
+    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _)).Times(1);
 
     auto spIndexerConnectorTramp = std::make_shared<TrampolineIndexerConnector>();
     auto spDatabaseFeedManager {
@@ -1717,22 +1729,20 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, FileProcessingOffsetAndHashUpdat
     std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    const auto expectedOffsetPutData = R"(
-        {
-            "topicName": "topicName",
-            "offset": 0
-        }
-    )"_json;
+    const std::variant<std::string, nlohmann::json> expectedOffsetPutData =
+        nlohmann::json::object({{"topicName", "topicName"}, {"offset", 0}});
+    const std::variant<std::string, nlohmann::json> expectedHashPutData =
+        nlohmann::json::object({{"topicName", "topicName"}, {"hash", "hash_value"}});
 
-    const auto expectedHashPutData = R"(
-        {
-            "topicName": "topicName",
-            "hash": "hash_value"
-        }
-    )"_json;
+    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, _, _))
+        .Times(2)
+        .WillRepeatedly(::testing::Invoke(
+            [&](RequestParameters requestParameters, PostRequestParameters, ConfigurationParameters)
+            {
+                EXPECT_TRUE(requestParameters.data == expectedOffsetPutData ||
 
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, expectedOffsetPutData, _, _)).Times(1);
-    EXPECT_CALL(MockUnixSocketRequest::instance(), put(_, expectedHashPutData, _, _)).Times(1);
+                            requestParameters.data == expectedHashPutData);
+            }));
 
     auto spIndexerConnectorTramp {std::make_shared<TrampolineIndexerConnector>()};
     auto spDatabaseFeedManager {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -1243,7 +1243,7 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, TestOffsetFileWithDataSuccessBut
         .WillOnce(::testing::Invoke(
             [&](RequestParameters, PostRequestParameters postRequestParams, ConfigurationParameters)
             {
-                // Simulate the success callback
+                // Simulate an error callback
                 postRequestParams.onError(std::string {"Error"}, 400);
             }));
 


### PR DESCRIPTION
|Related issue|
|---|
| #25416 |

## Description
This PR improves upon the monitoring to be more reliable

To do so:
- Initializes all servers with its corresponding status
- Updates the http-request submodule to make use of timeouts
- Improves the headers used to get the indexer information to one easier-to-parse
