### PR TITLE
Drop invalid mesages of `indexerConnector`

### DIFF
--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -17,7 +17,6 @@
 #include "secureCommunication.hpp"
 #include "serverSelector.hpp"
 #include <fstream>
-#include <ostream>
 
 constexpr auto INDEXER_COLUMN {"indexer"};
 constexpr auto USER_KEY {"username"};

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -17,7 +17,6 @@
 #include "secureCommunication.hpp"
 #include "serverSelector.hpp"
 #include <fstream>
-#include <iostream>
 #include <ostream>
 
 constexpr auto INDEXER_COLUMN {"indexer"};

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -17,6 +17,8 @@
 #include "secureCommunication.hpp"
 #include "serverSelector.hpp"
 #include <fstream>
+#include <iostream>
+#include <ostream>
 
 constexpr auto INDEXER_COLUMN {"indexer"};
 constexpr auto USER_KEY {"username"};
@@ -153,7 +155,12 @@ IndexerConnector::IndexerConnector(const nlohmann::json& config, const uint32_t&
             {
                 auto data = dataQueue.front();
                 dataQueue.pop();
-                auto parsedData = nlohmann::json::parse(data);
+                auto parsedData = nlohmann::json::parse(data, nullptr, false);
+
+                if (parsedData.is_discarded())
+                {
+                    continue;
+                }
 
                 if (parsedData.at("operation").get_ref<const std::string&>().compare("DELETED") == 0)
                 {


### PR DESCRIPTION
|Related issue|
|---|
|[26015](https://github.com/wazuh/wazuh/issues/26015)|


# Objective

This PR aims to enable `json::parser` function to accept a bool parameter allow_exceptions which controls whether an exception is thrown when a parse error occurs (true, default) or whether a discarded value should be returned (false).
This behavior is similar to the function `accept()`, which can be used which does not return a JSON value, but a bool indicating whether the input is valid JSON.

In any case, no diagnostic information available in this scenario.

