### PR TITLE
Change thread event dispatch instantiation

### DIFF
--- a/src/engine/source/base/test/src/unit/utils/threadEventDispatcher_test.cpp
+++ b/src/engine/source/base/test/src/unit/utils/threadEventDispatcher_test.cpp
@@ -70,8 +70,7 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestSingleThread)
                     promise.set_value();
                 }
             },
-            TEST_DB,
-            BULK_SIZE);
+            {.dbPath = TEST_DB, .bulkSize = BULK_SIZE});
 
         for (int i = 0; i < MESSAGES_TO_SEND; ++i)
         {
@@ -109,10 +108,10 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThread)
                     promise.set_value();
                 }
             },
-            TEST_DB,
-            BULK_SIZE,
-            UNLIMITED_QUEUE_SIZE,
-            ThreadEventDispatcherType::MULTI_THREADED_UNORDERED);
+            {.dbPath = TEST_DB,
+             .bulkSize = BULK_SIZE,
+             .maxQueueSize = UNLIMITED_QUEUE_SIZE,
+             .dispatcherType = ThreadEventDispatcherType::MULTI_THREADED_UNORDERED});
 
         for (int i = 0; i < MESSAGES_TO_SEND; ++i)
         {
@@ -167,10 +166,10 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThreadDifferentTypeExcepti
                     promise.set_value();
                 }
             },
-            TEST_DB,
-            BULK_SIZE,
-            UNLIMITED_QUEUE_SIZE,
-            ThreadEventDispatcherType::MULTI_THREADED_UNORDERED);
+            {.dbPath = TEST_DB,
+             .bulkSize = BULK_SIZE,
+             .maxQueueSize = UNLIMITED_QUEUE_SIZE,
+             .dispatcherType = ThreadEventDispatcherType::MULTI_THREADED_UNORDERED});
 
     for (int i = 0; i < MESSAGES_TO_SEND; ++i)
     {
@@ -239,10 +238,10 @@ TEST_F(ThreadEventDispatcherTest, ConstructorTestMultiThreadDifferentTypeExcepti
                     promise.set_value();
                 }
             },
-            TEST_DB,
-            BULK_SIZE,
-            UNLIMITED_QUEUE_SIZE,
-            ThreadEventDispatcherType::MULTI_THREADED_UNORDERED);
+            {.dbPath = TEST_DB,
+             .bulkSize = BULK_SIZE,
+             .maxQueueSize = UNLIMITED_QUEUE_SIZE,
+             .dispatcherType = ThreadEventDispatcherType::MULTI_THREADED_UNORDERED});
 
     for (int i = 0; i < MESSAGES_TO_SEND; ++i)
     {
@@ -282,8 +281,8 @@ TEST_F(ThreadEventDispatcherTest, CtorNoWorkerSingleThread)
         std::promise<void> promise;
         auto index {0};
 
-        ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>> dispatcher(TEST_DB,
-                                                                                                     BULK_SIZE);
+        ThreadEventDispatcher<std::string, std::function<void(std::queue<std::string>&)>> dispatcher(
+            {.dbPath = TEST_DB, .bulkSize = BULK_SIZE});
 
         for (int i = 0; i < MESSAGES_TO_SEND; ++i)
         {
@@ -345,8 +344,7 @@ TEST_F(ThreadEventDispatcherTest, CtorPopFeatureSingleThread)
                 promise.set_value();
             }
         },
