### PR TITLE
Fix compilation in HP-UX/AIX systems removing anti_tampering functionality

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -204,6 +204,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     }
 }
 
+#if !defined(HPUX) && !defined(AIX) && !defined(SOLARIS)
 bool check_uninstall_permission(const char *token, const char *host, bool ssl_verify) {
     char url[OS_SIZE_8192];
     snprintf(url, sizeof(url), "https://%s/agents/uninstall", host);
@@ -279,3 +280,4 @@ bool package_uninstall_validation(const char *uninstall_auth_token, const char *
     }
     return validate_result;
 }
+#endif

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -107,6 +107,7 @@ void send_agent_stopped_message();
  * */
 int try_enroll_to_server(const char *server_rip, uint32_t network_interface);
 
+#if !defined(HPUX) && !defined(AIX) && !defined(SOLARIS)
 /**
  * Function that makes the request to the API for the request of uninstallation permissions.
  * @return true if validation is granted, false if denied
@@ -134,6 +135,7 @@ char* authenticate_and_get_token(const char *userpass, const char *host, bool ss
  * @return true if validation is granted, false if denied
  * */
 bool package_uninstall_validation(const char *uninstall_auth_token, const char *uninstall_auth_login, const char *uninstall_auth_host, bool ssl_verify);
+#endif
 
 /* Notify server */
 void run_notify(void);

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -12,7 +12,10 @@
 
 #include "shared.h"
 #include "agentd.h"
+
+#if !defined(HPUX) && !defined(AIX) && !defined(SOLARIS)
 #include <getopt.h>
+#endif
 
 #ifndef ARGV0
 #define ARGV0 "wazuh-agentd"
@@ -74,6 +77,7 @@ int main(int argc, char **argv)
 
     agent_debug_level = getDefine_Int("agent", "debug", 0, 2);
 
+#if !defined(HPUX) && !defined(AIX) && !defined(SOLARIS)
     struct option long_opts[] = {
         {"uninstall-auth-login", 1, NULL, 1},
         {"uninstall-auth-token", 1, NULL, 2},
@@ -82,6 +86,9 @@ int main(int argc, char **argv)
     };
 
     while ((c = getopt_long(argc, argv, "Vtdfhu:g:D:c:", long_opts, NULL)) != -1) {
+#else
+    while ((c = getopt(argc, argv, "Vtdfhu:g:D:c:")) != -1) {
+#endif
         switch (c) {
             case 'V':
                 print_version();
@@ -123,6 +130,7 @@ int main(int argc, char **argv)
                 }
                 cfg = optarg;
                 break;
+#if !defined(HPUX) && !defined(AIX) && !defined(SOLARIS)
             case 1:
                 if (!optarg) {
                     merror_exit("--uninstall-auth-login needs an argument");
@@ -150,16 +158,19 @@ int main(int argc, char **argv)
                     merror_exit("--uninstall-ssl-verify accepts 'true'/'false' or '1'/'0' as arguments");
                 }
                 break;
+#endif
             default:
                 help_agentd(home_path);
                 break;
         }
     }
 
+#if !defined(HPUX) && !defined(AIX) && !defined(SOLARIS)
     /* Anti tampering functionality */
     if ((uninstall_auth_token || uninstall_auth_login) && uninstall_auth_host) {
         exit(package_uninstall_validation(uninstall_auth_token, uninstall_auth_login, uninstall_auth_host, ssl_verify));
     }
+#endif
 
     agt = (agent *)calloc(1, sizeof(agent));
     if (!agt) {


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25789|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Removing getopt lib from HP-UX and AIX compilation.


# Testing
Tested basic antitampering functionality in Ubuntu, it worked without problems.


Using:
![image](https://github.com/user-attachments/assets/1605a228-c39f-4f40-8db3-f783eaf346a7)


Execution pipelines:
- HP-UX: https://ci.wazuh.info/job/Packages_builder_special/1088/🟢 
- AIX: https://ci.wazuh.info/job/Packages_builder_special/1087/🟢 
- Solaris 10: https://ci.wazuh.info/job/Packages_builder_solaris/31880/🟢 
- Solaris 11: https://ci.wazuh.info/job/Packages_builder_solaris/31881/🟢 