### PR TITLE
Get auth context hash from JWT token

### DIFF
--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -37,6 +37,9 @@ UNKNOWN_USER_STRING = "unknown_user"
 RUN_AS_LOGIN_ENDPOINT = "/security/user/authenticate/run_as"
 LOGIN_ENDPOINT = '/security/user/authenticate'
 
+# Authentication context hash key
+HASH_AUTH_CONTEXT_KEY = 'hash_auth_context'
+
 # API secure headers
 server = Server().set("Wazuh")
 csp = ContentSecurityPolicy().set('none')
@@ -69,6 +72,7 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
     # first time the json function is awaited. This check avoids raising an
     # exception when the request json content is invalid.
     body = await request.json() if hasattr(request, '_json') else {}
+    hash_auth_context = context.get('token_info', {}).get(HASH_AUTH_CONTEXT_KEY, '')
 
     if 'password' in query:
         query['password'] = '****'
@@ -91,11 +95,11 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
                             audience='Wazuh API REST',
                             options={'verify_exp': False})
                 user = s['sub']
+                if HASH_AUTH_CONTEXT_KEY in s:
+                    hash_auth_context = s[HASH_AUTH_CONTEXT_KEY]
         except (KeyError, IndexError, binascii.Error, jwt.exceptions.PyJWTError, OAuthProblem):
             user = UNKNOWN_USER_STRING
 
