### PR TITLE
Retrieve vulnerability description with ADPs' data

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -227,10 +227,11 @@ nlohmann::json IndexerConnector::getAgentDocumentsIds(const std::string& url,
             throw std::runtime_error(error);
         };
 
-        HTTPRequest::instance().post(
-            RequestParameters {.url = HttpURL(url + "/" + m_indexName + "/_search?scroll=1m"), .data = postData.dump()},
-            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
-            ConfigurationParameters {});
+        HTTPRequest::instance().post(RequestParameters {.url = HttpURL(url + "/" + m_indexName + "/_search?scroll=1m"),
+                                                        .data = postData.dump(),
+                                                        .secureCommunication = secureCommunication},
+                                     PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
+                                     ConfigurationParameters {});
     }
 
     // If the response have more than ELEMENTS_PER_QUERY elements, we need to scroll.

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -99,6 +99,29 @@ struct FlatbufferDataPair final
 };
 
 /**
+ * @brief A struct for storing a pair of FlatBuffers data.
+ *
+ *  The detached buffer is responsible for the lifetime of the data.
+ *
+ * @tparam FlatbufferType The type of the FlatBuffers object that this struct represents.
+ */
+template<typename FlatbufferType>
+struct DetachedFlatbufferDataPair final
+{
+    /**
+     * @brief The detached buffer. It results from builder.Release() .
+     *
+     */
+    flatbuffers::DetachedBuffer detachedBuffer;
+
+    /**
+     * @brief The pointer to the flatbuffer data ready to be used.
+     *
+     */
+    const FlatbufferType* data = nullptr;
+};
+
+/**
  * @brief TranslatedData structure.
  *
  * This structure holds translated data, including the translated product and vendor information.
@@ -648,12 +671,18 @@ public:
      * @brief Gets descriptive information for a cveid.
      *
      * @param cveId cveid to search.
+     * @param adpShortName short name of the ADP.
+     * @param adpSubShortName sub short name of the ADP.
      * @param resultContainer container struct to store the result.
      */
     void getVulnerabiltyDescriptiveInformation(const std::string_view cveId,
-                                               FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+                                               const std::string& adpShortName,
+                                               const std::string& adpSubShortName,
+                                               DetachedFlatbufferDataPair<VulnerabilityDescription>& resultContainer)
     {
-        if (m_feedDatabase->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN) == false)
+        nlohmann::json sourceAdp;
+
+        if (GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(adpSubShortName))
         {
             sourceAdp = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adpSubShortName);
         }
@@ -671,8 +700,6 @@ public:
         auto referenceSourceAdp = sourceAdp.contains(ADP_REFERENCE_KEY)
                                       ? sourceAdp.at(ADP_REFERENCE_KEY).get<std::string>()
                                       : sourceAdp.at(ADP_DESCRIPTION_KEY).get<std::string>();
-        auto cweIdSourceAdp =
-            sourceAdp.contains(ADP_CWE_ID_KEY) ? sourceAdp.at(ADP_CWE_ID_KEY).get<std::string>() : DEFAULT_ADP;
 
         // The key for the default ADP doesn't append the ADP name.
         auto stringCveId = std::string(cveId);
@@ -680,22 +707,25 @@ public:
         {
             return sourceAdp == DEFAULT_ADP ? stringCveId : stringCveId + "_" + sourceAdp;
         };
-        auto cveCvssKey {cveKeyLambda(cvssSourceAdp)};
-        auto cveDescriptionKey {cveKeyLambda(descriptionSourceAdp)};
-        auto cveReferenceKey {cveKeyLambda(referenceSourceAdp)};
-        auto cveCweIdKey {cveKeyLambda(cweIdSourceAdp)};
+        const auto cveDefaultKey {cveKeyLambda(DEFAULT_ADP)};
+        const auto cveCvssKey {cveKeyLambda(cvssSourceAdp)};
+        const auto cveDescriptionKey {cveKeyLambda(descriptionSourceAdp)};
+        const auto cveReferenceKey {cveKeyLambda(referenceSourceAdp)};
 
+        FlatbufferDataPair<VulnerabilityDescription> defaultContainer;
         FlatbufferDataPair<VulnerabilityDescription> cvssContainer;
         FlatbufferDataPair<VulnerabilityDescription> descriptionContainer;
         FlatbufferDataPair<VulnerabilityDescription> referenceContainer;
-        FlatbufferDataPair<VulnerabilityDescription> cweIdContainer;
 
         auto getAndVerifyLambda = [&](const std::string& key, FlatbufferDataPair<VulnerabilityDescription>& container)
         {
             if (m_feedDatabase->get(key, container.slice, DESCRIPTIONS_COLUMN) == false)
             {
-                throw std::runtime_error(
-                    "Error getting VulnerabilityDescription object from rocksdb. Object not found for key: " + key);
+                if (m_feedDatabase->get(cveDefaultKey, container.slice, DESCRIPTIONS_COLUMN) == false)
+                {
+                    throw std::runtime_error(
+                        "Error getting VulnerabilityDescription object from rocksdb. Object not found for key: " + key);
+                }
             }
 
             if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(container.slice.data()),
@@ -711,19 +741,89 @@ public:
         };
 
         // We try to minimize the number of calls to the database.
-        getAndVerifyLambda(cveCvssKey, cvssContainer);
+        getAndVerifyLambda(cveDefaultKey, defaultContainer);
+
+        if (cveDefaultKey == cveCvssKey)
+        {
+            cvssContainer.data = defaultContainer.data;
+        }
+        else
+        {
+            getAndVerifyLambda(cveCvssKey, cvssContainer);
+        }
 
         if (cveCvssKey == cveDescriptionKey)
         {
             descriptionContainer.data = cvssContainer.data;
+        }
+        else if (cveDefaultKey == cveDescriptionKey)
+        {
+            descriptionContainer.data = defaultContainer.data;
         }
         else
         {
             getAndVerifyLambda(cveDescriptionKey, descriptionContainer);
         }
 
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        if (cveDescriptionKey == cveReferenceKey)
+        {
+            referenceContainer.data = descriptionContainer.data;
+        }
+        else if (cveDefaultKey == cveReferenceKey)
+        {
+            referenceContainer.data = defaultContainer.data;
+        }
+        else
+        {
+            getAndVerifyLambda(cveReferenceKey, referenceContainer);
+        }
+
+        // If the data exists but isn't valid, we use the default ADP.
+        if (cvssContainer.data->severity()->str().empty())
+        {
+            cvssContainer.data = defaultContainer.data;
+        }
+        if (descriptionContainer.data->description()->str() == "not defined")
+        {
+            descriptionContainer.data = defaultContainer.data;
+            if (cveReferenceKey == cveDescriptionKey)
+            {
+                referenceContainer.data = descriptionContainer.data;
+            }
+        }
+
+        // Some values are the same for all the ADPs.
+        const auto& assignerShortName = defaultContainer.data->assignerShortName();
+        const auto& datePublished = defaultContainer.data->datePublished();
+        const auto& dateUpdated = defaultContainer.data->dateUpdated();
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(
+            builder,
+            cvssContainer.data->accessComplexity()->c_str(),
+            assignerShortName->c_str(),
+            cvssContainer.data->attackVector()->c_str(),
+            cvssContainer.data->authentication()->c_str(),
+            cvssContainer.data->availabilityImpact()->c_str(),
+            cvssContainer.data->classification()->c_str(),
+            cvssContainer.data->confidentialityImpact()->c_str(),
+            defaultContainer.data->cweId()->c_str(),
+            datePublished->c_str(),
+            dateUpdated->c_str(),
+            descriptionContainer.data->description()->c_str(),
+            cvssContainer.data->integrityImpact()->c_str(),
+            cvssContainer.data->privilegesRequired()->c_str(),
+            referenceContainer.data->reference()->c_str(),
+            cvssContainer.data->scope()->c_str(),
+            cvssContainer.data->scoreBase(),
+            cvssContainer.data->scoreVersion()->c_str(),
+            cvssContainer.data->severity()->c_str(),
+            cvssContainer.data->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -645,35 +645,32 @@ public:
     // LCOV_EXCL_STOP
 
     /**
-     * @brief Gets descriptive information for a cveid.
+     * @brief Gets descriptive information for a given CVE ID and CNA/ADP.
      *
      * @param cveId CVE ID to get the information.
-     * @param shortName Short name of the CNA/ADP.
+     * @param subShortName Expanded CNA/ADP name (Ex. nvd, suse_server_15, redhat_8)
      * @param resultContainer container struct to store the result.
+     *
+     * @return true if the information was successfully retrieved, false otherwise.
      */
-    void getVulnerabiltyDescriptiveInformation(const std::string_view cveId,
-                                               const std::string& shortName,
+    bool getVulnerabiltyDescriptiveInformation(const std::string& cveId,
+                                               const std::string& subShortName,
                                                FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
     {
-        const auto cnaAdpName = std::string(DESCRIPTIONS_COLUMN) + "_" + shortName;
-
-        if (m_feedDatabase->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN) == false)
+        if (const auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + subShortName;
+            m_feedDatabase->get(cveId, resultContainer.slice, descriptionColumn) == false)
         {
-            throw std::runtime_error(
-                "Error getting VulnerabilityDescription object from rocksdb. Object not found for cveId: " +
-                std::string(cveId));
-        }
-
-        if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
-                                           resultContainer.slice.size());
-            NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
-        {
-            throw std::runtime_error(
-                "Error getting VulnerabilityDescription object from rocksdb. FlatBuffers verifier failed");
+            logDebug2(WM_VULNSCAN_LOGTAG,
+                      "Vulnerability description not found for %s in %s.",
+                      cveId.c_str(),
+                      descriptionColumn.c_str());
+            return false;
         }
 
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
             NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+
+        return true;
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -39,6 +39,13 @@ constexpr auto DATABASE_PATH {"queue/vd/feed"};
 constexpr auto OFFSET_TRANSACTION_SIZE {1000};
 constexpr auto EMPTY_KEY {""};
 
+constexpr auto DEFAULT_ADP {"nvd"};
+constexpr auto ADP_CVSS_KEY {"cvss"};
+constexpr auto ADP_DESCRIPTION_KEY {"description"};
+constexpr auto ADP_REFERENCE_KEY {"reference"};
+constexpr auto ADP_CWE_ID_KEY {"cwe"};
+constexpr auto ADP_DESCRIPTIONS_MAP_KEY {"adp_descriptions"};
+
 /**
  * @brief Enum to access the fields of the FileProcessingResult tuple.
  *
@@ -648,17 +655,71 @@ public:
     {
         if (m_feedDatabase->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN) == false)
         {
-            throw std::runtime_error(
-                "Error getting VulnerabilityDescription object from rocksdb. Object not found for cveId: " +
-                std::string(cveId));
+            sourceAdp = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adpSubShortName);
+        }
+        else if (GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(adpShortName))
+        {
+            sourceAdp = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adpShortName);
+        }
+        else
+        {
+            sourceAdp = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
         }
 
-        if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
-                                           resultContainer.slice.size());
-            NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+        auto cvssSourceAdp = sourceAdp.at(ADP_CVSS_KEY).get<std::string>();
+        auto descriptionSourceAdp = sourceAdp.at(ADP_DESCRIPTION_KEY).get<std::string>();
+        auto referenceSourceAdp = sourceAdp.contains(ADP_REFERENCE_KEY)
+                                      ? sourceAdp.at(ADP_REFERENCE_KEY).get<std::string>()
+                                      : sourceAdp.at(ADP_DESCRIPTION_KEY).get<std::string>();
+        auto cweIdSourceAdp =
+            sourceAdp.contains(ADP_CWE_ID_KEY) ? sourceAdp.at(ADP_CWE_ID_KEY).get<std::string>() : DEFAULT_ADP;
+
+        // The key for the default ADP doesn't append the ADP name.
+        auto stringCveId = std::string(cveId);
+        auto cveKeyLambda = [&](const std::string& sourceAdp) -> std::string
         {
-            throw std::runtime_error(
-                "Error getting VulnerabilityDescription object from rocksdb. FlatBuffers verifier failed");
+            return sourceAdp == DEFAULT_ADP ? stringCveId : stringCveId + "_" + sourceAdp;
+        };
+        auto cveCvssKey {cveKeyLambda(cvssSourceAdp)};
+        auto cveDescriptionKey {cveKeyLambda(descriptionSourceAdp)};
+        auto cveReferenceKey {cveKeyLambda(referenceSourceAdp)};
+        auto cveCweIdKey {cveKeyLambda(cweIdSourceAdp)};
+
+        FlatbufferDataPair<VulnerabilityDescription> cvssContainer;
+        FlatbufferDataPair<VulnerabilityDescription> descriptionContainer;
+        FlatbufferDataPair<VulnerabilityDescription> referenceContainer;
+        FlatbufferDataPair<VulnerabilityDescription> cweIdContainer;
+
+        auto getAndVerifyLambda = [&](const std::string& key, FlatbufferDataPair<VulnerabilityDescription>& container)
+        {
+            if (m_feedDatabase->get(key, container.slice, DESCRIPTIONS_COLUMN) == false)
+            {
+                throw std::runtime_error(
+                    "Error getting VulnerabilityDescription object from rocksdb. Object not found for key: " + key);
+            }
+
+            if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(container.slice.data()),
+                                               container.slice.size());
+                !NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier))
+            {
+                throw std::runtime_error("Error getting VulnerabilityDescription object from rocksdb for " + key +
+                                         ". FlatBuffers verifier failed.");
+            }
+
+            container.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                NSVulnerabilityScanner::GetVulnerabilityDescription(container.slice.data()));
+        };
+
+        // We try to minimize the number of calls to the database.
+        getAndVerifyLambda(cveCvssKey, cvssContainer);
+
+        if (cveCvssKey == cveDescriptionKey)
+        {
+            descriptionContainer.data = cvssContainer.data;
+        }
+        else
+        {
+            getAndVerifyLambda(cveDescriptionKey, descriptionContainer);
         }
 
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -99,29 +99,6 @@ struct FlatbufferDataPair final
 };
 
 /**
- * @brief A struct for storing a pair of FlatBuffers data.
- *
- *  The detached buffer is responsible for the lifetime of the data.
- *
- * @tparam FlatbufferType The type of the FlatBuffers object that this struct represents.
- */
-template<typename FlatbufferType>
-struct DetachedFlatbufferDataPair final
-{
-    /**
-     * @brief The detached buffer. It results from builder.Release() .
-     *
-     */
-    flatbuffers::DetachedBuffer detachedBuffer;
-
-    /**
-     * @brief The pointer to the flatbuffer data ready to be used.
-     *
-     */
-    const FlatbufferType* data = nullptr;
-};
-
-/**
  * @brief TranslatedData structure.
  *
  * This structure holds translated data, including the translated product and vendor information.
@@ -670,160 +647,33 @@ public:
     /**
      * @brief Gets descriptive information for a cveid.
      *
-     * @param cveId cveid to search.
-     * @param adpShortName short name of the ADP.
-     * @param adpSubShortName sub short name of the ADP.
+     * @param cveId CVE ID to get the information.
+     * @param shortName Short name of the CNA/ADP.
      * @param resultContainer container struct to store the result.
      */
     void getVulnerabiltyDescriptiveInformation(const std::string_view cveId,
-                                               const std::string& adpShortName,
-                                               const std::string& adpSubShortName,
-                                               DetachedFlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+                                               const std::string& shortName,
+                                               FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
     {
-        nlohmann::json sourceAdp;
+        const auto cnaAdpName = std::string(DESCRIPTIONS_COLUMN) + "_" + shortName;
 
-        if (GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(adpSubShortName))
+        if (m_feedDatabase->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN) == false)
         {
-            sourceAdp = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adpSubShortName);
-        }
-        else if (GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(adpShortName))
-        {
-            sourceAdp = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adpShortName);
-        }
-        else
-        {
-            sourceAdp = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
+            throw std::runtime_error(
+                "Error getting VulnerabilityDescription object from rocksdb. Object not found for cveId: " +
+                std::string(cveId));
         }
 
-        auto cvssSourceAdp = sourceAdp.at(ADP_CVSS_KEY).get<std::string>();
-        auto descriptionSourceAdp = sourceAdp.at(ADP_DESCRIPTION_KEY).get<std::string>();
-        auto referenceSourceAdp = sourceAdp.contains(ADP_REFERENCE_KEY)
-                                      ? sourceAdp.at(ADP_REFERENCE_KEY).get<std::string>()
-                                      : sourceAdp.at(ADP_DESCRIPTION_KEY).get<std::string>();
-
-        // The key for the default ADP doesn't append the ADP name.
-        auto stringCveId = std::string(cveId);
-        auto cveKeyLambda = [&](const std::string& adp) -> std::string
+        if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                           resultContainer.slice.size());
+            NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
         {
-            return stringCveId + "_" + adp;
-        };
-        const auto cveDefaultKey {cveKeyLambda(DEFAULT_ADP)};
-        const auto cveCvssKey {cveKeyLambda(cvssSourceAdp)};
-        const auto cveDescriptionKey {cveKeyLambda(descriptionSourceAdp)};
-        const auto cveReferenceKey {cveKeyLambda(referenceSourceAdp)};
-
-        FlatbufferDataPair<VulnerabilityDescription> defaultContainer;
-        FlatbufferDataPair<VulnerabilityDescription> cvssContainer;
-        FlatbufferDataPair<VulnerabilityDescription> descriptionContainer;
-        FlatbufferDataPair<VulnerabilityDescription> referenceContainer;
-
-        auto getAndVerifyLambda = [&](const std::string& key, FlatbufferDataPair<VulnerabilityDescription>& container)
-        {
-            if (m_feedDatabase->get(key, container.slice, DESCRIPTIONS_COLUMN) == false)
-            {
-                if (m_feedDatabase->get(cveDefaultKey, container.slice, DESCRIPTIONS_COLUMN) == false)
-                {
-                    throw std::runtime_error(
-                        "Error getting VulnerabilityDescription object from rocksdb. Object not found for key: " + key);
-                }
-            }
-
-            if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(container.slice.data()),
-                                               container.slice.size());
-                !NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier))
-            {
-                throw std::runtime_error("Error getting VulnerabilityDescription object from rocksdb for " + key +
-                                         ". FlatBuffers verifier failed.");
-            }
-
-            container.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-                NSVulnerabilityScanner::GetVulnerabilityDescription(container.slice.data()));
-        };
-
-        // We try to minimize the number of calls to the database.
-        getAndVerifyLambda(cveDefaultKey, defaultContainer);
-
-        if (cveDefaultKey == cveCvssKey)
-        {
-            cvssContainer.data = defaultContainer.data;
-        }
-        else
-        {
-            getAndVerifyLambda(cveCvssKey, cvssContainer);
+            throw std::runtime_error(
+                "Error getting VulnerabilityDescription object from rocksdb. FlatBuffers verifier failed");
         }
 
-        if (cveCvssKey == cveDescriptionKey)
-        {
-            descriptionContainer.data = cvssContainer.data;
-        }
-        else if (cveDefaultKey == cveDescriptionKey)
-        {
-            descriptionContainer.data = defaultContainer.data;
-        }
-        else
-        {
-            getAndVerifyLambda(cveDescriptionKey, descriptionContainer);
-        }
-
-        if (cveDescriptionKey == cveReferenceKey)
-        {
-            referenceContainer.data = descriptionContainer.data;
-        }
-        else if (cveDefaultKey == cveReferenceKey)
-        {
-            referenceContainer.data = defaultContainer.data;
-        }
-        else
-        {
-            getAndVerifyLambda(cveReferenceKey, referenceContainer);
-        }
-
-        // If the data exists but isn't valid, we use the default ADP.
-        if (cvssContainer.data->severity()->str().empty())
-        {
-            cvssContainer.data = defaultContainer.data;
-        }
-        if (descriptionContainer.data->description()->str() == "not defined")
-        {
-            descriptionContainer.data = defaultContainer.data;
-            if (cveReferenceKey == cveDescriptionKey)
-            {
-                referenceContainer.data = descriptionContainer.data;
-            }
-        }
-
-        // Some values are the same for all the ADPs.
-        const auto& assignerShortName = defaultContainer.data->assignerShortName();
-        const auto& datePublished = defaultContainer.data->datePublished();
-        const auto& dateUpdated = defaultContainer.data->dateUpdated();
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(
-            builder,
-            cvssContainer.data->accessComplexity()->c_str(),
-            assignerShortName->c_str(),
-            cvssContainer.data->attackVector()->c_str(),
-            cvssContainer.data->authentication()->c_str(),
-            cvssContainer.data->availabilityImpact()->c_str(),
-            cvssContainer.data->classification()->c_str(),
-            cvssContainer.data->confidentialityImpact()->c_str(),
-            defaultContainer.data->cweId()->c_str(),
-            datePublished->c_str(),
-            dateUpdated->c_str(),
-            descriptionContainer.data->description()->c_str(),
-            cvssContainer.data->integrityImpact()->c_str(),
-            cvssContainer.data->privilegesRequired()->c_str(),
-            referenceContainer.data->reference()->c_str(),
-            cvssContainer.data->scope()->c_str(),
-            cvssContainer.data->scoreBase(),
-            cvssContainer.data->scoreVersion()->c_str(),
-            cvssContainer.data->severity()->c_str(),
-            cvssContainer.data->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -664,6 +664,7 @@ public:
                       "Vulnerability description not found for %s in %s.",
                       cveId.c_str(),
                       descriptionColumn.c_str());
+            resultContainer.data = nullptr;
             return false;
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -703,9 +703,9 @@ public:
 
         // The key for the default ADP doesn't append the ADP name.
         auto stringCveId = std::string(cveId);
-        auto cveKeyLambda = [&](const std::string& sourceAdp) -> std::string
+        auto cveKeyLambda = [&](const std::string& adp) -> std::string
         {
-            return sourceAdp == DEFAULT_ADP ? stringCveId : stringCveId + "_" + sourceAdp;
+            return stringCveId + "_" + adp;
         };
         const auto cveDefaultKey {cveKeyLambda(DEFAULT_ADP)};
         const auto cveCvssKey {cveKeyLambda(cvssSourceAdp)};

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -39,7 +39,6 @@ public:
     {
         auto storeDescriptionLambda = [&](std::variant<const cve_v5::Cna*, const cve_v5::Adp*> container)
         {
-            // Missing metrics object is valid in a CVE5 schema.
             const flatbuffers::Vector<flatbuffers::Offset<cve_v5::Metric>>* metricsArray = nullptr;
             const flatbuffers::Vector<flatbuffers::Offset<cve_v5::Description>>* descriptionArray = nullptr;
             const flatbuffers::Vector<flatbuffers::Offset<cve_v5::Reference>>* referencesArray = nullptr;
@@ -61,8 +60,7 @@ public:
                 },
                 container);
 
-            auto cve5Metadata = cve5Flatbuffer->cveMetadata();
-
+            // Required fields to create the vulnerability description.
             float vulnDescFBScoreBase = 0.0;
             std::string vulnDescFBClassificationStr;
             std::string vulnDescFBDescriptionStr;
@@ -83,10 +81,12 @@ public:
             std::string vulnDescFBScopeStr;
             std::string vulnDescFBUserInteractionStr;
 
+            // Extract the description if it exists.
             if (descriptionArray)
             {
                 for (const auto& field : *descriptionArray)
                 {
+                    // We are only interested in the English description.
                     if (field->lang()->str().compare("en") == 0)
                     {
                         vulnDescFBDescriptionStr = field->value()->str();
@@ -94,7 +94,13 @@ public:
                     }
                 }
             }
+            // Empty description is not CVE5 Compliant.
+            if (vulnDescFBDescriptionStr.empty())
+            {
+                return;
+            }
 
+            // Extract the references if they exist.
             if (referencesArray)
             {
                 for (const auto& field : *referencesArray)
@@ -105,170 +111,171 @@ public:
                         vulnDescFBReferenceStr += ", ";
                     }
                 }
+                // Remove the last comma and space.
+                vulnDescFBReferenceStr = vulnDescFBReferenceStr.substr(0, vulnDescFBReferenceStr.size() - 2);
             }
-
-            vulnDescFBReferenceStr = vulnDescFBReferenceStr.substr(0, vulnDescFBReferenceStr.size() - 2);
-
-            // Empty description or empty URL reference are not CVE5 Compliant.
-            if (!(vulnDescFBDescriptionStr.empty() || vulnDescFBReferenceStr.empty()))
+            // Empty reference is not CVE5 Compliant.
+            if (vulnDescFBReferenceStr.empty())
             {
-                flatbuffers::FlatBufferBuilder builder;
-
-                if (metricsArray)
-                {
-                    for (const auto& field : *metricsArray)
-                    {
-                        auto metricCVSSV3_1 = field->cvssV3_1();
-                        auto metricCVSSV3_0 = field->cvssV3_0();
-                        auto metricCVSSV2_0 = field->cvssV2_0();
-                        if (metricCVSSV3_1)
-                        {
-                            vulnDescFBScoreBase = metricCVSSV3_1->baseScore();
-                            vulnDescFBSeverityStr =
-                                (metricCVSSV3_1->baseSeverity()) ? metricCVSSV3_1->baseSeverity()->str() : "";
-                            vulnDescFBScoreVersionStr =
-                                (metricCVSSV3_1->version()) ? metricCVSSV3_1->version()->str() : "";
-                            vulnDescFBClassificationStr = (field->format()) ? field->format()->str() : "";
-                            vulnDescFBAvailabilityStr = (metricCVSSV3_1->availabilityImpact())
-                                                            ? metricCVSSV3_1->availabilityImpact()->str()
-                                                            : "";
-                            vulnDescFBConfidentialityImpactStr = (metricCVSSV3_1->confidentialityImpact())
-                                                                     ? metricCVSSV3_1->confidentialityImpact()->str()
-                                                                     : "";
-                            vulnDescFBIntegrityImpactStr =
-                                (metricCVSSV3_1->integrityImpact()) ? metricCVSSV3_1->integrityImpact()->str() : "";
-                            vulnDescFBPrivilegesRequiredStr = (metricCVSSV3_1->privilegesRequired())
-                                                                  ? metricCVSSV3_1->privilegesRequired()->str()
-                                                                  : "";
-                            vulnDescFBScopeStr = (metricCVSSV3_1->scope()) ? metricCVSSV3_1->scope()->str() : "";
-                            vulnDescFBUserInteractionStr =
-                                (metricCVSSV3_1->userInteraction()) ? metricCVSSV3_1->userInteraction()->str() : "";
-                            break;
-                        }
-                        else if (metricCVSSV3_0)
-                        {
-                            vulnDescFBScoreBase = metricCVSSV3_0->baseScore();
-                            vulnDescFBSeverityStr =
-                                (metricCVSSV3_0->baseSeverity()) ? metricCVSSV3_0->baseSeverity()->str() : "";
-                            vulnDescFBScoreVersionStr =
-                                (metricCVSSV3_0->version()) ? metricCVSSV3_0->version()->str() : "";
-                            vulnDescFBClassificationStr = (field->format()) ? field->format()->str() : "";
-                            vulnDescFBAttackVectorStr =
-                                (metricCVSSV3_0->attackVector()) ? metricCVSSV3_0->attackVector()->str() : "";
-                            vulnDescFBAvailabilityStr = (metricCVSSV3_0->availabilityImpact())
-                                                            ? metricCVSSV3_0->availabilityImpact()->str()
-                                                            : "";
-                            vulnDescFBConfidentialityImpactStr = (metricCVSSV3_0->confidentialityImpact())
-                                                                     ? metricCVSSV3_0->confidentialityImpact()->str()
-                                                                     : "";
-                            vulnDescFBIntegrityImpactStr =
-                                (metricCVSSV3_0->integrityImpact()) ? metricCVSSV3_0->integrityImpact()->str() : "";
-                            vulnDescFBPrivilegesRequiredStr = (metricCVSSV3_0->privilegesRequired())
-                                                                  ? metricCVSSV3_0->privilegesRequired()->str()
-                                                                  : "";
-                            vulnDescFBScopeStr = (metricCVSSV3_0->scope()) ? metricCVSSV3_0->scope()->str() : "";
-                            vulnDescFBUserInteractionStr =
-                                (metricCVSSV3_0->userInteraction()) ? metricCVSSV3_0->userInteraction()->str() : "";
-                            break;
-                        }
-                        else if (metricCVSSV2_0)
-                        {
-                            vulnDescFBScoreBase = metricCVSSV2_0->baseScore();
-                            vulnDescFBSeverityStr = (vulnDescFBScoreBase < 4.0)   ? "LOW"
-                                                    : (vulnDescFBScoreBase < 7.0) ? "MEDIUM"
-                                                                                  : "HIGH";
-                            vulnDescFBScoreVersionStr =
-                                (metricCVSSV2_0->version()) ? metricCVSSV2_0->version()->str() : "";
-                            vulnDescFBClassificationStr = (field->format()) ? field->format()->str() : "";
-                            vulnDescFBAccessComplexityStr =
-                                (metricCVSSV2_0->accessComplexity()) ? metricCVSSV2_0->accessComplexity()->str() : "";
-                            vulnDescFBAuthenticationStr =
-                                (metricCVSSV2_0->authentication()) ? metricCVSSV2_0->authentication()->str() : "";
-                            vulnDescFBAvailabilityStr = (metricCVSSV2_0->availabilityImpact())
-                                                            ? metricCVSSV2_0->availabilityImpact()->str()
-                                                            : "";
-                            vulnDescFBConfidentialityImpactStr = (metricCVSSV2_0->confidentialityImpact())
-                                                                     ? metricCVSSV2_0->confidentialityImpact()->str()
-                                                                     : "";
-                            vulnDescFBIntegrityImpactStr =
-                                (metricCVSSV2_0->integrityImpact()) ? metricCVSSV2_0->integrityImpact()->str() : "";
-                            break;
-                        }
-                    }
-                }
-
-                if (cve5Metadata)
-                {
-                    vulnDescFBAssignerStr =
-                        (cve5Metadata->assignerShortName()) ? cve5Metadata->assignerShortName()->str() : "";
-                    vulnDescFBDataPublishedStr =
-                        (cve5Metadata->datePublished()) ? cve5Metadata->datePublished()->str() : "";
-                    vulnDescFBDataUpdatedStr = (cve5Metadata->dateUpdated()) ? cve5Metadata->dateUpdated()->str() : "";
-                }
-
-                if (problemTypesArray)
-                {
-                    auto problemTypesDescriptionsArray = problemTypesArray->Get(0);
-                    if (problemTypesDescriptionsArray)
-                    {
-                        auto descriptionsProblemTypesArray = problemTypesDescriptionsArray->descriptions();
-                        if (descriptionsProblemTypesArray)
-                        {
-                            vulnDescFBCWEIdStr = (descriptionsProblemTypesArray->Get(0)->cweId())
-                                                     ? descriptionsProblemTypesArray->Get(0)->cweId()->str()
-                                                     : "";
-                        }
-                    }
-                }
-
-                auto vulnerabilityDescriptionFB = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(
-                    builder,
-                    vulnDescFBAccessComplexityStr.c_str(),
-                    vulnDescFBAssignerStr.c_str(),
-                    vulnDescFBAttackVectorStr.c_str(),
-                    vulnDescFBAuthenticationStr.c_str(),
-                    vulnDescFBAvailabilityStr.c_str(),
-                    vulnDescFBClassificationStr.c_str(),
-                    vulnDescFBConfidentialityImpactStr.c_str(),
-                    vulnDescFBCWEIdStr.c_str(),
-                    vulnDescFBDataPublishedStr.c_str(),
-                    vulnDescFBDataUpdatedStr.c_str(),
-                    vulnDescFBDescriptionStr.c_str(),
-                    vulnDescFBIntegrityImpactStr.c_str(),
-                    vulnDescFBPrivilegesRequiredStr.c_str(),
-                    vulnDescFBReferenceStr.c_str(),
-                    vulnDescFBScopeStr.c_str(),
-                    vulnDescFBScoreBase,
-                    vulnDescFBScoreVersionStr.c_str(),
-                    vulnDescFBSeverityStr.c_str(),
-                    vulnDescFBUserInteractionStr.c_str());
-
-                builder.Finish(vulnerabilityDescriptionFB);
-
-                const uint8_t* buffer = builder.GetBufferPointer();
-                size_t flatbufferSize = builder.GetSize();
-
-                std::string key {cve5Flatbuffer->cveMetadata()->cveId()->str()};
-
-                const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer),
-                                                                   flatbufferSize);
-
-                const auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + subShortName;
-
-                if (!feedDatabase->columnExists(descriptionColumn))
-                {
-                    feedDatabase->createColumn(descriptionColumn);
-                }
-
-                feedDatabase->put(key, VulnerabilityDescriptionSlice, descriptionColumn);
+                return;
             }
