### PR TITLE
Adds Indexer exporter for opentelemetry metrics

### DIFF
--- a/src/engine/source/metrics/CMakeLists.txt
+++ b/src/engine/source/metrics/CMakeLists.txt
@@ -3,11 +3,64 @@ set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(INC_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
 set(IFACE_DIR ${CMAKE_CURRENT_LIST_DIR}/interface)
 
+## Interface
 add_library(metrics_imetrics INTERFACE)
 target_include_directories(metrics_imetrics INTERFACE ${IFACE_DIR})
 target_link_libraries(metrics_imetrics INTERFACE base)
 add_library(metrics::imetrics ALIAS metrics_imetrics)
 
+## Metrics
+add_library(metricsWIP STATIC
+    ${SRC_DIR}/exporter/indexerMetricsExporter.cpp
+)
+target_include_directories(metricsWIP
+    PUBLIC
+    ${INC_DIR}
+
+    PRIVATE
+    ${SRC_DIR}
+)
+target_link_libraries(metricsWIP
+  PUBLIC
+  metrics::imetrics
+  base
+
+  PRIVATE
+  opentelemetry-cpp::api
+  opentelemetry-cpp::metrics
+  opentelemetry-cpp::sdk
+  opentelemetry-cpp::resources
+  indexerconnector::iindexerconnector
+)
+
+## Tests
+if(ENGINE_BUILD_TEST)
+
+set(TEST_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/test/src)
+set(TEST_MOCK_DIR ${CMAKE_CURRENT_LIST_DIR}/test/mocks)
+set(UNIT_SRC_DIR ${TEST_SRC_DIR}/unit)
+set(COMPONENT_SRC_DIR ${TEST_SRC_DIR}/component)
+
+add_executable(metrics_utest
+  ${UNIT_SRC_DIR}/exporter/indexerMetricsExporter_test.cpp
+)
+target_include_directories(metrics_utest
+  PRIVATE
+  ${SRC_DIR}
+)
+target_link_libraries(metrics_utest
+  GTest::gtest_main
+  metricsWIP
+  indexerconnector::mocks
+  opentelemetry-cpp::api
+  opentelemetry-cpp::metrics
+  opentelemetry-cpp::sdk
+  opentelemetry-cpp::resources
+  base::test
+)
+gtest_discover_tests(metrics_utest)
+
+endif(ENGINE_BUILD_TEST)
 
 set(ENGINE_METRICS_SOURCE_DIR ${ENGINE_SOURCE_DIR}/metrics/src)
 set(ENGINE_METRICS_INCLUDE_DIR ${ENGINE_SOURCE_DIR}/metrics/include)
@@ -35,25 +88,3 @@ target_link_libraries(metrics PRIVATE
 target_include_directories(metrics PUBLIC
 ${ENGINE_METRICS_INCLUDE_DIR}
 )
-
-# Tests
-if(ENGINE_BUILD_TEST)
-set(TEST_UNIT_DIR ${CMAKE_CURRENT_LIST_DIR}/test/unit)
-set(TEST_MOCK_DIR ${CMAKE_CURRENT_LIST_DIR}/test/unit/mocks)
-
-add_executable(metrics_utest
-  ${TEST_UNIT_DIR}/dataHubExporter_test.cpp
-)
-
-# Mocks
-add_library(metrics_mocks INTERFACE)
-target_include_directories(metrics_mocks INTERFACE ${TEST_MOCK_DIR})
-target_link_libraries(metrics_mocks INTERFACE GTest::gmock)
-add_library(metrics::mocks ALIAS metrics_mocks)
-
-target_include_directories(metrics_utest INTERFACE ${TEST_MOCK_DIR})
-
-# TODO: Replace test_mocks with the metrics executable when you have the test folder available.
-target_link_libraries(metrics_utest GTest::gtest_main GTest::gmock base metrics)
-gtest_discover_tests(metrics_utest)
-endif(ENGINE_BUILD_TEST)

--- a/src/engine/source/metrics/include/metrics/ot.hpp
+++ b/src/engine/source/metrics/include/metrics/ot.hpp
@@ -1,0 +1,15 @@
+#ifndef _METRICS_INCLUDES_HPP
+#define _METRICS_INCLUDES_HPP
+
+namespace metrics
+{
+namespace ot
+{
+using namespace opentelemetry;
+using namespace opentelemetry::sdk::common;
+using namespace opentelemetry::sdk::metrics;
+using namespace opentelemetry::sdk::instrumentationscope;
+} // namespace ot
+} // namespace metrics
+
+#endif // _METRICS_INCLUDES_HPP

--- a/src/engine/source/metrics/src/exporter/indexerMetricsExporter.cpp
+++ b/src/engine/source/metrics/src/exporter/indexerMetricsExporter.cpp
@@ -1,0 +1,64 @@
+#include "indexerMetricsExporter.hpp"
+
+#include <stdexcept>
+
+#include <base/logging.hpp>
+
+#include <metrics/ot.hpp>
+
+#include "metricSerializer.hpp"
+#include "pointDataSerializer.hpp"
+#include "scopeSerializer.hpp"
+
+namespace metrics
+{
+
+ot::ExportResult IndexerMetricsExporter::Export(const ot::ResourceMetrics& data) noexcept
+{
+    try
+    {
+
+        for (const auto& record : data.scope_metric_data_)
+        {
+            json::Json jsonMessage;
+            jsonMessage.setString("ADD", "/operation");
+            jsonMessage.set("/data", details::scopeToJson(*record.scope_));
+            for (const auto& metric : record.metric_data_)
+            {
+                auto metricJson = details::metricDataToJson(metric);
+                for (const auto& point : metric.point_data_attr_)
+                {
+                    auto pointDataJson = details::pointDataToJson(point.point_data);
+                    metricJson.appendJson(pointDataJson, "/points");
+                }
+                jsonMessage.appendJson(metricJson, "/data/metrics");
+            }
+
+            this->m_indexerConnector->publish(jsonMessage.str());
+        }
+        return ot::ExportResult::kSuccess;
+    }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR("Failure exporting metrics: {}", e.what());
+        return ot::ExportResult::kFailure;
+    }
+}
+
+ot::AggregationTemporality
+IndexerMetricsExporter::GetAggregationTemporality(ot::InstrumentType instrument_type) const noexcept
+{
+    return ot::AggregationTemporality::kCumulative;
+}
+
+bool IndexerMetricsExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+    return true;
+}
+
+bool IndexerMetricsExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+    return true;
+}
+
+} // namespace metrics

