### PR TITLE
Add YARA wazuh-template fields

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -1135,6 +1135,9 @@
               }
             }
           },
+          "file": {
+            "type": "keyword"
+          },
           "protocol": {
             "type": "keyword"
           },
@@ -2710,6 +2713,37 @@
           "parameters": {
             "properties": {
               "extra_args": {
+                "type": "keyword"
+              }
+            }
+          },
+          "YARA": {
+            "properties": {
+              "reference": {
+                "type": "keyword"
+              },
+              "api_customer": {
+                "type": "keyword"
+              },
+              "log_type": {
+                "type": "keyword"
+              },
+              "scanned_file": {
+                "type": "keyword"
+              },
+              "rule_author": {
+                "type": "keyword"
+              },
+              "rule_name": {
+                "type": "keyword"
+              },
+              "rule_description": {
+                "type": "keyword"
+              },
+              "published_date": {
+                "type": "date"
+              },
+              "tags": {
                 "type": "keyword"
               }
             }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-dashboard-plugins/issues/6964|

## Description

To PR enhance the visibility and searchability of YARA integration events within the Wazuh platform, we need to update the OpenSearch template to include new fields pulled from YARA integration. This will ensure that all relevant data points from the YARA information is indexed properly, allowing for more efficient searches and data analysis.

## Functional Requirements

Modify the existing OpenSearch template to include fields from the Intune integration, such as:
- "data.file"
- "data.YARA.reference"
- "data.YARA.api_customer"
- "data.YARA.log_type"
- "data.YARA.scanned_file"
- "data.YARA.rule_author"
- "data.YARA.rule_name"
- "data.YARA.rule_description"
