### PR TITLE
Fix replaceAll util

### DIFF
--- a/src/engine/source/base/include/base/utils/stringUtils.hpp
+++ b/src/engine/source/base/include/base/utils/stringUtils.hpp
@@ -144,7 +144,7 @@ std::string toSentenceCase(const std::string& str);
 
 bool isNumber(const std::string& str);
 
-bool replaceAll(std::string& data, std::string_view toSearch, std::string_view toReplace);
+bool replaceAll(std::string& data, const std::string_view toSearch, const std::string_view toReplace);
 bool haveUpperCaseCharacters(const std::string& str);
 
 } // namespace base::utils::string

--- a/src/engine/source/base/src/utils/stringUtils.cpp
+++ b/src/engine/source/base/src/utils/stringUtils.cpp
@@ -204,7 +204,7 @@ bool isNumber(const std::string& str)
 
 bool replaceAll(std::string& data, const std::string_view toSearch, const std::string_view toReplace)
 {
-    if (toSearch.empty() || toSearch == toReplace)
+    if (toSearch.empty() || toSearch == toReplace || toReplace.find(toSearch) != std::string_view::npos)
     {
         return false; // Nothing to search for if toSearch is empty
     }

--- a/src/engine/source/base/src/utils/stringUtils.cpp
+++ b/src/engine/source/base/src/utils/stringUtils.cpp
@@ -210,9 +210,8 @@ bool replaceAll(std::string& data, const std::string_view toSearch, const std::s
     }
 
     bool found = false;
-    size_t pos = data.find(toSearch);
 
-    if (pos != std::string::npos)
+    if (size_t pos = data.find(toSearch); pos != std::string::npos)
     {
         found = true;
         data.replace(pos, toSearch.length(), toReplace);

--- a/src/engine/source/base/src/utils/stringUtils.cpp
+++ b/src/engine/source/base/src/utils/stringUtils.cpp
@@ -204,16 +204,23 @@ bool isNumber(const std::string& str)
 
 bool replaceAll(std::string& data, const std::string_view toSearch, const std::string_view toReplace)
 {
-    auto pos {data.find(toSearch)};
-    const auto ret {std::string::npos != pos};
-
-    while (std::string::npos != pos)
+    if (toSearch.empty() || toSearch == toReplace)
     {
-        data.replace(pos, toSearch.size(), toReplace);
-        pos = data.find(toSearch, pos + toReplace.size());
+        return false; // Nothing to search for if toSearch is empty
     }
 
-    return ret;
+    bool found = false;
+    size_t pos = data.find(toSearch);
+
+    if (pos != std::string::npos)
+    {
+        found = true;
+        data.replace(pos, toSearch.length(), toReplace);
+        // Recursively call replaceAll from the new position (pos + toReplace.length())
+        replaceAll(data, toSearch, toReplace);
+    }
+
+    return found;
 }
 
 bool haveUpperCaseCharacters(const std::string& str)

--- a/src/engine/source/base/test/src/unit/stringUtils_test.cpp
+++ b/src/engine/source/base/test/src/unit/stringUtils_test.cpp
@@ -250,3 +250,66 @@ TEST(splitEscaped, EcapeEscapedChar)
     std::vector<std::string> result = base::utils::string::splitEscaped(input, '!', '#');
     ASSERT_EQ(result, expected);
 }
+
+TEST(StringUtilsTest, CheckReplacementReplace)
+{
+    std::string string_base = "The quick brown fox jumps over the lazy fox";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, "fox", "dog"));
+    EXPECT_EQ(string_base, "The quick brown dog jumps over the lazy dog");
+}
+
+TEST(StringUtilsTest, CheckReplacementReplaceIsInSearch)
+{
+    std::string string_base = "aaaa aaaaa a";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, "aa", "a"));
+    EXPECT_EQ(string_base, "a a a");
+}
+
+TEST(StringUtilsTest, BasicOverlapReplacement)
+{
+    std::string string_base = "abababab";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, "aba", "a"));
+    EXPECT_EQ(string_base, "ab");
+}
+
+TEST(StringUtilsTest, OverlapWithSmallerReplacement)
+{
+    std::string string_base = "aaaaa";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, "aa", "a"));
+    EXPECT_EQ(string_base, "a");
+}
+
+TEST(StringUtilsTest, ReplaceEmptySearchString)
+{
+    std::string string_base = "this should not change";
+    EXPECT_FALSE(base::utils::string::replaceAll(string_base, "", "new"));
+    EXPECT_EQ(string_base, "this should not change");
+}
+
+TEST(StringUtilsTest, SearchEqualsReplace)
+{
+    std::string string_base = "no change expected";
+    EXPECT_FALSE(base::utils::string::replaceAll(string_base, "change", "change"));
+    EXPECT_EQ(string_base, "no change expected");
+}
+
+TEST(StringUtilsTest, ReplaceWithLongerString)
+{
+    std::string string_base = "ab cd ef";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, " ", "_verylongseparator_"));
+    EXPECT_EQ(string_base, "ab_verylongseparator_cd_verylongseparator_ef");
+}
+
+TEST(StringUtilsTest, NoOccurrence)
+{
+    std::string string_base = "there is no match here";
+    EXPECT_FALSE(base::utils::string::replaceAll(string_base, "xyz", "replacement"));
+    EXPECT_EQ(string_base, "there is no match here");
+}
+
+TEST(StringUtilsTest, PartialMatches)
+{
+    std::string string_base = "abacada";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, "aba", "x"));
+    EXPECT_EQ(string_base, "xcada");
+}

