### PR TITLE
Integrate AWS Security Lake with v2.0

### DIFF
--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -281,7 +281,7 @@ class AWSSLSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler)
         pfile = pq.ParquetFile(raw_parquet)
         for i in pfile.iter_batches():
             for j in i.to_pylist():
-                events.append(json.dumps(j))
+                events.append(json.dumps(j, default=str))
         aws_tools.debug(f'Found {len(events)} events in file {log_path}', 2)
         return events
 

--- a/wodles/aws/tests/test_s3_log_handler.py
+++ b/wodles/aws/tests/test_s3_log_handler.py
@@ -9,6 +9,7 @@ import re
 from unittest.mock import patch, MagicMock, call
 import pytest
 import json
+import datetime
 
 import wodles.aws.tests.aws_constants
 
@@ -26,6 +27,8 @@ import s3_log_handler
 SAMPLE_PARQUET_KEY = 'aws/source/region=region/accountId=accountID/eventHour=YYYYMMDDHH/file.gz.parquet'
 SAMPLE_MESSAGE = {'bucket_path': test_constants.TEST_MESSAGE, 'log_path': SAMPLE_PARQUET_KEY}
 SAMPLE_PARQUET_EVENT_1 = {'key1': 'value1', 'key2': 'value2'}
+SAMPLE_PARQUET_EVENT_WITH_DATETIME = {"timestamp": datetime.datetime(2024, 9, 18, 12, 0, 0),
+                                       "event": "sample_event"}
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 logs_path = os.path.join(test_data_path, 'log_files')
@@ -90,6 +93,22 @@ def test_aws_sl_subscriber_bucket_obtain_logs_handles_exception(mock_wazuh_integ
     with pytest.raises(SystemExit) as e:
         instance.obtain_logs(test_constants.TEST_BUCKET, SAMPLE_PARQUET_KEY)
     assert e.value.code == wodles.aws.tests.aws_constants.UNABLE_TO_FETCH_DELETE_FROM_QUEUE
+
+
+@patch('wazuh_integration.WazuhIntegration.get_sts_client')
+@patch('wazuh_integration.WazuhIntegration.__init__', side_effect=wazuh_integration.WazuhIntegration.__init__)
+def test_aws_sl_subscriber_bucket_obtain_logs_with_datetime(mock_wazuh_integration, mock_sts_client):
+    """Test 'obtain_information_from_parquet' correctly processes events containing datetime objects."""
+    instance = utils.get_mocked_aws_sl_subscriber_bucket()
+    mock_get_object = instance.client.get_object
+
+    with patch('pyarrow.parquet.ParquetFile', return_value=MagicMock()) as mock_parquet_file:
+        mock_parquet_file.return_value.iter_batches.return_value = [MagicMock(to_pylist=lambda: [SAMPLE_PARQUET_EVENT_WITH_DATETIME])]
+        with patch('io.BytesIO', return_value=b"fake parquet data"):
+            events = instance.obtain_logs(test_constants.TEST_BUCKET, SAMPLE_PARQUET_KEY)
+
+    assert events == [json.dumps(SAMPLE_PARQUET_EVENT_WITH_DATETIME, default=str)]
+    mock_get_object.assert_called_with(Bucket=test_constants.TEST_BUCKET, Key=SAMPLE_PARQUET_KEY)
 
 
 @patch('s3_log_handler.AWSSLSubscriberBucket.obtain_logs')


### PR DESCRIPTION
|Related issue|
|---|
| #22880  |

## Description

This PR closes https://github.com/wazuh/wazuh/issues/22880, where work and testing are done to ensure that `Security Lake` is compatible with both `v1.0` and `v2.0`.