### PR TITLE
Fix DAPI basic services down error

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -226,7 +226,7 @@ class DistributedAPI:
                 'node_name': self.node_info.get('node', 'UNKNOWN NODE'),
                 'not_ready_daemons': ', '.join([f'{key}->{value}' for key, value in not_ready_daemons.items()])
             }
-            raise exception.WazuhError(1017, extra_message=extra_info)
+            raise exception.WazuhInternalError(1017, extra_message=extra_info)
 
     @staticmethod
     def run_local(f, f_kwargs, rbac_permissions, broadcasting, nodes, current_user, origin_module):
@@ -302,7 +302,7 @@ class DistributedAPI:
             # Avoid exception info if it is an asyncio timeout error, JSONDecodeError, /proc availability error or
             # WazuhClusterError
             self.logger.error(f"{e.message}",
-                              exc_info=e.code not in {3021, 3036, 1913} and not isinstance(e,
+                              exc_info=e.code not in {3021, 3036, 1913, 1017} and not isinstance(e,
                                                                                            exception.WazuhClusterError))
             if self.debug:
                 raise

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -540,7 +540,7 @@ def test_DistributedAPI_check_wazuh_status_exception(node_info_mock, status_valu
         dapi = DistributedAPI(f=agent.get_agents_summary_status, logger=logger)
         try:
             dapi.check_wazuh_status()
-        except WazuhError as e:
+        except WazuhInternalError as e:
             assert e.code == 1017
             assert statuses
             assert e._extra_message['node_name'] == 'random_node'


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/26102 |

## Description

Replaces the **400 (Bad request)** error thrown when basic services are down with **500 (Internal error)**.

## Tests

### Before

<details><summary>Authentication request</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -u wazuh:wazuh -k -X POST https://localhost:55050/security/user/authenticate -v
*   Trying 127.0.0.1:55050...
* Connected to localhost (127.0.0.1) port 55050 (#0)
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  start date: Oct  2 14:58:43 2024 GMT
*  expire date: Oct  2 14:58:43 2025 GMT
*  issuer: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
* using HTTP/1.x
* Server auth using Basic with user 'wazuh'
> POST /security/user/authenticate HTTP/1.1
> Host: localhost:55050
> Authorization: Basic d2F6dWg6d2F6dWg=
> User-Agent: curl/7.88.1
> Accept: */*
> 
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
< HTTP/1.1 400 Bad Request
< date: Wed, 02 Oct 2024 15:00:33 GMT
< content-type: application/problem+json; charset=utf-8
< content-length: 454
< 
* Connection #0 to host localhost left intact
{"title": "Bad Request", "detail": "Some Wazuh daemons are not ready yet in node \"master-node\" (wazuh-modulesd->stopped, wazuh-analysisd->stopped, wazuh-execd->stopped, wazuh-db->stopped, wazuh-remoted->stopped)", "dapi_errors": {"master-node": {"error": "Some Wazuh daemons are not ready yet in node \"master-node\" (wazuh-modulesd->stopped, wazuh-analysisd->stopped, wazuh-execd->stopped, wazuh-db->stopped, wazuh-remoted->stopped)"}}, "error": 1017}
```

</details>

<details><summary>API log</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
2024/10/02 15:00:11 INFO: Starting API in foreground
2024/10/02 15:00:11 INFO: Checking RBAC database integrity...
2024/10/02 15:00:11 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2024/10/02 15:00:11 INFO: RBAC database integrity check finished successfully
2024/10/02 15:00:13 INFO: Listening on ['0.0.0.0', '::']:55000.
2024/10/02 15:00:13 INFO: Getting installation UID...
2024/10/02 15:00:13 INFO: Getting updates information...
2024/10/02 15:00:34 INFO: wazuh 172.18.0.1 "POST /security/user/authenticate" with parameters {} and body {} done in 0.006s: 400
```

</details>

### After

<details><summary>Authentication request</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -u wazuh:wazuh -k -X POST https://localhost:55050/security/user/authenticate -v
*   Trying 127.0.0.1:55050...
* Connected to localhost (127.0.0.1) port 55050 (#0)
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  start date: Oct  2 14:58:43 2024 GMT
*  expire date: Oct  2 14:58:43 2025 GMT
*  issuer: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
* using HTTP/1.x
* Server auth using Basic with user 'wazuh'
> POST /security/user/authenticate HTTP/1.1
> Host: localhost:55050
> Authorization: Basic d2F6dWg6d2F6dWg=
> User-Agent: curl/7.88.1
> Accept: */*
> 
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
< HTTP/1.1 500 Internal Server Error
< date: Wed, 02 Oct 2024 14:59:38 GMT
< content-type: application/problem+json; charset=utf-8
< content-length: 501
< 
* Connection #0 to host localhost left intact
{"title": "Wazuh Internal Error", "detail": "Some Wazuh daemons are not ready yet in node \"master-node\" (wazuh-modulesd->stopped, wazuh-analysisd->stopped, wazuh-execd->stopped, wazuh-db->stopped, wazuh-remoted->stopped)", "dapi_errors": {"master-node": {"error": "Some Wazuh daemons are not ready yet in node \"master-node\" (wazuh-modulesd->stopped, wazuh-analysisd->stopped, wazuh-execd->stopped, wazuh-db->stopped, wazuh-remoted->stopped)", "logfile": "WAZUH_HOME/logs/api.log"}}, "error": 1017}
```

</details>

<details><summary>API log</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-apid -f
2024/10/02 15:08:40 INFO: Starting API in foreground
2024/10/02 15:08:40 INFO: Checking RBAC database integrity...
2024/10/02 15:08:40 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2024/10/02 15:08:40 INFO: RBAC database integrity check finished successfully
2024/10/02 15:08:42 INFO: Listening on ['0.0.0.0', '::']:55000.
2024/10/02 15:08:42 INFO: Getting installation UID...
2024/10/02 15:08:42 INFO: Getting updates information...
2024/10/02 15:08:44 ERROR: Some Wazuh daemons are not ready yet in node "master-node" (wazuh-modulesd->stopped, wazuh-analysisd->stopped, wazuh-execd->stopped, wazuh-db->stopped, wazuh-remoted->stopped)
2024/10/02 15:08:44 INFO: wazuh 172.18.0.1 "POST /security/user/authenticate" with parameters {} and body {} done in 0.006s: 500
```

</details>
