### PR TITLE
Content Manager - Avoid error log when provider name is not found

### DIFF
--- a/src/shared_modules/content_manager/src/contentModuleFacade.cpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.cpp
@@ -46,16 +46,14 @@ void ContentModuleFacade::addProvider(const std::string& name, const nlohmann::j
 void ContentModuleFacade::startScheduling(const std::string& name, size_t interval)
 {
     std::shared_lock<std::shared_mutex> lock {m_mutex};
-    const auto providerIt {m_providers.find(name)};
-    if (providerIt == m_providers.end())
-    {
-        logDebug1(WM_CONTENTUPDATER, "Couldn't start scheduled action: Provider '%s' not found.", name);
-        return;
-    }
-
     try
     {
-        providerIt->second->startActionScheduler(interval);
+        if (const auto providerIt {m_providers.find(name)}; providerIt != m_providers.end())
+        {
+            providerIt->second->startActionScheduler(interval);
+            return;
+        }
+        logDebug1(WM_CONTENTUPDATER, "Couldn't start scheduled action: Provider '%s' not found.", name.c_str());
     }
     catch (const std::exception& e)
     {
@@ -65,16 +63,14 @@ void ContentModuleFacade::startScheduling(const std::string& name, size_t interv
 void ContentModuleFacade::startOndemand(const std::string& name)
 {
     std::shared_lock<std::shared_mutex> lock {m_mutex};
-    const auto providerIt {m_providers.find(name)};
-    if (providerIt == m_providers.end())
-    {
-        logDebug1(WM_CONTENTUPDATER, "Couldn't start on-demand action: Provider '%s' not found.", name);
-        return;
-    }
-
     try
     {
-        providerIt->second->startOnDemandAction();
+        if (const auto providerIt {m_providers.find(name)}; providerIt != m_providers.end())
+        {
+            providerIt->second->startOnDemandAction();
+            return;
+        }
+        logDebug1(WM_CONTENTUPDATER, "Couldn't start on-demand action: Provider '%s' not found.", name.c_str());
     }
     catch (const std::exception& e)
     {
@@ -85,16 +81,14 @@ void ContentModuleFacade::startOndemand(const std::string& name)
 void ContentModuleFacade::changeSchedulerInterval(const std::string& name, const size_t interval)
 {
     std::shared_lock<std::shared_mutex> lock {m_mutex};
-    const auto providerIt {m_providers.find(name)};
-    if (providerIt == m_providers.end())
-    {
-        logDebug1(WM_CONTENTUPDATER, "Couldn't change scheduled interval: Provider '%s' not found.", name);
-        return;
-    }
-
     try
     {
-        providerIt->second->changeSchedulerInterval(interval);
+        if (const auto providerIt {m_providers.find(name)}; providerIt != m_providers.end())
+        {
+            providerIt->second->changeSchedulerInterval(interval);
+            return;
+        }
+        logDebug1(WM_CONTENTUPDATER, "Couldn't change scheduled interval: Provider '%s' not found.", name.c_str());
     }
     catch (const std::exception& e)
     {

--- a/src/shared_modules/content_manager/src/contentModuleFacade.cpp
+++ b/src/shared_modules/content_manager/src/contentModuleFacade.cpp
@@ -46,9 +46,16 @@ void ContentModuleFacade::addProvider(const std::string& name, const nlohmann::j
 void ContentModuleFacade::startScheduling(const std::string& name, size_t interval)
 {
     std::shared_lock<std::shared_mutex> lock {m_mutex};
+    const auto providerIt {m_providers.find(name)};
+    if (providerIt == m_providers.end())
+    {
+        logDebug1(WM_CONTENTUPDATER, "Couldn't start scheduled action: Provider '%s' not found.", name);
+        return;
+    }
+
     try
     {
-        m_providers.at(name)->startActionScheduler(interval);
+        providerIt->second->startActionScheduler(interval);
     }
     catch (const std::exception& e)
     {
@@ -58,9 +65,16 @@ void ContentModuleFacade::startScheduling(const std::string& name, size_t interv
 void ContentModuleFacade::startOndemand(const std::string& name)
 {
     std::shared_lock<std::shared_mutex> lock {m_mutex};
+    const auto providerIt {m_providers.find(name)};
+    if (providerIt == m_providers.end())
+    {
+        logDebug1(WM_CONTENTUPDATER, "Couldn't start on-demand action: Provider '%s' not found.", name);
+        return;
+    }
+
     try
     {
-        m_providers.at(name)->startOnDemandAction();
+        providerIt->second->startOnDemandAction();
     }
     catch (const std::exception& e)
     {
@@ -71,9 +85,16 @@ void ContentModuleFacade::startOndemand(const std::string& name)
 void ContentModuleFacade::changeSchedulerInterval(const std::string& name, const size_t interval)
 {
     std::shared_lock<std::shared_mutex> lock {m_mutex};
+    const auto providerIt {m_providers.find(name)};
+    if (providerIt == m_providers.end())
+    {
+        logDebug1(WM_CONTENTUPDATER, "Couldn't change scheduled interval: Provider '%s' not found.", name);
+        return;
+    }
+
     try
     {
-        m_providers.at(name)->changeSchedulerInterval(interval);
+        providerIt->second->changeSchedulerInterval(interval);
     }
     catch (const std::exception& e)
     {

--- a/src/shared_modules/content_manager/tests/component/contentModuleFacade_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/contentModuleFacade_test.cpp
@@ -11,6 +11,8 @@
 
 #include "contentModuleFacade_test.hpp"
 #include "contentModuleFacade.hpp"
+#include "defer.hpp"
+#include "loggerHelper.h"
 #include "stringHelper.h"
 #include <filesystem>
 #include <memory>
@@ -163,9 +165,17 @@ TEST_F(ContentModuleFacadeTest, TestSingletonAndChangeSchedulerIntervalWithoutPr
 
     EXPECT_EQ(&contentModuleFacade, &ContentModuleFacade::instance());
 
-    EXPECT_NO_THROW(contentModuleFacade.start({}));
+    auto logCalled {false};
+    const auto logFunction {[&logCalled](const int level, ...)
+                            {
+                                logCalled = true;
+                                ASSERT_EQ(level, LOGLEVEL_DEBUG);
+                            }};
+    Log::assignLogFunction(logFunction);
+    DEFER([]() { Log::deassignLogFunction(); });
 
     EXPECT_NO_THROW(contentModuleFacade.changeSchedulerInterval(topicName, interval + 1));
+    EXPECT_TRUE(logCalled);
 
     std::this_thread::sleep_for(std::chrono::seconds(interval + 1));
 
@@ -229,9 +239,17 @@ TEST_F(ContentModuleFacadeTest, TestSingletonAndStartOnDemandWithoutProvider)
 
     EXPECT_EQ(&contentModuleFacade, &ContentModuleFacade::instance());
 
-    EXPECT_NO_THROW(contentModuleFacade.start({}));
+    auto logCalled {false};
+    const auto logFunction {[&logCalled](const int level, ...)
+                            {
+                                logCalled = true;
+                                ASSERT_EQ(level, LOGLEVEL_DEBUG);
+                            }};
+    Log::assignLogFunction(logFunction);
+    DEFER([]() { Log::deassignLogFunction(); });
 
     EXPECT_NO_THROW(contentModuleFacade.startOndemand(topicName));
+    EXPECT_TRUE(logCalled);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
@@ -297,9 +315,17 @@ TEST_F(ContentModuleFacadeTest, TestSingletonAndStartSchedulingWithoutProvider)
 
     EXPECT_EQ(&contentModuleFacade, &ContentModuleFacade::instance());
 
-    EXPECT_NO_THROW(contentModuleFacade.start({}));
+    auto logCalled {false};
+    const auto logFunction {[&logCalled](const int level, ...)
+                            {
+                                logCalled = true;
+                                ASSERT_EQ(level, LOGLEVEL_DEBUG);
+                            }};
+    Log::assignLogFunction(logFunction);
+    DEFER([]() { Log::deassignLogFunction(); });
 
     EXPECT_NO_THROW(contentModuleFacade.startScheduling(topicName, interval));
+    EXPECT_TRUE(logCalled);
 
     std::this_thread::sleep_for(std::chrono::seconds(interval + 1));
 


### PR DESCRIPTION
|Related issue|
|---|
|#25575|

## Description

This PR aims to better handle and error found in the Content Manager module when the scheduling was started but the provider name was not found due to a race condition.

With these changes, no more error logs should be raised when this happens.

## Results

The expected logs (debug level) should now be:
```
wazuh-modulesd:content-updater: DEBUG: Couldn't start scheduled action: Provider 'content' not found.
wazuh-modulesd:content-updater: DEBUG: Couldn't start on-demand action: Provider 'content' not found.
```