### PR TITLE
Fix framework import in Vuln Detector integration tests

### DIFF
--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/__init__.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/__init__.py
@@ -2,7 +2,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from pathlib import Path
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 from wazuh_testing import FEEDS_PATH
 
 # Constants & base paths

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_missing_field.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_missing_field.py
@@ -54,7 +54,7 @@ from wazuh_testing.utils.configuration import (load_configuration_template, get_
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from test_vulnerability_detector.utils import check_baseline_scan_start

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_tags.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_tags.py
@@ -55,7 +55,7 @@ from wazuh_testing.utils.configuration import (load_configuration_template, get_
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES

--- a/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_values.py
+++ b/tests/integration/test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_values.py
@@ -55,7 +55,7 @@ from wazuh_testing.utils.configuration import (load_configuration_template, get_
                                                update_configuration_template)
 from wazuh_testing.utils.callbacks import generate_callback
 from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.utils.mocking import VULNERABLE_PACKAGES

--- a/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
+++ b/tests/integration/test_vulnerability_detector/test_feeds/test_duplicate_feeds.py
@@ -63,7 +63,7 @@ from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils.db_queries import cve_db
 from wazuh_testing.utils.configuration import (load_configuration_template, get_test_cases_data,
                                                update_configuration_template)
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 from wazuh_testing.modules.modulesd.configuration import MODULESD_DEBUG
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.modules.modulesd.vulnerability_detector import patterns as cb

--- a/tests/integration/test_vulnerability_detector/test_general_settings/__init__.py
+++ b/tests/integration/test_vulnerability_detector/test_general_settings/__init__.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from pathlib import Path
 from wazuh_testing import FEEDS_PATH
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 
 # Constants & base paths
 DATA_PATH = Path(Path(__file__).parent, 'data')

--- a/tests/integration/test_vulnerability_detector/test_providers/__init__.py
+++ b/tests/integration/test_vulnerability_detector/test_providers/__init__.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from pathlib import Path
 from wazuh_testing import FEEDS_PATH
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 
 # Constants & base paths
 DATA_PATH = Path(Path(__file__).parent, 'data')

--- a/tests/integration/test_vulnerability_detector/test_scan_results/__init__.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_results/__init__.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from pathlib import Path
 from wazuh_testing import FEEDS_PATH
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 
 # Constants & base paths
 DATA_PATH = Path(Path(__file__).parent, 'data')

--- a/tests/integration/test_vulnerability_detector/test_scan_types/__init__.py
+++ b/tests/integration/test_vulnerability_detector/test_scan_types/__init__.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from pathlib import Path
 from wazuh_testing import FEEDS_PATH
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 
 # Constants & base paths
 DATA_PATH = Path(Path(__file__).parent, 'data')

--- a/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/__init__.py
+++ b/tests/integration/test_vulnerability_detector/test_vulnerability_inventory/__init__.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 from pathlib import Path
 from wazuh_testing import FEEDS_PATH
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
 
 
 # Constants & base paths


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25432|

This PR aims to fix an import mistype in the Vulnerability Detector integration tests, that could remain outdated after migrating the QA Framework:

```diff
-from wazuh_testing.modules import vulnerability_detector as vd
+from wazuh_testing.modules.modulesd import vulnerability_detector as vd
```

However, these tests are deprecated:

```
=========================================== test session starts ============================================
platform linux -- Python 3.12.3, pytest-7.1.2, pluggy-1.5.0
rootdir: /root/wazuh-4.9.0/tests/integration, configfile: pytest.ini
plugins: metadata-3.1.1, html-3.1.1
collected 0 items / 29 skipped

========================================= short test summary info ==========================================
SKIPPED [1] test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_empty_fields.py:65: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_empty_vendor_version.py:64: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_missing_field.py:66: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_tags.py:66: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_cpe_helper/test_cpe_indexing_wrong_values.py:66: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_feeds/test_cpe_indexing.py:67: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_feeds/test_duplicate_feeds.py:73: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_feeds/test_import_invalid_feed_type.py:69: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_feeds/test_msu_inventory.py:76: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_general_settings/test_enabled.py:65: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_general_settings/test_interval.py:62: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_general_settings/test_min_full_scan_interval.py:69: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_general_settings/test_retry_interval.py:75: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_general_settings/test_run_on_start.py:62: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_providers/test_enabled.py:75: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_providers/test_missing_os.py:77: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_providers/test_multiple_provider_feeds.py:69: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_providers/test_update_interval.py:71: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_results/test_scan_nvd_vulnerabilities.py:75: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_results/test_scan_provider_and_nvd_vulnerabilities.py:70: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_results/test_scan_provider_vulnerabilities.py:70: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_results/test_scan_vulnerabilities_triaged_null.py:74: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_results/test_scan_vulnerability_removal.py:78: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_types/test_baseline_scan_type.py:61: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_types/test_full_scan_type.py:65: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_scan_types/test_partial_scan_type.py:65: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_baseline_scan.py:60: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_full_scan.py:60: The tests will be deprecated, they test the old Vulnerability Detector.
SKIPPED [1] test_vulnerability_detector/test_vulnerability_inventory/test_vulnerability_inventory_partial_scan.py:61: The tests will be deprecated, they test the old Vulnerability Detector.
=========================================== 29 skipped in 0.11s ============================================
```