### PR TITLE
Improve engine log error

### DIFF
--- a/src/engine/source/base/include/base/utils/threadEventDispatcher.hpp
+++ b/src/engine/source/base/include/base/utils/threadEventDispatcher.hpp
@@ -12,11 +12,14 @@
 #ifndef _THREAD_EVENT_DISPATCHER_HPP
 #define _THREAD_EVENT_DISPATCHER_HPP
 
-#include "rocksDBQueue.hpp"
-#include "threadSafeQueue.hpp"
 #include <atomic>
 #include <iostream>
 #include <thread>
+
+#include <base/logging.hpp>
+
+#include "rocksDBQueue.hpp"
+#include "threadSafeQueue.hpp"
 
 constexpr auto UNLIMITED_QUEUE_SIZE = 0;
 static const unsigned int SINGLE_THREAD = 1;
@@ -202,7 +205,7 @@ private:
         catch (const std::exception& ex)
         {
             // Log the error if an exception occurs
-            std::cerr << "Dispatch handler error: " << ex.what() << "\n";
+            LOG_ERROR("Dispatch handler error: {}", ex.what());
         }
     }
 

--- a/src/engine/source/base/test/src/unit/utils/threadEventDispatcher_test.cpp
+++ b/src/engine/source/base/test/src/unit/utils/threadEventDispatcher_test.cpp
@@ -9,13 +9,15 @@
  * Foundation.
  */
 
-#include "base/utils/rocksDBQueue.hpp"
-#include "base/utils/threadEventDispatcher.hpp"
-#include "base/utils/threadSafeMultiQueue.hpp"
 #include <future>
 #include <gtest/gtest.h>
 #include <memory>
 #include <thread>
+
+#include <base/logging.hpp>
+#include <base/utils/rocksDBQueue.hpp>
+#include <base/utils/threadEventDispatcher.hpp>
+#include <base/utils/threadSafeMultiQueue.hpp>
 
 class ThreadEventDispatcherTest : public ::testing::Test
 {
@@ -30,6 +32,7 @@ auto constexpr TEST_DB = "test.db";
 
 void ThreadEventDispatcherTest::SetUp()
 {
+    logging::testInit();
     std::filesystem::remove_all(TEST_DB);
 };
 
@@ -220,8 +223,6 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThreadDifferentTypeExcepti
                             catch (const std::exception& e)
                             {
                                 // The log message is resposibility of the lambda function.
-                                std::cout << __FUNCTION__ << " ERROR: event discarded: " << value.ToString() << ". "
-                                          << e.what() << "." << std::endl;
                                 ++dropped;
                                 messagesDiscarded.push_back(std::stoi(value.ToString()));
                                 throw std::runtime_error(e.what());

--- a/src/engine/source/base/test/src/unit/utils/threadEventDispatcher_test.cpp
+++ b/src/engine/source/base/test/src/unit/utils/threadEventDispatcher_test.cpp
@@ -10,9 +10,10 @@
  */
 
 #include <future>
-#include <gtest/gtest.h>
 #include <memory>
 #include <thread>
+
+#include <gtest/gtest.h>
 
 #include <base/logging.hpp>
 #include <base/utils/rocksDBQueue.hpp>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26013|

# Objective

This PR aims to change the `std::cerr` current output, for the login approach which is splog.

We apply only to source code inside of the `engine` folder, excluding:

- Dependencies
- UTs
- TesTools