### PR TITLE
Engine - Add tools for validate metadata, schema and mandatory mapping in assets

### DIFF
--- a/src/engine/test/health_test/README.md
+++ b/src/engine/test/health_test/README.md
@@ -26,7 +26,100 @@ The `engine-test.conf` file specifies the settings necessary to run `engine-test
 - **Input Files (`${test_name}_input.txt`)**: Contains lines where each line represents an event to be tested.
 - **Expected Output Files (`${test_name}_expected.json`)**: Includes an array of JSON objects, each corresponding to the expected outcome for the respective input event.
 
-## Running Health Tests
+### Install health test
+```bash
+pip install ./engine-health-test
+```
+
+## Running Static tests
+These tests do not require the engine to be running as they evaluate the expected values ​​of each test performed in each of the integrations. From this, conclusions can be drawn about custom fields used in the assets, mandatory fields that should be mapped and finally the verification that the metadata of each asset is correctly added.
+
+### Metadata validate
+This tool validates that the metadata field contains all the required information:
+- Module to which the decoder belongs.
+- Title of the product that generates the logs to decode.
+- Description of the decoder source.
+- Compatibility, versions Versions for which the logs have been tested and supported.
+- Author: name and email address
+- References from a URL, a site, or any documentation where those logs are defined and established.
+```bash
+usage: engine-health-test metadata_validate [-h] -r RULESET [--integration INTEGRATION] [--asset ASSET]
+
+options:
+  -h, --help            show this help message and exit
+  -r RULESET, --ruleset RULESET
+                        Specify the path to the ruleset directory
+  --integration INTEGRATION
+                        Specify integration name
+  --asset ASSET         Specify asset name
+```
+
+#### Use
+To evaluate the metadata in a particular integration
+```bash
+engine-health-test metadata_validate -r ruleset_dir --integration windows
+```
+To evaluate the metadata in a particular asset
+```bash
+engine-health-test metadata_validate -r ruleset_dir --integration windows --asset rule/execution-python-script-in-cmdline/0
+```
+To evaluate the metadata in all integrations
+```bash
+engine-health-test metadata_validate -r ruleset_dir
+```
+
+### Schema validate
+This tool validates that the fields present in the output event exist in the wazuh schema. If not, they should be defined in the custom_fields.yml file within the test folder of each integration. Otherwise the test will fail.
+
+```bash
+usage: engine-health-test schema_validate [-h] -r RULESET [--integration INTEGRATION]
+
+options:
+  -h, --help            show this help message and exit
+  -r RULESET, --ruleset RULESET
+                        Specify the path to the ruleset directory
+  --integration INTEGRATION
+                        Specify integration name
+```
+
+#### Use
+To evaluate the schema in a particular integration
+```bash
+engine-health-test schema_validate -r ruleset_dir --integration windows
+```
+To evaluate the schema in all integrations
+```bash
+engine-health-test schema_validate -r ruleset_dir
+```
+
+### Mapping validate
+This tool validates that certain fields that are required are mapped in the output event.
+Such as 'wazuh.decoders'. This list can be expanded and is located within base-rules
+
+```bash
+usage: engine-health-test mapping_validate [-h] -r RULESET [--integration INTEGRATION]
+
+options:
+  -h, --help            show this help message and exit
+  -r RULESET, --ruleset RULESET
+                        Specify the path to the ruleset directory
+  --integration INTEGRATION
+                        Specify integration name
+```
+
+#### Use
+To evaluate the mapping in a particular integration
+```bash
+engine-health-test mapping_validate -r ruleset_dir --integration windows
+```
+To evaluate the mapping in all integrations
+```bash
+engine-health-test mapping_validate -r ruleset_dir
+```
+
+## Running Dynamic Tests
+
+These tests need the engine to communicate with the API. Therefore each dynamic test starts its instance of the engine, performs the tests and then stops the engine.
 
 ### Setup the Environment
 
@@ -36,14 +129,9 @@ First, set up an isolated environment to run the tests using the `setupEnvironme
 ./test/setupEnvironment.py -e health_test/environment
 ```
 
-### Install health test
-```bash
-pip install ./engine-health-test
-```
-
 ### Initialize Test Environment
 
-Load all necessary configurations and integration from ruleset tests:
+Load all necessary configurations and geo-as databases.
 
 ```bash
 engine-health-test -e health_test/environment init -b build/main -r engine/ruleset -t test/health_test/
@@ -64,19 +152,52 @@ options:
                         Specify the path to the test directory
 ```
 
-### Execute Tests
-
-Run all tests for a specific integration or execute health tests across all integrations:
+### Integration validate
+This tool validates an entire integration or a particular asset using the catalog API
 
 ```bash
-engine-health-test -e health_test/environment run
-# To run a specific test
-engine-health-test -e health_test/environment run -i windows
-# To skip specific tests
-engine-health-test -e health_test/environment run --skip windows,syslog
+usage: engine-health-test integration_validate [-h] [--integration INTEGRATION] [--asset ASSET]
+
+options:
+  -h, --help            show this help message and exit
+  --integration INTEGRATION
+                        Specify integration name
+  --asset ASSET         Specify asset name
 ```
 
-All parameters available:
+#### Use
+To validate a particular integration
+```bash
+engine-health-test -e health_test/environment integration_validate --integration windows
+```
+To validate a particular asset
+```bash
+engine-health-test -e health_test/environment integration_validate --integration windows --asset rule/execution-python-script-in-cmdline/0
+```
+To validate all integrations
+```bash
+engine-health-test -e health_test/environment integration_validate
+```
+
+### Load ruleset
+This tool create the filters, load the integrations and add the assets to the policy
+
+```bash
+usage: engine-health-test load_ruleset [-h]
+
+options:
+  -h, --help  show this help message and exit
+```
+
+#### Use
+To validate a particular integration
+```bash
+engine-health-test -e health_test/environment load_ruleset
+```
+
+
+### Run
+This tool injects events into the engine and evaluates the output events with an expected event
 ```bash
 $ engine-health-test -e ____test/integration/ run -h
 usage: engine-health-test run [-h] [-i INTEGRATION] [--skip SKIP]
@@ -86,6 +207,15 @@ options:
   -i INTEGRATION, --integration INTEGRATION
                         Specify the name of the integration to test, if not specified all integrations will be tested
   --skip SKIP           Skip the tests with the specified name
+```
+
+#### Usage
+```bash
+engine-health-test -e health_test/environment run
+# To run a specific test
+engine-health-test -e health_test/environment run -i windows
+# To skip specific tests
+engine-health-test -e health_test/environment run --skip windows,syslog
 ```
 
 ## Error Handling and Reports

--- a/src/engine/test/health_test/engine-health-test/src/health_test/__main__.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/__main__.py
@@ -2,10 +2,10 @@
 import sys
 from argparse import ArgumentParser, Namespace
 
-from health_test.initial_state import run as init_run
 from health_test.metadata_validate import run as metadata_validate_run
 from health_test.schema_validate import run as schema_validate_run
 from health_test.mapping_validate import run as mapping_validate_run
+from health_test.initial_state import run as init_run
 from health_test.load_ruleset import run as load_ruleset_run
 from health_test.integration_validate import run as integration_validate_run
 from health_test.health_test import run as test_run
@@ -14,28 +14,17 @@ from health_test.health_test import run as test_run
 def parse_args() -> Namespace:
     parser = ArgumentParser(prog='engine-health-test')
     parser.add_argument('-e', '--environment',
-                        help='Environment to run the tests in', type=str, required=True)
+                        help='Environment to run the tests in', type=str, required=False)
 
     # dest used because of bug: https://bugs.python.org/issue29298
     subparsers = parser.add_subparsers(
         title='subcommands', required=True, dest='subcommand')
 
-    # init subcommand
-    init_parser = subparsers.add_parser(
-        'init', help='Initialize the test environment')
-    init_parser.add_argument(
-        '-b', '--binary', help='Specify the path to the engine binary', required=True)
-    init_parser.add_argument('-r', '--ruleset',
-                             help='Specify the path to the ruleset directory', required=True)
-    init_parser.add_argument(
-        '-t', '--test-dir', help='Specify the path to the test directory', required=True)
-    init_parser.add_argument('--stop-on-warning', action='store_true',
-                             help='Stop the initialization process if a warning is encountered when creating the policy')
-    init_parser.set_defaults(func=init_run)
-
     # metadata validate subcommand
     metadata_validate_parser = subparsers.add_parser(
         'metadata_validate', help='Validate metadata field in all integrations or specifies assets.')
+    metadata_validate_parser.add_argument('-r', '--ruleset',
+                            help='Specify the path to the ruleset directory', required=True)
     metadata_validate_parser.add_argument('--integration', help='Specify integration name', required=False)
     metadata_validate_parser.add_argument('--asset', help='Specify asset name', required=False)
     metadata_validate_parser.set_defaults(func=metadata_validate_run)
@@ -43,19 +32,31 @@ def parse_args() -> Namespace:
     # schema validate subcommand
     schema_validate_parser = subparsers.add_parser(
         'schema_validate', help='Validate schema in integrations.')
+    schema_validate_parser.add_argument('-r', '--ruleset',
+                            help='Specify the path to the ruleset directory', required=True)
     schema_validate_parser.add_argument('--integration', help='Specify integration name', required=False)
     schema_validate_parser.set_defaults(func=schema_validate_run)
 
     # mapping validate subcommand
     mapping_validate_parser = subparsers.add_parser(
         'mapping_validate', help='Validates that mandatory mapping fields are present after the decoding stage')
+    mapping_validate_parser.add_argument('-r', '--ruleset',
+                            help='Specify the path to the ruleset directory', required=True)
     mapping_validate_parser.add_argument('--integration', help='Specify integration name', required=False)
     mapping_validate_parser.set_defaults(func=mapping_validate_run)
 
-    # load ruleset
-    load_ruleset_parser = subparsers.add_parser(
-        'load_ruleset', help='Create the filters, load the integrations and add the assets to the policy')
-    load_ruleset_parser.set_defaults(func=load_ruleset_run)
+    # init subcommand
+    init_parser = subparsers.add_parser(
+        'init', help='Initialize the test environment')
+    init_parser.add_argument(
+        '-b', '--binary', help='Specify the path to the engine binary', required=True)
+    init_parser.add_argument('-r', '--ruleset',
+                            help='Specify the path to the ruleset directory', required=True)
+    init_parser.add_argument(
+        '-t', '--test-dir', help='Specify the path to the test directory', required=True)
+    init_parser.add_argument('--stop-on-warning', action='store_true',
+                             help='Stop the initialization process if a warning is encountered when creating the policy')
+    init_parser.set_defaults(func=init_run)
 
     # integration validate subcommand
     integration_validate = subparsers.add_parser(
@@ -63,6 +64,11 @@ def parse_args() -> Namespace:
     integration_validate.add_argument('--integration', help='Specify integration name', required=False)
     integration_validate.add_argument('--asset', help='Specify asset name', required=False)
     integration_validate.set_defaults(func=integration_validate_run)
+
+    # load ruleset
+    load_ruleset_parser = subparsers.add_parser(
+        'load_ruleset', help='Create the filters, load the integrations and add the assets to the policy')
+    load_ruleset_parser.set_defaults(func=load_ruleset_run)
 
     # test subcommand
     test_parser = subparsers.add_parser(

--- a/src/engine/test/health_test/engine-health-test/src/health_test/__main__.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/__main__.py
@@ -3,6 +3,11 @@ import sys
 from argparse import ArgumentParser, Namespace
 
 from health_test.initial_state import run as init_run
+from health_test.metadata_validate import run as metadata_validate_run
+from health_test.schema_validate import run as schema_validate_run
+from health_test.mapping_validate import run as mapping_validate_run
+from health_test.load_ruleset import run as load_ruleset_run
+from health_test.integration_validate import run as integration_validate_run
 from health_test.health_test import run as test_run
 
 
@@ -27,6 +32,37 @@ def parse_args() -> Namespace:
     init_parser.add_argument('--stop-on-warning', action='store_true',
                              help='Stop the initialization process if a warning is encountered when creating the policy')
     init_parser.set_defaults(func=init_run)
+
+    # metadata validate subcommand
+    metadata_validate_parser = subparsers.add_parser(
+        'metadata_validate', help='Validate metadata field in all integrations or specifies assets.')
+    metadata_validate_parser.add_argument('--integration', help='Specify integration name', required=False)
+    metadata_validate_parser.add_argument('--asset', help='Specify asset name', required=False)
+    metadata_validate_parser.set_defaults(func=metadata_validate_run)
+
+    # schema validate subcommand
+    schema_validate_parser = subparsers.add_parser(
+        'schema_validate', help='Validate schema in integrations.')
+    schema_validate_parser.add_argument('--integration', help='Specify integration name', required=False)
+    schema_validate_parser.set_defaults(func=schema_validate_run)
+
+    # mapping validate subcommand
+    mapping_validate_parser = subparsers.add_parser(
+        'mapping_validate', help='Validates that mandatory mapping fields are present after the decoding stage')
+    mapping_validate_parser.add_argument('--integration', help='Specify integration name', required=False)
+    mapping_validate_parser.set_defaults(func=mapping_validate_run)
+
+    # load ruleset
+    load_ruleset_parser = subparsers.add_parser(
+        'load_ruleset', help='Create the filters, load the integrations and add the assets to the policy')
+    load_ruleset_parser.set_defaults(func=load_ruleset_run)
+
+    # integration validate subcommand
+    integration_validate = subparsers.add_parser(
+        'integration_validate', help='Validate integrations or specifies assets.')
+    integration_validate.add_argument('--integration', help='Specify integration name', required=False)
+    integration_validate.add_argument('--asset', help='Specify asset name', required=False)
+    integration_validate.set_defaults(func=integration_validate_run)
 
     # test subcommand
     test_parser = subparsers.add_parser(

--- a/src/engine/test/health_test/engine-health-test/src/health_test/error_managment.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/error_managment.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+class ErrorReporter:
+    def __init__(self):
+        self.errors = {}
+
+    def add_error(self, integration, asset, field):
+        """
+        Adds a missing field error for a specific integration and asset.
+        If the field has already been recorded, it won't be duplicated.
+        """
+        if integration not in self.errors:
+            self.errors[integration] = {}
+
+        if asset not in self.errors[integration]:
+            self.errors[integration][asset] = set()
+
+        self.errors[integration][asset].add(field)
+
+    def has_errors(self):
+        """
+        Returns True if there are accumulated errors.
+        """
+        return bool(self.errors)
+
+    def generate_report(self, description, base_path):
+        """
+        Generates a report of all accumulated errors, showing relative paths to 'integrations'.
+        """
+        if not self.has_errors():
+            return "No errors found."
+
+        report = "\nValidation Report:\n"
+        report += f"Failed: {description}.\n"
+
+        base_path = Path(base_path).resolve()
+
+        for integration, assets in self.errors.items():
+            report += f"\nIntegration: {integration}\n"
+            for asset, missing_fields in assets.items():
+                relative_path = Path(asset).relative_to(base_path)
+                report += f"  File: {relative_path}\n"
+                report += "   Fields:\n"
+                for field in sorted(missing_fields):
+                    report += f"    - {field}\n"
+        return report
+
+    def exit_with_errors(self, description, base_path):
+        """
+        If there are errors, generates the report and terminates the program with sys.exit(1).
+        """
+        if self.has_errors():
+            sys.exit(self.generate_report(description, base_path))

--- a/src/engine/test/health_test/engine-health-test/src/health_test/health_test.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/health_test.py
@@ -307,6 +307,8 @@ def health_test(env_path: Path, integration_name: Optional[str] = None, skip: Op
 
 
 def run(args):
+    if 'environment' not in args:
+        sys.exit("It is mandatory to indicate the '-e' environment path")
     env_path = Path(args['environment'])
     integration_path = args['integration']
     skip = args['skip']

--- a/src/engine/test/health_test/engine-health-test/src/health_test/health_test.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/health_test.py
@@ -232,7 +232,7 @@ def health_test(env_path: Path, integration_name: Optional[str] = None, skip: Op
         print(f"Engine binary not found: {bin_path}")
         sys.exit(1)
 
-    integrations_path = (env_path / "ruleset/engine/integrations").resolve()
+    integrations_path = (env_path / "ruleset/integrations").resolve()
     if not integrations_path.exists():
         print(f"Integrations directory not found: {integrations_path}")
         sys.exit(1)

--- a/src/engine/test/health_test/engine-health-test/src/health_test/initial_state.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/initial_state.py
@@ -55,7 +55,7 @@ def cpy_mmdb(env_path: Path, health_test_path: Path) -> Tuple[Path, Path]:
 
 
 def cpy_ruleset(env_path: Path, ruleset_path: Path) -> Path:
-    dest_ruleset_path = env_path / 'ruleset/engine'
+    dest_ruleset_path = env_path / 'ruleset'
     copytree(ruleset_path, dest_ruleset_path)
 
     # Modify outputs paths
@@ -91,135 +91,6 @@ def load_mmdb(engine_handler: EngineHandler, mmdb_path: Path, mmdb_type: str) ->
     print(f"MMDB file loaded.")
 
 
-def load_filters(ruleset_path: Path, engine_handler: EngineHandler) -> None:
-    for filter_file in (ruleset_path / 'filters').rglob('*.yml'):
-        request = api_catalog.ResourcePost_Request()
-        request.type = api_catalog.ResourceType.filter
-        request.namespaceid = "system"
-        request.content = filter_file.read_text()
-        request.format = api_catalog.ResourceFormat.yml
-        print(f"Loading filter...\n{request}")
-        error, response = engine_handler.api_client.send_recv(request)
-        if error:
-            raise Exception(error)
-
-        parsed_response = ParseDict(
-            response, api_engine.GenericStatus_Response())
-        if parsed_response.status == api_engine.ERROR:
-            raise Exception(parsed_response.error)
-        print(f"Filter loaded.")
-
-
-def load_integrations(ruleset_path: Path, engine_handler: EngineHandler) -> None:
-    for integration_dir in (ruleset_path / 'integrations').iterdir():
-        ns = "system" if integration_dir.name == 'wazuh-core' else "wazuh"
-        command_str = f'engine-integration add --api-sock {engine_handler.api_socket_path} --namespace {ns} {integration_dir.resolve().as_posix()}'
-        print(f"Loading integration...\n{command_str}")
-        subprocess.run(command_str, check=True, shell=True)
-        print(f"Integration loaded.")
-
-
-def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn: bool) -> None:
-    # Create policy
-    request = api_policy.StorePost_Request()
-    request.policy = "policy/wazuh/0"
-    print(f"Creating policy...\n{request}")
-    error, response = engine_handler.api_client.send_recv(request)
-    if error:
-        raise Exception(error)
-    parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
-    if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
-    print("Policy created.")
-
-    # Set default parents for wazuh and user namespaces
-    request = api_policy.DefaultParentPost_Request()
-    request.parent = "decoder/integrations/0"
-    request.namespace = "wazuh"
-    request.policy = "policy/wazuh/0"
-    print(f"Setting default parent...\n{request}")
-    error, response = engine_handler.api_client.send_recv(request)
-    if error:
-        raise Exception(error)
-    parsed_response = ParseDict(
-        response, api_policy.DefaultParentPost_Response())
-    if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
-    if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
-    print("Default parent set.")
-
-    request = api_policy.DefaultParentPost_Request()
-    request.parent = "decoder/integrations/0"
-    request.namespace = "user"
-    request.policy = "policy/wazuh/0"
-    print(f"Setting default parent...\n{request}")
-    error, response = engine_handler.api_client.send_recv(request)
-    if error:
-        raise Exception(error)
-    parsed_response = ParseDict(
-        response, api_policy.DefaultParentPost_Response())
-    if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
-    if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
-    print("Default parent set.")
-
-    # Add wazuh-core
-    request = api_policy.AssetPost_Request()
-    request.asset = "integration/wazuh-core/0"
-    request.policy = "policy/wazuh/0"
-    request.namespace = "system"
-    print(f"Adding wazuh-core...\n{request}")
-    error, response = engine_handler.api_client.send_recv(request)
-    if error:
-        raise Exception(error)
-    parsed_response = ParseDict(response, api_policy.AssetPost_Response())
-    if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
-    if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
-    print("wazuh-core added.")
-
-    # Add rest of integrations
-    for integration_dir in (ruleset_path / 'integrations').iterdir():
-        if integration_dir.name == 'wazuh-core':
-            continue
-
-        integration_name = f'integration/{integration_dir.name}/0'
-        request = api_policy.AssetPost_Request()
-        request.asset = integration_name
-        request.policy = "policy/wazuh/0"
-        request.namespace = "wazuh"
-        print(f"Adding {integration_name}...\n{request}")
-        error, response = engine_handler.api_client.send_recv(request)
-        if error:
-            raise Exception(error)
-        parsed_response = ParseDict(
-            response, api_policy.AssetPost_Response())
-        if parsed_response.status == api_engine.ERROR:
-            raise Exception(parsed_response.error)
-        if len(parsed_response.warning) > 0 and stop_on_warn:
-            raise Exception(parsed_response.warning)
-        print(f"{integration_name} added.")
-
-    # Load environment
-    request = api_router.RoutePost_Request()
-    request.route.name = "default"
-    request.route.policy = "policy/wazuh/0"
-    request.route.filter = "filter/allow-all/0"
-    request.route.priority = 254
-    request.route.description = "Default route"
-    print(f"Loading environment...\n{request}")
-    error, response = engine_handler.api_client.send_recv(request)
-    if error:
-        raise Exception(error)
-    parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
-    if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
-    print("Environment loaded.")
-
-
 def init(env_path: Path, bin_path: Path, ruleset_path: Path, health_test_path: Path, stop_on_warn: bool) -> None:
     engine_handler: Optional[EngineHandler] = None
 
@@ -233,6 +104,7 @@ def init(env_path: Path, bin_path: Path, ruleset_path: Path, health_test_path: P
         print("MMDB test files copied.")
 
         print("Copying ruleset files...")
+        print(ruleset_path)
         ruleset_path = cpy_ruleset(env_path, ruleset_path)
         print("Ruleset files copied.")
 
@@ -249,15 +121,6 @@ def init(env_path: Path, bin_path: Path, ruleset_path: Path, health_test_path: P
         # Load mmdbs
         load_mmdb(engine_handler, asn_path, "asn")
         load_mmdb(engine_handler, city_path, "city")
-
-        # Load filters
-        load_filters(ruleset_path, engine_handler)
-
-        # Load integrations
-        load_integrations(ruleset_path, engine_handler)
-
-        # Create policy
-        load_policy(ruleset_path, engine_handler, stop_on_warn)
 
         print("Stopping the engine...")
         engine_handler.stop()

--- a/src/engine/test/health_test/engine-health-test/src/health_test/initial_state.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/initial_state.py
@@ -139,6 +139,8 @@ def init(env_path: Path, bin_path: Path, ruleset_path: Path, health_test_path: P
 
 
 def run(args):
+    if 'environment' not in args:
+        sys.exit("It is mandatory to indicate the '-e' environment path")
     env_path = Path(args['environment']).resolve()
     bin_path = Path(args['binary']).resolve()
     ruleset_path = Path(args['ruleset']).resolve()

--- a/src/engine/test/health_test/engine-health-test/src/health_test/integration_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/integration_validate.py
@@ -1,0 +1,124 @@
+import sys
+import shared.resource_handler as rs
+import shared.executor as exec
+from pathlib import Path
+from engine_handler.handler import EngineHandler
+
+DEFAULT_NAMESPACE = 'user'
+
+def process_integration_entry(api_socket, entry, kvdbs, added_kvdbs_paths, executor, resource_handler, namespace):
+    """
+    Process a single integration entry, creating tasks for kvdbs and catalog validation.
+    """
+    original = resource_handler.load_file(entry)
+    
+    name = original['name']
+
+    if entry.parent.as_posix() not in added_kvdbs_paths:
+        added_kvdbs_paths.append(entry.parent.as_posix())
+        for kvdb_entry in entry.parent.glob('*.json'):
+            if kvdb_entry.stem not in kvdbs:
+                recoverable_task = resource_handler.get_create_kvdb_task(
+                    api_socket, kvdb_entry.stem, str(kvdb_entry))
+                executor.add(recoverable_task)
+
+    task = resource_handler.get_validate_catalog_task(
+        api_socket, name.split('/')[0], name, original, namespace)
+    executor.add(task)
+
+def validator(args, ruleset_path: Path, resource_handler: rs.ResourceHandler, api_socket: str):
+    integration = args.get('integration')
+    asset = args.get('asset')
+    kvdbs = resource_handler.get_kvdb_list(api_socket)["data"]["dbs"]
+
+    # Restrict specifying an asset without an integration
+    if asset and not integration:
+        sys.exit("Error: An asset cannot be specified without an integration.")
+
+    if integration:
+        integration_path = ruleset_path / 'integrations' / integration
+        if not integration_path.exists() or not integration_path.is_dir():
+            sys.exit(f"Integration '{integration}' not found in '{ruleset_path / 'integrations'}'.")
+        integrations_to_process = [integration_path]
+    else:
+        # If no integration is provided, process all integration directories
+        integrations_path = ruleset_path / 'integrations'
+        if not integrations_path.exists() or not integrations_path.is_dir():
+            sys.exit(f"Integrations directory not found in '{ruleset_path}'.")
+        integrations_to_process = [d for d in integrations_path.iterdir() if d.is_dir()]
+
+    executor = exec.Executor()
+    added_kvdbs_paths = []
+
+    for integration_path in integrations_to_process:
+        working_path = str(integration_path.resolve())
+        print(f'Validating integration from: {working_path}')
+
+        manifest = dict()
+        integration_full_name = ''
+        try:
+            manifest_path = integration_path / 'manifest.yml'
+            manifest = resource_handler.load_file(manifest_path.as_posix())
+            integration_full_name = manifest['name']
+        except Exception as e:
+            sys.exit(f'Error: {e}')
+
+        for type_name in manifest.keys():
+            if type_name not in ['decoders', 'rules', 'outputs', 'filters']:
+                continue
+
+            path = ruleset_path / type_name
+            if not path.exists():
+                sys.exit(f'Error: {type_name} directory does not exist')
+
+            for entry in path.rglob('*.yml'):
+                original = resource_handler.load_file(entry)
+                name = original['name']
+                if asset:
+                    if asset == name:
+                        process_integration_entry(api_socket, entry, kvdbs, added_kvdbs_paths, executor, resource_handler, DEFAULT_NAMESPACE)
+                        break
+                else:
+                    if name in manifest[type_name]:
+                        process_integration_entry(api_socket, entry, kvdbs, added_kvdbs_paths, executor, resource_handler, DEFAULT_NAMESPACE)
+
+        print(f'Validating {integration_full_name} to the catalog')
+
+    print('\nTasks:')
+    executor.list_tasks()
+    print('\nExecuting tasks...')
+    executor.execute()
+    print('\nDone')
+
+def run(args):
+    env_path = Path(args['environment']).resolve()
+    resource_handler = rs.ResourceHandler()
+    conf_path = (env_path / "engine/general.conf").resolve()
+    if not conf_path.is_file():
+        print(f"Configuration file not found: {conf_path}")
+        sys.exit(1)
+
+    bin_path = (env_path / "bin/wazuh-engine").resolve()
+    if not bin_path.is_file():
+        print(f"Engine binary not found: {bin_path}")
+        sys.exit(1)
+
+    ruleset_path = (env_path / "ruleset").resolve()
+    if not ruleset_path.is_dir():
+        print(f"Engine ruleset not found: {ruleset_path}")
+        sys.exit(1)
+    
+    print("Starting engine...")
+    engine_handler = EngineHandler(bin_path.as_posix(), conf_path.as_posix())
+    api_socket = engine_handler.api_socket_path
+
+    try:
+        engine_handler.start()
+        print("Engine started.")
+        validator(args, ruleset_path, resource_handler, api_socket)
+    except Exception as e:
+        print(f"Error running test: {e}")
+    finally:
+        print("Stopping engine...")
+        engine_handler.stop()
+        print("Engine stopped.")

--- a/src/engine/test/health_test/engine-health-test/src/health_test/integration_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/integration_validate.py
@@ -91,6 +91,8 @@ def validator(args, ruleset_path: Path, resource_handler: rs.ResourceHandler, ap
     print('\nDone')
 
 def run(args):
+    if 'environment' not in args:
+        sys.exit("It is mandatory to indicate the '-e' environment path")
     env_path = Path(args['environment']).resolve()
     resource_handler = rs.ResourceHandler()
     conf_path = (env_path / "engine/general.conf").resolve()

--- a/src/engine/test/health_test/engine-health-test/src/health_test/load_ruleset.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/load_ruleset.py
@@ -139,6 +139,8 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
 
 
 def run(args):
+    if 'environment' not in args:
+        sys.exit("It is mandatory to indicate the '-e' environment path")
     env_path = Path(args['environment']).resolve()
 
     conf_path = (env_path / "engine/general.conf").resolve()

--- a/src/engine/test/health_test/engine-health-test/src/health_test/load_ruleset.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/load_ruleset.py
@@ -1,0 +1,184 @@
+import subprocess
+import sys
+from pathlib import Path
+from google.protobuf.json_format import ParseDict
+
+from engine_handler.handler import EngineHandler
+from api_communication.proto import catalog_pb2 as api_catalog
+from api_communication.proto import engine_pb2 as api_engine
+from api_communication.proto import policy_pb2 as api_policy
+from api_communication.proto import router_pb2 as api_router
+
+def load_filters(ruleset_path: Path, engine_handler: EngineHandler) -> None:
+    for filter_file in (ruleset_path / 'filters').rglob('*.yml'):
+        request = api_catalog.ResourcePost_Request()
+        request.type = api_catalog.ResourceType.filter
+        request.namespaceid = "system"
+        request.content = filter_file.read_text()
+        request.format = api_catalog.ResourceFormat.yml
+        print(f"Loading filter...\n{request}")
+        error, response = engine_handler.api_client.send_recv(request)
+        if error:
+            raise Exception(error)
+
+        parsed_response = ParseDict(
+            response, api_engine.GenericStatus_Response())
+        if parsed_response.status == api_engine.ERROR:
+            raise Exception(parsed_response.error)
+        print(f"Filter loaded.")
+
+
+def load_integrations(ruleset_path: Path, engine_handler: EngineHandler) -> None:
+    for integration_dir in (ruleset_path / 'integrations').iterdir():
+        ns = "system" if integration_dir.name == 'wazuh-core' else "wazuh"
+        command_str = f'engine-integration add --api-sock {engine_handler.api_socket_path} --namespace {ns} {integration_dir.resolve().as_posix()}'
+        print(f"Loading integration...\n{command_str}")
+        subprocess.run(command_str, check=True, shell=True)
+        print(f"Integration loaded.")
+
+
+def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn: bool) -> None:
+    # Create policy
+    request = api_policy.StorePost_Request()
+    request.policy = "policy/wazuh/0"
+    print(f"Creating policy...\n{request}")
+    error, response = engine_handler.api_client.send_recv(request)
+    if error:
+        raise Exception(error)
+    parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
+    if parsed_response.status == api_engine.ERROR:
+        raise Exception(parsed_response.error)
+    print("Policy created.")
+
+    # Set default parents for wazuh and user namespaces
+    request = api_policy.DefaultParentPost_Request()
+    request.parent = "decoder/integrations/0"
+    request.namespace = "wazuh"
+    request.policy = "policy/wazuh/0"
+    print(f"Setting default parent...\n{request}")
+    error, response = engine_handler.api_client.send_recv(request)
+    if error:
+        raise Exception(error)
+    parsed_response = ParseDict(
+        response, api_policy.DefaultParentPost_Response())
+    if parsed_response.status == api_engine.ERROR:
+        raise Exception(parsed_response.error)
+    if len(parsed_response.warning) > 0 and stop_on_warn:
+        raise Exception(parsed_response.warning)
+    print("Default parent set.")
+
+    request = api_policy.DefaultParentPost_Request()
+    request.parent = "decoder/integrations/0"
+    request.namespace = "user"
+    request.policy = "policy/wazuh/0"
+    print(f"Setting default parent...\n{request}")
+    error, response = engine_handler.api_client.send_recv(request)
+    if error:
+        raise Exception(error)
+    parsed_response = ParseDict(
+        response, api_policy.DefaultParentPost_Response())
+    if parsed_response.status == api_engine.ERROR:
+        raise Exception(parsed_response.error)
+    if len(parsed_response.warning) > 0 and stop_on_warn:
+        raise Exception(parsed_response.warning)
+    print("Default parent set.")
+
+    # Add wazuh-core
+    request = api_policy.AssetPost_Request()
+    request.asset = "integration/wazuh-core/0"
+    request.policy = "policy/wazuh/0"
+    request.namespace = "system"
+    print(f"Adding wazuh-core...\n{request}")
+    error, response = engine_handler.api_client.send_recv(request)
+    if error:
+        raise Exception(error)
+    parsed_response = ParseDict(response, api_policy.AssetPost_Response())
+    if parsed_response.status == api_engine.ERROR:
+        raise Exception(parsed_response.error)
+    if len(parsed_response.warning) > 0 and stop_on_warn:
+        raise Exception(parsed_response.warning)
+    print("wazuh-core added.")
+
+    # Add rest of integrations
+    for integration_dir in (ruleset_path / 'integrations').iterdir():
+        if integration_dir.name == 'wazuh-core':
+            continue
+
+        integration_name = f'integration/{integration_dir.name}/0'
+        request = api_policy.AssetPost_Request()
+        request.asset = integration_name
+        request.policy = "policy/wazuh/0"
+        request.namespace = "wazuh"
+        print(f"Adding {integration_name}...\n{request}")
+        error, response = engine_handler.api_client.send_recv(request)
+        if error:
+            raise Exception(error)
+        parsed_response = ParseDict(
+            response, api_policy.AssetPost_Response())
+        if parsed_response.status == api_engine.ERROR:
+            raise Exception(parsed_response.error)
+        if len(parsed_response.warning) > 0 and stop_on_warn:
+            raise Exception(parsed_response.warning)
+        print(f"{integration_name} added.")
+
+    # Load environment
+    request = api_router.RoutePost_Request()
+    request.route.name = "default"
+    request.route.policy = "policy/wazuh/0"
+    request.route.filter = "filter/allow-all/0"
+    request.route.priority = 254
+    request.route.description = "Default route"
+    print(f"Loading environment...\n{request}")
+    error, response = engine_handler.api_client.send_recv(request)
+    if error:
+        raise Exception(error)
+    parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
+    if parsed_response.status == api_engine.ERROR:
+        raise Exception(parsed_response.error)
+    print("Environment loaded.")
+
+
+def run(args):
+    env_path = Path(args['environment']).resolve()
+
+    conf_path = (env_path / "engine/general.conf").resolve()
+    if not conf_path.is_file():
+        print(f"Configuration file not found: {conf_path}")
+        sys.exit(1)
+
+    bin_path = (env_path / "bin/wazuh-engine").resolve()
+    if not bin_path.is_file():
+        print(f"Engine binary not found: {bin_path}")
+        sys.exit(1)
+
+    ruleset_path = (env_path / "ruleset").resolve()
+    if not ruleset_path.is_dir():
+        print(f"Engine ruleset not found: {ruleset_path}")
+        sys.exit(1)
+
+    stop_on_warn = args.get('stop_on_warning', False)
+
+    print("Starting the engine...")
+    engine_handler = EngineHandler(
+    bin_path.as_posix(), conf_path.as_posix())
+    engine_handler.start()
+    print("Engine started.")
+
+    # Clear environmet
+    command_str = f'engine-clear --api-sock {engine_handler.api_socket_path} -f'
+    print(f"Clear environment...\n{command_str}")
+    subprocess.run(command_str, check=True, shell=True)
+    print(f"Environment cleared.")
+    
+    # Load filters
+    load_filters(ruleset_path, engine_handler)
+
+    # Load integrations
+    load_integrations(ruleset_path, engine_handler)
+
+    # Create policy
+    load_policy(ruleset_path, engine_handler, stop_on_warn)
+
+    print("Stopping the engine...")
+    engine_handler.stop()
+    print("Engine stopped.")

--- a/src/engine/test/health_test/engine-health-test/src/health_test/mapping_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/mapping_validate.py
@@ -1,0 +1,92 @@
+import sys
+import json
+import shared.resource_handler as rs
+from pathlib import Path
+
+def load_mandatory_mapping(mandatory_mapping_path: Path):
+    """
+    Load mandatory_mapping from 'mandatory_mapping.yml'.
+    """
+    try:
+        mandatory_mapping = rs.ResourceHandler().load_file(mandatory_mapping_path.as_posix())
+        return mandatory_mapping.get('mandatory_mapping', [])
+    except Exception as e:
+        sys.exit(f"Error loading mandatory mapping from '{mandatory_mapping_path}'")
+
+def transform_dict_to_list(d):
+    def extract_keys(d, prefix=""):
+        result = []
+        for key, value in d.items():
+            new_prefix = f"{prefix}.{key}" if prefix else key
+            if isinstance(value, dict):
+                result.extend(extract_keys(value, new_prefix))
+            else:
+                result.append(new_prefix)
+        return result
+    
+    return extract_keys(d)
+
+def verify_mandatory_mapping(expected_json_files, mandatory_mapping):
+    """
+    Compare the fields in the '_expected.json' files with the mandatory fields.
+    """
+    mandatory_mapping_set = set(mandatory_mapping)
+    
+    for json_file in expected_json_files:
+        try:
+            with open(json_file, 'r') as f:
+                expected_data = json.load(f)
+                for expected in expected_data:
+                    extracted_fields = transform_dict_to_list(expected)
+                    for mandatory in mandatory_mapping_set:
+                        if mandatory not in extracted_fields:
+                            sys.exit(f"Error: {mandatory} field is not present in {json_file} expected")
+        except Exception as e:
+            sys.exit(f"Error reading the file '{json_file}': {e}")
+
+def find_expected_json_files(test_folder):
+    return list(test_folder.rglob('*_expected.json'))
+
+def verify(mandatory_mapping_path, integration: Path):
+    mandatory_mapping = load_mandatory_mapping(mandatory_mapping_path)    
+    if integration.name != 'wazuh-core':
+        test_folder = integration / 'test'
+        if not test_folder.exists() or not test_folder.is_dir():
+            sys.exit(f"No 'test' folder found in '{integration}'.")
+
+        expected_json_files = find_expected_json_files(test_folder)
+        if not expected_json_files:
+            sys.exit(f"No '_expected.json' files found in '{test_folder}' or its subfolders.")
+
+        verify_mandatory_mapping(expected_json_files, mandatory_mapping)
+
+def validator(ruleset_path: Path, integration: str):
+    integration_path = ruleset_path / 'integrations'
+    if not integration_path.exists() or not integration_path.is_dir():
+        sys.exit(f"Error: '{integration_path}' directory does not exist or not found.")
+
+    mandatory_mapping_path = ruleset_path / 'mandatory_mapping.yml'
+    if not mandatory_mapping_path.exists():
+        sys.exit(f'Error: {mandatory_mapping_path} file does not exist in the integration.')
+
+    if integration:
+        verify(mandatory_mapping_path, integration_path / integration)
+    else:
+        for integration in integration_path.iterdir():
+            if integration.is_dir():
+                verify(mandatory_mapping_path, integration)
+
+def run(args):
+    integration = args['integration']
+    env_path = Path(args['environment']).resolve()
+    ruleset_path = (env_path / "ruleset").resolve()
+    if not ruleset_path.is_dir():
+        print(f"Engine ruleset not found: {ruleset_path}")
+        sys.exit(1)
+
+    try:
+        print("Running mapping tests.")
+        validator(ruleset_path, integration)
+        print("Success execution")
+    except Exception as e:
+        print(f"Error running test: {e}")

--- a/src/engine/test/health_test/engine-health-test/src/health_test/mapping_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/mapping_validate.py
@@ -1,7 +1,10 @@
 import sys
 import json
-import shared.resource_handler as rs
 from pathlib import Path
+import shared.resource_handler as rs
+from health_test.error_managment import ErrorReporter
+
+reporter = ErrorReporter()
 
 def load_mandatory_mapping(mandatory_mapping_path: Path):
     """
@@ -11,7 +14,7 @@ def load_mandatory_mapping(mandatory_mapping_path: Path):
         mandatory_mapping = rs.ResourceHandler().load_file(mandatory_mapping_path.as_posix())
         return mandatory_mapping.get('mandatory_mapping', [])
     except Exception as e:
-        sys.exit(f"Error loading mandatory mapping from '{mandatory_mapping_path}'")
+        return f"Error loading mandatory mapping from '{mandatory_mapping_path}': {e}"
 
 def transform_dict_to_list(d):
     def extract_keys(d, prefix=""):
@@ -26,9 +29,10 @@ def transform_dict_to_list(d):
     
     return extract_keys(d)
 
-def verify_mandatory_mapping(expected_json_files, mandatory_mapping):
+def verify_mandatory_mapping(expected_json_files, mandatory_mapping, integration_name):
     """
     Compare the fields in the '_expected.json' files with the mandatory fields.
+    Report missing fields once per expected JSON file.
     """
     mandatory_mapping_set = set(mandatory_mapping)
     
@@ -36,11 +40,14 @@ def verify_mandatory_mapping(expected_json_files, mandatory_mapping):
         try:
             with open(json_file, 'r') as f:
                 expected_data = json.load(f)
+                missing_fields = set()
                 for expected in expected_data:
                     extracted_fields = transform_dict_to_list(expected)
-                    for mandatory in mandatory_mapping_set:
-                        if mandatory not in extracted_fields:
-                            sys.exit(f"Error: {mandatory} field is not present in {json_file} expected")
+                    missing_fields.update(mandatory for mandatory in mandatory_mapping_set if mandatory not in extracted_fields)
+                
+                if missing_fields:
+                    for field in missing_fields:
+                        reporter.add_error(integration_name, json_file, f"{field}")
         except Exception as e:
             sys.exit(f"Error reading the file '{json_file}': {e}")
 
@@ -58,14 +65,19 @@ def verify(mandatory_mapping_path, integration: Path):
         if not expected_json_files:
             sys.exit(f"No '_expected.json' files found in '{test_folder}' or its subfolders.")
 
-        verify_mandatory_mapping(expected_json_files, mandatory_mapping)
+        verify_mandatory_mapping(expected_json_files, mandatory_mapping, integration.name)
 
 def validator(ruleset_path: Path, integration: str):
+    """
+    Validate the mandatory mapping for all integrations or a specific one.
+    Accumulate and report errors at the end of the validation.
+    """
     integration_path = ruleset_path / 'integrations'
+    
     if not integration_path.exists() or not integration_path.is_dir():
         sys.exit(f"Error: '{integration_path}' directory does not exist or not found.")
 
-    mandatory_mapping_path = ruleset_path / 'mandatory_mapping.yml'
+    mandatory_mapping_path = ruleset_path / 'base-rules' / 'mandatory_mapping.yml'
     if not mandatory_mapping_path.exists():
         sys.exit(f'Error: {mandatory_mapping_path} file does not exist in the integration.')
 
@@ -75,11 +87,12 @@ def validator(ruleset_path: Path, integration: str):
         for integration in integration_path.iterdir():
             if integration.is_dir():
                 verify(mandatory_mapping_path, integration)
+    
+    reporter.exit_with_errors("There are fields that should be mapped and are not present in the expected event", integration_path)
 
 def run(args):
     integration = args['integration']
-    env_path = Path(args['environment']).resolve()
-    ruleset_path = (env_path / "ruleset").resolve()
+    ruleset_path = Path(args['ruleset']).resolve()
     if not ruleset_path.is_dir():
         print(f"Engine ruleset not found: {ruleset_path}")
         sys.exit(1)
@@ -90,3 +103,4 @@ def run(args):
         print("Success execution")
     except Exception as e:
         print(f"Error running test: {e}")
+        sys.exit(1)

--- a/src/engine/test/health_test/engine-health-test/src/health_test/metadata_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/metadata_validate.py
@@ -1,0 +1,117 @@
+import sys
+import shared.resource_handler as rs
+from pathlib import Path
+
+def validate_metadata(content):
+    """
+    Validate the metadata of an integration entry.
+    """
+    required_metadata_fields = ['module', 'title', 'description', 'compatibility', 'versions', 'references', 'author']
+    required_author_fields = ['name', 'date']
+    
+    metadata = content.get('metadata', {})
+    missing_fields = [field for field in required_metadata_fields if field not in metadata]
+    
+    if missing_fields:
+        raise Exception(f"Missing required metadata fields: {', '.join(missing_fields)}")
+    
+    # Check that certain fields are of type string
+    for field in ['module', 'title', 'description', 'compatibility']:
+        if not isinstance(metadata.get(field), str):
+            raise Exception(f"'{field}' must be of type string")
+    
+    author_metadata = metadata.get('author', {})
+    missing_author_fields = [field for field in required_author_fields if field not in author_metadata]
+    
+    if missing_author_fields:
+        raise Exception(f"Missing required author fields: {', '.join(missing_author_fields)}")
+    
+    # Check that author fields are of type string
+    for field in ['name', 'date']:
+        if not isinstance(author_metadata.get(field), str):
+            raise Exception(f"'{field}' in author metadata must be of type string")
+    
+    # Check that 'versions' and 'references' are lists
+    if not isinstance(metadata.get('versions', None), list):
+        raise Exception("'versions' must be of type list")
+    
+    if not isinstance(metadata.get('references', None), list):
+        raise Exception("'references' must be of type list")
+    
+
+def process_integration_entry(entry, resource_handler: rs.ResourceHandler):
+    """
+    Process a single integration entry, creating tasks for kvdbs and catalog validation.
+    """
+    original = resource_handler.load_file(entry)
+    
+    try:
+        validate_metadata(original)
+    except Exception as e:
+        sys.exit(f'Error in metadata validation for {entry}: {e}')
+    
+
+def validator(args, ruleset_path: Path, resource_handler: rs.ResourceHandler):
+    integration = args.get('integration')
+    asset = args.get('asset')
+
+    # Restrict specifying an asset without an integration
+    if asset and not integration:
+        sys.exit("Error: An asset cannot be specified without an integration.")
+
+    if integration:
+        integration_path = ruleset_path / 'integrations' / integration
+        if not integration_path.exists() or not integration_path.is_dir():
+            sys.exit(f"Integration '{integration}' not found in '{ruleset_path / 'integrations'}'.")
+        integrations_to_process = [integration_path]
+    else:
+        # If no integration is provided, process all integration directories
+        integrations_path = ruleset_path / 'integrations'
+        if not integrations_path.exists() or not integrations_path.is_dir():
+            sys.exit(f"Integrations directory not found in '{ruleset_path}'.")
+        integrations_to_process = [d for d in integrations_path.iterdir() if d.is_dir()]
+
+    for integration_path in integrations_to_process:
+        working_path = str(integration_path.resolve())
+        print(f'Validating metadata from: {working_path}')
+
+        manifest = dict()
+        try:
+            manifest_path = integration_path / 'manifest.yml'
+            manifest = resource_handler.load_file(manifest_path.as_posix())
+        except Exception as e:
+            sys.exit(f'Error: {e}')
+
+        for type_name in manifest.keys():
+            if type_name not in ['decoders', 'rules', 'outputs', 'filters']:
+                continue
+
+            path = ruleset_path / type_name
+            if not path.exists():
+                sys.exit(f'Error: {type_name} directory does not exist')
+
+            for entry in path.rglob('*.yml'):
+                original = resource_handler.load_file(entry)
+                name = original['name']
+                if asset:
+                    if asset == name:
+                        process_integration_entry(entry, resource_handler)
+                        break
+                else:
+                    if name in manifest[type_name]:
+                        process_integration_entry(entry, resource_handler)
+
+def run(args):
+    env_path = Path(args['environment']).resolve()
+    resource_handler = rs.ResourceHandler()
+
+    ruleset_path = (env_path / "ruleset").resolve()
+    if not ruleset_path.is_dir():
+        print(f"Engine ruleset not found: {ruleset_path}")
+        sys.exit(1)
+
+    try:
+        print("Running metadata tests.")
+        validator(args, ruleset_path, resource_handler)
+    except Exception as e:
+        print(f"Error running test: {e}")

--- a/src/engine/test/health_test/engine-health-test/src/health_test/schema_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/schema_validate.py
@@ -1,0 +1,115 @@
+import sys
+import json
+import shared.resource_handler as rs
+from pathlib import Path
+
+def load_custom_fields(custom_fields_path):
+    """
+    Load custom fields from 'custom_fields.yml'.
+    """
+    try:
+        custom_fields = rs.ResourceHandler().load_file(custom_fields_path.as_posix())
+        return custom_fields.get('custom_fields', [])
+    except Exception as e:
+        sys.exit(f"Error loading custom fields from '{custom_fields_path}'")
+
+def transform_dict_to_list(d):
+    def extract_keys(d, prefix=""):
+        result = []
+        for key, value in d.items():
+            new_prefix = f"{prefix}.{key}" if prefix else key
+            if isinstance(value, dict):
+                result.extend(extract_keys(value, new_prefix))
+            else:
+                result.append(new_prefix)
+        return result
+    
+    return extract_keys(d)
+
+def verify_schema_types(schema, expected_json_files, custom_fields):
+    """
+    Compare the fields in the '_expected.json' files with the schema and custom fields.
+    """
+    try:
+        with open(schema, 'r') as schema_file:
+            schema_data = json.load(schema_file)
+            schema_fields = set(schema_data.get("fields", {}).keys())
+    except Exception as e:
+        sys.exit(f"Error reading the JSON schema file '{schema}': {e}")
+
+    custom_fields_set = set(custom_fields)
+    
+    for json_file in expected_json_files:
+        try:
+            with open(json_file, 'r') as f:
+                expected_data = json.load(f)
+                for expected in expected_data:
+
+                    extracted_fields = transform_dict_to_list(expected)
+                    def is_custom_field(field, custom_fields_set):
+                        if '.' in field:
+                            prefix = field.split('.')[0]
+                            return prefix in custom_fields_set
+                        else:
+                            return field in custom_fields_set
+
+                    # Check for invalid fields
+                    invalid_fields = [
+                        field for field in extracted_fields
+                        if field not in schema_fields and not is_custom_field(field, custom_fields_set)
+                    ]
+                    
+                    if invalid_fields:
+                        sys.exit(f"Error: Invalid fields found in '{json_file}': {invalid_fields}")
+        except Exception as e:
+            sys.exit(f"Error reading the file '{json_file}': {e}")
+
+def find_expected_json_files(test_folder):
+    return list(test_folder.rglob('*_expected.json'))
+
+def verify(schema, integration: Path):
+    if integration.name != 'wazuh-core':
+        custom_fields_path = integration / 'test' / 'custom_fields.yml'
+        if not custom_fields_path.exists():
+            print(f'Error: {custom_fields_path} file does not exist in the integration.')
+            sys.exit(1)
+
+        custom_fields = load_custom_fields(custom_fields_path)    
+        test_folder = integration / 'test'
+        if not test_folder.exists() or not test_folder.is_dir():
+            sys.exit(f"No 'test' folder found in '{integration}'.")
+
+        expected_json_files = find_expected_json_files(test_folder)
+        if not expected_json_files:
+            sys.exit(f"No '_expected.json' files found in '{test_folder}' or its subfolders.")
+
+        verify_schema_types(schema, expected_json_files, custom_fields)
+
+def validator(schema, ruleset_path: Path, integration: str):
+    integration_path = ruleset_path / 'integrations'
+    if not integration_path.exists() or not integration_path.is_dir():
+        sys.exit(f"Error: '{integration_path}' directory does not exist or not found.")
+
+    if integration:
+        verify(schema, integration_path / integration)
+    else:
+        for integration in integration_path.iterdir():
+            if integration.is_dir():
+                verify(schema, integration)
+
+def run(args):
+    env_path = Path(args['environment']).resolve()
+    integration = args['integration']
+    schema = env_path / "engine/store/schema/engine-schema/0"
+
+    ruleset_path = (env_path / "ruleset").resolve()
+    if not ruleset_path.is_dir():
+        print(f"Engine ruleset not found: {ruleset_path}")
+        sys.exit(1)
+
+    try:
+        print("Running schema tests.")
+        validator(schema, ruleset_path, integration)
+        print("Success execution")
+    except Exception as e:
+        print(f"Error running test: {e}")

--- a/src/engine/tools/engine-suite/src/shared/resource_handler.py
+++ b/src/engine/tools/engine-suite/src/shared/resource_handler.py
@@ -172,6 +172,10 @@ class ResourceHandler:
             raise Exception(
                 f'{response["data"]["error"]}')
 
+    def validate_catalog_file(self, path: str, type: str, name: str, content: dict, namespace: str, format: Format):                
+        self._base_catalog_command(
+            path, type, name, yaml.dump(content, sort_keys=False), namespace, format, 'validate')
+
     def update_catalog_file(self, path: str, type: str, name: str, content: dict, namespace: str, format: Format):
         self._base_catalog_command(
             path, type, name, content, namespace, format, 'put')
@@ -190,6 +194,21 @@ class ResourceHandler:
             return None
 
         info = f'[{namespace}] Add {name} to catalog'
+
+        return exec.RecoverableTask(do_task, undo_task, info)
+
+    def get_validate_catalog_task(self, path: str,  type: str, name: str, content: dict, namespace: str, format: Format = Format.YML) -> exec.RecoverableTask:
+        def do_task():
+            self.validate_catalog_file(
+                path, type, name, content, namespace, format)
+            return None
+
+        def undo_task():
+            self.validate_catalog_file(
+                path, type, name, content, namespace, format)
+            return None
+
+        info = f'[{namespace}] Validate {name} from catalog'
 
         return exec.RecoverableTask(do_task, undo_task, info)
 


### PR DESCRIPTION
## Description

Automate the validation process for policies and assets when they are loaded into the engine. The workflow will check the following:
- [x] **Policy and Asset Validation**: Automatically validate that the policy and assets are correctly loaded into the engine.
- [x] **Schema and Metadata**: Ensure there are no typos in schema fields and that metadata definitions are correct.
- [x] **Mandatory Mappings**: Validate that required mappings (e.g., `wazuh.decoders`) are defined and present.