### PR TITLE
Vulnerability Scanner - Fix key used when registering the first-scan of an agent

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
@@ -49,10 +49,10 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
-        std::string key = data->agentId().compare("000") == 0 && data->clusterStatus()
-                              ? std::string(data->clusterNodeName()) + "_"
-                              : "";
-        key.append(data->agentId());
+        const auto agentId = std::string(data->agentId());
+        std::string key =
+            agentId.compare("000") == 0 && data->clusterStatus() ? std::string(data->clusterNodeName()) + "_" : "";
+        key.append(agentId);
         key.append("_");
 
         // Create the key for the inventory.
@@ -133,11 +133,11 @@ public:
             }
         }
 
-        // If the inventory is empty, set the initial scan to true.
-        if (!m_inventoryDatabase.get(key, rawInventory, OS_INITIAL_SCAN))
+        // Check if the agent is doing its first scan.
+        if (!m_inventoryDatabase.get(agentId, rawInventory, OS_INITIAL_SCAN))
         {
-            // Put the initial value(utc time) for the initial scan.
-            m_inventoryDatabase.put(key, Utils::getCurrentISO8601(), OS_INITIAL_SCAN);
+            // Save the initial UTC time for the initial scan of the agent.
+            m_inventoryDatabase.put(agentId, Utils::getCurrentISO8601(), OS_INITIAL_SCAN);
         }
         else
         {


### PR DESCRIPTION

|Related issue|
|---|
| #26157 |

## Description
This PR fixes the key used when registering the first-scan time of an agent, to align with its usage later:

https://github.com/wazuh/wazuh/blob/7ef6c244c8b004231096b298e83fa9b177bc9d31/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanAgentInventory.hpp#L122-L123