### PR TITLE
Fix Get API configuration integration test

### DIFF
--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -899,9 +899,8 @@ stages:
           affected_items:
             - node_name: !anystr
               node_api_config:
-                host: !anystr
+                host: !anylist
                 port: !anyint
-
                 https:
                   enabled: !anybool
                   key: !anystr
@@ -944,10 +943,10 @@ stages:
                   indexer:
                     allow: !anybool
                   integrations:
-                       virustotal:
-                         public_key:
-                           allow: !anybool
-                           minimum_quota: !anyint
+                    virustotal:
+                      public_key:
+                        allow: !anybool
+                        minimum_quota: !anyint
           total_affected_items: 1
           total_failed_items: 0
           failed_items: []


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25905|

## Description

This failure is due to the changes introduced in https://github.com/wazuh/wazuh/pull/25216 in `4.9.1`, specifically in [this commit](https://github.com/wazuh/wazuh/commit/b38018e34d2b8cbd42939170a602603f6ba2e87c), which were not reflected in the corresponding test (`GET /manager/api/config`). The field `host` was changed to keep a list instead of a string. By modifying the test to expect a list by replacing `!anystr` with `!anylist` the test is fixed.

## Execution

```
$ pytest -vv --disable-warnings 'test_manager_endpoints.tavern.yaml::GET /manager/api/config' --nobuild
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.0, pytest-7.3.1, pluggy-1.5.0
cachedir: .pytest_cache
metadata: {'Python': '3.10.0', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'tavern': '1.23.5', 'html': '2.1.1'
, 'asyncio': '0.18.1', 'trio': '0.8.0', 'anyio': '4.1.0', 'metadata': '3.1.1'}}
rootdir: /wazuh/api/test/integration
configfile: pytest.ini
plugins: tavern-1.23.5, html-2.1.1, asyncio-0.18.1, trio-0.8.0, anyio-4.1.0, metadata-3.1.1
asyncio: mode=auto
collected 1 item                                                                                                                                                                             

test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                     [100%]
========================================================================= 1 passed, 2 warnings in 162.12s (0:02:42) ==========================================================================
``` 