### PR TITLE
Improve Docker image generation using cache

### DIFF
--- a/.github/actions/ghcr-pull-and-push/build_and_push_image_to_ghcr.sh
+++ b/.github/actions/ghcr-pull-and-push/build_and_push_image_to_ghcr.sh
@@ -10,13 +10,20 @@ else
 fi
 GITHUB_REPOSITORY="wazuh/wazuh"
 GITHUB_OWNER="wazuh"
+IMAGE_ID_CACHE=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:latest
+IMAGE_ID_CACHE=$(echo ${IMAGE_ID_CACHE} | tr '[A-Z]' '[a-z]')
 IMAGE_ID=ghcr.io/${GITHUB_OWNER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
 IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
 
 # Login to GHCR
 echo ${GITHUB_PUSH_SECRET} | docker login https://ghcr.io -u $GITHUB_USER --password-stdin
 
+# Pull latest image id from cache
+echo pull ${IMAGE_ID_CACHE}
+docker pull ${IMAGE_ID_CACHE}
+
 # Build image
-echo build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
-docker build -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
+echo build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ${IMAGE_ID_CACHE} -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
+docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ${IMAGE_ID_CACHE} -t ${IMAGE_ID} -f ${DOCKERFILE_PATH} ${BUILD_CONTEXT}
 docker push ${IMAGE_ID}
+

--- a/.github/workflows/packages-upload-images.yml
+++ b/.github/workflows/packages-upload-images.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Request pkg_rpm_agent_builder_i386 update
         if: steps.changes.outputs.pkg_rpm_agent_builder_i386 == 'true'
         run: |
-          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=amd64 -f source_reference=${{ github.ref_name }}
+          gh workflow run packages-upload-agent-images-amd.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=rpm -f architecture=i386 -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}
 


### PR DESCRIPTION
|Related issue|
|---|
|#26143|

## Description

A pull of the `latest` image (which will have the inline cache) has been added to the build and push script, and also the `BUILDKIT_INLINE_CACHE` variable has been included to generate the inline cache in the images, together with the `--cache-from ${IMAGE_ID_CACHE}` parameter, which will use the `latest` downloaded image to use the layers cache.

On the other hand, a bug has been fixed, where the parameter to generate the i386 image from the RPM agent was not set correctly.

## Tests

- Upload docker images pkg_deb_agent_builder_i386
  - Attempt 1 - **1h 59m**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160757734/attempts/1
  - Attempt 2 - **46s**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160757734/attempts/2

- Upload docker images pkg_rpm_agent_builder_x86_64
  - Attempt 1 - **1h 58m**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160740753/attempts/1
  - Attempt 2 - **56s**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160740753/attempts/2

- Upload docker images pkg_rpm_agent_builder_armhf
  - Attempt 1 - **1h 46m**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160810510/attempts/1
  - Attempt 2 - **5m**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160810510/attempts/2

- Upload docker images pkg_rpm_legacy_builder_x86_64
  - Attempt 1 - **1h 57m**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160718922/attempts/1
  - Attempt 2 - **1m**: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11160718922/attempts/2

