### PR TITLE
Add ARM64 Support for Wazuh Manager Packages

### DIFF
--- a/.github/actions/ghcr-pull-and-push/retag_image.sh
+++ b/.github/actions/ghcr-pull-and-push/retag_image.sh
@@ -15,11 +15,13 @@ IMAGES_LIST=(
     "pkg_deb_agent_builder_arm64"
     "pkg_deb_agent_builder_armhf"
     "pkg_deb_manager_builder_amd64"
+    "pkg_deb_manager_builder_arm64"
     "pkg_rpm_agent_builder_i386"
     "pkg_rpm_agent_builder_amd64"
     "pkg_rpm_agent_builder_arm64"
     "pkg_rpm_agent_builder_armhf"
     "pkg_rpm_manager_builder_amd64"
+    "pkg_rpm_manager_builder_arm64"
     "pkg_rpm_legacy_builder_i386"
     "pkg_rpm_legacy_builder_amd64"
 )

--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -16,11 +16,12 @@ on:
         required: false
       architecture:
         description: |
-          Architecture of the package [amd64, x86_64]
+          Architecture of the package [amd64, x86_64, arm64]
         type: choice
         options:
           - amd64
           - x86_64
+          - arm64
         required: true
       system:
         description: 'Package format [deb, rpm]'
@@ -90,7 +91,7 @@ on:
 
 jobs:
   Build-manager-packages:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-22.04' }}
     timeout-minutes: 35
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
@@ -104,13 +105,22 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Set ARCH
+        run: |
+            if [ ${{ inputs.architecture }} = 'x86_64' ]; then
+              arch="amd64"
+            else
+              arch=${{ inputs.architecture }}
+            fi
+            echo "ARCH=$arch" >> $GITHUB_ENV;
+
       - name: Set tag and container name
         run: |
           VERSION=$(sed 's/^v\([0-9]*\.[0-9]*\.[0-9]*\)/\1/' $GITHUB_WORKSPACE/src/VERSION)
           if [ "${{ inputs.docker_image_tag }}" == "auto" ]; then echo "TAG=$VERSION" >> $GITHUB_ENV;
           elif [ "${{ inputs.docker_image_tag }}" == "developer" ]; then echo "TAG=$(sed 's|[/\]|--|g' <<< ${{ github.ref_name }})" >> $GITHUB_ENV;
           else echo "TAG=${{ inputs.docker_image_tag }}" >> $GITHUB_ENV; fi
-          echo "CONTAINER_NAME=pkg_${{ inputs.system }}_manager_builder_amd64" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=pkg_${{ inputs.system }}_manager_builder_${{ env.ARCH }}" >> $GITHUB_ENV
 
       - name: Download docker image for package building
         run: |
@@ -126,8 +136,8 @@ jobs:
           if [ "${{ inputs.checksum }}" == "true" ]; then FLAGS+="--checksum "; fi
           if [ "${{ inputs.debug}}" == "true" ]; then FLAGS+="--debug "; fi
           # Every call to this workflow will be internally managed as amd64, which is synonymous with x86_64
-          echo "generate_package.sh -a amd64 --tag ${{ env.TAG }} --system ${{ inputs.system }} $FLAGS"
-          bash generate_package.sh -a amd64 --tag ${{ env.TAG }} --system ${{ inputs.system }} $FLAGS
+          echo "generate_package.sh -a ${{ env.ARCH }} --tag ${{ env.TAG }} --system ${{ inputs.system }} $FLAGS"
+          bash generate_package.sh -a ${{ env.ARCH }} --tag ${{ env.TAG }} --system ${{ inputs.system }} $FLAGS
           echo "PACKAGE_NAME=$(find /tmp -maxdepth 1 -type f -name *manager*.${{ inputs.system }} -exec basename {} 2>/dev/null \;)" | tee -a $GITHUB_ENV
 
       - name: Test install built manager

--- a/.github/workflows/packages-upload-images.yml
+++ b/.github/workflows/packages-upload-images.yml
@@ -34,10 +34,20 @@ jobs:
               - 'packages/generate_package.sh'
               - 'packages/debs/amd64/manager/**'
               - 'packages/debs/utils/**'
