### PR TITLE
Pre-installation Architecture Check for Wazuh Agent Packages

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -135,6 +135,8 @@ function prepare_building_folder() {
     cp $preinstall_script $CURRENT_PATH/wazuh-agent/scripts/preinstall
     cp $postinstall_script $CURRENT_PATH/wazuh-agent/scripts/postinstall
 
+    sed -i '' "s|PACKAGE_ARCH|$ARCH|g" $CURRENT_PATH/wazuh-agent/scripts/preinstall
+
     mkdir -p ${packaged_directory}$(dirname ${SERVICE_PATH})
     cp -p $SERVICE_PATH ${packaged_directory}$(dirname ${SERVICE_PATH})
 

--- a/packages/macos/package_files/preinstall.sh
+++ b/packages/macos/package_files/preinstall.sh
@@ -10,6 +10,7 @@
 # $2 is the error code
 
 DIR="/Library/Ossec"
+ARCH="PACKAGE_ARCH"
 
 function check_errm
 {
@@ -19,6 +20,23 @@ function check_errm
         exit ${2};
         fi
 }
+
+function check_arch
+{
+    local system_arch=$(uname -m)
+
+    if [ "$ARCH" = "intel64" ] && [ "$system_arch" = "arm64" ]; then
+        if ! arch -x86_64 zsh -c '' &> /dev/null; then
+            >&2 echo "ERROR: Rosetta is not installed. Please install it and try again."
+            exit 1
+        fi
+    elif [ "$ARCH" = "arm64" ] && [ "$system_arch" = "x86_64" ]; then
+        >&2 echo "ERROR: Incompatible architecture. Please use the Intel package on this system."
+        exit 1
+    fi
+}
+
+check_arch
 
 if [ -d "${DIR}" ]; then
     echo "A Wazuh agent installation was found in ${DIR}. Will perform an upgrade."


### PR DESCRIPTION
|Related issue|
|---|
|Closes #26455|

## Description

This PR introduces a pre-installation architecture check to ensure compatibility between the system architecture and the Wazuh agent package being installed. The pre-installation script now includes a constant `ARCH`, which is set during the package generation process (either `intel64` or `arm64`), and performs the following checks:

- **Intel64 Package on ARM (Apple Silicon) Systems**:  
  The script checks if Rosetta is installed and active. If Rosetta is not operational, the installation will fail, ensuring that Intel64 packages are not installed without proper Rosetta support.

- **ARM64 Package on Intel Systems**:  
  If an ARM64 package is being installed on an Intel-based system, the installation will fail, preventing the installation of an incompatible package.

## Changes

- Added the `ARCH` constant to the pre-installation script, populated during package generation.
- Implemented system architecture checks in the pre-installation script to ensure compatibility.
- Added logic to check for Rosetta on Apple Silicon when installing Intel64 packages.

## Testing

- [x] Verified the behavior on macOS ARM64 systems (Apple Silicon) for ARM64 packages.
> installer: Package name is wazuh-agent_4.10.0-0_arm64_d64ecc998
installer: Installing at base path /
installer: The install was successful.
- [x] Confirmed that the installation fails if Rosetta is not installed for Intel64 packages on Apple Silicon.
> ./preinstall: ERROR: Rosetta is not installed. Please install it and try again.
- [x] Confirmed that the Intel64 package works on Apple Silicon if Rosetta is installed.
> installer: Package name is wazuh-agent_4.10.0-0_intel64
installer: Installing at base path /
installer: The install was successful.
- [x] Verified that installation fails when attempting to install ARM64 packages on Intel-based macOS systems.

<!--
Run: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11483316415
File: s3://packages-dev.internal.wazuh.com/development/wazuh/4.x/main/packages/wazuh-agent_4.10.0-0_intel64_a3d3d3e22e.pkg
-->