### PR TITLE
Fix coverity warnings

### DIFF
--- a/src/shared_modules/content_manager/src/components/updaterContext.hpp
+++ b/src/shared_modules/content_manager/src/components/updaterContext.hpp
@@ -102,7 +102,7 @@ struct UpdaterBaseContext
     explicit UpdaterBaseContext(std::shared_ptr<ConditionSync> spStopCondition,
                                 FileProcessingCallback fileProcessingCallback)
         : spStopCondition(std::move(spStopCondition))
-        , fileProcessingCallback(fileProcessingCallback)
+        , fileProcessingCallback(std::move(fileProcessingCallback))
     {
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/007/expected_001.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/007/expected_001.out
@@ -11,7 +11,6 @@
 "Processing and publish key: CVE-2024-23204",
 "Processing and publish key: CVE-2024-23213",
 "Processing and publish key: CVE-2024-23203",
-"Processing and publish key: CVE-2023-4734",
 "Processing and publish key: CVE-2024-23214",
 "Processing and publish key: CVE-2023-45866",
 "Processing and publish key: CVE-2023-42940",

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/007/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/007/expected_002.out
@@ -72,7 +72,6 @@
 "Removing element from inventory: 001_macOS_CVE-2023-42937",
 "Removing element from inventory: 001_macOS_CVE-2023-42940",
 "Removing element from inventory: 001_macOS_CVE-2023-45866",
-"Removing element from inventory: 001_macOS_CVE-2023-4734",
 "Removing element from inventory: 001_macOS_CVE-2024-23203",
 "Removing element from inventory: 001_macOS_CVE-2024-23204",
 "Removing element from inventory: 001_macOS_CVE-2024-23206",

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/014/expected_001.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/014/expected_001.out
@@ -11,7 +11,6 @@
 "Processing and publish key: CVE-2024-23204",
 "Processing and publish key: CVE-2024-23213",
 "Processing and publish key: CVE-2024-23203",
-"Processing and publish key: CVE-2023-4734",
 "Processing and publish key: CVE-2024-23214",
 "Processing and publish key: CVE-2023-45866",
 "Processing and publish key: CVE-2023-42940",


### PR DESCRIPTION
|Related issue|
|---|
|Closes #26059|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

I analyzed the warnings reported by coverity:
- It seemed safe to move the callback, because it wasn't being used anywhere else. But it might happen that the constructor of `DatabaseFeedManager` provides a callback and the caller tries to use it after (although very unlikely).
- The `this` pointer can't be manually initialized and it's safe to use it in the constructor. I ignored the issue in the Coverity page.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The Coverity scan shows the issue has been fixed. The other two were ignored

![2024-10-01_20-43](https://github.com/user-attachments/assets/f29394b6-e368-4988-8fb1-69b2fec2b57d)


<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Coverity
