### PR TITLE
Fix regular expressions for usernames

### DIFF
--- a/ruleset/sca/debian/cis_debian12.yml
+++ b/ruleset/sca/debian/cis_debian12.yml
@@ -3534,7 +3534,7 @@ checks:
       - nist_sp_800-53: ["IA-5 (1)"]
     condition: all
     rules:
-      - 'not f:/etc/passwd -> r:^\w+:x:'
+      - 'not f:/etc/passwd -> r:^[\w\-]+:x:'
 
   # 6.2.2 Ensure password fields are not empty. (Automated)
   - id: 33179
@@ -3551,7 +3551,7 @@ checks:
       - nist_sp_800-53: ["IA-5 (1)"]
     condition: all
     rules:
-      - 'not f:/etc/shadow -> r:^\w+::'
+      - 'not f:/etc/shadow -> r:^[\w\-]+::'
 
   # 6.2.3 Ensure all users' home directories exist. (Automated) - Not Implemented
   # 6.2.4 Ensure users own their home directories. (Automated) - Not Implemented
@@ -3575,7 +3575,7 @@ checks:
       - mitre_techniques: ["T1019", "T1098", "T1017", "T1043", "T1175", "T1136", "T1094", "T1482", "T1048", "T1190", "T1210", "T1133", "T1046", "T1145", "T1076", "T1494", "T1489", "T1051", "T1095", "T1072", "T1199", "T1065", "T1028", "T1112", "T1058", "T1198", "T1209"]
     condition: all
     rules:
-      - 'not f:/etc/passwd -> !r:^\s*\t*# && !r:^root: && r:^\w+:\w+:0:'
+      - 'not f:/etc/passwd -> !r:^\s*\t*# && !r:^root: && r:^[\w\-]+:\w+:0:'
 
   # 6.2.11 Ensure root PATH Integrity. (Automated) - Not Implemented
   # 6.2.12 Ensure all groups in /etc/passwd exist in /etc/group. (Automated) - Not Implemented


### PR DESCRIPTION

|Related issue|
None

## Description

Usernames in a debian passwd or shadow file can contain more than just \w. Debian by default has a systemd-coredump user and "-" is not part of \w. This leads to rule id 33178, 3319 and 33180 failing

## Configuration options

None

## Logs/Alerts example
Alerts due to rule 33178, 3319 and 33180 failing for Debian 12 CIS

## Tests
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [x] runtests.py executed without errors