### PR TITLE
Fix decoder integration tests and fix a typo

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -15213,7 +15213,7 @@ paths:
                       position: 0
                       details:
                         prematch:
-                          patten: ^{\\s*\"
+                          pattern: ^{\\s*\"
                         plugin_decoder: JSON_Decoder
                   total_affected_items: 182
                   total_failed_items: 0

--- a/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_decoder_endpoints.tavern.yaml
@@ -26,7 +26,7 @@ stages:
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders
-              filename: 0007-wazuh-api_decoders.xml
+              filename: 0006-json_decoders.xml
             - <<: *full_item_decoders
               filename: 0007-wazuh-api_decoders.xml
             - <<: *full_item_decoders
@@ -259,13 +259,13 @@ stages:
               position: !anyint
               status: !anystr
             - <<: *full_item_decoders_parent
-              filename: 0007-wazuh-api_decoders.xml
+              filename: 0006-json_decoders.xml
             - <<: *full_item_decoders_parent
               filename: 0007-wazuh-api_decoders.xml
             - <<: *full_item_decoders_parent
               filename: 0007-wazuh-api_decoders.xml
             - <<: *full_item_decoders_parent
-              filename: 0010-active-response_decoders.xml
+              filename: 0007-wazuh-api_decoders.xml
           failed_items: []
           total_affected_items: !anyint
           total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25738|

## Description

A new decoder was added to the `0006-json_decoders.xml` file in [this commit](https://github.com/wazuh/wazuh/commit/2ba25f01b3451cdf836c8840154acc898c0ea31e#diff-2483cf2793089548ca75f138d2c216484d2af2a07270a8e66424e171847ecefe), which resulted in the response in the tests showing a second occurrence of that file, shifting the other elements while dropping the last one. As these tests were not updated to reflect the change, they were failing due to expecting different values associated to the field `filename`. To fix this, the definition of the tests was modified by adding the new occurrence of the `0006-json_decoders.xml` file.

## Execution

```
$ pytest -vv --disable-warnings 'test_rbac_black_decoder_endpoints.tavern.yaml::GET DECODERS RBAC' 'test_rbac_black_decoder_endpoints.tavern.yaml::GET DECODERS PARENTS RBAC' --nobuild
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.0, pytest-7.3.1, pluggy-1.5.0
cachedir: .pytest_cache
metadata: {'Python': '3.10.0', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'tavern': '1.23.5', 'html': '2.1.1'
, 'asyncio': '0.18.1', 'trio': '0.8.0', 'anyio': '4.1.0', 'metadata': '3.1.1'}}
rootdir: /wazuh/api/test/integration
configfile: pytest.ini
plugins: tavern-1.23.5, html-2.1.1, asyncio-0.18.1, trio-0.8.0, anyio-4.1.0, metadata-3.1.1
asyncio: mode=auto
collected 2 items                                                                                                                                                                            

test_rbac_black_decoder_endpoints.tavern.yaml::GET DECODERS RBAC PASSED                                                                                                                [ 50%]
test_rbac_black_decoder_endpoints.tavern.yaml::GET DECODERS PARENTS RBAC PASSED                                                                                                        [100%]
========================================================================= 2 passed, 3 warnings in 216.33s (0:03:36) ==========================================================================
``` 