### PR TITLE
Add efficacy tests for Canonical products

### DIFF
--- a/src/engine/source/vdscanner/qa/test_false_negative_data/045/Readme.md
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/045/Readme.md
@@ -1,0 +1,16 @@
+# Description
+
+Vulnerability detection validation for `perl-modules` and `linux-hwe-6.8` on Ubuntu.
+
+# Platforms
+
+## Windows
+
+- Input events
+  - [001](input_001.json)
+  - [002](input_001.json)
+
+| Name           | Version             | Feed      | CVE IDs        | Expected       |
+| ---------------| ------------------- | --------- | -------------- | -------------- |
+| perl-modules   | 5.7.8-12ubuntu0.3   | Canonical | CVE-2007-4829  | Not Vulnerable |
+| linux-hwe-6.8  | 6.7.0-40.40~22.04.3 | Canonical | CVE-2024-36001 | vulnerable     |

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/045/Readme.md
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/045/Readme.md
@@ -4,13 +4,20 @@ Vulnerability detection validation for `perl-modules` and `linux-hwe-6.8` on Ubu
 
 # Platforms
 
-## Windows
+## Ubuntu Hardy
 
 - Input events
   - [001](input_001.json)
-  - [002](input_001.json)
 
 | Name           | Version             | Feed      | CVE IDs        | Expected       |
 | ---------------| ------------------- | --------- | -------------- | -------------- |
 | perl-modules   | 5.7.8-12ubuntu0.3   | Canonical | CVE-2007-4829  | Not Vulnerable |
-| linux-hwe-6.8  | 6.7.0-40.40~22.04.3 | Canonical | CVE-2024-36001 | vulnerable     |
+
+## Ubuntu Jammy
+
+- Input events
+  - [002](input_002.json)
+
+| Name           | Version             | Feed      | CVE IDs        | Expected       |
+| ---------------| ------------------- | --------- | -------------- | -------------- |
+| linux-hwe-6.8  | 6.7.0-40.40~22.04.3 | Canonical | CVE-2024-36001 | Vulnerable     |

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/045/expected_001.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/045/expected_001.out
@@ -1,0 +1,3 @@
+[
+    "No match due to default status for Package: perl-modules, Version: 5.7.8-12ubuntu0.3 while scanning for Vulnerability: CVE-2007-4829"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/045/expected_002.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/045/expected_002.out
@@ -1,0 +1,3 @@
+[
+    "Match found, the package 'linux-hwe-6.8', is vulnerable to 'CVE-2024-36001'. Current version: '6.7.0-40.40~22.04.3' (less than '6.8.0-40.40~22.04.3' or equal to ''). - Agent '' (ID: '002', Version: '')."
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/045/input_001.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/045/input_001.json
@@ -1,0 +1,43 @@
+{
+  "type": "packagelist",
+  "agent": {
+    "id": "002"
+  },
+  "packages": [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": " ",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "perl-modules",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": " ",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "5.7.8-12ubuntu0.3"
+    }
+  ],
+  "hotfixes": [],
+  "os": {
+    "architecture": "x86_64",
+    "checksum": "1708734360392506855",
+    "hostname": "qa_test",
+    "codename": "hardy",
+    "major_version": "22",
+    "minor_version": "04",
+    "name": "Ubuntu",
+    "patch": "3",
+    "platform": "ubuntu",
+    "version": "Ubuntu 8.04 LTS (The Hardy Heron)",
+    "kernel_release": "6.5.0-18-generic",
+    "scan_time": "2024/02/24 00:26:02",
+    "kernel_name": "Linux",
+    "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/045/input_002.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/045/input_002.json
@@ -1,0 +1,43 @@
+{
+  "type": "packagelist",
+  "agent": {
+    "id": "002"
+  },
+  "packages": [
+    {
+      "architecture": "amd64",
+      "checksum": "b800d14290607fe293713459d384464f75dc46d4",
+      "description": " ",
+      "format": "deb",
+      "groups": " ",
+      "install_time": " ",
+      "item_id": "bde447c43d09d5967fe308dbf7688d645f1e1d9c",
+      "location": " ",
+      "multiarch": "same",
+      "name": "linux-hwe-6.8",
+      "priority": "optional",
+      "scan_time": "2024/08/20 12:30:36",
+      "size": 5768,
+      "source": " ",
+      "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
+      "version": "6.7.0-40.40~22.04.3"
+    }
+  ],
+  "hotfixes": [],
+  "os": {
+    "architecture": "x86_64",
+    "checksum": "1708734360392506855",
+    "hostname": "qa_test",
+    "codename": "jammy",
+    "major_version": "22",
+    "minor_version": "04",
+    "name": "Ubuntu",
+    "patch": "3",
+    "platform": "ubuntu",
+    "version": "Ubuntu 22.04 LTS (The Jammy Jellyfish)",
+    "kernel_release": "6.5.0-18-generic",
+    "scan_time": "2024/02/24 00:26:02",
+    "kernel_name": "Linux",
+    "kernel_version": "#18~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb  7 11:40:03 UTC 2"
+  }
+}


### PR DESCRIPTION
|Related issue|
|---|
| Closes #24956 |

## Description

This pull requests adds a new VD efficacy tests that ensures correct vulnerability detection is made when a source package contains several binaries.