### PR TITLE
Add efficacy test for `TeraTerm`

### DIFF
--- a/src/engine/source/vdscanner/qa/test_false_negative_data/042/Readme.md
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/042/Readme.md
@@ -1,0 +1,18 @@
+# Description
+
+Vulnerability detection validation for `TeraTerm` on Windows.
+
+# Platforms
+
+## Windows
+
+- Input events
+  - [001](input_001.json)
+  - [002](input_002.json)
+
+| Name               | Version | Feed | CVE IDs        | Expected       |
+| ------------------ | ------- | ---- | -------------- | -------------- |
+| TeraTerm           | 4.63    | NVD  | CVE-2017-2193  | Vulnerable     |
+| TeraTerm           | 4.63    | NVD  | CVE-2023-48795 | Vulnerable     |
+| TeraTerm           | 5.2     | NVD  | CVE-2017-2193  | Not vulnerable |
+| TeraTerm           | 5.2     | NVD  | CVE-2023-48795 | Not vulnerable |

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/042/expected_001.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/042/expected_001.out
@@ -1,0 +1,5 @@
+[
+    "Translation for package 'Tera Term 4.63' on platform 'windows' found in Level 2 cache.",
+    "Match found, the package 'tera_term', is vulnerable to 'CVE-2017-2193'. Current version: '4.63' (less than '' or equal to '4.94'). - Agent '' (ID: '041', Version: '').",
+    "Match found, the package 'tera_term', is vulnerable to 'CVE-2023-48795'. Current version: '4.63' (less than '' or equal to '5.1'). - Agent '' (ID: '041', Version: '')."
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/042/expected_002.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/042/expected_002.out
@@ -1,0 +1,5 @@
+[
+    "Translation for package 'Tera Term 4.63' on platform 'windows' found in Level 2 cache.",
+    "No match due to default status for Package: tera_term, Version: 5.2 while scanning for Vulnerability: CVE-2017-2193",
+    "No match due to default status for Package: tera_term, Version: 5.2 while scanning for Vulnerability: CVE-2023-48795"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/042/input_001.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/042/input_001.json
@@ -1,0 +1,36 @@
+{
+  "type": "packagelist",
+  "agent": {
+    "id": "041"
+  },
+  "packages": [
+    {
+      "format": "win",
+      "name": "Tera Term 4.63",
+      "vendor": " ",
+      "install_time": "2024-08-27T20:15:18+00:00",
+      "version": " ",
+      "architecture": " ",
+      "description": " ",
+      "size": 0,
+      "location": "C:\\Users\\Administrator\\AppData\\Local\\Postman",
+      "priority": " ",
+      "checksum": "c4b71764ef99e7002f3132852a84a5c1e1b25fcc",
+      "item_id": "61e71c9fe4bab8cd4a5eb2a10ec16c99f8326c7b"
+    }
+  ],
+  "hotfixes": [],
+  "os": {
+    "architecture": "x86_64",
+    "checksum": "1691178971959743855",
+    "hostname": "fd9b83c25f30",
+    "major_version": "10",
+    "minor_version": "0",
+    "build": "19045",
+    "name": "Microsoft Windows 10 Pro",
+    "display_version": "22H2",
+    "platform": "windows",
+    "version": "10.0.19045",
+    "scan_time": "2023/08/04 19:56:11"
+  }
+}

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/042/input_002.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/042/input_002.json
@@ -1,0 +1,36 @@
+{
+  "type": "packagelist",
+  "agent": {
+    "id": "041"
+  },
+  "packages": [
+    {
+      "format": "win",
+      "name": "Tera Term version 5.2",
+      "vendor": "TeraTerm Project",
+      "install_time": "2024-08-27T20:15:18+00:00",
+      "version": "5.2",
+      "architecture": " ",
+      "description": " ",
+      "size": 0,
+      "location": "C:\\Users\\Administrator\\AppData\\Local\\Postman",
+      "priority": " ",
+      "checksum": "c4b71764ef99e7002f3132852a84a5c1e1b25fcc",
+      "item_id": "61e71c9fe4bab8cd4a5eb2a10ec16c99f8326c7b"
+    }
+  ],
+  "hotfixes": [],
+  "os": {
+    "architecture": "x86_64",
+    "checksum": "1691178971959743855",
+    "hostname": "fd9b83c25f30",
+    "major_version": "10",
+    "minor_version": "0",
+    "build": "19045",
+    "name": "Microsoft Windows 10 Pro",
+    "display_version": "22H2",
+    "platform": "windows",
+    "version": "10.0.19045",
+    "scan_time": "2023/08/04 19:56:11"
+  }
+}


### PR DESCRIPTION
|Related issue|
|---|
| #25001 |

## Description

This PR adds a new efficacy test for the TeraTerm package on Windows ecosystems.

## Results

Efficacy tests executed locally:
```bash
# python3 -m pytest engine/source/vdscanner/qa/test_efficacy_log.py -v      
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.12, pytest-7.2.2, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.10.12', 'Platform': 'Linux-5.14.0-427.35.1.el9_4.x86_64-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.2.2', 'pluggy': '1.4.0'}, 'Plugins': {'metadata': '3.1.1', 'testinfra': '5.0.0', 'md-report': '0.6.2', 'html': '4.1.1'}}
rootdir: /home/wazuh-master/src
plugins: metadata-3.1.1, testinfra-5.0.0, md-report-0.6.2, html-4.1.1
collected 37 items                                                                                                                                                                           

engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log0] PASSED                                                                             [  2%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log1] PASSED                                                                             [  5%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log2] PASSED                                                                             [  8%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log3] PASSED                                                                             [ 10%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log4] PASSED                                                                             [ 13%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log5] PASSED                                                                             [ 16%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log6] PASSED                                                                             [ 18%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log7] PASSED                                                                             [ 21%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log8] PASSED                                                                             [ 24%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log9] PASSED                                                                             [ 27%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log10] PASSED                                                                            [ 29%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log11] PASSED                                                                            [ 32%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log12] PASSED                                                                            [ 35%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log13] PASSED                                                                            [ 37%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log14] PASSED                                                                            [ 40%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log15] PASSED                                                                            [ 43%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log16] PASSED                                                                            [ 45%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log17] PASSED                                                                            [ 48%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log18] PASSED                                                                            [ 51%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log19] PASSED                                                                            [ 54%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log20] PASSED                                                                            [ 56%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log21] PASSED                                                                            [ 59%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log22] PASSED                                                                            [ 62%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log23] PASSED                                                                            [ 64%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log24] PASSED                                                                            [ 67%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log25] PASSED                                                                            [ 70%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log26] PASSED                                                                            [ 72%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log27] PASSED                                                                            [ 75%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log28] PASSED                                                                            [ 78%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log29] PASSED                                                                            [ 81%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log30] PASSED                                                                            [ 83%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log31] PASSED                                                                            [ 86%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_negatives[run_process_and_monitor_log32] PASSED                                                                            [ 89%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_positives[run_process_and_monitor_log0] PASSED                                                                             [ 91%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_positives[run_process_and_monitor_log1] PASSED                                                                             [ 94%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_positives[run_process_and_monitor_log2] PASSED                                                                             [ 97%]
engine/source/vdscanner/qa/test_efficacy_log.py::test_false_positives[run_process_and_monitor_log3] PASSED                                                                             [100%]

=============================================================================== 37 passed in 229.75s (0:03:49) ===============================================================================
```