### PR TITLE
Remove unused fields from the vulnerabilities index template

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -15,15 +15,14 @@
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
-          "base.tags",
           "agent.id",
           "host.os.family",
-          "host.os.full.text",
+          "host.os.full",
           "host.os.version",
           "package.name",
           "package.version",
           "vulnerability.id",
-          "vulnerability.description.text",
+          "vulnerability.description",
           "vulnerability.severity",
           "wazuh.cluster.name"
         ],
@@ -70,16 +69,7 @@
           "properties": {
             "os": {
               "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "full": {
-                  "fields": {
-                    "text": {
-                      "type": "text"
-                    }
-                  },
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -88,11 +78,6 @@
                   "type": "keyword"
                 },
                 "name": {
-                  "fields": {
-                    "text": {
-                      "type": "text"
-                    }
-                  },
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -111,9 +96,6 @@
               }
             }
           }
-        },
-        "message": {
-          "type": "text"
         },
         "package": {
           "properties": {
@@ -169,10 +151,6 @@
             }
           }
         },
-        "tags": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
         "vulnerability": {
           "properties": {
             "category": {
@@ -184,11 +162,6 @@
               "type": "keyword"
             },
             "description": {
-              "fields": {
-                "text": {
-                  "type": "text"
-                }
-              },
               "ignore_above": 1024,
               "type": "keyword"
             },


### PR DESCRIPTION
|Related issue|
|---|
| #25485 |

## Description

This PR removes the unused fields in the vulnerabilities index template.

Closes #25485 

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors