### PR TITLE
Fix batcher processes and signals handling

### DIFF
--- a/apis/comms_api/core/batcher.py
+++ b/apis/comms_api/core/batcher.py
@@ -1,4 +1,4 @@
-from wazuh.core.batcher.mux_demux import MuxDemuxQueue, MuxDemuxManager
+from wazuh.core.batcher.mux_demux import MuxDemuxManager
 from wazuh.core.batcher.batcher import BatcherConfig, BatcherProcess
 
 
@@ -17,7 +17,7 @@ def create_batcher_process(config: BatcherConfig) -> (MuxDemuxManager, BatcherPr
     """
     batcher_mux_demux_manager = MuxDemuxManager()
     batcher_process = BatcherProcess(
-        queue=batcher_mux_demux_manager.get_queue(),
+        mux_demux_queue=batcher_mux_demux_manager.get_queue(),
         config=config,
     )
     batcher_process.start()

--- a/apis/comms_api/core/batcher.py
+++ b/apis/comms_api/core/batcher.py
@@ -1,8 +1,10 @@
+from typing import Tuple
+
 from wazuh.core.batcher.mux_demux import MuxDemuxManager
 from wazuh.core.batcher.batcher import BatcherConfig, BatcherProcess
 
 
-def create_batcher_process(config: BatcherConfig) -> (MuxDemuxManager, BatcherProcess):
+def create_batcher_process(config: BatcherConfig) -> Tuple[MuxDemuxManager, BatcherProcess]:
     """Create and start a batcher process with the provided configuration.
 
     Parameters

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -105,7 +105,7 @@ def configure_ssl(keyfile: str, certfile: str) -> None:
     try:
         if not os.path.exists(keyfile) or not os.path.exists(certfile):
             private_key = generate_private_key(keyfile)
-            logger.info(f"Generated private key file in {certfile}")
+            logger.info(f"Generated private key file in {keyfile}")
             
             generate_self_signed_certificate(private_key, certfile)
             logger.info(f"Generated certificate file in {certfile}")

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -249,7 +249,7 @@ def signal_handler(
     This function is designed to be used with the `signal` module to handle termination and
     interruption signals (e.g., SIGTERM).
     """
-    logger.info(f"Received signal {signal.Signals(signum).name}, initiating shutdown.")
+    logger.info(f"Received signal {signal.Signals(signum).name}, shutting down")
     terminate_processes(parent_pid, mux_demux_manager, batcher_process)
 
 
@@ -271,6 +271,7 @@ def terminate_processes(parent_pid: int, mux_demux_manager: MuxDemuxManager, bat
         The batcher process to be terminated.
     """
     if parent_pid == os.getpid():
+        logger.info('Shutting down')
         batcher_process.terminate()
         mux_demux_manager.shutdown()
         pyDaemonModule.delete_child_pids(MAIN_PROCESS, pid, logger)
@@ -316,6 +317,8 @@ if __name__ == '__main__':
         signal_handler, parent_pid=pid, mux_demux_manager=mux_demux_manager, batcher_process=batcher_process))
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
+    logger.info(f'Listening on {args.host}:{args.port}')
+    
     try:
         app = create_app(mux_demux_manager.get_queue())
         options = get_gunicorn_options(pid, args.foreground, log_config_dict)

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -221,6 +221,7 @@ class StandaloneApplication(BaseApplication):
 def signal_handler(
     signum: int,
     frame: Any,
+    parent_pid: int,
     mux_demux_manager: MuxDemuxManager,
     batcher_process: Process
 ) -> None:
@@ -236,6 +237,8 @@ def signal_handler(
         The signal number received.
     frame : Any
         The current stack frame (unused).
+    parent_pid : int
+        The parent process ID used to verify if the termination should proceed.
     mux_demux_manager : MuxDemuxManager
         The MuxDemux manager instance to be shut down.
     batcher_process : Process
@@ -247,7 +250,7 @@ def signal_handler(
     interruption signals (e.g., SIGTERM).
     """
     logger.info(f"Received signal {signal.Signals(signum).name}, initiating shutdown.")
-    terminate_processes(mux_demux_manager, batcher_process)
+    terminate_processes(parent_pid, mux_demux_manager, batcher_process)
 
 
 def terminate_processes(parent_pid: int, mux_demux_manager: MuxDemuxManager, batcher_process: Process):

--- a/framework/wazuh/core/batcher/batcher.py
+++ b/framework/wazuh/core/batcher/batcher.py
@@ -170,7 +170,8 @@ class Batcher:
         signal_number : int
             Signal number indicating the type of signal received (e.g., SIGINT, SIGTERM).
         """
-        logger.info(f'Batcher pid {os.getpid()} - Received signal {signal_number}, initiating shutdown.')
+        signal_name = signal.Signals(signal_number).name
+        logger.info(f'Batcher pid {os.getpid()} - Received signal {signal_name}, initiating shutdown.')
         self._shutdown_event.set()
 
 

--- a/framework/wazuh/core/batcher/batcher.py
+++ b/framework/wazuh/core/batcher/batcher.py
@@ -123,8 +123,8 @@ class Batcher:
         # Register signal handlers
         self._shutdown_event = asyncio.Event()
         loop = asyncio.get_running_loop()
-        loop.add_signal_handler(signal.SIGINT, self._handle_signal, signal.SIGINT)
         loop.add_signal_handler(signal.SIGTERM, self._handle_signal, signal.SIGTERM)
+        loop.add_signal_handler(signal.SIGINT, self._handle_signal, signal.SIGINT)
 
         try:
             while not self._shutdown_event.is_set():
@@ -170,8 +170,10 @@ class Batcher:
         signal_number : int
             Signal number indicating the type of signal received (e.g., SIGINT, SIGTERM).
         """
+        if signal_number == signal.Signals.SIGINT:
+            return
         signal_name = signal.Signals(signal_number).name
-        logger.info(f'Batcher pid {os.getpid()} - Received signal {signal_name}, initiating shutdown.')
+        logger.info(f'Batcher (pid: {os.getpid()}) - Received signal {signal_name}, shutting down')
         self._shutdown_event.set()
 
 

--- a/framework/wazuh/core/batcher/batcher.py
+++ b/framework/wazuh/core/batcher/batcher.py
@@ -18,7 +18,7 @@ from wazuh.core.batcher.config import BatcherConfig
 
 logger = logging.getLogger('wazuh-comms-api')
 
-WAIT_TIME_BETWEEN_QUEUE_READ = 0.01
+QUEUE_READ_INTERVAL = 0.01
 
 
 class Batcher:
@@ -57,7 +57,7 @@ class Batcher:
                 message = self.q.receive_from_mux(block=False)
                 return message
             except queue.Empty:
-                await asyncio.sleep(WAIT_TIME_BETWEEN_QUEUE_READ)
+                await asyncio.sleep(QUEUE_READ_INTERVAL)
             except asyncio.CancelledError:
                 if message is not None:
                     self.q.send_to_mux(uid=message.uid, msg=message.msg)
@@ -170,7 +170,7 @@ class Batcher:
         signal_number : int
             Signal number indicating the type of signal received (e.g., SIGINT, SIGTERM).
         """
-        logger.info(f'Batcher pid {os.getpid()}- Received signal {signal_number}, initiating shutdown.')
+        logger.info(f'Batcher pid {os.getpid()} - Received signal {signal_number}, initiating shutdown.')
         self._shutdown_event.set()
 
 

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -60,8 +60,9 @@ def assign_wazuh_ownership(filepath: str):
         os.stat(filepath).st_uid != common.wazuh_uid():
         os.chown(filepath, common.wazuh_uid(), common.wazuh_gid())
 
+
 def clean_pid_files(daemon: str) -> None:
-    """Check the existence of '.pid' files for a specified daemon.
+    """Clean the '.pid' files for a specified daemon and kill their process group.
 
     Parameters
     ----------
@@ -77,7 +78,8 @@ def clean_pid_files(daemon: str) -> None:
                 command = process.cmdline()[-1]
 
                 if daemon.replace('-', '_') in command:
-                    os.kill(pid, SIGKILL)
+                    pgid = os.getpgid(pid)
+                    os.killpg(pgid, SIGKILL)
                     print(f"{daemon}: Orphan child process {pid} was terminated.")
                 else:
                     print(f"{daemon}: Process {pid} does not belong to {daemon}, removing from {common.WAZUH_PATH}/var/run...")


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/26086 |

## Description

Fixes some issues during the batcher process creation and signal handling.

## Tests


<details><summary>Starting API</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-comms-apid -f
2024/10/02 13:05:55 INFO: Starting API in foreground
2024/10/02 13:05:55 INFO: Generated private key file in /var/ossec/api/configuration/ssl/server.key
2024/10/02 13:05:55 INFO: Generated certificate file in /var/ossec/api/configuration/ssl/server.crt
```

</details>

<details><summary>Listing processes</summary>

```console
root@wazuh-master:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4364  3152 ?        Ss   12:23   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          37  0.0  0.0   4628  3568 pts/0    Ss   12:23   0:00 bash
root        7836  0.0  0.0   4628  3760 pts/1    Ss   12:39   0:00 bash
root       21082  0.0  0.0   2892  1000 pts/0    S+   13:05   0:00 /bin/sh /var/ossec/bin/wazuh-comms-apid -f
wazuh      21090 13.1  1.3 186144 112224 pts/0   S+   13:05   0:01 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
wazuh      21131  1.1  1.1 405748 91188 pts/0    Sl+  13:05   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
wazuh      21142  0.0  1.1 184572 89508 pts/0    S+   13:05   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
wazuh      21144  2.0  1.1 184704 90760 pts/0    S+   13:05   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
wazuh      21152  0.5  1.2 187712 99200 pts/0    S+   13:05   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
wazuh      21153  0.4  1.2 187720 99136 pts/0    S+   13:05   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
wazuh      21154  0.4  1.2 187712 99204 pts/0    S+   13:05   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
wazuh      21155  0.4  1.2 187716 99204 pts/0    S+   13:05   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py -f
root       21156  0.0  0.0   2792   996 ?        S    13:05   0:00 sleep 10
root       21200  0.0  0.0   7064  1560 pts/1    R+   13:06   0:00 ps aux
```

</details>

<details><summary>Shutdown</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-comms-apid -f
2024/10/02 13:05:55 INFO: Starting API in foreground
2024/10/02 13:05:55 INFO: Generated private key file in /var/ossec/api/configuration/ssl/server.key
2024/10/02 13:05:55 INFO: Generated certificate file in /var/ossec/api/configuration/ssl/server.crt
^C2024/10/02 13:06:12 INFO: Batcher pid 21144 - Received signal 2, initiating shutdown.
2024/10/02 13:06:13 INFO: Batcher pid 21144 - Received signal 15, initiating shutdown.
2024/10/02 13:06:13 INFO: MuxDemuxQueue pid 21142 - received signal SIGTERM
2024/10/02 13:06:13 INFO: MuxDemuxQueue pid 21142 - shutting down
root@wazuh-master:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4364  3152 ?        Ss   12:23   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          37  0.0  0.0   4628  3568 pts/0    Ss+  12:23   0:00 bash
root        7836  0.0  0.0   4628  3760 pts/1    Ss   12:39   0:00 bash
root       21327  0.0  0.0   2792  1008 ?        S    13:06   0:00 sleep 10
root       21368  0.0  0.0   7064  1580 pts/1    R+   13:06   0:00 ps aux
```

</details>

<details><summary>Same tests in background mode</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-comms-apid   
root@wazuh-master:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4364  3152 ?        Ss   12:23   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          37  0.0  0.0   4628  3556 pts/0    Ss   12:23   0:00 bash
root        7836  0.0  0.0   4628  3520 pts/1    Ss+  12:39   0:00 bash
root       60576  0.0  0.0   2792  1048 ?        S    14:27   0:00 sleep 10
wazuh      60578  1.5  1.1 184720 95008 ?        S    14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      60579  2.0  1.1 553228 91976 ?        Sl   14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      60596  0.0  1.0 184588 89044 ?        S    14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      60598  1.5  1.1 184588 90404 ?        S    14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      60604  2.0  1.2 187264 98508 ?        S    14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      60605  1.5  1.2 187268 98516 ?        S    14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      60606  2.0  1.2 187268 98516 ?        S    14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
wazuh      60607  2.0  1.2 187268 98520 ?        S    14:27   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/apis/scripts/wazuh_comms_apid.py
root       60608  0.0  0.0   7064  1600 pts/0    R+   14:27   0:00 ps aux
root@wazuh-master:/# kill 60578
root@wazuh-master:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4364  3152 ?        Ss   12:23   0:00 bash /scripts/entrypoint.sh wazuh-master master-node master
root          37  0.0  0.0   4628  3568 pts/0    Ss   12:23   0:00 bash
root        7836  0.0  0.0   4628  3520 pts/1    Ss+  12:39   0:00 bash
root       60694  0.0  0.0   2792   988 ?        S    14:27   0:00 sleep 10
root       60695  0.0  0.0   7064  1604 pts/0    R+   14:27   0:00 ps aux
```

</details>

<details><summary>wazuh-control start</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-control start
2024/10/02 14:36:50 wazuh-db[64988] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/10/02 14:36:50 wazuh-db[64988] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/10/02 14:36:50 wazuh-remoted[64994] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/10/02 14:36:50 wazuh-remoted[64994] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/10/02 14:36:50 wazuh-remoted[64994] main.c:148 at main(): DEBUG: This is not a worker
2024/10/02 14:36:50 wazuh-modulesd:router: INFO: Loaded router module.
2024/10/02 14:36:50 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Starting Wazuh v5.0.0...
Started wazuh-comms-apid...
Started wazuh-apid...
Started wazuh-csyslogd...
Started wazuh-dbd...
2024/10/02 14:36:53 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
Started wazuh-integratord...
Started wazuh-agentlessd...
2024/10/02 14:36:53 wazuh-authd[65140] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/10/02 14:36:53 wazuh-authd[65140] config.c:24 at authd_read_config(): DEBUG: Reading configuration 'etc/ossec.conf'
2024/10/02 14:36:53 wazuh-authd[65140] authd-config.c:276 at Read_Authd(): DEBUG: The tag <force><after_registration_time> is not defined. Applied default value: '3600'
2024/10/02 14:36:53 wazuh-authd[65140] authd-config.c:278 at Read_Authd(): DEBUG: The tag <force><key_mismatch> is not defined. Applied default value: 'true'
2024/10/02 14:36:53 wazuh-authd[65140] main-server.c:465 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-authd...
2024/10/02 14:36:53 wazuh-db[65149] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/10/02 14:36:53 wazuh-db[65149] main.c:125 at main(): DEBUG: Wazuh home directory: /var/ossec
Started wazuh-db...
Started wazuh-execd...
Started wazuh-analysisd...
Started wazuh-syscheckd...
2024/10/02 14:36:54 wazuh-remoted[65214] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2024/10/02 14:36:54 wazuh-remoted[65214] main.c:130 at main(): DEBUG: Wazuh home directory: /var/ossec
2024/10/02 14:36:54 wazuh-remoted[65214] main.c:148 at main(): DEBUG: This is not a worker
Started wazuh-remoted...
Started wazuh-logcollector...
Started wazuh-monitord...
2024/10/02 14:36:55 wazuh-modulesd:router: INFO: Loaded router module.
2024/10/02 14:36:55 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Started wazuh-modulesd...
Started wazuh-clusterd...
Completed.
```

</details>

<details><summary>wazuh-control stop</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-control stop
Killing wazuh-clusterd...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Killing wazuh-comms-apid...
Wazuh v5.0.0 Stopped
```

</details>