-        TEST_DB,
-        BULK_SIZE);
+        {.dbPath = TEST_DB, .bulkSize = BULK_SIZE});
 
     for (int i = 0; i < MESSAGES_TO_SEND; ++i)
     {

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -158,22 +158,25 @@ IndexerConnector::IndexerConnector(const IndexerConnectorOptions& indexerConnect
             {
                 // Process data.
                 HTTPRequest::instance().post(
-                    {HttpURL(url), bulkData, secureCommunication},
-                    {[functionName = logging::getLambdaName(__FUNCTION__, "handleSuccessfulPostResponse")](
-                         const std::string& response)
+                    {.url = HttpURL(url), .data = bulkData, .secureCommunication = secureCommunication},
+                    {.onSuccess = [functionName = logging::getLambdaName(__FUNCTION__, "handleSuccessfulPostResponse")](
+                                      const std::string& response)
                      { LOG_DEBUG_L(functionName.c_str(), "Response: %s", response.c_str()); },
-                     [functionName = logging::getLambdaName(__FUNCTION__, "handlePostResponseError")](
-                         const std::string& error, const long statusCode)
+                     .onError =
+                         [functionName = logging::getLambdaName(__FUNCTION__, "handlePostResponseError")](
+                             const std::string& error, const long statusCode)
                      {
                          LOG_ERROR_L(functionName.c_str(), "%s, status code: %ld.", error.c_str(), statusCode);
                          throw std::runtime_error(error);
                      }});
             }
         },
-        indexerConnectorOptions.databasePath + m_indexName,
-        ELEMENTS_PER_BULK,
-        indexerConnectorOptions.workingThreads <= 0 ? SINGLE_ORDERED_DISPATCHING
-                                                    : indexerConnectorOptions.workingThreads);
+        ThreadEventDispatcherParams {.dbPath = indexerConnectorOptions.databasePath + m_indexName,
+                                     .bulkSize = ELEMENTS_PER_BULK,
+                                     .dispatcherType =
+                                         (indexerConnectorOptions.workingThreads <= SINGLE_ORDERED_DISPATCHING
+                                              ? ThreadEventDispatcherType::SINGLE_THREADED_ORDERED
+                                              : ThreadEventDispatcherType::MULTI_THREADED_UNORDERED)});
 }
 
 IndexerConnector::~IndexerConnector()

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -161,12 +161,12 @@ IndexerConnector::IndexerConnector(const IndexerConnectorOptions& indexerConnect
                     {.url = HttpURL(url), .data = bulkData, .secureCommunication = secureCommunication},
                     {.onSuccess = [functionName = logging::getLambdaName(__FUNCTION__, "handleSuccessfulPostResponse")](
                                       const std::string& response)
-                     { LOG_DEBUG_L(functionName.c_str(), "Response: %s", response.c_str()); },
+                     { LOG_DEBUG_L(functionName.c_str(), "Response: {}", response.c_str()); },
                      .onError =
                          [functionName = logging::getLambdaName(__FUNCTION__, "handlePostResponseError")](
                              const std::string& error, const long statusCode)
                      {
-                         LOG_ERROR_L(functionName.c_str(), "%s, status code: %ld.", error.c_str(), statusCode);
+                         LOG_ERROR_L(functionName.c_str(), "{}, status code: {}.", error.c_str(), statusCode);
                          throw std::runtime_error(error);
                      }});
             }

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/012/expected_001.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/012/expected_001.out
@@ -1,7 +1,5 @@
 [
-    "Translation for package 'Microsoft Office Professional Plus 2016' on platform 'windows' found in Level 2 cache.",
-    "Vendor match for Package: office, Version: 2016, CVE: CVE-2024-20673, Vendor: microsoft",
-    "Scanning package - 'office' (Installed Version: 2016, Security Vulnerability: CVE-2024-20673). Identified vulnerability: Version: 2016. Required Version Threshold: . Required Version Threshold (or Equal): .",
-    "Match found, the package 'office', is vulnerable to 'CVE-2024-20673'. Current version: '2016' is equal to '2016'. - Agent '' (ID: '001', Version: '')",
-    "No remediations for agent '001' have been found"
+    "No translation exists for package 'Microsoft Office Professional Plus 2016' on platform 'windows'. Using provided package data.",
+    "Initiating a vulnerability scan for package 'microsoft office professional plus 2016' (win) (microsoft corporation) with CVE Numbering Authorities (CNA) 'nvd' on Agent '' (ID: '001', Version: '').",
+    "Vulnerability scan for package 'Microsoft Office Professional Plus 2016' on Agent '001' has completed."
 ]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/013/expected_001.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/013/expected_001.out
@@ -1,7 +1,3 @@
 [
-    "Translation for package 'Microsoft Office Professional Plus 2016' on platform 'windows' found in Level 2 cache.",
-    "Vendor match for Package: office, Version: 2016, CVE: CVE-2024-20673, Vendor: microsoft",
-    "Scanning package - 'office' (Installed Version: 2016, Security Vulnerability: CVE-2024-20673). Identified vulnerability: Version: 2016. Required Version Threshold: . Required Version Threshold (or Equal): .",
-    "Match found, the package 'office', is vulnerable to 'CVE-2024-20673'. Current version: '2016' is equal to '2016'. - Agent '' (ID: '001', Version: '')",
-    "Remediation 'KB5002537' for package 'office' on agent '001' that solves CVE 'CVE-2024-20673' has been found"
+    "No translation exists for package 'Microsoft Office Professional Plus 2016' on platform 'windows'. Using provided package data."
 ]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/025/expected_004.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/025/expected_004.out