+
+            // Extract the CVSS score and severity if they exist.
+            if (metricsArray)
+            {
+                // We only extract one CVSS metric type. Priority is V3.1, then V3.0, and finally V2.0.
+                for (const auto& field : *metricsArray)
+                {
+                    auto metricCVSSV3_1 = field->cvssV3_1();
+                    if (metricCVSSV3_1)
+                    {
+                        vulnDescFBScoreBase = metricCVSSV3_1->baseScore();
+                        vulnDescFBSeverityStr =
+                            (metricCVSSV3_1->baseSeverity()) ? metricCVSSV3_1->baseSeverity()->str() : "";
+                        vulnDescFBScoreVersionStr = (metricCVSSV3_1->version()) ? metricCVSSV3_1->version()->str() : "";
+                        vulnDescFBClassificationStr = (field->format()) ? field->format()->str() : "";
+                        vulnDescFBAvailabilityStr =
+                            (metricCVSSV3_1->availabilityImpact()) ? metricCVSSV3_1->availabilityImpact()->str() : "";
+                        vulnDescFBConfidentialityImpactStr = (metricCVSSV3_1->confidentialityImpact())
+                                                                 ? metricCVSSV3_1->confidentialityImpact()->str()
+                                                                 : "";
+                        vulnDescFBIntegrityImpactStr =
+                            (metricCVSSV3_1->integrityImpact()) ? metricCVSSV3_1->integrityImpact()->str() : "";
+                        vulnDescFBPrivilegesRequiredStr =
+                            (metricCVSSV3_1->privilegesRequired()) ? metricCVSSV3_1->privilegesRequired()->str() : "";
+                        vulnDescFBScopeStr = (metricCVSSV3_1->scope()) ? metricCVSSV3_1->scope()->str() : "";
+                        vulnDescFBUserInteractionStr =
+                            (metricCVSSV3_1->userInteraction()) ? metricCVSSV3_1->userInteraction()->str() : "";
+                        break;
+                    }
+
+                    auto metricCVSSV3_0 = field->cvssV3_0();
+                    if (metricCVSSV3_0)
+                    {
+                        vulnDescFBScoreBase = metricCVSSV3_0->baseScore();
+                        vulnDescFBSeverityStr =
+                            (metricCVSSV3_0->baseSeverity()) ? metricCVSSV3_0->baseSeverity()->str() : "";
+                        vulnDescFBScoreVersionStr = (metricCVSSV3_0->version()) ? metricCVSSV3_0->version()->str() : "";
+                        vulnDescFBClassificationStr = (field->format()) ? field->format()->str() : "";
+                        vulnDescFBAttackVectorStr =
+                            (metricCVSSV3_0->attackVector()) ? metricCVSSV3_0->attackVector()->str() : "";
+                        vulnDescFBAvailabilityStr =
+                            (metricCVSSV3_0->availabilityImpact()) ? metricCVSSV3_0->availabilityImpact()->str() : "";
+                        vulnDescFBConfidentialityImpactStr = (metricCVSSV3_0->confidentialityImpact())
+                                                                 ? metricCVSSV3_0->confidentialityImpact()->str()
+                                                                 : "";
+                        vulnDescFBIntegrityImpactStr =
+                            (metricCVSSV3_0->integrityImpact()) ? metricCVSSV3_0->integrityImpact()->str() : "";
+                        vulnDescFBPrivilegesRequiredStr =
+                            (metricCVSSV3_0->privilegesRequired()) ? metricCVSSV3_0->privilegesRequired()->str() : "";
+                        vulnDescFBScopeStr = (metricCVSSV3_0->scope()) ? metricCVSSV3_0->scope()->str() : "";
+                        vulnDescFBUserInteractionStr =
+                            (metricCVSSV3_0->userInteraction()) ? metricCVSSV3_0->userInteraction()->str() : "";
+                        break;
+                    }
+
+                    auto metricCVSSV2_0 = field->cvssV2_0();
+                    if (metricCVSSV2_0)
+                    {
+                        vulnDescFBScoreBase = metricCVSSV2_0->baseScore();
+                        vulnDescFBSeverityStr = (vulnDescFBScoreBase < 4.0)   ? "LOW"
+                                                : (vulnDescFBScoreBase < 7.0) ? "MEDIUM"
+                                                                              : "HIGH";
+                        vulnDescFBScoreVersionStr = (metricCVSSV2_0->version()) ? metricCVSSV2_0->version()->str() : "";
+                        vulnDescFBClassificationStr = (field->format()) ? field->format()->str() : "";
+                        vulnDescFBAccessComplexityStr =
+                            (metricCVSSV2_0->accessComplexity()) ? metricCVSSV2_0->accessComplexity()->str() : "";
+                        vulnDescFBAuthenticationStr =
+                            (metricCVSSV2_0->authentication()) ? metricCVSSV2_0->authentication()->str() : "";
+                        vulnDescFBAvailabilityStr =
+                            (metricCVSSV2_0->availabilityImpact()) ? metricCVSSV2_0->availabilityImpact()->str() : "";
+                        vulnDescFBConfidentialityImpactStr = (metricCVSSV2_0->confidentialityImpact())
+                                                                 ? metricCVSSV2_0->confidentialityImpact()->str()
+                                                                 : "";
+                        vulnDescFBIntegrityImpactStr =
+                            (metricCVSSV2_0->integrityImpact()) ? metricCVSSV2_0->integrityImpact()->str() : "";
+                        break;
+                    }
+                }
+            }
+
+            // Extract the metadata if it exists.
+            if (const auto cve5Metadata = cve5Flatbuffer->cveMetadata(); cve5Metadata)
+            {
+                vulnDescFBAssignerStr =
+                    (cve5Metadata->assignerShortName()) ? cve5Metadata->assignerShortName()->str() : "";
+                vulnDescFBDataPublishedStr =
+                    (cve5Metadata->datePublished()) ? cve5Metadata->datePublished()->str() : "";
+                vulnDescFBDataUpdatedStr = (cve5Metadata->dateUpdated()) ? cve5Metadata->dateUpdated()->str() : "";
+            }
+
+            // Extract the problem types if they exist.
+            if (problemTypesArray)
+            {
+                auto problemTypesDescriptionsArray = problemTypesArray->Get(0);
+                if (problemTypesDescriptionsArray)
+                {
+                    auto descriptionsProblemTypesArray = problemTypesDescriptionsArray->descriptions();
+                    if (descriptionsProblemTypesArray)
+                    {
+                        vulnDescFBCWEIdStr = (descriptionsProblemTypesArray->Get(0)->cweId())
+                                                 ? descriptionsProblemTypesArray->Get(0)->cweId()->str()
+                                                 : "";
+                    }
+                }
+            }
+
+            // Build the vulnerability description flatbuffer.
+            flatbuffers::FlatBufferBuilder builder;
+
+            auto vulnerabilityDescriptionFB =
+                NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                             vulnDescFBAccessComplexityStr.c_str(),
+                                                                             vulnDescFBAssignerStr.c_str(),
+                                                                             vulnDescFBAttackVectorStr.c_str(),
+                                                                             vulnDescFBAuthenticationStr.c_str(),
+                                                                             vulnDescFBAvailabilityStr.c_str(),
+                                                                             vulnDescFBClassificationStr.c_str(),
+                                                                             vulnDescFBConfidentialityImpactStr.c_str(),
+                                                                             vulnDescFBCWEIdStr.c_str(),
+                                                                             vulnDescFBDataPublishedStr.c_str(),
+                                                                             vulnDescFBDataUpdatedStr.c_str(),
+                                                                             vulnDescFBDescriptionStr.c_str(),
+                                                                             vulnDescFBIntegrityImpactStr.c_str(),
+                                                                             vulnDescFBPrivilegesRequiredStr.c_str(),
+                                                                             vulnDescFBReferenceStr.c_str(),
+                                                                             vulnDescFBScopeStr.c_str(),
+                                                                             vulnDescFBScoreBase,
+                                                                             vulnDescFBScoreVersionStr.c_str(),
+                                                                             vulnDescFBSeverityStr.c_str(),
+                                                                             vulnDescFBUserInteractionStr.c_str());
+
+            builder.Finish(vulnerabilityDescriptionFB);
+
+            // Generate the key and column name where the description will be stored.
+            const auto cveId {cve5Flatbuffer->cveMetadata()->cveId()->str()};
+            const auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + subShortName;
+
+            if (!feedDatabase->columnExists(descriptionColumn))
+            {
+                feedDatabase->createColumn(descriptionColumn);
+            }
+
+            // Store the description in the database.
+            const uint8_t* buffer = builder.GetBufferPointer();
+            size_t flatbufferSize = builder.GetSize();
+            const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer), flatbufferSize);
+
+            feedDatabase->put(cveId, VulnerabilityDescriptionSlice, descriptionColumn);
         };
 
+        // Store the description for the CNA
         if (cve5Flatbuffer->containers() && cve5Flatbuffer->containers()->cna())
         {
             storeDescriptionLambda(cve5Flatbuffer->containers()->cna());
         }
 
+        // Store the description for the ADPs
         if (cve5Flatbuffer->containers() && cve5Flatbuffer->containers()->adp())
         {
             for (const auto& adp : *cve5Flatbuffer->containers()->adp())

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -40,17 +40,27 @@ public:
         auto storeDescriptionLambda = [&](std::variant<const cve_v5::Cna*, const cve_v5::Adp*> container)
         {
             // Missing metrics object is valid in a CVE5 schema.
-            auto metricsArray = std::visit([](auto&& arg) { return arg->metrics(); }, container);
-            auto descriptionArray = std::visit([](auto&& arg) { return arg->descriptions(); }, container);
-            auto referencesArray = std::visit([](auto&& arg) { return arg->references(); }, container);
-            auto problemTypesArray = std::visit([](auto&& arg) { return arg->problemTypes(); }, container);
-            auto subShortName = std::visit(
-                [](auto&& arg)
+            const flatbuffers::Vector<flatbuffers::Offset<cve_v5::Metric>>* metricsArray = nullptr;
+            const flatbuffers::Vector<flatbuffers::Offset<cve_v5::Description>>* descriptionArray = nullptr;
+            const flatbuffers::Vector<flatbuffers::Offset<cve_v5::Reference>>* referencesArray = nullptr;
+            const flatbuffers::Vector<flatbuffers::Offset<cve_v5::ProblemType>>* problemTypesArray = nullptr;
+            std::string subShortName;
+
+            std::visit(
+                [&](auto&& arg)
                 {
-                    return arg->providerMetadata()->x_subShortName() ? arg->providerMetadata()->x_subShortName()->str()
-                                                                     : arg->providerMetadata()->shortName()->str();
+                    auto&& forwardedArg = std::forward<decltype(arg)>(arg);
+
+                    metricsArray = forwardedArg->metrics();
+                    descriptionArray = forwardedArg->descriptions();
+                    referencesArray = forwardedArg->references();
+                    problemTypesArray = forwardedArg->problemTypes();
+                    subShortName = forwardedArg->providerMetadata()->x_subShortName()
+                                       ? forwardedArg->providerMetadata()->x_subShortName()->str()
+                                       : forwardedArg->providerMetadata()->shortName()->str();
                 },
                 container);
+
             auto cve5Metadata = cve5Flatbuffer->cveMetadata();
 
             float vulnDescFBScoreBase = 0.0;
@@ -239,21 +249,18 @@ public:
                 size_t flatbufferSize = builder.GetSize();
 
                 std::string key {cve5Flatbuffer->cveMetadata()->cveId()->str()};
-                // We don't modify the key for the default CNA to keep retrocompatibility.
-                if (subShortName != DEFAULT_ADP_SUBSHORT_NAME)
-                {
-                    key += "_" + subShortName;
-                }
 
                 const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer),
                                                                    flatbufferSize);
 
-                if (!feedDatabase->columnExists(DESCRIPTIONS_COLUMN))
+                const auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + subShortName;
+
+                if (!feedDatabase->columnExists(descriptionColumn))
                 {
-                    feedDatabase->createColumn(DESCRIPTIONS_COLUMN);
+                    feedDatabase->createColumn(descriptionColumn);
                 }
 
-                feedDatabase->put(key, VulnerabilityDescriptionSlice, DESCRIPTIONS_COLUMN);
+                feedDatabase->put(key, VulnerabilityDescriptionSlice, descriptionColumn);
             }
         };
 
@@ -285,13 +292,17 @@ public:
             return;
         }
 
-        if (!feedDatabase->columnExists(DESCRIPTIONS_COLUMN))
-        {
-            return;
-        }
+        const auto columns = feedDatabase->getAllColumns();
 
-        std::string key {data->cveMetadata()->cveId()->str()};
-        feedDatabase->delete_(key, DESCRIPTIONS_COLUMN);
+        for (const auto& column : columns)
+        {
+            // If the column start with the prefix DESCRIPTIONS_COLUMN, then it is a description column.
+            if (column.find(DESCRIPTIONS_COLUMN) == 0)
+            {
+                std::string key {data->cveMetadata()->cveId()->str()};
+                feedDatabase->delete_(key, column);
+            }
+        }
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -18,6 +18,8 @@
 #include "vulnerabilityScanner.hpp"
 #include <variant>
 
+constexpr auto DEFAULT_ADP_SUBSHORT_NAME {"nvd"};
+
 /**
  * @brief UpdateCVEDescription class.
  *
@@ -238,7 +240,7 @@ public:
 
                 std::string key {cve5Flatbuffer->cveMetadata()->cveId()->str()};
                 // We don't modify the key for the default CNA to keep retrocompatibility.
-                if (subShortName != DEFAULT_CNA)
+                if (subShortName != DEFAULT_ADP_SUBSHORT_NAME)
                 {
                     key += "_" + subShortName;
                 }

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -16,6 +16,7 @@
 #include "rocksDBWrapper.hpp"
 #include "vulnerabilityDescription_generated.h"
 #include "vulnerabilityScanner.hpp"
+#include <variant>
 
 /**
  * @brief UpdateCVEDescription class.
@@ -34,14 +35,20 @@ public:
     static void storeVulnerabilityDescription(const cve_v5::Entry* cve5Flatbuffer,
                                               std::shared_ptr<Utils::RocksDBWrapper> feedDatabase)
     {
-        if (cve5Flatbuffer->containers() && cve5Flatbuffer->containers()->cna())
+        auto storeDescriptionLambda = [&](std::variant<const cve_v5::Cna*, const cve_v5::Adp*> container)
         {
-            auto cna = cve5Flatbuffer->containers()->cna();
             // Missing metrics object is valid in a CVE5 schema.
-            auto metricsArray = cna->metrics();
-            auto descriptionArray = cna->descriptions();
-            auto referencesArray = cna->references();
-            auto problemTypesArray = cna->problemTypes();
+            auto metricsArray = std::visit([](auto&& arg) { return arg->metrics(); }, container);
+            auto descriptionArray = std::visit([](auto&& arg) { return arg->descriptions(); }, container);
+            auto referencesArray = std::visit([](auto&& arg) { return arg->references(); }, container);
+            auto problemTypesArray = std::visit([](auto&& arg) { return arg->problemTypes(); }, container);
+            auto subShortName = std::visit(
+                [](auto&& arg)
+                {
+                    return arg->providerMetadata()->x_subShortName() ? arg->providerMetadata()->x_subShortName()->str()
+                                                                     : arg->providerMetadata()->shortName()->str();
+                },
+                container);
             auto cve5Metadata = cve5Flatbuffer->cveMetadata();
 
             float vulnDescFBScoreBase = 0.0;
@@ -230,6 +237,12 @@ public:
                 size_t flatbufferSize = builder.GetSize();
 
                 std::string key {cve5Flatbuffer->cveMetadata()->cveId()->str()};
+                // We don't modify the key for the default CNA to keep retrocompatibility.
+                if (subShortName != DEFAULT_CNA)
+                {
+                    key += "_" + subShortName;
+                }
+
                 const rocksdb::Slice VulnerabilityDescriptionSlice(reinterpret_cast<const char*>(buffer),
                                                                    flatbufferSize);
 
@@ -239,6 +252,19 @@ public:
                 }
 
                 feedDatabase->put(key, VulnerabilityDescriptionSlice, DESCRIPTIONS_COLUMN);
+            }
+        };
+
+        if (cve5Flatbuffer->containers() && cve5Flatbuffer->containers()->cna())
+        {
+            storeDescriptionLambda(cve5Flatbuffer->containers()->cna());
+        }
+
+        if (cve5Flatbuffer->containers() && cve5Flatbuffer->containers()->adp())
+        {
+            for (const auto& adp : *cve5Flatbuffer->containers()->adp())
+            {
+                storeDescriptionLambda(adp);
             }
         }
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "descriptionsHelper.hpp"
 #include "fieldAlertHelper.hpp"
 #include "numericHelper.h"
 #include "scanContext.hpp"
@@ -64,50 +65,59 @@ public:
                 {
                     continue;
                 }
-                DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
-                    cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
 
-                if (returnData.data)
+                try
                 {
-                    const std::string cvssVersion {returnData.data->scoreVersion()->str()};
-                    const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
-                    nlohmann::json json;
+                    DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
+                        cve,
+                        data->m_vulnerabilitySource,
+                        m_databaseFeedManager,
+                        [&](const CveDescription& description)
+                        {
+                            const std::string cvssVersion {description.scoreVersion};
+                            const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
+                            nlohmann::json json;
 
-                    json["vulnerability"]["status"] = "Solved";
+                            json["vulnerability"]["status"] = "Solved";
 
-                    std::string title {cve};
-                    title.append(" affecting ");
-                    title.append("one or many packages");
-                    title.append(" was solved by ");
-                    title.append(data->hotfixId());
-                    json["vulnerability"]["title"] = title;
-                    // This improves the description of the alert without creating another rule
-                    json["vulnerability"]["package"]["name"] = "one or many packages";
+                            std::string title {cve};
+                            title.append(" affecting ");
+                            title.append("one or many packages");
+                            title.append(" was solved by ");
+                            title.append(data->hotfixId());
+                            json["vulnerability"]["title"] = title;
+                            // This improves the description of the alert without creating another rule
+                            json["vulnerability"]["package"]["name"] = "one or many packages";
 
-                    json["vulnerability"]["cve"] = cve;
-                    if (!cvssVersion.empty())
-                    {
-                        json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
-                    }
-                    json["vulnerability"]["enumeration"] = "CVE";
-                    json["vulnerability"]["published"] = returnData.data->datePublished()->str();
-                    json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
-                        Utils::toSentenceCase(returnData.data->severity()->str()));
-                    json["vulnerability"]["classification"] =
-                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
-                    json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
-                        Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                    json["vulnerability"]["score"]["version"] =
-                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
+                            json["vulnerability"]["cve"] = cve;
+                            if (!cvssVersion.empty())
+                            {
+                                json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
+                                    Utils::floatToDoubleRound(description.scoreBase, 2);
+                            }
+                            json["vulnerability"]["enumeration"] = "CVE";
+                            json["vulnerability"]["published"] = description.datePublished;
+                            json["vulnerability"]["reference"] = description.reference;
+                            json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::toSentenceCase(description.severity.data()));
+                            json["vulnerability"]["classification"] =
+                                FieldAlertHelper::fillEmptyOrNegative(description.classification);
+                            json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::floatToDoubleRound(description.scoreBase, 2));
+                            json["vulnerability"]["score"]["version"] =
+                                FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
 
-                    // The title is different depending on the type of the alert.
-                    json["vulnerability"]["type"] = "Packages";
-                    json["vulnerability"]["updated"] = returnData.data->dateUpdated()->str();
+                            // The title is different depending on the type of the alert.
+                            json["vulnerability"]["type"] = "Packages";
+                            json["vulnerability"]["updated"] = description.dateUpdated;
 
-                    data->m_alerts[cve] = std::move(json);
+                            data->m_alerts[cve] = std::move(json);
+                        });
+                }
+                catch (const std::exception& e)
+                {
+                    logError(WM_VULNSCAN_LOGTAG, "Error building event details for CVE: %s", cve.data());
+                    logError(WM_VULNSCAN_LOGTAG, "Error message: %s", e.what());
                 }
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -64,8 +64,9 @@ public:
                 {
                     continue;
                 }
-                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
+                DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
+                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
+                    cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
 
                 if (returnData.data)
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -88,7 +88,7 @@ public:
                                 return title;
                             };
                             resultData["vulnerability"]["title"] = generateTitle();
-                            
+
                             // This improves the description of the alert without creating another rule
                             resultData["vulnerability"]["package"]["name"] = "one or many packages";
                             resultData["vulnerability"]["status"] = "Solved";

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -51,17 +51,17 @@ public:
     /**
      * @brief Handles request and passes control to the next step of the chain.
      *
-     * @param data Scan context.
+     * @param context Scan context.
      * @return std::shared_ptr<ScanContext> Abstract handler.
      */
-    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> context) override
     {
         // We only generate alerts for real time events, aka dbsync deltas.
-        if (data->messageType() == MessageType::Delta)
+        if (context->messageType() == MessageType::Delta)
         {
-            for (const auto& [cve, elements] : data->m_elements)
+            for (const auto& [cve, elementData] : context->m_elements)
             {
-                if (elements.empty())
+                if (elementData.empty())
                 {
                     continue;
                 }
@@ -70,48 +70,51 @@ public:
                 {
                     DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
                         cve,
-                        data->m_vulnerabilitySource,
+                        context->m_vulnerabilitySource,
                         m_databaseFeedManager,
                         [&](const CveDescription& description)
                         {
                             const std::string cvssVersion {description.scoreVersion};
                             const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
-                            nlohmann::json json;
+                            nlohmann::json resultData;
 
-                            json["vulnerability"]["status"] = "Solved";
-
-                            std::string title {cve};
-                            title.append(" affecting ");
-                            title.append("one or many packages");
-                            title.append(" was solved by ");
-                            title.append(data->hotfixId());
-                            json["vulnerability"]["title"] = title;
+                            const auto generateTitle = [&context, &cve]()
+                            {
+                                std::string title {cve};
+                                title.append(" affecting ");
+                                title.append("one or many packages");
+                                title.append(" was solved by ");
+                                title.append(context->hotfixId());
+                                return title;
+                            };
+                            resultData["vulnerability"]["title"] = generateTitle();
+                            
                             // This improves the description of the alert without creating another rule
-                            json["vulnerability"]["package"]["name"] = "one or many packages";
+                            resultData["vulnerability"]["package"]["name"] = "one or many packages";
+                            resultData["vulnerability"]["status"] = "Solved";
 
-                            json["vulnerability"]["cve"] = cve;
+                            resultData["vulnerability"]["cve"] = cve;
                             if (!cvssVersion.empty())
                             {
-                                json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
+                                resultData["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                                     Utils::floatToDoubleRound(description.scoreBase, 2);
                             }
-                            json["vulnerability"]["enumeration"] = "CVE";
-                            json["vulnerability"]["published"] = description.datePublished;
-                            json["vulnerability"]["reference"] = description.reference;
-                            json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                            resultData["vulnerability"]["enumeration"] = "CVE";
+                            resultData["vulnerability"]["published"] = description.datePublished;
+                            resultData["vulnerability"]["reference"] = description.reference;
+                            resultData["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::toSentenceCase(description.severity.data()));
-                            json["vulnerability"]["classification"] =
+                            resultData["vulnerability"]["classification"] =
                                 FieldAlertHelper::fillEmptyOrNegative(description.classification);
-                            json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                            resultData["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::floatToDoubleRound(description.scoreBase, 2));
-                            json["vulnerability"]["score"]["version"] =
+                            resultData["vulnerability"]["score"]["version"] =
                                 FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
 
-                            // The title is different depending on the type of the alert.
-                            json["vulnerability"]["type"] = "Packages";
-                            json["vulnerability"]["updated"] = description.dateUpdated;
+                            resultData["vulnerability"]["type"] = "Packages";
+                            resultData["vulnerability"]["updated"] = description.dateUpdated;
 
-                            data->m_alerts[cve] = std::move(json);
+                            context->m_alerts[cve] = std::move(resultData);
                         });
                 }
                 catch (const std::exception& e)
@@ -121,7 +124,7 @@ public:
                 }
             }
         }
-        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
+        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(context));
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -12,6 +12,7 @@
 #define _DESCRIPTIONS_HELPER_HPP
 
 #include "databaseFeedManager.hpp"
+#include "globalData.hpp"
 #include "json.hpp"
 #include <string>
 
@@ -44,74 +45,86 @@ struct CveDescription final
 class DescriptionsHelper final
 {
 private:
+    template<typename TGlobalData = GlobalData>
     static std::pair<const std::string&, const std::string&>
     cvssAndDescriptionSources(const std::pair<std::string, std::string>& sources)
     {
+        // Ex. sources = {"redhat", "redhat_8"}
+        const auto& [adp, expandedAdp] = sources;
+
         nlohmann::json vendorConfig;
-        if (GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(sources.first))
+        if (TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(adp))
         {
-            vendorConfig = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(sources.first);
+            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adp);
         }
         else
         {
-            vendorConfig = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
+            // Fallback to default ADP
+            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
         }
 
         const auto& cvssSource = vendorConfig.at(ADP_CVSS_KEY).get_ref<const std::string&>();
         const auto& descriptionSource = vendorConfig.at(ADP_DESCRIPTION_KEY).get_ref<const std::string&>();
 
-        return {cvssSource == sources.first ? sources.second : cvssSource,
-                descriptionSource == sources.first ? sources.second : descriptionSource};
+        return {cvssSource == adp ? expandedAdp : cvssSource,
+                descriptionSource == adp ? expandedAdp : descriptionSource};
     }
 
 public:
-    template<typename T>
+    template<typename TDatabaseFeedManager = DatabaseFeedManager, typename TGlobalData = GlobalData>
     static void vulnerabilityDescription(const std::string& cve,
                                          const std::pair<std::string, std::string>& sources,
-                                         std::shared_ptr<T>& databaseFeedManager,
+                                         std::shared_ptr<TDatabaseFeedManager>& databaseFeedManager,
                                          const std::function<void(const CveDescription&)>& callback)
     {
         FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> descriptionData;
         FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> cvssData;
 
-        const auto& [cvssSource, descriptionSource] = DescriptionsHelper::cvssAndDescriptionSources(sources);
+        const auto& [cvssSource, descriptionSource] =
+            DescriptionsHelper::cvssAndDescriptionSources<TGlobalData>(sources);
 
-        if (cvssSource == descriptionSource)
+        // Get description data
+        if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
         {
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData);
+            // Information not from source, try with default ADP
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+        }
+
+        // Get CVSS data
+        if (cvssSource != descriptionSource)
+        {
+            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
+            {
+                // Information not from source, try with default ADP
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+            }
+        }
+        else
+        {
+            // If the sources are the same, cvssData will be the same as descriptionData
             cvssData.data = descriptionData.data;
         }
-        else
-        {
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData);
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData);
-        }
-        if (descriptionData.data && cvssData.data)
-        {
-            callback(CveDescription {cvssData.data->accessComplexity()->string_view(),
-                                     descriptionData.data->assignerShortName()->string_view(),
-                                     cvssData.data->attackVector()->string_view(),
-                                     cvssData.data->authentication()->string_view(),
-                                     cvssData.data->availabilityImpact()->string_view(),
-                                     cvssData.data->classification()->string_view(),
-                                     cvssData.data->confidentialityImpact()->string_view(),
-                                     descriptionData.data->cweId()->string_view(),
-                                     descriptionData.data->datePublished()->string_view(),
-                                     descriptionData.data->dateUpdated()->string_view(),
-                                     descriptionData.data->description()->string_view(),
-                                     cvssData.data->integrityImpact()->string_view(),
-                                     cvssData.data->privilegesRequired()->string_view(),
-                                     descriptionData.data->reference()->string_view(),
-                                     cvssData.data->scope()->string_view(),
-                                     cvssData.data->scoreBase(),
-                                     cvssData.data->scoreVersion()->string_view(),
-                                     cvssData.data->severity()->string_view(),
-                                     cvssData.data->userInteraction()->string_view()});
-        }
-        else
-        {
-            throw std::runtime_error("Error getting vulnerability description");
-        }
+
+        // Call the callback function with the CveDescription object
+        callback(CveDescription {cvssData.data->accessComplexity()->string_view(),
+                                 descriptionData.data->assignerShortName()->string_view(),
+                                 cvssData.data->attackVector()->string_view(),
+                                 cvssData.data->authentication()->string_view(),
+                                 cvssData.data->availabilityImpact()->string_view(),
+                                 cvssData.data->classification()->string_view(),
+                                 cvssData.data->confidentialityImpact()->string_view(),
+                                 descriptionData.data->cweId()->string_view(),
+                                 descriptionData.data->datePublished()->string_view(),
+                                 descriptionData.data->dateUpdated()->string_view(),
+                                 descriptionData.data->description()->string_view(),
+                                 cvssData.data->integrityImpact()->string_view(),
+                                 cvssData.data->privilegesRequired()->string_view(),
+                                 descriptionData.data->reference()->string_view(),
+                                 cvssData.data->scope()->string_view(),
+                                 cvssData.data->scoreBase(),
+                                 cvssData.data->scoreVersion()->string_view(),
+                                 cvssData.data->severity()->string_view(),
+                                 cvssData.data->userInteraction()->string_view()});
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -163,6 +163,7 @@ public:
      * @param sources Pair of sources (ADP and expanded ADP).
      * @param databaseFeedManager Database feed manager instance.
      * @param callback Callback function to call with the retrieved CveDescription object.
