### PR TITLE
Fix - Vulnerability Scanner tools 

### DIFF
--- a/.github/workflows/engine_vdscanner_tools_delivery.yml
+++ b/.github/workflows/engine_vdscanner_tools_delivery.yml
@@ -89,11 +89,9 @@ jobs:
             exit 1
           fi
 
-      # Only uploads the vdscanner tools if:
-      # - The PR is merged into master
-      # - The workflow is manually triggered
+      # Upload vdscanner tools
       - name: Upload vdscanner tools
-        if: ${{ success() && ((github.event_name == 'push' && github.base_ref == 'master') || github.event_name == 'workflow_dispatch') }}
+        if: ${{ success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{env.TOOLS_FILE_NAME}}

--- a/.github/workflows/engine_vdscanner_tools_delivery.yml
+++ b/.github/workflows/engine_vdscanner_tools_delivery.yml
@@ -89,9 +89,11 @@ jobs:
             exit 1
           fi
 
-      # Only uploads the vdscanner tools if the PR is merged or it was manually triggered.
+      # Only uploads the vdscanner tools if:
+      # - The PR is merged into master
+      # - The workflow is manually triggered
       - name: Upload vdscanner tools
-        if: ${{ success() && github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'}}
+        if: ${{ success() && ((github.event_name == 'push' && github.base_ref == 'master') || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{env.TOOLS_FILE_NAME}}


### PR DESCRIPTION
|Related issue|
|---|
| #26217 |

## Description
It was found that there was an error on the vdscanner tools delivery upload filters, so there weren't updated on merges into master

## Tests
I've validated the fix in a private repo:

- Changes on fix PR 🟢 
![image](https://github.com/user-attachments/assets/5ecd83b5-fc8f-44ca-a226-42ace1272573)

- Fix PR merged into master 🟢 
![image](https://github.com/user-attachments/assets/3c7ca95c-155d-44c8-b783-b0ec26531181)

- Changes on new PR 🟢 
![image](https://github.com/user-attachments/assets/ad778b29-ff8a-43d0-828e-b3ff24323e63)

- New PR merged into master 🟢 
![image](https://github.com/user-attachments/assets/d4f465fb-fe1e-4a66-b5dc-d144d55aaf58)

>[!NOTE]
> "Echo test" is equivalent to the upload