### PR TITLE
Fix Intune mapping and create decoder to filter null values

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -1439,7 +1439,6 @@
                 "type": "keyword"
               },
               "actor": {
-                "type": "nested",
                 "properties": {
                   "@odata.type": {
                     "type": "keyword"

--- a/ruleset/decoders/0006-json_decoders.xml
+++ b/ruleset/decoders/0006-json_decoders.xml
@@ -9,6 +9,12 @@
 - Foundation.
 -->
 
+<decoder name="json-msgraph">
+  <prematch>"integration":"ms-graph"</prematch>
+  <plugin_decoder>JSON_Decoder</plugin_decoder>
+  <json_null_field>discard</json_null_field>
+</decoder>
+
 <decoder name="json">
   <prematch>^{\s*"</prematch>
   <plugin_decoder>JSON_Decoder</plugin_decoder>

--- a/ruleset/rules/0995-microsoft-graph_rules.xml
+++ b/ruleset/rules/0995-microsoft-graph_rules.xml
@@ -12,7 +12,7 @@
 <group name="ms-graph">
     <!--Add catchall rule -->
     <rule id="99500" level="0">
-        <decoded_as>json</decoded_as>
+        <decoded_as>json-msgraph</decoded_as>
         <field name="integration">ms-graph</field>
         <options>no_full_log</options>
         <description>MS Graph message: Microsoft graph messages grouped.</description>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24498|

## Description

This PR adds a new decoder to filter null values ​​in ms-graph JSON events.

Additionally, an incorrect mapping in Intune events is fixed.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade