### PR TITLE
Increase connection attempts to wazuh-db

### DIFF
--- a/src/shared/wazuhdb_op.c
+++ b/src/shared/wazuhdb_op.c
@@ -18,7 +18,7 @@
  * @return Socket descriptor or -1 if error.
  */
 int wdbc_connect() {
-    return wdbc_connect_with_attempts(3);
+    return wdbc_connect_with_attempts(5);
 }
 
 /**


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25574|

### Description
Problem During Installation metrics 4.9.0 - RC 2 Testing

The following error was found in https://ci.wazuh.info/job/Test_install/166302

This sporadic issue was primarily noticed in environments with limited CPU resources, indicating a timing issue rather than a persistent fault.

### Errors Reported
The error manifested sporadically during the initialization phase:
```
10:24:45  2024/09/02 08:21:41 wazuh-db: INFO: Created Global database backup "backup/db/global.db-backup-2024-09-02-08:21:41.gz"
10:24:45  2024/09/02 08:21:42 wazuh-remoted: ERROR: Unable to connect to socket 'queue/db/wdb'.
10:24:45  2024/09/02 08:21:42 wazuh-remoted: ERROR: Unable to connect to socket 'queue/db/wdb'.
10:24:45  2024/09/02 08:21:42 wazuh-remoted: ERROR: Error querying Wazuh DB to get agent's groups.
```

### Solution Implemented
To mitigate this error caused by limited resource, the number of connection attempts for modules connecting to wazuh-db will be increased to 5.

