### PR TITLE
Vulnerability Detector - Add 4.10.0  pipeline to generate content

### DIFF
--- a/.github/actions/vulnerability_scanner/content_generation/action.yml
+++ b/.github/actions/vulnerability_scanner/content_generation/action.yml
@@ -30,12 +30,6 @@ runs:
       CONFIG_PATH=${{ inputs.config_path }}
       TEMPLATE_PATH=${{ inputs.indexer_template_path }}
 
-      #TODO: Remove this logic once 4.8.0 is merged into master
-      if [ ! -f "${TEMPLATE_PATH}" ]; then
-        TEMPLATE_PATH=src/wazuh_modules/vulnerability_scanner/indexer/template/legacy-template.json
-      fi
-      # END TODO
-
       if [ ! -f "${VULNERABILITY_SCANNER_PATH}" ]; then
         echo "Error: The file '${VULNERABILITY_SCANNER_PATH}' does not exist."
         exit 1

--- a/.github/actions/vulnerability_scanner/content_generation/action.yml
+++ b/.github/actions/vulnerability_scanner/content_generation/action.yml
@@ -17,9 +17,9 @@ inputs:
     description: "Path to the indexer template file"
     default: src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
 
-  wazuh_version:
+  content_version:
     required: true
-    description: "Identifier for the generated content. The content will be compressed into a file named 'vd_1.0.0_vd_<wazuh_version>.tar.xz'"
+    description: "Identifier for the generated content. The content will be compressed into a file named 'vd_1.0.0_vd_<content_version>.tar.xz'"
 
 runs:
   using: "composite"
@@ -61,7 +61,7 @@ runs:
       rm -rf queue/vd/state_track
       rm -rf queue/keystore
 
-      VD_FILENAME=vd_1.0.0_vd_${{ inputs.wazuh_version }}.tar.xz
+      VD_FILENAME=vd_1.0.0_vd_${{ inputs.content_version }}.tar.xz
 
       echo "Compressing into '${VD_FILENAME}' ..."
       tar -cJf ${VD_FILENAME} --owner=0 --group=0 --no-same-owner --no-same-permissions queue

--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -14,8 +14,8 @@ on:
 
   workflow_dispatch:
     inputs:
-      wazuh_version:
-        description: 'Identifier of the generated content. The generated file will be named vd_1.0.0_vd_<wazuh_version>.tar.xz'
+      content_version:
+        description: 'Identifier of the generated content. The generated file will be named vd_1.0.0_vd_<content_version>.tar.xz'
         required: true
         type: string
 
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
-          wazuh_version: ["4.8.0", "4.10.0"]
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<content_version>.tar.xz
+          content_version: ["4.8.0", "4.10.0"]
 
     steps:
       # Checkout to the branch
@@ -38,15 +38,15 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-          ref: ${{ matrix.wazuh_version }}
+          ref: ${{ matrix.content_version }}
 
       # Checkout to the tag. If it doesn't exist, continue with the branch
       - name: Checkout to tag
         run: |
-          if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.wazuh_version }}"; then
-            git checkout --quiet "tags/v${{ matrix.wazuh_version }}"
+          if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.content_version }}"; then
+            git checkout --quiet "tags/v${{ matrix.content_version }}"
           else
-            echo "Warning: Unable to find tag v${{ matrix.wazuh_version }}. Continuing with branch ${{ matrix.wazuh_version }}"
+            echo "Warning: Unable to find tag v${{ matrix.content_version }}. Continuing with branch ${{ matrix.content_version }}"
           fi
 
       ########################
@@ -61,7 +61,7 @@ jobs:
       - name: Generate vulnerability database
         uses: ./.github/actions/vulnerability_scanner/content_generation
         with:
-          wazuh_version: ${{ matrix.wazuh_version }}
+          content_version: ${{ matrix.content_version }}
 
       ########################
       # Content upload       #
@@ -71,7 +71,7 @@ jobs:
         run: |
           root_folder=$(pwd)
           bucket="${{ secrets.FEED_AWS_BUCKET }}"
-          file="vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz"
+          file="vd_1.0.0_vd_${{ matrix.content_version }}.tar.xz"
           dest_dir="deps/vulnerability_model_database"
           aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file} --acl public-read
         env:
@@ -104,7 +104,7 @@ jobs:
       - name: Generate vulnerability database
         uses: ./.github/actions/vulnerability_scanner/content_generation
         with:
-          wazuh_version: "pull_request"
+          content_version: "pull_request"
 
   vulnerability_scanner_database_manual_update:
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -130,7 +130,7 @@ jobs:
         - name: Generate vulnerability database
           uses: ./.github/actions/vulnerability_scanner/content_generation
           with:
