### PR TITLE
Remove published_date field from YARA template

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -2740,9 +2740,6 @@
               "rule_description": {
                 "type": "keyword"
               },
-              "published_date": {
-                "type": "date"
-              },
               "tags": {
                 "type": "keyword"
               }


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-dashboard/issues/377 |

## Description

This pull request removes the definition of the field `data.YARA.published_date` from the `wazuh-template.json` file because no visualizations use this field and it causes unnecessary conflicts with previous installations that already have a YARA integration, as it was interpreted as a keyword. 