### PR TITLE
Change `deleteAll` column data avoiding dropping

### DIFF
--- a/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
+++ b/src/shared_modules/utils/tests/rocksDBWrapper_test.cpp
@@ -213,6 +213,52 @@ TEST_F(RocksDBWrapperTest, TestDeleteAllEmptyDB)
 }
 
 /**
+ * @brief Tests the deleteAll function with concurrent threads
+ */
+TEST_F(RocksDBWrapperTest, MultiThreadTest)
+{
+    constexpr auto COLUMN_NAME_A {"column_A"};
+    constexpr auto KEY_A {"key_A"};
+    constexpr auto VALUE_A {"value_A"};
+
+    const int MAX_ELEMENTS {10000};
+
+    if (!db_wrapper->columnExists(COLUMN_NAME_A))
+    {
+        db_wrapper->createColumn(COLUMN_NAME_A);
+    }
+
+    std::thread switcher(
+        [&]()
+        {
+            for (int i = 0; i < MAX_ELEMENTS; ++i)
+            {
+                std::string value;
+                if (db_wrapper->get(KEY_A, value, COLUMN_NAME_A))
+                {
+                    db_wrapper->delete_(KEY_A, COLUMN_NAME_A);
+                }
+                else
+                {
+                    db_wrapper->put(KEY_A, VALUE_A, COLUMN_NAME_A);
+                }
+            }
+        });
+
+    std::thread pruner(
+        [&]()
+        {
+            for (int i = 0; i < MAX_ELEMENTS; ++i)
+            {
+                db_wrapper->deleteAll(COLUMN_NAME_A);
+            }
+        });
+
+    switcher.join();
+    pruner.join();
+}
+
+/**
  * @brief Tests the range for loop
  */
 TEST_F(RocksDBWrapperTest, TestRangeForLoop)


### PR DESCRIPTION
|Related issue|
|---|
|#26212|

# Objective 
This PR aims to simplify data handling by clearing all elements in the specified column instead of dropping the entire column. This change maintains the column structure while removing sensitive or unwanted data, improving data consistency for subsequent processing steps.
We validate this approach through the following benchmarking (100 tries, E:+/-2ms)


```console
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from RocksDBWrapperTest
[ RUN      ] RocksDBWrapperTest.TestDeleteAllBenchmark
Time taken to delete 10,000 elements: 1 ms
Time taken to delete 10,000 elements iterating: 30 ms
[       OK ] RocksDBWrapperTest.TestDeleteAllBenchmark (125 ms)
[----------] 1 test from RocksDBWrapperTest (125 ms total)
```