### PR TITLE
Support macOS 15 "Sequoia" name in agent

### DIFF
--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -438,6 +438,7 @@ bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
         {"21", "Monterey"},
         {"22", "Ventura"},
         {"23", "Sonoma"},
+        {"24", "Sequoia"},
     };
     constexpr auto PATTERN_MATCH{"[0-9]+"};
     std::string match;

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -377,6 +377,7 @@ const char *OSX_ReleaseName(int version) {
     /* 21 */ "Monterey",
     /* 22 */ "Ventura",
     /* 23 */ "Sonoma",
+    /* 24 */ "Sequoia",
     };
 
     version -= 10;


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25652|

This PR adds support for macOS 15 "Sequoia" to the Wazuh agent, ensuring proper version detection and system inventory reporting.

Changes include:
- Legacy version detection component
- DataProvider (Syscollector base)

The new macOS release was integrated based on the early known details of macOS 15.