### PR TITLE
Engine-policy cli tool

### DIFF
--- a/src/engine/source/proto/src/policy.proto
+++ b/src/engine/source/proto/src/policy.proto
@@ -7,11 +7,8 @@ package com.wazuh.api.engine.policy;
 // Store of policy handlers
 
 /***************************************************
- * Create a new policy in the store.
+ * Create a new empty policy in the store.
  *
- * Create a new policy in the store.
- * If forceEmpty is true, the policy will be created without default integrations
- * (Wazuh-Core)
  * command: policy.store/post
  **************************************************/
 message StorePost_Request

--- a/src/engine/tools/engine-suite/README.md
+++ b/src/engine/tools/engine-suite/README.md
@@ -6,6 +6,7 @@
     1. [Engine decoder](#engine-decoder)
     1. [Engine diff](#engine-diff)
     1. [Engine integration](#engine-integration)
+    1. [Engine policy](#engine-policy)
     1. [Engine test](#engine-test)
 3. [Installation](#installation)
 
@@ -22,6 +23,7 @@ The `engine-suite` python package contains various scripts to help developing co
 │       └── engine_decoder
 │       └── engine_diff
 │       └── engine_integration
+│       └── engine_policy
 │       └── engine_schema
 │       └── engine_test
 │       └── shared
@@ -70,6 +72,12 @@ The `engine-suite` python package contains various scripts to help developing co
 - **Integrations Management**: Allows you to create, add, update and delete integrations centrally.
 
 - **Generation of Documentation and Resources**: Generates documentation, graphics and manifests for integrations, facilitating administration and monitoring.
+
+## Engine policy
+- **Policy Management**:
+    - **List and Get Policies**: Provides the ability to list and get details of policies.
+    - **Creation of Policies**: Allows you to create new policies, specifying assets such as decoders, rules, integrations, etc.
+    - **Deletion and Update**: Provides the ability to delete or update existing policies, providing flexibility in configuration management.
 
 ## Engine test
 

--- a/src/engine/tools/engine-suite/setup.cfg
+++ b/src/engine/tools/engine-suite/setup.cfg
@@ -36,6 +36,7 @@ console_scripts =
     engine-diff = engine_diff.__main__:main
     engine-test = engine_test.__main__:main
     engine-catalog = engine_catalog.__main__:main
+    engine-policy = engine_policy.__main__:main
 
 [options.extras_require]
 dev =

--- a/src/engine/tools/engine-suite/src/engine_clear/__main__.py
+++ b/src/engine/tools/engine-suite/src/engine_clear/__main__.py
@@ -70,13 +70,13 @@ def main():
         if asset == "policy":
             policies = []
             try:
-                policies = resource_handler._get_policies_command(args.api_sock)['data']['data']
+                policies = resource_handler.get_policies_command(args.api_sock)['data']['data']
             except Exception as e:
                 pass
             for policy in policies:
                 try:
                     print(f'Deleting policy {policy}')
-                    resource_handler._delete_asset(args.api_sock, policy)
+                    resource_handler.policy_store_delete(args.api_sock, policy)
                 except Exception as e:
                     print(f'Error deleting {policy}: {e}')
         else:

--- a/src/engine/tools/engine-suite/src/engine_policy/README.md
+++ b/src/engine/tools/engine-suite/src/engine_policy/README.md
@@ -1,0 +1,60 @@
+## engine-policy
+
+The `engine-policy` tool is a command-line interface that allows you to manage policies in the Wazuh engine. It provides the ability to list, create, update, and delete policies. The tool is part of the `engine-suite` package.
+
+## Directory structure
+
+The `engine-policy` tool is located in the `engine_policy` directory of the `engine-suite` package. The directory structure is as follows:
+
+```
+engine_policy/
+├── README.md
+├── cmds # Command modules
+│   ├── __init__.py
+│   ├── ...
+|   └── ...
+├── __main__.py # Main script
+```
+
+
+## Installation
+
+
+The script is packaged along the `engine-suite` python package. To install, simply run:
+
+```bash
+pip install tools/engine-suite
+```
+
+To verify it's working:
+
+```bash
+engine-catalog --version
+```
+
+## Usage
+
+```console
+usage: engine-policy [-h] [--version] [--api-socket API_SOCKET] {create,delete,get,list,asset-add,asset-remove,asset-list,asset-clean-deleted,parent-set,parent-remove,namespace-list} ...
+
+options:
+  -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  --api-socket API_SOCKET
+                        Path to the Wazuh API socket
+
+subcommands:
+  {create,delete,get,list,asset-add,asset-remove,asset-list,asset-clean-deleted,parent-set,parent-remove,namespace-list}
+    create              Create a new, empty policy
+    delete              Remove a policy
+    get                 Get a policy
+    list                List all policies
+    asset-add           Add an asset to a policy
+    asset-remove        Remove an asset to a policy
+    asset-list          List all assets in a policy
+    asset-clean-deleted
+                        Remove all deleted assets from a policy
+    parent-set          Set the default parent for assets under a specific namespace
+    parent-remove       Remove the default parent for assets under a specific namespace
+    namespace-list      List all namespaces included in a policy
+```

--- a/src/engine/tools/engine-suite/src/engine_policy/__main__.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/__main__.py
@@ -1,0 +1,60 @@
+import sys
+import argparse
+from importlib.metadata import metadata
+
+from shared.default_settings import Constants
+from engine_policy.cmds.create import configure as configure_create
+from engine_policy.cmds.delete import configure as configure_delete
+from engine_policy.cmds.get import configure as configure_get
+from engine_policy.cmds.list import configure as configure_list
+from engine_policy.cmds.asset_add import configure as configure_asset_add
+from engine_policy.cmds.asset_delete import configure as configure_asset_remove
+from engine_policy.cmds.asset_list import configure as configure_asset_list
+from engine_policy.cmds.asset_clean import configure as configure_asset_clean
+from engine_policy.cmds.parent_set import configure as configure_default_parent_set
+from engine_policy.cmds.parent_remove import configure as configure_default_parent_remove
+from engine_policy.cmds.namespace_get import configure as configure_namespace_get
+
+
+def parse_args():
+    meta = metadata('engine-suite')
+    parser = argparse.ArgumentParser(prog='engine-policy')
+    parser.add_argument('--version', action='version',
+                        version=f'%(prog)s {meta.get("Version")}')
+
+    # Add socket path argument
+    parser.add_argument('--api-socket', type=str, default=Constants.SOCKET_PATH,
+                        help='Path to the Wazuh API socket')
+
+    # dest used because of bug: https://bugs.python.org/issue29298
+    subparsers = parser.add_subparsers(
+        title='subcommands', required=True, dest='subcommand')
+
+    # Store
+    configure_create(subparsers)
+    configure_delete(subparsers)
+    configure_get(subparsers)
+    # Policies
+    configure_list(subparsers)
+    # Assets
+    configure_asset_add(subparsers)
+    configure_asset_remove(subparsers)
+    configure_asset_list(subparsers)
+    configure_asset_clean(subparsers)
+    # Default parent
+    configure_default_parent_set(subparsers)
+    configure_default_parent_remove(subparsers)
+    # Namespaces
+    configure_namespace_get(subparsers)
+
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    args.func(vars(args))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_add.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_add.py
@@ -1,0 +1,50 @@
+import os
+from google.protobuf.json_format import ParseDict
+from shared.default_settings import Constants
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+    namespace: str = args['namespace']
+    asset_name: str = args['asset-name']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.AssetPost_Request()
+    request.policy = policy
+    request.asset = asset_name
+    request.namespace = namespace
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error adding asset: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.AssetPost_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error adding asset: {parsed_response.error}')
+
+    if parsed_response.warning != '':
+        print(f'Warning: {parsed_response.warning}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser('asset-add', help='Add an asset to a policy')
+
+    parser_create.add_argument('-p', '--policy', type=str, help='Policy name to add asset to', default=Constants.DEFAULT_POLICY)
+    parser_create.add_argument('-n', '--namespace', type=str, help='Namespace of asset to add', default=Constants.DEFAULT_NS)
+    parser_create.add_argument('asset-name', type=str, help='Name of the asset to add')
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_clean.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_clean.py
@@ -1,0 +1,47 @@
+import os
+from google.protobuf.json_format import ParseDict
+from shared.default_settings import Constants
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.AssetCleanDeleted_Request()
+    request.policy = policy
+
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error cleaning deleted assets: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.AssetCleanDeleted_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error cleaning deleted assets: {parsed_response.error}')
+
+    if parsed_response.data != '':
+        print(f'{parsed_response.data}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser(
+        'asset-clean-deleted', help='Remove all deleted assets from a policy')
+
+    parser_create.add_argument(
+        '-p', '--policy', type=str, help='Policy name to remove asset to', default=Constants.DEFAULT_POLICY)
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_delete.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_delete.py
@@ -1,0 +1,50 @@
+import os
+from google.protobuf.json_format import ParseDict
+from shared.default_settings import Constants
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+    namespace: str = args['namespace']
+    asset_name = args['asset-name']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.AssetDelete_Request()
+    request.policy = policy
+    request.asset = asset_name
+    request.namespace = namespace
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error removing asset: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.AssetDelete_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error removing asset: {parsed_response.error}')
+
+    if parsed_response.warning != '':
+        print(f'Warning: {parsed_response.warning}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser('asset-remove', help='Remove an asset to a policy')
+
+    parser_create.add_argument('-p', '--policy', type=str, help='Policy name to remove asset to', default=Constants.DEFAULT_POLICY)
+    parser_create.add_argument('-n', '--namespace', type=str, help='Namespace of asset to remove', default=Constants.DEFAULT_NS)
+    parser_create.add_argument('asset-name', type=str, help='Name of the asset to add')
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_list.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/asset_list.py
@@ -1,0 +1,53 @@
+import os
+from google.protobuf.json_format import ParseDict
+from shared.default_settings import Constants
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+from shared.dumpers import dict_to_yml
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+    namespace: str = args['namespace']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.AssetGet_Request()
+    request.policy = policy
+    request.namespace = namespace
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error getting assets: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.AssetGet_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error getting assets: {parsed_response.error}')
+
+    # Dictionary to yml
+    data: str = dict_to_yml(response['data'])
+    print(data)
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser(
+        'asset-list', help='List all assets in a policy')
+
+    parser_create.add_argument(
+        '-p', '--policy', type=str, help='Policy name to list assets from', default=Constants.DEFAULT_POLICY)
+    parser_create.add_argument(
+        '-n', '--namespace', type=str, help='Namespace of asset to get', default=Constants.DEFAULT_NS)
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/create.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/create.py
@@ -1,0 +1,41 @@
+import os
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+from google.protobuf.json_format import ParseDict
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.StorePost_Request()
+    request.policy = policy
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error creating policy: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, engine.GenericStatus_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error creating policy: {parsed_response.error}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser(
+        'create', help='Create a new, empty policy')
+
+    parser_create.add_argument(
+        '-p', '--policy', type=str, help='Policy name to create', required=True)
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/delete.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/delete.py
@@ -1,0 +1,42 @@
+import os
+from google.protobuf.json_format import ParseDict
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.StoreDelete_Request()
+    request.policy = policy
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error removing policy: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, engine.GenericStatus_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error removing policy: {parsed_response.error}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser(
+        'delete', help='Remove a policy')
+
+    parser_create.add_argument(
+        '-p', '--policy', type=str, help='Policy name to remove', required=True)
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/get.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/get.py
@@ -1,0 +1,49 @@
+import os
+from google.protobuf.json_format import ParseDict
+from shared.default_settings import Constants
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+    namespace: list[str] = args['namespace']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.StoreGet_Request()
+    request.policy = policy
+    request.namespaces.extend(namespace)
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error getting policy: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.StoreGet_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error getting policy: {parsed_response.error}')
+
+    print(parsed_response.data)
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser(
+        'get', help='Get a policy')
+
+    parser_create.add_argument(
+        '-p', '--policy', type=str, help='Policy name to get', default=Constants.DEFAULT_POLICY)
+    parser_create.add_argument('-n', '--namespace', type=str,
+                               help='Namespace of asset to get', action='append', default=[Constants.DEFAULT_NS])
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/list.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/list.py
@@ -1,0 +1,41 @@
+import os
+from google.protobuf.json_format import ParseDict
+from google.protobuf.json_format import MessageToDict
+
+from shared.dumpers import dict_to_yml
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.PoliciesGet_Request()
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error getting policies: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.PoliciesGet_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error getting policies: {parsed_response.error}')
+
+    # Message to dic
+    data : str = dict_to_yml(response['data'])
+    print(data)
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser('list', help='List all policies')
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/namespace_get.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/namespace_get.py
@@ -1,0 +1,46 @@
+import os
+from shared.dumpers import dict_to_yml
+from shared.default_settings import Constants
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+from google.protobuf.json_format import ParseDict
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.NamespacesGet_Request()
+    request.policy = policy
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error creating policy: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.NamespacesGet_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error creating policy: {parsed_response.error}')
+
+    if len(response['data']):
+        print(dict_to_yml(response['data']))
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser(
+        'namespace-list', help='List all namespaces included in a policy')
+
+    parser_create.add_argument(
+        '-p', '--policy', type=str, help='Policy name to create', default=Constants.DEFAULT_POLICY)
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/parent_remove.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/parent_remove.py
@@ -1,0 +1,50 @@
+import os
+from google.protobuf.json_format import ParseDict
+from shared.default_settings import Constants
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+    namespace: str = args['namespace']
+    parent_name: str = args['parent_name']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.DefaultParentDelete_Request()
+    request.policy = policy
+    request.parent = parent_name
+    request.namespace = namespace
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error setting default parent: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.DefaultParentDelete_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error setting default parent: {parsed_response.error}')
+
+    if parsed_response.warning != '':
+        print(f'Warning: {parsed_response.warning}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser('parent-remove', help='Remove the default parent for assets under a specific namespace')
+
+    parser_create.add_argument('-p', '--policy', type=str, help='Name of the policy to remove the default parent', default=Constants.DEFAULT_POLICY)
+    parser_create.add_argument('-n', '--namespace', type=str, help='Namespace to remove the default parent', default=Constants.DEFAULT_NS)
+    parser_create.add_argument('parent_name', type=str, help='Name of the default parent')
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_policy/cmds/parent_set.py
+++ b/src/engine/tools/engine-suite/src/engine_policy/cmds/parent_set.py
@@ -1,0 +1,50 @@
+import os
+from google.protobuf.json_format import ParseDict
+from shared.default_settings import Constants
+
+from api_communication.client import APIClient
+import api_communication.proto.policy_pb2 as epolicy
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    policy: str = args['policy']
+    namespace: str = args['namespace']
+    parent_name: str = args['parent_name']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = epolicy.DefaultParentPost_Request()
+    request.policy = policy
+    request.parent = parent_name
+    request.namespace = namespace
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        os.sys.exit(f'Error setting default parent: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, epolicy.DefaultParentPost_Response())
+    if parsed_response.status == engine.ERROR:
+        os.sys.exit(f'Error setting default parent: {parsed_response.error}')
+
+    if parsed_response.warning != '':
+        print(f'Warning: {parsed_response.warning}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser_create = subparsers.add_parser('parent-set', help='Set the default parent for assets under a specific namespace')
+
+    parser_create.add_argument('-p', '--policy', type=str, help='Name of the policy to set the default parent', default=Constants.DEFAULT_POLICY)
+    parser_create.add_argument('-n', '--namespace', type=str, help='Namespace to set the default parent', default=Constants.DEFAULT_NS)
+    parser_create.add_argument('parent_name', type=str, help='Name of the default parent')
+
+    parser_create.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/shared/default_settings.py
+++ b/src/engine/tools/engine-suite/src/shared/default_settings.py
@@ -1,0 +1,5 @@
+
+class Constants:
+    SOCKET_PATH: str = '/var/run/wazuh/api.sock'
+    DEFAULT_POLICY: str = 'policy/wazuh/0'
+    DEFAULT_NS: str = 'user'

--- a/src/engine/tools/engine-suite/src/shared/dumpers.py
+++ b/src/engine/tools/engine-suite/src/shared/dumpers.py
@@ -1,0 +1,20 @@
+import yaml
+
+try:
+    from yaml import CDumper as BaseDumper
+except ImportError:
+    from yaml import Dumper as BaseDumper
+
+class EngineDumper(BaseDumper):
+    def represent_scalar(self, tag, value, style=None):
+        # If the value contains a single quote, force double quotes
+        if style is None and "'" in value:
+            style = '"'
+        # If the value contains a line break, force literal style
+        if '\n' in value:
+            style = '|'
+        return super(EngineDumper, self).represent_scalar(tag, value, style)
+
+def dict_to_yml(data) -> str:
+    data = yaml.dump(data, sort_keys=True, Dumper=EngineDumper, allow_unicode=True)
+    return data

--- a/src/engine/tools/engine-suite/src/shared/resource_handler.py
+++ b/src/engine/tools/engine-suite/src/shared/resource_handler.py
@@ -20,18 +20,23 @@ class Format(Enum):
     TEXT = auto()
 
 def StringToFormat(string: str) -> Format:
+
     if string == 'json':
         return Format.JSON
-    elif string == 'yml' or string == 'yaml':
+    if string == 'yml' or string == 'yaml':
         return Format.YML
-    elif string == 'text':
+    if string == 'text':
         return Format.TEXT
-    else:
-        raise Exception(f'Format {string} not supported')
+
+    raise Exception(f'Format {string} not supported')
 
 class ResourceHandler:
     def __init__(self):
         self._files = files('engine-suite')
+
+    ############################################################################
+    #                          File operations
+    ############################################################################
 
     def _read_json(self, content: str) -> dict:
         read = {}
@@ -135,6 +140,50 @@ class ResourceHandler:
         pure_path = PurePath(path / name)
 
         self._write_file(pure_path, content, format)
+
+    def save_plain_text_file(self, path_str: str, name: str, content: str):
+        path = Path(path_str)
+        path.mkdir(parents=True, exist_ok=True)
+        pure_path = PurePath(path / name)
+        Path(pure_path).write_text(content)
+
+    def read_plain_text_file(self, path_str: str) -> str:
+        path = Path(path_str)
+        with path.open(mode='r') as fid:
+            content = fid.read()
+        if not content:
+            raise Exception(f'Failed to read plain text {full_name}')
+        return content
+
+    def create_dir(self, path_str: str):
+        path = Path(path_str)
+        path.mkdir(parents=True, exist_ok=False)
+
+    def create_file(self, path_str: str, content: str = ""):
+        path = Path(path_str)
+        path.write_text(content)
+
+    def walk_dir(self, path_str: str, function, recursive: bool = False):
+        path = Path(path_str)
+        if path.exists():
+            if recursive:
+                for entry in path.rglob('*'):
+                    if entry.is_file():
+                        function(entry)
+            else:
+                for entry in path.iterdir():
+                    if entry.is_file():
+                        function(entry)
+
+    def current_dir_name(self) -> str:
+        return str(Path.cwd().name)
+
+    def cwd(self) -> str:
+        return str(Path.cwd())
+
+    ############################################################################
+    #                          Catalog operations
+    ############################################################################
 
     def _base_catalog_command(self, path: str, type: str, name: str, content: str, namespace: str, format: Format, command: str):
         format_str = ''
@@ -322,46 +371,6 @@ class ResourceHandler:
 
         return assets
 
-    def save_plain_text_file(self, path_str: str, name: str, content: str):
-        path = Path(path_str)
-        path.mkdir(parents=True, exist_ok=True)
-        pure_path = PurePath(path / name)
-        Path(pure_path).write_text(content)
-
-    def read_plain_text_file(self, path_str: str) -> str:
-        path = Path(path_str)
-        with path.open(mode='r') as fid:
-            content = fid.read()
-        if not content:
-            raise Exception(f'Failed to read plain text {full_name}')
-        return content
-
-    def create_dir(self, path_str: str):
-        path = Path(path_str)
-        path.mkdir(parents=True, exist_ok=False)
-
-    def create_file(self, path_str: str, content: str = ""):
-        path = Path(path_str)
-        path.write_text(content)
-
-    def walk_dir(self, path_str: str, function, recursive: bool = False):
-        path = Path(path_str)
-        if path.exists():
-            if recursive:
-                for entry in path.rglob('*'):
-                    if entry.is_file():
-                        function(entry)
-            else:
-                for entry in path.iterdir():
-                    if entry.is_file():
-                        function(entry)
-
-    def current_dir_name(self) -> str:
-        return str(Path.cwd().name)
-
-    def cwd(self) -> str:
-        return str(Path.cwd())
-
     def _get_all_namespaces(self, api_socket: str):
         request = {'version': 1, 'command': 'catalog.namespaces/get', 'origin': {
             'name': 'engine-suite', 'module': 'engine-suite'}, 'parameters': {}}
@@ -392,6 +401,10 @@ class ResourceHandler:
             raise Exception(
                 f'{resp_message["data"]["error"]}')
         return resp_message
+
+    ############################################################################
+    #                          KVDB operations
+    ############################################################################
 
     def _base_command_kvdb(self, api_socket: str, name: str, path: str, subcommand):
         request = {'version': 1, 'command': 'kvdb.manager/' + subcommand, 'origin': {
@@ -528,7 +541,11 @@ class ResourceHandler:
     def get_store_integration(self, path: str, name: str, namespace: str):
         return self.get_catalog_file(path, 'integration', f'integration/{name}/0', namespace, Format.JSON)
 
-    def _base_store_command(self, path: str, policy: str, namespaces: List[str], command: str):
+    ############################################################################
+    #                          Policy operations: Store
+    ############################################################################
+
+    def _base_policy_store_command(self, path: str, policy: str, namespaces: List[str], command: str):
         request = {'version': 1, 'command': 'policy.store/' + command, 'origin': {
             'name': 'engine-suite', 'module': 'engine-suite'}, 'parameters': {'policy': policy, 'namespaces': namespaces}}
         request_raw = json.dumps(request)
@@ -547,12 +564,6 @@ class ResourceHandler:
         resp_size = int.from_bytes(data[:4], 'little')
         resp_message = data[4:resp_size+4].decode('UTF-8')
 
-        # Change post for update and put for add
-        if command == 'post':
-            command = 'add'
-        elif command == 'put':
-            command = 'update'
-
         if not len(resp_message):
             raise Exception(
                 f'Store command [{command}] received an empty response.')
@@ -568,8 +579,18 @@ class ResourceHandler:
                 f'{response["data"]["error"]}')
         return response
 
-    def _delete_asset(self, path: str, policy: str):
-        self._base_store_command(path, policy, [], 'delete')
+    def policy_store_delete(self, path: str, policy: str):
+        self._base_policy_store_command(path, policy, [], 'delete')
+
+    def policy_store_add(self, path: str, policy: str):
+        self._base_policy_store_command(path, policy, [], 'post')
+
+    def policy_store_get(self, path: str, policy: str, namespaces: List[str]):
+        return self._base_policy_store_command(path, policy, namespaces, 'get')
+
+    ############################################################################
+    #                          Policy operations: Asset
+    ############################################################################
 
     def _base_asset_command(self, path: str, policy: str, namespace: str, asset: str, command: str):
         request = {'version': 1, 'command': 'policy.asset/' + command, 'origin': {
@@ -589,12 +610,6 @@ class ResourceHandler:
 
         resp_size = int.from_bytes(data[:4], 'little')
         resp_message = data[4:resp_size+4].decode('UTF-8')
-
-        # Change post for update and put for add
-        if command == 'post':
-            command = 'add'
-        elif command == 'put':
-            command = 'update'
 
         if not len(resp_message):
             raise Exception(
@@ -651,7 +666,7 @@ class ResourceHandler:
                 f'{response["data"]["error"]}')
         return response
 
-    def _get_policies_command(self, path: str):
+    def get_policies_command(self, path: str):
         request = {'version': 1, 'command': 'policy.policies/get', 'origin': {
             'name': 'engine-suite', 'module': 'engine-suite'}, 'parameters': {}}
         request_raw = json.dumps(request)


### PR DESCRIPTION
|Related issue|
|---|
| Closes #25815 |

This PR adds the `engine-policy` python tool that remplace the `wazuh-engine policy` cli command.