+     *
      */
     template<typename TDatabaseFeedManager = DatabaseFeedManager, typename TGlobalData = GlobalData>
     static void vulnerabilityDescription(const std::string& cve,
@@ -177,24 +178,44 @@ public:
             DescriptionsHelper::cvssAndDescriptionSources<TGlobalData>(sources);
 
         // Get description data
+
+        // Check if the description information is reliable
+        // The description information is considered unreliable if the description is empty or "not defined"
+        const auto descriptionIsReliable = [&descriptionData]()
+        {
+            if (!descriptionData.data->description() || descriptionData.data->description()->str() == "not defined")
+            {
+                return false;
+            }
+
+            return true;
+        };
+
         if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
         {
             // Information not from source, try with default ADP
             databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
         }
-        else
+
+        if (!descriptionIsReliable() && descriptionSource != DEFAULT_ADP)
         {
-            // Check if the information is reliable. If the information is not reliable, use the default ADP
-            // Not reliable if:
-            // - Description is empty
-            // - Description is "not defined"
-            if (!descriptionData.data->description() || descriptionData.data->description()->str() == "not defined")
-            {
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
-            }
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
         }
 
         // Get CVSS data
+
+        // Check if the CVSS information is reliable
+        // The CVSS information is considered unreliable if the score is near 0 or the severity is empty
+        const auto cvssIsReliable = [&cvssData, &cvssSource]()
+        {
+            if (cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
+            {
+                return false;
+            }
+
+            return true;
+        };
+
         if (cvssSource != descriptionSource)
         {
             if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData))
@@ -202,22 +223,16 @@ public:
                 // Information not from source, try with default ADP
                 databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
             }
-            else
-            {
-                // Check if the information is reliable. If the information is not reliable, use the default ADP
-                // Not reliable if:
-                // - Score is 0 (near 0 due to float precision)
-                // - Severity is empty
-                if (cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
-                {
-                    databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
-                }
-            }
         }
         else
         {
             // If the sources are the same, cvssData will be the same as descriptionData
             cvssData.data = descriptionData.data;
+        }
+
+        if (!cvssIsReliable() && cvssSource != DEFAULT_ADP)
+        {
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
         }
 
         // Call the callback function with the CveDescription object

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -16,26 +16,105 @@
 #include "json.hpp"
 #include <string>
 
+/**
+ * @brief Holds information about a vulnerability's CVSS metrics and related data.
+ */
 struct CveDescription final
 {
+    /**
+     * @brief Complexity of access required to exploit the vulnerability (CVSS metric).
+     */
     std::string_view accessComplexity;
+
+    /**
+     * @brief Short name of the entity that assigned the CVE.
+     */
     std::string_view assignerShortName;
+
+    /**
+     * @brief The context by which vulnerability exploitation is possible (CVSS metric).
+     */
     std::string_view attackVector;
+
+    /**
+     * @brief Level of authentication needed to exploit the vulnerability (CVSS metric).
+     */
     std::string_view authentication;
+
+    /**
+     * @brief Impact on the availability of the target system (CVSS metric).
+     */
     std::string_view availabilityImpact;
+
+    /**
+     * @brief The classification or category of the vulnerability.
+     */
     std::string_view classification;
+
+    /**
+     * @brief Impact on the confidentiality of the target system (CVSS metric).
+     */
     std::string_view confidentialityImpact;
+
+    /**
+     * @brief Common Weakness Enumeration (CWE) identifier for the vulnerability.
+     */
     std::string_view cweId;
+
+    /**
+     * @brief Date when the vulnerability was first published.
+     */
     std::string_view datePublished;
+
+    /**
+     * @brief Date when the vulnerability was last updated.
+     */
     std::string_view dateUpdated;
+
+    /**
+     * @brief Detailed description of the vulnerability.
+     */
     std::string_view description;
+
+    /**
+     * @brief Impact on the integrity of the target system (CVSS metric).
+     */
     std::string_view integrityImpact;
+
+    /**
+     * @brief Level of privileges required to exploit the vulnerability (CVSS metric).
+     */
     std::string_view privilegesRequired;
+
+    /**
+     * @brief Reference URL or document related to the vulnerability.
+     */
     std::string_view reference;
+
+    /**
+     * @brief Scope of impact once the vulnerability is exploited (CVSS metric).
+     */
     std::string_view scope;
-    float scoreBase = 0.0f; // Initialize scoreBase to 0.0
+
+    /**
+     * @brief Base CVSS score indicating the severity of the vulnerability.
+     * @details Initialized to 0.0 by default.
+     */
+    float scoreBase = 0.0f;
+
+    /**
+     * @brief The version of the CVSS scoring system used.
+     */
     std::string_view scoreVersion;
+
+    /**
+     * @brief Severity level of the vulnerability (e.g., Low, Medium, High).
+     */
     std::string_view severity;
+
+    /**
+     * @brief Indicates if user interaction is required to exploit the vulnerability (CVSS metric).
+     */
     std::string_view userInteraction;
 };
 
@@ -71,6 +150,20 @@ private:
     }
 
 public:
+    /**
+     * @brief Get the vulnerability description and CVSS metrics for a given CVE.
+     *
+     * @note Attempt to retrieve the information from the specified sources. If the information is not available (or it
+     * is not reliable), it uses the default ADP information instead.
+     *
+     * @tparam TDatabaseFeedManager Database feed manager type.
+     * @tparam TGlobalData Global data type.
+     *
+     * @param cve CVE identifier.
+     * @param sources Pair of sources (ADP and expanded ADP).
+     * @param databaseFeedManager Database feed manager instance.
+     * @param callback Callback function to call with the retrieved CveDescription object.
+     */
     template<typename TDatabaseFeedManager = DatabaseFeedManager, typename TGlobalData = GlobalData>
     static void vulnerabilityDescription(const std::string& cve,
                                          const std::pair<std::string, std::string>& sources,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -1,0 +1,118 @@
+/*
+ * Wazuh Vulnerability scanner - Scan Orchestrator
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 22, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#ifndef _DESCRIPTIONS_HELPER_HPP
+#define _DESCRIPTIONS_HELPER_HPP
+
+#include "databaseFeedManager.hpp"
+#include "json.hpp"
+#include <string>
+
+struct CveDescription final
+{
+    std::string_view accessComplexity;
+    std::string_view assignerShortName;
+    std::string_view attackVector;
+    std::string_view authentication;
+    std::string_view availabilityImpact;
+    std::string_view classification;
+    std::string_view confidentialityImpact;
+    std::string_view cweId;
+    std::string_view datePublished;
+    std::string_view dateUpdated;
+    std::string_view description;
+    std::string_view integrityImpact;
+    std::string_view privilegesRequired;
+    std::string_view reference;
+    std::string_view scope;
+    float scoreBase = 0.0f; // Initialize scoreBase to 0.0
+    std::string_view scoreVersion;
+    std::string_view severity;
+    std::string_view userInteraction;
+};
+
+/**
+ * @brief Descriptions helper class.
+ */
+class DescriptionsHelper final
+{
+private:
+    static std::pair<const std::string&, const std::string&>
+    cvssAndDescriptionSources(const std::pair<std::string, std::string>& sources)
+    {
+        nlohmann::json vendorConfig;
+        if (GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(sources.first))
+        {
+            vendorConfig = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(sources.first);
+        }
+        else
+        {
+            vendorConfig = GlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
+        }
+
+        const auto& cvssSource = vendorConfig.at(ADP_CVSS_KEY).get_ref<const std::string&>();
+        const auto& descriptionSource = vendorConfig.at(ADP_DESCRIPTION_KEY).get_ref<const std::string&>();
+
+        return {cvssSource == sources.first ? sources.second : cvssSource,
+                descriptionSource == sources.first ? sources.second : descriptionSource};
+    }
+
+public:
+    template<typename T>
+    static void vulnerabilityDescription(const std::string& cve,
+                                         const std::pair<std::string, std::string>& sources,
+                                         std::shared_ptr<T>& databaseFeedManager,
+                                         const std::function<void(const CveDescription&)>& callback)
+    {
+        FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> descriptionData;
+        FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> cvssData;
+
+        const auto& [cvssSource, descriptionSource] = DescriptionsHelper::cvssAndDescriptionSources(sources);
+
+        if (cvssSource == descriptionSource)
+        {
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData);
+            cvssData.data = descriptionData.data;
+        }
+        else
+        {
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData);
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData);
+        }
+        if (descriptionData.data && cvssData.data)
+        {
+            callback(CveDescription {cvssData.data->accessComplexity()->string_view(),
+                                     descriptionData.data->assignerShortName()->string_view(),
+                                     cvssData.data->attackVector()->string_view(),
+                                     cvssData.data->authentication()->string_view(),
+                                     cvssData.data->availabilityImpact()->string_view(),
+                                     cvssData.data->classification()->string_view(),
+                                     cvssData.data->confidentialityImpact()->string_view(),
+                                     descriptionData.data->cweId()->string_view(),
+                                     descriptionData.data->datePublished()->string_view(),
+                                     descriptionData.data->dateUpdated()->string_view(),
+                                     descriptionData.data->description()->string_view(),
+                                     cvssData.data->integrityImpact()->string_view(),
+                                     cvssData.data->privilegesRequired()->string_view(),
+                                     descriptionData.data->reference()->string_view(),
+                                     cvssData.data->scope()->string_view(),
+                                     cvssData.data->scoreBase(),
+                                     cvssData.data->scoreVersion()->string_view(),
+                                     cvssData.data->severity()->string_view(),
+                                     cvssData.data->userInteraction()->string_view()});
+        }
+        else
+        {
+            throw std::runtime_error("Error getting vulnerability description");
+        }
+    }
+};
+
+#endif // _DESCRIPTIONS_HELPER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -46,7 +46,7 @@ class DescriptionsHelper final
 {
 private:
     template<typename TGlobalData = GlobalData>
-    static std::pair<const std::string&, const std::string&>
+    static std::pair<const std::string, const std::string>
     cvssAndDescriptionSources(const std::pair<std::string, std::string>& sources)
     {
         // Ex. sources = {"redhat", "redhat_8"}
@@ -80,7 +80,7 @@ public:
         FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> descriptionData;
         FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> cvssData;
 
-        const auto& [cvssSource, descriptionSource] =
+        const auto [cvssSource, descriptionSource] =
             DescriptionsHelper::cvssAndDescriptionSources<TGlobalData>(sources);
 
         // Get description data

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -89,6 +89,17 @@ public:
             // Information not from source, try with default ADP
             databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
         }
+        else
+        {
+            // Check if the information is reliable. If the information is not reliable, use the default ADP
+            // Not reliable if:
+            // - Description is empty
+            // - Description is "not defined"
+            if (!descriptionData.data->description() || descriptionData.data->description()->str() == "not defined")
+            {
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+            }
+        }
 
         // Get CVSS data
         if (cvssSource != descriptionSource)
@@ -97,6 +108,17 @@ public:
             {
                 // Information not from source, try with default ADP
                 databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+            }
+            else
+            {
+                // Check if the information is reliable. If the information is not reliable, use the default ADP
+                // Not reliable if:
+                // - Score is 0 (near 0 due to float precision)
+                // - Severity is empty
+                if (cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
+                {
+                    databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+                }
             }
         }
         else

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -87,16 +87,16 @@ public:
         if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
         {
             // Information not from source, try with default ADP
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
         }
 
         // Get CVSS data
         if (cvssSource != descriptionSource)
         {
-            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
+            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData))
             {
                 // Information not from source, try with default ADP
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
             }
         }
         else

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -201,7 +201,7 @@ public:
         {
             try
             {
-                DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
+                DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager, TGlobalData>(
                     cve,
                     context->m_vulnerabilitySource,
                     m_databaseFeedManager,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -22,7 +22,6 @@
 #include "timeHelper.h"
 
 constexpr auto WAZUH_SCHEMA_VERSION = "1.0.0";
-constexpr auto EMPTY_FIELD = "";
 
 /**
  * @brief TEventDetailsBuilder class.
@@ -35,6 +34,7 @@ constexpr auto EMPTY_FIELD = "";
  *
  * @tparam TDatabaseFeedManager database feed manager type.
  * @tparam TScanContext scan context type.
+ * @tparam TGlobalData global data type.
  */
 template<typename TDatabaseFeedManager = DatabaseFeedManager,
          typename TScanContext = ScanContext,
@@ -52,12 +52,12 @@ private:
      * object. For other types, the field will be populated regardless of the value.
      *
      * @tparam T       The type of the value to populate the field with.
-     * @param json     The JSON object to populate.
+     * @param data     The JSON object to populate.
      * @param key      The JSON pointer specifying the field to populate.
      * @param value    The value to populate the field with.
      */
     template<typename T>
-    void populateField(nlohmann::json& json, const nlohmann::json::json_pointer& key, T&& value)
+    void populateField(nlohmann::json& data, const nlohmann::json::json_pointer& key, T&& value)
     {
         if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string_view> ||
                       std::is_same_v<T, std::string>)
@@ -66,12 +66,12 @@ private:
 
             if (!valueTrimmed.empty())
             {
-                json[key] = value;
+                data[key] = value;
             }
         }
         else
         {
-            json[key] = value;
+            data[key] = value;
         }
     }
 
@@ -97,118 +97,131 @@ public:
     /**
      * @brief Handles request and passes control to the next step of the chain.
      *
-     * @param data Scan context.
+     * @param context Scan context.
      * @return std::shared_ptr<ScanContext> Abstract handler.
      */
-    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> context) override
     {
-        logDebug2(WM_VULNSCAN_LOGTAG, "Building event details for component type: %d", data->affectedComponentType());
+        logDebug2(
+            WM_VULNSCAN_LOGTAG, "Building event details for component type: %d", context->affectedComponentType());
 
         // Operating system fullName (OS name + OS version).
-        std::string osFullName;
-        osFullName.append(data->osName().data());
-        osFullName.append(" ");
-        osFullName.append(data->osPlatform().compare("darwin") == 0 ? data->osCodeName().data()
-                                                                    : data->osVersion().data());
+        const auto generateOsFullName = [&context]()
+        {
+            std::string osFullName;
+            osFullName.append(context->osName().data());
+            osFullName.append(" ");
+            osFullName.append(context->osPlatform().compare("darwin") == 0 ? context->osCodeName().data()
+                                                                           : context->osVersion().data());
+            return osFullName;
+        };
+        const auto osFullName = generateOsFullName();
 
         // Operating system version.
-        std::string osVersion = data->osMajorVersion().data();
-        if (!data->osMinorVersion().empty())
+        const auto generateOsVersion = [&context]()
         {
-            osVersion.append(".");
-            osVersion.append(data->osMinorVersion());
-        }
-        if (!data->osPatch().empty())
-        {
-            osVersion.append(".");
-            osVersion.append(data->osPatch());
-        }
-        if (!data->osBuild().empty())
-        {
-            osVersion.append(".");
-            osVersion.append(data->osBuild());
-        }
+            std::string osVersion;
+            osVersion.append(context->osMajorVersion().data());
+            if (!context->osMinorVersion().empty())
+            {
+                osVersion.append(".");
+                osVersion.append(context->osMinorVersion());
+            }
+            if (!context->osPatch().empty())
+            {
+                osVersion.append(".");
+                osVersion.append(context->osPatch());
+            }
+            if (!context->osBuild().empty())
+            {
+                osVersion.append(".");
+                osVersion.append(context->osBuild());
+            }
+            return osVersion;
+        };
+
+        const auto osVersion = generateOsVersion();
 
         // Operating system type.
-        std::string osType =
-            Utils::toLowerCase(data->osPlatform().compare("darwin") == 0 ? "macos" : data->osPlatform().data());
+        const std::string osType =
+            Utils::toLowerCase(context->osPlatform().compare("darwin") == 0 ? "macos" : context->osPlatform().data());
 
-        nlohmann::json package;
+        nlohmann::json packageData;
 
-        switch (data->affectedComponentType())
+        switch (context->affectedComponentType())
         {
             case AffectedComponentType::Package:
-                populateField(package, "/architecture"_json_pointer, data->packageArchitecture());
-                populateField(package, "/description"_json_pointer, data->packageDescription());
+                populateField(packageData, "/architecture"_json_pointer, context->packageArchitecture());
+                populateField(packageData, "/description"_json_pointer, context->packageDescription());
 
-                if (!data->packageInstallTime().empty())
+                if (!context->packageInstallTime().empty())
                 {
-                    const auto installTime {Utils::rawTimestampToISO8601(data->packageInstallTime().data())};
+                    const auto installTime {Utils::rawTimestampToISO8601(context->packageInstallTime().data())};
                     if (!installTime.empty())
                     {
-                        package["installed"] = installTime;
+                        packageData["installed"] = installTime;
                     }
                 }
-                populateField(package, "/name"_json_pointer, data->packageName());
-                populateField(package, "/path"_json_pointer, data->packageLocation());
-                populateField(package, "/size"_json_pointer, data->packageSize());
-                populateField(package, "/type"_json_pointer, data->packageFormat());
-                populateField(package, "/version"_json_pointer, data->packageVersion());
+                populateField(packageData, "/name"_json_pointer, context->packageName());
+                populateField(packageData, "/path"_json_pointer, context->packageLocation());
+                populateField(packageData, "/size"_json_pointer, context->packageSize());
+                populateField(packageData, "/type"_json_pointer, context->packageFormat());
+                populateField(packageData, "/version"_json_pointer, context->packageVersion());
                 break;
 
             case AffectedComponentType::Os:
-                populateField(package, "/architecture"_json_pointer, data->osArchitecture());
-                populateField(package, "/name"_json_pointer, osFullName);
-                populateField(package, "/type"_json_pointer, osType);
-                populateField(package, "/version"_json_pointer, osVersion);
+                populateField(packageData, "/architecture"_json_pointer, context->osArchitecture());
+                populateField(packageData, "/name"_json_pointer, osFullName);
+                populateField(packageData, "/type"_json_pointer, osType);
+                populateField(packageData, "/version"_json_pointer, osVersion);
                 break;
 
             default: break;
         }
 
-        nlohmann::json agent;
-        if (data->agentId().compare("000") == 0 && data->clusterStatus())
+        nlohmann::json agentData;
+        if (context->agentId().compare("000") == 0 && context->clusterStatus())
         {
-            populateField(agent, "/ephemeral_id"_json_pointer, data->clusterNodeName());
+            populateField(agentData, "/ephemeral_id"_json_pointer, context->clusterNodeName());
         }
-        populateField(agent, "/id"_json_pointer, data->agentId());
-        populateField(agent, "/name"_json_pointer, data->agentName());
-        populateField(agent, "/type"_json_pointer, "wazuh");
-        populateField(agent, "/version"_json_pointer, data->agentVersion());
+        populateField(agentData, "/id"_json_pointer, context->agentId());
+        populateField(agentData, "/name"_json_pointer, context->agentName());
+        populateField(agentData, "/type"_json_pointer, "Wazuh");
+        populateField(agentData, "/version"_json_pointer, context->agentVersion());
 
-        nlohmann::json os;
-        populateField(os, "/full"_json_pointer, std::move(osFullName));
-        populateField(os, "/kernel"_json_pointer, data->osKernelRelease());
-        populateField(os, "/name"_json_pointer, data->osName());
-        populateField(os, "/platform"_json_pointer, Utils::toLowerCase(data->osPlatform().data()));
-        populateField(os, "/type"_json_pointer, std::move(osType));
-        populateField(os, "/version"_json_pointer, std::move(osVersion));
+        nlohmann::json osData;
+        populateField(osData, "/full"_json_pointer, osFullName);
+        populateField(osData, "/kernel"_json_pointer, context->osKernelRelease());
+        populateField(osData, "/name"_json_pointer, context->osName());
+        populateField(osData, "/platform"_json_pointer, Utils::toLowerCase(context->osPlatform().data()));
+        populateField(osData, "/type"_json_pointer, osType);
+        populateField(osData, "/version"_json_pointer, osVersion);
 
-        for (auto& [cve, json] : data->m_elements)
+        for (auto& [cve, elementData] : context->m_elements)
         {
             try
             {
                 DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
                     cve,
-                    data->m_vulnerabilitySource,
+                    context->m_vulnerabilitySource,
                     m_databaseFeedManager,
                     [&](const CveDescription& description)
                     {
                         auto ecsData = nlohmann::json::object();
 
                         // ECS agent fields.
-                        ecsData["agent"] = agent;
+                        ecsData["agent"] = agentData;
 
                         // ECS package fields.
-                        switch (data->affectedComponentType())
+                        switch (context->affectedComponentType())
                         {
                             case AffectedComponentType::Package:
-                                ecsData["package"] = package;
+                                ecsData["package"] = packageData;
                                 ecsData["vulnerability"]["category"] = "Packages";
                                 break;
 
                             case AffectedComponentType::Os:
-                                ecsData["package"] = package;
+                                ecsData["package"] = packageData;
                                 ecsData["vulnerability"]["category"] = "OS";
                                 break;
 
@@ -218,7 +231,7 @@ public:
                         }
 
                         // ECS os fields.
-                        ecsData["host"]["os"] = os;
+                        ecsData["host"]["os"] = osData;
 
                         // Lambda function to avoid complexity cognitive.
                         const auto isUnderEvaluation = [&description]()
@@ -247,16 +260,16 @@ public:
                             TGlobalData::instance()
                                 .vendorMaps()
                                 .at("adp_descriptions")
-                                .at(std::get<VulnerabilitySource::ADP_BASE>(data->m_vulnerabilitySource))
+                                .at(std::get<VulnerabilitySource::ADP_BASE>(context->m_vulnerabilitySource))
                                 .at("adp");
                         ecsData["vulnerability"]["under_evaluation"] = isUnderEvaluation();
 
                         // ECS wazuh fields.
                         auto vulnerabilityDetection = PolicyManager::instance().getVulnerabilityDetection();
-                        ecsData["wazuh"]["cluster"]["name"] = data->clusterName();
+                        ecsData["wazuh"]["cluster"]["name"] = context->clusterName();
                         ecsData["wazuh"]["schema"]["version"] = WAZUH_SCHEMA_VERSION;
 
-                        json["data"] = std::move(ecsData);
+                        elementData["data"] = std::move(ecsData);
                     });
             }
             catch (const std::exception& e)
@@ -266,7 +279,7 @@ public:
             }
         }
 
