### PR TITLE
Fix race condition during the osdatacache and remediationdatacache functionality.

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -18,7 +18,7 @@
 #include "socketDBWrapper.hpp"
 #include "wazuhDBQueryBuilder.hpp"
 #include "wdbDataException.hpp"
-#include <shared_mutex>
+#include <mutex>
 #include <string>
 
 /**
@@ -52,9 +52,9 @@ class OsDataCache final : public Singleton<OsDataCache<>>
 {
 private:
     LRUCache<std::string, Os> m_osData {PolicyManager::instance().getOsdataLRUSize()};
-    std::shared_mutex m_mutex;
+    std::mutex m_mutex;
 
-    Os getOsDataFromWdb(const std::string& agentId)
+    Os getOsDataFromWdb(const std::string& agentId) const
     {
         nlohmann::json response;
         try
@@ -109,15 +109,24 @@ public:
      */
     Os getOsData(const std::string& agentId)
     {
-        std::shared_lock lock(m_mutex);
-        if (auto value = m_osData.getValue(agentId); value)
+        const auto getValue = [this](const std::string& agentIdValue) -> std::optional<Os>
         {
-            return *value;
+            std::scoped_lock lock(m_mutex);
+            if (auto value = m_osData.getValue(agentIdValue); value)
+            {
+                return *value;
+            }
+            return std::nullopt;
+        };
+
+        if (const auto osData = getValue(agentId); osData != std::nullopt)
+        {
+            return *osData;
         }
 
         // This may throw an exception that will be captured by the caller method.
-        auto osData = getOsDataFromWdb(agentId);
-        m_osData.insertKey(agentId, osData);
+        const auto osData = getOsDataFromWdb(agentId);
+        setOsData(agentId, osData);
         return osData;
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/remediationDataCache.hpp
@@ -18,7 +18,7 @@
 #include "socketDBWrapper.hpp"
 #include "wazuhDBQueryBuilder.hpp"
 #include "wdbDataException.hpp"
-#include <shared_mutex>
+#include <mutex>
 #include <string>
 #include <unordered_set>
 
@@ -40,7 +40,7 @@ class RemediationDataCache final : public Singleton<RemediationDataCache<>>
 {
 private:
     LRUCache<std::string, Remediation> m_remediationData {PolicyManager::instance().getRemediationLRUSize()};
-    std::shared_mutex m_mutex;
+    std::mutex m_mutex;
 
     Remediation getRemediationDataFromWdb(const std::string& agentId) const
     {
@@ -89,16 +89,26 @@ public:
      */
     Remediation getRemediationData(const std::string& agentId)
     {
-        std::shared_lock lock(m_mutex);
-        if (auto value = m_remediationData.getValue(agentId); value)
+        auto getValue = [this](const std::string& agentIdValue) -> std::optional<Remediation>
         {
-            return *value;
+            std::scoped_lock lock(m_mutex);
+            if (auto value = m_remediationData.getValue(agentIdValue); value)
+            {
+                return *value;
+            }
+            return std::nullopt;
+        };
+
+        if (auto remediationData = getValue(agentId); remediationData != std::nullopt)
+        {
+            return *remediationData;
         }
 
         const auto remediationData = getRemediationDataFromWdb(agentId);
 
         if (!remediationData.hotfixes.empty())
         {
+            std::scoped_lock lock(m_mutex);
             // Update the cache with the queried data
             m_remediationData.insertKey(agentId, remediationData);
         }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25897|

This PR aims to solve a problem during the usage of some LRU caches.

Basically with this change, we prevent the concurrent write/read operations in a LRU cache.