### PR TITLE
Added `events/stateless` endpoint to engine

### DIFF
--- a/.github/workflows/engine_style_documentation.yml
+++ b/.github/workflows/engine_style_documentation.yml
@@ -122,8 +122,8 @@ jobs:
         with:
           name: APIDOC/OPENAPI errors
           path: |
-            apidoc_errors.txt
-            openapi_errors.txt
+            src/engine/apidoc_errors.txt
+            src/engine/openapi_errors.txt
           retention-days: 1
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #25619 


This PR:
- Adds the  `POST events/stateless`  endpoint to engine
- Set the path of the socket api relative to `bin` path and not the working directory.

## Expected params:
```json
{
    "wazuh": {
        "queue": 50, // Queue number 1-127
        "location": "[003] (agent-name) any->/tmp/syslog.log", // Location
    },
    "event": {
        "original": "orginal message, recollected from the agent", // Original message
    }
}

```

#### Curl example

```bash
curl --unix-socket /workspaces/repos/wazuh/src/engine/build/sockets/engine.sock http://localhost/events/stateless -X POST -d '{"wazuh": {"queue": 50, "location": "[003] (agent-name) any->/tmp/syslog.log"}, "event": {"original": "original message, recollected from the agent"}}' -H "Content-Type: application/json"
```

**Current output in alert file**
```json
{
    "wazuh": {
        "queue": 50,
        "location": "[003] (agent-name) any->/tmp/syslog.log",
        "origin": "/tmp/syslog.log",
        "registered_ip": "any",
        "source": "wazuh-syslog-server"
    },
    "event": {
        "original": "original message, recollected from the agent"
    },
    "agent": {
        "id": "003",
        "name": "agent-name",
        "type": "wazuh-agent"
    },
    "host": {
        "id": "003"
    }
}
```