### PR TITLE
Fix - Remove unsupported field from index

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -217,7 +217,6 @@
               "type": "keyword"
             },
             "under_evaluation": {
-              "ignore_above": 1024,
               "type": "boolean"
             }
           }


### PR DESCRIPTION
|Related issue|
|---|
| #25482 |

## Description
This PR fixes the index template, as it has an option unsupported by the data type


## Test
```json
      {
        "_index": "wazuh-states-vulnerabilities-thinkpad-sebas",
        "_id": "000_08b2644ff887bc2b6e7f2771a95bc7919c57f7da_CVE-2022-40896",
        "_score": 1,
        "_source": {
          "agent": {
            "id": "000",
            "name": "Thinkpad-Sebas",
            "type": "wazuh",
            "version": "v4.10.0"
          },
          "host": {
            "os": {
              "full": "Linux Mint 21.1 (Vera)",
              "kernel": "5.15.0-119-generic",
              "name": "Linux Mint",
              "platform": "linuxmint",
              "type": "linuxmint",
              "version": "21.1"
            }
          },
          "package": {
            "name": "Pygments",
            "path": "/usr/lib/python3/dist-packages/Pygments-2.11.2.egg-info/PKG-INFO",
            "size": 0,
            "type": "pypi",
            "version": "2.11.2"
          },
          "vulnerability": {
            "category": "Packages",
            "classification": "CVSS",
            "description": "A ReDoS issue was discovered in pygments/lexers/smithy.py in pygments through 2.15.0 via SmithyLexer.",
            "detected_at": "2024-09-16T15:52:23.067Z",
            "enumeration": "CVE",
            "id": "CVE-2022-40896",
            "published_at": "2023-07-19T15:15:10Z",
            "reference": "https://pyup.io/posts/pyup-discovers-redos-vulnerabilities-in-top-python-packages-part-2/, https://pypi.org/project/Pygments/, https://github.com/pygments/pygments/blob/master/pygments/lexers/smithy.py#L61, https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/EZGMXALE3HSP4OXC7UUWIKX3OXKZDTY3/, https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VUZO4BQCIY2S2KZYHERQMKURB7AHXDBO/",
            "scanner": {
              "vendor": "Wazuh"
            },
            "score": {
              "base": 5.5,
              "version": "3.1"
            },
            "severity": "Medium",
            "under_evaluation": false
          },
          "wazuh": {
            "cluster": {
              "name": "Thinkpad-Sebas"
            },
            "schema": {
              "version": "1.0.0"
            }
          }
        }
      },

```

The index is created and `under_evaluation` field added