### PR TITLE
Vulnerability Detector - Update content generation branch (master)

### DIFF
--- a/.github/actions/vulnerability_scanner/content_generation/action.yml
+++ b/.github/actions/vulnerability_scanner/content_generation/action.yml
@@ -12,9 +12,9 @@ inputs:
     description: "Path to the configuration file"
     default: src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
 
-  wazuh_version:
+  content_version:
     required: true
-    description: "Identifier for the generated content. The content will be compressed into a file named 'vd_1.0.0_vd_<wazuh_version>.tar.xz'"
+    description: "Identifier for the generated content. The content will be compressed into a file named 'vd_1.0.0_vd_<content_version>.tar.xz'"
 
 runs:
   using: "composite"
@@ -50,7 +50,7 @@ runs:
       rm -rf queue/vd/state_track
       rm -rf queue/keystore
 
-      VD_FILENAME=vd_1.0.0_vd_${{ inputs.wazuh_version }}.tar.xz
+      VD_FILENAME=vd_1.0.0_vd_${{ inputs.content_version }}.tar.xz
 
       echo "Compressing into '${VD_FILENAME}' ..."
       tar -cJf ${VD_FILENAME} --owner=0 --group=0 --no-same-owner --no-same-permissions queue

--- a/.github/workflows/engine_vdscanner_efficacy.yml
+++ b/.github/workflows/engine_vdscanner_efficacy.yml
@@ -39,6 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
+    strategy:
+      fail-fast: false
+      matrix:
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
+          wazuh_version: ["4.8.0", "4.10.0"]
+
     steps:
       - name: Install dependencies (lzip)
         run: sudo apt-get install lzip
@@ -74,10 +80,11 @@ jobs:
 
       - name: Download feed
         run: |
-          # Download feed
           cd src
-          curl -LO https://packages.wazuh.com/deps/vulnerability_model_database/vd_1.0.0_vd_4.8.0.tar.xz
-          tar -xf vd_1.0.0_vd_4.8.0.tar.xz
+          vd_filename="vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz"
+
+          curl -LO https://packages.wazuh.com/deps/vulnerability_model_database/${vd_filename}
+          tar -xf ${vd_filename}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/engine_vdscanner_efficacy.yml
+++ b/.github/workflows/engine_vdscanner_efficacy.yml
@@ -110,7 +110,9 @@ jobs:
       # Upload HTML report
       - name: Upload HTML report
         if: always()
+        env:
+          REPORT_FILENAME: report_${{ matrix.wazuh_version }}.html
         uses: actions/upload-artifact@v4
         with:
-          name: report.html
-          path: ${{ github.workspace }}/src/report.html
+          name: ${REPORT_FILENAME}
+          path: ${{ github.workspace }}/src/${REPORT_FILENAME}

--- a/.github/workflows/engine_vdscanner_efficacy.yml
+++ b/.github/workflows/engine_vdscanner_efficacy.yml
@@ -42,8 +42,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
-          wazuh_version: ["4.8.0", "4.10.0"]
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<content_version>.tar.xz
+          # From 4.10.0 onwards we use 4.10.0 content
+          content_version: ["4.10.0"]
 
     steps:
       - name: Install dependencies (lzip)
@@ -81,7 +82,7 @@ jobs:
       - name: Download feed
         run: |
           cd src
-          vd_filename="vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz"
+          vd_filename="vd_1.0.0_vd_${{ matrix.content_version }}.tar.xz"
 
           curl -LO https://packages.wazuh.com/deps/vulnerability_model_database/${vd_filename}
           tar -xf ${vd_filename}
@@ -92,7 +93,7 @@ jobs:
 
       - name: Run tests
         env:
-          REPORT_OUTPUT: md_report_${{ matrix.wazuh_version }}.md
+          REPORT_OUTPUT: report.md
         run: |
           echo "REPORT_FILE=${REPORT_OUTPUT}" >> "$GITHUB_ENV"
           cd src
@@ -111,7 +112,7 @@ jobs:
       - name: Upload HTML report
         if: always()
         env:
-          REPORT_FILENAME: report_${{ matrix.wazuh_version }}.html
+          REPORT_FILENAME: report.html
         uses: actions/upload-artifact@v4
         with:
           name: ${REPORT_FILENAME}

--- a/.github/workflows/engine_vdscanner_efficacy.yml
+++ b/.github/workflows/engine_vdscanner_efficacy.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run tests
         env:
