### PR TITLE
Added the same rules for powershell core but updated groups

### DIFF
--- a/ruleset/rules/0915-win-powershell_rules.xml
+++ b/ruleset/rules/0915-win-powershell_rules.xml
@@ -6,7 +6,7 @@
   Powershell Rules 91801 - 92000
 -->
 
-<group name="windows, powershell,">
+<group name="windows,powershell,windows_powershell">
 
   <!-- Powershell Operational grouping -->
   <rule id="91801" level="0">
@@ -462,3 +462,465 @@
   </rule>
 
 </group>
+
+
+<!--
+  Copyright (C) 2015, Wazuh Inc.,   2024, Zafer Balkan zafer@zaferbalkan.com
+-->
+<group name="windows,powershell,powershell_core,">
+
+  <!-- Powershell Operational grouping -->
+  <rule id="91901" level="0">
+    <if_sid>60000, 60010</if_sid>
+    <field name="win.system.channel">^PowerShellCore/Operational$</field>
+    <options>no_full_log</options>
+    <description>Group of Windows rules for the PowerShellCore/Operational channel.</description>
+  </rule>
+
+  <!-- Powershell Script Block rules -->
+  <rule id="91902" level="0">
+    <if_sid>91901</if_sid>
+    <field name="win.eventdata.ScriptBlockId" type="pcre2">.+</field>
+    <options>no_full_log</options>
+    <description>Group of Windows rules for the PowerShellCore/Operational channel.</description>
+  </rule>
+
+  <rule id="91903" level="14">
+    <if_sid>91902</if_sid>
+    <field name="win.system.message" type="pcre2">CopyFromScreen</field>
+    <options>no_full_log</options>
+    <description>Screen capture method invoked from PowerShell script.</description>
+    <mitre>
+      <id>T1113</id>
+    </mitre>
+  </rule>
+
+  <rule id="91905" level="3">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-ADComputer</field>
+    <options>no_full_log</options>
+    <description>Executed Powershell script "Get-ADComputer" executed.</description>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="91906" level="3">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-NetUser</field>
+    <options>no_full_log</options>
+    <description>Powershell script "Get-NetUser executed".</description>
+    <mitre>
+      <id>T1087.002</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91907" level="0">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-ItemProperty</field>
+    <options>no_full_log</options>
+    <description>Powershell script did a query using Get-ItemProperty</description>
+  </rule>
+
+  <rule id="91908" level="3">
+    <if_sid>91907</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)-Path\sHK(CU|LM)</field>
+    <options>no_full_log</options>
+    <description>Powershell script queried registry value</description>
+    <mitre>
+      <id>T1012</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91909" level="10">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)FromBase64String</field>
+    <options>no_full_log</options>
+    <description>Powershell script may be using Base64 decoding method</description>
+    <mitre>
+      <id>T1140</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91910" level="10">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)CreateThread</field>
+    <options>no_full_log</options>
+    <description>Powershell script may be executing suspicious code with CreateThread API</description>
+    <mitre>
+      <id>T1106</id>>
+    </mitre>
+  </rule>
+
+  <rule id="91911" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Expand-Archive</field>
+    <options>no_full_log</options>
+    <description>Powershell script executed "Expand-Archive"</description>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="91912" level="0">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Remove-Item\s-Path</field>
+    <options>no_full_log</options>
+    <description>Powershell script executed an object deletion</description>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91913" level="3">
+    <if_sid>91912</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\sHK(LM|CU)\:</field>
+    <options>no_full_log</options>
+    <description>Powershell script deleted a registry key from an object</description>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91914" level="4">
+    <if_sid>91913</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\\\\Software\\\\Classes\\\\Folder</field>
+    <options>no_full_log</options>
+    <description>Powershell script deleted an auto start entry registry key</description>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91915" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-Process</field>
+    <options>no_full_log</options>
+    <description>Powershell executing process discovery</description>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="91916" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(\$env\:TEMP|\$env\:USERNAME|\$env\:COMPUTERNAME|\$env\:USERDOMAIN|\$PID)</field>
+    <options>no_full_log</options>
+    <description>Powershell script querying system environment variables</description>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91917" level="4">
+    <if_sid>91916, 91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)ConvertSidToStringSid</field>
+    <options>no_full_log</options>
+    <description>Powershell script executed "ConvertSidToStringSid" API. Possible domain SID enumeration</description>
+    <mitre>
+      <id>T1033</id>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91918" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)new-service</field>
+    <options>no_full_log</options>
+    <description>Powershell script executed "New-Service" command</description>
+    <mitre>
+      <id>T1543.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="91919" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)ChildItem</field>
+    <options>no_full_log</options>
+    <description>Powershell script searching filesystem</description>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="91920" level="4">
+    <if_sid>91919</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)recurse</field>
+    <options>no_full_log</options>
+    <description>Powershell script recursively collected files from a filesystem search</description>
+    <mitre>
+      <id>T1083</id>
+      <id>T1119</id>
+    </mitre>
+  </rule>
+
+  <rule id="91921" level="4">
+    <if_sid>91920, 91921</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Compress-Archive</field>
+    <options>no_full_log</options>
+    <description>Powershell script created a compressed file from results of filesystem search</description>
+    <mitre>
+      <id>T1083</id>
+      <id>T1074.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91922" level="12">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Invoke-Command</field>
+    <options>no_full_log</options>
+    <description>Powershell script used "Invoke-command" cmdlet to execute sub script</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91923" level="14">
+    <if_sid>91922</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(ComputerName|Cn)</field>
+    <options>no_full_log</options>
+    <description>Powershell script used "Invoke-command" cmdlet to execute code on remote computer</description>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1021.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="91924" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-Clipboard</field>
+    <options>no_full_log</options>
+    <description>Powershell collected clipboard data</description>
+    <mitre>
+      <id>T1115</id>
+    </mitre>
+  </rule>
+
+  <rule id="91925" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Compress-7Zip</field>
+    <options>no_full_log</options>
+    <description>Powershell executed file compression</description>
+    <mitre>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91926" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Copy-Item</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "Copy-Item"</description>
+    <mitre>
+      <id>T1560</id>
+    </mitre>
+  </rule>
+
+  <rule id="91927" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Set-WmiInstance</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "Set-WmiInstance". Possible creation or update of a WMI instance</description>
+    <mitre>
+      <id>T1560</id>
+    </mitre>
+  </rule>
+
+  <rule id="91928" level="6">
+    <if_sid>91927</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Text\.Encoding</field>
+    <options>no_full_log</options>
+    <description>Powershell executed a creation or update of a WMI instance with encoded values</description>
+    <mitre>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="91929" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)GetComputerNameEx</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "GetComputerNameEx". Possible system configuration discovery</description>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91930" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)NetWkstaGetInfo</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "NetWkstaGetInfo". Possible network configuration discovery</description>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="91931" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)GetUserNameEx</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "GetUserNameEx". Possible user information discovery</description>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="91932" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)CreateToolhelp32Snapshot</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "CreateToolhelp32Snapshot". Possible process discovery</description>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="91933" level="3">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(Get-ChildItem|gci).+(env\:windir|system32|windows)</field>
+    <options>no_full_log</options>
+    <description>Possible discovery activity: Powershell executed "Get-ChildItem" command on a system folder</description>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="91934" level="6">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(SetCreationTime|SetLastAccessTime|SetLastWriteTime)</field>
+    <options>no_full_log</options>
+    <description>Powershell executed a command that modifies file timestamp, possible timestomp attempt</description>
+    <mitre>
+      <id>T1070.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="91935" level="6">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)AntiVirusProduct</field>
+    <options>no_full_log</options>
+    <description>Powershell tampering with WMI AntiVirusProduct class - Antivirus Software discovery</description>
+    <mitre>
+      <id>T1518.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91936" level="3">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall</field>
+    <options>no_full_log</options>
+    <description>Powershell tampering software installation info on system registry</description>
+    <mitre>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="91937" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(Get-Content.+\-Stream|IEX|Invoke-Expresion)</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "Get-Content -Stream or Invoke-Expresion". Possible string execution as code</description>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91938" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_BIOS</field>
+    <options>no_full_log</options>
+    <description>Powershell queried Win32_BIOS. Possible sandbox detection activity</description>
+    <mitre>
+      <id>T1497</id>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="91939" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_ComputerSystem</field>
+    <options>no_full_log</options>
+    <description>Powershell queried Win32_ComputerSystem. Possible system discovery activity</description>
+    <mitre>
+      <id>T1497</id>
+      <id>T1033</id>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="91940" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_PnPEntity</field>
+    <options>no_full_log</options>
+    <description>Powershell queried Win32_PnPEntity. Possible devices/adapter discovery activity</description>
+    <mitre>
+      <id>T1120</id>
+    </mitre>
+  </rule>
+
+  <rule id="91941" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)(gwmi|get-wmiobject).+ Win32_Process</field>
+    <options>no_full_log</options>
+    <description>Powershell queried Win32_Process. Possible process discovery activity</description>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="91942" level="4">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Get-Item \-Path</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "Get-Item -Path". Script trying to see files in path</description>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="91943" level="3">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)New-ItemProperty.+\-Path</field>
+    <options>no_full_log</options>
+    <description>Powershell executed "New-ItemProperty -Path". Possible addition of new item to registry</description>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91944" level="12">
+    <if_sid>91943</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run</field>
+    <options>no_full_log</options>
+    <description>Possible addition of new item to Windows startup registry</description>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="91945" level="10">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)Microsoft.Office.Interop.Outlook</field>
+    <options>no_full_log</options>
+    <description>Outlook add-in was loaded by powershell, possible use for email collection</description>
+    <mitre>
+      <id>T1114.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="91946" level="10">
+    <if_sid>91902</if_sid>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)::CreateFromDirectory</field>
+    <options>no_full_log</options>
+    <description>Powershell used .NET compression method, possible data extraction operation</description>
+    <mitre>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+</group>
+


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/25912 |

## Description

The `powershell.exe`, aka the `Windows Powershell`, is using `Microsoft-Windows-PowerShell/Operational` event channel. On the other hand, `pwsh.exe`, aka the `PowerShell Core, is using `PowerShellCore/Operational` event channel.

The second is not covered by Wazuh yet. Therefore, in order to cover both but being able to flexible in updating them later, it makes sense to update the ruleset that covers both in two separate groups.

The ruleset update focuses on only providing PowerShell rules for the new channel while updating the group names to `windows_powershell` and `powershell_core` to be able to filter easily.

I have been using this in production for a while.

## Configuration options

These event channels must be enabled on agent side.

```xml
	<!-- Powershell script logging -->
	<localfile>
		<location>Microsoft-Windows-PowerShell/Operational</location>
		<log_format>eventchannel</log_format>
	</localfile>
	<!-- Powershell script logging for new PowerShell -->
	<localfile>
		<location>PowerShellCore/Operational</location>
		<log_format>eventchannel</log_format>
	</localfile>
```

## Logs/Alerts example



## Tests



<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors