### PR TITLE
Engine fixed protobuf numbers types

### DIFF
--- a/.github/workflows/engine_coverage.yml
+++ b/.github/workflows/engine_coverage.yml
@@ -19,7 +19,7 @@ on:
         type: string
         description: 'Modules to exclude, separated by commas'
         required: false
-        default: "feedmanager"
+        default: "feedmanager,proto"
       min_coverage:
         type: number
         description: 'Minimum coverage required'
@@ -40,7 +40,7 @@ env:
   BUILD_PATH: src/engine/build
   BUILD_MODULES_PATH: src/engine/build/source
   FULL_COVERAGE: ${{ inputs.full_coverage }}
-  EXCLUDE_MODULES: ${{ inputs.exlude_modules || 'feedmanager' }}
+  EXCLUDE_MODULES: ${{ inputs.exlude_modules || 'feedmanager,proto' }}
   MIN_COVERAGE: ${{ inputs.min_coverage || 80 }}
 
 jobs:

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -25,6 +25,7 @@ option(ENGINE_BUILD_TEST "Generate tests" ON)
 option(ENGINE_BUILD_BENCHMARK "Generate benchmarks" ON)
 option(ENGINE_BUILD_DOCUMENTATION "Generate doxygen documentation" ON)
 option(ENGINE_ASSERT_WITH_SYMBOLS "Exports exe symbols to have asserts with full symbolicated functions" ON)
+option(ENGINE_GENERATE_PROTO "Generate protobuf code" OFF)
 
 # TODO put this in a better place together with other global options like warnings
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/engine/source/api/src/tester/handlers.cpp
+++ b/src/engine/source/api/src/tester/handlers.cpp
@@ -169,13 +169,7 @@ eTester::Result fromOutput(const ::router::test::Output& output)
     eTester::Result result {};
 
     // Set event
-    auto resProtoEvent = eMessage::eMessageFromJson<google::protobuf::Value>(output.event()->str());
-    if (std::holds_alternative<base::Error>(resProtoEvent))
-    {
-        throw std::runtime_error {std::get<base::Error>(resProtoEvent).message}; // Should never happen
-    }
-    auto& protoEvent = std::get<google::protobuf::Value>(resProtoEvent);
-    result.mutable_output()->CopyFrom(protoEvent);
+    result.mutable_output()->assign(output.event()->str());
 
     // Set traces
     for (const auto& [assetName, assetTrace] : output.traceList())

--- a/src/engine/source/api/test/src/unit/tester/handlers_test.cpp
+++ b/src/engine/source/api/test/src/unit/tester/handlers_test.cpp
@@ -671,13 +671,7 @@ eTester::Result getResultFromOutput(const ::router::test::Output& output)
     eTester::Result result {};
 
     // Set event
-    auto resProtoEvent = eMessage::eMessageFromJson<google::protobuf::Value>(output.event()->str());
-    if (std::holds_alternative<base::Error>(resProtoEvent))
-    {
-        throw std::runtime_error {std::get<base::Error>(resProtoEvent).message}; // Should never happen
-    }
-    auto& protoEvent = std::get<google::protobuf::Value>(resProtoEvent);
-    result.mutable_output()->CopyFrom(protoEvent);
+    result.mutable_output()->assign(output.event()->str());
 
     // Set traces
     for (const auto& [assetName, assetTrace] : output.traceList())

--- a/src/engine/source/cmds/src/tester.cpp
+++ b/src/engine/source/cmds/src/tester.cpp
@@ -106,14 +106,10 @@ void processEvent(const std::string& eventStr,
     const auto eResponse = utils::apiAdapter::fromWazuhResponse<ResponseType>(response);
 
     // Print results
-    // TODO Check if eResponse.run().output() is empty and errroe in message to json string
-    std::string jsonOutputAndTrace;
-    google::protobuf::util::MessageToJsonString(eResponse.result().output(), &jsonOutputAndTrace);
-
     if (parameters.jsonFormat)
     {
         json::Json jPrint {};
-        auto jOutput = json::Json {jsonOutputAndTrace.c_str()};
+        auto jOutput = json::Json {eResponse.result().output().c_str()};
         jPrint.set("/output", jOutput);
         for (const auto& data : eResponse.result().asset_traces())
         {
@@ -143,7 +139,7 @@ void processEvent(const std::string& eventStr,
             }
         }
 
-        std::cout << "\n" << yml::utils::ymlToPrettyYaml(jsonOutputAndTrace, true) << "\n\n";
+        std::cout << "\n" << yml::utils::ymlToPrettyYaml(eResponse.result().output(), true) << "\n\n";
     }
 }
 

--- a/src/engine/source/proto/CMakeLists.txt
+++ b/src/engine/source/proto/CMakeLists.txt
@@ -25,10 +25,16 @@ target_link_libraries(eMessages PUBLIC protobuf::libprotobuf base)
 # ###################################################################################################
 find_program(PROTOC_EXECUTABLE NAMES protoc)
 
+# Execute only if protoc is found and ENGINE_GENERATE_PROTO is ON
 if(PROTOC_EXECUTABLE)
     message(STATUS "Found protoc: ${PROTOC_EXECUTABLE}")
     set(VCPKG_INSTALLED_DIR ${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET})
 
+    # Check if ENGINE_GENERATE_PROTO is ON
+    if(NOT ENGINE_GENERATE_PROTO)
+        message(INFO "ENGINE_GENERATE_PROTO is OFF. Skipping Protobuf generation.")
+        return()
+    endif()
     add_custom_target(generate_protobuf_code
         COMMAND VCPKG_INSTALLED_DIR=${VCPKG_INSTALLED_DIR} /bin/sh ${GENERATE_PROTOBUF_SCRIPT}
     )

