### PR TITLE
Restore FIM database data type in Wazuh DB

### DIFF
--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -46,7 +46,7 @@ constexpr auto CREATE_FILE_DB_STATEMENT
     checksum TEXT NOT NULL,
     dev INTEGER,
     inode INTEGER,
-    size BIGINT,
+    size INTEGER,
     perm TEXT,
     attributes TEXT,
     uid TEXT,

--- a/src/syscheckd/src/db/src/fimDB.hpp
+++ b/src/syscheckd/src/db/src/fimDB.hpp
@@ -88,7 +88,7 @@ constexpr auto CREATE_REGISTRY_VALUE_DB_STATEMENT
     arch TEXT CHECK (arch IN ('[x32]', '[x64]')),
     name TEXT NOT NULL,
     type INTEGER,
-    size BIGINT,
+    size INTEGER,
     hash_md5 TEXT,
     hash_sha1 TEXT,
     hash_sha256 TEXT,

--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS fim_entry (
     arch TEXT CHECK (arch IN (NULL, '[x64]', '[x32]')),
     value_name TEXT,
     value_type TEXT,
-    size BIGINT,
+    size INTEGER,
     perm TEXT,
     uid TEXT,
     gid TEXT,


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/wazuh/issues/25570|

This PR aims to revert commit 646b19af731b8a25678d1b4bc0f378c3810783f4 from PR https://github.com/wazuh/wazuh/pull/17415, since this does not produce an actual change (`BIGINT` is treated as `INTEGER`), and wazuh-db is not applying the change on existing databases.