### PR TITLE
Add new check to verify the default configuration of new OS versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/planned--specific-support-new-oss.md
+++ b/.github/ISSUE_TEMPLATE/planned--specific-support-new-oss.md
@@ -87,10 +87,12 @@ assignees: ''
 -->
 
 <!-- Uncomment for AGENT issue
+**Agent**
+
 - [ ] Smoke test that the package works, including installation, upgrade, and its related tier functionality.
+- [ ] Check the default settings of previous versions, and adapt them to the new OS version if necessary.
 - [ ] Add support for the new OS to the GitHub Actions package builder.
 
-**Agent**
 Requested testing code:
 :white_circle: Requested.
 :black_circle: Not requested.


### PR DESCRIPTION
|Related issue|
|---|
|#26108|

## Description

With this PR, we modify the template used to generate the issues of the new OSs that appear, so that the agent test section will have the new check to verify the default configurations of the new OS. 
- This allows us to adapt the new OSs, so that they act similarly to the old versions.

