### PR TITLE
Add aditional package location paths

### DIFF
--- a/.github/workflows/macos-syscollector-tests.yml
+++ b/.github/workflows/macos-syscollector-tests.yml
@@ -32,6 +32,7 @@ jobs:
           rm -rf MacPorts-2.8.1-13-Ventura.pkg
       - name: Install port
         run: |
+          sudo /opt/local/bin/port selfupdate
           sudo /opt/local/bin/port -b install nano
       - name: Run tests
         run: |

--- a/src/data_provider/src/sharedDefs.h
+++ b/src/data_provider/src/sharedDefs.h
@@ -120,6 +120,8 @@ static const std::set<std::string> UNIX_PYPI_DEFAULT_BASE_DIRS
     "/opt/homebrew/lib",
     "/Library/Python",
     "/Library/Frameworks/Python.framework/Versions/*/lib/python*/*-packages",
+    "/root/.pyenv/versions/*/lib/python*/*-packages",
+    "/home/*/.pyenv/versions/*/lib/python*/*-packages"
 };
 
 static const std::set<std::string> UNIX_NPM_DEFAULT_BASE_DIRS
@@ -132,6 +134,8 @@ static const std::set<std::string> UNIX_NPM_DEFAULT_BASE_DIRS
     "/home/*/.nvm/versions/node/v*/lib",
     "/root/.nvm/versions/node/v*/lib",
     "/opt/local/lib",
+    "/Users/*/.nvm/versions/node/v*/lib",
+    "/private/var/root/.nvm/versions/node/v*/lib"
 };
 
 #endif //_SHARED_DEFS_H

--- a/src/data_provider/src/sysInfoMac.cpp
+++ b/src/data_provider/src/sysInfoMac.cpp
@@ -440,7 +440,9 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 
     // Add macOS specific paths
     pypyMacOSPaths.emplace("/Library/Python/*/*-packages");
-    pypyMacOSPaths.emplace("/Library/Frameworks/Python.framework/Versions/*/lib/python*/*-packages");
+    pypyMacOSPaths.emplace("/Users/*/Library/Python/*/lib/python/*-packages");
+    pypyMacOSPaths.emplace("/Users/*/.pyenv/versions/*/lib/python*/*-packages");
+    pypyMacOSPaths.emplace("/private/var/root/.pyenv/versions/*/lib/python*/*-packages");
     pypyMacOSPaths.emplace(
         "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/*/lib/python*/*-packages");
     pypyMacOSPaths.emplace("/System/Library/Frameworks/Python.framework/*-packages");


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/25941|
|https://github.com/wazuh/wazuh/issues/25943|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team, after the analysis performed in the related issues, this PR adds some missing paths to look for pip and npm packages for both linux and mac OS systems.

Analysis can be found in 
* https://github.com/wazuh/wazuh/issues/25941#issuecomment-2399138885
* https://github.com/wazuh/wazuh/issues/25943#issuecomment-2397146829


## Tests
To test it an additional python version was added using pyenv, specifically, 3.9.0, the pandas package was installed for this version.

Now the agent can retrieve this package information:

```command
root@dashboard-ubu22:/home/vagrant# sqlite3 /var/ossec/queue/syscollector/db/local.db
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite> select * from dbsync_packages where name="pandas";
pandas|2.2.3| | |/home/vagrant/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pandas-2.2.3.dist-info/METADATA| | | |0| || |pypi|533b2db0e23a9ced2ffa8a71c616a230c3c6b325|968afb17cf2e68d64cc42e66ba26dd6373438858|1
```