### PR TITLE
Fix newly introduced "diff" false negatives in rootkit_trojans.txt

### DIFF
--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -40,7 +40,7 @@ sudo        !satori|vejeta|conf\.inv!
 crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
-diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^nf]ull|^/bin/.*sh!
+diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^nf]|^/bin/.*sh!
 md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!


### PR DESCRIPTION
|Related issue|
|---|
|#25634, #26137, #26141, #13278, #19000, #19346, #11808|

## Description

#25634 changed the related regex from:

```
/dev/[^n]
```

to:

```
/dev/[^nf]ull
```

with goal to exclude `/dev/null` and `/dev/full`. But actually introduced a lot of false negatives because it now only reports anything in `/dev` which:
1. Doesn't start with a `n`
2. Doesn't start with a `f`
3. Includes `ull`

The newly updated regex (as suggested in https://github.com/ossec/ossec-hids/issues/2020#issuecomment-1418331744) now only reports anything in `/dev` which:
1. Doesn't start with a `n`
2. Doesn't start with a `f`

Unfortunately it still causes false negatives for e.g. `/dev/fd0` or `/dev/fuse` but this is now a middle ground (due to the limitations of the search pattern functionality).

Another possibility would be to drop the `/dev` check completely as done in https://github.com/ossec/ossec-hids/pull/2062 but this is IMHO causing even more false negatives.

Yet another alternative is currently discussed in https://github.com/wazuh/wazuh/pull/26160#discussion_r1789004744

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors