### PR TITLE
Reorder Events in the API specification

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -7199,6 +7199,8 @@ tags:
     description: "Wazuh cluster and nodes management"
   - name: Decoders
     description: "Decoders management"
+  - name: Events
+    description: "Ingestion endpoints"
   - name: Experimental
     description: "Not ready for production endpoints. Use with caution"
   - name: Groups
@@ -7227,8 +7229,6 @@ tags:
     description: "Syscollector information"
   - name: Tasks
     description: "Tasks information"
-  - name: Events
-    description: "Ingestion endpoints"
 
 security:
   - jwt: []
@@ -15231,6 +15231,70 @@ paths:
         '429':
           $ref: '#/components/responses/TooManyRequestsResponse'
 
+  /events:
+    post:
+      tags:
+        - Events
+      summary: "Ingest events"
+      description: |-
+        Send security events to analysisd.
+
+        The endpoint is limited to receiving a max of 30 requests per minute and a max bulk size of 100 events per request.
+      operationId: api.controllers.event_controller.forward_event
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/event:ingest'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+      requestBody:
+        content:
+          application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    description: "Bulk of events"
+                    type: array
+                    items:
+                      type: string
+                required:
+                - events
+              example:
+                events:
+                  - "Event value 1"
+                  - "{\"someKey\": \"Event value 2\"}"
+      responses:
+        '200':
+          description: "Events accepted"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              example:
+                data:
+                  affected_items:
+                    - "Event value 1"
+                    - "{\"someKey\": \"Event value 2\"}"
+                  total_affected_items: 2
+                  total_failed_items: 0
+                  failed_items: []
+                message: "All events were forwarded to analisysd"
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '406':
+          $ref: '#/components/responses/WrongContentTypeResponse'
+        '413':
+          $ref: '#/components/responses/RequestTooLargeResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+
   /experimental/rootcheck:
     delete:
       tags:
@@ -19043,70 +19107,6 @@ paths:
                   failed_items: []
                 message: "All specified task's status were returned"
                 error: 0
-
-  /events:
-    post:
-      tags:
-        - Events
-      summary: "Ingest events"
-      description: |-
-        Send security events to analysisd.
-
-        The endpoint is limited to receiving a max of 30 requests per minute and a max bulk size of 100 events per request.
-      operationId: api.controllers.event_controller.forward_event
-      x-rbac-actions:
-        - $ref: '#/x-rbac-catalog/actions/event:ingest'
-      parameters:
-        - $ref: '#/components/parameters/pretty'
-        - $ref: '#/components/parameters/wait_for_complete'
-      requestBody:
-        content:
-          application/json:
-              schema:
-                type: object
-                properties:
-                  events:
-                    description: "Bulk of events"
-                    type: array
-                    items:
-                      type: string
-                required:
-                - events
-              example:
-                events:
-                  - "Event value 1"
-                  - "{\"someKey\": \"Event value 2\"}"
-      responses:
-        '200':
-          description: "Events accepted"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponse'
-              example:
-                data:
-                  affected_items:
-                    - "Event value 1"
-                    - "{\"someKey\": \"Event value 2\"}"
-                  total_affected_items: 2
-                  total_failed_items: 0
-                  failed_items: []
-                message: "All events were forwarded to analisysd"
-                error: 0
-        '400':
-          $ref: '#/components/responses/ResponseError'
-        '401':
-          $ref: '#/components/responses/UnauthorizedResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDeniedResponse'
-        '405':
-          $ref: '#/components/responses/InvalidHTTPMethodResponse'
-        '406':
-          $ref: '#/components/responses/WrongContentTypeResponse'
-        '413':
-          $ref: '#/components/responses/RequestTooLargeResponse'
-        '429':
-          $ref: '#/components/responses/TooManyRequestsResponse'
 
 externalDocs:
   description: "Learn more about the Wazuh API"


### PR DESCRIPTION
## Description

The `Events` section was moved in the API reference page to be alphabetically ordered.

![API reference · Wazuh documentation](https://github.com/user-attachments/assets/3633a274-684a-4591-a48e-600d8fbbcfc7)

## Tests

```
$ pytest -vv --disable-warnings test_event_endpoints.tavern.yaml
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.0, pytest-7.3.1, pluggy-1.5.0
cachedir: .pytest_cache
metadata: {'Python': '3.10.0', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'tavern': '1.23.5', 'html': '2.1.1'
, 'asyncio': '0.18.1', 'trio': '0.8.0', 'anyio': '4.1.0', 'metadata': '3.1.1'}}
rootdir: /wazuh/api/test/integration
configfile: pytest.ini
plugins: tavern-1.23.5, html-2.1.1, asyncio-0.18.1, trio-0.8.0, anyio-4.1.0, metadata-3.1.1
asyncio: mode=auto
collected 5 items                                                                                                                                                                            

test_event_endpoints.tavern.yaml::POST /events PASSED                                                                                                                                  [ 20%]
test_event_endpoints.tavern.yaml::POST /events with invalid formats PASSED                                                                                                             [ 40%]
test_event_endpoints.tavern.yaml::POST /events with more than 100 events PASSED                                                                                                        [ 60%]
test_event_endpoints.tavern.yaml::POST /events with big events PASSED                                                                                                                  [ 80%]
test_event_endpoints.tavern.yaml::Try to send more than 30 requests per minute PASSED                                                                                                  [100%]
========================================================================= 5 passed, 6 warnings in 934.28s (0:15:34) ==========================================================================
``` 

The `test_event_endpoints` API integration tests were successfully executed.