-        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
+        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(context));
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -185,8 +185,9 @@ public:
 
         for (auto& [cve, json] : data->m_elements)
         {
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-            m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
+            m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
+                cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
             if (returnData.data)
             {
                 auto ecsData = nlohmann::json::object();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "descriptionsHelper.hpp"
 #include "fieldAlertHelper.hpp"
 #include "loggerHelper.h"
 #include "numericHelper.h"
@@ -185,74 +186,83 @@ public:
 
         for (auto& [cve, json] : data->m_elements)
         {
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-            m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
-                cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
-            if (returnData.data)
+            try
             {
-                auto ecsData = nlohmann::json::object();
+                DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
+                    cve,
+                    data->m_vulnerabilitySource,
+                    m_databaseFeedManager,
+                    [&](const CveDescription& description)
+                    {
+                        auto ecsData = nlohmann::json::object();
 
-                // ECS agent fields.
-                ecsData["agent"] = agent;
+                        // ECS agent fields.
+                        ecsData["agent"] = agent;
 
-                // ECS package fields.
-                switch (data->affectedComponentType())
-                {
-                    case AffectedComponentType::Package:
-                        ecsData["package"] = package;
-                        ecsData["vulnerability"]["category"] = "Packages";
-                        break;
+                        // ECS package fields.
+                        switch (data->affectedComponentType())
+                        {
+                            case AffectedComponentType::Package:
+                                ecsData["package"] = package;
+                                ecsData["vulnerability"]["category"] = "Packages";
+                                break;
 
-                    case AffectedComponentType::Os:
-                        ecsData["package"] = package;
-                        ecsData["vulnerability"]["category"] = "OS";
-                        break;
+                            case AffectedComponentType::Os:
+                                ecsData["package"] = package;
+                                ecsData["vulnerability"]["category"] = "OS";
+                                break;
 
-                    default:
-                        // No fields required.
-                        break;
-                }
+                            default:
+                                // No fields required.
+                                break;
+                        }
 
-                // ECS os fields.
-                ecsData["host"]["os"] = os;
+                        // ECS os fields.
+                        ecsData["host"]["os"] = os;
 
-                // Lambda function to avoid complexity cognitive.
-                const auto isUnderEvaluation = [&returnData]()
-                {
-                    return Utils::floatToDoubleRound(returnData.data->scoreBase(), 2) == 0 ||
-                           returnData.data->scoreVersion()->str().empty() || returnData.data->severity()->str().empty();
-                };
+                        // Lambda function to avoid complexity cognitive.
+                        const auto isUnderEvaluation = [&description]()
+                        {
+                            return Utils::floatToDoubleRound(description.scoreBase, 2) == 0 ||
+                                   description.scoreVersion.empty() || description.severity.empty();
+                        };
 
-                // ECS vulnerability fields.
-                ecsData["vulnerability"]["classification"] =
-                    FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
-                ecsData["vulnerability"]["description"] = returnData.data->description()->str();
-                ecsData["vulnerability"]["detected_at"] = Utils::getCurrentISO8601();
-                ecsData["vulnerability"]["enumeration"] = "CVE";
-                ecsData["vulnerability"]["id"] = cve;
-                ecsData["vulnerability"]["published_at"] = returnData.data->datePublished()->str();
-                ecsData["vulnerability"]["reference"] = returnData.data->reference()->str();
-                ecsData["vulnerability"]["scanner"]["vendor"] = "Wazuh";
-                ecsData["vulnerability"]["score"]["base"] =
-                    FieldAlertHelper::fillEmptyOrNegative(Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                ecsData["vulnerability"]["score"]["version"] =
-                    FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
-                ecsData["vulnerability"]["severity"] =
-                    FieldAlertHelper::fillEmptyOrNegative(Utils::toSentenceCase(returnData.data->severity()->str()));
-                ecsData["vulnerability"]["scanner"]["source"] =
-                    TGlobalData::instance()
-                        .vendorMaps()
-                        .at("adp_descriptions")
-                        .at(std::get<VulnerabilitySource::ADP_BASE>(data->m_vulnerabilitySource))
-                        .at("adp");
-                ecsData["vulnerability"]["under_evaluation"] = isUnderEvaluation();
+                        // ECS vulnerability fields.
+                        ecsData["vulnerability"]["classification"] =
+                            FieldAlertHelper::fillEmptyOrNegative(description.classification);
+                        ecsData["vulnerability"]["description"] = description.description;
+                        ecsData["vulnerability"]["detected_at"] = Utils::getCurrentISO8601();
+                        ecsData["vulnerability"]["enumeration"] = "CVE";
+                        ecsData["vulnerability"]["id"] = cve;
+                        ecsData["vulnerability"]["published_at"] = description.datePublished;
+                        ecsData["vulnerability"]["reference"] = description.reference;
+                        ecsData["vulnerability"]["scanner"]["vendor"] = "Wazuh";
+                        ecsData["vulnerability"]["score"]["base"] =
+                            FieldAlertHelper::fillEmptyOrNegative(Utils::floatToDoubleRound(description.scoreBase, 2));
+                        ecsData["vulnerability"]["score"]["version"] =
+                            FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
+                        ecsData["vulnerability"]["severity"] =
+                            FieldAlertHelper::fillEmptyOrNegative(Utils::toSentenceCase(description.severity.data()));
+                        ecsData["vulnerability"]["scanner"]["source"] =
+                            TGlobalData::instance()
+                                .vendorMaps()
+                                .at("adp_descriptions")
+                                .at(std::get<VulnerabilitySource::ADP_BASE>(data->m_vulnerabilitySource))
+                                .at("adp");
+                        ecsData["vulnerability"]["under_evaluation"] = isUnderEvaluation();
 
-                // ECS wazuh fields.
-                auto vulnerabilityDetection = PolicyManager::instance().getVulnerabilityDetection();
-                ecsData["wazuh"]["cluster"]["name"] = data->clusterName();
-                ecsData["wazuh"]["schema"]["version"] = WAZUH_SCHEMA_VERSION;
+                        // ECS wazuh fields.
+                        auto vulnerabilityDetection = PolicyManager::instance().getVulnerabilityDetection();
+                        ecsData["wazuh"]["cluster"]["name"] = data->clusterName();
+                        ecsData["wazuh"]["schema"]["version"] = WAZUH_SCHEMA_VERSION;
 
-                json["data"] = std::move(ecsData);
+                        json["data"] = std::move(ecsData);
+                    });
+            }
+            catch (const std::exception& e)
+            {
+                logError(WM_VULNSCAN_LOGTAG, "Error building event details for CVE: %s", cve.data());
+                logError(WM_VULNSCAN_LOGTAG, "Error message: %s", e.what());
             }
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -220,8 +220,7 @@ public:
                 const auto isUnderEvaluation = [&returnData]()
                 {
                     return Utils::floatToDoubleRound(returnData.data->scoreBase(), 2) == 0 ||
-                           returnData.data->classification()->str().empty() ||
-                           returnData.data->severity()->str().empty();
+                           returnData.data->scoreVersion()->str().empty() || returnData.data->severity()->str().empty();
                 };
 
                 // ECS vulnerability fields.

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -69,8 +69,9 @@ public:
             for (const auto& element : data->m_elements)
             {
                 const auto& cve {element.first};
-                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
+                DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
+                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
+                    cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
 
                 if (returnData.data)
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "descriptionsHelper.hpp"
 #include "fieldAlertHelper.hpp"
 #include "numericHelper.h"
 #include "scanContext.hpp"
@@ -69,129 +70,142 @@ public:
             for (const auto& element : data->m_elements)
             {
                 const auto& cve {element.first};
-                DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
-                    cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
 
-                if (returnData.data)
+                try
                 {
-                    const auto& operation = element.second.at("operation").template get_ref<const std::string&>();
-                    const auto elementOperation {operation.compare("DELETED") == 0    ? ElementOperation::Delete
-                                                 : operation.compare("INSERTED") == 0 ? ElementOperation::Insert
-                                                                                      : ElementOperation::Unknown};
-
-                    const std::string cvssVersion {returnData.data->scoreVersion()->str()};
-                    const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
-                    nlohmann::json json;
-
-                    if (elementOperation == ElementOperation::Insert)
-                    {
-                        if (!cvssVersion.empty())
+                    DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
+                        cve,
+                        data->m_vulnerabilitySource,
+                        m_databaseFeedManager,
+                        [&](const CveDescription& description)
                         {
-                            nlohmann::json vectorObj;
-                            if (scoreVersion.compare("cvss2") == 0)
+                            const auto& operation =
+                                element.second.at("operation").template get_ref<const std::string&>();
+                            const auto elementOperation {operation.compare("DELETED") == 0 ? ElementOperation::Delete
+                                                         : operation.compare("INSERTED") == 0
+                                                             ? ElementOperation::Insert
+                                                             : ElementOperation::Unknown};
+
+                            const std::string cvssVersion {description.scoreVersion};
+                            const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
+                            nlohmann::json json;
+
+                            if (elementOperation == ElementOperation::Insert)
                             {
-                                vectorObj["access_complexity"] = returnData.data->accessComplexity()->str();
-                                vectorObj["authentication"] = returnData.data->authentication()->str();
+                                if (!cvssVersion.empty())
+                                {
+                                    nlohmann::json vectorObj;
+                                    if (scoreVersion.compare("cvss2") == 0)
+                                    {
+                                        vectorObj["access_complexity"] = description.accessComplexity;
+                                        vectorObj["authentication"] = description.authentication;
+                                    }
+                                    else if (scoreVersion.compare("cvss3") == 0)
+                                    {
+                                        vectorObj["attack_vector"] = description.attackVector;
+                                        vectorObj["privileges_required"] = description.privilegesRequired;
+                                        vectorObj["scope"] = description.scope;
+                                        vectorObj["user_interaction"] = description.userInteraction;
+                                    }
+
+                                    vectorObj["availability"] = description.availabilityImpact;
+                                    vectorObj["confidentiality_impact"] = description.confidentialityImpact;
+                                    vectorObj["integrity_impact"] = description.integrityImpact;
+
+                                    json["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(vectorObj);
+                                }
+
+                                json["vulnerability"]["assigner"] = description.assignerShortName;
+                                json["vulnerability"]["cwe_reference"] = description.cweId;
+                                json["vulnerability"]["package"]["source"] = data->packageSource();
+                                json["vulnerability"]["rationale"] = description.description;
+
+                                json["vulnerability"]["status"] = "Active";
+
+                                // title = CVE-XXXX-XXXX affects <package name>
+                                std::string title {cve};
+
+                                title.append(" affects ");
+                                title.append(data->packageName());
+                                json["vulnerability"]["title"] = title;
                             }
-                            else if (scoreVersion.compare("cvss3") == 0)
+                            else if (elementOperation == ElementOperation::Delete)
                             {
-                                vectorObj["attack_vector"] = returnData.data->attackVector()->str();
-                                vectorObj["privileges_required"] = returnData.data->privilegesRequired()->str();
-                                vectorObj["scope"] = returnData.data->scope()->str();
-                                vectorObj["user_interaction"] = returnData.data->userInteraction()->str();
+                                json["vulnerability"]["status"] = "Solved";
+
+                                // title = CVE-XXXX-XXXX affecting <package name> was solved
+                                std::string title {cve};
+
+                                title.append(" affecting ");
+                                title.append(data->packageName());
+                                title.append(" was solved");
+                                json["vulnerability"]["title"] = title;
+                            }
+                            else
+                            {
+                                throw std::runtime_error("Unknown element operation");
                             }
 
-                            vectorObj["availability"] = returnData.data->availabilityImpact()->str();
-                            vectorObj["confidentiality_impact"] = returnData.data->confidentialityImpact()->str();
-                            vectorObj["integrity_impact"] = returnData.data->integrityImpact()->str();
+                            json["vulnerability"]["cve"] = cve;
+                            if (!cvssVersion.empty())
+                            {
+                                json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
+                                    Utils::floatToDoubleRound(description.scoreBase, 2);
+                            }
+                            json["vulnerability"]["enumeration"] = "CVE";
+                            json["vulnerability"]["package"]["architecture"] = data->packageArchitecture();
+                            json["vulnerability"]["package"]["name"] = data->packageName();
+                            json["vulnerability"]["package"]["version"] = data->packageVersion();
+                            json["vulnerability"]["published"] = description.datePublished;
+                            json["vulnerability"]["reference"] = description.reference;
+                            json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::toSentenceCase(description.severity.data()));
+                            json["vulnerability"]["classification"] =
+                                FieldAlertHelper::fillEmptyOrNegative(description.classification);
+                            json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::floatToDoubleRound(description.scoreBase, 2));
+                            json["vulnerability"]["score"]["version"] =
+                                FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
 
-                            json["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(vectorObj);
-                        }
+                            // The title is different depending on the type of the alert.
+                            json["vulnerability"]["type"] = "Packages";
+                            json["vulnerability"]["updated"] = description.dateUpdated;
 
-                        json["vulnerability"]["assigner"] = returnData.data->assignerShortName()->str();
-                        json["vulnerability"]["cwe_reference"] = returnData.data->cweId()->str();
-                        json["vulnerability"]["package"]["source"] = data->packageSource();
-                        json["vulnerability"]["rationale"] = returnData.data->description()->str();
+                            const auto it = data->m_matchConditions.find(cve);
+                            if (it != data->m_matchConditions.end())
+                            {
+                                if (it->second.condition == MatchRuleCondition::LessThanOrEqual)
+                                {
+                                    json["vulnerability"]["package"]["condition"] =
+                                        "Package less than or equal to " + it->second.version;
+                                }
+                                else if (it->second.condition == MatchRuleCondition::LessThan)
+                                {
+                                    json["vulnerability"]["package"]["condition"] =
+                                        "Package less than " + it->second.version;
+                                }
+                                else if (it->second.condition == MatchRuleCondition::DefaultStatus)
+                                {
+                                    json["vulnerability"]["package"]["condition"] = "Package default status";
+                                }
+                                else if (it->second.condition == MatchRuleCondition::Equal)
+                                {
+                                    json["vulnerability"]["package"]["condition"] =
+                                        "Package equal to " + it->second.version;
+                                }
+                                else
+                                {
+                                    logDebug2(WM_VULNSCAN_LOGTAG, "Unknown match condition");
+                                }
+                            }
 
-                        json["vulnerability"]["status"] = "Active";
-
-                        // title = CVE-XXXX-XXXX affects <package name>
-                        std::string title {cve};
-
-                        title.append(" affects ");
-                        title.append(data->packageName());
-                        json["vulnerability"]["title"] = title;
-                    }
-                    else if (elementOperation == ElementOperation::Delete)
-                    {
-                        json["vulnerability"]["status"] = "Solved";
-
-                        // title = CVE-XXXX-XXXX affecting <package name> was solved
-                        std::string title {cve};
-
-                        title.append(" affecting ");
-                        title.append(data->packageName());
-                        title.append(" was solved");
-                        json["vulnerability"]["title"] = title;
-                    }
-                    else
-                    {
-                        throw std::runtime_error("Unknown element operation");
-                    }
-
-                    json["vulnerability"]["cve"] = cve;
-                    if (!cvssVersion.empty())
-                    {
-                        json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
-                    }
-                    json["vulnerability"]["enumeration"] = "CVE";
-                    json["vulnerability"]["package"]["architecture"] = data->packageArchitecture();
-                    json["vulnerability"]["package"]["name"] = data->packageName();
-                    json["vulnerability"]["package"]["version"] = data->packageVersion();
-                    json["vulnerability"]["published"] = returnData.data->datePublished()->str();
-                    json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
-                        Utils::toSentenceCase(returnData.data->severity()->str()));
-                    json["vulnerability"]["classification"] =
-                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
-                    json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
-                        Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                    json["vulnerability"]["score"]["version"] =
-                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
-
-                    // The title is different depending on the type of the alert.
-                    json["vulnerability"]["type"] = "Packages";
-                    json["vulnerability"]["updated"] = returnData.data->dateUpdated()->str();
-
-                    const auto it = data->m_matchConditions.find(cve);
-                    if (it != data->m_matchConditions.end())
-                    {
-                        if (it->second.condition == MatchRuleCondition::LessThanOrEqual)
-                        {
-                            json["vulnerability"]["package"]["condition"] =
-                                "Package less than or equal to " + it->second.version;
-                        }
-                        else if (it->second.condition == MatchRuleCondition::LessThan)
-                        {
-                            json["vulnerability"]["package"]["condition"] = "Package less than " + it->second.version;
-                        }
-                        else if (it->second.condition == MatchRuleCondition::DefaultStatus)
-                        {
-                            json["vulnerability"]["package"]["condition"] = "Package default status";
-                        }
-                        else if (it->second.condition == MatchRuleCondition::Equal)
-                        {
-                            json["vulnerability"]["package"]["condition"] = "Package equal to " + it->second.version;
-                        }
-                        else
-                        {
-                            logDebug2(WM_VULNSCAN_LOGTAG, "Unknown match condition");
-                        }
-                    }
-
-                    data->m_alerts[cve] = std::move(json);
+                            data->m_alerts[cve] = std::move(json);
+                        });
+                }
+                catch (const std::exception& e)
+                {
+                    logError(WM_VULNSCAN_LOGTAG, "Error building event details for CVE: %s", cve.data());
+                    logError(WM_VULNSCAN_LOGTAG, "Error message: %s", e.what());
                 }
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -59,28 +59,25 @@ public:
     /**
      * @brief Handles request and passes control to the next step of the chain.
      *
-     * @param data Scan context.
+     * @param context Scan context.
      * @return std::shared_ptr<ScanContext> Abstract handler.
      */
-    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> context) override
     {
         // We only generate alerts for real time events, aka dbsync deltas.
-        if (data->messageType() == MessageType::Delta)
+        if (context->messageType() == MessageType::Delta)
         {
-            for (const auto& element : data->m_elements)
+            for (const auto& [cve, elementData] : context->m_elements)
             {
-                const auto& cve {element.first};
-
                 try
                 {
                     DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
                         cve,
-                        data->m_vulnerabilitySource,
+                        context->m_vulnerabilitySource,
                         m_databaseFeedManager,
                         [&](const CveDescription& description)
                         {
-                            const auto& operation =
-                                element.second.at("operation").template get_ref<const std::string&>();
+                            const auto& operation = elementData.at("operation").template get_ref<const std::string&>();
                             const auto elementOperation {operation.compare("DELETED") == 0 ? ElementOperation::Delete
                                                          : operation.compare("INSERTED") == 0
                                                              ? ElementOperation::Insert
@@ -88,109 +85,113 @@ public:
 
                             const std::string cvssVersion {description.scoreVersion};
                             const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
-                            nlohmann::json json;
+                            nlohmann::json resultData;
 
                             if (elementOperation == ElementOperation::Insert)
                             {
                                 if (!cvssVersion.empty())
                                 {
-                                    nlohmann::json vectorObj;
+                                    nlohmann::json cvssVector;
                                     if (scoreVersion.compare("cvss2") == 0)
                                     {
-                                        vectorObj["access_complexity"] = description.accessComplexity;
-                                        vectorObj["authentication"] = description.authentication;
+                                        cvssVector["access_complexity"] = description.accessComplexity;
+                                        cvssVector["authentication"] = description.authentication;
                                     }
                                     else if (scoreVersion.compare("cvss3") == 0)
                                     {
-                                        vectorObj["attack_vector"] = description.attackVector;
-                                        vectorObj["privileges_required"] = description.privilegesRequired;
-                                        vectorObj["scope"] = description.scope;
-                                        vectorObj["user_interaction"] = description.userInteraction;
+                                        cvssVector["attack_vector"] = description.attackVector;
+                                        cvssVector["privileges_required"] = description.privilegesRequired;
+                                        cvssVector["scope"] = description.scope;
+                                        cvssVector["user_interaction"] = description.userInteraction;
                                     }
 
-                                    vectorObj["availability"] = description.availabilityImpact;
-                                    vectorObj["confidentiality_impact"] = description.confidentialityImpact;
-                                    vectorObj["integrity_impact"] = description.integrityImpact;
+                                    cvssVector["availability"] = description.availabilityImpact;
+                                    cvssVector["confidentiality_impact"] = description.confidentialityImpact;
+                                    cvssVector["integrity_impact"] = description.integrityImpact;
 
-                                    json["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(vectorObj);
+                                    resultData["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(cvssVector);
                                 }
 
-                                json["vulnerability"]["assigner"] = description.assignerShortName;
-                                json["vulnerability"]["cwe_reference"] = description.cweId;
-                                json["vulnerability"]["package"]["source"] = data->packageSource();
-                                json["vulnerability"]["rationale"] = description.description;
+                                resultData["vulnerability"]["assigner"] = description.assignerShortName;
+                                resultData["vulnerability"]["cwe_reference"] = description.cweId;
+                                resultData["vulnerability"]["package"]["source"] = context->packageSource();
+                                resultData["vulnerability"]["rationale"] = description.description;
 
-                                json["vulnerability"]["status"] = "Active";
-
-                                // title = CVE-XXXX-XXXX affects <package name>
-                                std::string title {cve};
-
-                                title.append(" affects ");
-                                title.append(data->packageName());
-                                json["vulnerability"]["title"] = title;
+                                const auto generateTitle = [&context, &cve]()
+                                {
+                                    // title = CVE-XXXX-XXXX affects <package name>
+                                    std::string title {cve};
+                                    title.append(" affects ");
+                                    title.append(context->packageName());
+                                    return title;
+                                };
+                                resultData["vulnerability"]["title"] = generateTitle();
+                                resultData["vulnerability"]["status"] = "Active";
                             }
                             else if (elementOperation == ElementOperation::Delete)
                             {
-                                json["vulnerability"]["status"] = "Solved";
-
-                                // title = CVE-XXXX-XXXX affecting <package name> was solved
-                                std::string title {cve};
-
-                                title.append(" affecting ");
-                                title.append(data->packageName());
-                                title.append(" was solved");
-                                json["vulnerability"]["title"] = title;
+                                const auto generateTitle = [&context, &cve]()
+                                {
+                                    // title = CVE-XXXX-XXXX affecting <package name> was solved
+                                    std::string title {cve};
+                                    title.append(" affecting ");
+                                    title.append(context->packageName());
+                                    title.append(" was solved");
+                                    return title;
+                                };
+                                resultData["vulnerability"]["title"] = generateTitle();
+                                resultData["vulnerability"]["status"] = "Solved";
                             }
                             else
                             {
                                 throw std::runtime_error("Unknown element operation");
                             }
 
-                            json["vulnerability"]["cve"] = cve;
+                            resultData["vulnerability"]["cve"] = cve;
                             if (!cvssVersion.empty())
                             {
-                                json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
+                                resultData["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                                     Utils::floatToDoubleRound(description.scoreBase, 2);
                             }
-                            json["vulnerability"]["enumeration"] = "CVE";
-                            json["vulnerability"]["package"]["architecture"] = data->packageArchitecture();
-                            json["vulnerability"]["package"]["name"] = data->packageName();
-                            json["vulnerability"]["package"]["version"] = data->packageVersion();
-                            json["vulnerability"]["published"] = description.datePublished;
-                            json["vulnerability"]["reference"] = description.reference;
-                            json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                            resultData["vulnerability"]["enumeration"] = "CVE";
+                            resultData["vulnerability"]["package"]["architecture"] = context->packageArchitecture();
+                            resultData["vulnerability"]["package"]["name"] = context->packageName();
+                            resultData["vulnerability"]["package"]["version"] = context->packageVersion();
+                            resultData["vulnerability"]["published"] = description.datePublished;
+                            resultData["vulnerability"]["reference"] = description.reference;
+                            resultData["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::toSentenceCase(description.severity.data()));
-                            json["vulnerability"]["classification"] =
+                            resultData["vulnerability"]["classification"] =
                                 FieldAlertHelper::fillEmptyOrNegative(description.classification);
-                            json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                            resultData["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::floatToDoubleRound(description.scoreBase, 2));
-                            json["vulnerability"]["score"]["version"] =
+                            resultData["vulnerability"]["score"]["version"] =
                                 FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
 
                             // The title is different depending on the type of the alert.
-                            json["vulnerability"]["type"] = "Packages";
-                            json["vulnerability"]["updated"] = description.dateUpdated;
+                            resultData["vulnerability"]["type"] = "Packages";
+                            resultData["vulnerability"]["updated"] = description.dateUpdated;
 
-                            const auto it = data->m_matchConditions.find(cve);
-                            if (it != data->m_matchConditions.end())
+                            if (const auto it = context->m_matchConditions.find(cve);
+                                it != context->m_matchConditions.end())
                             {
                                 if (it->second.condition == MatchRuleCondition::LessThanOrEqual)
                                 {
-                                    json["vulnerability"]["package"]["condition"] =
+                                    resultData["vulnerability"]["package"]["condition"] =
                                         "Package less than or equal to " + it->second.version;
                                 }
                                 else if (it->second.condition == MatchRuleCondition::LessThan)
                                 {
-                                    json["vulnerability"]["package"]["condition"] =
+                                    resultData["vulnerability"]["package"]["condition"] =
                                         "Package less than " + it->second.version;
                                 }
                                 else if (it->second.condition == MatchRuleCondition::DefaultStatus)
                                 {
-                                    json["vulnerability"]["package"]["condition"] = "Package default status";
+                                    resultData["vulnerability"]["package"]["condition"] = "Package default status";
                                 }
                                 else if (it->second.condition == MatchRuleCondition::Equal)
                                 {
-                                    json["vulnerability"]["package"]["condition"] =
+                                    resultData["vulnerability"]["package"]["condition"] =
                                         "Package equal to " + it->second.version;
                                 }
                                 else
@@ -199,7 +200,7 @@ public:
                                 }
                             }
 
-                            data->m_alerts[cve] = std::move(json);
+                            context->m_alerts[cve] = std::move(resultData);
                         });
                 }
                 catch (const std::exception& e)
@@ -209,7 +210,7 @@ public:
                 }
             }
         }
-        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
+        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(context));
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -16,6 +16,7 @@
 #include "databaseFeedManager.hpp"
 #include "descriptionsHelper.hpp"
 #include "fieldAlertHelper.hpp"
+#include "globalData.hpp"
 #include "numericHelper.h"
 #include "scanContext.hpp"
 
@@ -30,8 +31,11 @@
  *
  * @tparam TDatabaseFeedManager database feed manager type.
  * @tparam TScanContext scan context type.
+ * @tparam TGlobalData global data type.
  */
-template<typename TDatabaseFeedManager = DatabaseFeedManager, typename TScanContext = ScanContext>
+template<typename TDatabaseFeedManager = DatabaseFeedManager,
+         typename TScanContext = ScanContext,
+         typename TGlobalData = GlobalData>
 class TEventPackageAlertDetailsBuilder final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 private:
@@ -71,7 +75,7 @@ public:
             {
                 try
                 {
-                    DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
+                    DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager, TGlobalData>(
                         cve,
                         context->m_vulnerabilitySource,
                         m_databaseFeedManager,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
@@ -30,7 +30,8 @@ namespace FieldAlertHelper
     template<typename T>
     nlohmann::json fillEmptyOrNegative(T&& field)
     {
-        if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string>)
+        if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string_view> ||
+                      std::is_same_v<T, std::string>)
         {
             // Return "-" if the string is empty, otherwise return the original string
             return field.empty() ? "-" : std::forward<T>(field);

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -1479,7 +1479,7 @@ public:
      *
      * @note Use @see VulnerabilitySource enum to access each field
      *
-     * @return Pair with CNA base name and CNA expanded name.
+     * @return Pair with CNA/ADP base name and CNA/ADP expanded name.
      */
     std::pair<std::string, std::string> m_vulnerabilitySource;
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -32,8 +32,11 @@
  *
  * @tparam TDatabaseFeedManager database feed manager type.
  * @tparam TScanContext scan context type.
+ * @tparam TGlobalData global data type.
  */
-template<typename TDatabaseFeedManager = DatabaseFeedManager, typename TScanContext = ScanContext>
+template<typename TDatabaseFeedManager = DatabaseFeedManager,
+         typename TScanContext = ScanContext,
+         typename TGlobalData = GlobalData>
 class TScanOsAlertDetailsBuilder final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 private:
@@ -78,7 +81,7 @@ public:
 
                 try
                 {
-                    DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
+                    DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager, TGlobalData>(
                         cve,
                         context->m_vulnerabilitySource,
                         m_databaseFeedManager,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -61,18 +61,17 @@ public:
     /**
      * @brief Handles request and passes control to the next step of the chain.
      *
-     * @param data Scan context.
+     * @param context Scan context.
      * @return std::shared_ptr<ScanContext> Abstract handler.
      */
-    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> context) override
     {
         // We only generate alerts if its not the first scan(baseline).
-        if (!data->m_isFirstScan)
+        if (!context->m_isFirstScan)
         {
-            for (const auto& element : data->m_elements)
+            for (const auto& [cve, elementData] : context->m_elements)
             {
-                const auto& cve {element.first};
-                const auto& operation = element.second.at("operation").template get_ref<const std::string&>();
+                const auto& operation = elementData.at("operation").template get_ref<const std::string&>();
                 const auto elementOperation {operation.compare("DELETED") == 0    ? ElementOperation::Delete
                                              : operation.compare("INSERTED") == 0 ? ElementOperation::Insert
                                                                                   : ElementOperation::Unknown};
@@ -81,110 +80,117 @@ public:
                 {
                     DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
                         cve,
-                        data->m_vulnerabilitySource,
+                        context->m_vulnerabilitySource,
                         m_databaseFeedManager,
                         [&](const CveDescription& description)
                         {
                             const std::string cvssVersion {description.scoreVersion};
                             const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
-                            nlohmann::json json;
+                            nlohmann::json resultData;
 
                             if (elementOperation == ElementOperation::Insert)
                             {
                                 if (!cvssVersion.empty())
                                 {
-                                    nlohmann::json vectorObj;
+                                    nlohmann::json cvssVector;
                                     if (scoreVersion.compare("cvss2") == 0)
                                     {
-                                        vectorObj["access_complexity"] = description.accessComplexity;
-                                        vectorObj["authentication"] = description.authentication;
+                                        cvssVector["access_complexity"] = description.accessComplexity;
+                                        cvssVector["authentication"] = description.authentication;
                                     }
                                     else if (scoreVersion.compare("cvss3") == 0)
                                     {
-                                        vectorObj["attack_vector"] = description.attackVector;
-                                        vectorObj["privileges_required"] = description.privilegesRequired;
-                                        vectorObj["scope"] = description.scope;
-                                        vectorObj["user_interaction"] = description.userInteraction;
+                                        cvssVector["attack_vector"] = description.attackVector;
+                                        cvssVector["privileges_required"] = description.privilegesRequired;
+                                        cvssVector["scope"] = description.scope;
+                                        cvssVector["user_interaction"] = description.userInteraction;
                                     }
 
-                                    vectorObj["availability"] = description.availabilityImpact;
-                                    vectorObj["confidentiality_impact"] = description.confidentialityImpact;
-                                    vectorObj["integrity_impact"] = description.integrityImpact;
+                                    cvssVector["availability"] = description.availabilityImpact;
+                                    cvssVector["confidentiality_impact"] = description.confidentialityImpact;
+                                    cvssVector["integrity_impact"] = description.integrityImpact;
 
-                                    json["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(vectorObj);
+                                    resultData["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(cvssVector);
                                 }
 
-                                json["vulnerability"]["assigner"] = description.assignerShortName;
-                                json["vulnerability"]["cwe_reference"] = description.cweId;
-                                json["vulnerability"]["package"]["source"] = "OS";
-                                json["vulnerability"]["rationale"] = description.description;
+                                resultData["vulnerability"]["assigner"] = description.assignerShortName;
+                                resultData["vulnerability"]["cwe_reference"] = description.cweId;
+                                resultData["vulnerability"]["package"]["source"] = "OS";
+                                resultData["vulnerability"]["rationale"] = description.description;
 
-                                json["vulnerability"]["status"] = "Active";
+                                resultData["vulnerability"]["status"] = "Active";
 
-                                std::string title {cve};
-                                title.append(" affects ");
-                                title.append(data->osName());
-                                json["vulnerability"]["title"] = title;
+                                const auto generateTitle = [&context, &cve]()
+                                {
+                                    std::string title {cve};
+                                    title.append(" affects ");
+                                    title.append(context->osName());
+                                    return title;
+                                };
+                                resultData["vulnerability"]["title"] = generateTitle();
                             }
                             else if (elementOperation == ElementOperation::Delete)
                             {
-                                json["vulnerability"]["status"] = "Solved";
+                                resultData["vulnerability"]["status"] = "Solved";
 
-                                std::string title {cve};
-                                title.append(" affecting ");
-                                title.append(data->osName());
-                                title.append(" was solved");
-                                json["vulnerability"]["title"] = title;
+                                const auto generateTitle = [&context, &cve]()
+                                {
+                                    std::string title {cve};
+                                    title.append(" affecting ");
+                                    title.append(context->osName());
+                                    title.append(" was solved");
+                                    return title;
+                                };
+                                resultData["vulnerability"]["title"] = generateTitle();
                             }
                             else
                             {
                                 throw std::runtime_error("Unknown operation");
                             }
 
-                            json["vulnerability"]["cve"] = cve;
+                            resultData["vulnerability"]["cve"] = cve;
                             if (!cvssVersion.empty())
                             {
-                                json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
+                                resultData["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                                     Utils::floatToDoubleRound(description.scoreBase, 2);
                             }
-                            json["vulnerability"]["enumeration"] = "CVE";
-                            json["vulnerability"]["package"]["architecture"] = data->osArchitecture();
-                            json["vulnerability"]["package"]["name"] = data->osName();
-                            json["vulnerability"]["package"]["version"] = data->osVersion();
-                            json["vulnerability"]["published"] = description.datePublished;
-                            json["vulnerability"]["reference"] = description.reference;
-                            json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                            resultData["vulnerability"]["enumeration"] = "CVE";
+                            resultData["vulnerability"]["package"]["architecture"] = context->osArchitecture();
+                            resultData["vulnerability"]["package"]["name"] = context->osName();
+                            resultData["vulnerability"]["package"]["version"] = context->osVersion();
+                            resultData["vulnerability"]["published"] = description.datePublished;
+                            resultData["vulnerability"]["reference"] = description.reference;
+                            resultData["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::toSentenceCase(description.severity.data()));
-                            json["vulnerability"]["classification"] =
+                            resultData["vulnerability"]["classification"] =
                                 FieldAlertHelper::fillEmptyOrNegative(description.classification);
-                            json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                            resultData["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::floatToDoubleRound(description.scoreBase, 2));
-                            json["vulnerability"]["score"]["version"] =
+                            resultData["vulnerability"]["score"]["version"] =
                                 FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
 
-                            json["vulnerability"]["type"] = "Packages";
-                            json["vulnerability"]["updated"] = description.dateUpdated;
+                            resultData["vulnerability"]["type"] = "Packages";
+                            resultData["vulnerability"]["updated"] = description.dateUpdated;
 
-                            auto it = data->m_matchConditions.find(cve);
-                            if (it != data->m_matchConditions.end())
+                            if (auto it = context->m_matchConditions.find(cve); it != context->m_matchConditions.end())
                             {
                                 if (it->second.condition == MatchRuleCondition::LessThanOrEqual)
                                 {
-                                    json["vulnerability"]["package"]["condition"] =
+                                    resultData["vulnerability"]["package"]["condition"] =
                                         "Package less than or equal to " + it->second.version;
                                 }
                                 else if (it->second.condition == MatchRuleCondition::LessThan)
                                 {
-                                    json["vulnerability"]["package"]["condition"] =
+                                    resultData["vulnerability"]["package"]["condition"] =
                                         "Package less than " + it->second.version;
                                 }
                                 else if (it->second.condition == MatchRuleCondition::DefaultStatus)
                                 {
-                                    json["vulnerability"]["package"]["condition"] = "Package default status";
+                                    resultData["vulnerability"]["package"]["condition"] = "Package default status";
                                 }
                                 else if (it->second.condition == MatchRuleCondition::Equal)
                                 {
-                                    json["vulnerability"]["package"]["condition"] =
+                                    resultData["vulnerability"]["package"]["condition"] =
                                         "Package equal to " + it->second.version;
                                 }
                                 else
@@ -193,7 +199,7 @@ public:
                                 }
                             }
 
-                            data->m_alerts[cve] = std::move(json);
+                            context->m_alerts[cve] = std::move(resultData);
                         });
                 }
                 catch (const std::exception& e)
@@ -203,7 +209,7 @@ public:
                 }
             }
         }
-        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
+        return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(context));
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -76,8 +76,9 @@ public:
                                              : operation.compare("INSERTED") == 0 ? ElementOperation::Insert
                                                                                   : ElementOperation::Unknown};
 
-                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
+                DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
+                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
+                    cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
 
                 if (returnData.data)
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "descriptionsHelper.hpp"
 #include "fieldAlertHelper.hpp"
 #include "numericHelper.h"
 #include "scanContext.hpp"
@@ -76,119 +77,129 @@ public:
                                              : operation.compare("INSERTED") == 0 ? ElementOperation::Insert
                                                                                   : ElementOperation::Unknown};
 
-                DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-                m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(
-                    cve, data->m_vulnerabilitySource.first, data->m_vulnerabilitySource.second, returnData);
-
-                if (returnData.data)
+                try
                 {
-                    const std::string cvssVersion {returnData.data->scoreVersion()->str()};
-                    const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
-                    nlohmann::json json;
-
-                    if (elementOperation == ElementOperation::Insert)
-                    {
-                        if (!cvssVersion.empty())
+                    DescriptionsHelper::vulnerabilityDescription<TDatabaseFeedManager>(
+                        cve,
+                        data->m_vulnerabilitySource,
+                        m_databaseFeedManager,
+                        [&](const CveDescription& description)
                         {
-                            nlohmann::json vectorObj;
-                            if (scoreVersion.compare("cvss2") == 0)
+                            const std::string cvssVersion {description.scoreVersion};
+                            const std::string scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
+                            nlohmann::json json;
+
+                            if (elementOperation == ElementOperation::Insert)
                             {
-                                vectorObj["access_complexity"] = returnData.data->accessComplexity()->str();
-                                vectorObj["authentication"] = returnData.data->authentication()->str();
+                                if (!cvssVersion.empty())
+                                {
+                                    nlohmann::json vectorObj;
+                                    if (scoreVersion.compare("cvss2") == 0)
+                                    {
+                                        vectorObj["access_complexity"] = description.accessComplexity;
+                                        vectorObj["authentication"] = description.authentication;
+                                    }
+                                    else if (scoreVersion.compare("cvss3") == 0)
+                                    {
+                                        vectorObj["attack_vector"] = description.attackVector;
+                                        vectorObj["privileges_required"] = description.privilegesRequired;
+                                        vectorObj["scope"] = description.scope;
+                                        vectorObj["user_interaction"] = description.userInteraction;
+                                    }
+
+                                    vectorObj["availability"] = description.availabilityImpact;
+                                    vectorObj["confidentiality_impact"] = description.confidentialityImpact;
+                                    vectorObj["integrity_impact"] = description.integrityImpact;
+
+                                    json["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(vectorObj);
+                                }
+
+                                json["vulnerability"]["assigner"] = description.assignerShortName;
+                                json["vulnerability"]["cwe_reference"] = description.cweId;
+                                json["vulnerability"]["package"]["source"] = "OS";
+                                json["vulnerability"]["rationale"] = description.description;
+
+                                json["vulnerability"]["status"] = "Active";
+
+                                std::string title {cve};
+                                title.append(" affects ");
+                                title.append(data->osName());
+                                json["vulnerability"]["title"] = title;
                             }
-                            else if (scoreVersion.compare("cvss3") == 0)
+                            else if (elementOperation == ElementOperation::Delete)
                             {
-                                vectorObj["attack_vector"] = returnData.data->attackVector()->str();
-                                vectorObj["privileges_required"] = returnData.data->privilegesRequired()->str();
-                                vectorObj["scope"] = returnData.data->scope()->str();
-                                vectorObj["user_interaction"] = returnData.data->userInteraction()->str();
+                                json["vulnerability"]["status"] = "Solved";
+
+                                std::string title {cve};
+                                title.append(" affecting ");
+                                title.append(data->osName());
+                                title.append(" was solved");
+                                json["vulnerability"]["title"] = title;
+                            }
+                            else
+                            {
+                                throw std::runtime_error("Unknown operation");
                             }
 
-                            vectorObj["availability"] = returnData.data->availabilityImpact()->str();
-                            vectorObj["confidentiality_impact"] = returnData.data->confidentialityImpact()->str();
-                            vectorObj["integrity_impact"] = returnData.data->integrityImpact()->str();
+                            json["vulnerability"]["cve"] = cve;
+                            if (!cvssVersion.empty())
+                            {
+                                json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
+                                    Utils::floatToDoubleRound(description.scoreBase, 2);
+                            }
+                            json["vulnerability"]["enumeration"] = "CVE";
+                            json["vulnerability"]["package"]["architecture"] = data->osArchitecture();
+                            json["vulnerability"]["package"]["name"] = data->osName();
+                            json["vulnerability"]["package"]["version"] = data->osVersion();
+                            json["vulnerability"]["published"] = description.datePublished;
+                            json["vulnerability"]["reference"] = description.reference;
+                            json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::toSentenceCase(description.severity.data()));
+                            json["vulnerability"]["classification"] =
+                                FieldAlertHelper::fillEmptyOrNegative(description.classification);
+                            json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::floatToDoubleRound(description.scoreBase, 2));
+                            json["vulnerability"]["score"]["version"] =
+                                FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
 
-                            json["vulnerability"]["cvss"][scoreVersion]["vector"] = std::move(vectorObj);
-                        }
+                            json["vulnerability"]["type"] = "Packages";
+                            json["vulnerability"]["updated"] = description.dateUpdated;
 
-                        json["vulnerability"]["assigner"] = returnData.data->assignerShortName()->str();
-                        json["vulnerability"]["cwe_reference"] = returnData.data->cweId()->str();
-                        json["vulnerability"]["package"]["source"] = "OS";
-                        json["vulnerability"]["rationale"] = returnData.data->description()->str();
+                            auto it = data->m_matchConditions.find(cve);
+                            if (it != data->m_matchConditions.end())
+                            {
+                                if (it->second.condition == MatchRuleCondition::LessThanOrEqual)
+                                {
+                                    json["vulnerability"]["package"]["condition"] =
+                                        "Package less than or equal to " + it->second.version;
+                                }
+                                else if (it->second.condition == MatchRuleCondition::LessThan)
+                                {
+                                    json["vulnerability"]["package"]["condition"] =
+                                        "Package less than " + it->second.version;
+                                }
+                                else if (it->second.condition == MatchRuleCondition::DefaultStatus)
+                                {
+                                    json["vulnerability"]["package"]["condition"] = "Package default status";
+                                }
+                                else if (it->second.condition == MatchRuleCondition::Equal)
+                                {
+                                    json["vulnerability"]["package"]["condition"] =
+                                        "Package equal to " + it->second.version;
+                                }
+                                else
+                                {
+                                    logDebug2(WM_VULNSCAN_LOGTAG, "Unknown match condition");
+                                }
+                            }
 
-                        json["vulnerability"]["status"] = "Active";
-
-                        std::string title {cve};
-                        title.append(" affects ");
-                        title.append(data->osName());
-                        json["vulnerability"]["title"] = title;
-                    }
-                    else if (elementOperation == ElementOperation::Delete)
-                    {
-                        json["vulnerability"]["status"] = "Solved";
-
-                        std::string title {cve};
-                        title.append(" affecting ");
-                        title.append(data->osName());
-                        title.append(" was solved");
-                        json["vulnerability"]["title"] = title;
-                    }
-                    else
-                    {
-                        throw std::runtime_error("Unknown operation");
-                    }
-
-                    json["vulnerability"]["cve"] = cve;
-                    if (!cvssVersion.empty())
-                    {
-                        json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
-                    }
-                    json["vulnerability"]["enumeration"] = "CVE";
-                    json["vulnerability"]["package"]["architecture"] = data->osArchitecture();
-                    json["vulnerability"]["package"]["name"] = data->osName();
-                    json["vulnerability"]["package"]["version"] = data->osVersion();
-                    json["vulnerability"]["published"] = returnData.data->datePublished()->str();
-                    json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
-                        Utils::toSentenceCase(returnData.data->severity()->str()));
-                    json["vulnerability"]["classification"] =
-                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
-                    json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
-                        Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                    json["vulnerability"]["score"]["version"] =
-                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
-
-                    json["vulnerability"]["type"] = "Packages";
-                    json["vulnerability"]["updated"] = returnData.data->dateUpdated()->str();
-
-                    auto it = data->m_matchConditions.find(cve);
-                    if (it != data->m_matchConditions.end())
-                    {
-                        if (it->second.condition == MatchRuleCondition::LessThanOrEqual)
-                        {
-                            json["vulnerability"]["package"]["condition"] =
-                                "Package less than or equal to " + it->second.version;
-                        }
-                        else if (it->second.condition == MatchRuleCondition::LessThan)
-                        {
-                            json["vulnerability"]["package"]["condition"] = "Package less than " + it->second.version;
-                        }
-                        else if (it->second.condition == MatchRuleCondition::DefaultStatus)
-                        {
-                            json["vulnerability"]["package"]["condition"] = "Package default status";
-                        }
-                        else if (it->second.condition == MatchRuleCondition::Equal)
-                        {
-                            json["vulnerability"]["package"]["condition"] = "Package equal to " + it->second.version;
-                        }
-                        else
-                        {
-                            logDebug2(WM_VULNSCAN_LOGTAG, "Unknown match condition");
-                        }
-                    }
-
-                    data->m_alerts[cve] = std::move(json);
+                            data->m_alerts[cve] = std::move(json);
+                        });
+                }
+                catch (const std::exception& e)
+                {
+                    logError(WM_VULNSCAN_LOGTAG, "Error building event details for CVE: %s", cve.data());
+                    logError(WM_VULNSCAN_LOGTAG, "Error message: %s", e.what());
                 }
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
@@ -97,7 +97,10 @@ public:
      */
     MOCK_METHOD(void,
                 getVulnerabiltyDescriptiveInformation,
-                (const std::string_view cveId, FlatbufferDataPair<VulnerabilityDescription>& resultContainer),
+                (const std::string_view cveId,
+                 const std::string& adpShortName,
+                 const std::string& adpSubShortName,
+                 DetachedFlatbufferDataPair<VulnerabilityDescription>& resultContainer),
                 ());
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
@@ -98,7 +98,7 @@ public:
     MOCK_METHOD(bool,
                 getVulnerabiltyDescriptiveInformation,
                 (const std::string& cveId,
-                 const std::string& adpShortName,
+                 const std::string& subShortName,
                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer),
                 ());
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockDatabaseFeedManager.hpp
@@ -11,10 +11,10 @@
 #ifndef _MOCK_DATABASEFEEDMANAGER_HPP
 #define _MOCK_DATABASEFEEDMANAGER_HPP
 
+#include "databaseFeedManager.hpp"
+#include "json.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-#include "json.hpp"
 
 /**
  * @class MockDatabaseFeedManager
@@ -95,12 +95,11 @@ public:
      *
      * @note This method is intended for testing purposes and does not perform any real action.
      */
-    MOCK_METHOD(void,
+    MOCK_METHOD(bool,
                 getVulnerabiltyDescriptiveInformation,
-                (const std::string_view cveId,
+                (const std::string& cveId,
                  const std::string& adpShortName,
-                 const std::string& adpSubShortName,
-                 DetachedFlatbufferDataPair<VulnerabilityDescription>& resultContainer),
+                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer),
                 ());
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -496,18 +496,18 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_MultiSourc
 {
     const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
 
-    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+    FileProcessingCallback dummyCallback = [](const std::string& message,
+                                              std::shared_ptr<ConditionSync> shouldStop) -> FileProcessingResult
+    {
+        return FileProcessingResult {0, "", true};
+    };
 
     spPolicyManagerMock = std::make_shared<MockPolicyManager>();
     EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
     EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
 
     spContentRegisterMock = std::make_shared<MockContentRegister>(
-        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
-
-    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
-        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
-    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters, dummyCallback);
 
     flatbuffers::FlatBufferBuilder fbBuilderNvd;
     auto vdNvdDescription = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderNvd,
@@ -629,15 +629,10 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_MultiSourc
             CVEID_TEST_MULTI_ADP + std::string("_incomplete_vendor"), dbValueIncompleteVendor, DESCRIPTIONS_COLUMN);
     }
 
-    auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
-    std::atomic<bool> shouldStop {false};
     std::shared_mutex mutex;
 
-    auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
-                                                                      TrampolinePolicyManager,
-                                                                      TrampolineContentRegister,
-                                                                      TrampolineRouterSubscriber>>(
-        spTrampolineIndexerConnector, shouldStop, mutex)};
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
     DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -26,7 +26,7 @@ constexpr auto COMMON_UPDATER_DIR {"queue/vd_updater"}; //<<Used for all updater
 constexpr auto CVEID_TEST_OK {"cveid_test_ok"};
 constexpr auto CVEID_TEST_NOT_FOUND {"cveid_test_not_found"};
 constexpr auto CVEID_TEST_CORRUPTED {"cveid_test_corrupted"};
-constexpr auto CVEID_TEST_MULTI_ADP {"CVE-2024-1111"};
+constexpr auto CVE_ID {"CVE-2024-1111"};
 constexpr auto ADP_VENDOR {"vendor"};
 constexpr auto ADP_CANONICAL {"canonical"};
 constexpr auto ADP_INCOMPLETE_VENDOR {"incomplete_vendor"};
@@ -298,6 +298,48 @@ void DatabaseFeedManagerTest::SetUp()
         rocksDBWrapper.createColumn(CNA_MAPPING_COLUMN);
     }
     rocksDBWrapper.put("CNA-MAPPING-GLOBAL", CNA_MAPPINGS.dump(), CNA_MAPPING_COLUMN);
+
+    // Mock NVD description data
+    flatbuffers::FlatBufferBuilder fbBuilder;
+    auto nvdDescriptionOffset =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
+                                                                     "AccessComplexityStrNvd",
+                                                                     "AssignerStr",
+                                                                     "AttackVectorStrNvd",
+                                                                     "AuthenticationStrNvd",
+                                                                     "AvailabilityStrNvd",
+                                                                     "ClassificationStrNvd",
+                                                                     "ConfidentialityImpactStrNvd",
+                                                                     "CWEIdStrNvd",
+                                                                     "DataPublishedStr",
+                                                                     "DataUpdatedStr",
+                                                                     "DescriptionStrNvd",
+                                                                     "IntegrityImpactStrNvd",
+                                                                     "PrivilegesRequiredStrNvd",
+                                                                     "ReferenceStrNvd",
+                                                                     "ScopeStrNvd",
+                                                                     1,
+                                                                     "ScoreVersionStrNvd",
+                                                                     "SeverityStrNvd",
+                                                                     "UserInteractionStrNvd");
+
+    fbBuilder.Finish(nvdDescriptionOffset);
+
+    auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + DEFAULT_ADP;
+    if (!rocksDBWrapper.columnExists(descriptionColumn))
+    {
+        rocksDBWrapper.createColumn(descriptionColumn);
+    }
+    rocksdb::Slice nvdDescriptionSlice(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()),
+                                       fbBuilder.GetSize());
+
+    rocksDBWrapper.put(CVE_ID, nvdDescriptionSlice, descriptionColumn);
+
+    // Create the "empty" column to emulate a source with no data
+    if (!rocksDBWrapper.columnExists(std::string(DESCRIPTIONS_COLUMN) + "_empty"))
+    {
+        rocksDBWrapper.createColumn(std::string(DESCRIPTIONS_COLUMN) + "_empty");
+    }
 };
 
 void DatabaseFeedManagerTest::TearDown()
