### PR TITLE
Added Engine lambda logging macro

### DIFF
--- a/src/engine/source/base/include/base/logging.hpp
+++ b/src/engine/source/base/include/base/logging.hpp
@@ -1,5 +1,5 @@
-#ifndef _H_LOGGING
-#define _H_LOGGING
+#ifndef _LOGGING_HPP
+#define _LOGGING_HPP
 
 #include <iostream>
 #include <map>
@@ -8,6 +8,8 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
+
+#define LAMBDA_SEPARATOR "::<lambda>"
 
 namespace logging
 {
@@ -197,6 +199,11 @@ void stop();
  */
 void testInit();
 
+inline std::string getLambdaName(const char* parentScope, const std::string& lambdaName)
+{
+    return std::string(parentScope) + LAMBDA_SEPARATOR + lambdaName;
+}
+
 } // namespace logging
 
 #define LOG_TRACE(msg, ...)                                                                                            \
@@ -218,4 +225,26 @@ void testInit();
     logging::getDefaultLogger()->log(                                                                                  \
         spdlog::source_loc {__FILE__, __LINE__, SPDLOG_FUNCTION}, spdlog::level::critical, msg, ##__VA_ARGS__)
 
-#endif // _H_LOGGING
+#define LOG_TRACE_L(functionName, msg, ...)                                                                            \
+    logging::getDefaultLogger()->log(                                                                                  \
+        spdlog::source_loc {__FILE__, __LINE__, functionName}, spdlog::level::trace, msg, ##__VA_ARGS__)
+#define LOG_DEBUG_L(functionName, msg, ...)                                                                            \
+    logging::getDefaultLogger()->log(                                                                                  \
+        spdlog::source_loc {__FILE__, __LINE__, functionName}, spdlog::level::debug, msg, ##__VA_ARGS__)
+#define LOG_TRACE_L(functionName, msg, ...)                                                                            \
+    logging::getDefaultLogger()->log(                                                                                  \
+        spdlog::source_loc {__FILE__, __LINE__, functionName}, spdlog::level::trace, msg, ##__VA_ARGS__)
+#define LOG_INFO_L(functionName, msg, ...)                                                                             \
+    logging::getDefaultLogger()->log(                                                                                  \
+        spdlog::source_loc {__FILE__, __LINE__, functionName}, spdlog::level::info, msg, ##__VA_ARGS__)
+#define LOG_WARNING_L(functionName, msg, ...)                                                                          \
+    logging::getDefaultLogger()->log(                                                                                  \
+        spdlog::source_loc {__FILE__, __LINE__, functionName}, spdlog::level::warn, msg, ##__VA_ARGS__)
+#define LOG_ERROR_L(functionName, msg, ...)                                                                            \
+    logging::getDefaultLogger()->log(                                                                                  \
+        spdlog::source_loc {__FILE__, __LINE__, functionName}, spdlog::level::err, msg, ##__VA_ARGS__)
+#define LOG_CRITICAL_L(functionName, msg, ...)                                                                         \
+    logging::getDefaultLogger()->log(                                                                                  \
+        spdlog::source_loc {__FILE__, __LINE__, functionName}, spdlog::level::critical, msg, ##__VA_ARGS__)
+
+#endif // _LOGGING_HPP

--- a/src/engine/source/base/test/src/unit/logger_test.cpp
+++ b/src/engine/source/base/test/src/unit/logger_test.cpp
@@ -39,6 +39,24 @@ public:
     }
 };
 
+std::string testFunc(std::string lamdaName)
+{
+    auto lambda = [functionName = logging::getLambdaName(__FUNCTION__, lamdaName)]()
+    {
+        return functionName;
+    };
+
+    return lambda();
+}
+
+TEST(LoggerUtilTest, getLambdaName)
+{
+    std::string expectedFunctionName =
+        std::string("testFunc") + std::string(LAMBDA_SEPARATOR) + std::string("lambdaName");
+    std::string actualFunctionName = testFunc("lambdaName");
+    EXPECT_EQ(expectedFunctionName, actualFunctionName);
+}
+
 TEST_F(LoggerTest, LogNonExist)
 {
     ASSERT_ANY_THROW(logging::setLevel(logging::Level::Info));
@@ -107,19 +125,36 @@ TEST_P(LoggerTestLevels, LogChangeLevelInRuntime)
 
     ASSERT_NO_THROW(logging::start(logging::LoggingConfig {.filePath = m_tmpPath, .level = level}));
 
+    auto l = [functionName = logging::getLambdaName(__FUNCTION__, "lambdaName")]()
+    {
+        return functionName;
+    };
+
     LOG_TRACE("TRACE message");
+    LOG_TRACE_L(l().c_str(), "L_TRACE message");
     LOG_DEBUG("DEBUG message");
+    LOG_DEBUG_L(l().c_str(), "L_DEBUG message");
     LOG_INFO("INFO message");
+    LOG_INFO_L(l().c_str(), "L_INFO message");
     LOG_WARNING("WARNING message");
+    LOG_WARNING_L(l().c_str(), "L_WARNING message");
     LOG_ERROR("ERROR message");
+    LOG_ERROR_L(l().c_str(), "L_ERROR message");
     LOG_CRITICAL("CRITICAL message");
+    LOG_CRITICAL_L(l().c_str(), "L_CRITICAL message");
 
     checkLogFileContent("TRACE message", shouldContainMessage(level, logging::Level::Trace));
+    checkLogFileContent("L_TRACE message", shouldContainMessage(level, logging::Level::Trace));
     checkLogFileContent("DEBUG message", shouldContainMessage(level, logging::Level::Debug));
+    checkLogFileContent("L_DEBUG message", shouldContainMessage(level, logging::Level::Debug));
     checkLogFileContent("INFO message", shouldContainMessage(level, logging::Level::Info));
+    checkLogFileContent("L_INFO message", shouldContainMessage(level, logging::Level::Info));
     checkLogFileContent("WARNING message", shouldContainMessage(level, logging::Level::Warn));
+    checkLogFileContent("L_WARNING message", shouldContainMessage(level, logging::Level::Warn));
     checkLogFileContent("ERROR message", shouldContainMessage(level, logging::Level::Err));
+    checkLogFileContent("L_ERROR message", shouldContainMessage(level, logging::Level::Err));
     checkLogFileContent("CRITICAL message", shouldContainMessage(level, logging::Level::Critical));
+    checkLogFileContent("L_CRITICAL message", shouldContainMessage(level, logging::Level::Critical));
 }
 
 INSTANTIATE_TEST_CASE_P(Levels,
@@ -156,12 +191,23 @@ TEST_P(LoggerTestExtraInfo, LogPatternMatching)
 
     ASSERT_NO_THROW(logging::start(logging::LoggingConfig {.filePath = m_tmpPath, .level = level}));
 
+    auto l = [functionName = logging::getLambdaName(__FUNCTION__, "lambdaName")]()
+    {
+        return functionName;
+    };
+
     LOG_TRACE("TRACE message");
+    LOG_TRACE_L(l().c_str(), "L_TRACE message");
     LOG_DEBUG("DEBUG message");
+    LOG_DEBUG_L(l().c_str(), "L_DEBUG message");
     LOG_INFO("INFO message");
+    LOG_INFO_L(l().c_str(), "L_INFO message");
     LOG_WARNING("WARNING message");
+    LOG_WARNING_L(l().c_str(), "L_WARNING message");
     LOG_ERROR("ERROR message");
+    LOG_ERROR_L(l().c_str(), "L_ERROR message");
     LOG_CRITICAL("CRITICAL message");
+    LOG_CRITICAL_L(l().c_str(), "L_CRITICAL message");
 
     std::istringstream iss(readFileContents(m_tmpPath));
     std::string line;

--- a/src/engine/source/vdscanner/src/osScanner.hpp
+++ b/src/engine/source/vdscanner/src/osScanner.hpp
@@ -56,7 +56,8 @@ public:
 
         const auto osCPE = ScannerHelper::parseCPE(data->osCPEName(m_databaseFeedManager->cpeMappings()).data());
 
-        auto vulnerabilityScan = [&](const std::string& cnaName,
+        auto vulnerabilityScan = [&, functionName = logging::getLambdaName(__FUNCTION__, "vulnerabilityScan").c_str()](
+                                     const std::string& cnaName,
                                      const PackageData& package,
                                      const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
@@ -70,15 +71,17 @@ public:
                     std::string versionStringLessThan {version->lessThan() ? version->lessThan()->str() : ""};
                     std::string versionStringLessThanOrEqual {
                         version->lessThanOrEqual() ? version->lessThanOrEqual()->str() : ""};
-                    LOG_DEBUG("Scanning OS - '{}' (Installed Version: {}, Security Vulnerability: {}). Identified "
-                              "vulnerability: "
-                              "Version: {}. Required Version Threshold: {}. Required Version Threshold (or Equal): {}.",
-                              osCPE.product,
-                              osVersion,
-                              callbackData.cveId()->str(),
-                              versionString,
-                              versionStringLessThan,
-                              versionStringLessThanOrEqual);
+                    LOG_DEBUG_L(
+                        functionName,
+                        "Scanning OS - '{}' (Installed Version: {}, Security Vulnerability: {}). Identified "
+                        "vulnerability: "
+                        "Version: {}. Required Version Threshold: {}. Required Version Threshold (or Equal): {}.",
+                        osCPE.product,
+                        osVersion,
+                        callbackData.cveId()->str(),
+                        versionString,
+                        versionStringLessThan,
+                        versionStringLessThanOrEqual);
 
                     // No version range specified, check if the installed version is equal to the required version.
                     if (versionStringLessThan.empty() && versionStringLessThanOrEqual.empty())
@@ -89,15 +92,16 @@ public:
                             // Version match found, the package status is defined by the vulnerability status.
                             if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                             {
-                                LOG_DEBUG("Match found, the OS '{}', is vulnerable to '{}'. Current version: '{}' is "
-                                          "equal to '{}'. - Agent '{}' (ID: '{}', Version: '{}').",
-                                          osCPE.product,
-                                          callbackData.cveId()->str(),
-                                          osVersion,
-                                          versionString,
-                                          data->agentName(),
-                                          data->agentId(),
-                                          data->agentVersion());
+                                LOG_DEBUG_L(functionName,
+                                            "Match found, the OS '{}', is vulnerable to '{}'. Current version: '{}' is "
+                                            "equal to '{}'. - Agent '{}' (ID: '{}', Version: '{}').",
+                                            osCPE.product,
+                                            callbackData.cveId()->str(),
+                                            osVersion,
+                                            versionString,
+                                            data->agentName(),
+                                            data->agentId(),
+                                            data->agentVersion());
 
                                 data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
                                 data->m_matchConditions[callbackData.cveId()->str()] = {std::move(versionString),
@@ -151,7 +155,8 @@ public:
                                 // Version match found, the package status is defined by the vulnerability status.
                                 if (version->status() == NSVulnerabilityScanner::Status::Status_affected)
                                 {
-                                    LOG_DEBUG(
+                                    LOG_DEBUG_L(
+                                        functionName,
                                         "Match found, the OS '{}', is vulnerable to '{}'. Current version: "
                                         "'{}' ("
                                         "less than '{}' or equal to '{}'). - Agent '{}' (ID: '{}', Version: '{}').",
@@ -181,16 +186,18 @@ public:
                                 }
                                 else
                                 {
-                                    LOG_DEBUG("No match due to default status for OS: {}, Version: {} while scanning "
-                                              "for Vulnerability: {}, "
-                                              "Installed Version: {}, Required Version Threshold: {}, Required Version "
-                                              "Threshold (or Equal): {}",
-                                              osCPE.product,
-                                              osVersion,
-                                              callbackData.cveId()->str(),
-                                              versionString,
-                                              versionStringLessThan,
-                                              versionStringLessThanOrEqual);
+                                    LOG_DEBUG_L(
+                                        functionName,
+                                        "No match due to default status for OS: {}, Version: {} while scanning "
+                                        "for Vulnerability: {}, "
+                                        "Installed Version: {}, Required Version Threshold: {}, Required Version "
+                                        "Threshold (or Equal): {}",
+                                        osCPE.product,
+                                        osVersion,
+                                        callbackData.cveId()->str(),
+                                        versionString,
+                                        versionStringLessThan,
+                                        versionStringLessThanOrEqual);
 
                                     return false;
                                 }
@@ -202,9 +209,10 @@ public:
                 // No match found, the default status defines the package status.
                 if (callbackData.defaultStatus() == NSVulnerabilityScanner::Status::Status_affected)
                 {
-                    LOG_DEBUG("Match found for OS: {} for vulnerability: {} due to default status.",
-                              osCPE.product,
-                              callbackData.cveId()->str());
+                    LOG_DEBUG_L(functionName,
+                                "Match found for OS: {} for vulnerability: {} due to default status.",
+                                osCPE.product,
+                                callbackData.cveId()->str());
 
                     data->m_elements[callbackData.cveId()->str()] = nlohmann::json::object();
 
@@ -212,20 +220,23 @@ public:
                     return true;
                 }
 
-                LOG_DEBUG("No match due to default status for OS: {}, Version: {} while scanning for Vulnerability: {}",
-                          osCPE.product,
-                          data->osVersion(),
-                          callbackData.cveId()->str());
+                LOG_DEBUG_L(
+                    functionName,
+                    "No match due to default status for OS: {}, Version: {} while scanning for Vulnerability: {}",
+                    osCPE.product,
+                    data->osVersion(),
+                    callbackData.cveId()->str());
 
                 return false;
             }
             catch (const std::exception& e)
             {
                 // Log the warning and continue with the next vulnerability.
-                LOG_DEBUG("Failed to scan OS: '{}', CVE Numbering Authorities (CNA): '{}', Error: '{}'",
-                          osCPE.product,
-                          cnaName,
-                          e.what());
+                LOG_DEBUG_L(functionName,
+                            "Failed to scan OS: '{}', CVE Numbering Authorities (CNA): '{}', Error: '{}'",
+                            osCPE.product,
+                            cnaName,
+                            e.what());
 
                 return false;
             }

--- a/src/engine/source/vdscanner/src/osScanner.hpp
+++ b/src/engine/source/vdscanner/src/osScanner.hpp
@@ -56,11 +56,12 @@ public:
 
         const auto osCPE = ScannerHelper::parseCPE(data->osCPEName(m_databaseFeedManager->cpeMappings()).data());
 
-        auto vulnerabilityScan = [&, functionName = logging::getLambdaName(__FUNCTION__, "vulnerabilityScan").c_str()](
+        auto vulnerabilityScan = [&, getLambdaName = logging::getLambdaName(__FUNCTION__, "vulnerabilityScan")](
                                      const std::string& cnaName,
                                      const PackageData& package,
                                      const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
+            const auto functionName = getLambdaName.c_str();
             try
             {
                 VersionObjectType objectType = VersionObjectType::DPKG;

--- a/src/engine/source/vdscanner/src/packageScanner.hpp
+++ b/src/engine/source/vdscanner/src/packageScanner.hpp
@@ -82,17 +82,24 @@ private:
         const auto osPlatform = data->osPlatform().data();
         const auto translations = m_databaseFeedManager->checkAndTranslatePackage(packageCandidate, osPlatform);
 
-        auto scanPackage = [this, &data, &cnaName, &vulnerabilityScan](const PackageData& package)
+        auto scanPackage =
+            [this,
+             &data,
+             &cnaName,
+             &vulnerabilityScan,
+             functionName = logging::getLambdaName(__FUNCTION__, "scanPackage").c_str()](const PackageData& package)
         {
-            LOG_DEBUG("Initiating a vulnerability scan for package '{}' ({}) ({}) with CVE Numbering Authorities (CNA)"
-                      " '{}' on Agent '{}' (ID: '{}', Version: '{}').",
-                      package.name,
-                      package.format,
-                      package.vendor,
-                      cnaName,
-                      data->agentName(),
-                      data->agentId(),
-                      data->agentVersion());
+            LOG_DEBUG_L(
+                functionName,
+                "Initiating a vulnerability scan for package '{}' ({}) ({}) with CVE Numbering Authorities (CNA)"
+                " '{}' on Agent '{}' (ID: '{}', Version: '{}').",
+                package.name,
+                package.format,
+                package.vendor,
+                cnaName,
+                data->agentName(),
+                data->agentId(),
+                data->agentVersion());
 
             m_databaseFeedManager->getVulnerabilitiesCandidates(cnaName, package, vulnerabilityScan);
         };
@@ -551,9 +558,11 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
-        auto vulnerabilityScan = [&data, this](const std::string& cnaName,
-                                               const PackageData& package,
-                                               const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
+        auto vulnerabilityScan =
+            [&data, this, functionName = logging::getLambdaName(__FUNCTION__, "vulnerabilityScan").c_str()](
+                const std::string& cnaName,
+                const PackageData& package,
+                const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
             try
             {
@@ -591,10 +600,11 @@ public:
             catch (const std::exception& e)
             {
                 // Log the warning and continue with the next vulnerability.
-                LOG_DEBUG("Failed to scan package: '{}', CVE Numbering Authorities (CNA): '{}', Error: '{}'",
-                          package.name,
-                          cnaName,
-                          e.what());
+                LOG_DEBUG_L(functionName,
+                            "Failed to scan package: '{}', CVE Numbering Authorities (CNA): '{}', Error: '{}'",
+                            package.name,
+                            cnaName,
+                            e.what());
 
                 return false;
             }

--- a/src/engine/source/vdscanner/src/packageScanner.hpp
+++ b/src/engine/source/vdscanner/src/packageScanner.hpp
@@ -87,8 +87,9 @@ private:
              &data,
              &cnaName,
              &vulnerabilityScan,
-             functionName = logging::getLambdaName(__FUNCTION__, "scanPackage").c_str()](const PackageData& package)
+             getLambdaName = logging::getLambdaName(__FUNCTION__, "scanPackage")](const PackageData& package)
         {
+            const auto functionName = getLambdaName.c_str();
             LOG_DEBUG_L(
                 functionName,
                 "Initiating a vulnerability scan for package '{}' ({}) ({}) with CVE Numbering Authorities (CNA)"
@@ -558,12 +559,12 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
-        auto vulnerabilityScan =
-            [&data, this, functionName = logging::getLambdaName(__FUNCTION__, "vulnerabilityScan").c_str()](
-                const std::string& cnaName,
-                const PackageData& package,
-                const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
+        auto vulnerabilityScan = [&data, this, getLambdaName = logging::getLambdaName(__FUNCTION__, "scanPackage")](
+                                     const std::string& cnaName,
+                                     const PackageData& package,
+                                     const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
+            const auto functionName = getLambdaName.c_str();
             try
             {
                 /* Preliminary verifications before version matching. We return if the basic conditions are not met. */


### PR DESCRIPTION
|Related issue|
|---|
|closes #25326|

- Adds logging macros that use the provided function name in the logger.
- Adds a function to format lambda names from the parent scope __FUNTION__ variable and a specified name.
- Adds tests for the new macros and functions.
- Updated VD logging macro calls that were inside lambdas.

