### PR TITLE
Fix efficacy test for Microsoft Office, Emacs and Linux Kernel

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/012/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/012/expected_002.out
@@ -1,8 +1,5 @@
 [
-    "Translation for package 'Microsoft Office Professional Plus 2016' in platform 'windows' found in Level 2 cache.",
-    "Vendor match for Package: office, Version: 2016, CVE: CVE-2024-20673, Vendor: microsoft",
-    "Scanning package - 'office' (Installed Version: 2016, Security Vulnerability: CVE-2024-20673). Identified vulnerability: Version: 2016. Required Version Threshold: . Required Version Threshold (or Equal): .",
-    "Match found, the package 'office', is vulnerable to 'CVE-2024-20673'. Current version: '2016' is equal to '2016'. - Agent '' (ID: '001', Version: '')",
-    "No remediations for agent '001' have been found",
-    "Processing and publish key: CVE-2024-20673"
+    "Translation for package 'Microsoft Office Professional Plus 2016' in platform 'windows' not found.",
+    "Initiating a vulnerability scan for package 'microsoft office professional plus 2016' (win) (microsoft corporation) with CVE Numbering Authorities (CNA) 'nvd' on Agent '' (ID: '001', Version: '').",
+    "Vulnerability scan for package 'Microsoft Office Professional Plus 2016' on Agent '001' has completed."
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/012/expected_003.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/012/expected_003.out
@@ -1,6 +1,3 @@
 [
-    "Getting associated vulnerabilities for hotfix 'KB5002537'",
-    "CVE 'CVE-2024-20673' was remediated by hotfix 'KB5002537' for '001_eff251a49a142accf85b170526462e13d3265f03_CVE-2024-20673'",
-    "Vulnerability report for agent ID 001, hotfix: KB5002537, cve: CVE-2024-20673",
-    "Processing and publish key: CVE-2024-20673"
+    "Getting associated vulnerabilities for hotfix 'KB5002537'"
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/013/expected_003.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/013/expected_003.out
@@ -1,7 +1,5 @@
 [
-    "Translation for package 'Microsoft Office Professional Plus 2016' in platform 'windows' found in Level 2 cache.",
-    "Vendor match for Package: office, Version: 2016, CVE: CVE-2024-20673, Vendor: microsoft",
-    "Scanning package - 'office' (Installed Version: 2016, Security Vulnerability: CVE-2024-20673). Identified vulnerability: Version: 2016. Required Version Threshold: . Required Version Threshold (or Equal): .",
-    "Match found, the package 'office', is vulnerable to 'CVE-2024-20673'. Current version: '2016' is equal to '2016'. - Agent '' (ID: '001', Version: '')",
-    "Remediation 'KB5002537' for package 'office' on agent '001' that solves CVE 'CVE-2024-20673' has been found"
+    "Translation for package 'Microsoft Office Professional Plus 2016' in platform 'windows' not found.",
+    "Initiating a vulnerability scan for package 'microsoft office professional plus 2016' (win) (microsoft corporation) with CVE Numbering Authorities (CNA) 'nvd' on Agent '' (ID: '001', Version: '').",
+    "Vulnerability scan for package 'Microsoft Office Professional Plus 2016' on Agent '001' has completed."
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/026/expected_004.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/026/expected_004.out
@@ -1,10 +1,10 @@
 [
-    "Match found, the package 'emacs' is vulnerable to 'CVE-2022-45939' due to default status. - Agent '' (ID: '026', Version: '').",
-    "Match found, the package 'emacs' is vulnerable to 'CVE-2022-48337' due to default status. - Agent '' (ID: '026', Version: '').",
-    "Match found, the package 'emacs' is vulnerable to 'CVE-2022-48338' due to default status. - Agent '' (ID: '026', Version: '').",
-    "Match found, the package 'emacs' is vulnerable to 'CVE-2022-48339' due to default status. - Agent '' (ID: '026', Version: '').",
+    "Match found, the package 'emacs', is vulnerable to 'CVE-2022-45939'. Current version: '1:27.1+1-3ubuntu5.1' (less than '1:27.1+1-3ubuntu5.2' or equal to ''). - Agent '' (ID: '026', Version: '').",
+    "Match found, the package 'emacs', is vulnerable to 'CVE-2022-48337'. Current version: '1:27.1+1-3ubuntu5.1' (less than '1:27.1+1-3ubuntu5.2' or equal to ''). - Agent '' (ID: '026', Version: '').",
+    "Match found, the package 'emacs', is vulnerable to 'CVE-2022-48338'. Current version: '1:27.1+1-3ubuntu5.1' (less than '1:27.1+1-3ubuntu5.2' or equal to ''). - Agent '' (ID: '026', Version: '').",
+    "Match found, the package 'emacs', is vulnerable to 'CVE-2022-48339'. Current version: '1:27.1+1-3ubuntu5.1' (less than '1:27.1+1-3ubuntu5.2' or equal to ''). - Agent '' (ID: '026', Version: '').",
+    "Match found, the package 'emacs', is vulnerable to 'CVE-2023-28617'. Current version: '1:27.1+1-3ubuntu5.1' (less than '1:27.1+1-3ubuntu5.2' or equal to ''). - Agent '' (ID: '026', Version: '').",
     "No match due to default status for Package: emacs, Version: 1:27.1+1-3ubuntu5.1 while scanning for Vulnerability: CVE-2023-2491",
     "No match due to default status for Package: emacs, Version: 1:27.1+1-3ubuntu5.1 while scanning for Vulnerability: CVE-2023-27985",
-    "No match due to default status for Package: emacs, Version: 1:27.1+1-3ubuntu5.1 while scanning for Vulnerability: CVE-2023-27986",
-    "No match due to default status for Package: emacs, Version: 1:27.1+1-3ubuntu5.1 while scanning for Vulnerability: CVE-2023-28617"
+    "No match due to default status for Package: emacs, Version: 1:27.1+1-3ubuntu5.1 while scanning for Vulnerability: CVE-2023-27986"
 ]

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_data/030/expected_002.out
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_data/030/expected_002.out
@@ -1,5 +1,5 @@
 [
 	"Initiating a vulnerability scan for package 'kernel' (rpm) (centos) with CVE Numbering Authorities (CNA) 'redhat_9' on Agent '' (ID: '001', Version: '').",
 	"No match due to default status for Package: kernel, Version: 5.14.0-391.el9 while scanning for Vulnerability: CVE-2021-46934",
-	"Match found, the package 'kernel' is vulnerable to 'CVE-2021-47515' due to default status. - Agent '' (ID: '001', Version: '')."
+	"No match due to default status for Package: kernel, Version: 5.14.0-391.el9 while scanning for Vulnerability: CVE-2021-47515"
 ]


### PR DESCRIPTION
|Related issue|
|---|
|#26205|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes the efficacy test for the following packages:

- Microsoft Office: The reason behind the failure is that the translation was removed. So, for now no translation is found, and the vulnerability scanner is unable to match vulnerabilities for that package. I decided to keep the folder for this package for the future if we decide to bring the translation back (I think we should).
 
- Kernel for Centos 9: The CVE-2021-47515 does not affect RedHat9 https://access.redhat.com/security/cve/cve-2021-47515, so the fix is correct.
![image](https://github.com/user-attachments/assets/3faddbc4-ec5d-4640-9a5b-1f8fcbaa3c6e)

- Emacs for Ubuntu Jammy: The CVE-2023-28617 affects Emacs package (https://ubuntu.com/security/CVE-2023-28617) because it was fixed in version `1:27.1+1-3ubuntu5.2` but we have `1:27.1+1-3ubuntu5.1`
![image](https://github.com/user-attachments/assets/19a1b52d-9679-4adc-bae7-adf19830b431)

  It is the same case for all the CVEs modified on this PR: 
   - https://ubuntu.com/security/CVE-2022-45939
   - https://ubuntu.com/security/CVE-2022-48337 
   - https://ubuntu.com/security/CVE-2022-48338 
   - https://ubuntu.com/security/CVE-2022-48339