### PR TITLE
Use ubuntu 22.04 in the python code analysis workflow

### DIFF
--- a/.github/workflows/python-code-analysis.yml
+++ b/.github/workflows/python-code-analysis.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: write
       actions: read
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Bandit Scan


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/26395 |

## Description

Replaces the workflow machine type from `ubuntu-latest` to `ubuntu-22.04`.