### PR TITLE
Delete restriction for `aws_profile` in Security Lake

### DIFF
--- a/src/config/wmodules-aws.c
+++ b/src/config/wmodules-aws.c
@@ -621,21 +621,10 @@ int wm_aws_read(const OS_XML *xml, xml_node **nodes, wmodule *module)
                         os_strdup(children[j]->content, cur_subscriber->service_endpoint);
                     }
                 } else if (!strcmp(children[j]->element, XML_AWS_PROFILE)) {
-                    if (strcmp(*nodes[i]->values, SECURITY_LAKE_SUBSCRIBER_TYPE) == 0){
-                        merror("The '%s' parameter is not available for Security Lake.", XML_AWS_PROFILE);
-                        OS_ClearNode(children);
-                        return OS_INVALID;
-                    } else {
-                        if (strlen(children[j]->content) != 0)  {
+                     if (strlen(children[j]->content) != 0)  {
                         free(cur_subscriber->aws_profile);
                         os_strdup(children[j]->content, cur_subscriber->aws_profile);
-                        } else {
-                         // If the value is empty, raise error
-                         merror("Invalid content for tag '%s': It cannot be empty", XML_IAM_ROLE_ARN);
-                         return OS_INVALID;
-                        }
-                    }
-
+                     }
                 } else if (strcmp(children[j]->element, XML_DISCARD_REGEX) == 0) {
                     if (strcmp(*nodes[i]->values, SECURITY_LAKE_SUBSCRIBER_TYPE) == 0) {
                         merror("The '%s' parameter is not available for Security Lake.", XML_DISCARD_REGEX);

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -159,12 +159,6 @@ def main(argv):
                 service.get_alerts()
         elif options.subscriber:
             if options.subscriber.lower() == "security_lake":
-                if options.aws_profile:
-                    aws_tools.error(
-                        "The AWS Security Lake integration does not make use of the Profile authentication "
-                        f"method. Check the available ones for it in "
-                        f"{aws_tools.SECURITY_LAKE_IAM_ROLE_AUTHENTICATION_URL}")
-                    sys.exit(3)
                 aws_tools.arg_validate_security_lake_auth_params(options.external_id,
                                                                  options.queue,
                                                                  options.iam_role_arn)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/24378|


## Description

Deletes the `aws_profile` configuration restriction for Security Lake subscriber in AWS wodle.