-          REPORT_OUTPUT: md_report.md
+          REPORT_OUTPUT: md_report_${{ matrix.wazuh_version }}.md
         run: |
           echo "REPORT_FILE=${REPORT_OUTPUT}" >> "$GITHUB_ENV"
           cd src

--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -19,6 +19,12 @@ on:
         required: true
         type: string
 
+      upload_to_s3:
+        description: 'Upload the generated content to S3'
+        required: false
+        default: false
+        type: boolean
+
 jobs:
   vulnerability_scanner_database_scheduled_update:
     if: github.event_name == 'schedule'
@@ -29,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
           # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
-          wazuh_version: ["4.8.0"]
+          wazuh_version: ["4.8.0", "4.10.0"]
 
     steps:
       # Checkout repository to the default branch
@@ -92,12 +98,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
-          wazuh_version: ["4.8.0"]
-
     steps:
       # Checkout repository to the default branch
       - name: Checkout repository
@@ -105,23 +105,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-
-      # Checkout to the tag. If it doesn't exist, continue with the branch
-      - name: Checkout to ${{ matrix.wazuh_version }}
-        run: |
-          if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.wazuh_version }}"; then
-            git checkout --quiet "tags/v${{ matrix.wazuh_version }}"
-          else
-            echo "Warning: Unable to find tag v${{ matrix.wazuh_version }}. Continuing with branch ${{ matrix.wazuh_version }}"
-            git show-branch --no-name "${{ matrix.wazuh_version }}" 2> /dev/null
-            if [ $? -eq 0 ]; then
-              git checkout --quiet "${{ matrix.wazuh_version }}"
-            else
-              echo "Warning: Unable to find branch ${{ matrix.wazuh_version }}. Exiting"
-              exit 1
-            fi
-          fi
-          echo "Git branch: $(git branch | grep "*")"
 
       ########################
       # Compilation          #
@@ -167,6 +150,7 @@ jobs:
         # Content upload       #
         ########################
         - name: Upload database to S3
+          if: ${{ inputs.upload_to_s3 }}
           run: |
             root_folder=$(pwd)
             bucket="${{ secrets.FEED_AWS_BUCKET }}"

--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -14,8 +14,8 @@ on:
 
   workflow_dispatch:
     inputs:
-      wazuh_version:
-        description: 'Identifier of the generated content. The generated file will be named vd_1.0.0_vd_<wazuh_version>.tar.xz'
+      content_version:
+        description: 'Identifier of the generated content. The generated file will be named vd_1.0.0_vd_<content_version>.tar.xz'
         required: true
         type: string
 
@@ -34,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<wazuh_version>.tar.xz
-          wazuh_version: ["4.8.0", "4.10.0"]
+          # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<content_version>.tar.xz
+          content_version: ["4.8.0", "4.10.0"]
 
     steps:
       # Checkout repository to the default branch
@@ -46,17 +46,17 @@ jobs:
           fetch-depth: 0
 
       # Checkout to the tag. If it doesn't exist, continue with the branch
-      - name: Checkout to ${{ matrix.wazuh_version }}
+      - name: Checkout to ${{ matrix.content_version }}
         run: |
-          if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.wazuh_version }}"; then
-            git checkout --quiet "tags/v${{ matrix.wazuh_version }}"
+          if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.content_version }}"; then
+            git checkout --quiet "tags/v${{ matrix.content_version }}"
           else
-            echo "Warning: Unable to find tag v${{ matrix.wazuh_version }}. Continuing with branch ${{ matrix.wazuh_version }}"
-            git show-branch --no-name "${{ matrix.wazuh_version }}" 2> /dev/null
+            echo "Warning: Unable to find tag v${{ matrix.content_version }}. Continuing with branch ${{ matrix.content_version }}"
+            git show-branch --no-name "${{ matrix.content_version }}" 2> /dev/null
             if [ $? -eq 0 ]; then
-              git checkout --quiet "${{ matrix.wazuh_version }}"
+              git checkout --quiet "${{ matrix.content_version }}"
             else
-              echo "Warning: Unable to find branch ${{ matrix.wazuh_version }}. Exiting"
+              echo "Warning: Unable to find branch ${{ matrix.content_version }}. Exiting"
               exit 1
             fi
           fi
@@ -74,7 +74,7 @@ jobs:
       - name: Generate vulnerability database
         uses: ./.github/actions/vulnerability_scanner/content_generation
         with:
