### PR TITLE
Updated starlette and uvicorn deps

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -83,13 +83,13 @@ secure==0.3.0
 six==1.16.0
 sniffio==1.3.0
 SQLAlchemy==2.0.23
-starlette==0.37.2
+starlette==0.39.2
 tabulate==0.8.9
 typing-extensions==4.12.2
 typing-inspect==0.7.1
 urllib3==2.2.2
 uvloop==0.17.0
-uvicorn==0.24.0.post1
+uvicorn==0.31.0
 websocket-client==0.57.0
 Werkzeug==3.0.3
 xmltodict==0.12.0


### PR DESCRIPTION
## Description

- This PR closes https://github.com/wazuh/wazuh/issues/26140

The `starlette` dep has been updated to `0.39.2` and `uvicorn` to `0.31.0` for `4.10.0`