### PR TITLE
Add aarch64 to manager package building workflow

### DIFF
--- a/.github/workflows/packages-build-manager.yml
+++ b/.github/workflows/packages-build-manager.yml
@@ -16,12 +16,13 @@ on:
         required: false
       architecture:
         description: |
-          Architecture of the package [amd64, x86_64, arm64]
+          Architecture of the package [amd64, x86_64, arm64, aarch64]
         type: choice
         options:
           - amd64
           - x86_64
           - arm64
+          - aarch64
         required: true
       system:
         description: 'Package format [deb, rpm]'
@@ -91,7 +92,7 @@ on:
 
 jobs:
   Build-manager-packages:
-    runs-on: ${{ inputs.architecture == 'arm64' && 'wz-linux-arm64' || 'ubuntu-22.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-22.04' }}
     timeout-minutes: 35
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
@@ -109,6 +110,8 @@ jobs:
         run: |
             if [ ${{ inputs.architecture }} = 'x86_64' ]; then
               arch="amd64"
+            elif [ ${{ inputs.architecture }} = 'aarch64' ]; then
+              arch="arm64"
             else
               arch=${{ inputs.architecture }}
             fi


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/25975 |

This PR adds the "aarch64" architecture option to the manager's package generation workflow.

The workflow will do this mapping:
- _amd64_ | _x86_64_ → _amd64_
- _arm64_ | _aarch64_ → _arm64_

## Tests

- [x] RPM package generation for _aarch64_: Job [11068863056](https://github.com/wazuh/wazuh/actions/runs/11068863056)
```bash
gh workflow run packages-build-manager.yml --repo=wazuh/wazuh --ref=enhancement/25975-manager-rpm-aarch64 -f "architecture=aarch64" -f "system=rpm"
```