-    # Get or create authorization context hash
-    hash_auth_context = context.get('token_info', {}).get('hash_auth_context', '')
     # Create hash if run_as login
     if not hash_auth_context and path == RUN_AS_LOGIN_ENDPOINT:
         hash_auth_context = hashlib.blake2b(json.dumps(body).encode(),

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -235,6 +235,36 @@ async def test_access_log(json_body, q_password, b_password, b_key, c_user,
                 f"IP blocked due to exceeded number of logins attempts: {mock_req.client.host}")
 
 
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_access_log_hash_auth_context(mock_req):
+    """Check that `access_log` obtains the authentication context hash from the JWT token."""
+    response = MagicMock()
+    response.status_code = 200
+    user = 'wazuh'
+    hash_auth_context = '5a5e646ea0bc6e3653cfc593d62b16f7'
+    sec_header = ('bearer', {'sub': user, 'hash_auth_context': hash_auth_context})
+    body = {}
+    endpoint = '/agents'
+
+    mock_req.json = AsyncMock(return_value=body)
+    mock_req.method = 'GET'
+    mock_req.scope = {'path': endpoint}
+    mock_req.headers = {}
+    mock_req.query_params = {}
+
+    with patch('api.middlewares.custom_logging') as mock_custom_logging, \
+        patch('api.middlewares.jwt.decode', return_value=sec_header[1]), \
+        patch('api.middlewares.get_keypair', return_value=(None, None)), \
+        patch('api.middlewares.AbstractSecurityHandler.get_auth_header_value', return_value=sec_header):
+        await access_log(request=mock_req, response=response, prev_time=datetime(1970, 1, 1, 0, 0, 10).timestamp())
+
+        mock_custom_logging.assert_called_once_with(
+            user, mock_req.client.host, mock_req.method, endpoint, mock_req.query_params, body, 0.0,
+            response.status_code, hash_auth_context=hash_auth_context, headers=mock_req.headers
+        )
+
+
 @freeze_time(datetime(1970, 1, 1, 0, 0, 0))
 @pytest.mark.asyncio
 @pytest.mark.parametrize("exception", [


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/25736 |

## Description

Gets the authentication context hash from the JWT token that comes in the `Authorization` header.

## Tests

<details><summary>Run as authentication</summary>

```console
gasti@gasti:~/work/wazuh$ TOKEN=$(curl -u wazuh:wazuh -s -k -X POST -H "Content-Type: application/json" https://localhost:55050/security/user/authenticate/run_as -d '{
  "name": "Initial_auth",
  "auth": {
	"name": "test",
	"office": [
  	"20",
  	"21",
  	"30"
	]
  }
}' | jq -r '.data.token')
gasti@gasti:~/work/wazuh$ echo $TOKEN
eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzI2NTk3MzAyLCJleHAiOjE3MjY1OTgyMDIsInN1YiI6IndhenVoIiwicnVuX2FzIjp0cnVlLCJyYmFjX3JvbGVzIjpbXSwicmJhY19tb2RlIjoid2hpdGUiLCJoYXNoX2F1dGhfY29udGV4dCI6IjVhNWU2NDZlYTBiYzZlMzY1M2NmYzU5M2Q2MmIxNmY3In0.AVLuOBxS4q0rEh5ntkPt9JAW7aCZiCOlCXF5iAGrPHO0avFawE_YnlEFxnP2GfXYpco34huV79HANzNgGdRRWQwcAdOCpiEjdNpEzy9EH3BKtr0fVbqzDOD2GgFaK1jF9UzeSppyDUjLab-qGbuWN1oMWmDkTUEblI2lmDZ0Jiq0L-zC
```

</details>

<details><summary>Authenticated requests</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -X GET -k https://0.0.0.0:55050/groups
{"data": {"affected_items": [], "total_affected_items": 0, "total_failed_items": 0, "failed_items": []}, "message": "No group information was returned", "error": 0}
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -X GET -k https://0.0.0.0:55050/
{"data": {"title": "Wazuh API REST", "api_version": "5.0.0", "revision": 50000, "license_name": "GPL 2.0", "license_url": "https://github.com/wazuh/wazuh/blob/v5.0.0/LICENSE", "hostname": "wazuh-master", "timestamp": "2024-09-17T18:23:26Z"}, "error": 0}
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -X GET -k https://0.0.0.0:55050/security/users
{"data": {"affected_items": [], "total_affected_items": 0, "total_failed_items": 0, "failed_items": []}, "message": "No user was returned", "error": 0}
```

</details>

<details><summary>API Logs</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
2024/09/17 18:20:14 INFO: Starting API in foreground
2024/09/17 18:20:14 INFO: Checking RBAC database integrity...
2024/09/17 18:20:14 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2024/09/17 18:20:14 INFO: RBAC database integrity check finished successfully
2024/09/17 18:20:16 INFO: Listening on 0.0.0.0:55000.
2024/09/17 18:20:16 INFO: Getting installation UID...
2024/09/17 18:20:16 INFO: Getting updates information...
2024/09/17 18:21:42 INFO: wazuh (5a5e646ea0bc6e3653cfc593d62b16f7) 172.18.0.1 "POST /security/user/authenticate/run_as" with parameters {} and body {"name": "Initial_auth", "auth": {"name": "test", "office": ["20", "21", "30"]}} done in 0.183s: 200
2024/09/17 18:22:09 INFO: wazuh (5a5e646ea0bc6e3653cfc593d62b16f7) 172.18.0.1 "GET /groups" with parameters {} and body {} done in 0.056s: 200
2024/09/17 18:23:26 INFO: wazuh (5a5e646ea0bc6e3653cfc593d62b16f7) 172.18.0.1 "GET /" with parameters {} and body {} done in 1.461s: 200
2024/09/17 18:24:05 INFO: wazuh (5a5e646ea0bc6e3653cfc593d62b16f7) 172.18.0.1 "GET /security/users" with parameters {} and body {} done in 0.334s: 200
```

</details>

<details><summary>Requests with no auth context</summary>

```console
2024/09/17 18:27:34 INFO: wazuh 172.18.0.1 "POST /security/user/authenticate" with parameters {} and body {} done in 0.211s: 200
2024/09/17 18:27:37 INFO: wazuh 172.18.0.1 "GET /groups" with parameters {} and body {} done in 0.048s: 200
2024/09/17 18:28:24 INFO: wazuh 172.18.0.1 "GET /" with parameters {} and body {} done in 0.012s: 200
```

</details>
