### PR TITLE
Implement the new wazuh-server initialization

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -19,6 +19,8 @@ logger = logging.getLogger('wazuh-api')
 # Variable used to specify an unknown user
 UNKNOWN_USER_STRING = "unknown_user"
 WARNING = 'WARNING'
+INFO = 'INFO'
+
 
 class APILoggerSize:
     size_regex = re.compile(r"(\d+)([KM])")
@@ -82,7 +84,7 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
         log_record['data'] = record.message
 
 
-def set_logging(log_filepath, log_level = 'INFO', foreground_mode = False) -> dict:
+def set_logging(log_filepath, log_level = INFO, foreground_mode = False) -> dict:
     """Set up logging for API.
     
     This function creates a logging configuration dictionary, configure the wazuh-api logger
@@ -183,7 +185,7 @@ def set_logging(log_filepath, log_level = 'INFO', foreground_mode = False) -> di
         },
         "loggers": {
             "wazuh-api": {"handlers": hdls, "level": log_level, "propagate": False},
-            "start-stop-api": {"handlers": hdls, "level": 'INFO', "propagate": False},
+            "start-stop-api": {"handlers": hdls, "level": INFO, "propagate": False},
             "wazuh-comms-api": {"handlers": hdls, "level": log_level, "propagate": False}
         }
     }
@@ -211,9 +213,9 @@ def set_logging(log_filepath, log_level = 'INFO', foreground_mode = False) -> di
     log_config_dict['loggers']['uvicorn.access'] = {'level': WARNING}
 
     # Configure the gunicorn loggers. They will be created by the gunicorn process.
-    log_config_dict['loggers']['gunicorn'] = {'handlers': hdls, 'level': WARNING, 'propagate': False}
-    log_config_dict['loggers']['gunicorn.error'] = {'handlers': hdls, 'level': WARNING, 'propagate': False}
-    log_config_dict['loggers']['gunicorn.access'] = {'level': WARNING}
+    log_config_dict['loggers']['gunicorn'] = {'handlers': hdls, 'level': INFO, 'propagate': False}
+    log_config_dict['loggers']['gunicorn.error'] = {'handlers': hdls, 'level': INFO, 'propagate': False}
+    log_config_dict['loggers']['gunicorn.access'] = {'level': INFO}
 
     return log_config_dict
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -9093,6 +9093,7 @@ paths:
                       nodes:
                         - wazuh-master
                       hidden: "no"
+                      cafile: "/var/wazuh_server/etc/sslmanager.ca"
                       certfile: "/var/wazuh_server/etc/sslmanager.cert"
                       keyfile: "/var/wazuh_server/etc/sslmanager.key"
                       keyfile_password: ""

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -1,3 +1,9 @@
+#!/var/ossec/framework/python/bin/python3
+
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
 import logging
 import logging.config
 import os

--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import asyncio
+import signal
 import sys
 from unittest.mock import call, patch
 
@@ -34,13 +35,13 @@ def test_print_version(print_mock):
             'Free Software Foundation. For more details, go to \nhttps://www.gnu.org/licenses/gpl.html\n')
 
 
-@patch('scripts.wazuh_clusterd.os.kill')
 @patch('scripts.wazuh_clusterd.os.getpid', return_value=1001)
-def test_exit_handler(os_getpid_mock, os_kill_mock):
+def test_exit_handler(os_getpid_mock):
     """Set the behavior when exiting the script."""
     from wazuh.core import pyDaemonModule
 
     class SignalMock:
+        SIGTERM = 0
         SIG_DFL = 1
 
         class Signals:
@@ -67,28 +68,81 @@ def test_exit_handler(os_getpid_mock, os_kill_mock):
     wazuh_clusterd.main_logger = LoggerMock()
     wazuh_clusterd.pyDaemonModule = pyDaemonModule
     wazuh_clusterd.original_sig_handler = original_sig_handler
-    with patch('scripts.wazuh_clusterd.signal', SignalMock):
-        with patch.object(wazuh_clusterd, 'main_logger') as main_logger_mock:
-            with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids') as delete_child_pids_mock:
-                with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_pid') as delete_pid_mock:
-                    with patch.object(wazuh_clusterd, 'original_sig_handler') as original_sig_handler_mock:
-                        wazuh_clusterd.exit_handler(9, 99)
-                        main_logger_mock.assert_has_calls([call.info('SIGNAL [(9)-(9)] received. Exit...')])
-                        delete_child_pids_mock.assert_called_once_with(
-                            'wazuh-clusterd', os_getpid_mock.return_value, main_logger_mock)
-                        delete_pid_mock.assert_called_once_with('wazuh-clusterd', os_getpid_mock.return_value)
-                        original_sig_handler_mock.assert_called_once_with(9, 99)
-                        main_logger_mock.reset_mock()
-                        delete_child_pids_mock.reset_mock()
-                        delete_pid_mock.reset_mock()
-                        original_sig_handler_mock.reset_mock()
+    with patch('scripts.wazuh_clusterd.signal', SignalMock), \
+        patch.object(wazuh_clusterd, 'main_logger') as main_logger_mock, \
+        patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids') as delete_child_pids_mock, \
+        patch.object(wazuh_clusterd.pyDaemonModule, 'delete_pid') as delete_pid_mock, \
+        patch.object(wazuh_clusterd, 'original_sig_handler') as original_sig_handler_mock, \
+        patch.object(wazuh_clusterd.pyDaemonModule, 'get_parent_pid', return_value=999), \
+        patch('scripts.wazuh_clusterd.os.kill') as os_kill_mock:
+        wazuh_clusterd.exit_handler(9, 99)
+        main_logger_mock.assert_has_calls([call.info('SIGNAL [(9)-(9)] received. Shutting down...')])
+        os_kill_mock.assert_has_calls([
+            call(999, SignalMock.SIGTERM),
+            call(999, SignalMock.SIGTERM),
+        ])
+        delete_child_pids_mock.assert_has_calls([
+            call('wazuh-clusterd', os_getpid_mock.return_value, main_logger_mock),
+        ])
+        delete_pid_mock.assert_has_calls([
+            call('wazuh-clusterd', os_getpid_mock.return_value),
+        ])
+        original_sig_handler_mock.assert_called_once_with(9, 99)
+        main_logger_mock.reset_mock()
+        delete_child_pids_mock.reset_mock()
+        delete_pid_mock.reset_mock()
+        original_sig_handler_mock.reset_mock()
 
-                        wazuh_clusterd.original_sig_handler = original_sig_handler_not_callable
-                        wazuh_clusterd.exit_handler(9, 99)
-                        main_logger_mock.assert_has_calls([call.info('SIGNAL [(9)-(9)] received. Exit...')])
-                        delete_child_pids_mock.assert_called_once_with('wazuh-clusterd', 1001, main_logger_mock)
-                        delete_pid_mock.assert_called_once_with('wazuh-clusterd', 1001)
-                        original_sig_handler_mock.assert_not_called()
+        wazuh_clusterd.original_sig_handler = original_sig_handler_not_callable
+        wazuh_clusterd.exit_handler(9, 99)
+        main_logger_mock.assert_has_calls([call.info('SIGNAL [(9)-(9)] received. Shutting down...')])
+        os_kill_mock.assert_has_calls([
+            call(999, SignalMock.SIGTERM),
+            call(999, SignalMock.SIGTERM),
+        ])
+        delete_child_pids_mock.assert_has_calls([
+            call('wazuh-clusterd', 1001, main_logger_mock),
+        ])
+        delete_pid_mock.assert_has_calls([
+            call('wazuh-clusterd', 1001),
+        ])
+        original_sig_handler_mock.assert_not_called()
+
+
+@patch('subprocess.Popen')
+def test_start_subprocesses(mock_popen):
+    """Validate that `start_subprocesses` works as expected."""
+    class LoggerMock:
+        def __init__(self):
+            pass
+
+        def info(self, msg):
+            pass
+
+    wazuh_clusterd.main_logger = LoggerMock
+
+    with patch.object(wazuh_clusterd, 'main_logger') as main_logger_mock:
+        wazuh_clusterd.start_subprocesses()
+
+    mock_popen.assert_has_calls([
+        call([wazuh_clusterd.EMBEDDED_PYTHON_PATH, wazuh_clusterd.MANAGEMENT_API_SCRIPT_PATH]),
+        call([wazuh_clusterd.EMBEDDED_PYTHON_PATH, wazuh_clusterd.COMMS_API_SCRIPT_PATH]),
+    ], any_order=True)
+
+    main_logger_mock.info.assert_has_calls([
+        call(f'Started the Management API (pid: {mock_popen().pid})'),
+        call(f'Started the Communications API (pid: {mock_popen().pid})'),
+    ])
+
+
+@patch('scripts.wazuh_clusterd.os.kill')
+@patch('scripts.wazuh_clusterd.os.getpid', return_value=999)
+def test_shutdown_daemon(os_getpid_mock, os_kill_mock):
+    """Validate that `shutdown_daemon` works as expected."""
+    with patch.object(wazuh_clusterd.pyDaemonModule, 'get_parent_pid', return_value=os_getpid_mock.return_value):
+        wazuh_clusterd.shutdown_daemon('wazuh-apid')
+
+    os_kill_mock.assert_called_once_with(999, signal.SIGTERM)
 
 
 @pytest.mark.asyncio
@@ -149,10 +203,7 @@ async def test_master_main(helper_disabled: bool):
 
     wazuh_clusterd.cluster_utils = cluster_utils
     args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test')
-    with patch.object(wazuh_clusterd, 'main_logger') as main_logger_mock, \
-        patch('wazuh.core.authentication.keypair_exists', return_value=False), \
-        patch('wazuh.core.authentication.generate_keypair') as generate_keypair_mock, \
-        patch('scripts.wazuh_clusterd.asyncio.gather', gather), \
+    with patch('scripts.wazuh_clusterd.asyncio.gather', gather), \
         patch('wazuh.core.cluster.master.Master', MasterMock), \
         patch('wazuh.core.cluster.local_server.LocalServerMaster', LocalServerMasterMock), \
         patch('wazuh.core.cluster.hap_helper.hap_helper.HAPHelper', HAPHElperMock):
@@ -162,10 +213,6 @@ async def test_master_main(helper_disabled: bool):
             cluster_items={'node': 'item'},
             logger='test_logger'
         )
-
-        main_logger_mock.info.assert_called_once_with('Generating JWT signing key pair')
-        generate_keypair_mock.assert_called_once()
-
 
 @pytest.mark.asyncio
 @patch("asyncio.sleep", side_effect=IndexError)
@@ -319,76 +366,85 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
     wazuh_clusterd.common = common
     wazuh_clusterd.pyDaemonModule = pyDaemonModule
     wazuh_clusterd.cluster_utils = cluster_utils
-    with patch.object(common, 'wazuh_uid', return_value='uid_test'):
-        with patch.object(common, 'wazuh_gid', return_value='gid_test'):
-            with patch.object(wazuh_clusterd.cluster_utils, 'read_config',
-                              return_value={'node_type': 'master'}):
-                with patch.object(wazuh_clusterd.main_logger, 'error') as main_logger_mock:
-                    with patch.object(wazuh_clusterd.main_logger, 'info') as main_logger_info_mock:
-                        with patch.object(wazuh_clusterd.cluster_utils, 'read_config', side_effect=Exception):
-                            with pytest.raises(SystemExit):
-                                wazuh_clusterd.main()
-                            main_logger_mock.assert_called_once()
-                            main_logger_mock.reset_mock()
-                            path_exists_mock.assert_any_call(f'{common.WAZUH_PATH}/logs/cluster.log')
-                            chown_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 'uid_test',
-                                                          'gid_test')
-                            chmod_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 432)
-                            exit_mock.assert_called_once_with(1)
-                            exit_mock.reset_mock()
+    with patch.object(common, 'wazuh_uid', return_value='uid_test'), \
+        patch.object(common, 'wazuh_gid', return_value='gid_test'), \
+        patch.object(wazuh_clusterd.cluster_utils, 'read_config', return_value={'node_type': 'master'}), \
+        patch.object(wazuh_clusterd.main_logger, 'error') as main_logger_mock, \
+        patch.object(wazuh_clusterd.main_logger, 'info') as main_logger_info_mock:
+    
+        with patch.object(wazuh_clusterd.cluster_utils, 'read_config', side_effect=Exception):
+            with pytest.raises(SystemExit):
+                wazuh_clusterd.main()
+            main_logger_mock.assert_called_once()
+            main_logger_mock.reset_mock()
+            path_exists_mock.assert_any_call(f'{common.WAZUH_PATH}/logs/cluster.log')
+            chown_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 'uid_test',
+                                        'gid_test')
+            chmod_mock.assert_called_with(f'{common.WAZUH_PATH}/logs/cluster.log', 432)
+            exit_mock.assert_called_once_with(1)
+            exit_mock.reset_mock()
 
-                        with patch('wazuh.core.cluster.cluster.check_cluster_config', side_effect=IndexError):
-                            with pytest.raises(SystemExit):
-                                wazuh_clusterd.main()
-                            main_logger_mock.assert_called_once()
-                            exit_mock.assert_called_once_with(1)
-                            exit_mock.reset_mock()
+        with patch('wazuh.core.cluster.cluster.check_cluster_config', side_effect=IndexError):
+            with pytest.raises(SystemExit):
+                wazuh_clusterd.main()
+            main_logger_mock.assert_called_once()
+            exit_mock.assert_called_once_with(1)
+            exit_mock.reset_mock()
 
-                        with patch('wazuh.core.cluster.cluster.check_cluster_config', return_value=None):
-                            with pytest.raises(SystemExit):
-                                wazuh_clusterd.main()
-                            main_logger_mock.assert_called_once()
-                            exit_mock.assert_called_once_with(0)
-                            main_logger_mock.reset_mock()
-                            exit_mock.reset_mock()
+        with patch('wazuh.core.cluster.cluster.check_cluster_config', return_value=None):
+            with pytest.raises(SystemExit):
+                wazuh_clusterd.main()
+            main_logger_mock.assert_called_once()
+            exit_mock.assert_called_once_with(0)
+            main_logger_mock.reset_mock()
+            exit_mock.reset_mock()
 
-                            args.test_config = False
-                            wazuh_clusterd.args = args
-                            with patch('wazuh.core.cluster.cluster.clean_up') as clean_up_mock:
-                                with patch('scripts.wazuh_clusterd.clean_pid_files') as clean_pid_files_mock:
-                                    with patch.object(wazuh_clusterd.pyDaemonModule, 'pyDaemon') as pyDaemon_mock:
-                                        with patch.object(wazuh_clusterd.pyDaemonModule,
-                                                          'create_pid') as create_pid_mock:
-                                            with patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids'):
-                                                with patch.object(wazuh_clusterd.pyDaemonModule,
-                                                                  'delete_pid') as delete_pid_mock:
-                                                    wazuh_clusterd.main()
-                                                    main_logger_mock.assert_any_call(
-                                                        "Unhandled exception: name 'cluster_items' is not defined")
-                                                    clean_up_mock.assert_called_once()
-                                                    clean_pid_files_mock.assert_called_once_with('wazuh-clusterd')
-                                                    pyDaemon_mock.assert_called_once()
-                                                    setuid_mock.assert_called_once_with('uid_test')
-                                                    setgid_mock.assert_called_once_with('gid_test')
-                                                    getpid_mock.assert_called()
-                                                    create_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
-                                                    delete_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
+            args.test_config = False
+            wazuh_clusterd.args = args
+            with patch('wazuh.core.cluster.cluster.clean_up') as clean_up_mock, \
+                patch('scripts.wazuh_clusterd.clean_pid_files') as clean_pid_files_mock, \
+                patch('wazuh.core.authentication.keypair_exists', return_value=False), \
+                patch('wazuh.core.authentication.generate_keypair') as generate_keypair_mock, \
+                patch('scripts.wazuh_clusterd.start_subprocesses') as start_subprocesses_mock, \
+                patch.object(wazuh_clusterd.pyDaemonModule, 'get_parent_pid', return_value=999), \
+                patch('os.kill') as os_kill_mock, \
+                patch.object(wazuh_clusterd.pyDaemonModule, 'pyDaemon') as pyDaemon_mock, \
+                patch.object(wazuh_clusterd.pyDaemonModule, 'create_pid') as create_pid_mock, \
+                patch.object(wazuh_clusterd.pyDaemonModule, 'delete_child_pids'), \
+                patch.object(wazuh_clusterd.pyDaemonModule,'delete_pid') as delete_pid_mock:
+                wazuh_clusterd.main()
+                main_logger_mock.assert_any_call(
+                    "Unhandled exception: name 'cluster_items' is not defined")
+                main_logger_mock.reset_mock()
+                clean_up_mock.assert_called_once()
+                clean_pid_files_mock.assert_called_once_with('wazuh-clusterd')
+                pyDaemon_mock.assert_called_once()
+                setuid_mock.assert_called_once_with('uid_test')
+                setgid_mock.assert_called_once_with('gid_test')
+                getpid_mock.assert_called()
+                os_kill_mock.assert_has_calls([
+                    call(999, signal.SIGTERM),
+                    call(999, signal.SIGTERM),
+                ])
+                create_pid_mock.assert_called_once_with('wazuh-clusterd', 543)
+                delete_pid_mock.assert_has_calls([
+                    call('wazuh-clusterd', 543),
+                ])
+                main_logger_info_mock.assert_called_once_with('Generating JWT signing key pair')
+                generate_keypair_mock.assert_called_once()
+                start_subprocesses_mock.assert_called_once()
 
-                                                    args.foreground = True
-                                                    wazuh_clusterd.main()
-                                                    print_mock.assert_called_once_with(
-                                                        'Starting cluster in foreground (pid: 543)')
+                args.foreground = True
+                wazuh_clusterd.main()
+                print_mock.assert_called_once_with('Starting cluster in foreground (pid: 543)')
 
-                                                    wazuh_clusterd.cluster_items = {}
-                                                    with patch('scripts.wazuh_clusterd.master_main',
-                                                               side_effect=KeyboardInterrupt('TESTING')):
-                                                        wazuh_clusterd.main()
-                                                        main_logger_info_mock.assert_any_call(
-                                                            'SIGINT received. Bye!')
+                wazuh_clusterd.cluster_items = {}
+                with patch('scripts.wazuh_clusterd.master_main', side_effect=KeyboardInterrupt('TESTING')):
+                    wazuh_clusterd.main()
+                    main_logger_info_mock.assert_any_call('SIGINT received. Shutting down...')
 
-                                                    with patch('scripts.wazuh_clusterd.master_main',
-                                                               side_effect=MemoryError('TESTING')):
-                                                        wazuh_clusterd.main()
-                                                        main_logger_mock.assert_any_call(
-                                                            "Directory '/tmp' needs read, write & execution "
-                                                            "permission for 'wazuh' user")
+                with patch('scripts.wazuh_clusterd.master_main', side_effect=MemoryError('TESTING')):
+                    wazuh_clusterd.main()
+                    main_logger_mock.assert_any_call(
+                        "Directory '/tmp' needs read, write & execution "
+                        "permission for 'wazuh' user")

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -36,7 +36,7 @@ def set_logging(foreground_mode=False, debug_mode=0) -> WazuhLogger:
     Parameters
     ----------
     foreground_mode : bool
-        Whether to log in the standard output or not.
+        Whether the script is running in foreground mode or not.
     debug_mode : int
         Debug mode.
 
@@ -73,7 +73,7 @@ def exit_handler(signum, frame):
 
 
 def start_daemon(foreground: bool, name: str, args: List[str]):
-    """Starts a daemon in a subprocess and validates that there were no errors during its execution.
+    """Start a daemon in a subprocess and validate that there were no errors during its execution.
     
     Parameters
     ----------
@@ -107,7 +107,7 @@ def start_daemon(foreground: bool, name: str, args: List[str]):
 
 
 def start_daemons(foreground: bool, root: bool):
-    """Starts the engine, the management and communications APIs daemons in subprocesses.
+    """Start the engine and the management and communications APIs daemons in subprocesses.
     
     Parameters
     ----------
@@ -128,7 +128,7 @@ def start_daemons(foreground: bool, root: bool):
 
 
 def shutdown_daemon(name: str):
-    """Sends a SIGTERM signal to the daemon process.
+    """Send a SIGTERM signal to the daemon process.
     
     Parameters
     ----------
@@ -145,7 +145,7 @@ def shutdown_daemon(name: str):
 
 
 def shutdown_cluster(cluster_pid: int):
-    """Terminates parent and child processes.
+    """Terminate daemons and cluster parent and child processes.
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ def shutdown_cluster(cluster_pid: int):
 # Master main
 #
 async def master_main(args: argparse.Namespace, cluster_config: dict, cluster_items: dict, logger: WazuhLogger):
-    """Start main process of the master node.
+    """Start the master node main process.
 
     Parameters
     ----------

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -12,7 +12,6 @@ import zlib
 from asyncio import wait_for
 from collections import defaultdict
 from functools import partial
-from operator import eq
 from os import listdir, path, remove, stat, walk
 from uuid import uuid4
 

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -4,7 +4,6 @@
 
 import ast
 import asyncio
-import base64
 import contextlib
 import datetime
 import hashlib

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -9,7 +9,6 @@ from wazuh.core import common
 from wazuh.core.agent import Agent
 from wazuh.core.cluster import local_client
 from wazuh.core.cluster.common import as_wazuh_object, WazuhJSONEncoder
-from wazuh.core.exception import WazuhError
 from wazuh.core.utils import filter_array_by_query
 
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -100,7 +100,7 @@ class DistributedAPI:
         self.origin_module = 'API'
         self.nodes = nodes if nodes is not None else list()
         if not basic_services:
-            self.basic_services = ('wazuh-modulesd', 'wazuh-analysisd', 'wazuh-execd', 'wazuh-remoted')
+            self.basic_services = ('wazuh-clusterd',)
         else:
             self.basic_services = basic_services
 
@@ -206,7 +206,7 @@ class DistributedAPI:
               in failed status.
             * Wazuh must be started before using the API is the services are stopped.
 
-        The basic services wazuh needs to be running are: wazuh-modulesd, wazuh-remoted, wazuh-analysisd and wazuh-execd
+        The basic service wazuh needs to be running is: wazuh-clusterd.
         """
         if self.f == wazuh.core.manager.status:
             return

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -96,7 +96,7 @@ class TestingLogger:
 
 @pytest.mark.parametrize('kwargs', [
     {'f_kwargs': {'select': ['id']}, 'rbac_permissions': {'mode': 'black'}, 'nodes': ['worker1'],
-     'basic_services': ('wazuh-modulesd', 'wazuh-db'), 'request_type': 'local_master'},
+     'basic_services': ('wazuh-clusterd',), 'request_type': 'local_master'},
     {'request_type': 'local_master'},
     {'api_timeout': 15},
     {'api_timeout': 5}

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -256,7 +256,7 @@ def get_manager_status(cache=False) -> typing.Dict:
     except (PermissionError, FileNotFoundError) as e:
         raise WazuhInternalError(1913, extra_message=str(e))
 
-    processes = ['wazuh-clusterd', 'wazuh-apid', 'wazuh-comms-apid']
+    processes = ['wazuh-clusterd', 'wazuh-engined', 'wazuh-apid', 'wazuh-comms-apid']
 
     data, pidfile_regex, run_dir = {}, re.compile(r'.+\-(\d+)\.pid$'), os.path.join(common.WAZUH_PATH, "var", "run")
     for process in processes:

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -256,10 +256,7 @@ def get_manager_status(cache=False) -> typing.Dict:
     except (PermissionError, FileNotFoundError) as e:
         raise WazuhInternalError(1913, extra_message=str(e))
 
-    processes = ['wazuh-agentlessd', 'wazuh-analysisd', 'wazuh-authd', 'wazuh-csyslogd', 'wazuh-monitord',
-                 'wazuh-execd', 'wazuh-integratord', 'wazuh-logcollector', 'wazuh-maild', 'wazuh-remoted',
-                 'wazuh-reportd', 'wazuh-syscheckd', 'wazuh-clusterd', 'wazuh-modulesd', 'wazuh-apid',
-                 'wazuh-comms-apid']
+    processes = ['wazuh-clusterd', 'wazuh-apid', 'wazuh-comms-apid']
 
     data, pidfile_regex, run_dir = {}, re.compile(r'.+\-(\d+)\.pid$'), os.path.join(common.WAZUH_PATH, "var", "run")
     for process in processes:

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -6,11 +6,9 @@ import asyncio
 import contextlib
 import errno
 import json
-import logging
 import os
 import shutil
 from collections import defaultdict
-from datetime import datetime, timezone
 from time import perf_counter
 from typing import Tuple, Dict, Callable, List
 from typing import Union

--- a/framework/wazuh/core/tests/test_pyDaemonModule.py
+++ b/framework/wazuh/core/tests/test_pyDaemonModule.py
@@ -56,6 +56,19 @@ def test_create_pid_ko(mock_chmod):
                 create_pid(tmpfile.name.split('/')[3].split('-')[0], '255')
 
 
+@pytest.mark.parametrize('process_name, expected_pid', [
+   ('foo', 123),
+   ('bar', 456),
+   ('wazuh-apid', 789),
+   ('wazuh-clusterd', None)
+])
+@patch('os.listdir', return_value=['foo-123.pid', 'bar-456.pid', 'wazuh-apid-789.pid'])
+def test_get_parent_pid(os_listdir_mock, expected_pid, process_name):
+    """Validates that the get_parent_pid function works as expected."""
+    actual_pid = get_parent_pid(process_name)
+    assert expected_pid == actual_pid
+
+
 @patch('wazuh.core.pyDaemonModule.common.WAZUH_PATH', new='/tmp')
 def test_delete_pid():
     """Tests delete_pid function works"""


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/25778 |

## Description

Implements the new wazuh-server initialization.

## Tests

<details><summary>Start the cluster</summary>

> I had to execute it as `root` because the Engine tries to create files in places where the `wazuh` user does not have access.
>
> Engine process logs are expected, since everything is logging to standard output. However, they are not logged to the `cluster.log` file.

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-clusterd -r -f
Starting cluster in foreground (pid: 19329)
2024/10/01 17:47:07 INFO: [Cluster] [Main] Started the Engine (pid: 19330)
2024-10-01 17:47:07.727 19330:19330 info: Logging initialized.
2024-10-01 17:47:07.728 19330:19330 info: Store initialized.
2024-10-01 17:47:07.728 19330:19330 info: RBAC initialized.
2024-10-01 17:47:07.728 19330:19330 info: MetricsManager: Created new scope: (KVDB)
2024-10-01 17:47:07.745 19330:19330 info: KVDB initialized.
2024-10-01 17:47:07.745 19330:19330 info: Geo initialized.
2024-10-01 17:47:07.757 19330:19330 info: Schema initialized.
2024/10/01 17:47:08 INFO: [Cluster] [Main] Started the Management API (pid: 19372)
2024-10-01 17:47:08.647 19330:19330 info: Loaded timezone database version: '2024a'
2024-10-01 17:47:08.652 19330:19330 info: HLP initialized.
2024-10-01 17:47:08.665 19330:19330 info: Builder initialized.
2024-10-01 17:47:08.665 19330:19330 info: Catalog initialized.
2024-10-01 17:47:08.665 19330:19330 info: Policy manager initialized.
2024-10-01 17:47:08.665 19330:19330 info: MetricsManager: Created new scope: (EventQueue)
2024-10-01 17:47:08.665 19330:19330 info: MetricsManager: Created new scope: (EventQueueDelta)
2024-10-01 17:47:08.665 19330:19330 info: The queue will be flooded in the file: /var/ossec/logs/engine-flood.log
2024-10-01 17:47:08.666 19330:19330 info: MetricsManager: Created new scope: (TestQueue)
2024-10-01 17:47:08.666 19330:19330 info: MetricsManager: Created new scope: (TestQueueDelta)
2024-10-01 17:47:08.669 19330:19330 info: No flooding file provided, the queue will not be flooded.
2024-10-01 17:47:08.670 19330:19330 warning: Router: router/router/0 table is empty
2024-10-01 17:47:08.670 19330:19330 warning: Router: router/tester/0 table is empty
2024-10-01 17:47:08.670 19330:19330 info: Router initialized.
2024-10-01 17:47:08.670 19330:19330 info: Starting database file decompression.
2024-10-01 17:47:08.689 19330:19330 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2024-10-01 17:47:08.689 19330:19330 info: MetricsManager: Created new scope: (endpointAPI)
2024-10-01 17:47:08.689 19330:19330 info: MetricsManager: Created new scope: (endpointAPIRate)
2024-10-01 17:47:08.690 19330:19330 info: MetricsManager: Created new scope: (endpointEvent)
2024-10-01 17:47:08.690 19330:19330 info: MetricsManager: Created new scope: (endpointEventRate)
2024-10-01 17:47:08.691 19330:19330 info: Starting the server...
2024/10/01 17:47:09 INFO: [Cluster] [Main] Started the Communications API (pid: 19490)
2024/10/01 17:47:10 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/10/01 17:47:10 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/10/01 17:47:10 INFO: [Master] [Local integrity] Starting.
2024/10/01 17:47:10 INFO: [Master] [Local integrity] Finished in 0.099s. Calculated metadata of 3 files.
```

</details>

<details><summary>List processes</summary>

```console
root@wazuh-master:/$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   7372  2756 ?        Ss   17:10   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          53  0.0  0.0   7768  3648 pts/0    Ss   17:10   0:00 bash
wazuh      14743  0.0  0.0   7636  4404 pts/1    Ss   17:39   0:00 bash
root       19321  0.0  0.0   2892  1056 pts/0    S+   17:47   0:00 /bin/sh /var/ossec/bin/wazuh-clusterd -r -f
root       19329  3.4  1.2 323008 100100 pts/0   Sl+  17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py -r -f
root       19330  0.3  0.8 2976348 65820 pts/0   Sl+  17:47   0:00 /var/ossec/bin/wazuh-engine server start
wazuh      19372 12.3  1.5 820496 128756 ?       Sl   17:47   0:02 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      19373  0.0  0.9 179408 80836 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      19376  0.0  0.9 326872 81004 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      19379  0.0  1.0 474336 83076 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      19490  0.1  1.1 187188 92012 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      19491  0.3  1.2 189700 97592 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      19492  0.2  1.2 189700 97596 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      19501  0.2  1.2 189700 97600 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      19502  0.3  1.2 189700 97600 ?        S    17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
root       19504  0.0  0.9 175544 78232 pts/0    S+   17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py -r -f
root       19505  0.0  0.9 175544 78104 pts/0    S+   17:47   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py -r -f
root       19704  0.0  0.0   5772  1032 ?        S    17:47   0:00 sleep 10
wazuh      19818  0.0  0.0  10072  1608 pts/1    R+   17:47   0:00 ps aux
root@wazuh-master:/$ ls -la /var/ossec/var/run/
total 44
drwxrwx--- 1 root  wazuh 4096 Oct  1 17:47 .
drwxr-x--- 1 root  wazuh 4096 Oct  1 17:47 ..
-rw-r----- 1 wazuh wazuh    6 Oct  1 17:47 wazuh-apid-19372.pid
-rw-r----- 1 wazuh wazuh    6 Oct  1 17:47 wazuh-apid_auth-19376.pid
-rw-r----- 1 wazuh wazuh    6 Oct  1 17:47 wazuh-apid_events-19379.pid
-rw-r----- 1 wazuh wazuh    6 Oct  1 17:47 wazuh-apid_exec-19373.pid
-rw-r----- 1 root  root     6 Oct  1 17:47 wazuh-clusterd-19329.pid
-rw-r----- 1 root  root     6 Oct  1 17:47 wazuh-clusterd_child_0-19504.pid
-rw-r----- 1 root  root     6 Oct  1 17:47 wazuh-clusterd_child_1-19505.pid
-rw-r--r-- 1 wazuh wazuh    6 Oct  1 17:47 wazuh-comms-apid-19490.pid
```

</details>

<details><summary>Shutdown</summary>

```console
2024/10/01 17:47:10 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/10/01 17:47:10 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/10/01 17:47:10 INFO: [Master] [Local integrity] Starting.
2024/10/01 17:47:10 INFO: [Master] [Local integrity] Finished in 0.099s. Calculated metadata of 3 files.
2024/10/01 17:47:18 INFO: [Master] [Local integrity] Starting.
...
^C2024-10-01 17:48:39.063 26865:26865 info: Stopping the server
2024-10-01 17:48:39.063 26865:26865 info: Server closed
2024-10-01 17:48:39.063 26865:26865 info: [Endpoint: /var/ossec/queue/sockets/queue] Closed.
2024-10-01 17:48:39.063 26865:26865 info: [Endpoint: /var/ossec/queue/sockets/engine-api] Closed
2024-10-01 17:48:39.063 26865:26865 info: Server stopped
2024-10-01 17:48:39.063 26865:26865 info: API terminated.
2024/10/01 17:48:39 INFO: [Cluster] [Main] SIGINT received. Shutting down...
```

</details>

<details><summary>List processes</summary>

```console
root@wazuh-master:/$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   7372  2756 ?        Ss   17:10   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          53  0.0  0.0   7768  3648 pts/0    Ss+  17:10   0:00 bash
wazuh      14743  0.0  0.0   7636  4408 pts/1    Ss   17:39   0:00 bash
root       21389  0.0  0.0   5772  1012 ?        S    17:49   0:00 sleep 10
wazuh      21390  0.0  0.0  10072  1556 pts/1    R+   17:49   0:00 ps aux
root@wazuh-master:/$ ls -la /var/ossec/var/run/
total 12
drwxrwx--- 1 root wazuh 4096 Oct  1 17:48 .
drwxr-x--- 1 root wazuh 4096 Oct  1 17:49 ..
```

</details>

<details><summary>Killing the cluster main process when in background mode</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-clusterd -r
root@wazuh-master:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   7372  2756 ?        Ss   17:10   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          53  0.0  0.0   7768  3648 pts/0    Ss   17:10   0:00 bash
wazuh      14743  0.0  0.0   7636  4404 pts/1    Ss+  17:39   0:00 bash
root       21594  0.0  0.0   5772  1004 ?        S    17:49   0:00 sleep 10
root       21645  6.2  1.0 320868 89144 ?        Sl   17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py -r
root       21646  1.0  0.8 2894420 65872 ?       Sl   17:49   0:00 /var/ossec/bin/wazuh-engine server start
wazuh      21749 61.0  1.5 820504 126836 ?       Sl   17:49   0:02 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      21750  0.0  0.9 179416 80856 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      21753  0.0  0.9 326880 81076 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      21756  0.0  0.9 474344 81064 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh      21814  0.3  1.1 187204 92048 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      21815  1.0  1.2 189716 97628 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      21816  1.0  1.2 189828 97632 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      21818  1.0  1.2 189716 97632 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      21819  1.3  1.2 189720 97636 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
root       21820  0.0  0.9 173404 76688 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py -r
root       21821  0.0  0.9 173404 76672 ?        S    17:49   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/framework/scripts/wazuh_clusterd.py -r
root       21846  0.0  0.0  10072  1580 pts/0    R+   17:49   0:00 ps aux
root@wazuh-master:/# kill 21645
root@wazuh-master:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   7372  2756 ?        Ss   17:10   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          53  0.0  0.0   7768  3648 pts/0    Ss   17:10   0:00 bash
wazuh      14743  0.0  0.0   7636  4404 pts/1    Ss+  17:39   0:00 bash
root       21867  0.0  0.0   5772  1004 ?        S    17:49   0:00 sleep 10
root       21996  0.0  0.0  10072  1576 pts/0    R+   17:49   0:00 ps aux
root@wazuh-master:/# ls -la /var/ossec/var/run/
total 12
drwxrwx--- 1 root wazuh 4096 Oct  1 17:49 .
drwxr-x--- 1 root wazuh 4096 Oct  1 17:50 ..
```

</details>

<details><summary>cluster.log</summary>

```console
2024/10/01 17:57:27 INFO: [Cluster] [Main] Started the Engine (pid: 25577)
2024/10/01 17:57:28 INFO: [Cluster] [Main] Started the Management API (pid: 25619)
2024/10/01 17:57:29 INFO: [Cluster] [Main] Started the Communications API (pid: 25745)
2024/10/01 17:57:29 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/10/01 17:57:29 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/10/01 17:57:29 INFO: [Master] [Local integrity] Starting.
2024/10/01 17:57:29 INFO: [Master] [Local integrity] Finished in 0.096s. Calculated metadata of 3 files.
2024/10/01 17:57:37 INFO: [Master] [Local integrity] Starting.
2024/10/01 17:57:37 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 3 files.
2024/10/01 17:57:45 INFO: [Cluster] [Main] SIGNAL [(15)-(SIGTERM)] received. Shutting down...
```

</details>

<details><summary>Connecting the worker</summary>

Worker

```console
root@wazuh-worker1:/# /var/ossec/bin/wazuh-clusterd -r -f
Starting cluster in foreground (pid: 34494)
2024/10/01 18:16:58 INFO: [Cluster] [Main] Started the Engine (pid: 34495)
2024-10-01 18:16:58.715 34495:34495 info: Logging initialized.
2024-10-01 18:16:58.715 34495:34495 info: Store initialized.
2024-10-01 18:16:58.715 34495:34495 info: RBAC initialized.
2024-10-01 18:16:58.715 34495:34495 info: MetricsManager: Created new scope: (KVDB)
2024-10-01 18:16:58.730 34495:34495 info: KVDB initialized.
2024-10-01 18:16:58.730 34495:34495 info: Geo initialized.
2024-10-01 18:16:58.740 34495:34495 info: Schema initialized.
2024-10-01 18:16:59.304 34495:34495 info: Loaded timezone database version: '2024a'
2024-10-01 18:16:59.308 34495:34495 info: HLP initialized.
2024-10-01 18:16:59.320 34495:34495 info: Builder initialized.
2024-10-01 18:16:59.320 34495:34495 info: Catalog initialized.
2024-10-01 18:16:59.320 34495:34495 info: Policy manager initialized.
2024-10-01 18:16:59.320 34495:34495 info: MetricsManager: Created new scope: (EventQueue)
2024-10-01 18:16:59.320 34495:34495 info: MetricsManager: Created new scope: (EventQueueDelta)
2024-10-01 18:16:59.321 34495:34495 info: The queue will be flooded in the file: /var/ossec/logs/engine-flood.log
2024-10-01 18:16:59.322 34495:34495 info: MetricsManager: Created new scope: (TestQueue)
2024-10-01 18:16:59.322 34495:34495 info: MetricsManager: Created new scope: (TestQueueDelta)
2024-10-01 18:16:59.326 34495:34495 info: No flooding file provided, the queue will not be flooded.
2024-10-01 18:16:59.327 34495:34495 warning: Router: router/router/0 table is empty
2024-10-01 18:16:59.327 34495:34495 warning: Router: router/tester/0 table is empty
2024-10-01 18:16:59.327 34495:34495 info: Router initialized.
2024-10-01 18:16:59.327 34495:34495 info: Starting database file decompression.
2024-10-01 18:16:59.344 34495:34495 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2024-10-01 18:16:59.345 34495:34495 info: MetricsManager: Created new scope: (endpointAPI)
2024-10-01 18:16:59.345 34495:34495 info: MetricsManager: Created new scope: (endpointAPIRate)
2024-10-01 18:16:59.345 34495:34495 info: MetricsManager: Created new scope: (endpointEvent)
2024-10-01 18:16:59.345 34495:34495 info: MetricsManager: Created new scope: (endpointEventRate)
2024-10-01 18:16:59.347 34495:34495 info: Starting the server...
2024/10/01 18:16:59 INFO: [Cluster] [Main] Started the Management API (pid: 34598)
2024/10/01 18:17:00 INFO: [Cluster] [Main] Started the Communications API (pid: 34620)
2024/10/01 18:17:01 INFO: [Local Server] [Main] Serving on /var/ossec/queue/cluster/c-internal.sock
2024/10/01 18:17:01 INFO: [Worker wazuh-worker1] [Main] Successfully connected to master.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity check] Starting.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.009s. Sync required.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity sync] Starting.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity sync] Files to create: 2 | Files to update: 0 | Files to delete: 0
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity sync] Finished in 0.003s.
```

Master

```console
2024/10/01 18:17:01 INFO: [Worker] [Main] Connection from ('172.18.0.5', 54658)
2024/10/01 18:17:08 INFO: [Master] [Local integrity] Starting.
2024/10/01 18:17:08 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 3 files.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity check] Starting.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.002s. Received metadata of 1 files. Sync required.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity sync] Starting.
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity sync] Files to create in worker: 2 | Files to update in worker: 0 | Files to delete in worker: 0
2024/10/01 18:17:10 INFO: [Worker wazuh-worker1] [Integrity sync] Finished in 0.003s.
2024/10/01 18:17:16 INFO: [Master] [Local integrity] Starting.
2024/10/01 18:17:16 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 3 files.
2024/10/01 18:17:19 INFO: [Worker wazuh-worker1] [Integrity check] Starting.
2024/10/01 18:17:19 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.002s. Received metadata of 3 files. Sync not required.
2024/10/01 18:17:24 INFO: [Master] [Local integrity] Starting.
2024/10/01 18:17:24 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 3 files.
2024/10/01 18:17:28 INFO: [Worker wazuh-worker1] [Integrity check] Starting.
2024/10/01 18:17:28 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.002s. Received metadata of 3 files. Sync not required.
2024/10/01 18:17:32 INFO: [Master] [Local integrity] Starting.
2024/10/01 18:17:32 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 3 files.
2024/10/01 18:17:37 INFO: [Worker wazuh-worker1] [Integrity check] Starting.
2024/10/01 18:17:37 INFO: [Worker wazuh-worker1] [Integrity check] Finished in 0.002s. Received metadata of 3 files. Sync not required.
2024/10/01 18:17:40 INFO: [Master] [Local integrity] Starting.
2024/10/01 18:17:40 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 3 files.
```

</details>

<details><summary>Management API authentication</summary>

```console
root@wazuh-master:/# curl -u wazuh:wazuh -s -k -X POST https://localhost:55000/security/user/authenticate
{"data": {"token": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzI3ODIzMjc2LCJleHAiOjE3Mjc4MjQxNzYsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.HW9aBQAUbF7KkNAABP5AX4MiW4RcAMKh6ftwRjbSDSvjiYXvUxFfkjE0MiDcroBhyw_iaEsCmmfnn5ETI9COhA"}, "error": 0}
```

</details>

<details><summary>Communications API authentication</summary>

```console
root@wazuh-master:/# curl -k -X POST -H "Content-Type: application/json" -d '{"uuid": "01912d07-b9b4-7528-bdad-15da902d651c", "key": "testing"}' https://localhost:27000/api/v1/authentication
{"token":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTcyNzgyMzQwNCwiZXhwIjoxNzI3ODI0MzA0LCJ1dWlkIjoiMDE5MTJkMDctYjliNC03NTI4LWJkYWQtMTVkYTkwMmQ2NTFjIn0.cNqnRGEJe1a5-jJEVKdjcz905cT7ReEDXbBYkKl7Mtut7uDqFcdUWpE3v-rJU0xE_WQtEZojjr6lcIlhllYfuA"}
```

</details>
