### PR TITLE
Assign placeholder for missing field values in alerts

### DIFF
--- a/packages/windows/Dockerfile
+++ b/packages/windows/Dockerfile
@@ -13,4 +13,4 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
 
 ADD entrypoint.sh /
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT /bin/bash

--- a/packages/windows/Dockerfile
+++ b/packages/windows/Dockerfile
@@ -13,4 +13,4 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
 
 ADD entrypoint.sh /
 
-ENTRYPOINT /bin/bash
+ENTRYPOINT ["/entrypoint.sh"]

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "fieldAlertHelper.hpp"
 #include "numericHelper.h"
 #include "scanContext.hpp"
 
@@ -92,7 +93,8 @@ public:
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                            FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
                         json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
                         json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
@@ -101,7 +103,8 @@ public:
                     json["vulnerability"]["published"] = returnData.data->datePublished()->str();
                     json["vulnerability"]["rationale"] = "-";
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                    json["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
+                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                        Utils::toSentenceCase(returnData.data->severity()->str()));
 
                     // The title is different depending on the type of the alert.
                     json["vulnerability"]["type"] = "Packages";

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -82,15 +82,24 @@ public:
                     json["vulnerability"]["title"] = title;
                     // This improves the description of the alert without creating another rule
                     json["vulnerability"]["package"]["name"] = "one or many packages";
+                    json["vulnerability"]["package"]["architecture"] = "-";
+                    json["vulnerability"]["package"]["condition"] = "-";
+                    json["vulnerability"]["package"]["generated_cpe"] = "-";
+                    json["vulnerability"]["package"]["source"] = "-";
+                    json["vulnerability"]["package"]["version"] = "-";
 
                     json["vulnerability"]["cve"] = cve;
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                             Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                        json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
+                        json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
+                    json["vulnerability"]["cwe_reference"] = "-";
                     json["vulnerability"]["published"] = returnData.data->datePublished()->str();
