### PR TITLE
Update PyServer test workflows

### DIFF
--- a/.github/workflows/comms-api-unit-tests.yml
+++ b/.github/workflows/comms-api-unit-tests.yml
@@ -1,0 +1,36 @@
+name: Comms API unit tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/comms-api-unit-tests.yml'
+      - 'apis/comms_api/**'
+      - 'src/Makefile'
+
+jobs:
+  build: 
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+    env:
+      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework:/home/runner/work/wazuh/wazuh/apis/comms_api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'framework/requirements-dev.txt'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r framework/requirements-dev.txt --no-build-isolation
+
+      - name: Run API tests
+        run: python -m pytest apis/comms_api --cov

--- a/.github/workflows/integration-tests-api-tier-0-1.yml
+++ b/.github/workflows/integration-tests-api-tier-0-1.yml
@@ -9,11 +9,12 @@ on:
         default: 'main'
   pull_request:
     paths:
-        - ".github/workflows/integration-tests-api-tier-0-1.yml"
-        - "api/**"
-        - "src/Makefile"
-        - "tests/integration/conftest.py"
-        - "tests/integration/test_api/**"
+      - ".github/workflows/integration-tests-api-tier-0-1.yml"
+      - "api/**"
+      - "src/Makefile"
+      - "tests/integration/conftest.py"
+      - "tests/integration/test_api/**"
+      - "!tests/integration/test_api/test_rbac/**"
 
 jobs:
   build:

--- a/.github/workflows/integration-tests-api-tier-0-1.yml
+++ b/.github/workflows/integration-tests-api-tier-0-1.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64

--- a/.github/workflows/integration-tests-api-tier-2.yml
+++ b/.github/workflows/integration-tests-api-tier-2.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64

--- a/.github/workflows/integration-tests-api-tier-2.yml
+++ b/.github/workflows/integration-tests-api-tier-2.yml
@@ -7,6 +7,14 @@ on:
         description: 'Base branch'
         required: true
         default: 'main'
+  pull_request:
+    paths:
+      - ".github/workflows/integration-tests-api-tier-2.yml"
+      - "api/**"
+      - "src/Makefile"
+      - "tests/integration/conftest.py"
+      - "tests/integration/test_api/**"
+      - "!tests/integration/test_api/test_rbac/**"
 
 jobs:
   build:

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64

--- a/.github/workflows/integration-tests-rbac-tier-0-1.yml
+++ b/.github/workflows/integration-tests-rbac-tier-0-1.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64


### PR DESCRIPTION
|Related issue|
|---|
| Closes #25646 |

## Description

Adds the Comms API unit tests and updates AIT tier 0/1 and 2 pull request paths and bumps the `checkout` and `setup-python` github action versions.

> [!Note]
> Integration tests are expected to fail because `master` does not compile at the moment.