+            pkg_deb_manager_builder_arm64:
+              - 'packages/build.sh'
+              - 'packages/generate_package.sh'
+              - 'packages/debs/arm64/manager/**'
+              - 'packages/debs/utils/**'
             pkg_rpm_manager_builder_amd64:
               - 'packages/build.sh'
               - 'packages/generate_package.sh'
               - 'packages/rpms/amd64/manager/**'
+              - 'packages/rpms/utils/**'
+            pkg_rpm_manager_builder_arm64:
+              - 'packages/build.sh'
+              - 'packages/generate_package.sh'
+              - 'packages/rpms/arm64/manager/**'
               - 'packages/rpms/utils/**'
             pkg_deb_agent_builder_amd64:
               - 'packages/build.sh'
@@ -105,14 +115,28 @@ jobs:
       - name: Request pkg_deb_manager_builder_amd64 update
         if: steps.changes.outputs.pkg_deb_manager_builder_amd64 == 'true'
         run: |
-          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=deb -f source_reference=${{ github.ref_name }}
+          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f architecture=amd64 -f docker_image_tag=${{ env.TAG }} -f system=deb -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Request pkg_rpm_manager_builder_amd64 update
         if: steps.changes.outputs.pkg_rpm_manager_builder_amd64 == 'true'
         run: |
-          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f source_reference=${{ github.ref_name }}
+          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f architecture=amd64 -f docker_image_tag=${{ env.TAG }} -f system=rpm -f source_reference=${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Request pkg_deb_manager_builder_arm64 update
+        if: steps.changes.outputs.pkg_deb_manager_builder_amd64 == 'true'
+        run: |
+          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f architecture=arm64 -f docker_image_tag=${{ env.TAG }} -f system=deb -f source_reference=${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Request pkg_rpm_manager_builder_arm64 update
+        if: steps.changes.outputs.pkg_rpm_manager_builder_amd64 == 'true'
+        run: |
+          gh workflow run packages-upload-manager-images.yml -r ${{ github.ref_name }} -f architecture=arm64 -f docker_image_tag=${{ env.TAG }} -f system=rpm -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/packages-upload-manager-images.yml
+++ b/.github/workflows/packages-upload-manager-images.yml
@@ -1,5 +1,5 @@
-run-name: Package - Upload pkg_${{ inputs.system }}_manager_builder_amd64 with tag ${{ inputs.docker_image_tag }}
-name: Package - Upload manager images amd64
+run-name: Package - Upload pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}
+name: Package - Upload manager images
 
 on:
   workflow_dispatch:
@@ -13,6 +13,14 @@ on:
           Default is 'auto'.
         required: false
         default: auto
+      architecture:
+        description: |
+          Architecture of the package [amd64, arm64]
+        type: choice
+        options:
+          - amd64
+          - arm64
+        required: true
       system:
         type: choice
         description: |
@@ -27,9 +35,9 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-22.04' }}
     timeout-minutes: 140
-    name: Package - Upload pkg_${{ inputs.system }}_manager_builder_amd64 with tag ${{ inputs.docker_image_tag }}
+    name: Package - Upload pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}
 
     steps:
       - name: Checkout wazuh/wazuh repository
@@ -51,11 +59,11 @@ jobs:
 
       - name: Copy build.sh and utils to Dockerfile path
         run: |
