### PR TITLE
Update default chunck size to update agent via wpk

### DIFF
--- a/src/config/wmodules-agent-upgrade.c
+++ b/src/config/wmodules-agent-upgrade.c
@@ -151,7 +151,7 @@ int wm_agent_upgrade_read(__attribute__((unused)) const OS_XML *xml, xml_node **
                 return (OS_INVALID);
             }
             int chunk;
-            if (chunk = atoi(nodes[i]->content), chunk < 64 || chunk > 32768) {
+            if (chunk = atoi(nodes[i]->content), chunk < WM_UPGRADE_CHUNK_SIZE_MIN || chunk > WM_UPGRADE_CHUNK_SIZE_MAX) {
                 merror("Invalid content for tag '%s' at module '%s'.", XML_CHUNK_SIZE, WM_AGENT_UPGRADE_CONTEXT.name);
                 return (OS_INVALID);
             }

--- a/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
+++ b/src/wazuh_modules/agent_upgrade/wm_agent_upgrade.h
@@ -16,7 +16,9 @@
 
 #define WM_UPGRADE_WPK_REPO_URL_3_X "packages.wazuh.com/wpk/"
 #define WM_UPGRADE_WPK_REPO_URL "packages.wazuh.com/%d.x/wpk/"
-#define WM_UPGRADE_CHUNK_SIZE 512
+#define WM_UPGRADE_CHUNK_SIZE 32768
+#define WM_UPGRADE_CHUNK_SIZE_MIN 64
+#define WM_UPGRADE_CHUNK_SIZE_MAX 60000
 #define WM_UPGRADE_MAX_THREADS 8
 #define WM_UPGRADE_WAIT_START 300
 #define WM_UPGRADE_WAIT_MAX 3600


### PR DESCRIPTION
|Related issue| Related Documentation|
|---|---|
|#14856| PR [7717](https://github.com/wazuh/wazuh-documentation/pull/7717)|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

The purpose of this PR is to increase the size of the chunk size that is used when updating an agent via wpk. [Definition](https://github.com/wazuh/wazuh/issues/14856#issuecomment-1564297940)
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

Default configuration.
<!--
When proceed, this section should include new configuration parameters.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
- Memory tests for Windows
  - [x] Scan-build report
  - [ ] Coverity
- Memory tests for macOS
  - [x] Scan-build report