-            wazuh_version: ${{ inputs.wazuh_version }}
+            content_version: ${{ inputs.content_version }}
 
         ########################
         # Content upload       #
@@ -139,7 +139,7 @@ jobs:
           run: |
             root_folder=$(pwd)
             bucket="${{ secrets.FEED_AWS_BUCKET }}"
-            file="vd_1.0.0_vd_${{ inputs.wazuh_version }}.tar.xz"
+            file="vd_1.0.0_vd_${{ inputs.content_version }}.tar.xz"
             dest_dir="deps/vulnerability_model_database"
             aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file} --acl public-read
           env:

--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # Idenentifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
-          wazuh_version: ["4.8.0"]
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
+          wazuh_version: ["4.8.0", "4.10.0"]
 
     steps:
       # Checkout to the branch

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -293,7 +293,8 @@ jobs:
           cd src
           vd_filename="vd_1.0.0_vd_${{ matrix.content_version }}.tar.xz"
           curl -LO https://packages.wazuh.com/deps/vulnerability_model_database/${vd_filename}
-          tar -xf ${vd_filename}
+          mkdir -p tmp
+          mv ${vd_filename} tmp
 
       # Install python dependencies
       - name: Install dependencies

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -249,8 +249,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
-          wazuh_version: ["4.8.0", "4.10.0"]
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<content_version>.tar.xz
+          # From 4.10.0 onwards we use 4.10.0 content
+          content_version: ["4.10.0"]
 
     steps:
       - name: Checkout repository
@@ -290,7 +291,7 @@ jobs:
         run: |
           # Download feed
           cd src
-          vd_filename="vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz"
+          vd_filename="vd_1.0.0_vd_${{ matrix.content_version }}.tar.xz"
           curl -LO https://packages.wazuh.com/deps/vulnerability_model_database/${vd_filename}
           tar -xf ${vd_filename}
 

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -245,6 +245,13 @@ jobs:
 
   vulnerability-scanner-modules-qa:
     runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
+          wazuh_version: ["4.8.0", "4.10.0"]
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -283,9 +290,9 @@ jobs:
         run: |
           # Download feed
           cd src
-          curl -LO https://packages.wazuh.com/deps/vulnerability_model_database/vd_1.0.0_vd_4.8.0.tar.xz
-          mkdir -p tmp
-          mv vd_1.0.0_vd_4.8.0.tar.xz tmp
+          vd_filename="vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz"
+          curl -LO https://packages.wazuh.com/deps/vulnerability_model_database/${vd_filename}
+          tar -xf ${vd_filename}
 
       # Install python dependencies
       - name: Install dependencies

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -327,7 +327,7 @@ if [ $1 = 2 ]; then
   fi
 fi
 
-%define _vdfilename vd_1.0.0_vd_4.8.0.tar.xz
+%define _vdfilename vd_1.0.0_vd_4.10.0.tar.xz
 
 # Fresh install code block
 if [ $1 = 1 ]; then

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1160,7 +1160,7 @@ TransferShared()
 
 checkDownloadContent()
 {
-    VD_FILENAME='vd_1.0.0_vd_4.8.0.tar.xz'
+    VD_FILENAME='vd_1.0.0_vd_4.10.0.tar.xz'
     VD_FULL_PATH=${INSTALLDIR}/tmp/${VD_FILENAME}
 
     if [ "X${DOWNLOAD_CONTENT}" = "Xy" ]; then

--- a/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/monitoring_test.cpp
@@ -120,7 +120,7 @@ TEST_F(MonitoringTest, TestInvalidServer)
     // Interval to check the health of the servers
     std::this_thread::sleep_for(std::chrono::seconds(MONITORING_HEALTH_CHECK_INTERVAL + 5));
 
-    EXPECT_STREQ(logMessage.c_str(), "Couldn't connect to server. Status code: -1");
+    EXPECT_STREQ(logMessage.c_str(), "Could not connect to server. Status code: -1");
 
     // It's false because the server isn't valid
     EXPECT_FALSE(m_monitoring->isAvailable(invalidServer));

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -29,8 +29,8 @@ constexpr auto EVENTS_BULK_SIZE {1};
 constexpr auto EVENTS_QUEUE_PATH = "queue/vd/event";
 constexpr auto MICROSEC_FACTOR {1000000};
 
-constexpr auto COMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.8.0.tar.xz"};
-constexpr auto DECOMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.8.0.tar"};
+constexpr auto COMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.10.0.tar.xz"};
+constexpr auto DECOMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.10.0.tar"};
 constexpr auto VD_STATE_QUEUE_PATH = "queue/vd/state_track";
 constexpr auto VD_KEYSTORE_PATH = "queue/keystore";
 constexpr auto VD_DATABASE_PATH {"queue/vd"};

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
@@ -1,7 +1,7 @@
 {
     "vulnerability-detection": {
         "enabled": "yes",
-        "index-status": "yes"
+        "index-status": "no"
     },
     "indexer": {
         "enabled": "yes",

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -314,48 +314,58 @@ int main(const int argc, const char* argv[])
             }
         }
 
-        vulnerabilityScanner.start(
-            [&logFile](const int logLevel,
-                       const std::string& tag,
-                       const std::string& file,
-                       const int line,
-                       const std::string& func,
-                       const std::string& message,
-                       va_list args)
+        // Flag to stop the scanner after the content is downloaded.
+        std::atomic<bool> contentProcessed {false};
+        const auto getOnlyDownloadContent = cmdLineArgs.getOnlyDownloadContent();
+        std::cout << "Only download content flag: " << getOnlyDownloadContent << std::endl;
+        const auto logFunction = [&logFile, &getOnlyDownloadContent, &contentProcessed](const int logLevel,
+                                                                                        const std::string& tag,
+                                                                                        const std::string& file,
+                                                                                        const int line,
+                                                                                        const std::string& func,
+                                                                                        const std::string& message,
+                                                                                        va_list args)
+        {
+            auto pos = file.find_last_of('/');
+            if (pos != std::string::npos)
             {
-                auto pos = file.find_last_of('/');
-                if (pos != std::string::npos)
-                {
-                    pos++;
-                }
-                std::string fileName = file.substr(pos, file.size() - pos);
-                char formattedStr[MAX_LEN] = {0};
-                vsnprintf(formattedStr, MAX_LEN, message.c_str(), args);
+                pos++;
+            }
+            std::string fileName = file.substr(pos, file.size() - pos);
+            char formattedStr[MAX_LEN] = {0};
+            vsnprintf(formattedStr, MAX_LEN, message.c_str(), args);
 
-                std::lock_guard<std::mutex> lock(G_MUTEX);
-                if (logLevel != LOG_ERROR)
-                {
-                    std::cout << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr
-                              << std::endl;
-                }
-                else
-                {
-                    std::cerr << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr
-                              << std::endl;
-                }
+            std::lock_guard<std::mutex> lock(G_MUTEX);
+            if (logLevel != LOG_ERROR)
+            {
+                std::cout << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr << std::endl;
+            }
+            else
+            {
+                std::cerr << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr << std::endl;
+            }
 
-                if (logFile.is_open())
-                {
-                    logFile << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr
-                            << std::endl;
-                }
-                // Flush the log file every time a message is written.
-                logFile.flush();
-            },
-            configuration,
-            false,
-            !cmdLineArgs.getOnlyDownloadContent(),
-            !cmdLineArgs.getDisableContentUpdater());
+            if (logFile.is_open())
+            {
+                logFile << tag << ":" << fileName << ":" << line << " " << func << " : " << formattedStr << std::endl;
+            }
+            // Flush the log file every time a message is written.
+            logFile.flush();
+
+            // To stop the scanner after the content is downloaded. Only if the flag is set.
+            if (getOnlyDownloadContent &&
+                std::string(formattedStr).find("Feed update process completed.") != std::string::npos)
+            {
+                std::cout << "Only download content flag is set. Stopping the scanner..." << std::endl;
+                contentProcessed.store(true);
+            }
+        };
+
+        vulnerabilityScanner.start(logFunction,
+                                   configuration,
+                                   false,
+                                   !cmdLineArgs.getOnlyDownloadContent(),
+                                   !cmdLineArgs.getDisableContentUpdater());
 
         if (!cmdLineArgs.getOnlyDownloadContent())
         {
@@ -426,8 +436,11 @@ int main(const int argc, const char* argv[])
         }
         else
         {
-            // Wait for the start of snapshot processing.
-            std::this_thread::sleep_for(std::chrono::seconds(60));
+            // Wait for the snapshot to be processed.
+            while (!contentProcessed.load())
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+            }
         }
 
         routerProviderDbSync.stop();


### PR DESCRIPTION
|Related issue|
|---|
| #25782 |

## Description
This PR introduces a new pipeline for the VD-generated content. It now uses 4.10.0 branch to generate the DBs and runs the efficacy tests using this new content

To do so it:
- Aligns the scanner testtool to work with the changes in the components
- Updates the workflows to also run on 4.10.0
- Updates the logic in code to retrieve the new generated compressed DB


## New content
New content was generated here:
- https://github.com/wazuh/wazuh/actions/runs/10950973244/job/30407211577