-          wazuh_version: ${{ matrix.wazuh_version }}
+          content_version: ${{ matrix.content_version }}
 
       ########################
       # Content upload       #
@@ -84,7 +84,7 @@ jobs:
         run: |
           root_folder=$(pwd)
           bucket="${{ secrets.FEED_AWS_BUCKET }}"
-          file="vd_1.0.0_vd_${{ matrix.wazuh_version }}.tar.xz"
+          file="vd_1.0.0_vd_${{ matrix.content_version }}.tar.xz"
           dest_dir="deps/vulnerability_model_database"
           aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file} --acl public-read
         env:
@@ -120,7 +120,7 @@ jobs:
       - name: Generate vulnerability database
         uses: ./.github/actions/vulnerability_scanner/content_generation
         with:
-          wazuh_version: "pull_request"
+          content_version: "pull_request"
 
   vulnerability_scanner_database_manual_update:
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -146,7 +146,7 @@ jobs:
         - name: Generate vulnerability database
           uses: ./.github/actions/vulnerability_scanner/content_generation
           with:
-            wazuh_version: ${{ inputs.wazuh_version }}
+            content_version: ${{ inputs.content_version }}
 
         ########################
         # Content upload       #
@@ -156,7 +156,7 @@ jobs:
           run: |
             root_folder=$(pwd)
             bucket="${{ secrets.FEED_AWS_BUCKET }}"
-            file="vd_1.0.0_vd_${{ inputs.wazuh_version }}.tar.xz"
+            file="vd_1.0.0_vd_${{ inputs.content_version }}.tar.xz"
             dest_dir="deps/vulnerability_model_database"
             aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file} --acl public-read
           env:

--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -93,8 +93,10 @@ jobs:
           AWS_DEFAULT_REGION: 'us-west-1'
         shell: bash
 
+  # This is disabled in master because it's not implemented yet
   vulnerability_scanner_database_workflow_changes:
-    if: github.event_name == 'pull_request'
+    if: ${{ !always() }}
+    # if: github.event_name == 'pull_request'
 
     runs-on: ubuntu-latest
 

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -315,7 +315,7 @@ if [ $1 = 2 ]; then
   fi
 fi
 
-%define _vdfilename vd_1.0.0_vd_4.8.0.tar.xz
+%define _vdfilename vd_1.0.0_vd_4.10.0.tar.xz
 
 # Fresh install code block
 if [ $1 = 1 ]; then

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1142,7 +1142,7 @@ TransferShared()
 
 checkDownloadContent()
 {
-    VD_FILENAME='vd_1.0.0_vd_4.8.0.tar.xz'
+    VD_FILENAME='vd_1.0.0_vd_4.10.0.tar.xz'
     VD_FULL_PATH=${INSTALLDIR}/tmp/${VD_FILENAME}
 
     if [ "X${DOWNLOAD_CONTENT}" = "Xy" ]; then

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -28,8 +28,8 @@ constexpr auto EVENTS_BULK_SIZE {1};
 constexpr auto EVENTS_QUEUE_PATH = "queue/vd/event";
 constexpr auto MICROSEC_FACTOR {1000000};
 
-constexpr auto COMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.8.0.tar.xz"};
-constexpr auto DECOMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.8.0.tar"};
+constexpr auto COMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.10.0.tar.xz"};
+constexpr auto DECOMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.10.0.tar"};
 constexpr auto VD_STATE_QUEUE_PATH = "queue/vd/state_track";
 constexpr auto VD_KEYSTORE_PATH = "queue/keystore";
 constexpr auto VD_DATABASE_PATH {"queue/vd"};

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/config.content_generation.json
@@ -1,7 +1,7 @@
 {
     "vulnerability-detection": {
         "enabled": "yes",
-        "index-status": "yes"
+        "index-status": "no"
     },
     "indexer": {
         "enabled": "yes",


### PR DESCRIPTION
|Related issue|
|---|
| #25782 |

> [!NOTE]
> This PR is the counterpart of https://github.com/wazuh/wazuh/pull/25798. Given that upward merges from 4.x to 5.x don't exist anymore we need to bring the changes this way

## Description
This PR introduces a new pipeline for the VD-generated content. It now uses 4.10.0 branch to generate the DBs and runs the efficacy tests using this new content

To do so it:
- Updates the workflows to also run on 4.10.0
- Updates the logic in code to retrieve the newly generated compressed DB

## New content
New content was generated here:
- https://github.com/wazuh/wazuh/actions/runs/10950973244/job/30407211577