### PR TITLE
Fix integration test for remoted tier 2

### DIFF
--- a/.github/workflows/integration-tests-remoted-tier-2.yml
+++ b/.github/workflows/integration-tests-remoted-tier-2.yml
@@ -52,7 +52,7 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
-          echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_AUTHD="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
           echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf
           echo "" >> ./etc/preloaded-vars.conf
@@ -71,8 +71,8 @@ jobs:
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
-      # Run analysisd integration tests.
-      - name: Run analysisd integration tests
+      # Run remoted integration tests.
+      - name: Run remoted integration tests
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_remoted/


### PR DESCRIPTION
|Related issue|
|---|
|#25564|


## Description

The objective of this pull request is to fix the bug in the remoted integration test with tear 2. The problem was that when setting the environment variables for the manager installation, the auhtd was disabled, which made it impossible for the manager to connect to the agent.

Test: https://github.com/wazuh/wazuh/actions/runs/11032481618