### PR TITLE
Add security:revoke action to related endpoint

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -17273,6 +17273,8 @@ paths:
       summary: "Revoke JWT tokens"
       description: "This method should be called to revoke all active JWT tokens"
       operationId: api.controllers.security_controller.revoke_all_tokens
+      x-rbac-actions:
+        - $ref: "#/x-rbac-catalog/actions/security:revoke"
       responses:
         '200':
           description: "Tokens were successfully revoked"

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -466,7 +466,7 @@ x-rbac-catalog:
         - $ref: '#/x-rbac-catalog/resources/user:id'
         - $ref: '#/x-rbac-catalog/resources/rule:id'
       example:
-        actions: ['security:update']
+        actions: ['security:delete']
         resources: ['policy:id:*', 'role:id:3', 'user:id:4', 'rule:id:2']
         effect: "deny"
     'security:read_config':
@@ -485,6 +485,14 @@ x-rbac-catalog:
         actions: ['security:update_config']
         resources: ['*:*:*']
         effect: "allow"
+    'security:revoke':
+      description: "Revoke all active JWT tokens"
+      resources:
+        - $ref: '#/x-rbac-catalog/resources/*:*'
+      example:
+        actions: ['security:revoke']
+        resources: ['*:*:*']
+        effect: "deny"
     'syscheck:read':
       description: "Access information from agents syscheck database"
       resources:


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26078|

## Description

The `security:revoke` action was added to the `GET /security/actions` endpoint in the `spec.yaml` definition.

## Test

The endpoint was executed and the `security:revoke` action is being displayed:

```
$ curl -k -X GET "https://localhost:55000/security/actions" -H "Authorization: Bearer $TOKEN" | jq
...
    "security:revoke": {
      "description": "Revoke all active JWT tokens",
      "resources": [
        "*:*"
      ],
      "example": {
        "actions": [
          "security:revoke"
        ],
        "resources": [
          "*:*:*"
        ],
        "effect": "deny"
      },
      "related_endpoints": [
        "PUT /security/user/revoke"
      ]
    },
...
``` 