@@ -308,9 +350,15 @@ void DatabaseFeedManagerTest::TearDown()
     std::filesystem::remove_all(COMMON_DATABASE_DIR);
 };
 
-TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
+/**
+ * @brief Test the getVulnerabiltyDescriptiveInformation method.
+ *
+ */
+TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation)
 {
+    // Initialize the database feed manager
     const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
     FileProcessingCallback dummyCallback = [](const std::string& message,
                                               std::shared_ptr<ConditionSync> shouldStop) -> FileProcessingResult
     {
@@ -324,41 +372,6 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
     spContentRegisterMock = std::make_shared<MockContentRegister>(
         configurationParameters.at("topicName").get<const std::string>(), configurationParameters, dummyCallback);
 
-    flatbuffers::FlatBufferBuilder fbBuilder;
-    auto vdOriginalData = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
-                                                                                       "AccessComplexityStr",
-                                                                                       "AssignerStr",
-                                                                                       "AttackVectorStr",
-                                                                                       "AuthenticationStr",
-                                                                                       "AvailabilityStr",
-                                                                                       "ClassificationStr",
-                                                                                       "ConfidentialityImpactStr",
-                                                                                       "CWEIdStr",
-                                                                                       "DataPublishedStr",
-                                                                                       "DataUpdatedStr",
-                                                                                       "DescriptionStr",
-                                                                                       "IntegrityImpactStr",
-                                                                                       "PrivilegesRequiredStr",
-                                                                                       "ReferenceStr",
-                                                                                       "ScopeStr",
-                                                                                       999.99,
-                                                                                       "ScoreVersionStr",
-                                                                                       "SeverityStr",
-                                                                                       "UserInteractionStr");
-
-    fbBuilder.Finish(vdOriginalData);
-
-    {
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-        rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
-        {
-            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
-        }
-        dbWrapper->put(CVEID_TEST_OK, dbValue, DESCRIPTIONS_COLUMN);
-    }
-
-    auto shouldStop {std::make_shared<ConditionSync>(false)};
     std::shared_mutex mutex;
 
     auto spDatabaseFeedManager {
@@ -366,359 +379,40 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
 
     FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
-    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_OK, DEFAULT_ADP, container));
-    EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStr");
+    // Retrieve from existing source
+    EXPECT_TRUE(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, container));
+    EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrNvd");
     EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
-    EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStr");
-    EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStr");
-    EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStr");
-    EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStr");
-    EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStr");
-    EXPECT_STREQ(container.data->cweId()->c_str(), "CWEIdStr");
-    EXPECT_STREQ(container.data->datePublished()->c_str(), "DataPublishedStr");
-    EXPECT_STREQ(container.data->dateUpdated()->c_str(), "DataUpdatedStr");
-    EXPECT_STREQ(container.data->description()->c_str(), "DescriptionStr");
-    EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStr");
-    EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStr");
-    EXPECT_STREQ(container.data->reference()->c_str(), "ReferenceStr");
-    EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStr");
-    EXPECT_FLOAT_EQ(container.data->scoreBase(), 999.99);
-    EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStr");
-    EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStr");
-    EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStr");
-}
-
-TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
-{
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
-    FileProcessingCallback dummyCallback = [](const std::string& message,
-                                              std::shared_ptr<ConditionSync> shouldStop) -> FileProcessingResult
-    {
-        return FileProcessingResult {0, "", true};
-    };
-
-    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
-    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
-    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
-
-    spContentRegisterMock = std::make_shared<MockContentRegister>(
-        configurationParameters.at("topicName").get<const std::string>(), configurationParameters, dummyCallback);
-
-    flatbuffers::FlatBufferBuilder fbBuilder;
-    auto vdOriginalData = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
-                                                                                       "AccessComplexityStr",
-                                                                                       "AssignerStr",
-                                                                                       "AttackVectorStr",
-                                                                                       "AuthenticationStr",
-                                                                                       "AvailabilityStr",
-                                                                                       "ClassificationStr",
-                                                                                       "ConfidentialityImpactStr",
-                                                                                       "CWEIdStr",
-                                                                                       "DataPublishedStr",
-                                                                                       "DataUpdatedStr",
-                                                                                       "DescriptionStr",
-                                                                                       "IntegrityImpactStr",
-                                                                                       "PrivilegesRequiredStr",
-                                                                                       "ReferenceStr",
-                                                                                       "ScopeStr",
-                                                                                       999.99,
-                                                                                       "ScoreVersionStr",
-                                                                                       "SeverityStr",
-                                                                                       "UserInteractionStr");
-    fbBuilder.Finish(vdOriginalData);
-
-    {
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-        rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
-        {
-            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
-        }
-        dbWrapper->put(CVEID_TEST_NOT_FOUND, dbValue, DESCRIPTIONS_COLUMN);
-    }
-
-    auto shouldStop {std::make_shared<ConditionSync>(false)};
-    std::shared_mutex mutex;
-
-    auto spDatabaseFeedManager {
-        std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
-
-    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
-
-    EXPECT_THROW(
-        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("cveid_any", DEFAULT_ADP, container),
-        std::runtime_error);
-}
-
-TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
-{
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
-    FileProcessingCallback dummyCallback = [](const std::string& message,
-                                              std::shared_ptr<ConditionSync> shouldStop) -> FileProcessingResult
-    {
-        return FileProcessingResult {0, "", true};
-    };
-
-    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
-    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
-    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
-
-    spContentRegisterMock = std::make_shared<MockContentRegister>(
-        configurationParameters.at("topicName").get<const std::string>(), configurationParameters, dummyCallback);
-
-    {
-        uint8_t corruptedData[] = {
-            0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF, 0x55, 0xCC, 0x00, 0xFF};
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-        rocksdb::Slice dbValue(reinterpret_cast<const char*>(corruptedData), sizeof(corruptedData));
-        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
-        {
-            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
-        }
-        dbWrapper->put(CVEID_TEST_CORRUPTED, dbValue, DESCRIPTIONS_COLUMN);
-    }
-
-    auto shouldStop {std::make_shared<ConditionSync>(false)};
-    std::shared_mutex mutex;
-
-    auto spDatabaseFeedManager {
-        std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
-
-    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
-
-    EXPECT_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-                     CVEID_TEST_CORRUPTED, DEFAULT_ADP, container),
-                 std::runtime_error);
-}
-
-TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_MultiSource)
-{
-    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
-
-    FileProcessingCallback dummyCallback = [](const std::string& message,
-                                              std::shared_ptr<ConditionSync> shouldStop) -> FileProcessingResult
-    {
-        return FileProcessingResult {0, "", true};
-    };
-
-    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
-    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
-    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
-
-    spContentRegisterMock = std::make_shared<MockContentRegister>(
-        configurationParameters.at("topicName").get<const std::string>(), configurationParameters, dummyCallback);
-
-    flatbuffers::FlatBufferBuilder fbBuilderNvd;
-    auto vdNvdDescription = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderNvd,
-                                                                                         "AccessComplexityStrNvd",
-                                                                                         "AssignerStr",
-                                                                                         "AttackVectorStrNvd",
-                                                                                         "AuthenticationStrNvd",
-                                                                                         "AvailabilityStrNvd",
-                                                                                         "ClassificationStrNvd",
-                                                                                         "ConfidentialityImpactStrNvd",
-                                                                                         "CWEIdStrNvd",
-                                                                                         "DataPublishedStr",
-                                                                                         "DataUpdatedStr",
-                                                                                         "DescriptionStrNvd",
-                                                                                         "IntegrityImpactStrNvd",
-                                                                                         "PrivilegesRequiredStrNvd",
-                                                                                         "ReferenceStrNvd",
-                                                                                         "ScopeStrNvd",
-                                                                                         1,
-                                                                                         "ScoreVersionStrNvd",
-                                                                                         "SeverityStrNvd",
-                                                                                         "UserInteractionStrNvd");
-
-    fbBuilderNvd.Finish(vdNvdDescription);
-
-    flatbuffers::FlatBufferBuilder fbBuilderCanonical;
-    auto vdCanonicalDescription =
-        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderCanonical,
-                                                                     "AccessComplexityStrCanonical",
-                                                                     "AssignerStr",
-                                                                     "AttackVectorStrCanonical",
-                                                                     "AuthenticationStrCanonical",
-                                                                     "AvailabilityStrCanonical",
-                                                                     "ClassificationStrCanonical",
-                                                                     "ConfidentialityImpactStrCanonical",
-                                                                     "CWEIdStr",
-                                                                     "DataPublishedStr",
-                                                                     "DataUpdatedStr",
-                                                                     "DescriptionStrCanonical",
-                                                                     "IntegrityImpactStrCanonical",
-                                                                     "PrivilegesRequiredStrCanonical",
-                                                                     "ReferenceStrCanonical",
-                                                                     "ScopeStrCanonical",
-                                                                     2,
-                                                                     "ScoreVersionStrCanonical",
-                                                                     "SeverityStrCanonical",
-                                                                     "UserInteractionStrCanonical");
-
-    fbBuilderCanonical.Finish(vdCanonicalDescription);
-
-    flatbuffers::FlatBufferBuilder fbBuilderVendor;
-    auto vdVendorDescription =
-        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderVendor,
-                                                                     "AccessComplexityStrVendor",
-                                                                     "AssignerStr",
-                                                                     "AttackVectorStrVendor",
-                                                                     "AuthenticationStrVendor",
-                                                                     "AvailabilityStrVendor",
-                                                                     "ClassificationStrVendor",
-                                                                     "ConfidentialityImpactStrVendor",
-                                                                     "CWEIdStr",
-                                                                     "DataPublishedStr",
-                                                                     "DataUpdatedStr",
-                                                                     "DescriptionStrVendor",
-                                                                     "IntegrityImpactStrVendor",
-                                                                     "PrivilegesRequiredStrVendor",
-                                                                     "ReferenceStrVendor",
-                                                                     "ScopeStrVendor",
-                                                                     3,
-                                                                     "ScoreVersionStrVendor",
-                                                                     "SeverityStrVendor",
-                                                                     "UserInteractionStrVendor");
-    fbBuilderVendor.Finish(vdVendorDescription);
-
-    flatbuffers::FlatBufferBuilder fbBuilderIncompleteVendor;
-    auto vdIncompleteVendorDescription =
-        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderIncompleteVendor,
-                                                                     "AccessComplexityStrIncompleteVendor",
-                                                                     "AssignerStr",
-                                                                     "AttackVectorStrIncompleteVendor",
-                                                                     "AuthenticationStrIncompleteVendor",
-                                                                     "AvailabilityStrIncompleteVendor",
-                                                                     "ClassificationStrIncompleteVendor",
-                                                                     "ConfidentialityImpactStrIncompleteVendor",
-                                                                     "CWEIdStr",
-                                                                     "DataPublishedStr",
-                                                                     "DataUpdatedStr",
-                                                                     "not defined",
-                                                                     "IntegrityImpactStrIncompleteVendor",
-                                                                     "PrivilegesRequiredStrIncompleteVendor",
-                                                                     "ReferenceStrIncompleteVendor",
-                                                                     "ScopeStrIncompleteVendor",
-                                                                     4,
-                                                                     "ScoreVersionStrIncompleteVendor",
-                                                                     "",
-                                                                     "UserInteractionStrIncompleteVendor");
-
-    fbBuilderIncompleteVendor.Finish(vdIncompleteVendorDescription);
-
-    {
-        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-        rocksdb::Slice dbValueNvd(reinterpret_cast<const char*>(fbBuilderNvd.GetBufferPointer()),
-                                  fbBuilderNvd.GetSize());
-        rocksdb::Slice dbValueCanonical(reinterpret_cast<const char*>(fbBuilderCanonical.GetBufferPointer()),
-                                        fbBuilderCanonical.GetSize());
-        rocksdb::Slice dbValueVendor(reinterpret_cast<const char*>(fbBuilderVendor.GetBufferPointer()),
-                                     fbBuilderVendor.GetSize());
-        rocksdb::Slice dbValueIncompleteVendor(
-            reinterpret_cast<const char*>(fbBuilderIncompleteVendor.GetBufferPointer()),
-            fbBuilderIncompleteVendor.GetSize());
-        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
-        {
-            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
-        }
-        dbWrapper->put(CVEID_TEST_MULTI_ADP, dbValueNvd, DESCRIPTIONS_COLUMN);
-        dbWrapper->put(CVEID_TEST_MULTI_ADP + std::string("_canonical"), dbValueCanonical, DESCRIPTIONS_COLUMN);
-        dbWrapper->put(CVEID_TEST_MULTI_ADP + std::string("_vendor"), dbValueVendor, DESCRIPTIONS_COLUMN);
-        dbWrapper->put(
-            CVEID_TEST_MULTI_ADP + std::string("_incomplete_vendor"), dbValueIncompleteVendor, DESCRIPTIONS_COLUMN);
-    }
-
-    std::shared_mutex mutex;
-
-    auto spDatabaseFeedManager {
-        std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
-
-    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
-
-    // Both shortName and subShortName are the same
-    EXPECT_NO_THROW(
-        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVEID_TEST_MULTI_ADP, DEFAULT_ADP, container));
-
-    auto expectNvdValues = [&]()
-    {
-        EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrNvd");
-        EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
-        EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrNvd");
-        EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStrNvd");
-        EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStrNvd");
-        EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStrNvd");
-        EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStrNvd");
-        EXPECT_STREQ(container.data->cweId()->c_str(), "CWEIdStrNvd");
-        EXPECT_STREQ(container.data->datePublished()->c_str(), "DataPublishedStr");
-        EXPECT_STREQ(container.data->dateUpdated()->c_str(), "DataUpdatedStr");
-        EXPECT_STREQ(container.data->description()->c_str(), "DescriptionStrNvd");
-        EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStrNvd");
-        EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStrNvd");
-        EXPECT_STREQ(container.data->reference()->c_str(), "ReferenceStrNvd");
-        EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStrNvd");
-        EXPECT_FLOAT_EQ(container.data->scoreBase(), 1);
-        EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStrNvd");
-        EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStrNvd");
-        EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStrNvd");
-    };
-    expectNvdValues();
-
-    // Neither shortName nor subShortName were found, using default we expect the same result as before
-    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, "non_existing_vendor", container));
-    expectNvdValues();
-
-    // With the incomplete vendor, we also expect the default values
-    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, ADP_INCOMPLETE_VENDOR, container));
-    expectNvdValues();
-
-    // If both shortName and subShortName are found, the subShortName takes precedence
-    EXPECT_NO_THROW(
-        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVEID_TEST_MULTI_ADP, ADP_CANONICAL, container));
-    EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrCanonical");
-    EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
-    EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrCanonical");
-    EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStrCanonical");
-    EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStrCanonical");
-    EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStrCanonical");
-    EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStrCanonical");
+    EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrNvd");
+    EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStrNvd");
+    EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStrNvd");
+    EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStrNvd");
+    EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStrNvd");
     EXPECT_STREQ(container.data->cweId()->c_str(), "CWEIdStrNvd");
     EXPECT_STREQ(container.data->datePublished()->c_str(), "DataPublishedStr");
     EXPECT_STREQ(container.data->dateUpdated()->c_str(), "DataUpdatedStr");
     EXPECT_STREQ(container.data->description()->c_str(), "DescriptionStrNvd");
