### PR TITLE
Add new test case `linux-kernel-generic`

### DIFF
--- a/src/engine/source/vdscanner/qa/test_false_negative_data/053/Readme.md
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/053/Readme.md
@@ -1,0 +1,20 @@
+# Description
+
+Vulnerability detection validation for **Kernel Generic**.
+
+# Platforms
+
+- Ubuntu
+
+## Windows
+
+- Input events
+  - [001](input_001.json)
+
+| Name  | Version       | Feed      | CVE IDs        | Expected       |
+| ----- | ------------- | --------- | -------------- | -------------- |
+| linux | 5.4.0-170.193 | Canonical | CVE-2024-1086  | Vulnerable     |
+| linux | 5.4.0-170.193 | Canonical | CVE-2024-46869 | Non vulnerable |
+
+> [!NOTE]
+> We take two examples of at least 1460 active vulnerabilities in the Canonical feed.

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/053/expected_001.out
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/053/expected_001.out
@@ -1,0 +1,4 @@
+[
+    "Match found, the package 'linux', is vulnerable to 'CVE-2024-1086'. Current version: '5.4.0-170.193' (less than '5.4.0-174.193' or equal to ''). - Agent '' (ID: '053', Version: '').",
+    "No match due to default status for Package: linux, Version: 5.4.0-170.193 while scanning for Vulnerability: CVE-2024-46869"
+]

--- a/src/engine/source/vdscanner/qa/test_false_negative_data/053/input_001.json
+++ b/src/engine/source/vdscanner/qa/test_false_negative_data/053/input_001.json
@@ -1,0 +1,45 @@
+{
+  "type": "packagelist",
+  "agent": {
+    "id": "053"
+  },
+  "packages": [
+    {
+      "scan_id": 0,
+      "scan_time": "2024/04/11 02:34:28",
+      "multiarch": "",
+      "msu_name": "",
+      "checksum": "e5fc4dada01977545372e12f40caca85f89be349",
+      "item_id": "3fd68525088b8459fd4b98cc84ade2b06baf1101",
+      "source": "linux-signed-hwe-5.04",
+      "name": "linux-image-5.04.0-124-generic",
+      "vendor": "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+      "description": "Signed kernel image generic",
+      "size": 11334,
+      "location": " ",
+      "format": "deb",
+      "priority": "optional",
+      "architecture": "amd64",
+      "section": "kernel",
+      "install_time": " ",
+      "version": "5.4.0-170.193"
+    }
+  ],
+  "hotfixes": [],
+  "os": {
+    "architecture": "x86_64",
+    "checksum": "1691178971959743855",
+    "hostname": "Ubuntu",
+    "codename": "focal",
+    "major_version": "20",
+    "minor_version": "04",
+    "name": "Ubuntu",
+    "patch": "1",
+    "platform": "ubuntu",
+    "version": "20.04.1",
+    "kernel_release": "5.4.0-155-generic",
+    "scan_time": "2023/08/04 19:56:11",
+    "kernel_name": "Linux",
+    "kernel_version": "#172-Ubuntu SMP Fri Jul 7 16:10:02 UTC 2023"
+  }
+}


### PR DESCRIPTION
|Related issue|
|---|
|#26292|

# Objetive
This PR introduces a new test case to our Quality Assurance (QA) suite specifically designed to assess the translation functionality of the scanner against false negatives. The goal is to ensure the correct behavior of the scanner, enhancing our software's confiability for users.