### PR TITLE
Update integration test host address

### DIFF
--- a/tests/integration/test_authd/test_api_registration/conftest.py
+++ b/tests/integration/test_authd/test_api_registration/conftest.py
@@ -21,7 +21,7 @@ def wait_for_api_startup_module():
     """
     # Set the default values
     logs_format = 'plain'
-    host = '0.0.0.0'
+    host = ['0.0.0.0', '::']
     port = WAZUH_API_PORT
 
     # Check if specific values were set or set the defaults


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/25443 |

## Description

Adds support for the IPv6 localhost address to the `wait_for_api_startup_module` fixture.