@@ -1,7 +1,7 @@
 [
     "Translation for package 'VMware Tools' on platform 'windows' found in Level 2 cache.",
     "Initiating a vulnerability scan for package 'tools' (win) (vmware) with CVE Numbering Authorities (CNA) 'nvd' on Agent '' (ID: '001', Version: '').",
-    "Match found, the package 'tools' is vulnerable to 'CVE-2014-4199' due to default status. - Agent '' (ID: '001', Version: '').",
-    "Match found, the package 'tools' is vulnerable to 'CVE-2014-4200' due to default status. - Agent '' (ID: '001', Version: '').",
+    "Match found, the package 'tools', is vulnerable to 'CVE-2014-4199'. Current version: '9.4.5.23787635' (less than '' or equal to '10.0.3'). - Agent '' (ID: '001', Version: '').",
+    "Match found, the package 'tools', is vulnerable to 'CVE-2014-4200'. Current version: '9.4.5.23787635' (less than '' or equal to '10.0.3'). - Agent '' (ID: '001', Version: '').",
     "Match found, the package 'tools', is vulnerable to 'CVE-2018-6969'. Current version: '9.4.5.23787635' (less than '10.3.0' or equal to ''). - Agent '' (ID: '001', Version: '')."
 ]

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -133,8 +133,7 @@ void VulnerabilityScannerFacade::initAlertReportDispatcher()
                 dataQueue.pop();
             }
         },
-        REPORTS_QUEUE_PATH,
-        REPORTS_BULK_SIZE);
+        {.dbPath = REPORTS_QUEUE_PATH, .bulkSize = REPORTS_BULK_SIZE});
 }
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -280,8 +280,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
         {
             // Not used
         },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE);
+        {.dbPath = TEST_REPORTS_QUEUE_PATH, .bulkSize = TEST_REPORTS_BULK_SIZE});
     std::shared_mutex mutexScanOrchestrator;
 
     spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
@@ -393,8 +392,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
         {
             // Not used
         },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE);
+        {.dbPath = TEST_REPORTS_QUEUE_PATH, .bulkSize = TEST_REPORTS_BULK_SIZE});
     std::shared_mutex mutexScanOrchestrator;
 
     spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
@@ -507,8 +505,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
         {
             // Not used
         },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE);
+        {.dbPath = TEST_REPORTS_QUEUE_PATH, .bulkSize = TEST_REPORTS_BULK_SIZE});
     std::shared_mutex mutexScanOrchestrator;
 
     spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
@@ -620,8 +617,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
         {
             // Not used
         },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE);
+        {.dbPath = TEST_REPORTS_QUEUE_PATH, .bulkSize = TEST_REPORTS_BULK_SIZE});
     std::shared_mutex mutexScanOrchestrator;
 
     spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
@@ -715,8 +711,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
         {
             // Not used
         },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE);
+        {.dbPath = TEST_REPORTS_QUEUE_PATH, .bulkSize = TEST_REPORTS_BULK_SIZE});
     std::shared_mutex mutexScanOrchestrator;
 
     spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
@@ -831,8 +826,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
         {
             // Not used
         },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE);
+        {.dbPath = TEST_REPORTS_QUEUE_PATH, .bulkSize = TEST_REPORTS_BULK_SIZE});
     std::shared_mutex mutexScanOrchestrator;
 
     spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
@@ -945,8 +939,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsertInDelayed)
         {
             // Not used
         },
-        TEST_REPORTS_QUEUE_PATH,
-        TEST_REPORTS_BULK_SIZE);
+        {.dbPath = TEST_REPORTS_QUEUE_PATH, .bulkSize = TEST_REPORTS_BULK_SIZE});
     std::shared_mutex mutexScanOrchestrator;
 
     spScanContext = std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(


### PR DESCRIPTION
|Related issue|
|---|
|#26126|

## Description

This PR adds:  

- A named parameter approach to avoid wrong initialization of parameters with the same type.
- Fixes some efficacy test
  - Microsoft Office efficacy tests are fixed here https://github.com/wazuh/wazuh/pull/26210
  - VMWare Tools 
     - https://nvd.nist.gov/vuln/detail/CVE-2014-4199 and https://nvd.nist.gov/vuln/detail/CVE-2014-4200 affects up to 10.0.3 version, but according to NVD, that match is related to `vmware:workstation`, not `vmware:tool`. The thing is that according to the description, `vm-support 0.88 in VMware Tools, as distributed with VMware Workstation through 10.0.3` refers to a script present only until 10.0.3. So the fix is correct. 

