### PR TITLE
Add timeout to HTTPX calls

### DIFF
--- a/framework/wazuh/core/cluster/hap_helper/proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/proxy.py
@@ -12,6 +12,7 @@ from wazuh.core.exception import WazuhHAPHelperError
 JSON_TYPE: TypeAlias = dict | list[dict]
 PROXY_API_RESPONSE: TypeAlias = JSON_TYPE | None
 HTTP_PROTOCOL = Literal['http', 'https']
+DEFAULT_TIMEOUT = 10.0
 
 
 def _convert_to_seconds(milliseconds: int) -> int:
@@ -111,7 +112,8 @@ class ProxyAPI:
             In case of errors communicating with the HAProxy REST API.
         """
         try:
-            async with httpx.AsyncClient(verify=self.haproxy_cert, cert=self.client_cert) as client:
+            async with httpx.AsyncClient(verify=self.haproxy_cert, cert=self.client_cert,
+                                         timeout=httpx.Timeout(DEFAULT_TIMEOUT)) as client:
                 response = await client.get(
                     join(f'{self.protocol}://', f'{self.address}:{self.port}', self.HAP_ENDPOINT, 'health'),
                     auth=(self.username, self.password),
@@ -165,7 +167,8 @@ class ProxyAPI:
 
         try:
             async with httpx.AsyncClient(verify=self.haproxy_cert,
-                                         cert=self.client_cert, follow_redirects=True) as client:
+                                         cert=self.client_cert, follow_redirects=True,
+                                         timeout=httpx.Timeout(DEFAULT_TIMEOUT)) as client:
                 response = await client.request(
                     method=method.value,
                     url=uri,

--- a/framework/wazuh/core/cluster/hap_helper/tests/test_proxy.py
+++ b/framework/wazuh/core/cluster/hap_helper/tests/test_proxy.py
@@ -11,6 +11,7 @@ from wazuh.core.cluster.hap_helper.proxy import (
     ProxyAPIMethod,
     ProxyBalanceAlgorithm,
     ProxyServerState,
+    DEFAULT_TIMEOUT,
 )
 from wazuh.core.exception import WazuhHAPHelperError
 
@@ -66,6 +67,14 @@ class TestProxyAPI:
             f'{proxy_api.protocol}://{proxy_api.address}:{proxy_api.port}/v2/health',
             auth=(proxy_api.username, proxy_api.password),
         )
+
+    async def test_initialize_timeout(self, proxy_api: mock.MagicMock):
+        """Check that the `initialize` method calls httpx.AsyncClient with a timeout."""
+
+        with mock.patch('httpx.AsyncClient') as client:
+            await proxy_api.initialize()
+
+            client.assert_called_with(verify=mock.ANY, cert=mock.ANY, timeout=httpx.Timeout(DEFAULT_TIMEOUT))
 
     @pytest.mark.parametrize(
         'status_code,side_effect,expected',

--- a/framework/wazuh/core/engine/__init__.py
+++ b/framework/wazuh/core/engine/__init__.py
@@ -12,7 +12,7 @@ logger = getLogger('wazuh')
 # TODO: use actual default path
 ENGINE_API_SOCKET_PATH = '/var/wazuh/queue/engine.sock'
 DEFAULT_RETRIES = 3
-DEFAULT_TIMEOUT = 0.5
+DEFAULT_TIMEOUT = 10.0
 
 
 class Engine:

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -503,7 +503,7 @@ class WazuhException(Exception):
         3041: "Server status check timed out after adding new servers",
         3042: "User configuration is not valid",
         3043: "Could not initialize Proxy API",
-        3044: "Could not connect to the HAProxy dataplane API",
+        3044: "Could not connect to the HAProxy Dataplane API",
         3045: "Could not connect to HAProxy",
         3046: "Invalid credentials for the Proxy API",
         3047: "Invalid HAProxy Dataplane API specification configured",

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -37,6 +37,7 @@ WAZUH_TAG_KEY = 'wazuh-tag'
 USER_AGENT_KEY = 'user-agent'
 DEFAULT_TIMEOUT = 10.0
 
+
 class LoggingFormat(Enum):
     plain = "plain"
     json = "json"

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -35,6 +35,7 @@ ONE_DAY_SLEEP = 60 * 60 * 24
 WAZUH_UID_KEY = 'wazuh-uid'
 WAZUH_TAG_KEY = 'wazuh-tag'
 USER_AGENT_KEY = 'user-agent'
+DEFAULT_TIMEOUT = 10.0
 
 class LoggingFormat(Enum):
     plain = "plain"
@@ -335,7 +336,7 @@ async def query_update_check_service(installation_uid: str) -> dict:
         last_check_date=get_utc_now()
     )
 
-    async with httpx.AsyncClient(verify=_get_ssl_context()) as client:
+    async with httpx.AsyncClient(verify=_get_ssl_context(), timeout=httpx.Timeout(DEFAULT_TIMEOUT)) as client:
         try:
             response = await client.get(RELEASE_UPDATES_URL, headers=headers, follow_redirects=True)
             response_data = response.json()

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -5,7 +5,7 @@
 
 import os
 from datetime import timezone, datetime
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 from uuid import uuid4
 
 import httpx
@@ -256,6 +256,15 @@ def test_get_update_information_template(last_check_date, update_check, installa
 
 
 @pytest.mark.asyncio
+async def test_query_update_check_service_timeout(installation_uid):
+    """Test that the query_update_check_service function calls httpx.AsyncClient with a timeout."""
+    with patch('httpx.AsyncClient') as client:
+        await query_update_check_service(installation_uid)
+
+        client.assert_called_with(verify=ANY, timeout=httpx.Timeout(DEFAULT_TIMEOUT))
+
+
+@pytest.mark.asyncio
 async def test_query_update_check_service_catch_exceptions_and_dont_raise(
     installation_uid, client_session_get_mock
 ):
@@ -353,6 +362,7 @@ async def test_query_update_check_service_returns_correct_data_when_status_200(
         assert update_information['last_available_patch'] == {}
 
 
+@pytest.mark.asyncio
 async def test_query_update_check_service_returns_correct_data_on_error(
     installation_uid, client_session_get_mock
 ):


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25973|

## Description

As commented [here](https://github.com/wazuh/wazuh/issues/25973#issuecomment-2397986246), it was decided to specify a timeout of 10 seconds to each `httpx` call, which sets 5 seconds by default, to be consistent across all calls and with the Management API.

No new definitions were added to the exception catching of each call because `httpx.TimeoutException` inherits from `httpx.RequestError`, which means that the specific timeout error will be caught with its parent class.

There were no changes in the behavior of the calls besides increasing the default timeout value.