### PR TITLE
Add path to find libatomic.a in AIX 7

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1951,7 +1951,7 @@ $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
 		ar -x libwazuhext/$$lib; \
 		mv *.o libwazuhext/; \
 	done
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc -latomic
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc -Wl,-blibpath:/opt/freeware/lib:/usr/lib:/lib -latomic
 else
 ifeq (${uname_S},HP-UX)
 $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25263|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team, this PR adds `/opt/freeware/lib` path to let the compiler locate the `libatomic.a` library for the AIX 6 and 7 case. 

**Problem context**
*  In AIX 6 there is no GCC package installed by default, in our case, the package is installed when the machine is provisioned with the [wazuh-packages script](https://github.com/wazuh/wazuh-packages/blob/master/aix/generate_wazuh_packages.sh). And checking the installed packages we find: 

```console
# rpm -q --filesbypkg libgcc-6.3.0-1 | grep "libatomic*"
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/libatomic.a
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/libatomic.la
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/ppc64/libatomic.a
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/ppc64/libatomic.la
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/pthread/libatomic.a
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/pthread/libatomic.la
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/pthread/ppc64/libatomic.a
libgcc                    /opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/pthread/ppc64/libatomic.la
libgcc                    /opt/freeware/lib/libatomic.a
libgcc                    /opt/freeware/lib/pthread/libatomic.a
libgcc                    /opt/freeware/lib/pthread/ppc64/libatomic.a
libgcc                    /opt/freeware/lib64/libatomic.a

# ls  -la /opt/freeware/lib/libatomic.a
lrwxrwxrwx    1 root     system           44 Aug 27 07:26 /opt/freeware/lib/libatomic.a -> gcc/powerpc-ibm-aix6.1.0.0/6.3.0/libatomic.a
```
The `libatomic.a`library is installed with the `libgcc-6.3.0-1` package, and checking `/opt/freeware/lib/libatomic.a` it's observer it's a symbolic link to the `/opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/ppc64/libatomic.a` file so we can simply add the `/opt/freeware/lib` path to link this library and solve the reported problem as done in https://github.com/wazuh/wazuh/commit/3e90c220f782def1fc8c4d6aa9047c8b1c69c06e.

* In AIX 7 by default the GCC 8 version is installed, so when the machine is provisioned the following message appears:

```console
# rpm -Uvh --nodeps http://packages-dev.wazuh.com/deps/aix/libgcc-6.3.0-1.aix7.2.ppc.rpm
Retrieving http://packages-dev.wazuh.com/deps/aix/libgcc-6.3.0-1.aix7.2.ppc.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
        package libgcc-1:8-1.ppc (which is newer than libgcc-6.3.0-1.ppc) is already installed
```

Performing the previous test we find the installed version is similar to AIX 6:

```console
# rpm -q --filesbypkg libgcc-8-1.ppc
libgcc                    /opt/freeware/lib/libatomic.a
libgcc                    /opt/freeware/lib/libgcc_s.a
libgcc                    /opt/freeware/lib/pthread/libatomic.a
libgcc                    /opt/freeware/lib/pthread/libgcc_s.a
libgcc                    /opt/freeware/lib/pthread/ppc64/libatomic.a
libgcc                    /opt/freeware/lib/pthread/ppc64/libgcc_s.a
libgcc                    /opt/freeware/lib64/libatomic.a
libgcc                    /opt/freeware/lib64/libgcc_s.a
# ls -la /opt/freeware/lib/libatomic.a
lrwxrwxrwx    1 root     system           40 May 19 2022  /opt/freeware/lib/libatomic.a -> gcc/powerpc-ibm-aix7.2.0.0/8/libatomic.a
```

So we can also link to the same file as mentioned previously.

It's worth mentioning that IBM advises to move the `libatomic.a` file to `/usr/lib` folder when installing it, as seen in this [documentation page](https://www.ibm.com/docs/en/connect-direct/6.3.0?topic=SS4PJT_6.3.0/cd_webservices/cd_webservices_install/cdws_install_AIX.htm) so **the reported behavior is expected if the library is not fully installed as required by IBM**.

## Testing

The proposed solution makes the compiler link with the `/opt/freeware/lib` letting the package find the library and making the agent start as expected.

This package [wazuh-agent-4.9.1-1.aix6.1.ppc.zip](https://github.com/user-attachments/files/16781763/wazuh-agent-4.9.1-1.aix6.1.ppc.zip) has been built using the `fix/25263-errors-related-to-libatomica-library-on-aix-7x` branch which implements the proposed fix. It works for both 6 and 7 AIX versions:

```console
# uname -a
AIX soaxp181 1 6 00CADA644C00

# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.9.1"
WAZUH_REVISION="40910"
WAZUH_TYPE="agent"

# /var/ossec/bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```

```console
# uname -a
AIX soaix426 2 7 00F9D80F4C00

# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.9.1"
WAZUH_REVISION="40910"
WAZUH_TYPE="agent"

# /var/ossec/bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```

On the other hand, if the [production package](https://packages.wazuh.com/4.x/aix/wazuh-agent-4.8.2-1.aix.ppc.rpm) is tested we still have the reported behavior.

```console
# rpm -qa | grep "wazuh"
wazuh-agent-4.8.2-1.ppc

# /var/ossec/bin/wazuh-control start
exec(): 0509-036 Cannot load program /var/ossec/bin/wazuh-execd because of the following errors:
        0509-022 Cannot load module /var/ossec/lib/libwazuhext.so.
        0509-150   Dependent module libatomic.a(libatomic.so.1) could not be loaded.
        0509-022 Cannot load module libatomic.a(libatomic.so.1).
        0509-026 System error: A file or directory in the path name does not exist.
        0509-022 Cannot load module wazuh-execd.
        0509-150   Dependent module /var/ossec/lib/libwazuhext.so could not be loaded.
wazuh-execd: Configuration error. Exiting
```