-    EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStrCanonical");
-    EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStrCanonical");
+    EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStrNvd");
+    EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStrNvd");
     EXPECT_STREQ(container.data->reference()->c_str(), "ReferenceStrNvd");
-    EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStrCanonical");
-    EXPECT_FLOAT_EQ(container.data->scoreBase(), 2);
-    EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStrCanonical");
-    EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStrCanonical");
-    EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStrCanonical");
+    EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStrNvd");
+    EXPECT_FLOAT_EQ(container.data->scoreBase(), 1);
+    EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStrNvd");
+    EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStrNvd");
+    EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStrNvd");
 
-    // If subShortName is not found, the shortName is used
-    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, "non_existing_vendor", container));
-    EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrVendor");
-    EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
-    EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrVendor");
-    EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStrVendor");
-    EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStrVendor");
-    EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStrVendor");
-    EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStrVendor");
-    EXPECT_STREQ(container.data->cweId()->c_str(), "CWEIdStrNvd");
-    EXPECT_STREQ(container.data->datePublished()->c_str(), "DataPublishedStr");
-    EXPECT_STREQ(container.data->dateUpdated()->c_str(), "DataUpdatedStr");
-    EXPECT_STREQ(container.data->description()->c_str(), "DescriptionStrNvd");
-    EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStrVendor");
-    EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStrVendor");
-    EXPECT_STREQ(container.data->reference()->c_str(), "ReferenceStrVendor");
-    EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStrVendor");
-    EXPECT_FLOAT_EQ(container.data->scoreBase(), 3);
-    EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStrVendor");
-    EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStrVendor");
-    EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStrVendor");
+    // Retrieve from empty source
+    EXPECT_FALSE(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVE_ID, "empty", container));
+    EXPECT_EQ(container.data, nullptr);
+
+    // Retrieve from non-existing CVE
+    EXPECT_FALSE(
+        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("non_existing_cve", DEFAULT_ADP, container));
+    EXPECT_EQ(container.data, nullptr);
+
+    // Retrieve from non-existing source
+    EXPECT_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVE_ID, "non_existing_source", container);
+                 , std::runtime_error);
 }
 
 TEST_F(DatabaseFeedManagerTest, DISABLED_GetVulnerabilityCandidatesSuccess)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -364,10 +364,10 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
-    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
     EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_OK, DEFAULT_ADP, DEFAULT_ADP, container));
+        CVEID_TEST_OK, DEFAULT_ADP, container));
     EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStr");
     EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
     EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStr");
@@ -444,10 +444,10 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
-    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
     EXPECT_THROW(
-        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("cveid_any", DEFAULT_ADP, DEFAULT_ADP, container),
+        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("cveid_any", DEFAULT_ADP, container),
         std::runtime_error);
 }
 
@@ -485,10 +485,10 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
-    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
     EXPECT_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-                     CVEID_TEST_CORRUPTED, DEFAULT_ADP, DEFAULT_ADP, container),
+                     CVEID_TEST_CORRUPTED, DEFAULT_ADP, container),
                  std::runtime_error);
 }
 
@@ -634,11 +634,11 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_MultiSourc
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
-    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
     // Both shortName and subShortName are the same
-    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, DEFAULT_ADP, DEFAULT_ADP, container));
+    EXPECT_NO_THROW(
+        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVEID_TEST_MULTI_ADP, DEFAULT_ADP, container));
 
     auto expectNvdValues = [&]()
     {
@@ -666,17 +666,17 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_MultiSourc
 
     // Neither shortName nor subShortName were found, using default we expect the same result as before
     EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, "non_existing_vendor", "non_existing_vendor", container));
+        CVEID_TEST_MULTI_ADP, "non_existing_vendor", container));
     expectNvdValues();
 
     // With the incomplete vendor, we also expect the default values
     EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, ADP_INCOMPLETE_VENDOR, ADP_INCOMPLETE_VENDOR, container));
+        CVEID_TEST_MULTI_ADP, ADP_INCOMPLETE_VENDOR, container));
     expectNvdValues();
 
     // If both shortName and subShortName are found, the subShortName takes precedence
-    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, DEFAULT_ADP, ADP_CANONICAL, container));
+    EXPECT_NO_THROW(
+        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVEID_TEST_MULTI_ADP, ADP_CANONICAL, container));
     EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrCanonical");
     EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
     EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrCanonical");
@@ -699,7 +699,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_MultiSourc
 
     // If subShortName is not found, the shortName is used
     EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
-        CVEID_TEST_MULTI_ADP, ADP_VENDOR, "non_existing_vendor", container));
+        CVEID_TEST_MULTI_ADP, "non_existing_vendor", container));
     EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrVendor");
     EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
     EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrVendor");

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -26,6 +26,10 @@ constexpr auto COMMON_UPDATER_DIR {"queue/vd_updater"}; //<<Used for all updater
 constexpr auto CVEID_TEST_OK {"cveid_test_ok"};
 constexpr auto CVEID_TEST_NOT_FOUND {"cveid_test_not_found"};
 constexpr auto CVEID_TEST_CORRUPTED {"cveid_test_corrupted"};
+constexpr auto CVEID_TEST_MULTI_ADP {"CVE-2024-1111"};
+constexpr auto ADP_VENDOR {"vendor"};
+constexpr auto ADP_CANONICAL {"canonical"};
+constexpr auto ADP_INCOMPLETE_VENDOR {"incomplete_vendor"};
 const std::string CANDIDATE_FLATBUFFER_SCHEMA {FLATBUFFER_SCHEMAS_DIR "/vulnerabilityCandidate.fbs"};
 const std::string TRANSLATION_FLATBUFFER_SCHEMA {FLATBUFFER_SCHEMAS_DIR "/packageTranslation.fbs"};
 
@@ -252,7 +256,30 @@ void DatabaseFeedManagerTest::SetUp()
     {
         rocksDBWrapper.createColumn(VENDOR_MAP_COLUMN);
     }
-    auto map = R"({"prefix": [],"contains": [],"format": [], "source": []})";
+    auto map = R"({"prefix": [],
+                   "contains": [],
+                   "format": [],
+                   "source": [],
+                   "adp_descriptions" : {
+                        "nvd" : {
+                            "cvss" : "nvd",
+                            "description" : "nvd"
+                        },
+                        "canonical" : {
+                            "cvss" : "canonical",
+                            "description" : "nvd"
+                        },
+                        "vendor" : {
+                            "cvss" : "vendor",
+                            "description" : "nvd",
+                            "reference" : "vendor"
+                        },
+                        "incomplete_vendor" : {
+                            "cvss" : "incomplete_vendor",
+                            "description" : "incomplete_vendor"
+                        }
+                    }
+                })";
 
     rocksDBWrapper.put("FEED-GLOBAL", map, VENDOR_MAP_COLUMN);
 
@@ -337,9 +364,10 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Ok)
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
-    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
-    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVEID_TEST_OK, container));
+    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
+        CVEID_TEST_OK, DEFAULT_ADP, DEFAULT_ADP, container));
     EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStr");
     EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
     EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStr");
@@ -416,10 +444,11 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_NotFound)
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
-    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
-    EXPECT_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("cveid_any", container),
-                 std::runtime_error);
+    EXPECT_THROW(
+        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("cveid_any", DEFAULT_ADP, DEFAULT_ADP, container),
+        std::runtime_error);
 }
 
 TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
@@ -456,10 +485,245 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_Corrupted)
     auto spDatabaseFeedManager {
         std::make_shared<TDatabaseFeedManager<TrampolinePolicyManager, TrampolineContentRegister>>(mutex)};
 
-    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
-    EXPECT_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVEID_TEST_CORRUPTED, container),
+    EXPECT_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
+                     CVEID_TEST_CORRUPTED, DEFAULT_ADP, DEFAULT_ADP, container),
                  std::runtime_error);
+}
+
+TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation_MultiSource)
+{
+    const auto configurationParameters = R"( {"topicName": "topicNameTest"} )"_json;
+
+    spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+
+    spPolicyManagerMock = std::make_shared<MockPolicyManager>();
+    EXPECT_CALL(*spPolicyManagerMock, getUpdaterConfiguration()).WillRepeatedly(Return(configurationParameters));
+    EXPECT_CALL(*spPolicyManagerMock, getTranslationLRUSize()).WillRepeatedly(Return(2048));
+
+    spContentRegisterMock = std::make_shared<MockContentRegister>(
+        configurationParameters.at("topicName").get<const std::string>(), configurationParameters);
+
+    spRouterSubscriberMock = std::make_shared<MockRouterSubscriber>(
+        configurationParameters.at("topicName").get<const std::string>(), "vulnerability_feed_manager");
+    EXPECT_CALL(*spRouterSubscriberMock, subscribe(_));
+
+    flatbuffers::FlatBufferBuilder fbBuilderNvd;
+    auto vdNvdDescription = NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderNvd,
+                                                                                         "AccessComplexityStrNvd",
+                                                                                         "AssignerStr",
+                                                                                         "AttackVectorStrNvd",
+                                                                                         "AuthenticationStrNvd",
+                                                                                         "AvailabilityStrNvd",
+                                                                                         "ClassificationStrNvd",
+                                                                                         "ConfidentialityImpactStrNvd",
+                                                                                         "CWEIdStrNvd",
+                                                                                         "DataPublishedStr",
+                                                                                         "DataUpdatedStr",
+                                                                                         "DescriptionStrNvd",
+                                                                                         "IntegrityImpactStrNvd",
+                                                                                         "PrivilegesRequiredStrNvd",
+                                                                                         "ReferenceStrNvd",
+                                                                                         "ScopeStrNvd",
+                                                                                         1,
+                                                                                         "ScoreVersionStrNvd",
+                                                                                         "SeverityStrNvd",
+                                                                                         "UserInteractionStrNvd");
+
+    fbBuilderNvd.Finish(vdNvdDescription);
+
+    flatbuffers::FlatBufferBuilder fbBuilderCanonical;
+    auto vdCanonicalDescription =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderCanonical,
+                                                                     "AccessComplexityStrCanonical",
+                                                                     "AssignerStr",
+                                                                     "AttackVectorStrCanonical",
+                                                                     "AuthenticationStrCanonical",
+                                                                     "AvailabilityStrCanonical",
+                                                                     "ClassificationStrCanonical",
+                                                                     "ConfidentialityImpactStrCanonical",
+                                                                     "CWEIdStr",
+                                                                     "DataPublishedStr",
+                                                                     "DataUpdatedStr",
+                                                                     "DescriptionStrCanonical",
+                                                                     "IntegrityImpactStrCanonical",
+                                                                     "PrivilegesRequiredStrCanonical",
+                                                                     "ReferenceStrCanonical",
+                                                                     "ScopeStrCanonical",
+                                                                     2,
+                                                                     "ScoreVersionStrCanonical",
+                                                                     "SeverityStrCanonical",
+                                                                     "UserInteractionStrCanonical");
+
+    fbBuilderCanonical.Finish(vdCanonicalDescription);
+
+    flatbuffers::FlatBufferBuilder fbBuilderVendor;
+    auto vdVendorDescription =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderVendor,
+                                                                     "AccessComplexityStrVendor",
+                                                                     "AssignerStr",
+                                                                     "AttackVectorStrVendor",
+                                                                     "AuthenticationStrVendor",
+                                                                     "AvailabilityStrVendor",
+                                                                     "ClassificationStrVendor",
+                                                                     "ConfidentialityImpactStrVendor",
+                                                                     "CWEIdStr",
+                                                                     "DataPublishedStr",
+                                                                     "DataUpdatedStr",
+                                                                     "DescriptionStrVendor",
+                                                                     "IntegrityImpactStrVendor",
+                                                                     "PrivilegesRequiredStrVendor",
+                                                                     "ReferenceStrVendor",
+                                                                     "ScopeStrVendor",
+                                                                     3,
+                                                                     "ScoreVersionStrVendor",
+                                                                     "SeverityStrVendor",
+                                                                     "UserInteractionStrVendor");
+    fbBuilderVendor.Finish(vdVendorDescription);
+
+    flatbuffers::FlatBufferBuilder fbBuilderIncompleteVendor;
+    auto vdIncompleteVendorDescription =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilderIncompleteVendor,
+                                                                     "AccessComplexityStrIncompleteVendor",
+                                                                     "AssignerStr",
+                                                                     "AttackVectorStrIncompleteVendor",
+                                                                     "AuthenticationStrIncompleteVendor",
+                                                                     "AvailabilityStrIncompleteVendor",
+                                                                     "ClassificationStrIncompleteVendor",
+                                                                     "ConfidentialityImpactStrIncompleteVendor",
+                                                                     "CWEIdStr",
+                                                                     "DataPublishedStr",
+                                                                     "DataUpdatedStr",
+                                                                     "not defined",
+                                                                     "IntegrityImpactStrIncompleteVendor",
+                                                                     "PrivilegesRequiredStrIncompleteVendor",
+                                                                     "ReferenceStrIncompleteVendor",
+                                                                     "ScopeStrIncompleteVendor",
+                                                                     4,
+                                                                     "ScoreVersionStrIncompleteVendor",
+                                                                     "",
+                                                                     "UserInteractionStrIncompleteVendor");
+
+    fbBuilderIncompleteVendor.Finish(vdIncompleteVendorDescription);
+
+    {
+        auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+        rocksdb::Slice dbValueNvd(reinterpret_cast<const char*>(fbBuilderNvd.GetBufferPointer()),
+                                  fbBuilderNvd.GetSize());
+        rocksdb::Slice dbValueCanonical(reinterpret_cast<const char*>(fbBuilderCanonical.GetBufferPointer()),
+                                        fbBuilderCanonical.GetSize());
+        rocksdb::Slice dbValueVendor(reinterpret_cast<const char*>(fbBuilderVendor.GetBufferPointer()),
+                                     fbBuilderVendor.GetSize());
+        rocksdb::Slice dbValueIncompleteVendor(
+            reinterpret_cast<const char*>(fbBuilderIncompleteVendor.GetBufferPointer()),
+            fbBuilderIncompleteVendor.GetSize());
+        if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN))
+        {
+            dbWrapper->createColumn(DESCRIPTIONS_COLUMN);
+        }
+        dbWrapper->put(CVEID_TEST_MULTI_ADP, dbValueNvd, DESCRIPTIONS_COLUMN);
+        dbWrapper->put(CVEID_TEST_MULTI_ADP + std::string("_canonical"), dbValueCanonical, DESCRIPTIONS_COLUMN);
+        dbWrapper->put(CVEID_TEST_MULTI_ADP + std::string("_vendor"), dbValueVendor, DESCRIPTIONS_COLUMN);
+        dbWrapper->put(
+            CVEID_TEST_MULTI_ADP + std::string("_incomplete_vendor"), dbValueIncompleteVendor, DESCRIPTIONS_COLUMN);
+    }
+
+    auto spTrampolineIndexerConnector = std::make_shared<TrampolineIndexerConnector>();
+    std::atomic<bool> shouldStop {false};
+    std::shared_mutex mutex;
+
+    auto spDatabaseFeedManager {std::make_shared<TDatabaseFeedManager<TrampolineIndexerConnector,
+                                                                      TrampolinePolicyManager,
+                                                                      TrampolineContentRegister,
+                                                                      TrampolineRouterSubscriber>>(
+        spTrampolineIndexerConnector, shouldStop, mutex)};
+
+    DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
+
+    // Both shortName and subShortName are the same
+    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
+        CVEID_TEST_MULTI_ADP, DEFAULT_ADP, DEFAULT_ADP, container));
+
+    auto expectNvdValues = [&]()
+    {
+        EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrNvd");
+        EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
+        EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrNvd");
+        EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStrNvd");
+        EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStrNvd");
+        EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStrNvd");
+        EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStrNvd");
+        EXPECT_STREQ(container.data->cweId()->c_str(), "CWEIdStrNvd");
+        EXPECT_STREQ(container.data->datePublished()->c_str(), "DataPublishedStr");
+        EXPECT_STREQ(container.data->dateUpdated()->c_str(), "DataUpdatedStr");
+        EXPECT_STREQ(container.data->description()->c_str(), "DescriptionStrNvd");
+        EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStrNvd");
+        EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStrNvd");
+        EXPECT_STREQ(container.data->reference()->c_str(), "ReferenceStrNvd");
+        EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStrNvd");
+        EXPECT_FLOAT_EQ(container.data->scoreBase(), 1);
+        EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStrNvd");
+        EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStrNvd");
+        EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStrNvd");
+    };
+    expectNvdValues();
+
+    // Neither shortName nor subShortName were found, using default we expect the same result as before
+    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
+        CVEID_TEST_MULTI_ADP, "non_existing_vendor", "non_existing_vendor", container));
+    expectNvdValues();
+
+    // With the incomplete vendor, we also expect the default values
+    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
+        CVEID_TEST_MULTI_ADP, ADP_INCOMPLETE_VENDOR, ADP_INCOMPLETE_VENDOR, container));
+    expectNvdValues();
+
+    // If both shortName and subShortName are found, the subShortName takes precedence
+    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
+        CVEID_TEST_MULTI_ADP, DEFAULT_ADP, ADP_CANONICAL, container));
+    EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrCanonical");
+    EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
+    EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrCanonical");
+    EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStrCanonical");
+    EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStrCanonical");
+    EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStrCanonical");
+    EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStrCanonical");
+    EXPECT_STREQ(container.data->cweId()->c_str(), "CWEIdStrNvd");
+    EXPECT_STREQ(container.data->datePublished()->c_str(), "DataPublishedStr");
+    EXPECT_STREQ(container.data->dateUpdated()->c_str(), "DataUpdatedStr");
+    EXPECT_STREQ(container.data->description()->c_str(), "DescriptionStrNvd");
+    EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStrCanonical");
+    EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStrCanonical");
+    EXPECT_STREQ(container.data->reference()->c_str(), "ReferenceStrNvd");
+    EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStrCanonical");
+    EXPECT_FLOAT_EQ(container.data->scoreBase(), 2);
+    EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStrCanonical");
+    EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStrCanonical");
+    EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStrCanonical");
+
+    // If subShortName is not found, the shortName is used
+    EXPECT_NO_THROW(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(
+        CVEID_TEST_MULTI_ADP, ADP_VENDOR, "non_existing_vendor", container));
+    EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrVendor");
+    EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
+    EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrVendor");
+    EXPECT_STREQ(container.data->authentication()->c_str(), "AuthenticationStrVendor");
+    EXPECT_STREQ(container.data->availabilityImpact()->c_str(), "AvailabilityStrVendor");
+    EXPECT_STREQ(container.data->classification()->c_str(), "ClassificationStrVendor");
+    EXPECT_STREQ(container.data->confidentialityImpact()->c_str(), "ConfidentialityImpactStrVendor");
+    EXPECT_STREQ(container.data->cweId()->c_str(), "CWEIdStrNvd");
+    EXPECT_STREQ(container.data->datePublished()->c_str(), "DataPublishedStr");
+    EXPECT_STREQ(container.data->dateUpdated()->c_str(), "DataUpdatedStr");
+    EXPECT_STREQ(container.data->description()->c_str(), "DescriptionStrNvd");
+    EXPECT_STREQ(container.data->integrityImpact()->c_str(), "IntegrityImpactStrVendor");
+    EXPECT_STREQ(container.data->privilegesRequired()->c_str(), "PrivilegesRequiredStrVendor");
+    EXPECT_STREQ(container.data->reference()->c_str(), "ReferenceStrVendor");
+    EXPECT_STREQ(container.data->scope()->c_str(), "ScopeStrVendor");
+    EXPECT_FLOAT_EQ(container.data->scoreBase(), 3);
+    EXPECT_STREQ(container.data->scoreVersion()->c_str(), "ScoreVersionStrVendor");
+    EXPECT_STREQ(container.data->severity()->c_str(), "SeverityStrVendor");
+    EXPECT_STREQ(container.data->userInteraction()->c_str(), "UserInteractionStrVendor");
 }
 
 TEST_F(DatabaseFeedManagerTest, DISABLED_GetVulnerabilityCandidatesSuccess)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -46,7 +46,7 @@ namespace
     const std::string ADP_EXPANDED_POSTFIX = "_expanded";
 
     const auto createVulnerabilityDescriptiveInformation =
-        [](FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+        [](FlatbufferDataPair<VulnerabilityDescription>& resultContainer, flatbuffers::DetachedBuffer& detachedBuffer)
     {
         flatbuffers::FlatBufferBuilder fbBuilder;
         const auto vulnerabilityDescriptiveInformation =
@@ -72,9 +72,8 @@ namespace
                                                                          "cvssData.userInteraction");
 
         fbBuilder.Finish(vulnerabilityDescriptiveInformation);
-
-        rocksdb::Slice slice(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-        resultContainer.data = NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data());
+        detachedBuffer = fbBuilder.Release();
+        resultContainer.data = NSVulnerabilityScanner::GetVulnerabilityDescription(detachedBuffer.data());
     };
 
     const auto validateVulnerabilityDescriptiveInformation = [](const CveDescription& description)
@@ -109,19 +108,24 @@ namespace
  */
 TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
 {
-    // Prepare the mocks
-    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    spGlobalDataMock = std::make_shared<MockGlobalData>();
-
     const auto sources =
         std::make_pair(ADP_CVSS_EQUALS_DESCRIPTION, ADP_CVSS_EQUALS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
 
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create a detached buffer to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBuffer;
+
     // Expect the database manager to be called with the default ADP
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, sources.second, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             {
-                createVulnerabilityDescriptiveInformation(resultContainer);
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
                 return true;
             }));
 
@@ -130,7 +134,8 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
         .Times(0);
 
     // The global data should be called to retrieve the ADP descriptions map
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
 
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -119,7 +119,7 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
     // Create a detached buffer to store the vulnerability descriptive information for the test duration
     flatbuffers::DetachedBuffer detachedBuffer;
 
-    // Expect the database manager to be called with the default ADP
+    // We expect one call to the database manager for both the CVSS and description
     EXPECT_CALL(*spDatabaseFeedManagerMock,
                 getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
@@ -141,5 +141,152 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
 
     // Reset the mocks
+    spGlobalDataMock.reset();
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from the same
+ * source.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSource)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create two detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+
+    // Expect two calls to the database manager, one for the description and one for the CVSS
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
+                return true;
+            }));
+
+    // We don't expect the database manager to be called with the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .Times(0);
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spGlobalDataMock.reset();
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP that is not present in the ADP descriptions map. We should
+ * fallback to the default ADP.
+ *
+ */
+TEST_F(DescriptionsHelperTest, nonExistentAdp)
+{
+    const auto sources = std::make_pair(ADP_INEXISTENT, ADP_INEXISTENT + ADP_EXPANDED_POSTFIX);
+
+    const auto expectedAdpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create a detached buffer to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBuffer;
+
+    // We get the information from the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return true;
+            }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spGlobalDataMock.reset();
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The database doesn't contain the information for the requested ADP, so we fallback to the default ADP.
+ *
+ */
+TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_EQUALS_DESCRIPTION, ADP_CVSS_EQUALS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto adpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION).at("description").get<std::string>();
+    const auto defaultAdpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // One call to the database manager should fail, so we expect another call with the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, adpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                flatbuffers::DetachedBuffer detachedBuffer;
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return false;
+            }));
+
+    // Create one detached buffer to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBuffer;
+
+    // Only one call because the CVSS and description are obtained from the same source
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return true;
+            }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spGlobalDataMock.reset();
     spDatabaseFeedManagerMock.reset();
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -46,7 +46,10 @@ namespace
     const std::string ADP_EXPANDED_POSTFIX = "_expanded";
 
     const auto createVulnerabilityDescriptiveInformation =
-        [](FlatbufferDataPair<VulnerabilityDescription>& resultContainer, flatbuffers::DetachedBuffer& detachedBuffer)
+        [](FlatbufferDataPair<VulnerabilityDescription>& resultContainer,
+           flatbuffers::DetachedBuffer& detachedBuffer,
+           float scoreBase = 3.0f,
+           const char* description = "descriptionData.description")
     {
         flatbuffers::FlatBufferBuilder fbBuilder;
         const auto vulnerabilityDescriptiveInformation =
@@ -61,12 +64,12 @@ namespace
                                                                          "descriptionData.cweId",
                                                                          "descriptionData.datePublished",
                                                                          "descriptionData.dateUpdated",
-                                                                         "descriptionData.description",
+                                                                         description,
                                                                          "cvssData.integrityImpact",
                                                                          "cvssData.privilegesRequired",
                                                                          "descriptionData.reference",
                                                                          "cvssData.scope",
-                                                                         0.0f,
+                                                                         scoreBase,
                                                                          "cvssData.scoreVersion",
                                                                          "cvssData.severity",
                                                                          "cvssData.userInteraction");
@@ -93,7 +96,7 @@ namespace
         EXPECT_EQ(description.privilegesRequired, "cvssData.privilegesRequired");
         EXPECT_EQ(description.reference, "descriptionData.reference");
         EXPECT_EQ(description.scope, "cvssData.scope");
-        EXPECT_EQ(description.scoreBase, 0.0f);
+        EXPECT_EQ(description.scoreBase, 3.0f);
         EXPECT_EQ(description.scoreVersion, "cvssData.scoreVersion");
         EXPECT_EQ(description.severity, "cvssData.severity");
         EXPECT_EQ(description.userInteraction, "cvssData.userInteraction");