--- a/src/engine/source/base/test/src/unit/stringUtils_test.cpp
+++ b/src/engine/source/base/test/src/unit/stringUtils_test.cpp
@@ -313,3 +313,23 @@ TEST(StringUtilsTest, PartialMatches)
     EXPECT_TRUE(base::utils::string::replaceAll(string_base, "aba", "x"));
     EXPECT_EQ(string_base, "xcada");
 }
+
+TEST(StringUtilsTest, ExitConditionRecursion)
+{
+    std::string string_base = "a";
+    EXPECT_FALSE(base::utils::string::replaceAll(string_base, "a", "aa"));
+}
+
+TEST(StringUtilsTest, ContinuousReplacements)
+{
+    std::string string_base = "abababababab";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, "ab", "cd"));
+    EXPECT_EQ(string_base, "cdcdcdcdcdcd");
+}
+
+TEST(StringUtilsTest, ReplaceWithEmptyString)
+{
+    std::string string_base = "remove this remove this";
+    EXPECT_TRUE(base::utils::string::replaceAll(string_base, "remove", ""));
+    EXPECT_EQ(string_base, " this  this");
+}

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -67,25 +67,18 @@ namespace Utils
         data = strOut;
     }
 
-    static bool replaceAll(std::string& data, const std::string_view toSearch, const std::string_view toReplace)
+    static bool replaceAll(std::string& data, const std::string& toSearch, const std::string& toReplace)
     {
-        if (toSearch.empty() || toSearch == toReplace)
+        auto pos {data.find(toSearch)};
+        const auto ret {std::string::npos != pos};
+
+        while (std::string::npos != pos)
         {
-            return false; // Nothing to search for if toSearch is empty
+            data.replace(pos, toSearch.size(), toReplace);
+            pos = data.find(toSearch, pos);
         }
 
-        bool found = false;
-        size_t pos = data.find(toSearch);
-
-        if (pos != std::string::npos)
-        {
-            found = true;
-            data.replace(pos, toSearch.length(), toReplace);
-            // Recursively call replaceAll from the new position (pos + toReplace.length())
-            replaceAll(data, toSearch, toReplace);
-        }
-
-        return found;
+        return ret;
     }
 
     static bool replaceFirst(std::string& data, const std::string& toSearch, const std::string& toReplace)

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -69,16 +69,24 @@ namespace Utils
 
     static bool replaceAll(std::string& data, const std::string& toSearch, const std::string& toReplace)
     {
-        auto pos {data.find(toSearch)};
-        const auto ret {std::string::npos != pos};
+        bool found = false;
+        auto pos = data.find(toSearch);
 
-        while (std::string::npos != pos)
+        while (pos != std::string::npos)
         {
             data.replace(pos, toSearch.size(), toReplace);
-            pos = data.find(toSearch, pos);
+            found = true;
+            pos = data.find(toSearch, pos + toReplace.size());
         }
 
-        return ret;
+        if (found && toSearch != toReplace)
+        {
+            while (replaceAll(data, toSearch, toReplace))
+            {
+            }
+        }
+
+        return found;
     }
 
     static bool replaceFirst(std::string& data, const std::string& toSearch, const std::string& toReplace)

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -67,23 +67,22 @@ namespace Utils
         data = strOut;
     }
 
-    static bool replaceAll(std::string& data, const std::string& toSearch, const std::string& toReplace)
+    static bool replaceAll(std::string& data, const std::string_view toSearch, const std::string_view toReplace)
     {
-        bool found = false;
-        auto pos = data.find(toSearch);
-
-        while (pos != std::string::npos)
+        if (toSearch.empty() || toSearch == toReplace)
         {
-            data.replace(pos, toSearch.size(), toReplace);
-            found = true;
-            pos = data.find(toSearch, pos + toReplace.size());
+            return false; // Nothing to search for if toSearch is empty
         }
 
-        if (found && toSearch != toReplace)
+        bool found = false;
+        size_t pos = data.find(toSearch);
+
+        if (pos != std::string::npos)
         {
-            while (replaceAll(data, toSearch, toReplace))
-            {
-            }
+            found = true;
+            data.replace(pos, toSearch.length(), toReplace);
+            // Recursively call replaceAll from the new position (pos + toReplace.length())
+            replaceAll(data, toSearch, toReplace);
         }
 
         return found;

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -25,6 +25,13 @@ TEST_F(StringUtilsTest, CheckReplacement)
     EXPECT_TRUE(retVal);
 }
 
+TEST_F(StringUtilsTest, CheckReplacementReplaceIsInSearch)
+{
+    std::string string_base = "aaaa aaaaa a";
+    EXPECT_TRUE(Utils::replaceAll(string_base, "aa", "a"));
+    EXPECT_EQ(string_base, "a a a");
+}
+
 TEST_F(StringUtilsTest, CheckNotReplacement)
 {
     std::string string_base {"hello_world"};
@@ -588,4 +595,3 @@ TEST_F(StringUtilsTest, haveUpperCaseCharacters)
     EXPECT_FALSE(Utils::haveUpperCaseCharacters("test"));
     EXPECT_FALSE(Utils::haveUpperCaseCharacters(""));
 }
-

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -25,13 +25,6 @@ TEST_F(StringUtilsTest, CheckReplacement)
     EXPECT_TRUE(retVal);
 }
 
-TEST_F(StringUtilsTest, CheckReplacementReplaceIsInSearch)
-{
-    std::string string_base = "aaaa aaaaa a";
-    EXPECT_TRUE(Utils::replaceAll(string_base, "aa", "a"));
-    EXPECT_EQ(string_base, "a a a");
-}
-
 TEST_F(StringUtilsTest, CheckNotReplacement)
 {
     std::string string_base {"hello_world"};


### PR DESCRIPTION
|Related issue|
|---|
| #25547 |

## Description
This PR fixes the implementation of the replaceAll helper function when the `toReplace` string is a subset of the `toSearch` string