### PR TITLE
Router stateless events to the engine

### DIFF
--- a/framework/wazuh/core/engine/models/events.py
+++ b/framework/wazuh/core/engine/models/events.py
@@ -2,7 +2,20 @@ from dataclasses import dataclass
 
 
 @dataclass
+class WazuhLocation:
+    """Stateless events send location data model."""
+    queue: int
+    location: str
+
+
+@dataclass
+class Event:
+    """Engine event data model."""
+    original: str
+
+
+@dataclass
 class StatelessEvent:
     """Stateless event data model."""
-    # TODO(25121): Update fields once they're defined.
-    data: str
+    wazuh: WazuhLocation
+    event: Event

--- a/framework/wazuh/core/engine/tests/test_events.py
+++ b/framework/wazuh/core/engine/tests/test_events.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from wazuh.core.engine.events import EventsModule
-from wazuh.core.engine.models.events import StatelessEvent
+from wazuh.core.engine.models.events import StatelessEvent, WazuhLocation, Event
 
 
 class TestEventsModule:
@@ -17,7 +17,12 @@ class TestEventsModule:
     def module_instance(self, client_mock) -> EventsModule:
         return self.module_class(client=client_mock)
 
-    async def test_send(self, module_instance: EventsModule):
+    async def test_send(self, client_mock, module_instance: EventsModule):
         """Check that the EventsModule `send` method works as expected."""
-        events = [StatelessEvent(data='data')]
+        response = mock.MagicMock()
+        response.status_code = 200
+        client_mock.post.return_value = response
+
+        events = [StatelessEvent(wazuh=WazuhLocation(queue=50, location="[003] (agent-name) any->/tmp/syslog.log"),
+                                 event=Event(original="original message, recollected from the agent"))]
         await module_instance.send(events)


### PR DESCRIPTION
|Related issue|
|---|
| #25620 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Sends the events received in the `POST /events/stateless` Comms API endpoint to the engine `/run/wazuh-server/engine.sock` socket

## Unit tests

<details><summary>Core Engine UTs</summary>

```
$ pytest -vvv framework/wazuh/core/engine/
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.15, pytest-7.3.1, pluggy-1.5.0 -- /home/fdalmau/venv/5.0-aca/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.15', 'Platform': 'Linux-5.15.0-124-generic-x86_64-with-glibc2.31', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'anyio': '4.1.0', 'metadata': '3.1.1', 'trio': '0.8.0', 'tavern': '1.23.5', 'cov': '4.1.0', 'asyncio': '0.18.1', 'html': '2.1.1'}}
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 13 items                                                                                                                                                                                        

framework/wazuh/core/engine/tests/test_base.py::test_base_module_init PASSED                                                                                                                        [  7%]
framework/wazuh/core/engine/tests/test_base.py::test_convert_enums PASSED                                                                                                                           [ 15%]
framework/wazuh/core/engine/tests/test_events.py::TestEventsModule::test_send PASSED                                                                                                                [ 23%]
framework/wazuh/core/engine/tests/test_init.py::test_engine_init[params0] PASSED                                                                                                                    [ 30%]
framework/wazuh/core/engine/tests/test_init.py::test_engine_init[params1] PASSED                                                                                                                    [ 38%]
framework/wazuh/core/engine/tests/test_init.py::test_engine_init[params2] PASSED                                                                                                                    [ 46%]
framework/wazuh/core/engine/tests/test_init.py::test_engine_init[params3] PASSED                                                                                                                    [ 53%]
framework/wazuh/core/engine/tests/test_init.py::test_engine_close PASSED                                                                                                                            [ 61%]
framework/wazuh/core/engine/tests/test_init.py::test_get_engine_client PASSED                                                                                                                       [ 69%]
framework/wazuh/core/engine/tests/test_init.py::test_get_engine_client_ko[http:/timeout-2800] PASSED                                                                                                [ 76%]
framework/wazuh/core/engine/tests/test_init.py::test_get_engine_client_ko[test-2801] PASSED                                                                                                         [ 84%]
framework/wazuh/core/engine/tests/test_init.py::test_get_engine_client_ko[http:/invalid-2802] PASSED                                                                                                [ 92%]
framework/wazuh/core/engine/tests/test_vulnerability.py::TestVulnerabilityModule::test_send_scan_request PASSED                                                                                     [100%]

=========================================================================================== 13 passed in 0.18s ============================================================================================
```

