### PR TITLE
Add QA test cases for VDP 1.0.2

### DIFF
--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/Readme.md
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/Readme.md
@@ -1,0 +1,45 @@
+# Description
+
+Vulnerability detection validation for **Python3.10** packages in **Ubuntu 22.04**. These tests validate the fix in binaries expansion made in https://github.com/wazuh/intelligence-platform/issues/1669.
+
+
+## CVE
+
+- CVE-2022-42919
+- CVE-2022-45061
+- CVE-2023-24329
+- CVE-2023-41105
+
+# Platforms
+
+## Ubuntu 22.04 (Jammy Jellyfish)
+
+- Input events
+  - [001](input_001.json)
+  - [002](input_002.json)
+  - [003](input_003.json)
+  - [004](input_004.json)
+  - [005](input_005.json)
+  - [006](input_006.json)
+  - [007](input_007.json)
+  - [008](input_008.json)
+  - [009](input_009.json)
+  - [010](input_010.json)
+  - [011](input_011.json)
+
+|Name|Version|Feed|Expected|
+|---|---|---|---|
+|libpython3.10|3.10.12-1~22.04.4|Canonical|Not vulnerable|
+|libpython3.10-dev|3.10.12-1~22.04.4|Canonical|Not vulnerable|
+|libpython3.10-minimal|3.10.12-1~22.04.4|Canonical|Not vulnerable|
+|libpython3.10-stdlib|3.10.12-1~22.04.4|Canonical|Not vulnerable|
+|python3.10|3.10.12-1~22.04.4|Canonical|Not vulnerable|
+|python3.10-dev|3.10.12-1~22.04.4|Canonical|Not vulnerable|
+|python3.10-minimal|3.10.12-1~22.04.4|Canonical|Not vulnerable|
+
+|Name|Version|Feed|Expected Vulnerable|Expected Not Vulnerable|
+|---|---|---|---|---|
+|libpython3.10|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|
+|libpython3.10-dev|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|
+|libpython3.10-minimal|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|
+|libpython3.10-stdlib|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_001.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_001.out
@@ -1,0 +1,6 @@
+[
+    "No match due to default status for Package: libpython3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-42919",
+    "No match due to default status for Package: libpython3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-45061",
+    "No match due to default status for Package: libpython3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-24329",
+    "No match due to default status for Package: libpython3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_002.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_002.out
@@ -1,0 +1,6 @@
+[
+    "No match due to default status for Package: libpython3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-42919",
+    "No match due to default status for Package: libpython3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-45061",
+    "No match due to default status for Package: libpython3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-24329",
+    "No match due to default status for Package: libpython3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_003.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_003.out
@@ -1,0 +1,6 @@
+[
+    "No match due to default status for Package: libpython3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-42919",
+    "No match due to default status for Package: libpython3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-45061",
+    "No match due to default status for Package: libpython3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-24329",
+    "No match due to default status for Package: libpython3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_004.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_004.out
@@ -1,0 +1,6 @@
+[
+    "No match due to default status for Package: libpython3.10-stdlib, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-42919",
+    "No match due to default status for Package: libpython3.10-stdlib, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-45061",
+    "No match due to default status for Package: libpython3.10-stdlib, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-24329",
+    "No match due to default status for Package: libpython3.10-stdlib, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_005.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_005.out
@@ -1,0 +1,6 @@
+[
+    "No match due to default status for Package: python3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-42919",
+    "No match due to default status for Package: python3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-45061",
+    "No match due to default status for Package: python3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-24329",
+    "No match due to default status for Package: python3.10, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_006.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_006.out
@@ -1,0 +1,6 @@
+[
+    "No match due to default status for Package: python3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-42919",
+    "No match due to default status for Package: python3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-45061",
+    "No match due to default status for Package: python3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-24329",
+    "No match due to default status for Package: python3.10-dev, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_007.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_007.out
@@ -1,0 +1,6 @@
+[
+    "No match due to default status for Package: python3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-42919",
+    "No match due to default status for Package: python3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2022-45061",
+    "No match due to default status for Package: python3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-24329",
+    "No match due to default status for Package: python3.10-minimal, Version: 3.10.12-1~22.04.4 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_008.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_008.out
@@ -1,0 +1,6 @@
+[
+    "Match found, the package 'libpython3.10', is vulnerable to 'CVE-2022-42919'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10', is vulnerable to 'CVE-2022-45061'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10', is vulnerable to 'CVE-2023-24329'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2ubuntu1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "No match due to default status for Package: libpython3.10, Version: 3.10.4-3 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_009.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_009.out
@@ -1,0 +1,6 @@
+[
+    "Match found, the package 'libpython3.10-dev', is vulnerable to 'CVE-2022-42919'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10-dev', is vulnerable to 'CVE-2022-45061'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10-dev', is vulnerable to 'CVE-2023-24329'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2ubuntu1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "No match due to default status for Package: libpython3.10-dev, Version: 3.10.4-3 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_010.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_010.out
@@ -1,0 +1,6 @@
+[
+    "Match found, the package 'libpython3.10-minimal', is vulnerable to 'CVE-2022-42919'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10-minimal', is vulnerable to 'CVE-2022-45061'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10-minimal', is vulnerable to 'CVE-2023-24329'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2ubuntu1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "No match due to default status for Package: libpython3.10-minimal, Version: 3.10.4-3 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_011.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/expected_011.out
@@ -1,0 +1,6 @@
+[
+    "Match found, the package 'libpython3.10-stdlib', is vulnerable to 'CVE-2022-42919'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10-stdlib', is vulnerable to 'CVE-2022-45061'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "Match found, the package 'libpython3.10-stdlib', is vulnerable to 'CVE-2023-24329'. Current version: '3.10.4-3' (less than '3.10.6-1~22.04.2ubuntu1' or equal to ''). - Agent '' (ID: '002', Version: '').",
+    "No match due to default status for Package: libpython3.10-stdlib, Version: 3.10.4-3 while scanning for Vulnerability: CVE-2023-41105"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_001.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_001.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+      {
+          "architecture": "amd64",
+          "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+          "description": "Shared Python runtime library (version 3.10)",
+          "format": "deb",
+          "groups": " ",
+          "install_time": " ",
+          "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+          "location": " ",
+          "multiarch": "same",
+          "name": "libpython3.10",
+          "priority": "optional",
+          "scan_time": "2024/08/20 12:30:36",
+          "size": 5768,
+          "source": "python3.10",
+          "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+          "version": "3.10.12-1~22.04.4"
+      }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_002.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_002.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+        "architecture": "amd64",
+        "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+        "description": "Header files and a static library for Python (v3.10)",
+        "format": "deb",
+        "groups": " ",
+        "install_time": " ",
+        "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+        "location": " ",
+        "multiarch": "same",
+        "name": "libpython3.10-dev",
+        "priority": "optional",
+        "scan_time": "2024/08/20 12:30:36",
+        "size": 5768,
+        "source": "python3.10",
+        "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+        "version": "3.10.12-1~22.04.4"
+    }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_003.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_003.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+        "architecture": "amd64",
+        "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+        "description": "Minimal subset of the Python language (version 3.10)",
+        "format": "deb",
+        "groups": " ",
+        "install_time": " ",
+        "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+        "location": " ",
+        "multiarch": "same",
+        "name": "libpython3.10-minimal",
+        "priority": "optional",
+        "scan_time": "2024/08/20 12:30:36",
+        "size": 5768,
+        "source": "python3.10",
+        "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+        "version": "3.10.12-1~22.04.4"
+    }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_004.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_004.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Interactive high-level object-oriented language (standard library, version 3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "libpython3.10-stdlib",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.12-1~22.04.4"
+    }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_005.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_005.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Interactive high-level object-oriented language (version 3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "python3.10",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.12-1~22.04.4"
+  }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_006.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_006.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Header files and a static library for Python (v3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "python3.10-dev",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.12-1~22.04.4"
+  }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_007.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_007.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Minimal subset of the Python language (version 3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "python3.10-minimal",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.12-1~22.04.4"
+   }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_008.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_008.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Shared Python runtime library (version 3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "libpython3.10",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.4-3"
+   }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_009.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_009.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Header files and a static library for Python (v3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "libpython3.10-dev",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.4-3"
+  }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_010.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_010.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Minimal subset of the Python language (version 3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "libpython3.10-minimal",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.4-3"
+   }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_011.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/037/input_011.json
@@ -1,0 +1,47 @@
+{
+  "type": "packagelist",
+  "agent":
+  {
+      "id": "002"
+  },
+  "packages":
+  [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": "Interactive high-level object-oriented language (standard library, version 3.10)",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "libpython3.10-stdlib",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": "python3.10",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "3.10.4-3"
+   }
+  ],
+  "hotfixes":
+  [],
+  "os":
+  {
+      "architecture": "x86_64",
+      "checksum": "1708734360392506855",
+      "hostname": "qa_test",
+      "codename": "jammy",
+      "major_version": "22",
+      "minor_version": "04",
+      "name": "Ubuntu",
+      "patch": "3",
+      "platform": "ubuntu",
+      "version": "22.04.3 LTS (Jammy Jellyfish)",
+      "kernel_release": "6.5.0-18-generic",
+      "scan_time": "2024/02/24 00:26:02",
+      "kernel_name": "Linux",
+      "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}


### PR DESCRIPTION
|Related issue|
|---|
| #25769 |

## Description

This PR adds new test cases to the Vulnerability Detector QA test suite to validate the content generated with VDP v1.0.2.

### New test case: 037

|Name|Version|Feed|Expected|
|---|---|---|---|
|libpython3.10|3.10.12-1~22.04.4|Canonical|Not vulnerable|
|libpython3.10-dev|3.10.12-1~22.04.4|Canonical|Not vulnerable|
|libpython3.10-minimal|3.10.12-1~22.04.4|Canonical|Not vulnerable|
|libpython3.10-stdlib|3.10.12-1~22.04.4|Canonical|Not vulnerable|
|python3.10|3.10.12-1~22.04.4|Canonical|Not vulnerable|
|python3.10-dev|3.10.12-1~22.04.4|Canonical|Not vulnerable|
|python3.10-minimal|3.10.12-1~22.04.4|Canonical|Not vulnerable|

|Name|Version|Feed|Expected Vulnerable|Expected Not Vulnerable|
|---|---|---|---|---|
|libpython3.10|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|
|libpython3.10-dev|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|
|libpython3.10-minimal|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|
|libpython3.10-stdlib|3.10.4-3|Canonical|CVE-2022-42919, CVE-2022-45061, CVE-2023-24329|CVE-2023-41105|


