### PR TITLE
Added Engine store installation on package building

### DIFF
--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -61,12 +61,13 @@ override_dh_install:
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/bin
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/run
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/var/lib
+	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/var/log
 
 	cp -p $(INSTALLATION_DIR)bin/wazuh-engine $(TARGET_DIR)$(INSTALLATION_DIR)bin/
-
 	cp -pr $(INSTALLATION_DIR)tmp/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)tmp/
 	cp -pr $(INSTALLATION_DIR)run/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)run/
 	cp -pr $(INSTALLATION_DIR)var/lib/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/
+	cp -pr $(INSTALLATION_DIR)var/log/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/log/
 
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
@@ -82,16 +83,13 @@ override_dh_fixperms:
 	dh_fixperms
 	# Folders
 	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)tmp/wazuh-server
-	chmod -R 750 $(TARGET_DIR)$(INSTALLATION_DIR)tmp/wazuh-server
+	find $(TARGET_DIR)$(INSTALLATION_DIR)tmp/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
-	chmod -R 750 $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
+	find $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
-	chmod -R 750 $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
-
-	chmod 640 $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server/engine/store/schema/wazuh-logpar-types/0
-	chmod 640 $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server/engine/store/schema/wazuh-asset/0
-	chmod 640 $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server/engine/store/schema/wazuh-policy/0
-	chmod 640 $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server/engine/store/schema/engine-schema/0
+	find $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
+	find $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 	# Binaries
 	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -78,12 +78,14 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}tmp/
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}run/wazuh-server
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}var/lib/wazuh-server
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}var/log
 
 cp -p %{_localstatedir}usr/bin/wazuh-engine ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin/
 
 cp -pr %{_localstatedir}tmp/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}tmp/
 cp -pr %{_localstatedir}run/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}run/
 cp -pr %{_localstatedir}var/lib/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}var/lib/
+cp -pr %{_localstatedir}var/log/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}var/log/
 
 sed -i "s:WAZUH_HOME_TMP:%{_localstatedir}:g" src/init/templates/wazuh-server-rh.init
 install -m 0755 src/init/templates/wazuh-server-rh.init ${RPM_BUILD_ROOT}%{_initrddir}/wazuh-server
@@ -185,6 +187,11 @@ if [ -f %{_localstatedir}/tmp/wazuh.restart ]; then
   fi
 fi
 
+chown -R root:wazuh %{_localstatedir}var/lib/wazuh-server
+find %{_localstatedir}var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+chown -R root:wazuh %{_localstatedir}var/log/wazuh-server
+find %{_localstatedir}var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
+
 %triggerin -- glibc
 
 %clean
@@ -197,22 +204,17 @@ rm -fr %{buildroot}
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/vd
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
+%dir %attr(750, root, wazuh) %{_localstatedir}var/log/wazuh-server
 %{_localstatedir}var/lib/wazuh-server/engine/tzdb/*
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/wazuh-logpar-types
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/wazuh-asset
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/wazuh-policy
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/engine-schema
+%{_localstatedir}var/lib/wazuh-server/engine/store/*
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
+%{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
 %attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-engine
 %attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/vd_1.0.0_vd_4.10.0.tar.xz
-%attr(640, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/wazuh-logpar-types/0
-%attr(640, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/wazuh-asset/0
-%attr(640, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/wazuh-policy/0
-%attr(640, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store/schema/engine-schema/0
+%attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/engine_store_0.0.2_5.0.0.tar.gz
 
 %config(missingok) %{_initrddir}/wazuh-server
 /usr/lib/systemd/system/wazuh-server.service

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -90,6 +90,27 @@ checkDownloadContent()
     fi
 }
 
+installEngineStore()
+{
+    STORE_FILENAME='engine_store_0.0.2_5.0.0.tar.gz'
+    STORE_FULL_PATH=${INSTALLDIR}tmp/wazuh-server/${STORE_FILENAME}
+    STORE_URL=https://packages.wazuh.com/deps/engine_store_model_database/${STORE_FILENAME}
+    DEST_FULL_PATH=${INSTALLDIR}var/lib/wazuh-server
+
+    echo "Download ${STORE_FILENAME} file"
+    mkdir -p ${INSTALLDIR}tmp/wazuh-server
+    wget -O ${STORE_FULL_PATH} ${STORE_URL}
+
+    chmod 640 ${STORE_FULL_PATH}
+    chown ${WAZUH_USER}:${WAZUH_GROUP} ${STORE_FULL_PATH}
+
+    tar -xzf ${STORE_FULL_PATH} -C ${DEST_FULL_PATH}
+    chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${DEST_FULL_PATH}/engine/store
+    chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${DEST_FULL_PATH}/engine/kvdb
+    find ${DEST_FULL_PATH}/engine/store -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+    find ${DEST_FULL_PATH}/engine/kvdb -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+}
+
 InstallEngine()
 {
   # Check if the content needs to be downloaded.
@@ -103,13 +124,9 @@ InstallEngine()
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/vd
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/store
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/wazuh-logpar-types
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/wazuh-asset
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/wazuh-policy
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/engine-schema
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/kvdb
+  ${INSTALL} -d -m 0755 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server
+  ${INSTALL} -d -m 0755 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server/engine
+
   #${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} engine/build/tzdb ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
   cp -rp engine/build/tzdb ${INSTALLDIR}var/lib/wazuh-server/engine/
   chown -R root:${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
@@ -118,12 +135,8 @@ InstallEngine()
 
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/indexer-connector
 
-  # Copy the engine configuration file
-  ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} engine/ruleset/schemas/wazuh-logpar-types.json ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/wazuh-logpar-types/0
-  ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} engine/ruleset/schemas/wazuh-asset.json ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/wazuh-asset/0
-  ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} engine/ruleset/schemas/wazuh-policy.json ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/wazuh-policy/0
-  ${INSTALL} -m 0640 -o root -g ${WAZUH_GROUP} engine/ruleset/schemas/engine-schema.json ${INSTALLDIR}var/lib/wazuh-server/engine/store/schema/engine-schema/0
-
+  # Download and extract the Engine store
+  installEngineStore
 }
 
 #InstallCluster()


### PR DESCRIPTION
|Related issue|
|---|
|#26325|

Added function to download and extract the Engine store on package building.
The store modifies the file outputs to write on `/var/log/wazuh-server/engine/*.json` and adds the indexer output.
The store comes with the policy:
```yml
policy: policy/wazuh/0
hash: 5097757755928008490
assets:
  - integration/wazuh-core/0
  - rule/enrichment/0
  - integration/syslog/0
  - integration/system/0
  - integration/windows/0
  - integration/apache-http/0
  - integration/suricata/0
default_parents:
  - user: decoder/integrations/0
  - user: rule/enrichment/0
  - wazuh: decoder/integrations/0
  - wazuh: rule/enrichment/0
```

And the route:
```yml
- name: default
  policy: policy/wazuh/0
  filter: filter/allow-all/0
  priority: 254
  policy_sync: UPDATED
  entry_status: ENABLED
  uptime: 56
```