--- a/src/engine/source/metrics/src/exporter/indexerMetricsExporter.hpp
+++ b/src/engine/source/metrics/src/exporter/indexerMetricsExporter.hpp
@@ -1,0 +1,71 @@
+#ifndef _METRICS_INDEXERMETRICSEXPORTER_HPP
+#define _METRICS_INDEXERMETRICSEXPORTER_HPP
+
+#include <memory>
+#include <stdexcept>
+
+#include <opentelemetry/sdk/metrics/push_metric_exporter.h>
+
+#include <base/json.hpp>
+#include <indexerConnector/iindexerconnector.hpp>
+
+#include <metrics/ot.hpp>
+
+namespace metrics
+{
+
+/**
+ * IndexerMetricsExporter push metrics data to the Indexer.
+ */
+class IndexerMetricsExporter final : public ot::PushMetricExporter
+{
+private:
+    std::shared_ptr<IIndexerConnector> m_indexerConnector;
+
+public:
+    ~IndexerMetricsExporter() override = default;
+
+    /**
+     * @brief Construct a new Indexer Metrics Exporter object
+     *
+     * @param indexerConnector Indexer Connector
+     */
+    IndexerMetricsExporter(const std::shared_ptr<IIndexerConnector>& indexerConnector)
+        : m_indexerConnector(indexerConnector)
+    {
+        if (!m_indexerConnector)
+        {
+            throw std::runtime_error("Cannot create IndexerMetricsExporter with a nullptr indexerConnector");
+        }
+    }
+
+    /**
+     * Exports a batch of metrics data. This method must not be called
+     * concurrently for the same exporter instance.
+     * @param data metrics data
+     */
+    ot::ExportResult Export(const ot::ResourceMetrics& data) noexcept override;
+
+    /**
+     * Get the AggregationTemporality for given Instrument Type for this exporter.
+     *
+     * @return AggregationTemporality
+     */
+    ot::AggregationTemporality GetAggregationTemporality(ot::InstrumentType instrument_type) const noexcept override;
+
+    /**
+     * Force flush the exporter.
+     */
+    bool ForceFlush(std::chrono::microseconds timeout) noexcept override;
+
+    /**
+     * Shut down the metric exporter.
+     * @param timeout an optional timeout.
+     * @return return the status of the operation.
+     */
+    bool Shutdown(std::chrono::microseconds timeout) noexcept override;
+};
+
+} // namespace metrics
+
+#endif // _METRICS_INDEXERMETRICSEXPORTER_HPP