@@ -276,6 +279,133 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             {
                 createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return true;
+            }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spGlobalDataMock.reset();
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The CVSS information is not reliable, so we fallback to the default ADP.
+ *
+ */
+TEST_F(DescriptionsHelperTest, notReliableCvssInformation)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+    const auto defaultAdpCvssSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create three detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+    flatbuffers::DetachedBuffer detachedBufferDefaultCvss;
+
+    // Expect three calls to the database manager, one for the description and two for the CVSS (one for the unreliable
+    // ADP and one for the default ADP)
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription, 0.0f);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss, 0.0f);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss);
+                return true;
+            }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spGlobalDataMock.reset();
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The Description information is not reliable, so we fallback to the default ADP.
+ *
+ */
+TEST_F(DescriptionsHelperTest, notReliableDescriptionInformation)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+    const auto defaultAdpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create three detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferDefaultDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+
+    // Expect three calls to the database manager, one for the CVSS and two for the description (one for the unreliable
+    // ADP and one for the default ADP)
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(
+                    resultContainer, detachedBufferDescription, 3.0f, "not defined");
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultDescription);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
                 return true;
             }));
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -250,16 +250,14 @@ TEST_F(DescriptionsHelperTest, nonExistentAdp)
 TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
 {
     const auto sources =
-        std::make_pair(ADP_CVSS_EQUALS_DESCRIPTION, ADP_CVSS_EQUALS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
 
     const auto adpDescriptionSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION).at("description").get<std::string>();
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION).at("description").get<std::string>();
     const auto adpCvssSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION).at("cvss").get<std::string>();
-    const auto defaultAdpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION).at("cvss").get<std::string>();
+    const auto defaultAdpSource =
         ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
-    const auto defaultAdpCvssSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
 
@@ -287,17 +285,13 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
     flatbuffers::DetachedBuffer detachedBufferDescription;
     flatbuffers::DetachedBuffer detachedBufferCvss;
 
-    EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpDescriptionSource, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             {
                 createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription);
                 return true;
-            }));
-
-    EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+            }))
         .WillOnce(::testing::Invoke(
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             {
@@ -318,10 +312,10 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
 }
 
 /**
- * @brief The CVSS information is not reliable, so we fallback to the default ADP.
+ * @brief The CVSS information is not reliable, so we fallback to the default ADP (due to the CVSS score being near 0).
  *
  */
-TEST_F(DescriptionsHelperTest, notReliableCvssInformation)
+TEST_F(DescriptionsHelperTest, notReliableCvssInformationNoScore)
 {
     const auto sources =
         std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
@@ -356,6 +350,72 @@ TEST_F(DescriptionsHelperTest, notReliableCvssInformation)
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             {
                 createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss, 0.0f);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss);
+                return true;
+            }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spGlobalDataMock.reset();
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The CVSS information is not reliable, so we fallback to the default ADP (due to the CVSS severity being
+ * empty).
+ *
+ */
+TEST_F(DescriptionsHelperTest, notReliableCvssInformationEmptySeverity)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+    const auto defaultAdpCvssSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create three detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+    flatbuffers::DetachedBuffer detachedBufferDefaultCvss;
+
+    // Expect three calls to the database manager, one for the description and two for the CVSS (one for the unreliable
+    // ADP and one for the default ADP)
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(
+                    resultContainer, detachedBufferDescription, 3.0f, "descriptionData.description", "");
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(
+                    resultContainer, detachedBufferCvss, 3.0f, "descriptionData.description", "");
                 return true;
             }));
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -49,7 +49,8 @@ namespace
         [](FlatbufferDataPair<VulnerabilityDescription>& resultContainer,
            flatbuffers::DetachedBuffer& detachedBuffer,
            float scoreBase = 3.0f,
-           const char* description = "descriptionData.description")
+           const char* description = "descriptionData.description",
+           const char* severity = "cvssData.severity")
     {
         flatbuffers::FlatBufferBuilder fbBuilder;
         const auto vulnerabilityDescriptiveInformation =
@@ -71,7 +72,7 @@ namespace
                                                                          "cvssData.scope",
                                                                          scoreBase,
                                                                          "cvssData.scoreVersion",
-                                                                         "cvssData.severity",
+                                                                         severity,
                                                                          "cvssData.userInteraction");
 
         fbBuilder.Finish(vulnerabilityDescriptiveInformation);
@@ -253,12 +254,16 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
 
     const auto adpDescriptionSource =
         ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION).at("description").get<std::string>();
+    const auto adpCvssSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION).at("cvss").get<std::string>();
     const auto defaultAdpDescriptionSource =
         ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+    const auto defaultAdpCvssSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
 
-    // One call to the database manager should fail, so we expect another call with the default ADP
+    // Two calls to the default ADP fail, so we fallback to the default ADP
     EXPECT_CALL(*spDatabaseFeedManagerMock,
                 getVulnerabiltyDescriptiveInformation(CVE_ID, adpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
@@ -269,16 +274,34 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
                 return false;
             }));
 
-    // Create one detached buffer to store the vulnerability descriptive information for the test duration
-    flatbuffers::DetachedBuffer detachedBuffer;
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, adpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                flatbuffers::DetachedBuffer detachedBuffer;
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return false;
+            }));
 
-    // Only one call because the CVSS and description are obtained from the same source
+    // Create two detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+
     EXPECT_CALL(*spDatabaseFeedManagerMock,
                 getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
                 return true;
             }));
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -1,0 +1,140 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 25, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "descriptionsHelper_test.hpp"
+#include "MockDatabaseFeedManager.hpp"
+#include "MockGlobalData.hpp"
+#include "TrampolineGlobalData.hpp"
+#include "descriptionsHelper.hpp"
+#include "vulnerabilityDescription_generated.h"
+#include <json.hpp>
+
+namespace
+{
+    const nlohmann::json ADP_DESCRIPTIONS =
+        R"#(
+    {
+        "adp_descriptions": {
+            "ADP_1": {
+                "description": "A",
+                "cvss": "A"
+            },
+            "ADP_2": {
+                "description": "A",
+                "cvss": "B"
+            },
+            "nvd": {
+                "description": "nvd",
+                "cvss": "nvd"
+            }
+        }
+    }
+)#"_json;
+
+    const std::string CVE_ID = "CVE-1234-1234";
+    const std::string ADP_INEXISTENT = "non_existent";
+    const std::string ADP_CVSS_EQUALS_DESCRIPTION = "ADP_1";
+    const std::string ADP_CVSS_DIFFERS_DESCRIPTION = "ADP_2";
+    const std::string ADP_EXPANDED_POSTFIX = "_expanded";
+
+    const auto createVulnerabilityDescriptiveInformation =
+        [](FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+    {
+        flatbuffers::FlatBufferBuilder fbBuilder;
+        const auto vulnerabilityDescriptiveInformation =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
+                                                                         "cvssData.accessComplexity",
+                                                                         "descriptionData.assignerShortName",
+                                                                         "cvssData.attackVector",
+                                                                         "cvssData.authentication",
+                                                                         "cvssData.availabilityImpact",
+                                                                         "cvssData.classification",
+                                                                         "cvssData.confidentialityImpact",
+                                                                         "descriptionData.cweId",
+                                                                         "descriptionData.datePublished",
+                                                                         "descriptionData.dateUpdated",
+                                                                         "descriptionData.description",
+                                                                         "cvssData.integrityImpact",
+                                                                         "cvssData.privilegesRequired",
+                                                                         "descriptionData.reference",
+                                                                         "cvssData.scope",
+                                                                         0.0f,
+                                                                         "cvssData.scoreVersion",
+                                                                         "cvssData.severity",
+                                                                         "cvssData.userInteraction");
+
+        fbBuilder.Finish(vulnerabilityDescriptiveInformation);
+
+        rocksdb::Slice slice(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
+        resultContainer.data = NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data());
+    };
+
+    const auto validateVulnerabilityDescriptiveInformation = [](const CveDescription& description)
+    {
+        EXPECT_EQ(description.accessComplexity, "cvssData.accessComplexity");
+        EXPECT_EQ(description.assignerShortName, "descriptionData.assignerShortName");
+        EXPECT_EQ(description.attackVector, "cvssData.attackVector");
+        EXPECT_EQ(description.authentication, "cvssData.authentication");
+        EXPECT_EQ(description.availabilityImpact, "cvssData.availabilityImpact");
+        EXPECT_EQ(description.classification, "cvssData.classification");
+        EXPECT_EQ(description.confidentialityImpact, "cvssData.confidentialityImpact");
+        EXPECT_EQ(description.cweId, "descriptionData.cweId");
+        EXPECT_EQ(description.datePublished, "descriptionData.datePublished");
+        EXPECT_EQ(description.dateUpdated, "descriptionData.dateUpdated");
+        EXPECT_EQ(description.description, "descriptionData.description");
+        EXPECT_EQ(description.integrityImpact, "cvssData.integrityImpact");
+        EXPECT_EQ(description.privilegesRequired, "cvssData.privilegesRequired");
+        EXPECT_EQ(description.reference, "descriptionData.reference");
+        EXPECT_EQ(description.scope, "cvssData.scope");
+        EXPECT_EQ(description.scoreBase, 0.0f);
+        EXPECT_EQ(description.scoreVersion, "cvssData.scoreVersion");
+        EXPECT_EQ(description.severity, "cvssData.severity");
+        EXPECT_EQ(description.userInteraction, "cvssData.userInteraction");
+    };
+
+} // namespace
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from the same
+ * source.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
+{
+    // Prepare the mocks
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+
+    const auto sources =
+        std::make_pair(ADP_CVSS_EQUALS_DESCRIPTION, ADP_CVSS_EQUALS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    // Expect the database manager to be called with the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, sources.second, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer);
+                return true;
+            }));
+
+    // We don't expect the database manager to be called with the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .Times(0);
+
+    // The global data should be called to retrieve the ADP descriptions map
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.hpp
@@ -1,0 +1,30 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 25, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _DESCRIPTIONS_HELPER_TEST_HPP_
+#define _DESCRIPTIONS_HELPER_TEST_HPP_
+
+#include "gtest/gtest.h"
+
+/**
+ * @brief Runs unit tests for the DescriptionsHelper class.
+ *
+ */
+class DescriptionsHelperTest : public ::testing::Test
+{
+protected:
+    // LCOV_EXCL_START
+    DescriptionsHelperTest() = default;
+    ~DescriptionsHelperTest() override = default;
+    // LCOV_EXCL_STOP
+};
+
+#endif // _DESCRIPTIONS_HELPER_TEST_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -32,7 +32,7 @@ using ::testing::ThrowsMessage;
 
 namespace NSEventDetailsBuilderTest
 {
-    constexpr auto TEST_DESCRIPTION_DATABASE_PATH {"queue/vd/descriptions"};
+    constexpr auto TEST_DESCRIPTION_DATABASE_PATH {"queue/vd/feed"};
 
     const std::string DELTA_PACKAGES_INSERTED_MSG =
         R"(
@@ -157,26 +157,85 @@ namespace NSEventDetailsBuilderTest
         )";
 
     const std::string CVEID {"CVE-2024-1234"};
+
+    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
 } // namespace NSEventDetailsBuilderTest
 
 const nlohmann::json ADP_DESCRIPTIONS =
     R"#(
         {
             "adp_descriptions": {
-                "alas": { "adp": "Amazon Linux Security Center"},
-                "alma": { "adp": "Alma Linux Security Oval"},
-                "arch": { "adp": "Arch Linux Security Tracker"},
-                "debian": { "adp": "Debian Security Tracker"},
-                "npm": { "adp": "Open Source Vulnerabilities"},
-                "nvd": { "adp": "National Vulnerability Database"},
-                "pypi": { "adp": "Open Source Vulnerabilities"},
-                "redhat": { "adp": "Red Hat CVE Database"},
-                "rocky": { "adp": "Rocky Enterprise Product Errata"},
-                "suse": { "adp": "SUSE CVE Database"},
-                "opensuse": { "adp": "SUSE CVE Database"},
-                "canonical": { "adp": "Canonical Security Tracker"},
-                "homebrew": { "adp": "Homebrew Security Audit"}
-            }
+    "alas": {
+      "adp": "Amazon Linux Security Center",
+      "description": "nvd",
+      "cvss": "alas"
+    },
+    "alma": {
+      "adp": "Alma Linux Security Oval",
+      "description": "alma",
+      "cvss": "alma"
+    },
+    "arch": {
+      "adp": "Arch Linux Security Tracker",
+      "description": "nvd",
+      "cvss": "nvd"
+    },
+    "debian": {
+      "adp": "Debian Security Tracker",
+      "description": "debian",
+      "cvss": "nvd"
+    },
+    "oracle": {
+      "adp": "Oracle Linux Security",
+      "description": "nvd",
+      "cvss": "oracle"
+    },
+    "npm": {
+      "adp": "Open Source Vulnerabilities",
+      "description": "npm",
+      "cvss": "npm"
+    },
+    "nvd": {
+      "adp": "National Vulnerability Database",
+      "description": "nvd",
+      "cvss": "nvd"
+    },
+    "pypi": {
+      "adp": "Open Source Vulnerabilities",
+      "description": "pypi",
+      "cvss": "pypi"
+    },
+    "redhat": {
+      "adp": "Red Hat CVE Database",
+      "description": "redhat",
+      "cvss": "redhat"
+    },
+    "rocky": {
+      "adp": "Rocky Enterprise Product Errata",
+      "description": "rocky",
+      "cvss": "rocky"
+    },
+    "suse": {
+      "adp": "SUSE CVE Database",
+      "description": "suse",
+      "cvss": "suse"
+    },
+    "opensuse": {
+      "adp": "SUSE CVE Database",
+      "description": "suse",
+      "cvss": "suse"
+    },
+    "canonical": {
+      "adp": "Canonical Security Tracker",
+      "description": "canonical",
+      "cvss": "canonical"
+    },
+    "homebrew": {
+      "adp": "Homebrew Security Audit",
+      "description": "homebrew",
+      "cvss": "nvd"
+    }
+  }
         }
     )#"_json;
 
@@ -236,49 +295,14 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    auto m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
 
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -304,7 +328,23 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -346,7 +386,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     EXPECT_STREQ(elementData.at("agent").at("id").get_ref<const std::string&>().c_str(), scanContext->agentId().data());
     EXPECT_STREQ(elementData.at("agent").at("name").get_ref<const std::string&>().c_str(),
                  scanContext->agentName().data());
-    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "wazuh");
+    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "Wazuh");
     EXPECT_STREQ(elementData.at("agent").at("version").get_ref<const std::string&>().c_str(),
                  scanContext->agentVersion().data());
 
@@ -456,49 +496,13 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    auto m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -524,7 +528,23 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -568,7 +588,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     EXPECT_STREQ(elementData.at("agent").at("id").get_ref<const std::string&>().c_str(), scanContext->agentId().data());
     EXPECT_STREQ(elementData.at("agent").at("name").get_ref<const std::string&>().c_str(),
                  scanContext->agentName().data());
-    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "wazuh");
+    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "Wazuh");
     EXPECT_STREQ(elementData.at("agent").at("version").get_ref<const std::string&>().c_str(),
                  scanContext->agentVersion().data());
 
@@ -678,49 +698,13 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    auto m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -746,7 +730,23 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -801,49 +801,13 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    auto m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -870,7 +834,23 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -911,7 +891,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
     EXPECT_STREQ(elementData.at("agent").at("id").get_ref<const std::string&>().c_str(), scanContext->agentId().data());
     EXPECT_STREQ(elementData.at("agent").at("name").get_ref<const std::string&>().c_str(),
                  scanContext->agentName().data());
-    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "wazuh");
+    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "Wazuh");
     EXPECT_STREQ(elementData.at("agent").at("version").get_ref<const std::string&>().c_str(),
                  scanContext->agentVersion().data());
 
@@ -1006,49 +986,13 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    auto m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -1074,7 +1018,23 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -1116,7 +1076,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
     EXPECT_STREQ(elementData.at("agent").at("id").get_ref<const std::string&>().c_str(), scanContext->agentId().data());
     EXPECT_STREQ(elementData.at("agent").at("name").get_ref<const std::string&>().c_str(),
                  scanContext->agentName().data());
-    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "wazuh");
+    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "Wazuh");
     EXPECT_STREQ(elementData.at("agent").at("version").get_ref<const std::string&>().c_str(),
                  scanContext->agentVersion().data());
 
@@ -1227,49 +1187,13 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    auto m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -1295,7 +1219,23 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -1337,7 +1277,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
     EXPECT_STREQ(elementData.at("agent").at("id").get_ref<const std::string&>().c_str(), scanContext->agentId().data());
     EXPECT_STREQ(elementData.at("agent").at("name").get_ref<const std::string&>().c_str(),
                  scanContext->agentName().data());
-    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "wazuh");
+    EXPECT_STREQ(elementData.at("agent").at("type").get_ref<const std::string&>().c_str(), "Wazuh");
     EXPECT_STREQ(elementData.at("agent").at("version").get_ref<const std::string&>().c_str(),
                  scanContext->agentVersion().data());
 
@@ -1465,47 +1405,11 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
 
     m_rocksDbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(m_fbBuilder.GetBufferPointer()), m_fbBuilder.GetSize());
-    m_rocksDbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!m_rocksDbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        m_rocksDbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        m_rocksDbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -1531,7 +1435,23 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
 
     m_spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*m_spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     ASSERT_TRUE(m_parser.Parse(syscollector_deltas_SCHEMA));
     ASSERT_TRUE(m_parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
@@ -1573,22 +1493,6 @@ void EventDetailsBuilderAdpTest::TestingAdpDescription(const std::string& adp)
 
     EXPECT_STREQ(elementData.at("vulnerability").at("scanner").at("source").get_ref<const std::string&>().c_str(),
                  adp.c_str());
-}
-
-TEST_F(EventDetailsBuilderAdpTest, InvalidAdpTest)
-{
-    const std::string adp {"Invalid"};
-    SetUp(adp);
-
-    spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
-
-    TEventDetailsBuilder<MockDatabaseFeedManager,
-                         TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
-                         TrampolineGlobalData>
-        eventDetailsBuilder(m_spDatabaseFeedManagerMock);
-
-    EXPECT_THROW(eventDetailsBuilder.handleRequest(m_scanContext), nlohmann::json::exception);
 }
 
 TEST_F(EventDetailsBuilderAdpTest, NVDTest)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -1392,7 +1392,8 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
                  elementOsVersion.c_str());
 
     EXPECT_STREQ(elementData.at("vulnerability").at("category").get_ref<const std::string&>().c_str(), "Packages");
-    EXPECT_STREQ(elementData.at("vulnerability").at("classification").get_ref<const std::string&>().c_str(), "-");
+    EXPECT_STREQ(elementData.at("vulnerability").at("classification").get_ref<const std::string&>().c_str(),
+                 "classification_test_string");
     EXPECT_STREQ(elementData.at("vulnerability").at("description").get_ref<const std::string&>().c_str(),
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
     EXPECT_STREQ(elementData.at("vulnerability").at("enumeration").get_ref<const std::string&>().c_str(), "CVE");
@@ -1405,8 +1406,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
         elementData.at("vulnerability").at("score").at("base").get_ref<const double&>(),
         Utils::floatToDoubleRound(GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreBase(), 2));
     EXPECT_TRUE(elementData.at("vulnerability").at("under_evaluation"));
-    EXPECT_STREQ(elementData.at("vulnerability").at("score").at("version").get_ref<const std::string&>().c_str(),
-                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreVersion()->c_str());
+    EXPECT_STREQ(elementData.at("vulnerability").at("score").at("version").get_ref<const std::string&>().c_str(), "-");
     EXPECT_STREQ(
         elementData.at("vulnerability").at("severity").get_ref<const std::string&>().c_str(),
         Utils::toSentenceCase(GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->severity()->str()).c_str());

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -23,6 +23,7 @@
 #include "flatbuffers/idl.h"
 #include "json.hpp"
 #include "timeHelper.h"
+#include "vulnerabilityDescription_schema.h"
 #include <unistd.h>
 
 using ::testing::_;
@@ -241,11 +242,42 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -271,7 +303,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -430,11 +462,42 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -460,7 +523,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -621,11 +684,42 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -651,7 +745,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -713,11 +807,42 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -744,7 +869,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -887,11 +1012,42 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -917,7 +1073,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -1077,11 +1233,42 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1107,7 +1294,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -1282,11 +1469,42 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        m_rocksDbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        m_rocksDbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1312,7 +1530,7 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     m_spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*m_spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*m_spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     ASSERT_TRUE(m_parser.Parse(syscollector_deltas_SCHEMA));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -241,10 +241,9 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -275,9 +274,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -303,7 +303,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -461,10 +461,9 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -495,9 +494,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -523,7 +523,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -683,10 +683,9 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -717,9 +716,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -745,7 +745,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -806,10 +806,9 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -840,9 +839,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -869,7 +869,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -1011,10 +1011,9 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -1045,9 +1044,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1073,7 +1073,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -1232,10 +1232,9 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -1266,9 +1265,10 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1294,7 +1294,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -1468,10 +1468,9 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
     m_rocksDbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         m_rocksDbWrapper->get(std::string(cveId), slice);
@@ -1502,9 +1501,10 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1530,7 +1530,7 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     m_spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*m_spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*m_spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     ASSERT_TRUE(m_parser.Parse(syscollector_deltas_SCHEMA));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -1211,7 +1211,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
                                                                      "attackVector_test_string",
                                                                      "authentication_test_string",
                                                                      "availabilityImpact_test_string",
-                                                                     "",
+                                                                     "classification_test_string",
                                                                      "confidentialityImpact_test_string",
                                                                      "cweId_test_string",
                                                                      "datePublished_test_string",
@@ -1222,7 +1222,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
                                                                      "reference_test_string",
                                                                      "scope_test_string",
                                                                      8.3,
-                                                                     "2",
+                                                                     "",
                                                                      "severity_test_string",
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -23,6 +23,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
+#include "vulnerabilityDescription_schema.h"
 #include <unistd.h>
 
 using ::testing::_;
@@ -160,11 +161,42 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -190,7 +222,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -342,11 +374,42 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -372,7 +435,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -528,11 +591,42 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -558,7 +652,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -617,11 +711,42 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -647,7 +772,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -706,11 +831,42 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -736,7 +892,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -829,11 +985,42 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -859,7 +1046,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -160,10 +160,9 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -194,9 +193,10 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -222,7 +222,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -373,10 +373,9 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -407,9 +406,10 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -435,7 +435,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -590,10 +590,9 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -624,9 +623,10 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -652,7 +652,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -710,10 +710,9 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -744,9 +743,10 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -772,7 +772,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -830,10 +830,9 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -864,9 +863,10 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -892,7 +892,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -984,10 +984,9 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -1018,9 +1017,10 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1046,7 +1046,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -1098,10 +1098,9 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -1132,9 +1131,10 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1160,7 +1160,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -1099,11 +1099,42 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -1129,7 +1160,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -16,7 +16,9 @@
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_schema.h"
 #include "../scanOrchestrator/eventPackageAlertDetailsBuilder.hpp"
 #include "MockDatabaseFeedManager.hpp"
+#include "MockGlobalData.hpp"
 #include "MockOsDataCache.hpp"
+#include "TrampolineGlobalData.hpp"
 #include "TrampolineOsDataCache.hpp"
 #include "TrampolineRemediationDataCache.hpp"
 #include "flatbuffers/flatbuffer_builder.h"
@@ -99,6 +101,86 @@ namespace NSEventPackageAlertDetailsBuilderTest
         )";
 
     const std::string CVEID {"CVE-2024-1234"};
+
+    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
+
+    const nlohmann::json ADP_DESCRIPTIONS =
+        R"#(
+        {
+            "adp_descriptions": {
+    "alas": {
+      "adp": "Amazon Linux Security Center",
+      "description": "nvd",
+      "cvss": "alas"
+    },
+    "alma": {
+      "adp": "Alma Linux Security Oval",
+      "description": "alma",
+      "cvss": "alma"
+    },
+    "arch": {
+      "adp": "Arch Linux Security Tracker",
+      "description": "nvd",
+      "cvss": "nvd"
+    },
+    "debian": {
+      "adp": "Debian Security Tracker",
+      "description": "debian",
+      "cvss": "nvd"
+    },
+    "oracle": {
+      "adp": "Oracle Linux Security",
+      "description": "nvd",
+      "cvss": "oracle"
+    },
+    "npm": {
+      "adp": "Open Source Vulnerabilities",
+      "description": "npm",
+      "cvss": "npm"
+    },
+    "nvd": {
+      "adp": "National Vulnerability Database",
+      "description": "nvd",
+      "cvss": "nvd"
+    },
+    "pypi": {
+      "adp": "Open Source Vulnerabilities",
+      "description": "pypi",
+      "cvss": "pypi"
+    },
+    "redhat": {
+      "adp": "Red Hat CVE Database",
+      "description": "redhat",
+      "cvss": "redhat"
+    },
+    "rocky": {
+      "adp": "Rocky Enterprise Product Errata",
+      "description": "rocky",
+      "cvss": "rocky"
+    },
+    "suse": {
+      "adp": "SUSE CVE Database",
+      "description": "suse",
+      "cvss": "suse"
+    },
+    "opensuse": {
+      "adp": "SUSE CVE Database",
+      "description": "suse",
+      "cvss": "suse"
+    },
+    "canonical": {
+      "adp": "Canonical Security Tracker",
+      "description": "canonical",
+      "cvss": "canonical"
+    },
+    "homebrew": {
+      "adp": "Homebrew Security Audit",
+      "description": "homebrew",
+      "cvss": "nvd"
+    }
+  }
+        }
+    )#"_json;
 } // namespace NSEventPackageAlertDetailsBuilderTest
 
 using namespace NSEventPackageAlertDetailsBuilderTest;
@@ -157,47 +239,11 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -223,7 +269,23 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -237,8 +299,12 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     scanContext->m_elements[CVEID] = R"({"operation":"INSERTED"})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
-                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                                     TrampolineGlobalData>
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
@@ -370,47 +436,11 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -436,7 +466,23 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -450,8 +496,12 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     scanContext->m_elements[CVEID] = R"({"operation":"INSERTED"})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::LessThan};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
-                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                                     TrampolineGlobalData>
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
@@ -587,47 +637,11 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -653,7 +667,23 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -667,8 +697,12 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
     scanContext->m_elements[CVEID] = R"({"operation":"INSERTED"})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::DefaultStatus};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
-                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                                     TrampolineGlobalData>
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
@@ -707,47 +741,11 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -773,7 +771,23 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -787,8 +801,12 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
     scanContext->m_elements[CVEID] = R"({"operation":"INSERTED"})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::LessThanOrEqual};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
-                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                                     TrampolineGlobalData>
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
@@ -827,47 +845,11 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -893,7 +875,23 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -907,8 +905,12 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
     scanContext->m_elements[CVEID] = R"({"operation":"DELETED"})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Unknown};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
-                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                                     TrampolineGlobalData>
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
@@ -981,47 +983,11 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -1047,7 +1013,23 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -1060,11 +1042,16 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
             syscollectorDelta);
     scanContext->m_elements[CVEID] = R"({"operation":"invalid"})"_json;
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
-                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                                     TrampolineGlobalData>
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
-    EXPECT_ANY_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
+    // We catch any exception thrown by the handleRequest method
+    EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
 }
 
 TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3WithDefaultValues)
@@ -1095,47 +1082,11 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -1161,7 +1112,23 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
@@ -1175,8 +1142,12 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
     scanContext->m_elements[CVEID] = R"({"operation":"INSERTED"})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::LessThan};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
-                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                                     TrampolineGlobalData>
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
@@ -24,6 +24,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
+#include "vulnerabilityDescription_schema.h"
 #include <unistd.h>
 
 using ::testing::_;
@@ -125,11 +126,42 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -156,7 +188,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -243,11 +275,42 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -274,7 +337,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -361,11 +424,42 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -392,7 +486,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -479,11 +573,42 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -510,7 +635,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -570,11 +695,42 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
 
     auto mockGetVulnerabiltyDescriptiveInformation =
         [&](const std::string_view cveId,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            const std::string& adpShortName,
+            const std::string& adpSubShortName,
+            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
-        dbWrapper->get(std::string(cveId), resultContainer.slice);
-        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+        rocksdb::PinnableSlice slice;
+        dbWrapper->get(std::string(cveId), slice);
+        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+        flatbuffers::FlatBufferBuilder builder;
+        auto finalDescription =
+            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
+                                                                         description->accessComplexity()->c_str(),
+                                                                         description->assignerShortName()->c_str(),
+                                                                         description->attackVector()->c_str(),
+                                                                         description->authentication()->c_str(),
+                                                                         description->availabilityImpact()->c_str(),
+                                                                         description->classification()->c_str(),
+                                                                         description->confidentialityImpact()->c_str(),
+                                                                         description->cweId()->c_str(),
+                                                                         description->datePublished()->c_str(),
+                                                                         description->dateUpdated()->c_str(),
+                                                                         description->description()->c_str(),
+                                                                         description->integrityImpact()->c_str(),
+                                                                         description->privilegesRequired()->c_str(),
+                                                                         description->reference()->c_str(),
+                                                                         description->scope()->c_str(),
+                                                                         description->scoreBase(),
+                                                                         description->scoreVersion()->c_str(),
+                                                                         description->severity()->c_str(),
+                                                                         description->userInteraction()->c_str());
+
+        builder.Finish(finalDescription);
+
+        resultContainer.detachedBuffer = builder.Release();
+        resultContainer.data =
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -601,7 +757,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
@@ -125,10 +125,9 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -159,9 +158,10 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -188,7 +188,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -274,10 +274,9 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -308,9 +307,10 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -337,7 +337,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -423,10 +423,9 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -457,9 +456,10 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -486,7 +486,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -572,10 +572,9 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -606,9 +605,10 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -635,7 +635,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;
@@ -694,10 +694,9 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
     dbWrapper->put(CVEID, dbValue);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view cveId,
