### PR TITLE
Engine field names supports escaped dots

### DIFF
--- a/src/engine/source/base/test/src/unit/json_test.cpp
+++ b/src/engine/source/base/test/src/unit/json_test.cpp
@@ -119,6 +119,10 @@ TEST_F(JsonStatic, FormatJsonPath)
     dotPath = "field.~tmp./field./tmp";
     ASSERT_NO_THROW(pointerPath = Json::formatJsonPath(dotPath););
     ASSERT_EQ(pointerPath, "/field/~0tmp/~1field/~1tmp");
+
+    dotPath = "field\\.with.dot";
+    ASSERT_NO_THROW(pointerPath = Json::formatJsonPath(dotPath););
+    ASSERT_EQ(pointerPath, "/field.with/dot");
 }
 
 TEST_F(JsonBuildtime, Size)

--- a/src/engine/source/builder/src/syntax.hpp
+++ b/src/engine/source/builder/src/syntax.hpp
@@ -44,6 +44,8 @@ constexpr auto REF_ANCHOR = '$';       ///< Char used to indicate a reference.
 constexpr auto SEPARATOR = '.';        ///< Char used to separate levels in a fields path.
 constexpr auto VAR_ANCHOR = '_';       ///< Char used to indicate a variable.
 constexpr auto NAME_EXTENDED = "_@#-"; ///< Extended allowed chars in a field name.
+constexpr auto DEFAULT_ESCAPE = '\\';  ///< Char used to escape special characters in a field name.
+constexpr auto ESCAPED_CHARS = ".";    ///< Characters that can be escaped in a field name.
 } // namespace field
 
 // Function helpers syntax

--- a/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/helperParser_test.cpp
@@ -326,7 +326,11 @@ INSTANTIATE_TEST_SUITE_P(
                     RefArgT(R"($ref}invalid)", makeSuccess<OpArg>(ref("ref"), 4)),
                     RefArgT(R"($ref_extended.name$leftover)", makeSuccess<OpArg>(ref("ref_extended.name"), 18)),
                     RefArgT(R"(ref)", makeError<OpArg>("", 0)),
-                    RefArgT(R"(\$ref)", makeError<OpArg>("", 0))));
+                    RefArgT(R"(\$ref)", makeError<OpArg>("", 0)),
+                    RefArgT(R"($ref\.withdot)", makeSuccess<OpArg>(ref("ref\\.withdot"), 13)),
+                    RefArgT(R"($ref\invalidescape)", makeError<OpArg>("", 4))
+
+                        ));
 
 INSTANTIATE_TEST_SUITE_P(
     Builder,


### PR DESCRIPTION
|Related issue|
|---|
|#26052|

The Engine operations now supports accessing/mapping fields with dots in their names, e.g.:
Decoder:
```yml
name: decoder/test/0

parse|event.original:
  - <tmp.json/json>

normalize:
  - map:
      - dotted\.mapped: $tmp.json.dotted\.field
```
Traces:
```
{"dotted.field": "value"}
Traces:
[🟢] decoder/test/0 -> success
  ↳ [/event/original: <tmp.json/json>] -> Success
  ↳ dotted\.mapped: map($tmp.json.dotted\.field) -> Success

dotted.mapped: value
event:
  original: "{\"dotted.field\": \"value\"}"
tmp:
  json:
    dotted.field: value
wazuh:
  location: api.test
  queue: 49
  ```