-          dockerfile_path="packages/${{ inputs.system }}s/amd64/manager"
+          dockerfile_path="packages/${{ inputs.system }}s/${{ inputs.architecture }}/manager"
           echo "DOCKERFILE_PATH=$dockerfile_path" >> $GITHUB_ENV
           cp packages/build.sh $dockerfile_path
           cp packages/${{ inputs.system }}s/utils/* $dockerfile_path
 
-      - name: Build and push image pkg_${{ inputs.system }}_manager_builder_amd64 with tag ${{ env.TAG }} to Github Container Registry
+      - name: Build and push image pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ env.TAG }} to Github Container Registry
         run:
-          bash .github/actions/ghcr-pull-and-push/build_and_push_image_to_ghcr.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.actor}} pkg_${{ inputs.system }}_manager_builder_amd64 ${{ env.DOCKERFILE_PATH }} ${{ env.TAG }}
+          bash .github/actions/ghcr-pull-and-push/build_and_push_image_to_ghcr.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.actor}} pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} ${{ env.DOCKERFILE_PATH }} ${{ env.TAG }}

--- a/packages/debs/arm64/manager/Dockerfile
+++ b/packages/debs/arm64/manager/Dockerfile
@@ -1,0 +1,47 @@
+FROM arm64v8/debian:stretch
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Installing necessary packages
+RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list && \
+    echo "deb-src http://archive.debian.org/debian stretch main" >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --allow-change-held-packages apt apt-utils  \
+    curl gcc g++ make sudo expect gnupg \
+    perl-base perl wget libc-bin libc6 libc6-dev \
+    build-essential cdbs devscripts equivs automake \
+    autoconf libtool libaudit-dev selinux-basics \
+    libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
+
+# Add Debian's source repository and, Install NodeJS 12
+RUN apt-get update &&  apt-get build-dep python3.5 -y --allow-change-held-packages
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    apt-get install --allow-change-held-packages -y nodejs
+
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
+    ./contrib/download_prerequisites && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
+        --disable-libsanitizer && \
+    make -j$(nproc) && make install && \
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
+
+RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
+    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
+    ./bootstrap --no-system-curl && \
+    make -j$(nproc) && make install && ln -s /usr/local/bin/cmake /usr/bin/cmake && \
+    cd / && rm -rf cmake-*
+
+# Add the script to build the Debian package
+ADD build.sh /usr/local/bin/build_package
+RUN chmod +x /usr/local/bin/build_package
+ADD helper_function.sh /usr/local/bin/helper_function.sh
+ADD gen_permissions.sh /tmp/gen_permissions.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/build_package"]

--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -70,7 +70,7 @@ build_pkg() {
         fi
     else
         CONTAINER_NAME="pkg_${SYSTEM}_${TARGET}_builder_${ARCHITECTURE}"
-        if [ "${ARCHITECTURE}" = "arm64" ] || [ "${ARCHITECTURE}" = "ppc64le" ]; then
+        if [ "${ARCHITECTURE}" = "ppc64le" ]; then
             DOCKERFILE_PATH="${CURRENT_PATH}/${SYSTEM}s/${ARCHITECTURE}"
         else
             DOCKERFILE_PATH="${CURRENT_PATH}/${SYSTEM}s/${ARCHITECTURE}/${TARGET}"

--- a/packages/rpms/arm64/manager/Dockerfile
+++ b/packages/rpms/arm64/manager/Dockerfile
@@ -1,0 +1,87 @@
+FROM arm64v8/centos:7
+
+# CentOS 7 is EOL, so we need to change the repositories to use the vault
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+# Enable EPEL
+RUN yum install -y http://packages.wazuh.com/utils/pkg/epel-release-latest-7.noarch.rpm
+
+# Install all the necessary tools to build the packages
+RUN yum install -y gcc make wget git \
+    openssh-clients sudo gnupg file-devel\
+    automake autoconf libtool policycoreutils-python \
+    yum-utils system-rpm-config rpm-devel \
+    gettext nspr nspr-devel \
+    nss nss-devel libdb libdb-devel \
+    zlib zlib-devel rpm-build bison \
+    sharutils bzip2-devel xz-devel lzo-devel \
+    e2fsprogs-devel libacl-devel libattr-devel \
+    openssl-devel libxml2-devel kexec-tools elfutils \
+    libcurl-devel elfutils-libelf-devel \
+    elfutils-libelf patchelf elfutils-devel libgcrypt-devel \
+    libarchive-devel libarchive bluez-libs-devel bzip2 \
+    desktop-file-utils expat-devel findutils gcc-c++ gdbm-devel \
+    glibc-devel gmp-devel gnupg2 libappstream-glib \
+    libffi-devel libtirpc-devel libGL-devel libuuid-devel \
+    libX11-devel ncurses-devel pkgconfig readline-devel \
+    redhat-rpm-config sqlite-devel gdb tar tcl-devel tix-devel tk-devel \
+    valgrind-devel python-rpm-macros python34 nodejs
+
+RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
+    tar xzf gcc-9.4.0.tar.gz  && cd gcc-9.4.0/ && \
+    ./contrib/download_prerequisites && \
+    ./configure --prefix=/usr/local/gcc-9.4.0 --enable-languages=c,c++ --disable-multilib \
+        --disable-libsanitizer --disable-bootstrap && \
+    make -j$(nproc) && make install && \
+    ln -fs /usr/local/gcc-9.4.0/bin/g++ /usr/bin/c++ && \
+    ln -fs /usr/local/gcc-9.4.0/bin/gcc /usr/bin/cc && cd / && rm -rf gcc-*
+
+ENV CPLUS_INCLUDE_PATH "/usr/local/gcc-9.4.0/include/c++/9.4.0/"
+ENV LD_LIBRARY_PATH "/usr/local/gcc-9.4.0/lib64/"
+ENV PATH "/usr/local/gcc-9.4.0/bin:${PATH}"
+
+RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \
+    tar -zxf cmake-3.18.3.tar.gz && cd cmake-3.18.3 && \
+    ./bootstrap --no-system-curl CC=/usr/local/gcc-9.4.0/bin/gcc \
+        CXX=/usr/local/gcc-9.4.0/bin/g++ && \
+    make -j$(nproc) && make install && cd / && rm -rf cmake-*
+
+# Install Perl 5.10
+RUN curl -OL http://packages.wazuh.com/utils/perl/perl-5.10.1.tar.gz && \
+    gunzip perl-5.10.1.tar.gz && tar -xf perl*.tar && \
+    cd /perl-5.10.1 && ./Configure -des -Dcc='gcc' -Dusethreads && \
+    make -j2 && make install && ln -fs /usr/local/bin/perl /bin/perl && \
+    cd / && rm -rf /perl-5.10.1*
+
+RUN curl -O http://packages.wazuh.com/utils/openssl/openssl-1.1.1a.tar.gz && \
+    tar -xzf openssl-1.1.1a.tar.gz && cd openssl* && \
+    ./config -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)' && \
+    make -j $(nproc) && make install && cd / && rm -rf openssl-*
+
+RUN curl -O http://packages.wazuh.com/utils/nodejs/node-v12.16.1-linux-arm64.tar.xz && \
+    tar -xJf node-v12.16.1-linux-arm64.tar.xz && \
+    cd node-v12.16* && cp -R * /usr/local/ && cd / && rm -rf node-v*
+
+# Update rpmbuild, rpm and autoconf
+RUN curl -O http://packages.wazuh.com/utils/autoconf/autoconf-2.69.tar.gz && \
+    gunzip autoconf-2.69.tar.gz && tar xvf autoconf-2.69.tar && \
+    cd autoconf-2.69 && ./configure && \
+    make -j $(nproc) && make install && cd / && rm -rf autoconf-*
+
+RUN curl -O http://packages.wazuh.com/utils/rpm/rpm-4.15.1.tar.bz2 && \
+    tar -xjf rpm-4.15.1.tar.bz2 && cd rpm-4.15.1 && \
+    ./configure --without-lua && make -j $(nproc) && \
+    make install && cd / && rm -rf rpm-*
+
+RUN mkdir -p /usr/local/var/lib/rpm && \
+    cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages && \
+    /usr/local/bin/rpm --rebuilddb && rm -rf /root/rpmbuild
+
+# Add the scripts to build the RPM package
+ADD build.sh /usr/local/bin/build_package
+RUN chmod +x /usr/local/bin/build_package
+ADD helper_function.sh /usr/local/bin/helper_function.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/build_package"]


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25937|

## Description

This PR adds support for ARM64 architecture in the Wazuh Manager packaging process. Previously, the Wazuh Manager packages were only available for AMD64 (x86_64). This update extends the support to ARM64, allowing the manager to run on devices with ARM-based architectures.

## Changes

- Updated the GitHub Actions workflow to support both ARM64 and AMD64 architectures for package builds.
- Added a new Dockerfile specifically designed to create the necessary environment for building ARM64 packages.

## Tests

- [x] New build image uploaded: [Job 30637867007](https://github.com/wazuh/wazuh/actions/runs/11031341841/job/30637867007)
- [x] Deb Package for ARM64 built: [Job 11033017382](https://github.com/wazuh/wazuh/actions/runs/11033017382)
- [x] Deb Package for ARM64 built - 4.9.1: [Job 30651506016](https://github.com/wazuh/wazuh/actions/runs/11035465798/job/30651506016)
- [x] RPM Package for ARM64 built - 4.9.1: [Job 30651471820](https://github.com/wazuh/wazuh/actions/runs/11035376732/job/30651471820)