### PR TITLE
Update windows install/upgrade permissions

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -423,8 +423,8 @@ Public Function SetWazuhPermissions()
         grantAuthenticatedUsersPermFolder = "icacls """ & install_dir & """ /grant *S-1-5-11:RX"
         WshShell.run grantAuthenticatedUsersPermFolder, 0, True
 
-        ' Remove Authenticated Users group for ossec.conf and client.key
-        remAuthenticatedUsersPermsConf = "icacls """ & home_dir & "ossec.conf" & """ /remove *S-1-5-11 /q"
+        ' Remove Authenticated Users group for ossec.conf, last-ossec.conf  and client.key
+        remAuthenticatedUsersPermsConf = "icacls """ & home_dir & "*ossec.conf" & """ /remove *S-1-5-11 /q"
         WshShell.run remAuthenticatedUsersPermsConf, 0, True
 
         remAuthenticatedUsersPermsKeys = "icacls """ & home_dir & "client.keys" & """ /remove *S-1-5-11 /q"

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -430,6 +430,11 @@ Public Function SetWazuhPermissions()
         remAuthenticatedUsersPermsKeys = "icacls """ & home_dir & "client.keys" & """ /remove *S-1-5-11 /q"
         WshShell.run remAuthenticatedUsersPermsKeys, 0, True
 
+        ' Remove the Authenticated Users group from the tmp directory to avoid
+        ' inherited permissions on client.keys and ossec.conf when using win32ui.
+        remAuthenticatedUsersPermsTmpDir = "icacls """ & home_dir & "tmp" & """ /remove:g *S-1-5-11 /q"
+        WshShell.run remAuthenticatedUsersPermsTmpDir, 0, True
+
     End If
 End Function
 

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -402,8 +402,8 @@ Public Function SetWazuhPermissions()
         ' Remove last backslash from home_dir
         install_dir = Left(home_dir, Len(home_dir) - 1)
 
-        remEveryonePerms = "icacls """ & install_dir & """ /reset /t"
-        WshShell.run remEveryonePerms, 0, True
+        resetPerms = "icacls """ & install_dir & """ /reset /t"
+        WshShell.run resetPerms, 0, True
 
         setPermsInherit = "icacls """ & install_dir & """ /inheritancelevel:r /q"
         WshShell.run setPermsInherit, 0, True
@@ -414,27 +414,22 @@ Public Function SetWazuhPermissions()
         grantSystemPerm = "icacls """ & install_dir & """ /grant *S-1-5-18:(OI)(CI)F"
         WshShell.run grantSystemPerm, 0, True
 
-        userSID = GetUserSID()
-        grantUserPerm = "icacls """ & install_dir & """ /grant *" & userSID & ":(OI)(CI)RX"
-        WshShell.run grantUserPerm, 0, True
+        grantAuthenticatedUsersPermSubfolders = "icacls """ & install_dir & """\* /grant *S-1-5-11:(OI)(CI)RX"
+        WshShell.run grantAuthenticatedUsersPermSubfolders, 0, True
 
-        ' Remove Everyone group for ossec.conf
-        remEveryonePerms = "icacls """ & home_dir & "ossec.conf" & """ /remove *S-1-1-0 /q"
-        WshShell.run remEveryonePerms, 0, True
-    End If
-End Function
+        grantAuthenticatedUsersPermSubfiles = "icacls """ & install_dir & """\* /grant *S-1-5-11:RX"
+        WshShell.run grantAuthenticatedUsersPermSubfiles, 0, True
 
-Private Function GetUserSID()
-    GetUserSID = ""
-    Dim sDomain, oWMI, sDomUser
+        grantAuthenticatedUsersPermFolder = "icacls """ & install_dir & """ /grant *S-1-5-11:RX"
+        WshShell.run grantAuthenticatedUsersPermFolder, 0, True
 
-    sDomain = CreateObject("WScript.Network").UserDomain
-    sDomUser = CreateObject( "WScript.Shell" ).ExpandEnvironmentStrings( "%USERNAME%" )
+        ' Remove Authenticated Users group for ossec.conf and client.key
+        remAuthenticatedUsersPermsConf = "icacls """ & home_dir & "ossec.conf" & """ /remove *S-1-5-11 /q"
+        WshShell.run remAuthenticatedUsersPermsConf, 0, True
 
-    On Error Resume Next
-    Set oWMI = GetObject("winmgmts:{impersonationlevel=impersonate}!" & "/root/cimv2:Win32_UserAccount.Domain='" & sDomain & "'" & ",Name='" & sDomUser & "'")
-    If Err.Number = 0 Then
-        GetUserSID = oWMI.SID
+        remAuthenticatedUsersPermsKeys = "icacls """ & home_dir & "client.keys" & """ /remove *S-1-5-11 /q"
+        WshShell.run remAuthenticatedUsersPermsKeys, 0, True
+
     End If
 End Function
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24078|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
This PR fixes the issue caused by Installing a Windows agent using a user different from the Administrator (with administrative permissions), registering the agent, and upgrading it remotely or locally the the files become inaccessible to the current user after the upgrade.

So, based on the [proposed B](https://github.com/wazuh/wazuh/issues/24078#issuecomment-2167705851) this PR implement the following permissions:


|Actor|Object|Privilege|Inheritable|
|--|--|--|--|
|Authenticated users|Agent folder|Read / Execute|No|
|Authenticated users|All items except configuration|Read / Execute|Yes|
|SYSTEM|Agent folder|Full access|Yes|
|Administrators|Agent folder|Full access|Yes|

This will allow every user to browse the agent's folder and run the UI while preventing them from reading files containing secrets. 


## Tests

- [x]  On clean install permissions: The permissions appear to be the same as those for the upgrade.
- [x] Check for more files that could contain sensitive data. 

Files that could contain sensitive data, the only ones identified are:
- ossec.conf
- last-ossec.conf
- client.keys
- tmp folder

### Check the upgrade from 4.7.5 to this PR.
Workflow run: https://github.com/wazuh/wazuh-agent-packages/actions/runs/10683755251/job/29612558080

| Files/ <br> Folder | <p align=center>Wazuh agent 4.7.5 <br> clean install </p> | <p align=center>       changes on this PR <br>(upgrade/clean Install)</p>| 
|:-------------:|-----------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------:|
| **ossec-agent** | ![ossec-agent-folder](https://github.com/user-attachments/assets/0f4d7ff8-ab50-44db-8be9-dab911e0f8a8) | ![ossec-agent](https://github.com/user-attachments/assets/d81e6514-9ff2-4aa2-99a2-82630a674a7d) |
| **syscollector-folder** | ![syscollector-folder](https://github.com/user-attachments/assets/322764e1-a9b0-4ddf-bff3-5cb6498b3fa8) | ![syscollector-folder](https://github.com/user-attachments/assets/e49c9972-4297-4f0f-83f8-6cd998dd110e) |
| **tmp-folder** | ![tmp-folder](https://github.com/user-attachments/assets/a134d155-7122-4cf0-a0ef-f5a76c15c540) | ![tmp-folder](https://github.com/user-attachments/assets/6e2b100a-a978-4b8a-90e9-690cd149320c) |
| **client-keys** | ![client-keys](https://github.com/user-attachments/assets/e968fb7f-94a8-4467-b805-9d2136c33c7a) | ![client-keys](https://github.com/user-attachments/assets/8000c8f6-3106-4735-92f3-bd0ce303a711) |
| **ossec.conf** | ![ossec-conf](https://github.com/user-attachments/assets/cdb5cf78-35e2-44fe-b2b4-d7469cc86d87) | ![ossec-conf](https://github.com/user-attachments/assets/10a97de8-0b56-406e-9046-fabfa01b0d92) |
| **last-ossec.conf** | ![last-ossec-conf](https://github.com/user-attachments/assets/c6ec65e8-16cd-4ace-b5aa-fcf58af0a561) | ![last-ossec-conf](https://github.com/user-attachments/assets/a3b6f4c1-6de8-49a5-881a-795a2c2bb512) |
| **win32ui** | ![win32ui](https://github.com/user-attachments/assets/afa2d19b-43da-425e-9d57-2d3693bc8315) | ![win32-ui](https://github.com/user-attachments/assets/84379c4c-3dd1-49f5-a22b-5cf307ff4947) |
| **norm-config.json** | ![norm-config-json](https://github.com/user-attachments/assets/06ca4a1c-746f-4b8c-a410-12e87cb5e327) | ![norm-config-json](https://github.com/user-attachments/assets/4b86da6c-b0ed-43e7-8531-10268248a920) |

