### PR TITLE
Fix uncaught exception in keystore testtool (non production toool).

### DIFF
--- a/src/shared_modules/keystore/testtool/main.cpp
+++ b/src/shared_modules/keystore/testtool/main.cpp
@@ -9,10 +9,10 @@
  * Foundation.
  */
 
-#include "testtoolArgsParser.hpp"
 #include "keyStore.hpp"
-#include <iostream>
+#include "testtoolArgsParser.hpp"
 #include <functional>
+#include <iostream>
 
 namespace Log
 {
@@ -23,13 +23,13 @@ namespace Log
 
 int main(int argc, char* argv[])
 {
-    CmdLineArgs args(argc, argv);
-    std::string key = args.getKey();
-    std::string column = args.getColumnFamily();
-    std::string value = args.getValue();
-
     try
     {
+        CmdLineArgs args(argc, argv);
+        std::string key = args.getKey();
+        std::string column = args.getColumnFamily();
+        std::string value = args.getValue();
+
         if (value.empty())
         {
             Keystore::get(column, key, value);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25608|

## Description
This issue aims to caught an exception during the argument parsing of the keystore testtool.



#### Previous the changes
```
➜  src git:(4.9.1) ✗ ./build/shared_modules/keystore/testtool/wazuh-keystore-testtool     
terminate called after throwing an instance of 'std::runtime_error'
  what():  Switch value: -k not found.
[1]    414340 IOT instruction (core dumped)  ./build/shared_modules/keystore/testtool/wazuh-keystore-testtool
```

#### After the changes
```
➜  src git:(bug/25608-fix-uncaught-exception) ✗ ./build/shared_modules/keystore/testtool/wazuh-keystore-testtool                     
Switch value: -k not found.
```