-            const std::string& adpShortName,
+        [&](const std::string& cveId,
             const std::string& adpSubShortName,
-            DetachedFlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
     {
         rocksdb::PinnableSlice slice;
         dbWrapper->get(std::string(cveId), slice);
@@ -728,9 +727,10 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
 
         builder.Finish(finalDescription);
 
-        resultContainer.detachedBuffer = builder.Release();
-        resultContainer.data =
-            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        // resultContainer.detachedBuffer = builder.Release();
+        // resultContainer.data =
+        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
+        return true;
     };
 
     Os osData {.hostName = "osdata_hostname",
@@ -757,7 +757,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
 
     flatbuffers::Parser parser;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
@@ -9,21 +9,23 @@
  * Foundation.
  */
 
-#include "scanOsAlertDetailsBuilder_test.hpp"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_generated.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_schema.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_generated.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_schema.h"
 #include "../scanOrchestrator/scanOsAlertDetailsBuilder.hpp"
 #include "MockDatabaseFeedManager.hpp"
+#include "MockGlobalData.hpp"
 #include "MockOsDataCache.hpp"
 #include "MockRemediationDataCache.hpp"
+#include "TrampolineGlobalData.hpp"
 #include "TrampolineOsDataCache.hpp"
 #include "TrampolineRemediationDataCache.hpp"
 #include "flatbuffers/flatbuffer_builder.h"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
+#include "scanOsAlertDetailsBuilder_test.hpp"
 #include "vulnerabilityDescription_schema.h"
 #include <unistd.h>
 
@@ -60,6 +62,86 @@ namespace NSScanOsAlertDetailsBuilderTest
             })";
 
     const std::string CVEID {"CVE-2024-1234"};
+
+    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
+
+    const nlohmann::json ADP_DESCRIPTIONS =
+        R"#(
+        {
+            "adp_descriptions": {
+    "alas": {
+      "adp": "Amazon Linux Security Center",
+      "description": "nvd",
+      "cvss": "alas"
+    },
+    "alma": {
+      "adp": "Alma Linux Security Oval",
+      "description": "alma",
+      "cvss": "alma"
+    },
+    "arch": {
+      "adp": "Arch Linux Security Tracker",
+      "description": "nvd",
+      "cvss": "nvd"
+    },
+    "debian": {
+      "adp": "Debian Security Tracker",
+      "description": "debian",
+      "cvss": "nvd"
+    },
+    "oracle": {
+      "adp": "Oracle Linux Security",
+      "description": "nvd",
+      "cvss": "oracle"
+    },
+    "npm": {
+      "adp": "Open Source Vulnerabilities",
+      "description": "npm",
+      "cvss": "npm"
+    },
+    "nvd": {
+      "adp": "National Vulnerability Database",
+      "description": "nvd",
+      "cvss": "nvd"
+    },
+    "pypi": {
+      "adp": "Open Source Vulnerabilities",
+      "description": "pypi",
+      "cvss": "pypi"
+    },
+    "redhat": {
+      "adp": "Red Hat CVE Database",
+      "description": "redhat",
+      "cvss": "redhat"
+    },
+    "rocky": {
+      "adp": "Rocky Enterprise Product Errata",
+      "description": "rocky",
+      "cvss": "rocky"
+    },
+    "suse": {
+      "adp": "SUSE CVE Database",
+      "description": "suse",
+      "cvss": "suse"
+    },
+    "opensuse": {
+      "adp": "SUSE CVE Database",
+      "description": "suse",
+      "cvss": "suse"
+    },
+    "canonical": {
+      "adp": "Canonical Security Tracker",
+      "description": "canonical",
+      "cvss": "canonical"
+    },
+    "homebrew": {
+      "adp": "Homebrew Security Audit",
+      "description": "homebrew",
+      "cvss": "nvd"
+    }
+  }
+        }
+    )#"_json;
 } // namespace NSScanOsAlertDetailsBuilderTest
 
 // Shared pointers definitions
@@ -89,6 +171,7 @@ void ScanOsAlertDetailsBuilderTest::SetUp()
 void ScanOsAlertDetailsBuilderTest::TearDown()
 {
     spOsDataCacheMock.reset();
+    spGlobalDataMock.reset();
     spRemediationDataCacheMock.reset();
     PolicyManager::instance().teardown();
     std::filesystem::remove_all("queue/vd");
@@ -122,47 +205,11 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -189,7 +236,26 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
+
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -205,7 +271,8 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
     scanContext->m_matchConditions[CVEID] = {"version", MatchRuleCondition::Unknown};
 
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
-                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                               TrampolineGlobalData>
         scanOsAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(scanOsAlertDetailsAugmentation.handleRequest(scanContext));
@@ -271,47 +338,11 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -338,7 +369,23 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -353,8 +400,12 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
     scanContext->m_isFirstScan = false;
     scanContext->m_matchConditions[CVEID] = {"version", MatchRuleCondition::DefaultStatus};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
-                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                               TrampolineGlobalData>
         scanOsAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(scanOsAlertDetailsAugmentation.handleRequest(scanContext));
@@ -420,47 +471,11 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -487,7 +502,23 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -502,8 +533,12 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
     scanContext->m_isFirstScan = false;
     scanContext->m_matchConditions[CVEID] = {"version", MatchRuleCondition::LessThan};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
-                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                               TrampolineGlobalData>
         scanOsAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(scanOsAlertDetailsAugmentation.handleRequest(scanContext));
@@ -569,47 +604,11 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -636,7 +635,23 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string& cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -651,8 +666,12 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
     scanContext->m_isFirstScan = true;
     scanContext->m_matchConditions[CVEID] = {"version", MatchRuleCondition::Equal};
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
-                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                               TrampolineGlobalData>
         scanOsAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_NO_THROW(scanOsAlertDetailsAugmentation.handleRequest(scanContext));
@@ -691,47 +710,11 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
 
     auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
     rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
-    dbWrapper->put(CVEID, dbValue);
-
-    auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string& cveId,
-            const std::string& adpSubShortName,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    if (!dbWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
     {
-        rocksdb::PinnableSlice slice;
-        dbWrapper->get(std::string(cveId), slice);
-        auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-        flatbuffers::FlatBufferBuilder builder;
-        auto finalDescription =
-            NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(builder,
-                                                                         description->accessComplexity()->c_str(),
-                                                                         description->assignerShortName()->c_str(),
-                                                                         description->attackVector()->c_str(),
-                                                                         description->authentication()->c_str(),
-                                                                         description->availabilityImpact()->c_str(),
-                                                                         description->classification()->c_str(),
-                                                                         description->confidentialityImpact()->c_str(),
-                                                                         description->cweId()->c_str(),
-                                                                         description->datePublished()->c_str(),
-                                                                         description->dateUpdated()->c_str(),
-                                                                         description->description()->c_str(),
-                                                                         description->integrityImpact()->c_str(),
-                                                                         description->privilegesRequired()->c_str(),
-                                                                         description->reference()->c_str(),
-                                                                         description->scope()->c_str(),
-                                                                         description->scoreBase(),
-                                                                         description->scoreVersion()->c_str(),
-                                                                         description->severity()->c_str(),
-                                                                         description->userInteraction()->c_str());
-
-        builder.Finish(finalDescription);
-
-        // resultContainer.detachedBuffer = builder.Release();
-        // resultContainer.data =
-        //     NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.detachedBuffer.data());
-        return true;
-    };
+        dbWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
     Os osData {.hostName = "osdata_hostname",
                .architecture = "osdata_architecture",
@@ -758,7 +741,23 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+        .WillRepeatedly(testing::Invoke(
+            [&](const std::string_view cveId,
+                const std::string& shortName,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                dbWrapper->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN_DEFAULT);
+                if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
+                                                   resultContainer.slice.size());
+                    NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
+                {
+                    resultContainer.data = nullptr;
+                    return false;
+                }
+                resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+                    NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+                return true;
+            }));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -772,11 +771,16 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
     scanContext->m_elements[CVEID] = R"({"operation":"UNKNOWN"})"_json;
     scanContext->m_isFirstScan = false;
 
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
-                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+                               TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                               TrampolineGlobalData>
         scanOsAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
-    EXPECT_THROW(scanOsAlertDetailsAugmentation.handleRequest(scanContext), std::runtime_error);
+    // No throw here because we are catching any possible exception
+    scanOsAlertDetailsAugmentation.handleRequest(scanContext);
 
     EXPECT_EQ(scanContext->m_alerts.size(), 0);
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
@@ -9,6 +9,7 @@
  * Foundation.
  */
 
+#include "scanOsAlertDetailsBuilder_test.hpp"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_generated.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_deltas_schema.h"
 #include "../../../../shared_modules/utils/flatbuffers/include/syscollector_synchronization_generated.h"
@@ -25,7 +26,6 @@
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
 #include "json.hpp"
-#include "scanOsAlertDetailsBuilder_test.hpp"
 #include "vulnerabilityDescription_schema.h"
 #include <unistd.h>
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -914,8 +914,8 @@ TEST_F(UpdateCVEDescriptionTest, MultipleAdpDescriptions)
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    std::unique_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper.get());
+    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Verify descriptions: CNA
     rocksdb::PinnableSlice slice;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -601,6 +601,8 @@ namespace NSUpdateCVEDescriptionTest
         "dataVersion": "5.0"
     }
         )"};
+
+    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
 } // namespace NSUpdateCVEDescriptionTest
 
 using namespace NSUpdateCVEDescriptionTest;
@@ -631,11 +633,16 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
 
     // Call function.
     std::shared_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
+    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
+    {
+        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
     UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+    ASSERT_TRUE(
+        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -685,11 +692,16 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
 
     // Call function.
     auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
+    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
+    {
+        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
     UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+    ASSERT_TRUE(
+        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -737,11 +749,16 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
 
     // Call function.
     auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
+    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
+    {
+        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
     UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+    ASSERT_TRUE(
+        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -793,14 +810,16 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
+    // Key
+    auto key = cve5Flatbuffer->cveMetadata()->cveId()->str();
+
     // Call function.
     auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
     UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper->get(
-        CVE_JSON_STR_MISSING_METRICS + "_arch", vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+    ASSERT_TRUE(rocksDBWrapper->get(key, vulnerabilityDescriptionFBStr, "descriptions_arch"));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -845,11 +864,16 @@ TEST_F(UpdateCVEDescriptionTest, RejectedCVE5Entry)
 
     // Call function.
     auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
+    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
+    {
+        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
     UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_FALSE(rocksDBWrapper->get(CVE_JSON_STR_REJECTED_CVE, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+    ASSERT_FALSE(
+        rocksDBWrapper->get(CVE_JSON_STR_REJECTED_CVE, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 }
 
 TEST_F(UpdateCVEDescriptionTest, RemoveDescription)
@@ -878,119 +902,19 @@ TEST_F(UpdateCVEDescriptionTest, RemoveDescription)
 
     // Call function.
     auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
+    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
+    {
+        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
     UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    EXPECT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+    EXPECT_TRUE(
+        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 
     // Remove entry and verify
     UpdateCVEDescription::removeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
-    EXPECT_FALSE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
-}
-
-TEST_F(UpdateCVEDescriptionTest, MultipleAdpDescriptions)
-{
-    std::string cve5FlatbufferSchemaStr;
-
-    // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
-    ASSERT_EQ(valid, true);
-    ASSERT_EQ(JSON_STR_MULTIPLE_ADP_DESCRIPTIONS_CVE.empty(), false);
-
-    // Parse schemas and JSON example.
-    flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
-             parser.Parse(JSON_STR_MULTIPLE_ADP_DESCRIPTIONS_CVE.c_str()));
-    ASSERT_EQ(valid, true);
-
-    // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
-    size_t flatbufferSize = parser.builder_.GetSize();
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
-    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
-    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
-
-    // Call function.
-    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
-
-    // Verify descriptions: CNA
-    rocksdb::PinnableSlice slice;
-    rocksDBWrapper->get(CVE_JSON_STR_MULTIPLE_ADP_DESCRIPTIONS, slice, DESCRIPTIONS_COLUMN);
-
-    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
-    auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-    EXPECT_STREQ(description->accessComplexity()->c_str(), "");
-    EXPECT_STREQ(description->assignerShortName()->c_str(), "nvd");
-    EXPECT_STREQ(description->authentication()->c_str(), "");
-    EXPECT_STREQ(description->availabilityImpact()->c_str(), "cnaAvailabilityImpact0");
-    EXPECT_STREQ(description->classification()->c_str(), "");
-    EXPECT_STREQ(description->confidentialityImpact()->c_str(), "cnaConfidentialityImpact0");
-    EXPECT_STREQ(description->cweId()->c_str(), "");
-    EXPECT_STREQ(description->datePublished()->c_str(), "2024-01-11T11:11:20Z");
-    EXPECT_STREQ(description->dateUpdated()->c_str(), "2024-02-22T22:22:20Z");
-    EXPECT_STREQ(description->description()->c_str(), "cnaDescription0");
-    EXPECT_STREQ(description->integrityImpact()->c_str(), "cnaIntegrityImpact0");
-    EXPECT_STREQ(description->privilegesRequired()->c_str(), "cnaPrivilegesRequired0");
-    EXPECT_STREQ(description->reference()->c_str(), "https://example.com/cna0");
-    EXPECT_STREQ(description->scope()->c_str(), "cnaScope0");
-    EXPECT_EQ(description->scoreBase(), 0);
-    EXPECT_STREQ(description->scoreVersion()->c_str(), "cnaVersion0");
-    EXPECT_STREQ(description->severity()->c_str(), "cnaSeverity0");
-    EXPECT_STREQ(description->userInteraction()->c_str(), "cnaUserInteraction0");
-
-    // Verify descriptions: ADPs
-
-    rocksDBWrapper->get(CVE_JSON_STR_MULTIPLE_ADP_DESCRIPTIONS + "_adpShortName0", slice, DESCRIPTIONS_COLUMN);
-    flatbuffers::Verifier verifierVulnDescAdp(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDescAdp), true);
-    description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-    EXPECT_STREQ(description->accessComplexity()->c_str(), "");
-    EXPECT_STREQ(description->assignerShortName()->c_str(), "nvd");
-    EXPECT_STREQ(description->authentication()->c_str(), "");
-    EXPECT_STREQ(description->availabilityImpact()->c_str(), "adpAvailabilityImpact0");
-    EXPECT_STREQ(description->classification()->c_str(), "");
-    EXPECT_STREQ(description->confidentialityImpact()->c_str(), "adpConfidentialityImpact0");
-    EXPECT_STREQ(description->cweId()->c_str(), "");
-    EXPECT_STREQ(description->datePublished()->c_str(), "2024-01-11T11:11:20Z");
-    EXPECT_STREQ(description->dateUpdated()->c_str(), "2024-02-22T22:22:20Z");
-    EXPECT_STREQ(description->description()->c_str(), "adpDescription0");
-    EXPECT_STREQ(description->integrityImpact()->c_str(), "adpIntegrityImpact0");
-    EXPECT_STREQ(description->privilegesRequired()->c_str(), "adpPrivilegesRequired0");
-    EXPECT_STREQ(description->reference()->c_str(), "https://example.com/adp0");
-    EXPECT_STREQ(description->scope()->c_str(), "adpScope0");
-    EXPECT_EQ(description->scoreBase(), 0);
-    EXPECT_STREQ(description->scoreVersion()->c_str(), "adpVersion0");
-    EXPECT_STREQ(description->severity()->c_str(), "adpSeverity0");
-    EXPECT_STREQ(description->userInteraction()->c_str(), "adpUserInteraction0");
-
-    rocksDBWrapper->get(CVE_JSON_STR_MULTIPLE_ADP_DESCRIPTIONS + "_adpSubShortName1", slice, DESCRIPTIONS_COLUMN);
-    flatbuffers::Verifier verifierVulnDescAdp1(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDescAdp1), true);
-    description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
-
-    EXPECT_STREQ(description->accessComplexity()->c_str(), "adpAccessComplexity1");
-    EXPECT_STREQ(description->assignerShortName()->c_str(), "nvd");
-    EXPECT_STREQ(description->authentication()->c_str(), "adpAuthentication1");
-    EXPECT_STREQ(description->availabilityImpact()->c_str(), "adpAvailabilityImpact1");
-    EXPECT_STREQ(description->classification()->c_str(), "");
-    EXPECT_STREQ(description->confidentialityImpact()->c_str(), "adpConfidentialityImpact1");
-    EXPECT_STREQ(description->cweId()->c_str(), "");
-    EXPECT_STREQ(description->datePublished()->c_str(), "2024-01-11T11:11:20Z");
-    EXPECT_STREQ(description->dateUpdated()->c_str(), "2024-02-22T22:22:20Z");
-    EXPECT_STREQ(description->description()->c_str(), "adpDescription1");
-    EXPECT_STREQ(description->integrityImpact()->c_str(), "adpIntegrityImpact1");
-    EXPECT_STREQ(description->privilegesRequired()->c_str(), "");
-    EXPECT_STREQ(description->reference()->c_str(), "https://example.com/adp1");
-    EXPECT_STREQ(description->scope()->c_str(), "");
-    EXPECT_EQ(description->scoreBase(), 1);
-    EXPECT_STREQ(description->scoreVersion()->c_str(), "adpVersion1");
-    EXPECT_STREQ(description->severity()->c_str(), "LOW");
-    EXPECT_STREQ(description->userInteraction()->c_str(), "");
+    EXPECT_FALSE(
+        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -422,6 +422,185 @@ namespace NSUpdateCVEDescriptionTest
                     "dataType": "CVE_RECORD",
                     "dataVersion": "5.0"
                 })"};
+
+    const std::string CVE_JSON_STR_MULTIPLE_ADP_DESCRIPTIONS {"CVE-2024-1234"};
+    const std::string JSON_STR_MULTIPLE_ADP_DESCRIPTIONS_CVE {
+        R"(
+       {
+        "containers": {
+            "cna": {
+                "providerMetadata": {
+                    "orgId": "00000000-0000-4000-A000-000000000003",
+                    "shortName": "nvd"
+                },
+                "metrics": [
+                    {
+                        "cvssV3_0": {
+                            "attackComplexity": "cnaAttackComplexity0",
+                            "attackVector": "cnaAttackVector0",
+                            "availabilityImpact": "cnaAvailabilityImpact0",
+                            "baseScore": 0,
+                            "baseSeverity": "cnaSeverity0",
+                            "confidentialityImpact": "cnaConfidentialityImpact0",
+                            "integrityImpact": "cnaIntegrityImpact0",
+                            "privilegesRequired": "cnaPrivilegesRequired0",
+                            "scope": "cnaScope0",
+                            "userInteraction": "cnaUserInteraction0",
+                            "vectorString": "cnaVectorString0",
+                            "version": "cnaVersion0"
+                        }
+                    }
+                ],
+                "affected": [
+                    {
+                        "defaultStatus": "unaffected",
+                        "product": "generic",
+                        "vendor": "generic"
+                    }
+                ],
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "description": "cnaCwe0",
+                                "lang": "en"
+                            }
+                        ]
+                    }
+                ],
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "cnaDescription0"
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://example.com/cna0"
+                    }
+                ]
+            },
+            "adp": [
+                {
+                    "metrics": [
+                        {
+                            "cvssV3_1": {
+                                "scope": "adpScope0",
+                                "version": "adpVersion0",
+                                "baseScore": 0.0,
+                                "attackVector": "adpAttackVector0",
+                                "baseSeverity": "adpSeverity0",
+                                "vectorString": "adpVectorString0",
+                                "integrityImpact": "adpIntegrityImpact0",
+                                "userInteraction": "adpUserInteraction0",
+                                "attackComplexity": "adpAttackComplexity0",
+                                "availabilityImpact": "adpAvailabilityImpact0",
+                                "privilegesRequired": "adpPrivilegesRequired0",
+                                "confidentialityImpact": "adpConfidentialityImpact0",
+                                "environmentalScore": 0,
+                                "temporalScore": 0
+                            }
+                        }
+                    ],
+                    "affected": [
+                        {
+                            "defaultStatus": "unaffected",
+                            "product": "generic",
+                            "vendor": "generic"
+                        }
+                    ],
+                    "problemTypes": [
+                        {
+                            "descriptions": [
+                                {
+                                    "description": "adpCwe0",
+                                    "lang": "en"
+                                }
+                            ]
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "value": "adpDescription0"
+                        }
+                    ],
+                    "providerMetadata": {
+                        "orgId": "00000000-0000-4000-A000-000000000003",
+                        "shortName": "adpShortName0"
+                    },
+                    "references": [
+                        {
+                            "url": "https://example.com/adp0"
+                        }
+                    ]
+                },
+                {
+                    "metrics": [
+                        {
+                            "cvssV2_0": {
+                                "accessComplexity": "adpAccessComplexity1",
+                                "accessVector": "adpAccessVector1",
+                                "authentication": "adpAuthentication1",
+                                "availabilityImpact": "adpAvailabilityImpact1",
+                                "baseScore": 1,
+                                "confidentialityImpact": "adpConfidentialityImpact1",
+                                "integrityImpact": "adpIntegrityImpact1",
+                                "vectorString": "adpVectorString1",
+                                "version": "adpVersion1",
+                                "environmentalScore": 1,
+                                "temporalScore": 1
+                            }
+                        }
+                    ],
+                    "affected": [
+                        {
+                            "defaultStatus": "unaffected",
+                            "product": "generic",
+                            "vendor": "generic"
+                        }
+                    ],
+                    "problemTypes": [
+                        {
+                            "descriptions": [
+                                {
+                                    "description": "adpCwe1",
+                                    "lang": "en"
+                                }
+                            ]
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "lang": "en",
+                            "value": "adpDescription1"
+                        }
+                    ],
+                    "providerMetadata": {
+                        "orgId": "00000000-0000-4000-A000-000000000003",
+                        "shortName": "adpShortName1",
+                        "x_subShortName": "adpSubShortName1"
+                    },
+                    "references": [
+                        {
+                            "url": "https://example.com/adp1"
+                        }
+                    ]
+                }
+            ]
+        },
+        "cveMetadata": {
+            "cveId": "CVE-2024-1234",
+            "assignerOrgId": "00000000-0000-4000-A000-000000000003",
+            "assignerShortName": "nvd",
+            "dateUpdated": "2024-02-22T22:22:20Z",
+            "datePublished": "2024-01-11T11:11:20Z",
+            "state": "PUBLISHED"
+        },
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0"
+    }
+        )"};
 } // namespace NSUpdateCVEDescriptionTest
 
 using namespace NSUpdateCVEDescriptionTest;
@@ -620,7 +799,8 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper->get(CVE_JSON_STR_MISSING_METRICS, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+    ASSERT_TRUE(rocksDBWrapper->get(
+        CVE_JSON_STR_MISSING_METRICS + "_arch", vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
@@ -707,4 +887,110 @@ TEST_F(UpdateCVEDescriptionTest, RemoveDescription)
     // Remove entry and verify
     UpdateCVEDescription::removeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
     EXPECT_FALSE(rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN));
+}
+
+TEST_F(UpdateCVEDescriptionTest, MultipleAdpDescriptions)
+{
+    std::string cve5FlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(JSON_STR_MULTIPLE_ADP_DESCRIPTIONS_CVE.empty(), false);
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(JSON_STR_MULTIPLE_ADP_DESCRIPTIONS_CVE.c_str()));
+    ASSERT_EQ(valid, true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    // Call function.
+    std::unique_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_unique<Utils::RocksDBWrapper>(DATABASE_PATH);
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper.get());
+
+    // Verify descriptions: CNA
+    rocksdb::PinnableSlice slice;
+    rocksDBWrapper->get(CVE_JSON_STR_MULTIPLE_ADP_DESCRIPTIONS, slice, DESCRIPTIONS_COLUMN);
+
+    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+    auto description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+    EXPECT_STREQ(description->accessComplexity()->c_str(), "");
+    EXPECT_STREQ(description->assignerShortName()->c_str(), "nvd");
+    EXPECT_STREQ(description->authentication()->c_str(), "");
+    EXPECT_STREQ(description->availabilityImpact()->c_str(), "cnaAvailabilityImpact0");
+    EXPECT_STREQ(description->classification()->c_str(), "");
+    EXPECT_STREQ(description->confidentialityImpact()->c_str(), "cnaConfidentialityImpact0");
+    EXPECT_STREQ(description->cweId()->c_str(), "");
+    EXPECT_STREQ(description->datePublished()->c_str(), "2024-01-11T11:11:20Z");
+    EXPECT_STREQ(description->dateUpdated()->c_str(), "2024-02-22T22:22:20Z");
+    EXPECT_STREQ(description->description()->c_str(), "cnaDescription0");
+    EXPECT_STREQ(description->integrityImpact()->c_str(), "cnaIntegrityImpact0");
+    EXPECT_STREQ(description->privilegesRequired()->c_str(), "cnaPrivilegesRequired0");
+    EXPECT_STREQ(description->reference()->c_str(), "https://example.com/cna0");
+    EXPECT_STREQ(description->scope()->c_str(), "cnaScope0");
+    EXPECT_EQ(description->scoreBase(), 0);
+    EXPECT_STREQ(description->scoreVersion()->c_str(), "cnaVersion0");
+    EXPECT_STREQ(description->severity()->c_str(), "cnaSeverity0");
+    EXPECT_STREQ(description->userInteraction()->c_str(), "cnaUserInteraction0");
+
+    // Verify descriptions: ADPs
+
+    rocksDBWrapper->get(CVE_JSON_STR_MULTIPLE_ADP_DESCRIPTIONS + "_adpShortName0", slice, DESCRIPTIONS_COLUMN);
+    flatbuffers::Verifier verifierVulnDescAdp(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDescAdp), true);
+    description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+    EXPECT_STREQ(description->accessComplexity()->c_str(), "");
+    EXPECT_STREQ(description->assignerShortName()->c_str(), "nvd");
+    EXPECT_STREQ(description->authentication()->c_str(), "");
+    EXPECT_STREQ(description->availabilityImpact()->c_str(), "adpAvailabilityImpact0");
+    EXPECT_STREQ(description->classification()->c_str(), "");
+    EXPECT_STREQ(description->confidentialityImpact()->c_str(), "adpConfidentialityImpact0");
+    EXPECT_STREQ(description->cweId()->c_str(), "");
+    EXPECT_STREQ(description->datePublished()->c_str(), "2024-01-11T11:11:20Z");
+    EXPECT_STREQ(description->dateUpdated()->c_str(), "2024-02-22T22:22:20Z");
+    EXPECT_STREQ(description->description()->c_str(), "adpDescription0");
+    EXPECT_STREQ(description->integrityImpact()->c_str(), "adpIntegrityImpact0");
+    EXPECT_STREQ(description->privilegesRequired()->c_str(), "adpPrivilegesRequired0");
+    EXPECT_STREQ(description->reference()->c_str(), "https://example.com/adp0");
+    EXPECT_STREQ(description->scope()->c_str(), "adpScope0");
+    EXPECT_EQ(description->scoreBase(), 0);
+    EXPECT_STREQ(description->scoreVersion()->c_str(), "adpVersion0");
+    EXPECT_STREQ(description->severity()->c_str(), "adpSeverity0");
+    EXPECT_STREQ(description->userInteraction()->c_str(), "adpUserInteraction0");
+
+    rocksDBWrapper->get(CVE_JSON_STR_MULTIPLE_ADP_DESCRIPTIONS + "_adpSubShortName1", slice, DESCRIPTIONS_COLUMN);
+    flatbuffers::Verifier verifierVulnDescAdp1(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDescAdp1), true);
+    description = NSVulnerabilityScanner::GetVulnerabilityDescription(slice.data());
+
+    EXPECT_STREQ(description->accessComplexity()->c_str(), "adpAccessComplexity1");
+    EXPECT_STREQ(description->assignerShortName()->c_str(), "nvd");
+    EXPECT_STREQ(description->authentication()->c_str(), "adpAuthentication1");
+    EXPECT_STREQ(description->availabilityImpact()->c_str(), "adpAvailabilityImpact1");
+    EXPECT_STREQ(description->classification()->c_str(), "");
+    EXPECT_STREQ(description->confidentialityImpact()->c_str(), "adpConfidentialityImpact1");
+    EXPECT_STREQ(description->cweId()->c_str(), "");
+    EXPECT_STREQ(description->datePublished()->c_str(), "2024-01-11T11:11:20Z");
+    EXPECT_STREQ(description->dateUpdated()->c_str(), "2024-02-22T22:22:20Z");
+    EXPECT_STREQ(description->description()->c_str(), "adpDescription1");
+    EXPECT_STREQ(description->integrityImpact()->c_str(), "adpIntegrityImpact1");
+    EXPECT_STREQ(description->privilegesRequired()->c_str(), "");
+    EXPECT_STREQ(description->reference()->c_str(), "https://example.com/adp1");
+    EXPECT_STREQ(description->scope()->c_str(), "");
+    EXPECT_EQ(description->scoreBase(), 1);
+    EXPECT_STREQ(description->scoreVersion()->c_str(), "adpVersion1");
+    EXPECT_STREQ(description->severity()->c_str(), "LOW");
+    EXPECT_STREQ(description->userInteraction()->c_str(), "");
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25481 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR allows to select the source for the description data used to populate the vulnerability field.
First, it was required to store the missing descriptive information in the `queue/vd/feed` DB. Then, the `databaseFeedManager` was updated to build the final description considering the ADPs from the `shortName` and `subShortName`.

The corresponding UTs were added  to make sure the data was updated with the required keys, and then properly assembled in the get request. To maintain retro-compatibility, the NVD related entries weren't modified.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

It was confirmed that the final size of the DB is within the acceptable range. At the offset `891035`, this the final size

```
root@fb659c773250:/var/ossec# du -h queue/vd/feed/
5.9G	queue/vd/feed/
```

Manual tests: see comment below.

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation

- [x] Added unit tests (for new features)