+                    json["vulnerability"]["rationale"] = "-";
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
                     json["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -88,8 +88,7 @@ public:
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            FieldAlertHelper::fillEmptyOrNegative(
-                                Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
+                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["published"] = returnData.data->datePublished()->str();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -83,11 +83,6 @@ public:
                     json["vulnerability"]["title"] = title;
                     // This improves the description of the alert without creating another rule
                     json["vulnerability"]["package"]["name"] = "one or many packages";
-                    json["vulnerability"]["package"]["architecture"] = "-";
-                    json["vulnerability"]["package"]["condition"] = "-";
-                    json["vulnerability"]["package"]["generated_cpe"] = "-";
-                    json["vulnerability"]["package"]["source"] = "-";
-                    json["vulnerability"]["package"]["version"] = "-";
 
                     json["vulnerability"]["cve"] = cve;
                     if (!cvssVersion.empty())
@@ -95,8 +90,6 @@ public:
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                             FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                        json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
-                        json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["cwe_reference"] = "-";
@@ -105,6 +98,12 @@ public:
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
                     json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
                         Utils::toSentenceCase(returnData.data->severity()->str()));
+                    json["vulnerability"]["classification"] =
+                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
+                    json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                        Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
+                    json["vulnerability"]["score"]["version"] =
+                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
 
                     // The title is different depending on the type of the alert.
                     json["vulnerability"]["type"] = "Packages";

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cveSolvedAlertDetailsBuilder.hpp
@@ -92,9 +92,7 @@ public:
                                 Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
-                    json["vulnerability"]["cwe_reference"] = "-";
                     json["vulnerability"]["published"] = returnData.data->datePublished()->str();
-                    json["vulnerability"]["rationale"] = "-";
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
                     json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
                         Utils::toSentenceCase(returnData.data->severity()->str()));

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -233,7 +233,8 @@ public:
                 ecsData["vulnerability"]["scanner"]["vendor"] = "Wazuh";
                 ecsData["vulnerability"]["score"]["base"] =
                     FieldAlertHelper::fillEmptyOrNegative(Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                ecsData["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
+                ecsData["vulnerability"]["score"]["version"] =
+                    FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
                 ecsData["vulnerability"]["severity"] =
                     FieldAlertHelper::fillEmptyOrNegative(Utils::toSentenceCase(returnData.data->severity()->str()));
                 ecsData["vulnerability"]["under_evaluation"] = isUnderEvaluation();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "fieldAlertHelper.hpp"
 #include "loggerHelper.h"
 #include "numericHelper.h"
 #include "scanContext.hpp"
@@ -221,7 +222,8 @@ public:
                 };
 
                 // ECS vulnerability fields.
-                ecsData["vulnerability"]["classification"] = returnData.data->classification()->str();
+                ecsData["vulnerability"]["classification"] =
+                    FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
                 ecsData["vulnerability"]["description"] = returnData.data->description()->str();
                 ecsData["vulnerability"]["detected_at"] = Utils::getCurrentISO8601();
                 ecsData["vulnerability"]["enumeration"] = "CVE";
@@ -229,9 +231,11 @@ public:
                 ecsData["vulnerability"]["published_at"] = returnData.data->datePublished()->str();
                 ecsData["vulnerability"]["reference"] = returnData.data->reference()->str();
                 ecsData["vulnerability"]["scanner"]["vendor"] = "Wazuh";
-                ecsData["vulnerability"]["score"]["base"] = Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                ecsData["vulnerability"]["score"]["base"] =
+                    FieldAlertHelper::fillEmptyOrNegative(Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
                 ecsData["vulnerability"]["score"]["version"] = returnData.data->scoreVersion()->str();
-                ecsData["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
+                ecsData["vulnerability"]["severity"] =
+                    FieldAlertHelper::fillEmptyOrNegative(Utils::toSentenceCase(returnData.data->severity()->str()));
                 ecsData["vulnerability"]["under_evaluation"] = isUnderEvaluation();
 
                 // ECS wazuh fields.

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -140,7 +140,6 @@ public:
                     }
 
                     json["vulnerability"]["cve"] = cve;
-                    json["vulnerability"]["cve_version"] = "-";
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -146,8 +146,6 @@ public:
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                             FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                        json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
-                        json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["package"]["architecture"] = data->packageArchitecture();
@@ -157,6 +155,12 @@ public:
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
                     json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
                         Utils::toSentenceCase(returnData.data->severity()->str()));
+                    json["vulnerability"]["classification"] =
+                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
+                    json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                        Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
+                    json["vulnerability"]["score"]["version"] =
+                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
 
                     // The title is different depending on the type of the alert.
                     json["vulnerability"]["type"] = "Packages";

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -143,8 +143,7 @@ public:
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            FieldAlertHelper::fillEmptyOrNegative(
-                                Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
+                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["package"]["architecture"] = data->packageArchitecture();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "fieldAlertHelper.hpp"
 #include "numericHelper.h"
 #include "scanContext.hpp"
 
@@ -143,7 +144,8 @@ public:
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                            FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
                         json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
                         json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
@@ -153,7 +155,8 @@ public:
                     json["vulnerability"]["package"]["version"] = data->packageVersion();
                     json["vulnerability"]["published"] = returnData.data->datePublished()->str();
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                    json["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
+                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                        Utils::toSentenceCase(returnData.data->severity()->str()));
 
                     // The title is different depending on the type of the alert.
                     json["vulnerability"]["type"] = "Packages";

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventPackageAlertDetailsBuilder.hpp
@@ -139,10 +139,13 @@ public:
                     }
 
                     json["vulnerability"]["cve"] = cve;
+                    json["vulnerability"]["cve_version"] = "-";
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                             Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                        json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
+                        json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["package"]["architecture"] = data->packageArchitecture();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
@@ -10,42 +10,54 @@ namespace FieldAlertHelper
 {
 
     /**
-     * @brief Utility function to fill empty strings or zero numeric values with default placeholders.
+     * @brief High-performance utility function to replace empty strings or zero/negative numeric values with
+     * placeholders.
      *
-     * This function is a helper to ensure that certain fields, such as strings and doubles,
-     * are not left empty or set to zero. It returns either the original value or a default
-     * placeholder depending on the input type and value.
+     * This function ensures fields such as strings and numeric values are not left empty or with undesired values.
+     * It either returns the original value or a default placeholder based on the input type and its value:
      *
      * - For `std::string` types, it returns `"-"` if the string is empty, otherwise it returns the original string.
-     * - For `double` types, it returns `-1` if the value is zero (rounded to two decimal places), otherwise it
+     * - For numeric types (`double`, `int`, etc.), it returns `-1` if the value is zero or negative, otherwise it
      * returns the original value.
      *
-     * The return type is compatible with `nlohmann::json`, making this function useful for
-     * preparing data for JSON serialization.
+     * The function is optimized for performance with minimal branching and efficient memory management.
      *
-     * @tparam T The type of the field being checked, either `std::string` or `double`.
-     * @param field The field value to check and potentially modify.
-     * @return nlohmann::json A JSON-compatible value: either the original field value or a default placeholder.
+     * @tparam T The type of the field being processed (`std::string`, `double`, `int`, etc.).
+     * @param field The field value to check and potentially replace.
+     * @return nlohmann::json A JSON-compatible value, either the original value or a placeholder.
      *
      * @throws std::runtime_error If the field type is unsupported.
      */
     template<typename T>
-    nlohmann::json fillEmptyOrNegative(const T& field)
+    nlohmann::json fillEmptyOrNegative(T&& field)
     {
-        if constexpr (std::is_same_v<std::decay_t<T>, std::string>)
+        if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string>)
         {
             // Return "-" if the string is empty, otherwise return the original string
-            return field.empty() ? "-" : field;
+            return field.empty() ? "-" : std::forward<T>(field);
         }
-        else if constexpr (std::is_same_v<std::decay_t<T>, double>)
+        else if constexpr (std::is_arithmetic_v<std::remove_cv_t<std::remove_reference_t<T>>>)
         {
-            // Return -1.0 if the double value rounds to zero, otherwise return the original value
-            return (Utils::floatToDoubleRound(field, 2) == 0) ? -1 : field;
+            // Use a small epsilon value for floating-point comparisons
+            constexpr double epsilon = 1e-9;
+
+            // Handle floating-point numbers
+            if constexpr (std::is_floating_point_v<std::remove_cv_t<std::remove_reference_t<T>>>)
+            {
+                return (std::abs(field) < epsilon) ? -1.0 : std::forward<T>(field);
+            }
+            else
+            {
+                // Handle integral numbers: return -1 for negatives
+                return (field < 0) ? -1 : std::forward<T>(field);
+            }
         }
         else
         {
-            // Throw an exception if an unsupported type is passed to the function
-            throw std::runtime_error("Unsupported type for fillEmptyOrNegative");
+            // Compile-time check to ensure unsupported types are caught early
+            static_assert(std::is_arithmetic_v<std::remove_cv_t<std::remove_reference_t<T>>> ||
+                              std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string>,
+                          "Unsupported type for fillEmptyOrNegative");
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
@@ -9,27 +9,46 @@
 namespace FieldAlertHelper
 {
 
-    // Utility function to handle both strings and doubles, returning values compatible with nlohmann::json
+    /**
+     * @brief Utility function to fill empty strings or zero numeric values with default placeholders.
+     *
+     * This function is a helper to ensure that certain fields, such as strings and doubles,
+     * are not left empty or set to zero. It returns either the original value or a default
+     * placeholder depending on the input type and value.
+     *
+     * - For `std::string` types, it returns `"-"` if the string is empty, otherwise it returns the original string.
+     * - For `double` types, it returns `-1` if the value is zero (rounded to two decimal places), otherwise it
+     * returns the original value.
+     *
+     * The return type is compatible with `nlohmann::json`, making this function useful for
+     * preparing data for JSON serialization.
+     *
+     * @tparam T The type of the field being checked, either `std::string` or `double`.
+     * @param field The field value to check and potentially modify.
+     * @return nlohmann::json A JSON-compatible value: either the original field value or a default placeholder.
+     *
+     * @throws std::runtime_error If the field type is unsupported.
+     */
     template<typename T>
     nlohmann::json fillEmptyOrNegative(const T& field)
     {
         if constexpr (std::is_same_v<std::decay_t<T>, std::string>)
         {
-            return field.empty() ? "-" : field; // Return "-" if string is empty, otherwise return original string
+            // Return "-" if the string is empty, otherwise return the original string
+            return field.empty() ? "-" : field;
         }
         else if constexpr (std::is_same_v<std::decay_t<T>, double>)
         {
-            return (Utils::floatToDoubleRound(field, 2) == 0)
-                       ? -1.0
-                       : field; // Return -1 if double is zero, otherwise return original value
+            // Return -1.0 if the double value rounds to zero, otherwise return the original value
+            return (Utils::floatToDoubleRound(field, 2) == 0) ? -1 : field;
         }
         else
         {
-            // If the type is unsupported, throw an exception
+            // Throw an exception if an unsupported type is passed to the function
             throw std::runtime_error("Unsupported type for fillEmptyOrNegative");
         }
     }
 
 } // namespace FieldAlertHelper
 
-#endif // FIEL_ALERT_HELPER_HPP
+#endif // FIELD_ALERT_HELPER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
@@ -1,7 +1,6 @@
 #ifndef FIEL_ALERT_HELPER_HPP
 #define FIEL_ALERT_HELPER_HPP
 
-#include "numericHelper.h"
 #include <json.hpp>
 #include <string>
 #include <type_traits>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/fieldAlertHelper.hpp
@@ -1,0 +1,35 @@
+#ifndef FIEL_ALERT_HELPER_HPP
+#define FIEL_ALERT_HELPER_HPP
+
+#include "numericHelper.h"
+#include <json.hpp>
+#include <string>
+#include <type_traits>
+
+namespace FieldAlertHelper
+{
+
+    // Utility function to handle both strings and doubles, returning values compatible with nlohmann::json
+    template<typename T>
+    nlohmann::json fillEmptyOrNegative(const T& field)
+    {
+        if constexpr (std::is_same_v<std::decay_t<T>, std::string>)
+        {
+            return field.empty() ? "-" : field; // Return "-" if string is empty, otherwise return original string
+        }
+        else if constexpr (std::is_same_v<std::decay_t<T>, double>)
+        {
+            return (Utils::floatToDoubleRound(field, 2) == 0)
+                       ? -1.0
+                       : field; // Return -1 if double is zero, otherwise return original value
+        }
+        else
+        {
+            // If the type is unsupported, throw an exception
+            throw std::runtime_error("Unsupported type for fillEmptyOrNegative");
+        }
+    }
+
+} // namespace FieldAlertHelper
+
+#endif // FIEL_ALERT_HELPER_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -138,7 +138,6 @@ public:
                     }
 
                     json["vulnerability"]["cve"] = cve;
-                    json["vulnerability"]["cve_version"] = "-";
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -137,10 +137,13 @@ public:
                     }
 
                     json["vulnerability"]["cve"] = cve;
+                    json["vulnerability"]["cve_version"] = "-";
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                             Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                        json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
+                        json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["package"]["architecture"] = data->osArchitecture();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -144,8 +144,6 @@ public:
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
                             FieldAlertHelper::fillEmptyOrNegative(
                                 Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
-                        json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
-                        json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["package"]["architecture"] = data->osArchitecture();
@@ -155,6 +153,12 @@ public:
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
                     json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
                         Utils::toSentenceCase(returnData.data->severity()->str()));
+                    json["vulnerability"]["classification"] =
+                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->classification()->str());
+                    json["vulnerability"]["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                        Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
+                    json["vulnerability"]["score"]["version"] =
+                        FieldAlertHelper::fillEmptyOrNegative(returnData.data->scoreVersion()->str());
 
                     json["vulnerability"]["type"] = "Packages";
                     json["vulnerability"]["updated"] = returnData.data->dateUpdated()->str();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -14,6 +14,7 @@
 
 #include "chainOfResponsability.hpp"
 #include "databaseFeedManager.hpp"
+#include "fieldAlertHelper.hpp"
 #include "numericHelper.h"
 #include "scanContext.hpp"
 
@@ -141,7 +142,7 @@ public:
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
+                            FieldAlertHelper::fillEmptyOrNegative(Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
                         json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
                         json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
@@ -151,7 +152,7 @@ public:
                     json["vulnerability"]["package"]["version"] = data->osVersion();
                     json["vulnerability"]["published"] = returnData.data->datePublished()->str();
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                    json["vulnerability"]["severity"] = Utils::toSentenceCase(returnData.data->severity()->str());
+                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(Utils::toSentenceCase(returnData.data->severity()->str()));
 
                     json["vulnerability"]["type"] = "Packages";
                     json["vulnerability"]["updated"] = returnData.data->dateUpdated()->str();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -141,8 +141,7 @@ public:
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            FieldAlertHelper::fillEmptyOrNegative(
-                                Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
+                            Utils::floatToDoubleRound(returnData.data->scoreBase(), 2);
                     }
                     json["vulnerability"]["enumeration"] = "CVE";
                     json["vulnerability"]["package"]["architecture"] = data->osArchitecture();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOsAlertDetailsBuilder.hpp
@@ -142,7 +142,8 @@ public:
                     if (!cvssVersion.empty())
                     {
                         json["vulnerability"]["cvss"][scoreVersion]["base_score"] =
-                            FieldAlertHelper::fillEmptyOrNegative(Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
+                            FieldAlertHelper::fillEmptyOrNegative(
+                                Utils::floatToDoubleRound(returnData.data->scoreBase(), 2));
                         json["vulnerability"]["cvss"][scoreVersion]["exploitability_score"] = "-";
                         json["vulnerability"]["cvss"][scoreVersion]["impact_score"] = "-";
                     }
@@ -152,7 +153,8 @@ public:
                     json["vulnerability"]["package"]["version"] = data->osVersion();
                     json["vulnerability"]["published"] = returnData.data->datePublished()->str();
                     json["vulnerability"]["reference"] = returnData.data->reference()->str();
-                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(Utils::toSentenceCase(returnData.data->severity()->str()));
+                    json["vulnerability"]["severity"] = FieldAlertHelper::fillEmptyOrNegative(
+                        Utils::toSentenceCase(returnData.data->severity()->str()));
 
                     json["vulnerability"]["type"] = "Packages";
                     json["vulnerability"]["updated"] = returnData.data->dateUpdated()->str();

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -1148,8 +1148,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
                  elementOsVersion.c_str());
 
     EXPECT_STREQ(elementData.at("vulnerability").at("category").get_ref<const std::string&>().c_str(), "Packages");
-    EXPECT_STREQ(elementData.at("vulnerability").at("classification").get_ref<const std::string&>().c_str(),
-                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->classification()->c_str());
+    EXPECT_STREQ(elementData.at("vulnerability").at("classification").get_ref<const std::string&>().c_str(), "-");
     EXPECT_STREQ(elementData.at("vulnerability").at("description").get_ref<const std::string&>().c_str(),
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
     EXPECT_STREQ(elementData.at("vulnerability").at("enumeration").get_ref<const std::string&>().c_str(), "CVE");

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -285,21 +285,6 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
         alert.at("vulnerability").at("cvss").at(alertScoreVersion).at("base_score").get_ref<const double&>(),
         Utils::floatToDoubleRound(GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreBase(), 2));
 
-    EXPECT_STREQ(alert.at("vulnerability")
-                     .at("cvss")
-                     .at(alertScoreVersion)
-                     .at("exploitability_score")
-                     .get_ref<const std::string&>()
-                     .c_str(),
-                 "-");
-    EXPECT_STREQ(alert.at("vulnerability")
-                     .at("cvss")
-                     .at(alertScoreVersion)
-                     .at("impact_score")
-                     .get_ref<const std::string&>()
-                     .c_str(),
-                 "-");
-
     EXPECT_STREQ(alert.at("vulnerability").at("enumeration").get_ref<const std::string&>().c_str(), "CVE");
     EXPECT_STREQ(alert.at("vulnerability").at("package").at("architecture").get_ref<const std::string&>().c_str(),
                  scanContext->packageArchitecture().data());

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -279,10 +279,26 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
 
     EXPECT_STREQ(alert.at("vulnerability").at("cve").get_ref<const std::string&>().c_str(), CVEID.c_str());
+    EXPECT_STREQ(alert.at("vulnerability").at("cve_version").get_ref<const std::string&>().c_str(), "-");
 
     EXPECT_DOUBLE_EQ(
         alert.at("vulnerability").at("cvss").at(alertScoreVersion).at("base_score").get_ref<const double&>(),
         Utils::floatToDoubleRound(GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreBase(), 2));
+
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("exploitability_score")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 "-");
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("impact_score")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 "-");
 
     EXPECT_STREQ(alert.at("vulnerability").at("enumeration").get_ref<const std::string&>().c_str(), "CVE");
     EXPECT_STREQ(alert.at("vulnerability").at("package").at("architecture").get_ref<const std::string&>().c_str(),
@@ -878,4 +894,190 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
         eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
 
     EXPECT_ANY_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
+}
+
+TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3WithDefaultValues)
+{
+    flatbuffers::FlatBufferBuilder fbBuilder;
+    auto vulnerabilityDescriptionData =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
+                                                                     "accessComplexity_test_string",
+                                                                     "assignerShortName_test_string",
+                                                                     "attackVector_test_string",
+                                                                     "authentication_test_string",
+                                                                     "availabilityImpact_test_string",
+                                                                     "classification_test_string",
+                                                                     "confidentialityImpact_test_string",
+                                                                     "cweId_test_string",
+                                                                     "datePublished_test_string",
+                                                                     "dateUpdated_test_string",
+                                                                     "description_test_string",
+                                                                     "integrityImpact_test_string",
+                                                                     "privilegesRequired_test_string",
+                                                                     "reference_test_string",
+                                                                     "scope_test_string",
+                                                                     8.3,
+                                                                     "3",
+                                                                     "severity_test_string",
+                                                                     "userInteraction_test_string");
+    fbBuilder.Finish(vulnerabilityDescriptionData);
+
+    auto dbWrapper = std::make_unique<Utils::RocksDBWrapper>(TEST_DESCRIPTION_DATABASE_PATH);
+    rocksdb::Slice dbValue(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
+    dbWrapper->put(CVEID, dbValue);
+
+    auto mockGetVulnerabiltyDescriptiveInformation =
+        [&](const std::string_view cveId,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    {
+        dbWrapper->get(std::string(cveId), resultContainer.slice);
+        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+    };
+
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "osdata_codeName",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_PACKAGES_INSERTED_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
+        syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+    auto scanContext =
+        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
+            syscollectorDelta);
+    scanContext->m_elements[CVEID] = R"({"operation":"INSERTED"})"_json;
+    scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::LessThan};
+
+    TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
+                                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>
+        eventPackageAlertDetailsAugmentation(spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(eventPackageAlertDetailsAugmentation.handleRequest(scanContext));
+
+    auto& alert = scanContext->m_alerts[CVEID];
+
+    std::string alertScoreVersion {"cvss3"};
+
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("vector")
+                     .at("attack_vector")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->attackVector()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("vector")
+                     .at("privileges_required")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->privilegesRequired()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("vector")
+                     .at("scope")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scope()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("vector")
+                     .at("user_interaction")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->userInteraction()->c_str());
+
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("vector")
+                     .at("availability")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->availabilityImpact()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("vector")
+                     .at("confidentiality_impact")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->confidentialityImpact()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability")
+                     .at("cvss")
+                     .at(alertScoreVersion)
+                     .at("vector")
+                     .at("integrity_impact")
+                     .get_ref<const std::string&>()
+                     .c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->integrityImpact()->c_str());
+
+    EXPECT_STREQ(alert.at("vulnerability").at("assigner").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->assignerShortName()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability").at("cwe_reference").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->cweId()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability").at("package").at("source").get_ref<const std::string&>().c_str(),
+                 scanContext->packageSource().data());
+    EXPECT_STREQ(alert.at("vulnerability").at("rationale").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
+
+    EXPECT_STREQ(alert.at("vulnerability").at("cve").get_ref<const std::string&>().c_str(), CVEID.c_str());
+
+    EXPECT_DOUBLE_EQ(
+        alert.at("vulnerability").at("cvss").at(alertScoreVersion).at("base_score").get_ref<const double&>(),
+        Utils::floatToDoubleRound(GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreBase(), 2));
+
+    EXPECT_STREQ(alert.at("vulnerability").at("enumeration").get_ref<const std::string&>().c_str(), "CVE");
+    EXPECT_STREQ(alert.at("vulnerability").at("package").at("architecture").get_ref<const std::string&>().c_str(),
+                 scanContext->packageArchitecture().data());
+    EXPECT_STREQ(alert.at("vulnerability").at("package").at("name").get_ref<const std::string&>().c_str(),
+                 scanContext->packageName().data());
+    EXPECT_STREQ(alert.at("vulnerability").at("package").at("version").get_ref<const std::string&>().c_str(),
+                 scanContext->packageVersion().data());
+
+    EXPECT_STREQ(alert.at("vulnerability").at("published").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability").at("reference").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->reference()->c_str());
+    EXPECT_STREQ(
+        alert.at("vulnerability").at("severity").get_ref<const std::string&>().c_str(),
+        Utils::toSentenceCase(GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->severity()->str()).c_str());
+    EXPECT_STREQ(alert.at("vulnerability").at("status").get_ref<const std::string&>().c_str(), "Active");
+
+    EXPECT_STREQ(alert.at("vulnerability").at("title").get_ref<const std::string&>().c_str(),
+                 (CVEID + " affects " + scanContext->packageName().data()).c_str());
+    EXPECT_STREQ(alert.at("vulnerability").at("type").get_ref<const std::string&>().c_str(), "Packages");
+    EXPECT_STREQ(alert.at("vulnerability").at("updated").get_ref<const std::string&>().c_str(),
+                 GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->dateUpdated()->c_str());
+    EXPECT_STREQ(alert.at("vulnerability").at("package").at("condition").get_ref<const std::string&>().c_str(),
+                 "Package less than 1.0.0");
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -279,7 +279,6 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
 
     EXPECT_STREQ(alert.at("vulnerability").at("cve").get_ref<const std::string&>().c_str(), CVEID.c_str());
-    EXPECT_STREQ(alert.at("vulnerability").at("cve_version").get_ref<const std::string&>().c_str(), "-");
 
     EXPECT_DOUBLE_EQ(
         alert.at("vulnerability").at("cvss").at(alertScoreVersion).at("base_score").get_ref<const double&>(),


### PR DESCRIPTION
| Related issue |
| --- |
| #25484 |

# Description
This PR introduces a new helper function, `populateField`, which simplifies the process of populating fields in a `nlohmann::json` object with appropriate values based on their types. This function ensures that empty or undefined values are handled consistently, improving the robustness of the alert system.

The field replacement is implemented according to the current index template used by alerts, and a unit test (UT) has been added to cover this new scenario.