### PR TITLE
Quick fix - Add new field for vulnerability evaluation status

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -218,7 +218,7 @@
             },
             "under_evaluation": {
               "ignore_above": 1024,
-              "type": "bool"
+              "type": "boolean"
             }
           }
         },


### PR DESCRIPTION
|Related issue|
|---|
|#25482|

### PR Summary: 

This pull request introduces a new field, `vulnerability.under_evaluation`, in the ECS data structure. The purpose of this field is to indicate whether a vulnerability is still under evaluation or disputed. This flag is relevant when the vulnerability status is **Awaiting analysis (NVD)**, and no conclusive data is available from the ADP.

> [!NOTE]
> Quick fix due a bad name of type.

#### Key Changes:
- **New Field**: `vulnerability.under_evaluation`
  - The field is set to `true` if the following conditions are not met:
    - A valid base score is present (`scoreBase()` is non-zero).
    - The vulnerability has non-empty classification and severity information.
  - Example logic:

```cpp
const auto isUnderEvaluation = [&returnData]()
{
    return Utils::floatToDoubleRound(returnData.data->scoreBase(), 2) == 0 ||
           returnData.data->classification()->str().empty() ||
           returnData.data->severity()->str().empty();
};
```

#### Condition:
The field will be `true` when:
1. The base score is either missing or zero.
2. The classification or severity data is empty.

This additional field improves the ability to track the evaluation status of vulnerabilities, especially when a vulnerability is awaiting the analysis from the NVD and no further classification or severity details are provided by ADP.

---------------------------