### PR TITLE
Enhance CA handling 

### DIFF
--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -9,22 +9,91 @@
  * Foundation.
  */
 
-#include "indexerConnector/indexerConnector.hpp"
-#include "HTTPRequest.hpp"
-#include "base/logging.hpp"
-#include "base/utils/stringUtils.hpp"
-#include "base/utils/timeUtils.hpp"
+#include <filesystem>
+#include <fstream>
+#include <grp.h>
+#include <pwd.h>
+#include <unistd.h>
+
+#include <HTTPRequest.hpp>
+#include <base/logging.hpp>
+#include <base/utils/stringUtils.hpp>
+#include <base/utils/timeUtils.hpp>
+#include <indexerConnector/indexerConnector.hpp>
+
 #include "secureCommunication.hpp"
 #include "serverSelector.hpp"
-#include <fstream>
 
 constexpr auto INDEXER_COLUMN {"indexer"};
 constexpr auto USER_KEY {"username"};
 constexpr auto PASSWORD_KEY {"password"};
 constexpr auto ELEMENTS_PER_BULK {1000};
+constexpr auto USER_GROUP {"wazuh"};
+constexpr auto DEFAULT_PATH {"tmp/root-ca-merged.pem"};
 
 // Single thread in case the events needs to be processed in order.
 constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
