### PR TITLE
Modified regexp string related to diff binary in order to avoid matching of /dev/null and /dev/full character device files

### DIFF
--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -40,7 +40,7 @@ sudo        !satori|vejeta|conf\.inv!
 crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
-diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh!
+diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^nf]ull|^/bin/.*sh!
 md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!


### PR DESCRIPTION
Newer diff binaries on various operating systems now contain string /dev/full, not just /dev/null. This change will fix false positives that report diff binary as a trojaned version of /bin/diff.

Related issues:
Closes #13278
Closes #19000
Closes #19346
Closes #11808

contribution

## Description
The root of the problem is that newer diff binaries contain not just /dev/null string but also /dev/full string.

The command `strings /usr/bin/diff | grep /dev/` can be used to check this.

In order to fix the false postives, regexp for the diff binary has been changed in order to exclude both, /dev/null and /dev/full character device files.
