### PR TITLE
Fix tier 2 FIM IT fail first test

### DIFF
--- a/.github/workflows/integration-tests-fim-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-0-1-win.yml
@@ -99,5 +99,6 @@ jobs:
       # Run fim integration tests.
       - name: Run fim integration tests
         run: |
+          NET START wazuh
           cd C:\wazuh\tests\integration
           python -m pytest --tier 0 --tier 1 test_fim\

--- a/.github/workflows/integration-tests-fim-tier-2-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-2-win.yml
@@ -1,4 +1,4 @@
-name: Integration tests for FIM on Windows - Tier 0 and 1
+name: Integration tests for FIM on Windows - Tier 2
 
 on:
   workflow_dispatch:
@@ -90,5 +90,6 @@ jobs:
       # Run fim integration tests.
       - name: Run fim integration tests
         run: |
+          NET START wazuh
           cd C:\wazuh\tests\integration
           python -m pytest --tier 2 test_fim\


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25563|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
In this PR we are going to include a small fix in the FIM integration test execution workflows, in which it is necessary to start the Wazuh agent before executing the tests, otherwise the first test will fail because the ossec.log does not exist yet.