### PR TITLE
Add `secureCommunication` missing parameter

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -161,7 +161,7 @@ nlohmann::json IndexerConnector::getAgentDocumentsIds(const std::string& url,
 
         HTTPRequest::instance().post(RequestParameters {.url = HttpURL(url + "/" + m_indexName + "/_search?scroll=1m"),
                                                         .data = postData.dump(),
-                                                        secureCommunication = secureCommunication},
+                                                        .secureCommunication = secureCommunication},
                                      PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                      ConfigurationParameters {});
     }

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -159,10 +159,11 @@ nlohmann::json IndexerConnector::getAgentDocumentsIds(const std::string& url,
             throw std::runtime_error(error);
         };
 
-        HTTPRequest::instance().post(
-            RequestParameters {.url = HttpURL(url + "/" + m_indexName + "/_search?scroll=1m"), .data = postData.dump()},
-            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
-            ConfigurationParameters {});
+        HTTPRequest::instance().post(RequestParameters {.url = HttpURL(url + "/" + m_indexName + "/_search?scroll=1m"),
+                                                        .data = postData.dump(),
+                                                        secureCommunication = secureCommunication},
+                                     PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
+                                     ConfigurationParameters {});
     }
 
     // If the response have more than ELEMENTS_PER_QUERY elements, we need to scroll.


### PR DESCRIPTION
|Related issue|
|---|
|#25919|

# Objective

This PR aims to add the missing parameter of `secureCommunication` used by `indexerConnector`