</details>

## Manual Tests

<details><summary>Request OK</summary>

```
$ curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-type: application/json" -kv https://0.0.0.0:27000/api/v1/events/stateless -d '{"events": [{"wazuh": {"queue": 50, "location": "[003] (agent-name) any->/tmp/syslog.log"}, "event": {"original": "original message, recollected from the agent"}}]}'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 0.0.0.0:27000...
* TCP_NODELAY set
* Connected to 0.0.0.0 (127.0.0.1) port 27000 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  start date: Oct 22 12:58:07 2024 GMT
*  expire date: Oct 22 12:58:07 2025 GMT
*  issuer: C=US; ST=California; L=San Francisco; O=Wazuh; CN=wazuh.com
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
> POST /api/v1/events/stateless HTTP/1.1
> Host: 0.0.0.0:27000
> User-Agent: curl/7.68.0
> Accept: */*
> Authorization: Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTcyOTYwMTk1MywiZXhwIjoxNzI5NjAyODUzLCJ1dWlkIjoiMDE5MTJkMDctYjliNC03NTI4LWJkYWQtMTVkYTkwMmQ2NTFjIn0.O99bZst1hdvUZlxFHIU9P8Ed4DaumIYCjm2rT4WKm-NrPowdvt_6Oh_MQnt-FS4rqlZAp4FnsqO8FYHX6tUvww
> Content-type: application/json
> Content-Length: 164
> 
* upload completely sent off: 164 out of 164 bytes
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< date: Tue, 22 Oct 2024 13:07:54 GMT
< server: uvicorn
< content-length: 0
< server: Wazuh
< strict-transport-security: max-age=63072000; includeSubdomains
< x-frame-options: deny
< x-xss-protection: 0
< x-content-type-options: nosniff
< content-security-policy: none
< referrer-policy: no-referrer, strict-origin-when-cross-origin
< cache-control: no-store
< 
* Connection #0 to host 0.0.0.0 left intact
```

Comms API log
```
2024/10/22 13:07:55 INFO: (01912d07-b9b4-7528-bdad-15da902d651c) "POST /api/v1/events/stateless" with parameters {} and body {"events": [{"wazuh": {"queue": 50, "location": "[003] (agent-name) any->/tmp/syslog.log"}, "event": {"original": "original message, recollected from the agent"}}]} done in 0.028s: 200
```

</details>

<details><summary>Request missing field</summary>

```
$ curl -sSk -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST https://0.0.0.0:27000/api/v1/events/stateless -d '{"events": [{"wazuh": {"queue": 50}, "event": {"original": "original message, recollected from the agent"}}]}'
{"message":"('body', 'events', 0, 'wazuh', 'location') field required","code":400}
```

Comms API log
```
2024/10/22 13:12:25 INFO: (01912d07-b9b4-7528-bdad-15da902d651c) "POST /api/v1/events/stateless" with parameters {} and body {"events": [{"wazuh": {"queue": 50}, "event": {"original": "original message, recollected from the agent"}}]} done in 0.004s: 400
```

</details>

<details><summary>Request unexpected type field</summary>

```
curl -sSk -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST https://0.0.0.0:27000/api/v1/events/stateless -d '{"events": [{"wazuh": {"queue": 50, "location": "[003] (agent-name) any->/tmp/syslog.log"}, "event": "original message, recollected from the agent"}]}'
{"message":"('body', 'events', 0, 'event') input should be a dictionary or an instance of event","code":400}
```

Comms API log
```
2024/10/22 13:27:02 INFO: (01912d07-b9b4-7528-bdad-15da902d651c) "POST /api/v1/events/stateless" with parameters {} and body {"events": [{"wazuh": {"queue": 50, "location": "[003] (agent-name) any->/tmp/syslog.log"}, "event": "original message, recollected from the agent"}]} done in 0.004s: 400
```

</details>