### PR TITLE
Make the ID field optional for the indexerConnector queries

### DIFF
--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -93,26 +93,19 @@ static void builderBulkDelete(std::string& bulkData, std::string_view id, std::s
 
 static void builderBulkIndex(std::string& bulkData, std::string_view id, std::string_view index, std::string_view data)
 {
+    bulkData.append(R"({"index":{"_index":")");
+    bulkData.append(index);
+
     if (!id.empty())
     {
-        bulkData.append(R"({"index":{"_index":")");
-        bulkData.append(index);
         bulkData.append(R"(","_id":")");
         bulkData.append(id);
-        bulkData.append(R"("}})");
-        bulkData.append("\n");
-        bulkData.append(data);
-        bulkData.append("\n");
     }
-    else
-    {
-        bulkData.append(R"({"index":{"_index":")");
-        bulkData.append(index);
-        bulkData.append(R"("}})");
-        bulkData.append("\n");
-        bulkData.append(data);
-        bulkData.append("\n");
-    }
+
+    bulkData.append(R"("}})");
+    bulkData.append("\n");
+    bulkData.append(data);
+    bulkData.append("\n");
 }
 
 IndexerConnector::IndexerConnector(const nlohmann::json& config, const uint32_t& timeout, const uint8_t workingThreads)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25541|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR allows to index elements that don't contain an ID field letting the indexer to create one.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux

- [x] Added unit tests (for new features)

The changes were validated manually using the test tool and a Wazuh docker deployment.
With these configuration files and command

<details><summary>config.json</summary>
<p>

```json
{
    "name": "wazuh-states-vulnerabilities-wazuh.manager",
    "enabled": "yes",
    "hosts": [
        "https://wazuh.indexer:9200"
    ],
    "ssl" : {
        "certificate_authorities" : ["/etc/filebeat/certs/root-ca.pem"],
        "certificate" : "/etc/filebeat/certs/filebeat.pem",
        "key" : "/etc/filebeat/certs/filebeat-key.pem"
    },
    "username" : "admin",
    "password" : "SecretPassword"
}
```

</p>
</details> 

<details><summary>events.json</summary>
<p>

```json
{
    "operation": "INSERTED",
    "data": {
        "package": {
            "name": "testPackage"
        }
    }
}
```

</p>
</details> 

```
./indexer_connector_tool -c config.json -e events.json -t /workspaces/wazuh.worktrees/master/src/engine/source/indexerconnector/qa/test_data/template.json
```

The test package was indexed with an ID assigned automatically
![2024-09-17_18-17](https://github.com/user-attachments/assets/4b80fa30-71c8-468a-8eba-6433cd5a2972)

> [!Note]
> Using the indexer tool, I found that the logging isn't working properly for the stdout. This could be solved at another issue
```
root@fb659c773250:/workspaces/wazuh.worktrees/master/src/engine/build/source/indexerconnector/tool# ./indexer_connector_tool -c config.json -e events.json -t /workspaces/wazuh.worktrees/master/src/engine/source/indexerconnector/qa/test_data/template.json
Press enter to stop the indexer connector tool... 
2024-09-19 14:44:12.854 32232:32252 indexerConnector.cpp:182 at operator()::<lambda>handleSuccessfulPostResponse(): debug: Response: %s
```