### PR TITLE
Support updated versions of diff and apachectl at rootkit trojans file

### DIFF
--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -62,7 +62,7 @@ w           !uname -a|proc\.h|bash!
 sendmail    !bash|fuck!
 named       !bash|blah|/dev/[0-9]|^/bin/sh!
 inetd       !bash|^/bin/sh|file\.h|proc\.h|/dev/[^un%]|^/bin/.*sh!
-apachectl   !bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh!
+apachectl   !^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh!
 sshd        !check_global_passwd|panasonic|satori|vejeta|\.ark|/hash\.zk|bash|/dev[a-s]|/dev[A-Z]/!
 syslogd     !bash|/usr/lib/pt07|/dev/[^cln]]|syslogs\.h|proc\.h!
 xinetd      !bash|file\.h|proc\.h!

--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -40,7 +40,7 @@ sudo        !satori|vejeta|conf\.inv!
 crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
-diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh!
+diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^nf]ull|^/bin/.*sh!
 md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!


### PR DESCRIPTION
|Related issue|
|---|
|Closes #26137 and #9337|

## Description

This PR aims to fix the following false positives:

### `diff` on Linux

```
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
Trojaned version of file '/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh' (Generic).
title: Trojaned version of file detected.
file: /bin/diff

Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
Trojaned version of file '/usr/bin/diff' detected. Signature used: 'bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh' (Generic).
title: Trojaned version of file detected.
file: /usr/bin/diff
```

#### Rationale

The `diff` tool now references `/dev/full` in addition to `/dev/null`.

### `apachectl` on macOS

```
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
Trojaned version of file '/usr/sbin/apachectl' detected. Signature used: 'bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh' (Generic).
title: Trojaned version of file detected.
file: /usr/sbin/apachectl
```

#### Rationale

Now, _/usr/sbin/apachectl_ is implemented as a Bash script. Therefore, it includes the "bash" word in the shebang:
```bash
#!/bin/bash
```

## Proposed changes

- Update the `diff` entry to exclude both "/dev/null" and "/dev/full", by @djosip.
- Exclude the "bash" from the `apachectl` entry.

## Tests

- [x] The agent produces no false positives from Rootcheck on Ubuntu 24.04.
- [x] The agent produces no false positives from Rootcheck on macOS 15 Sequoia.