--- a/src/engine/source/proto/generateCode.sh
+++ b/src/engine/source/proto/generateCode.sh
@@ -3,7 +3,8 @@
 set_proto_config() {
     if [ -z "$VCPKG_INSTALLED_DIR" ]; then
         echo "Error: VCPKG_INSTALLED_DIR is not set, build the code using cmake." >&2
-        echo "i.e: cd $ENGINE_DIR && cmake --preset debug && cmake --build ./build --target generate_protobuf_code" >&2
+        ENGINE_DIR=$(readlink -f "${ENGINE_DIR}")
+        echo "i.e: cd ${ENGINE_DIR} && cmake --preset debug -DENGINE_GENERATE_PROTO=ON && cmake --build ./build --target generate_protobuf_code" >&2
         exit 1
     fi
 
@@ -41,8 +42,8 @@ select_clang_format_version() {
     elif [ -x "$(command -v clang-format)" ]; then
         CLANG_FORMAT=clang-format
     else
-        echo 'Error: clang-format is not installed.' >&2
-        exit 1
+        CLANG_FORMAT=true
+        echo 'Warning: clang-format not found, skipping code formatting.'
     fi
 }
 

--- a/src/engine/source/proto/include/eMessages/tester.pb.cc
+++ b/src/engine/source/proto/include/eMessages/tester.pb.cc
@@ -80,7 +80,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 PROTOBUF_CONSTEXPR Result::Result(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.asset_traces_)*/{}
-  , /*decltype(_impl_.output_)*/nullptr
+  , /*decltype(_impl_.output_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct ResultDefaultTypeInternal {
   PROTOBUF_CONSTEXPR ResultDefaultTypeInternal()
@@ -402,58 +402,56 @@ static const ::_pb::Message* const file_default_instances[] = {
 
 const char descriptor_table_protodef_tester_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\014tester.proto\022\033com.wazuh.api.engine.tes"
-  "ter\032\014engine.proto\032\034google/protobuf/struc"
-  "t.proto\"g\n\013SessionPost\022\014\n\004name\030\001 \001(\t\022\016\n\006"
-  "policy\030\002 \001(\t\022\020\n\010lifetime\030\003 \001(\r\022\030\n\013descri"
-  "ption\030\004 \001(\tH\000\210\001\001B\016\n\014_description\"\347\001\n\007Ses"
-  "sion\022\014\n\004name\030\001 \001(\t\022\016\n\006policy\030\002 \001(\t\022\020\n\010li"
-  "fetime\030\003 \001(\r\022\030\n\013description\030\004 \001(\tH\000\210\001\001\0226"
-  "\n\013policy_sync\030\006 \001(\0162!.com.wazuh.api.engi"
-  "ne.tester.Sync\0228\n\014entry_status\030\007 \001(\0162\".c"
-  "om.wazuh.api.engine.tester.State\022\020\n\010last"
-  "_use\030\010 \001(\rB\016\n\014_description\"\264\001\n\006Result\022&\n"
-  "\006output\030\001 \001(\0132\026.google.protobuf.Value\022D\n"
-  "\014asset_traces\030\002 \003(\0132..com.wazuh.api.engi"
-  "ne.tester.Result.AssetTrace\032<\n\nAssetTrac"
-  "e\022\r\n\005asset\030\001 \001(\t\022\017\n\007success\030\002 \001(\010\022\016\n\006tra"
-  "ces\030\003 \003(\t\"a\n\023SessionPost_Request\022>\n\007sess"
-  "ion\030\001 \001(\0132(.com.wazuh.api.engine.tester."
-  "SessionPostH\000\210\001\001B\n\n\010_session\"%\n\025SessionD"
-  "elete_Request\022\014\n\004name\030\001 \001(\t\"\"\n\022SessionGe"
-  "t_Request\022\014\n\004name\030\001 \001(\t\"\257\001\n\023SessionGet_R"
-  "esponse\0222\n\006status\030\001 \001(\0162\".com.wazuh.api."
-  "engine.ReturnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022"
-  ":\n\007session\030\003 \001(\0132$.com.wazuh.api.engine."
-  "tester.SessionH\001\210\001\001B\010\n\006_errorB\n\n\010_sessio"
-  "n\"%\n\025SessionReload_Request\022\014\n\004name\030\001 \001(\t"
-  "\"\022\n\020TableGet_Request\"\235\001\n\021TableGet_Respon"
-  "se\0222\n\006status\030\001 \001(\0162\".com.wazuh.api.engin"
-  "e.ReturnStatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\0226\n\010se"
-  "ssions\030\003 \003(\0132$.com.wazuh.api.engine.test"
-  "er.SessionB\010\n\006_error\"\270\001\n\017RunPost_Request"
-  "\022\014\n\004name\030\001 \001(\t\022\017\n\007message\030\002 \001(\t\022\020\n\010locat"
-  "ion\030\003 \001(\t\022\r\n\005queue\030\004 \001(\t\022<\n\013trace_level\030"
-  "\005 \001(\0162\'.com.wazuh.api.engine.tester.Trac"
-  "eLevel\022\023\n\013asset_trace\030\006 \003(\t\022\022\n\nnamespace"
-  "s\030\007 \003(\t\"\251\001\n\020RunPost_Response\0222\n\006status\030\001"
+  "ter\032\014engine.proto\"g\n\013SessionPost\022\014\n\004name"
+  "\030\001 \001(\t\022\016\n\006policy\030\002 \001(\t\022\020\n\010lifetime\030\003 \001(\r"
+  "\022\030\n\013description\030\004 \001(\tH\000\210\001\001B\016\n\014_descripti"
+  "on\"\347\001\n\007Session\022\014\n\004name\030\001 \001(\t\022\016\n\006policy\030\002"
+  " \001(\t\022\020\n\010lifetime\030\003 \001(\r\022\030\n\013description\030\004 "
+  "\001(\tH\000\210\001\001\0226\n\013policy_sync\030\006 \001(\0162!.com.wazu"
+  "h.api.engine.tester.Sync\0228\n\014entry_status"
+  "\030\007 \001(\0162\".com.wazuh.api.engine.tester.Sta"
+  "te\022\020\n\010last_use\030\010 \001(\rB\016\n\014_description\"\234\001\n"
+  "\006Result\022\016\n\006output\030\001 \001(\t\022D\n\014asset_traces\030"
+  "\002 \003(\0132..com.wazuh.api.engine.tester.Resu"
+  "lt.AssetTrace\032<\n\nAssetTrace\022\r\n\005asset\030\001 \001"
+  "(\t\022\017\n\007success\030\002 \001(\010\022\016\n\006traces\030\003 \003(\t\"a\n\023S"
+  "essionPost_Request\022>\n\007session\030\001 \001(\0132(.co"
+  "m.wazuh.api.engine.tester.SessionPostH\000\210"
+  "\001\001B\n\n\010_session\"%\n\025SessionDelete_Request\022"
+  "\014\n\004name\030\001 \001(\t\"\"\n\022SessionGet_Request\022\014\n\004n"
+  "ame\030\001 \001(\t\"\257\001\n\023SessionGet_Response\0222\n\006sta"
+  "tus\030\001 \001(\0162\".com.wazuh.api.engine.ReturnS"
+  "tatus\022\022\n\005error\030\002 \001(\tH\000\210\001\001\022:\n\007session\030\003 \001"
+  "(\0132$.com.wazuh.api.engine.tester.Session"
+  "H\001\210\001\001B\010\n\006_errorB\n\n\010_session\"%\n\025SessionRe"
+  "load_Request\022\014\n\004name\030\001 \001(\t\"\022\n\020TableGet_R"
+  "equest\"\235\001\n\021TableGet_Response\0222\n\006status\030\001"
   " \001(\0162\".com.wazuh.api.engine.ReturnStatus"
-  "\022\022\n\005error\030\002 \001(\tH\000\210\001\001\0228\n\006result\030\003 \001(\0132#.c"
-  "om.wazuh.api.engine.tester.ResultH\001\210\001\001B\010"
-  "\n\006_errorB\t\n\007_result*5\n\005State\022\021\n\rSTATE_UN"
-  "KNOWN\020\000\022\014\n\010DISABLED\020\001\022\013\n\007ENABLED\020\002*>\n\004Sy"
-  "nc\022\020\n\014SYNC_UNKNOWN\020\000\022\013\n\007UPDATED\020\001\022\014\n\010OUT"
-  "DATED\020\002\022\t\n\005ERROR\020\003*/\n\nTraceLevel\022\010\n\004NONE"
-  "\020\000\022\016\n\nASSET_ONLY\020\001\022\007\n\003ALL\020\002b\006proto3"
+  "\022\022\n\005error\030\002 \001(\tH\000\210\001\001\0226\n\010sessions\030\003 \003(\0132$"
+  ".com.wazuh.api.engine.tester.SessionB\010\n\006"
+  "_error\"\270\001\n\017RunPost_Request\022\014\n\004name\030\001 \001(\t"
+  "\022\017\n\007message\030\002 \001(\t\022\020\n\010location\030\003 \001(\t\022\r\n\005q"
+  "ueue\030\004 \001(\t\022<\n\013trace_level\030\005 \001(\0162\'.com.wa"
+  "zuh.api.engine.tester.TraceLevel\022\023\n\013asse"
+  "t_trace\030\006 \003(\t\022\022\n\nnamespaces\030\007 \003(\t\"\251\001\n\020Ru"
+  "nPost_Response\0222\n\006status\030\001 \001(\0162\".com.waz"
+  "uh.api.engine.ReturnStatus\022\022\n\005error\030\002 \001("
+  "\tH\000\210\001\001\0228\n\006result\030\003 \001(\0132#.com.wazuh.api.e"
+  "ngine.tester.ResultH\001\210\001\001B\010\n\006_errorB\t\n\007_r"
+  "esult*5\n\005State\022\021\n\rSTATE_UNKNOWN\020\000\022\014\n\010DIS"
+  "ABLED\020\001\022\013\n\007ENABLED\020\002*>\n\004Sync\022\020\n\014SYNC_UNK"
+  "NOWN\020\000\022\013\n\007UPDATED\020\001\022\014\n\010OUTDATED\020\002\022\t\n\005ERR"
+  "OR\020\003*/\n\nTraceLevel\022\010\n\004NONE\020\000\022\016\n\nASSET_ON"
+  "LY\020\001\022\007\n\003ALL\020\002b\006proto3"
   ;
-static const ::_pbi::DescriptorTable* const descriptor_table_tester_2eproto_deps[2] = {
+static const ::_pbi::DescriptorTable* const descriptor_table_tester_2eproto_deps[1] = {
   &::descriptor_table_engine_2eproto,
-  &::descriptor_table_google_2fprotobuf_2fstruct_2eproto,
 };
 static ::_pbi::once_flag descriptor_table_tester_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_tester_2eproto = {
-    false, false, 1715, descriptor_table_protodef_tester_2eproto,
+    false, false, 1661, descriptor_table_protodef_tester_2eproto,
     "tester.proto",
-    &descriptor_table_tester_2eproto_once, descriptor_table_tester_2eproto_deps, 2, 13,
+    &descriptor_table_tester_2eproto_once, descriptor_table_tester_2eproto_deps, 1, 13,
     schemas, file_default_instances, TableStruct_tester_2eproto::offsets,
     file_level_metadata_tester_2eproto, file_level_enum_descriptors_tester_2eproto,
     file_level_service_descriptors_tester_2eproto,
@@ -1564,19 +1562,8 @@ void Result_AssetTrace::InternalSwap(Result_AssetTrace* other) {
 
 class Result::_Internal {
  public:
-  static const ::PROTOBUF_NAMESPACE_ID::Value& output(const Result* msg);
 };
 
-const ::PROTOBUF_NAMESPACE_ID::Value&
-Result::_Internal::output(const Result* msg) {
-  return *msg->_impl_.output_;
-}
-void Result::clear_output() {
-  if (GetArenaForAllocation() == nullptr && _impl_.output_ != nullptr) {
-    delete _impl_.output_;
-  }
-  _impl_.output_ = nullptr;
-}
 Result::Result(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
@@ -1588,12 +1575,17 @@ Result::Result(const Result& from)
   Result* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.asset_traces_){from._impl_.asset_traces_}
-    , decltype(_impl_.output_){nullptr}
+    , decltype(_impl_.output_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  if (from._internal_has_output()) {
-    _this->_impl_.output_ = new ::PROTOBUF_NAMESPACE_ID::Value(*from._impl_.output_);
+  _impl_.output_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.output_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_output().empty()) {
+    _this->_impl_.output_.Set(from._internal_output(), 
+      _this->GetArenaForAllocation());
   }
   // @@protoc_insertion_point(copy_constructor:com.wazuh.api.engine.tester.Result)
 }
@@ -1604,9 +1596,13 @@ inline void Result::SharedCtor(
   (void)is_message_owned;
   new (&_impl_) Impl_{
       decltype(_impl_.asset_traces_){arena}
-    , decltype(_impl_.output_){nullptr}
+    , decltype(_impl_.output_){}
     , /*decltype(_impl_._cached_size_)*/{}
   };
+  _impl_.output_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.output_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
 Result::~Result() {
@@ -1621,7 +1617,7 @@ Result::~Result() {
 inline void Result::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.asset_traces_.~RepeatedPtrField();
-  if (this != internal_default_instance()) delete _impl_.output_;
+  _impl_.output_.Destroy();
 }
 
 void Result::SetCachedSize(int size) const {
@@ -1635,10 +1631,7 @@ void Result::Clear() {
   (void) cached_has_bits;
 
   _impl_.asset_traces_.Clear();
-  if (GetArenaForAllocation() == nullptr && _impl_.output_ != nullptr) {
-    delete _impl_.output_;
-  }
-  _impl_.output_ = nullptr;
+  _impl_.output_.ClearToEmpty();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -1648,11 +1641,13 @@ const char* Result::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // .google.protobuf.Value output = 1;
+      // string output = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
-          ptr = ctx->ParseMessage(_internal_mutable_output(), ptr);
+          auto str = _internal_mutable_output();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "com.wazuh.api.engine.tester.Result.output"));
         } else
           goto handle_unusual;
         continue;
@@ -1698,11 +1693,14 @@ uint8_t* Result::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .google.protobuf.Value output = 1;
-  if (this->_internal_has_output()) {
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
-      InternalWriteMessage(1, _Internal::output(this),
-        _Internal::output(this).GetCachedSize(), target, stream);
+  // string output = 1;
+  if (!this->_internal_output().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_output().data(), static_cast<int>(this->_internal_output().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "com.wazuh.api.engine.tester.Result.output");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_output(), target);
   }
 
   // repeated .com.wazuh.api.engine.tester.Result.AssetTrace asset_traces = 2;
@@ -1736,11 +1734,11 @@ size_t Result::ByteSizeLong() const {
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
   }
 
-  // .google.protobuf.Value output = 1;
-  if (this->_internal_has_output()) {
+  // string output = 1;
+  if (!this->_internal_output().empty()) {
     total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *_impl_.output_);
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_output());
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
@@ -1762,9 +1760,8 @@ void Result::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBU
   (void) cached_has_bits;
 
   _this->_impl_.asset_traces_.MergeFrom(from._impl_.asset_traces_);
-  if (from._internal_has_output()) {
-    _this->_internal_mutable_output()->::PROTOBUF_NAMESPACE_ID::Value::MergeFrom(
-        from._internal_output());
+  if (!from._internal_output().empty()) {
+    _this->_internal_set_output(from._internal_output());
   }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -1782,9 +1779,14 @@ bool Result::IsInitialized() const {
 
 void Result::InternalSwap(Result* other) {
   using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   _impl_.asset_traces_.InternalSwap(&other->_impl_.asset_traces_);
-  swap(_impl_.output_, other->_impl_.output_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.output_, lhs_arena,
+      &other->_impl_.output_, rhs_arena
+  );
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata Result::GetMetadata() const {

--- a/src/engine/source/proto/include/eMessages/tester.pb.h
+++ b/src/engine/source/proto/include/eMessages/tester.pb.h
@@ -33,7 +33,6 @@
 #include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 #include "engine.pb.h"
-#include <google/protobuf/struct.pb.h>
 // @@protoc_insertion_point(includes)
 #include <google/protobuf/port_def.inc>
 #define PROTOBUF_INTERNAL_EXPORT_tester_2eproto
@@ -968,23 +967,19 @@ class Result final :
   const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::com::wazuh::api::engine::tester::Result_AssetTrace >&
       asset_traces() const;
 
-  // .google.protobuf.Value output = 1;
-  bool has_output() const;
-  private:
-  bool _internal_has_output() const;
-  public:
+  // string output = 1;
   void clear_output();
-  const ::PROTOBUF_NAMESPACE_ID::Value& output() const;
-  PROTOBUF_NODISCARD ::PROTOBUF_NAMESPACE_ID::Value* release_output();
-  ::PROTOBUF_NAMESPACE_ID::Value* mutable_output();
-  void set_allocated_output(::PROTOBUF_NAMESPACE_ID::Value* output);
+  const std::string& output() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_output(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_output();
+  PROTOBUF_NODISCARD std::string* release_output();
+  void set_allocated_output(std::string* output);
   private:
-  const ::PROTOBUF_NAMESPACE_ID::Value& _internal_output() const;
-  ::PROTOBUF_NAMESPACE_ID::Value* _internal_mutable_output();
+  const std::string& _internal_output() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_output(const std::string& value);
+  std::string* _internal_mutable_output();
   public:
-  void unsafe_arena_set_allocated_output(
-      ::PROTOBUF_NAMESPACE_ID::Value* output);
-  ::PROTOBUF_NAMESPACE_ID::Value* unsafe_arena_release_output();
 
   // @@protoc_insertion_point(class_scope:com.wazuh.api.engine.tester.Result)
  private:
@@ -995,7 +990,7 @@ class Result final :
   typedef void DestructorSkippable_;
   struct Impl_ {
     ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::com::wazuh::api::engine::tester::Result_AssetTrace > asset_traces_;
-    ::PROTOBUF_NAMESPACE_ID::Value* output_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr output_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -3171,88 +3166,53 @@ Result_AssetTrace::mutable_traces() {
 
 // Result
 
-// .google.protobuf.Value output = 1;
-inline bool Result::_internal_has_output() const {
-  return this != internal_default_instance() && _impl_.output_ != nullptr;
+// string output = 1;
+inline void Result::clear_output() {
+  _impl_.output_.ClearToEmpty();
 }
-inline bool Result::has_output() const {
-  return _internal_has_output();
-}
-inline const ::PROTOBUF_NAMESPACE_ID::Value& Result::_internal_output() const {
-  const ::PROTOBUF_NAMESPACE_ID::Value* p = _impl_.output_;
-  return p != nullptr ? *p : reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Value&>(
-      ::PROTOBUF_NAMESPACE_ID::_Value_default_instance_);
-}
-inline const ::PROTOBUF_NAMESPACE_ID::Value& Result::output() const {
+inline const std::string& Result::output() const {
   // @@protoc_insertion_point(field_get:com.wazuh.api.engine.tester.Result.output)
   return _internal_output();
 }
-inline void Result::unsafe_arena_set_allocated_output(
-    ::PROTOBUF_NAMESPACE_ID::Value* output) {
-  if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.output_);
-  }
-  _impl_.output_ = output;
-  if (output) {
-    
-  } else {
-    
-  }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:com.wazuh.api.engine.tester.Result.output)
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void Result::set_output(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.output_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:com.wazuh.api.engine.tester.Result.output)
 }
-inline ::PROTOBUF_NAMESPACE_ID::Value* Result::release_output() {
-  
-  ::PROTOBUF_NAMESPACE_ID::Value* temp = _impl_.output_;
-  _impl_.output_ = nullptr;
-#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
-  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
-  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
-  if (GetArenaForAllocation() == nullptr) { delete old; }
-#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
-  if (GetArenaForAllocation() != nullptr) {
-    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
-  }
-#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
-  return temp;
-}
-inline ::PROTOBUF_NAMESPACE_ID::Value* Result::unsafe_arena_release_output() {
-  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.tester.Result.output)
-  
-  ::PROTOBUF_NAMESPACE_ID::Value* temp = _impl_.output_;
-  _impl_.output_ = nullptr;
-  return temp;
-}
-inline ::PROTOBUF_NAMESPACE_ID::Value* Result::_internal_mutable_output() {
-  
-  if (_impl_.output_ == nullptr) {
-    auto* p = CreateMaybeMessage<::PROTOBUF_NAMESPACE_ID::Value>(GetArenaForAllocation());
-    _impl_.output_ = p;
-  }
-  return _impl_.output_;
-}
-inline ::PROTOBUF_NAMESPACE_ID::Value* Result::mutable_output() {
-  ::PROTOBUF_NAMESPACE_ID::Value* _msg = _internal_mutable_output();
+inline std::string* Result::mutable_output() {
+  std::string* _s = _internal_mutable_output();
   // @@protoc_insertion_point(field_mutable:com.wazuh.api.engine.tester.Result.output)
-  return _msg;
+  return _s;
 }
-inline void Result::set_allocated_output(::PROTOBUF_NAMESPACE_ID::Value* output) {
-  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
-  if (message_arena == nullptr) {
-    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.output_);
-  }
-  if (output) {
-    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(
-                reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(output));
-    if (message_arena != submessage_arena) {
-      output = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, output, submessage_arena);
-    }
+inline const std::string& Result::_internal_output() const {
+  return _impl_.output_.Get();
+}
+inline void Result::_internal_set_output(const std::string& value) {
+  
+  _impl_.output_.Set(value, GetArenaForAllocation());
+}
+inline std::string* Result::_internal_mutable_output() {
+  
+  return _impl_.output_.Mutable(GetArenaForAllocation());
+}
+inline std::string* Result::release_output() {
+  // @@protoc_insertion_point(field_release:com.wazuh.api.engine.tester.Result.output)
+  return _impl_.output_.Release();
+}
+inline void Result::set_allocated_output(std::string* output) {
+  if (output != nullptr) {
     
   } else {
     
   }
-  _impl_.output_ = output;
+  _impl_.output_.SetAllocated(output, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.output_.IsDefault()) {
+    _impl_.output_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   // @@protoc_insertion_point(field_set_allocated:com.wazuh.api.engine.tester.Result.output)
 }
 

--- a/src/engine/source/proto/src/tester.proto
+++ b/src/engine/source/proto/src/tester.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 import "engine.proto";
-import "google/protobuf/struct.proto"; // For Value
 
 package com.wazuh.api.engine.tester;
 
@@ -51,7 +50,7 @@ message Result
         bool success = 2;           // If the asset was successfully decoded
         repeated string traces = 3; // Traces of the asset
     }
-    google.protobuf.Value output = 1;     // test output
+    string output = 1;                    // JSON output of the event
     repeated AssetTrace asset_traces = 2; // Asset traces
 }
 

--- a/src/engine/test/helper_tests/engine-helper-test/src/helper_test/runner.py
+++ b/src/engine/test/helper_tests/engine-helper-test/src/helper_test/runner.py
@@ -189,8 +189,8 @@ class Evaluator:
             response: The response received from the API call.
         """
         if json.loads(MessageToJson(response)).get("result"):
-            json_response = json.loads(MessageToJson(response))[
-                "result"]["output"].get(self.field_mapping)
+            output = json.loads(MessageToJson(response))["result"]["output"]
+            json_response = json.loads(output).get(self.field_mapping)
         else:
             json_response = None
         failure_test = {
@@ -557,7 +557,7 @@ def extract_output_from_response(response: dict) -> dict:
         dict: The event output extracted from the response.
     """
     response = json.loads(MessageToJson(response))
-    return response["result"]["output"]
+    return json.loads(response["result"]["output"])
 
 
 def get_target_trace(traces: list, helper_name: str, count=1) -> Optional[str]:

--- a/src/engine/test/integration_tests/tester/features/api.feature
+++ b/src/engine/test/integration_tests/tester/features/api.feature
@@ -60,16 +60,16 @@ Feature: Tester API Management
     Given I have a policy "policy/wazuh/0" that has an integration called "other-wazuh-core-test" loaded
     And I create a "test" session that points to policy "policy/wazuh/0"
     When I send a request to send the event "hi! i am an event test!" from "test" session with "NONE" debug "system" namespace, queue "2" and "decoder/other-test-message/0" asset trace
-    Then I should receive the next output: "{"output": {"event": {"original": "hi! i am an event test!"}, "wazuh": {"location": "any", "queue": 50.0}}}"
+    Then I should receive the next output: "{"output":"{\"wazuh\":{\"queue\":50,\"location\":\"any\"},\"event\":{\"original\":\"hi! i am an event test!\"}}"}"
 
   Scenario: Send events to specific session with low debug via API
     Given I have a policy "policy/wazuh/0" that has an integration called "other-wazuh-core-test" loaded
     And I create a "test" session that points to policy "policy/wazuh/0"
     When I send a request to send the event "hi! i am an event test!" from "test" session with "ASSET_ONLY" debug "system" namespace, queue "2" and "decoder/other-test-message/0" asset trace
-    Then I should receive the next output: "{"output": {"wazuh": {"location": "any", "queue": 50.0}, "event": {"original": "hi! i am an event test!"}}, "assetTraces": [{"asset": "decoder/other-test-message/0", "success": true}]}"
+    Then I should receive the next output: "{"assetTraces":[{"asset":"decoder/other-test-message/0","success":true}],"output":"{\"wazuh\":{\"queue\":50,\"location\":\"any\"},\"event\":{\"original\":\"hi! i am an event test!\"}}"}"
 
   Scenario: Send events to specific session with high debug via API
     Given I have a policy "policy/wazuh/0" that has an integration called "other-wazuh-core-test" loaded
     And I create a "test" session that points to policy "policy/wazuh/0"
     When I send a request to send the event "hi! i am an event test!" from "test" session with "ALL" debug "system" namespace, queue "2" and "decoder/other-test-message/0" asset trace
-    Then I should receive the next output: "{"output": {"event": {"original": "hi! i am an event test!"}, "wazuh": {"queue": 50.0, "location": "any"}}, "assetTraces": [{"asset": "decoder/other-test-message/0", "success": true, "traces": ["[check: $wazuh.queue == 50] -> Success"]}]}"
+    Then I should receive the next output: "{"assetTraces":[{"asset":"decoder/other-test-message/0","success":true,"traces":["[check: $wazuh.queue == 50] -> Success"]}],"output":"{\"wazuh\":{\"queue\":50,\"location\":\"any\"},\"event\":{\"original\":\"hi! i am an event test!\"}}"}"

--- a/src/engine/tools/api-communication/src/api_communication/proto/tester_pb2.py
+++ b/src/engine/tools/api-communication/src/api_communication/proto/tester_pb2.py
@@ -12,46 +12,45 @@ _sym_db = _symbol_database.Default()
 
 
 import api_communication.proto.engine_pb2 as _engine_pb2
-from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0ctester.proto\x12\x1b\x63om.wazuh.api.engine.tester\x1a\x0c\x65ngine.proto\x1a\x1cgoogle/protobuf/struct.proto\"g\n\x0bSessionPost\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06policy\x18\x02 \x01(\t\x12\x10\n\x08lifetime\x18\x03 \x01(\r\x12\x18\n\x0b\x64\x65scription\x18\x04 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_description\"\xe7\x01\n\x07Session\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06policy\x18\x02 \x01(\t\x12\x10\n\x08lifetime\x18\x03 \x01(\r\x12\x18\n\x0b\x64\x65scription\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x36\n\x0bpolicy_sync\x18\x06 \x01(\x0e\x32!.com.wazuh.api.engine.tester.Sync\x12\x38\n\x0c\x65ntry_status\x18\x07 \x01(\x0e\x32\".com.wazuh.api.engine.tester.State\x12\x10\n\x08last_use\x18\x08 \x01(\rB\x0e\n\x0c_description\"\xb4\x01\n\x06Result\x12&\n\x06output\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12\x44\n\x0c\x61sset_traces\x18\x02 \x03(\x0b\x32..com.wazuh.api.engine.tester.Result.AssetTrace\x1a<\n\nAssetTrace\x12\r\n\x05\x61sset\x18\x01 \x01(\t\x12\x0f\n\x07success\x18\x02 \x01(\x08\x12\x0e\n\x06traces\x18\x03 \x03(\t\"a\n\x13SessionPost_Request\x12>\n\x07session\x18\x01 \x01(\x0b\x32(.com.wazuh.api.engine.tester.SessionPostH\x00\x88\x01\x01\x42\n\n\x08_session\"%\n\x15SessionDelete_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\"\"\n\x12SessionGet_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xaf\x01\n\x13SessionGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12:\n\x07session\x18\x03 \x01(\x0b\x32$.com.wazuh.api.engine.tester.SessionH\x01\x88\x01\x01\x42\x08\n\x06_errorB\n\n\x08_session\"%\n\x15SessionReload_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x12\n\x10TableGet_Request\"\x9d\x01\n\x11TableGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x36\n\x08sessions\x18\x03 \x03(\x0b\x32$.com.wazuh.api.engine.tester.SessionB\x08\n\x06_error\"\xb8\x01\n\x0fRunPost_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x10\n\x08location\x18\x03 \x01(\t\x12\r\n\x05queue\x18\x04 \x01(\t\x12<\n\x0btrace_level\x18\x05 \x01(\x0e\x32\'.com.wazuh.api.engine.tester.TraceLevel\x12\x13\n\x0b\x61sset_trace\x18\x06 \x03(\t\x12\x12\n\nnamespaces\x18\x07 \x03(\t\"\xa9\x01\n\x10RunPost_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x38\n\x06result\x18\x03 \x01(\x0b\x32#.com.wazuh.api.engine.tester.ResultH\x01\x88\x01\x01\x42\x08\n\x06_errorB\t\n\x07_result*5\n\x05State\x12\x11\n\rSTATE_UNKNOWN\x10\x00\x12\x0c\n\x08\x44ISABLED\x10\x01\x12\x0b\n\x07\x45NABLED\x10\x02*>\n\x04Sync\x12\x10\n\x0cSYNC_UNKNOWN\x10\x00\x12\x0b\n\x07UPDATED\x10\x01\x12\x0c\n\x08OUTDATED\x10\x02\x12\t\n\x05\x45RROR\x10\x03*/\n\nTraceLevel\x12\x08\n\x04NONE\x10\x00\x12\x0e\n\nASSET_ONLY\x10\x01\x12\x07\n\x03\x41LL\x10\x02\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0ctester.proto\x12\x1b\x63om.wazuh.api.engine.tester\x1a\x0c\x65ngine.proto\"g\n\x0bSessionPost\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06policy\x18\x02 \x01(\t\x12\x10\n\x08lifetime\x18\x03 \x01(\r\x12\x18\n\x0b\x64\x65scription\x18\x04 \x01(\tH\x00\x88\x01\x01\x42\x0e\n\x0c_description\"\xe7\x01\n\x07Session\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06policy\x18\x02 \x01(\t\x12\x10\n\x08lifetime\x18\x03 \x01(\r\x12\x18\n\x0b\x64\x65scription\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x36\n\x0bpolicy_sync\x18\x06 \x01(\x0e\x32!.com.wazuh.api.engine.tester.Sync\x12\x38\n\x0c\x65ntry_status\x18\x07 \x01(\x0e\x32\".com.wazuh.api.engine.tester.State\x12\x10\n\x08last_use\x18\x08 \x01(\rB\x0e\n\x0c_description\"\x9c\x01\n\x06Result\x12\x0e\n\x06output\x18\x01 \x01(\t\x12\x44\n\x0c\x61sset_traces\x18\x02 \x03(\x0b\x32..com.wazuh.api.engine.tester.Result.AssetTrace\x1a<\n\nAssetTrace\x12\r\n\x05\x61sset\x18\x01 \x01(\t\x12\x0f\n\x07success\x18\x02 \x01(\x08\x12\x0e\n\x06traces\x18\x03 \x03(\t\"a\n\x13SessionPost_Request\x12>\n\x07session\x18\x01 \x01(\x0b\x32(.com.wazuh.api.engine.tester.SessionPostH\x00\x88\x01\x01\x42\n\n\x08_session\"%\n\x15SessionDelete_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\"\"\n\x12SessionGet_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\"\xaf\x01\n\x13SessionGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12:\n\x07session\x18\x03 \x01(\x0b\x32$.com.wazuh.api.engine.tester.SessionH\x01\x88\x01\x01\x42\x08\n\x06_errorB\n\n\x08_session\"%\n\x15SessionReload_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\"\x12\n\x10TableGet_Request\"\x9d\x01\n\x11TableGet_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x36\n\x08sessions\x18\x03 \x03(\x0b\x32$.com.wazuh.api.engine.tester.SessionB\x08\n\x06_error\"\xb8\x01\n\x0fRunPost_Request\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x10\n\x08location\x18\x03 \x01(\t\x12\r\n\x05queue\x18\x04 \x01(\t\x12<\n\x0btrace_level\x18\x05 \x01(\x0e\x32\'.com.wazuh.api.engine.tester.TraceLevel\x12\x13\n\x0b\x61sset_trace\x18\x06 \x03(\t\x12\x12\n\nnamespaces\x18\x07 \x03(\t\"\xa9\x01\n\x10RunPost_Response\x12\x32\n\x06status\x18\x01 \x01(\x0e\x32\".com.wazuh.api.engine.ReturnStatus\x12\x12\n\x05\x65rror\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x38\n\x06result\x18\x03 \x01(\x0b\x32#.com.wazuh.api.engine.tester.ResultH\x01\x88\x01\x01\x42\x08\n\x06_errorB\t\n\x07_result*5\n\x05State\x12\x11\n\rSTATE_UNKNOWN\x10\x00\x12\x0c\n\x08\x44ISABLED\x10\x01\x12\x0b\n\x07\x45NABLED\x10\x02*>\n\x04Sync\x12\x10\n\x0cSYNC_UNKNOWN\x10\x00\x12\x0b\n\x07UPDATED\x10\x01\x12\x0c\n\x08OUTDATED\x10\x02\x12\t\n\x05\x45RROR\x10\x03*/\n\nTraceLevel\x12\x08\n\x04NONE\x10\x00\x12\x0e\n\nASSET_ONLY\x10\x01\x12\x07\n\x03\x41LL\x10\x02\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'tester_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _STATE._serialized_start=1541
-  _STATE._serialized_end=1594
-  _SYNC._serialized_start=1596
-  _SYNC._serialized_end=1658
-  _TRACELEVEL._serialized_start=1660
-  _TRACELEVEL._serialized_end=1707
-  _SESSIONPOST._serialized_start=89
-  _SESSIONPOST._serialized_end=192
-  _SESSION._serialized_start=195
-  _SESSION._serialized_end=426
-  _RESULT._serialized_start=429
-  _RESULT._serialized_end=609
-  _RESULT_ASSETTRACE._serialized_start=549
-  _RESULT_ASSETTRACE._serialized_end=609
-  _SESSIONPOST_REQUEST._serialized_start=611
-  _SESSIONPOST_REQUEST._serialized_end=708
-  _SESSIONDELETE_REQUEST._serialized_start=710
-  _SESSIONDELETE_REQUEST._serialized_end=747
-  _SESSIONGET_REQUEST._serialized_start=749
-  _SESSIONGET_REQUEST._serialized_end=783
-  _SESSIONGET_RESPONSE._serialized_start=786
-  _SESSIONGET_RESPONSE._serialized_end=961
-  _SESSIONRELOAD_REQUEST._serialized_start=963
-  _SESSIONRELOAD_REQUEST._serialized_end=1000
-  _TABLEGET_REQUEST._serialized_start=1002
-  _TABLEGET_REQUEST._serialized_end=1020
-  _TABLEGET_RESPONSE._serialized_start=1023
-  _TABLEGET_RESPONSE._serialized_end=1180
-  _RUNPOST_REQUEST._serialized_start=1183
-  _RUNPOST_REQUEST._serialized_end=1367
-  _RUNPOST_RESPONSE._serialized_start=1370
-  _RUNPOST_RESPONSE._serialized_end=1539
+  _STATE._serialized_start=1487
+  _STATE._serialized_end=1540
+  _SYNC._serialized_start=1542
+  _SYNC._serialized_end=1604
+  _TRACELEVEL._serialized_start=1606
+  _TRACELEVEL._serialized_end=1653
+  _SESSIONPOST._serialized_start=59
+  _SESSIONPOST._serialized_end=162
+  _SESSION._serialized_start=165
+  _SESSION._serialized_end=396
+  _RESULT._serialized_start=399
+  _RESULT._serialized_end=555
+  _RESULT_ASSETTRACE._serialized_start=495
+  _RESULT_ASSETTRACE._serialized_end=555
+  _SESSIONPOST_REQUEST._serialized_start=557
+  _SESSIONPOST_REQUEST._serialized_end=654
+  _SESSIONDELETE_REQUEST._serialized_start=656
+  _SESSIONDELETE_REQUEST._serialized_end=693
+  _SESSIONGET_REQUEST._serialized_start=695
+  _SESSIONGET_REQUEST._serialized_end=729
+  _SESSIONGET_RESPONSE._serialized_start=732
+  _SESSIONGET_RESPONSE._serialized_end=907
+  _SESSIONRELOAD_REQUEST._serialized_start=909
+  _SESSIONRELOAD_REQUEST._serialized_end=946
+  _TABLEGET_REQUEST._serialized_start=948
+  _TABLEGET_REQUEST._serialized_end=966
+  _TABLEGET_RESPONSE._serialized_start=969
+  _TABLEGET_RESPONSE._serialized_end=1126
+  _RUNPOST_REQUEST._serialized_start=1129
+  _RUNPOST_REQUEST._serialized_end=1313
+  _RUNPOST_RESPONSE._serialized_start=1316
+  _RUNPOST_RESPONSE._serialized_end=1485
 # @@protoc_insertion_point(module_scope)

--- a/src/engine/tools/api-communication/src/api_communication/proto/tester_pb2.pyi
+++ b/src/engine/tools/api-communication/src/api_communication/proto/tester_pb2.pyi
@@ -1,5 +1,4 @@
 import engine_pb2 as _engine_pb2
-from google.protobuf import struct_pb2 as _struct_pb2
 from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
@@ -32,8 +31,8 @@ class Result(_message.Message):
     ASSET_TRACES_FIELD_NUMBER: _ClassVar[int]
     OUTPUT_FIELD_NUMBER: _ClassVar[int]
     asset_traces: _containers.RepeatedCompositeFieldContainer[Result.AssetTrace]
-    output: _struct_pb2.Value
-    def __init__(self, output: _Optional[_Union[_struct_pb2.Value, _Mapping]] = ..., asset_traces: _Optional[_Iterable[_Union[Result.AssetTrace, _Mapping]]] = ...) -> None: ...
+    output: str
+    def __init__(self, output: _Optional[str] = ..., asset_traces: _Optional[_Iterable[_Union[Result.AssetTrace, _Mapping]]] = ...) -> None: ...
 
 class RunPost_Request(_message.Message):
     __slots__ = ["asset_trace", "location", "message", "name", "namespaces", "queue", "trace_level"]

--- a/src/engine/tools/engine-suite/src/engine_test/integration.py
+++ b/src/engine/tools/engine-suite/src/engine_test/integration.py
@@ -101,7 +101,8 @@ class Integration(CrudIntegration):
         # Get the values to send
         response : api_tester.RunPost_Response()
         response = self.api_client.tester_run(event)
-        rawOutput = MessageToDict(response.result.output)
+        # Output string to json
+        rawOutput = json.loads(response.result.output)
 
         hasTrace : bool = len(response.result.asset_traces) > 0
         rawTraces = response.result.asset_traces if hasTrace else []


### PR DESCRIPTION
## Description:

This PR:
- Change the protobuf test output data type from `google::value` to `std::string`, this preserves the numeric data types as they were originally ([Numerical values do not have subtypes in value.](https://protobuf.dev/reference/protobuf/google.protobuf/#type) ).
- Adapt the `engine-test` and `wazuh-enginen tester run`
- Modify cmake to not compile protobuf and add it as an option.
- Adapts the protobuf generation script and ignores automatic formatting if clang-format is not installed.
- Fixes the coverage workflow, since the proto module has no test and must be skipped.