--- a/src/engine/source/metrics/src/exporter/metricSerializer.hpp
+++ b/src/engine/source/metrics/src/exporter/metricSerializer.hpp
@@ -1,0 +1,28 @@
+#ifndef _METRICS_METRICSERIALIZER_HPP
+#define _METRICS_METRICSERIALIZER_HPP
+
+#include <opentelemetry/sdk/metrics/data/metric_data.h>
+
+#include <base/json.hpp>
+
+#include <metrics/ot.hpp>
+
+namespace metrics::details
+{
+/**
+ * @brief Serialize MetricData to json
+ *
+ * @param metricData
+ * @return json::Json
+ */
+inline json::Json metricDataToJson(const ot::MetricData& metricData)
+{
+    json::Json jsonMetric;
+    jsonMetric.setString(metricData.instrument_descriptor.name_, "/name");
+    jsonMetric.setString(metricData.instrument_descriptor.description_, "/description");
+    jsonMetric.setString(metricData.instrument_descriptor.unit_, "/unit");
+    return jsonMetric;
+}
+} // namespace metrics::details
+
+#endif // _METRICS_METRICSERIALIZER_HPP

--- a/src/engine/source/metrics/src/exporter/pointDataSerializer.hpp
+++ b/src/engine/source/metrics/src/exporter/pointDataSerializer.hpp
@@ -1,0 +1,161 @@
+#ifndef _METRICS_POINTDATASERIALIZER_HPP
+#define _METRICS_POINTDATASERIALIZER_HPP
+
+#include <opentelemetry/sdk/metrics/data/point_data.h>
+
+#include <base/json.hpp>
+
+#include <metrics/ot.hpp>
+
+namespace metrics::details
+{
+/**
+ * @brief Serialize SumPointData to json
+ *
+ * @param pointData
+ * @return json::Json
+ */
+inline json::Json pointDataToJson(const ot::SumPointData pointData)
+{
+    json::Json jsonPoint;
+    if (pointData.is_monotonic_)
+    {
+        jsonPoint.setBool(true, "/isMonotonic");
+    }
+    if (std::holds_alternative<int64_t>(pointData.value_))
+    {
+        jsonPoint.setInt64(std::get<int64_t>(pointData.value_), "/value");
+    }
+    else if (std::holds_alternative<double>(pointData.value_))
+    {
+        jsonPoint.setDouble(std::get<double>(pointData.value_), "/value");
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported point data value type");
+    }
+    return jsonPoint;
+}
+
+/**
+ * @brief Serialize LastValuePointData to json
+ *
+ * @param pointData
+ * @return json::Json
+ */
+inline json::Json pointDataToJson(const ot::LastValuePointData pointData)
+{
+    json::Json jsonPoint;
+    if (std::holds_alternative<int64_t>(pointData.value_))
+    {
+        jsonPoint.setInt64(std::get<int64_t>(pointData.value_), "/value");
+    }
+    else if (std::holds_alternative<double>(pointData.value_))
+    {
+        jsonPoint.setDouble(std::get<double>(pointData.value_), "/value");
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported point data value type");
+    }
+
+    jsonPoint.setBool(pointData.is_lastvalue_valid_, "/valid");
+    jsonPoint.setString(std::to_string(pointData.sample_ts_.time_since_epoch().count()), "/timestamp");
+
+    return jsonPoint;
+}
+
+/**
+ * @brief Serialize HistogramPointData to json
+ *
+ * @param pointData
+ * @return json::Json
+ */
+inline json::Json pointDataToJson(const ot::HistogramPointData pointData)
+{
+    json::Json jsonPoint;
+    jsonPoint.setInt64(pointData.count_, "/count");
+    if (pointData.record_min_max_)
+    {
+        if (std::holds_alternative<int64_t>(pointData.min_))
+        {
+            jsonPoint.setInt64(std::get<int64_t>(pointData.min_), "/min");
+        }
+        else if (std::holds_alternative<double>(pointData.min_))
+        {
+            jsonPoint.setDouble(std::get<double>(pointData.min_), "/min");
+        }
+        if (std::holds_alternative<int64_t>(pointData.max_))
+        {
+            jsonPoint.setInt64(std::get<int64_t>(pointData.max_), "/max");
+        }
+        else if (std::holds_alternative<double>(pointData.max_))
+        {
+            jsonPoint.setDouble(std::get<double>(pointData.max_), "/max");
+        }
+    }
+
+    if (std::holds_alternative<int64_t>(pointData.sum_))
+    {
+        jsonPoint.setInt64(std::get<int64_t>(pointData.sum_), "/sum");
+    }
+    else if (std::holds_alternative<double>(pointData.sum_))
+    {
+        jsonPoint.setDouble(std::get<double>(pointData.sum_), "/sum");
+    }
+
+    json::Json boundaries;
+    boundaries.setArray("/boundaries");
+    for (const auto& boundary : pointData.boundaries_)
+    {
+        json::Json boundaryJson;
+        boundaryJson.setDouble(boundary);
+        boundaries.appendJson(boundaryJson);
+    }
+    jsonPoint.appendJson(boundaries, "/boundaries");
+
+    json::Json counts;
+    counts.setArray("/counts");
+    for (const auto& count : pointData.counts_)
+    {
+        json::Json countJson;
+        countJson.setInt64(count);
+        counts.appendJson(countJson);
+    }
+    jsonPoint.appendJson(counts, "/counts");
+
+    return jsonPoint;
+}
+
+/**
+ * @brief Serialize DropPointData to json (Represents no recorded data)
+ *
+ * @param pointData
+ * @return json::Json
+ */
+inline json::Json pointDataToJson(const ot::DropPointData pointData)
+{
+    return json::Json {};
+}
+
+/**
+ * @brief Serialize PointData to json
+ *
+ * @param pointData
+ * @return json::Json
+ */
+inline json::Json pointDataToJson(const ot::PointType& pointData)
+{
+    switch (pointData.index())
+    {
+        case 0: return pointDataToJson(std::get<ot::SumPointData>(pointData));
+        case 1: return pointDataToJson(std::get<ot::HistogramPointData>(pointData));
+        case 2: return pointDataToJson(std::get<ot::LastValuePointData>(pointData));
+        case 3: return pointDataToJson(std::get<ot::DropPointData>(pointData));
+        default: throw std::runtime_error("Unsupported point data type");
+    }
+}
+
+} // namespace metrics::details
+
+#endif // _METRICS_POINTDATASERIALIZER_HPP

--- a/src/engine/source/metrics/src/exporter/scopeSerializer.hpp
+++ b/src/engine/source/metrics/src/exporter/scopeSerializer.hpp
@@ -1,0 +1,28 @@
+#ifndef _METRICS_SCOPESERIALIZER_HPP
+#define _METRICS_SCOPESERIALIZER_HPP
+
+#include <opentelemetry/sdk/instrumentationscope/instrumentation_scope.h>
+
+#include <base/json.hpp>
+
+#include <metrics/ot.hpp>
+
+namespace metrics::details
+{
+/**
+ * @brief Serialize InstrumentationScope to json
+ *
+ * @param scope
+ * @return json::Json
+ */
+inline json::Json scopeToJson(const ot::InstrumentationScope& scope)
+{
+    json::Json jsonScope;
+    jsonScope.setString(scope.GetName(), "/name");
+    jsonScope.setString(scope.GetSchemaURL(), "/schema");
+    jsonScope.setString(scope.GetVersion(), "/version");
+    return jsonScope;
+}
+} // namespace metrics::details
+
+#endif // _METRICS_SCOPESERIALIZER_HPP

--- a/src/engine/source/metrics/test/src/unit/exporter/indexerMetricsExporter_test.cpp
+++ b/src/engine/source/metrics/test/src/unit/exporter/indexerMetricsExporter_test.cpp
@@ -1,0 +1,407 @@
+#include <gtest/gtest.h>
+
+#include <opentelemetry/context/runtime_context.h>
+#include <opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h>
+#include <opentelemetry/sdk/metrics/meter.h>
+#include <opentelemetry/sdk/metrics/meter_context.h>
+#include <opentelemetry/sdk/metrics/meter_provider.h>
+
+#include <base/behaviour.hpp>
+#include <base/logging.hpp>
+#include <indexerConnector/mockiconnector.hpp>
+
+#include "exporter/indexerMetricsExporter.hpp"
+#include "metrics/ot.hpp"
+
+using namespace base::test;
+using namespace metrics;
+
+TEST(IndexerMetricsExporter, Instantiate)
+{
+    ASSERT_THROW(auto exporter = metrics::IndexerMetricsExporter(nullptr), std::runtime_error);
+    auto indexerConnector = std::make_shared<indexerconnector::mocks::MockIConnector>();
+    ASSERT_NO_THROW(auto exporter = metrics::IndexerMetricsExporter(indexerConnector));
+}
+
+TEST(IndexerMetricsExporter, GetAggregationTemporality)
+{
+    auto indexerConnector = std::make_shared<indexerconnector::mocks::MockIConnector>();
+    metrics::IndexerMetricsExporter exporter(indexerConnector);
+
+    auto types = {opentelemetry::sdk::metrics::InstrumentType::kCounter,
+                  opentelemetry::sdk::metrics::InstrumentType::kHistogram,
+                  opentelemetry::sdk::metrics::InstrumentType::kUpDownCounter,
+                  opentelemetry::sdk::metrics::InstrumentType::kObservableCounter,
+                  opentelemetry::sdk::metrics::InstrumentType::kObservableGauge,
+                  opentelemetry::sdk::metrics::InstrumentType::kObservableUpDownCounter};
+
+    for (auto type : types)
+    {
+        ASSERT_EQ(exporter.GetAggregationTemporality(type),
+                  opentelemetry::sdk::metrics::AggregationTemporality::kCumulative);
+    }
+}
+
+TEST(IndexerMetricsExporter, ForceFlush)
+{
+    auto indexerConnector = std::make_shared<indexerconnector::mocks::MockIConnector>();
+    metrics::IndexerMetricsExporter exporter(indexerConnector);
+
+    ASSERT_TRUE(exporter.ForceFlush(std::chrono::microseconds(500)));
+}
+
+TEST(IndexerMetricsExporter, Shutdown)
+{
+    auto indexerConnector = std::make_shared<indexerconnector::mocks::MockIConnector>();
+    metrics::IndexerMetricsExporter exporter(indexerConnector);
+
+    ASSERT_TRUE(exporter.Shutdown(std::chrono::microseconds(500)));
+}
+
+namespace exporttest
+{
+using SuccessExpected = InnerExpected<None, std::shared_ptr<indexerconnector::mocks::MockIConnector>, json::Json>;
+using FailureExpected = InnerExpected<None, std::shared_ptr<indexerconnector::mocks::MockIConnector>, json::Json>;
+using Expc = Expected<SuccessExpected, FailureExpected>;
+auto SUCCESS = Expc::success();
+auto FAILURE = Expc::failure();
+
+using ExportT = std::tuple<std::function<void(std::shared_ptr<ot::MeterProvider>)>, Expc>;
+
+class IndexerMetricsExportTest : public ::testing::TestWithParam<ExportT>
+{
+protected:
+    std::shared_ptr<indexerconnector::mocks::MockIConnector> m_indexerConnector;
+    std::shared_ptr<ot::MeterProvider> m_provider;
+
+public:
+    void SetUp() override
+    {
+        logging::testInit();
+        m_indexerConnector = std::make_shared<indexerconnector::mocks::MockIConnector>();
+
+        // Generate test opentelemetry pipeline
+        // Exporter
+        auto exporter = std::make_unique<metrics::IndexerMetricsExporter>(m_indexerConnector);
+
+        // Reader
+        auto readerOptions = opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions();
+        readerOptions.export_interval_millis = std::chrono::milliseconds(500);
+        readerOptions.export_timeout_millis = std::chrono::milliseconds(300);
+        auto reader = std::make_shared<ot::PeriodicExportingMetricReader>(
+            std::unique_ptr<ot::PushMetricExporter>(std::move(exporter)), readerOptions);
+
+        // Provider
+        m_provider = std::make_shared<ot::MeterProvider>();
+        m_provider->AddMetricReader(reader);
+    }
+
+    json::Json getExpectedJson() const
+    {
+        json::Json expectedJson;
+
+        expectedJson.setString("ADD", "/operation");
+        expectedJson.setObject("/data");
+        expectedJson.setString("test", "/data/name");
+        expectedJson.setString("", "/data/schema");
+        expectedJson.setString("", "/data/version");
+
+        return expectedJson;
+    }
+};
+
+TEST_P(IndexerMetricsExportTest, Export)
+{
+    auto [metricsLambda, expected] = GetParam();
+
+    auto expectedJson = getExpectedJson();
+    if (expected)
+    {
+        expected.succCase()(m_indexerConnector, expectedJson);
+    }
+    else
+    {
+        expected.failCase()(m_indexerConnector, expectedJson);
+    }
+
+    // Generate metrics
+    metricsLambda(m_provider);
+
+    // Sleep 2 cycles to allow the exporter to export the metrics
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+}
+
+json::Json getBoundaries()
+{
+    json::Json boundaries;
+    boundaries.setArray();
+    json::Json bound;
+    bound.setDouble(0.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(5.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(10.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(25.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(50.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(75.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(100.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(250.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(500.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(750.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(1000.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(2500.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(5000.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(7500.0);
+    boundaries.appendJson(bound);
+    bound.setDouble(10000.0);
+    boundaries.appendJson(bound);
+
+    return boundaries;
+}
+
+json::Json getCounts()
+{
+    json::Json count;
+    json::Json counts;
+    count.setInt64(0);
+    counts.appendJson(count);
+    count.setInt64(1);
+    counts.appendJson(count);
+    for (auto i = 0; i < 14; i++)
+    {
+        count.setInt64(0);
+        counts.appendJson(count);
+    }
+    return counts;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    // Test suite name
+    Metrics,
+    IndexerMetricsExportTest,
+    ::testing::Values(
+        // IndexerConnector throws exception
+        ExportT(
+            [](auto provider)
+            {
+                auto meter = provider->GetMeter("test");
+                auto counter = meter->CreateUInt64Counter("counter");
+                auto context = ot::context::RuntimeContext::GetCurrent();
+                counter->Add(1, context);
+            },
+            FAILURE(
+                [](auto connectorMock, auto)
+                {
+                    EXPECT_CALL(*connectorMock, publish(testing::_))
+                        .WillRepeatedly(testing::Throw(std::runtime_error("Mock error")));
+
+                    return None {};
+                })),
+        // Counter
+        ExportT(
+            [](auto provider)
+            {
+                auto meter = provider->GetMeter("test");
+                auto counter = meter->CreateUInt64Counter("counterInt");
+                auto context = ot::context::RuntimeContext::GetCurrent();
+                counter->Add(1, context);
+            },
+            SUCCESS(
+                [](auto connectorMock, auto expectedJson)
+                {
+                    expectedJson.setArray("/data/metrics");
+                    json::Json expectedCounter;
+                    expectedCounter.setString("counterInt", "/name");
+                    expectedCounter.setString("", "/description");
+                    expectedCounter.setString("", "/unit");
+
+                    json::Json expectedPoints;
+                    expectedPoints.setBool(true, "/isMonotonic");
+                    expectedPoints.setInt64(1, "/value");
+
+                    expectedCounter.appendJson(expectedPoints, "/points");
+                    expectedJson.appendJson(expectedCounter, "/data/metrics");
+
+                    auto expectedString = expectedJson.str();
+                    EXPECT_CALL(*connectorMock, publish(expectedString)).Times(testing::AtLeast(1));
+
+                    return None {};
+                })),
+        ExportT(
+            [](auto provider)
+            {
+                auto meter = provider->GetMeter("test");
+                auto counter = meter->CreateDoubleCounter("counterDouble");
+                auto context = ot::context::RuntimeContext::GetCurrent();
+                counter->Add(1.5, context);
+            },
+            SUCCESS(
+                [](auto connectorMock, auto expectedJson)
+                {
+                    expectedJson.setArray("/data/metrics");
+                    json::Json expectedCounter;
+                    expectedCounter.setString("counterDouble", "/name");
+                    expectedCounter.setString("", "/description");
+                    expectedCounter.setString("", "/unit");
+
+                    json::Json expectedPoints;
+                    expectedPoints.setBool(true, "/isMonotonic");
+                    expectedPoints.setDouble(1.5, "/value");
+
+                    expectedCounter.appendJson(expectedPoints, "/points");
+                    expectedJson.appendJson(expectedCounter, "/data/metrics");
+
+                    auto expectedString = expectedJson.str();
+                    EXPECT_CALL(*connectorMock, publish(expectedString)).Times(testing::AtLeast(1));
+
+                    return None {};
+                })),
+        // Histogram
+        ExportT(
+            [](auto provider)
+            {
+                auto meter = provider->GetMeter("test");
+                auto histogram = meter->CreateUInt64Histogram("histogram");
+                auto context = ot::context::RuntimeContext::GetCurrent();
+                histogram->Record(1, context);
+            },
+            SUCCESS(
+                [](auto connectorMock, auto expectedJson)
+                {
+                    expectedJson.setArray("/data/metrics");
+                    json::Json expectedHistogram;
+                    expectedHistogram.setString("histogram", "/name");
+                    expectedHistogram.setString("", "/description");
+                    expectedHistogram.setString("", "/unit");
+
+                    json::Json expectedPoints;
+                    expectedPoints.setInt64(1, "/count");
+                    expectedPoints.setInt64(1, "/min");
+                    expectedPoints.setInt64(1, "/max");
+                    expectedPoints.setInt64(1, "/sum");
+
+                    expectedPoints.setArray("/boundaries");
+                    auto boundaries = getBoundaries();
+                    expectedPoints.appendJson(boundaries, "/boundaries");
+
+                    expectedPoints.setArray("/counts");
+                    auto counts = getCounts();
+                    expectedPoints.appendJson(counts, "/counts");
+
+                    expectedHistogram.appendJson(expectedPoints, "/points");
+                    expectedJson.appendJson(expectedHistogram, "/data/metrics");
+
+                    auto expectedString = expectedJson.str();
+                    EXPECT_CALL(*connectorMock, publish(expectedString)).Times(testing::AtLeast(1));
+
+                    return None {};
+                })),
+        ExportT(
+            [](auto provider)
+            {
+                auto meter = provider->GetMeter("test");
+                auto histogram = meter->CreateDoubleHistogram("histogram");
+                auto context = ot::context::RuntimeContext::GetCurrent();
+                histogram->Record(1.5, context);
+            },
+            SUCCESS(
+                [](auto connectorMock, auto expectedJson)
+                {
+                    expectedJson.setArray("/data/metrics");
+                    json::Json expectedHistogram;
+                    expectedHistogram.setString("histogram", "/name");
+                    expectedHistogram.setString("", "/description");
+                    expectedHistogram.setString("", "/unit");
+
+                    json::Json expectedPoints;
+                    expectedPoints.setInt64(1, "/count");
+                    expectedPoints.setDouble(1.5, "/min");
+                    expectedPoints.setDouble(1.5, "/max");
+                    expectedPoints.setDouble(1.5, "/sum");
+
+                    expectedPoints.setArray("/boundaries");
+                    auto boundaries = getBoundaries();
+                    expectedPoints.appendJson(boundaries, "/boundaries");
+
+                    expectedPoints.setArray("/counts");
+                    auto counts = getCounts();
+                    expectedPoints.appendJson(counts, "/counts");
+
+                    expectedHistogram.appendJson(expectedPoints, "/points");
+                    expectedJson.appendJson(expectedHistogram, "/data/metrics");
+
+                    auto expectedString = expectedJson.str();
+                    EXPECT_CALL(*connectorMock, publish(expectedString)).Times(testing::AtLeast(1));
+
+                    return None {};
+                })),
+        // UpDownCounter
+        ExportT(
+            [](auto provider)
+            {
+                auto meter = provider->GetMeter("test");
+                auto upDownCounter = meter->CreateInt64UpDownCounter("upDownCounter");
+                auto context = ot::context::RuntimeContext::GetCurrent();
+                upDownCounter->Add(1, context);
+            },
+            SUCCESS(
+                [](auto connectorMock, auto expectedJson)
+                {
+                    expectedJson.setArray("/data/metrics");
+                    json::Json expectedUpDownCounter;
+                    expectedUpDownCounter.setString("upDownCounter", "/name");
+                    expectedUpDownCounter.setString("", "/description");
+                    expectedUpDownCounter.setString("", "/unit");
+
+                    json::Json expectedPoints;
+                    expectedPoints.setInt64(1, "/value");
+
+                    expectedUpDownCounter.appendJson(expectedPoints, "/points");
+                    expectedJson.appendJson(expectedUpDownCounter, "/data/metrics");
+
+                    auto expectedString = expectedJson.str();
+                    EXPECT_CALL(*connectorMock, publish(expectedString)).Times(testing::AtLeast(1));
+
+                    return None {};
+                })),
+        ExportT(
+            [](auto provider)
+            {
+                auto meter = provider->GetMeter("test");
+                auto upDownCounter = meter->CreateDoubleUpDownCounter("upDownCounter");
+                auto context = ot::context::RuntimeContext::GetCurrent();
+                upDownCounter->Add(1.5, context);
+            },
+            SUCCESS(
+                [](auto connectorMock, auto expectedJson)
+                {
+                    expectedJson.setArray("/data/metrics");
+                    json::Json expectedUpDownCounter;
+                    expectedUpDownCounter.setString("upDownCounter", "/name");
+                    expectedUpDownCounter.setString("", "/description");
+                    expectedUpDownCounter.setString("", "/unit");
+
+                    json::Json expectedPoints;
+                    expectedPoints.setDouble(1.5, "/value");
+
+                    expectedUpDownCounter.appendJson(expectedPoints, "/points");
+                    expectedJson.appendJson(expectedUpDownCounter, "/data/metrics");
+
+                    auto expectedString = expectedJson.str();
+                    EXPECT_CALL(*connectorMock, publish(expectedString)).Times(testing::AtLeast(1));
+
+                    return None {};
+                }))));
+
+} // namespace exporttest


### PR DESCRIPTION
Related Issue: #25578 

This PR adds the Indexer exporter for opentelemetry metrics. It defines serializers for counters, histograms, updown counters, and gauges metrics.

The Exporter only supports cumulative metrics updates and receives an indexer connector's handler on initialization. The parametrization and instantiation of the handler is delegated to the metrics module.

Currently, an event for each call to the Exporter is generated, containing all metrics and point data observed.