+
+/**
+ * @brief Merges the CA root certificates into a single file.
+ * @param filePaths The list of CA root certificates file paths.
+ * @param caRootCertificate The path to the merged CA root certificate.
+ * @throws std::runtime_error If the CA root certificate file does not exist, could not be opened, written or the
+ * ownership could not be changed.
+ * @note The merged file will be created in the same directory as the first file in the list.
+ */
+static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, std::string& caRootCertificate)
+{
+    std::string caRootCertificateContentMerged;
+
+    for (const auto& filePath : filePaths)
+    {
+        if (!std::filesystem::exists(filePath))
+        {
+            throw std::runtime_error("The CA root certificate file: '" + filePath + "' does not exist.");
+        }
+
+        std::ifstream file(filePath);
+        if (!file.is_open())
+        {
+            throw std::runtime_error("Could not open CA root certificate file: '" + filePath + "'.");
+        }
+
+        caRootCertificateContentMerged.append((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    }
+
+    caRootCertificate = DEFAULT_PATH;
+
+    if (std::filesystem::path dirPath = std::filesystem::path(caRootCertificate).parent_path();
+        !std::filesystem::exists(dirPath) && !std::filesystem::create_directories(dirPath))
+    {
+        throw std::runtime_error("Could not create the directory for the CA root merged file");
+    }
+
+    std::ofstream outputFile(caRootCertificate);
+    if (!outputFile.is_open())
+    {
+        throw std::runtime_error("Could not write the CA root merged file");
+    }
+
+    outputFile << caRootCertificateContentMerged;
+    outputFile.close();
+
+    struct passwd* pwd = getpwnam(USER_GROUP);
+    struct group* grp = getgrnam(USER_GROUP);
+
+    if (pwd == nullptr || grp == nullptr)
+    {
+        throw std::runtime_error("Could not get the user and group information.");
+    }
+
+    if (chown(caRootCertificate.c_str(), pwd->pw_uid, grp->gr_gid) != 0)
+    {
+        throw std::runtime_error("Could not change the ownership of the CA root merged file");
+    }
+
+    LOG_DEBUG("All CA files merged into '{}' successfully.", caRootCertificate.c_str());
+}
 
 static void initConfiguration(SecureCommunication& secureCommunication, const IndexerConnectorOptions& config)
 {
@@ -34,7 +103,11 @@ static void initConfiguration(SecureCommunication& secureCommunication, const In
     std::string username;
     std::string password;
 
-    if (!config.sslOptions.cacert.empty())
+    if (config.sslOptions.cacert.size() > 1)
+    {
+        mergeCaRootCertificates(config.sslOptions.cacert, caRootCertificate);
+    }
+    else if (!config.sslOptions.cacert.empty())
     {
         caRootCertificate = config.sslOptions.cacert.front();
     }

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -28,8 +28,9 @@ constexpr auto INDEXER_COLUMN {"indexer"};
 constexpr auto USER_KEY {"username"};
 constexpr auto PASSWORD_KEY {"password"};
 constexpr auto ELEMENTS_PER_BULK {1000};
-constexpr auto USER_GROUP {"wazuh"};
-constexpr auto DEFAULT_PATH {"tmp/root-ca-merged.pem"};
+constexpr auto WAZUH_OWNER {"wazuh"};
+constexpr auto WAZUH_GROUP {"wazuh"};
+constexpr auto MERGED_CA_PATH {"tmp/root-ca-merged.pem"};
 
 // Single thread in case the events needs to be processed in order.
 constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
@@ -40,7 +41,7 @@ constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
  * @param caRootCertificate The path to the merged CA root certificate.
  * @throws std::runtime_error If the CA root certificate file does not exist, could not be opened, written or the
  * ownership could not be changed.
- * @note The merged file will be created in the same directory as the first file in the list.
+ * @note The merged file will be created in the `tmp` directory of Wazuh installation.
  */
 static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, std::string& caRootCertificate)
 {
@@ -62,7 +63,7 @@ static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, s
         caRootCertificateContentMerged.append((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     }
 
-    caRootCertificate = DEFAULT_PATH;
+    caRootCertificate = MERGED_CA_PATH;
 
     if (std::filesystem::path dirPath = std::filesystem::path(caRootCertificate).parent_path();
         !std::filesystem::exists(dirPath) && !std::filesystem::create_directories(dirPath))
@@ -79,10 +80,10 @@ static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, s
     outputFile << caRootCertificateContentMerged;
     outputFile.close();
 
-    struct passwd* pwd = getpwnam(USER_GROUP);
-    struct group* grp = getgrnam(USER_GROUP);
+    struct passwd* pwd = getpwnam(WAZUH_OWNER);
+    struct group* grp = getgrnam(WAZUH_GROUP);
 
-    if (pwd == nullptr || grp == nullptr)
+    if (pwd == nullptr && grp == nullptr)
     {
         throw std::runtime_error("Could not get the user and group information.");
     }

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -30,7 +30,7 @@ constexpr auto PASSWORD_KEY {"password"};
 constexpr auto ELEMENTS_PER_BULK {1000};
 constexpr auto WAZUH_OWNER {"wazuh"};
 constexpr auto WAZUH_GROUP {"wazuh"};
-constexpr auto MERGED_CA_PATH {"tmp/root-ca-merged.pem"};
+constexpr auto MERGED_CA_PATH {"/tmp/wazuh-server/root-ca-merged.pem"};
 
 // Single thread in case the events needs to be processed in order.
 constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
@@ -110,6 +110,10 @@ static void initConfiguration(SecureCommunication& secureCommunication, const In
     else if (!config.sslOptions.cacert.empty())
     {
         caRootCertificate = config.sslOptions.cacert.front();
+    }
+    else
+    {
+        LOG_DEBUG("No CA root certificate found in the configuration.");
     }
 
     sslCertificate = config.sslOptions.cert;

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -41,7 +41,6 @@ constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
  * @param caRootCertificate The path to the merged CA root certificate.
  * @throws std::runtime_error If the CA root certificate file does not exist, could not be opened, written or the
  * ownership could not be changed.
- * @note The merged file will be created in the `tmp` directory of Wazuh installation.
  */
 static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, std::string& caRootCertificate)
 {

--- a/src/engine/source/indexerconnector/test/component/CMakeLists.txt
+++ b/src/engine/source/indexerconnector/test/component/CMakeLists.txt
@@ -14,4 +14,6 @@ target_link_libraries(${PROJECT_NAME}
         base
 )
 
+target_link_options(${PROJECT_NAME} PRIVATE -Wl,--wrap=getpwnam,--wrap=getgrnam,--wrap=chown)
+
 gtest_discover_tests(${PROJECT_NAME})

--- a/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
+++ b/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
@@ -207,7 +207,7 @@ extern "C" struct group* __wrap_getgrnam(const char* name)
 extern "C" int __wrap_chown(const char* path, uid_t owner, gid_t group)
 {
     // Simulate a successful chown operation for the "/tmp/success" file
-    if (strcmp(path, "tmp/root-ca-merged.pem") == 0)
+    if (strcmp(path, "/tmp/wazuh-server/root-ca-merged.pem") == 0)
     {
         return 0; // Return success
     }
@@ -265,7 +265,7 @@ TEST_F(IndexerConnectorTest, ConnectionWithCertsArray)
     // Setup for the test
     const std::string certFileOne = "./root-ca-one.pem";
     const std::string certFileTwo = "./root-ca-two.pem";
-    const std::string mergedCertFile = "tmp/root-ca-merged.pem";
+    const std::string mergedCertFile = "/tmp/wazuh-server/root-ca-merged.pem";
 
     // Create the first certificate file
     std::ofstream outputFile(certFileOne);

--- a/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
+++ b/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
@@ -9,12 +9,6 @@
  * Foundation.
  */
 
-#include "base/logging.hpp"
-#include "base/utils/stringUtils.hpp"
-#include "base/utils/timeUtils.hpp"
-#include "fakeIndexer.hpp"
-#include "indexerConnector/indexerConnector.hpp"
-#include "gtest/gtest.h"
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -25,6 +19,15 @@
 #include <stdexcept>
 #include <thread>
 #include <utility>
+
+#include <base/logging.hpp>
+#include <base/utils/stringUtils.hpp>
+#include <base/utils/timeUtils.hpp>
+
+#include <gtest/gtest.h>
+#include <indexerConnector/indexerConnector.hpp>
+
+#include "fakeIndexer.hpp"
 
 class IndexerConnectorTest : public ::testing::Test
 {
@@ -198,6 +201,28 @@ TEST_F(IndexerConnectorTest, ConnectionWithSslCredentials)
 
     // Create connector and wait until the connection is established.
     auto indexerConnector {IndexerConnector(indexerConfig)};
+}
+
+/**
+ * @brief Test the connection to an available server with SSL credentials.
+ *
+ * @note The SSL data is a dummy one and there are no functionality checks here. The target of this test is to increase
+ * the test coverage.
+ *
+ */
+TEST_F(IndexerConnectorTest, ConnectionWithCertsArray)
+{
+    IndexerConnectorOptions indexerConfig {
+        .name = INDEXER_NAME,
+        .hosts = {A_ADDRESS},
+        .sslOptions = {.cacert = {"/etc/filebeat/certs/root-ca.pem", "/etc/filebeat/certs/root-ca-two.pem"},
+                       .cert = "/etc/filebeat/certs/filebeat.pem",
+                       .key = "/etc/filebeat/certs/filebeat-key.pem"},
+        .timeout = INDEXER_TIMEOUT};
+
+    // Create connector and wait until the connection is established.
+    // Throw is expected if the certs are not found.
+    EXPECT_THROW(auto indexerConnector {IndexerConnector(indexerConfig)}, std::runtime_error);
 }
 
 /**


### PR DESCRIPTION
## Objective
This PR enhances the system's ability to handle multiple Certificate Authorities (CAs) by modifying the logic to read multiple CA certificates from the configuration and concatenate them into a single file.

## Description
We implemented the same logic that allows the system to read multiple CA entries from the configuration and concatenate them into a single CA bundle file. This streamlined approach simplifies the setup process for scenarios requiring multiple CAs, this approach has been validated in https://github.com/wazuh/wazuh/pull/24620 through testing and revision