### PR TITLE
Improve indexer connector configuration interface

### DIFF
--- a/src/engine/source/cmds/src/start.cpp
+++ b/src/engine/source/cmds/src/start.cpp
@@ -297,26 +297,26 @@ void runStart(ConfHandler confManager)
 
         // Indexer Connector
         {
-            nlohmann::json indexerConfig;
-            // TODO Change index to `wazuh-alerts-5.x-%{+yyyyy.MM.dd}` when supported placeholder is available
-            indexerConfig["name"] = getEnvOrDefault("WENGINE_ICONNECTOR_INDEX", "test-basic-index");
-            indexerConfig["hosts"] =
-                nlohmann::json::array({getEnvOrDefault("WENGINE_ICONNECTOR_HOSTS", "http://127.0.0.1:9200")});
-            indexerConfig["username"] = getEnvOrDefault("WENGINE_ICONNECTOR_USERNAME", "admin");
-            indexerConfig["password"] = getEnvOrDefault("WENGINE_ICONNECTOR_PASSWORD", "WazuhEngine5+");
-
             // SSL configuration
-            nlohmann::json ssl;
-            ssl["certificate_authorities"] = getEnvOrDefault("WENGINE_ICONNECTOR_CA", "");
-            ssl["certificate"] = getEnvOrDefault("WENGINE_ICONNECTOR_CERT", "");
-            ssl["key"] = getEnvOrDefault("WENGINE_ICONNECTOR_KEY", "");
-            if (ssl.contains("certificate_authorities") && !ssl["certificate_authorities"].empty())
-            {
-                indexerConfig["ssl"] = ssl;
-            }
+            SslOptions sslOptions {.cacert = {getEnvOrDefault("WENGINE_ICONNECTOR_CA", "")},
+                                   .cert = getEnvOrDefault("WENGINE_ICONNECTOR_CERT", ""),
+                                   .key = getEnvOrDefault("WENGINE_ICONNECTOR_KEY", "")};
+
+            // TODO Change index to `wazuh-alerts-5.x-%{+yyyyy.MM.dd}` when supported placeholder is available.
+            // IndexerConnector configuration.
+            IndexerConnectorOptions indexerConnectorOptions {
+                .name = getEnvOrDefault("WENGINE_ICONNECTOR_INDEX", "test-basic-index"),
+                .hosts = {getEnvOrDefault("WENGINE_ICONNECTOR_HOSTS", "http://127.0.0.1:9200")},
+                .username = getEnvOrDefault("WENGINE_ICONNECTOR_USERNAME", "admin"),
+                .password = getEnvOrDefault("WENGINE_ICONNECTOR_PASSWORD", "WazuhEngine5+"),
+                .sslOptions = sslOptions,
+                .timeout = static_cast<uint32_t>(std::stoul(getEnvOrDefault("WENGINE_ICONNECTOR_TIMEOUT", "60000"))),
+                .workingThreads =
+                    static_cast<uint8_t>(std::stoul(getEnvOrDefault("WENGINE_ICONNECTOR_WORKING_THREADS", "1"))),
+                .databasePath = getEnvOrDefault("WENGINE_ICONNECTOR_DB_PATH", getExecutablePath() + "/queue/indexer")};
 
             // Create connector and wait until the connection is established.
-            iConnector = std::make_shared<IndexerConnector>(indexerConfig);
+            iConnector = std::make_shared<IndexerConnector>(indexerConnectorOptions);
         }
 
         // Builder and registry

--- a/src/engine/source/cmds/src/start.cpp
+++ b/src/engine/source/cmds/src/start.cpp
@@ -296,20 +296,16 @@ void runStart(ConfHandler confManager)
         }
 
         // Indexer Connector
-        {
-            // SSL configuration
-            SslOptions sslOptions {.cacert = {getEnvOrDefault("WENGINE_ICONNECTOR_CA", "")},
-                                   .cert = getEnvOrDefault("WENGINE_ICONNECTOR_CERT", ""),
-                                   .key = getEnvOrDefault("WENGINE_ICONNECTOR_KEY", "")};
-
-            // TODO Change index to `wazuh-alerts-5.x-%{+yyyyy.MM.dd}` when supported placeholder is available.
+        { // TODO Change index to `wazuh-alerts-5.x-%{+yyyyy.MM.dd}` when supported placeholder is available.
             // IndexerConnector configuration.
             IndexerConnectorOptions indexerConnectorOptions {
                 .name = getEnvOrDefault("WENGINE_ICONNECTOR_INDEX", "test-basic-index"),
                 .hosts = {getEnvOrDefault("WENGINE_ICONNECTOR_HOSTS", "http://127.0.0.1:9200")},
                 .username = getEnvOrDefault("WENGINE_ICONNECTOR_USERNAME", "admin"),
                 .password = getEnvOrDefault("WENGINE_ICONNECTOR_PASSWORD", "WazuhEngine5+"),
-                .sslOptions = sslOptions,
+                .sslOptions = {.cacert = {getEnvOrDefault("WENGINE_ICONNECTOR_CA", "")},
+                               .cert = getEnvOrDefault("WENGINE_ICONNECTOR_CERT", ""),
+                               .key = getEnvOrDefault("WENGINE_ICONNECTOR_KEY", "")},
                 .timeout = static_cast<uint32_t>(std::stoul(getEnvOrDefault("WENGINE_ICONNECTOR_TIMEOUT", "60000"))),
                 .workingThreads =
                     static_cast<uint8_t>(std::stoul(getEnvOrDefault("WENGINE_ICONNECTOR_WORKING_THREADS", "1"))),

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -86,13 +86,7 @@ public:
      * bulk either when the maximum bulk size or the time interval is reached. The bulk size is 1000 messages and the
      * interval is 5 seconds.
      *
-     * @param config Indexer configuration includes:
-     *  - Index name .
-     *  - Server list .
-     *  - Ssl configuration (cacert, cert, and key).
-     *  - Authentication (username and password).
-     *  - Timeout (Interval for monitoring the server health).
-     *  - Working threads number (Number of working threads used by the dispatcher. More than one results in an
+     * @param config Indexer connector configuration 
     unordered
      * processing).
      */

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -29,30 +29,26 @@
 #endif
 
 /**
- * @brief Options for the secure communication.
- *
- */
-struct SslOptions
-{
-    std::vector<std::string> cacert;
-    std::string cert;
-    std::string key;
-};
-
-/**
- * @brief Options for the IndexerConnector.
- *
+ * @brief Configuration options for the Indexer Connector.
+ * 
  */
 struct IndexerConnectorOptions
 {
-    std::string name;
-    std::vector<std::string> hosts;
-    std::string username;
-    std::string password;
-    SslOptions sslOptions;
-    uint32_t timeout = 60000u;
-    uint8_t workingThreads = 1;
-    std::string databasePath;
+    std::string name;               ///< The name of the index to push the data.
+    std::vector<std::string> hosts; ///< The list of hosts to connect to. i.e. ["https://localhost:9200"]
+    std::string username;           ///< The username to authenticate with OpenSearch.
+    std::string password;           ///< The password to authenticate with OpenSearch.
+
+    struct
+    {
+        std::vector<std::string> cacert; ///< The list of CA certificates to trust.
+        std::string cert;                ///< The certificate to connect to OpenSearch.
+        std::string key;                 ///< The key to connect to OpenSearch.
+    } sslOptions;                        ///< The SSL options to connect to OpenSearch.
+
+    uint32_t timeout = 60000u;  ///< The timeout in milliseconds to connect to OpenSearch.
+    uint8_t workingThreads = 1; ///< The number of threads to dequeue and send the data.
+    std::string databasePath;   ///< The path to the database file.
 };
 
 template<typename TMonitoring = void>

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -30,7 +30,7 @@
 
 /**
  * @brief Configuration options for the Indexer Connector.
- * 
+ *
  */
 struct IndexerConnectorOptions
 {
@@ -72,7 +72,6 @@ class EXPORTED IndexerConnector final : public IIndexerConnector
     std::string m_indexName;
     std::mutex m_syncMutex;
     std::unique_ptr<ThreadDispatchQueue> m_dispatcher;
-    IndexerConnectorOptions m_indexerConnectorOptions;
 
 public:
     /**
@@ -86,7 +85,7 @@ public:
      * bulk either when the maximum bulk size or the time interval is reached. The bulk size is 1000 messages and the
      * interval is 5 seconds.
      *
-     * @param config Indexer connector configuration 
+     * @param config Indexer connector configuration
     unordered
      * processing).
      */

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -18,8 +18,6 @@
 #include <mutex>
 #include <queue>
 
-#include <nlohmann/json.hpp>
-
 #include <base/utils/threadEventDispatcher.hpp>
 
 #include <indexerConnector/iindexerconnector.hpp>
@@ -30,7 +28,32 @@
 #define EXPORTED
 #endif
 
-static constexpr auto DEFAULT_INTERVAL = 60000u;
+/**
+ * @brief Options for the secure communication.
+ *
+ */
+struct SslOptions
+{
+    std::vector<std::string> cacert;
+    std::string cert;
+    std::string key;
+};
+
+/**
+ * @brief Options for the IndexerConnector.
+ *
+ */
+struct IndexerConnectorOptions
+{
+    std::string name;
+    std::vector<std::string> hosts;
+    std::string username;
+    std::string password;
+    SslOptions sslOptions;
+    uint32_t timeout = 60000u;
+    uint8_t workingThreads = 1;
+    std::string databasePath;
+};
 
 template<typename TMonitoring = void>
 class TServerSelector;
@@ -53,6 +76,7 @@ class EXPORTED IndexerConnector final : public IIndexerConnector
     std::string m_indexName;
     std::mutex m_syncMutex;
     std::unique_ptr<ThreadDispatchQueue> m_dispatcher;
+    IndexerConnectorOptions m_indexerConnectorOptions;
 
 public:
     /**
@@ -66,27 +90,17 @@ public:
      * bulk either when the maximum bulk size or the time interval is reached. The bulk size is 1000 messages and the
      * interval is 5 seconds.
      *
-     * @param config Indexer configuration, including the index name, server list, ssl configuration and user and
-     * password.
-     * @param timeout Interval for monitoring the server health.
-     * @param workingThreads Number of working threads used by the dispatcher. More than one results in an unordered
-     * processing.
-     * @note Example of the configuration:
-     *  {
-     *      "name": "wazuh-alerts-5.x",
-     *      "host": ["localhost:9200"],
-     *      "user": "admin",
-     *      "password": "admin",
-     *      "ssl": {
-     *          "certificate_authorities": "/etc/ssl/certs/ca.pem",
-     *          "certificate": "/etc/ssl/certs/cert.pem",
-     *          "key": "/etc/ssl/certs/key.pem"
-     *      }
-     *  }
+     * @param config Indexer configuration includes:
+     *  - Index name .
+     *  - Server list .
+     *  - Ssl configuration (cacert, cert, and key).
+     *  - Authentication (username and password).
+     *  - Timeout (Interval for monitoring the server health).
+     *  - Working threads number (Number of working threads used by the dispatcher. More than one results in an
+    unordered
+     * processing).
      */
-    explicit IndexerConnector(const nlohmann::json& config,
-                              const uint32_t& timeout = DEFAULT_INTERVAL,
-                              uint8_t workingThreads = 1);
+    explicit IndexerConnector(const IndexerConnectorOptions& config);
 
     /**
      * @brief Class destructor.

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -91,7 +91,6 @@ static void builderBulkIndex(std::string& bulkData, std::string_view id, std::st
 
 IndexerConnector::IndexerConnector(const IndexerConnectorOptions& indexerConnectorOptions)
 {
-    m_indexerConnectorOptions = indexerConnectorOptions;
     // Get index name.
     m_indexName = indexerConnectorOptions.name;
 
@@ -103,14 +102,14 @@ IndexerConnector::IndexerConnector(const IndexerConnectorOptions& indexerConnect
     }
 
     auto secureCommunication = SecureCommunication::builder();
-    initConfiguration(secureCommunication, m_indexerConnectorOptions);
+    initConfiguration(secureCommunication, indexerConnectorOptions);
 
     // Initialize publisher.
     auto selector {std::make_shared<TServerSelector<Monitoring>>(
-        m_indexerConnectorOptions.hosts, m_indexerConnectorOptions.timeout, secureCommunication)};
+        indexerConnectorOptions.hosts, indexerConnectorOptions.timeout, secureCommunication)};
 
     // Validate threads number
-    if (m_indexerConnectorOptions.workingThreads <= 0)
+    if (indexerConnectorOptions.workingThreads <= 0)
     {
         LOG_DEBUG("Invalid number of working threads, using default value.");
     }
@@ -171,10 +170,10 @@ IndexerConnector::IndexerConnector(const IndexerConnectorOptions& indexerConnect
                      }});
             }
         },
-        m_indexerConnectorOptions.databasePath + m_indexName,
+        indexerConnectorOptions.databasePath + m_indexName,
         ELEMENTS_PER_BULK,
-        m_indexerConnectorOptions.workingThreads <= 0 ? SINGLE_ORDERED_DISPATCHING
-                                                      : m_indexerConnectorOptions.workingThreads);
+        indexerConnectorOptions.workingThreads <= 0 ? SINGLE_ORDERED_DISPATCHING
+                                                    : indexerConnectorOptions.workingThreads);
 }
 
 IndexerConnector::~IndexerConnector()

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -25,9 +25,8 @@ constexpr auto ELEMENTS_PER_BULK {1000};
 
 // Single thread in case the events needs to be processed in order.
 constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
-constexpr auto DATABASE_BASE_PATH = "queue/indexer/";
 
-static void initConfiguration(SecureCommunication& secureCommunication, const nlohmann::json& config)
+static void initConfiguration(SecureCommunication& secureCommunication, const IndexerConnectorOptions& config)
 {
     std::string caRootCertificate;
     std::string sslCertificate;
@@ -35,46 +34,26 @@ static void initConfiguration(SecureCommunication& secureCommunication, const nl
     std::string username;
     std::string password;
 
-    if (config.contains("ssl"))
+    if (!config.sslOptions.cacert.empty())
     {
-        if (config.at("ssl").contains("certificate_authorities")
-            && !config.at("ssl").at("certificate_authorities").empty())
-        {
-            caRootCertificate = config.at("ssl").at("certificate_authorities").front().get_ref<const std::string&>();
-        }
-
-        if (config.at("ssl").contains("certificate"))
-        {
-            sslCertificate = config.at("ssl").at("certificate").get_ref<const std::string&>();
-        }
-
-        if (config.at("ssl").contains("key"))
-        {
-            sslKey = config.at("ssl").at("key").get_ref<const std::string&>();
-        }
+        caRootCertificate = config.sslOptions.cacert.front();
     }
 
-    if (config.contains("username"))
-    {
-        username = config.at("username");
-    }
+    sslCertificate = config.sslOptions.cert;
+    sslKey = config.sslOptions.key;
+    username = config.username;
+    password = config.password;
 
-    if (config.contains("password"))
-    {
-        password = config.at("password");
-    }
-
-    if (username.empty() && password.empty())
-    {
-        username = "admin";
-        password = "admin";
-        LOG_WARNING("No username and password found in the configuration, using default values.");
-    }
-
-    if (username.empty())
+    if (config.username.empty())
     {
         username = "admin";
         LOG_WARNING("No username found in the configuration, using default value.");
+    }
+
+    if (config.password.empty())
+    {
+        password = "admin";
+        LOG_WARNING("No password found in the configuration, using default value.");
     }
 
     secureCommunication.basicAuth(username + ":" + password)
@@ -110,10 +89,12 @@ static void builderBulkIndex(std::string& bulkData, std::string_view id, std::st
     bulkData.append("\n");
 }
 
-IndexerConnector::IndexerConnector(const nlohmann::json& config, const uint32_t& timeout, const uint8_t workingThreads)
+IndexerConnector::IndexerConnector(const IndexerConnectorOptions& indexerConnectorOptions)
 {
+    m_indexerConnectorOptions = indexerConnectorOptions;
     // Get index name.
-    m_indexName = config.at("name").get_ref<const std::string&>();
+    m_indexName = indexerConnectorOptions.name;
+
     base::utils::string::replaceAll(m_indexName, "$(date)", base::utils::time::getCurrentDate("."));
 
     if (base::utils::string::haveUpperCaseCharacters(m_indexName))
@@ -122,13 +103,14 @@ IndexerConnector::IndexerConnector(const nlohmann::json& config, const uint32_t&
     }
 
     auto secureCommunication = SecureCommunication::builder();
-    initConfiguration(secureCommunication, config);
+    initConfiguration(secureCommunication, m_indexerConnectorOptions);
 
     // Initialize publisher.
-    auto selector {std::make_shared<TServerSelector<Monitoring>>(config.at("hosts"), timeout, secureCommunication)};
+    auto selector {std::make_shared<TServerSelector<Monitoring>>(
+        m_indexerConnectorOptions.hosts, m_indexerConnectorOptions.timeout, secureCommunication)};
 
     // Validate threads number
-    if (workingThreads <= 0)
+    if (m_indexerConnectorOptions.workingThreads <= 0)
     {
         LOG_DEBUG("Invalid number of working threads, using default value.");
     }
@@ -189,9 +171,10 @@ IndexerConnector::IndexerConnector(const nlohmann::json& config, const uint32_t&
                      }});
             }
         },
-        DATABASE_BASE_PATH + m_indexName,
+        m_indexerConnectorOptions.databasePath + m_indexName,
         ELEMENTS_PER_BULK,
-        workingThreads <= 0 ? SINGLE_ORDERED_DISPATCHING : workingThreads);
+        m_indexerConnectorOptions.workingThreads <= 0 ? SINGLE_ORDERED_DISPATCHING
+                                                      : m_indexerConnectorOptions.workingThreads);
 }
 
 IndexerConnector::~IndexerConnector()

--- a/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
+++ b/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
@@ -433,10 +433,8 @@ TEST_F(IndexerConnectorTest, DiscardInvalidJSON)
     m_indexerServers[A_IDX]->setPublishCallback(checkCallbackCalled);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {.name = INDEXER_NAME, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Trigger publication of invalid data.
     std::string invalidData = "This is not valid JSON"; // Invalid JSON string

--- a/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
+++ b/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
@@ -189,12 +189,12 @@ TEST_F(IndexerConnectorTest, ConnectionWithUserAndPassword)
  */
 TEST_F(IndexerConnectorTest, ConnectionWithSslCredentials)
 {
-    SslOptions sslOptions {.cacert = {"/etc/filebeat/certs/root-ca.pem"},
-                           .cert = "/etc/filebeat/certs/filebeat.pem",
-                           .key = "/etc/filebeat/certs/filebeat-key.pem"};
-
-    IndexerConnectorOptions indexerConfig {
-        .name = INDEXER_NAME, .hosts = {A_ADDRESS}, .sslOptions = sslOptions, .timeout = INDEXER_TIMEOUT};
+    IndexerConnectorOptions indexerConfig {.name = INDEXER_NAME,
+                                           .hosts = {A_ADDRESS},
+                                           .sslOptions = {.cacert = {"/etc/filebeat/certs/root-ca.pem"},
+                                                          .cert = "/etc/filebeat/certs/filebeat.pem",
+                                                          .key = "/etc/filebeat/certs/filebeat-key.pem"},
+                                           .timeout = INDEXER_TIMEOUT};
 
     // Create connector and wait until the connection is established.
     auto indexerConnector {IndexerConnector(indexerConfig)};

--- a/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
+++ b/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
@@ -56,6 +56,8 @@ protected:
     void waitUntil(const std::function<bool()>& stopCondition, const unsigned int& maxSleepTimeMs) const;
 };
 
+constexpr auto DATABASE_BASE_PATH = "queue/indexer/";
+
 // Template.
 static const auto TEMPLATE_FILE_PATH {std::filesystem::temp_directory_path() / "template.json"};
 static const auto TEMPLATE_DATA = R"(
@@ -168,14 +170,14 @@ void IndexerConnectorTest::waitUntil(const std::function<bool()>& stopCondition,
  */
 TEST_F(IndexerConnectorTest, ConnectionWithUserAndPassword)
 {
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    indexerConfig["username"] = "user";
-    indexerConfig["password"] = "password";
+    IndexerConnectorOptions indexerConfig {.name = INDEXER_NAME,
+                                           .hosts = {A_ADDRESS},
+                                           .username = "user",
+                                           .password = "password",
+                                           .timeout = INDEXER_TIMEOUT};
 
     // Create connector and wait until the connection is established.
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 }
 
 /**
@@ -187,15 +189,15 @@ TEST_F(IndexerConnectorTest, ConnectionWithUserAndPassword)
  */
 TEST_F(IndexerConnectorTest, ConnectionWithSslCredentials)
 {
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    indexerConfig["ssl"]["certificate_authorities"] = nlohmann::json::array({"/etc/filebeat/certs/root-ca.pem"});
-    indexerConfig["ssl"]["certificate"] = "/etc/filebeat/certs/filebeat.pem";
-    indexerConfig["ssl"]["key"] = "/etc/filebeat/certs/filebeat-key.pem";
+    SslOptions sslOptions {.cacert = {"/etc/filebeat/certs/root-ca.pem"},
+                           .cert = "/etc/filebeat/certs/filebeat.pem",
+                           .key = "/etc/filebeat/certs/filebeat-key.pem"};
+
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {A_ADDRESS}, .sslOptions = sslOptions, .timeout = INDEXER_TIMEOUT};
 
     // Create connector and wait until the connection is established.
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 }
 
 /**
@@ -204,12 +206,10 @@ TEST_F(IndexerConnectorTest, ConnectionWithSslCredentials)
  */
 TEST_F(IndexerConnectorTest, ConnectionUnavailableServer)
 {
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({B_ADDRESS});
+    IndexerConnectorOptions indexerConfig {.name = INDEXER_NAME, .hosts = {B_ADDRESS}, .timeout = INDEXER_TIMEOUT};
 
     // Create connector and wait until the max time is reached.
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
     EXPECT_THROW(waitUntil([this]() { return m_indexerServers[B_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS),
                  std::runtime_error);
 }
@@ -226,10 +226,9 @@ TEST_F(IndexerConnectorTest, ConnectionMultipleServers)
     m_indexerServers[C_IDX]->setHealth("green");
 
     // Create connector and wait until the connection is made with the available server.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS, B_ADDRESS, C_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {A_ADDRESS, B_ADDRESS, C_ADDRESS}, .timeout = INDEXER_TIMEOUT};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 }
 
 /**
@@ -240,10 +239,10 @@ TEST_F(IndexerConnectorTest, ConnectionInvalidServer)
 {
     // Trigger connection and expect that it is not made.
     constexpr auto INEXISTANT_SERVER {"localhost:6789"};
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({INEXISTANT_SERVER});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {INEXISTANT_SERVER}, .timeout = INDEXER_TIMEOUT};
+
+    auto indexerConnector {IndexerConnector(indexerConfig)};
     ASSERT_THROW(waitUntil([this]() { return m_indexerServers[A_IDX]->initialized(); }, MAX_INDEXER_INIT_TIME_MS),
                  std::runtime_error);
 }
@@ -275,10 +274,9 @@ TEST_F(IndexerConnectorTest, Publish)
     m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT, .databasePath = DATABASE_BASE_PATH};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Publish content and wait until the publication finishes.
     nlohmann::json publishData;
@@ -314,10 +312,9 @@ TEST_F(IndexerConnectorTest, PublishDeleted)
     m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT, .databasePath = DATABASE_BASE_PATH};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Publish content and wait until the publication finishes.
     nlohmann::json publishData;
@@ -353,10 +350,9 @@ TEST_F(IndexerConnectorTest, PublishWithoutId)
     m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT, .databasePath = DATABASE_BASE_PATH};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Publish content and wait until the publication finishes.
     nlohmann::json publishData;
@@ -383,10 +379,10 @@ TEST_F(IndexerConnectorTest, PublishUnavailableServer)
     m_indexerServers[B_IDX]->setPublishCallback(checkPublishedData);
 
     // Initialize connector.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({B_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {B_ADDRESS}, .timeout = INDEXER_TIMEOUT, .databasePath = DATABASE_BASE_PATH};
+
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Trigger publication and expect that it is not made.
     const auto publishData = R"({"dummy":true})"_json;
@@ -411,10 +407,8 @@ TEST_F(IndexerConnectorTest, PublishInvalidData)
     m_indexerServers[A_IDX]->setPublishCallback(checkCallbackCalled);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {.name = INDEXER_NAME, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Trigger publication and expect that it is not made.
     nlohmann::json publishData;
@@ -479,10 +473,9 @@ TEST_F(IndexerConnectorTest, PublishTwoIndexes)
     m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT, .databasePath = DATABASE_BASE_PATH};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Publish content to INDEX_ID_A and wait until is finished.
     constexpr auto INDEX_DATA_A {"contentA"};
@@ -531,10 +524,9 @@ TEST_F(IndexerConnectorTest, PublishErrorFromServer)
     m_indexerServers[A_IDX]->setPublishCallback(forceErrorCallback);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = INDEXER_NAME;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT, .databasePath = DATABASE_BASE_PATH};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Trigger publication and expect that it is not made.
     nlohmann::json publishData;
@@ -551,10 +543,10 @@ TEST_F(IndexerConnectorTest, PublishErrorFromServer)
 TEST_F(IndexerConnectorTest, UpperCaseCharactersIndexName)
 {
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["name"] = "UPPER_case_INDEX";
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    EXPECT_THROW(IndexerConnector(indexerConfig, INDEXER_TIMEOUT), std::invalid_argument);
+    IndexerConnectorOptions indexerConfig {
+        .name = "UPPER_case_INDEX", .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT};
+
+    EXPECT_THROW(IndexerConnector {indexerConfig}, std::invalid_argument);
 }
 
 /**
@@ -591,12 +583,11 @@ TEST_F(IndexerConnectorTest, PublishDatePlaceholder)
     m_indexerServers[A_IDX]->setPublishCallback(checkPublishedData);
 
     // Create connector and wait until the connection is established.
-    nlohmann::json indexerConfig;
-    indexerConfig["hosts"] = nlohmann::json::array({A_ADDRESS});
-    indexerConfig["name"] = indexerNameDatePlaceHolder;
+    IndexerConnectorOptions indexerConfig {
+        .name = indexerNameDatePlaceHolder, .hosts = {A_ADDRESS}, .timeout = INDEXER_TIMEOUT};
     const std::string INDEX_NAME_PLACE_HOLDER_FORMAT_REGEX_STR {std::string(INDEXER_NAME) + R"(_\$\(date\))"};
     EXPECT_TRUE(std::regex_match(indexerNameDatePlaceHolder, std::regex(INDEX_NAME_PLACE_HOLDER_FORMAT_REGEX_STR)));
-    auto indexerConnector {IndexerConnector(indexerConfig, INDEXER_TIMEOUT)};
+    auto indexerConnector {IndexerConnector(indexerConfig)};
 
     // Publish content and wait until the publication finishes.
     nlohmann::json publishData;

--- a/src/engine/source/indexerconnector/tool/main.cpp
+++ b/src/engine/source/indexerconnector/tool/main.cpp
@@ -90,6 +90,48 @@ nlohmann::json fillWithRandomData(const nlohmann::json& templateJson)
     return result;
 }
 
+void fillConfiguration(IndexerConnectorOptions& indexerConnectorOptions, const nlohmann::json& config)
+{
+    if (config.contains("name"))
+    {
+        indexerConnectorOptions.name = config.at("name").get_ref<const std::string&>();
+    }
+
+    if (config.contains("hosts"))
+    {
+        indexerConnectorOptions.hosts = config.at("hosts");
+    }
+
+    if (config.contains("ssl"))
+    {
+        if (config.at("ssl").contains("certificate_authorities")
+            && !config.at("ssl").at("certificate_authorities").empty())
+        {
+            indexerConnectorOptions.sslOptions.cacert = config.at("ssl").at("certificate_authorities");
+        }
+
+        if (config.at("ssl").contains("certificate"))
+        {
+            indexerConnectorOptions.sslOptions.cert = config.at("ssl").at("certificate").get_ref<const std::string&>();
+        }
+
+        if (config.at("ssl").contains("key"))
+        {
+            indexerConnectorOptions.sslOptions.key = config.at("ssl").at("key").get_ref<const std::string&>();
+        }
+    }
+
+    if (config.contains("username"))
+    {
+        indexerConnectorOptions.username = config.at("username");
+    }
+
+    if (config.contains("password"))
+    {
+        indexerConnectorOptions.password = config.at("password");
+    }
+}
+
 int main(const int argc, const char* argv[])
 {
     try
@@ -104,10 +146,13 @@ int main(const int argc, const char* argv[])
         {
             throw std::invalid_argument("Could not open configuration file.");
         }
+        // Parse configuration
         const auto configuration = nlohmann::json::parse(configurationFile);
+        IndexerConnectorOptions indexerConnectorOptions;
+        fillConfiguration(indexerConnectorOptions, configuration);
 
         // Create indexer connector.
-        IndexerConnector indexerConnector(configuration);
+        IndexerConnector indexerConnector(indexerConnectorOptions);
 
         // Read events file.
         // If the events file path is empty, then the events are generated


### PR DESCRIPTION
|Related issue|
|---|
|#26012|


## Description

This PR replaces the nlohmann::json configuration format with a new C struct with the required fields. The parameters timeout and workingThreads in the indexerConstructor, now are included in the structure. 
