### PR TITLE
Enabling Github Actions Workflow Manual Triggers

### DIFF
--- a/.github/workflows/macos-syscollector-tests.yml
+++ b/.github/workflows/macos-syscollector-tests.yml
@@ -1,6 +1,7 @@
 name: Syscollector test on macOS
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
         - ".github/workflows/macos-syscollector-tests.yml"

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -1,6 +1,7 @@
 name: macOS unit tests
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "src/**"

--- a/.github/workflows/rtr_syscheck.yml
+++ b/.github/workflows/rtr_syscheck.yml
@@ -1,6 +1,7 @@
 name: Running RTR. Module syscheck for agent/winagent targets
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "src/ci/**"

--- a/.github/workflows/rtr_syscollector.yml
+++ b/.github/workflows/rtr_syscollector.yml
@@ -1,6 +1,7 @@
 name: Running RTR. Module syscollector and its dependencies for agent/winagent targets
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "src/ci/**"

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -1,5 +1,6 @@
 name: Scan build
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "src/**"

--- a/.github/workflows/ubuntu-syscollector-tests.yml
+++ b/.github/workflows/ubuntu-syscollector-tests.yml
@@ -1,6 +1,7 @@
 name: Syscollector test on Ubuntu
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
         - ".github/workflows/ubuntu-syscollector-tests.yml"

--- a/.github/workflows/windows-syscollector-tests.yml
+++ b/.github/workflows/windows-syscollector-tests.yml
@@ -1,6 +1,7 @@
 name: Syscollector test on Windows
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/windows-syscollector-tests.yml"


### PR DESCRIPTION
|Related issue|
|---|
|#25656|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

Based on the analysis made on [#1501](https://github.com/wazuh/internal-devel-requests/issues/1501) in 4.10.0 branch it was concluded that great part of the workflow files didn't had the option of running them manually.
After some investigation it was found that adding the `workflow_dispatch:` on the corresponding _yml_ file this can be achieved.

## Tests

Based on the GHA configuration and this setting not being _branch dependent_, for this change to take place there's need of merging it to the master branch.
Thanks to @jnasselle that brought up this [issue](https://github.com/orgs/community/discussions/58022#discussioncomment-8716372). but we're not sure if this is a bug or it's working as it should. 

