### PR TITLE
Efficacy Tests - Align with sanitizations 4.10.0

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/009/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/009/expected_002.out
@@ -1,8 +1,7 @@
 [
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2007-4013' due to default status. - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox' is vulnerable to 'CVE-2007-6715' due to default status. - Agent '' (ID: '009', Version: '').",
+  "Match found, the package 'firefox' is vulnerable to 'CVE-2009-4129' due to default status. - Agent '' (ID: '009', Version: '').",  
   "Match found, the package 'firefox' is vulnerable to 'CVE-2008-4059' due to default status. - Agent '' (ID: '009', Version: '').",
-  "Match found, the package 'firefox' is vulnerable to 'CVE-2009-4129' due to default status. - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2023-4573'. Current version: '116.0.2-1' (less than '117.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2023-4574'. Current version: '116.0.2-1' (less than '117.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
   "Match found, the package 'firefox', is vulnerable to 'CVE-2023-4575'. Current version: '116.0.2-1' (less than '117.0' or equal to ''). - Agent '' (ID: '009', Version: '').",
@@ -78,5 +77,13 @@
   "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2011-0064",
   "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2012-4929",
   "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2012-4930",
-  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2016-7153"
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2016-7153",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2007-4013",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2007-0896",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2007-1970",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2007-2176",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2007-3827",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2007-4013",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2009-2469",
+  "No match due to default status for Package: firefox, Version: 116.0.2-1 while scanning for Vulnerability: CVE-2016-7152"
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/expected_002.out
@@ -1,6 +1,7 @@
 [
-    "Translation for package 'Opera Stable 108.0.5067.29' in platform 'windows' found in Level 2 cache.",
+    "Translation for package 'Opera Stable 9.0.5067.29' in platform 'windows' found in Level 2 cache.",
     "Initiating a vulnerability scan for package 'opera_browser' (win) (opera) with CVE Numbering Authorities (CNA) 'nvd' on Agent '' (ID: '001', Version: '').",
-    "Vendor match for Package: opera_browser, Version: 108.0.5067.29, CVE: CVE-2008-7297, Vendor: opera",
-    "Match found, the package 'opera_browser' is vulnerable to 'CVE-2008-7297' due to default status. - Agent '' (ID: '001', Version: '')."
+    "Vendor match for Package: opera_browser, Version: 9.0.5067.29, CVE: CVE-2008-7297, Vendor: opera",
+    "No match due to default status for Package: opera_browser, Version: 9.0.5067.29 while scanning for Vulnerability: CVE-2008-7297",
+    "Match found, the package 'opera_browser' is vulnerable to 'CVE-2010-0653' due to default status. - Agent '' (ID: '001', Version: '')."
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/input_002.json
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/011/input_002.json
@@ -4,10 +4,10 @@
     },
     "data_type": "dbsync_packages",
     "data": {
-      "version": "108.0.5067.29",
+      "version": "9.0.5067.29",
       "vendor": "Opera Software",
       "architecture": " ",
-      "name": "Opera Stable 108.0.5067.29",
+      "name": "Opera Stable 9.0.5067.29",
       "size": 0,
       "format": "win",
       "checksum": "12c8e8d9df8f9a9f54d4aaf43568d10c79f3cc56",


### PR DESCRIPTION
|Related issue|
|---|
| #25692 |

## Description
Due to changes in the content, some efficacy tests are now failing

- CVE-2007-4013: Default status is now unknown 
```json
        {
          "cpes": [
            "cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*"
          ],
          "defaultStatus": "unknown",
          "product": "firefox",
          "vendor": "mozilla"
        }
```

- CVE-2010-0653: Affected range changed
```json
        {
          "cpes": ["cpe:2.3:a:opera:opera_browser:*:*:*:*:*:*:*:*"],
          "defaultStatus": "unaffected",
          "product": "opera_browser",
          "vendor": "opera",
          "versions": [
            {
              "lessThan": "10.10",
              "status": "affected",
              "version": "0",
              "versionType": "custom"
            }
          ]
        }
```

- CVE-2008-7297: Affected range changed
```json
        {
          "cpes": ["cpe:2.3:a:opera:opera_browser:*:*:*:*:*:*:*:*"],
          "defaultStatus": "unaffected",
          "product": "opera_browser",
          "vendor": "opera",
          "versions": [
            {
              "lessThan": "10.10",
              "status": "affected",
              "version": "0",
              "versionType": "custom"
            }
          ]
```

- CVE-2007-0896: Default status is now unknown 

```json

          {
            "cpes": ["cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*"],
            "defaultStatus": "unknown",
            "product": "firefox",
            "vendor": "mozilla"
          }          
```
