### PR TITLE
Vulnerability Scanner - Prioritize CISA vulnerability content over NVD 

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -38,8 +38,8 @@ using namespace NSVulnerabilityScanner;
 constexpr auto DATABASE_PATH {"queue/vd/feed"};
 constexpr auto OFFSET_TRANSACTION_SIZE {1000};
 constexpr auto EMPTY_KEY {""};
-
-constexpr auto DEFAULT_ADP {"nvd"};
+constexpr auto DEFAULT_CNA {"cisa"};
+constexpr auto FALLBACK_CNA {"nvd"};
 constexpr auto ADP_CVSS_KEY {"cvss"};
 constexpr auto ADP_DESCRIPTION_KEY {"description"};
 constexpr auto ADP_REFERENCE_KEY {"reference"};
@@ -592,8 +592,11 @@ public:
         packageNameWithSeparator.append(package.name);
         packageNameWithSeparator.append("_CVE");
 
+        bool cvesFound = false;
         for (const auto& [key, value] : m_feedDatabase->seek(packageNameWithSeparator, cnaName))
         {
+            cvesFound = true;
+
             if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()), value.size());
                 !NSVulnerabilityScanner::VerifyScanVulnerabilityCandidateArrayBuffer(verifier))
             {
@@ -609,11 +612,17 @@ public:
                 {
                     if (callback(cnaName, package, *candidate))
                     {
-                        // If the candidate is vulnerable, we stop looking for.
-                        break;
+                        // If the candidate is vulnerable, we stop looking for more candidates.
+                        return;
                     }
                 }
             }
+        }
+
+        // If no CVEs are found and we were using the default CNA, attempt to find it with the fallback CNA.
+        if (cnaName == DEFAULT_CNA && !cvesFound)
+        {
+            getVulnerabilitiesCandidates(FALLBACK_CNA, package, callback);
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -31,6 +31,7 @@
 #include <fstream>
 #include <functional>
 #include <memory>
+#include <scanContext.hpp>
 #include <string>
 #include <vector>
 
@@ -38,8 +39,6 @@ using namespace NSVulnerabilityScanner;
 constexpr auto DATABASE_PATH {"queue/vd/feed"};
 constexpr auto OFFSET_TRANSACTION_SIZE {1000};
 constexpr auto EMPTY_KEY {""};
-constexpr auto DEFAULT_CNA {"cisa"};
-constexpr auto FALLBACK_CNA {"nvd"};
 constexpr auto ADP_CVSS_KEY {"cvss"};
 constexpr auto ADP_DESCRIPTION_KEY {"description"};
 constexpr auto ADP_REFERENCE_KEY {"reference"};
@@ -572,21 +571,24 @@ public:
     /**
      * @brief Get the Vulnerabilities Candidates information.
      *
-     * @param cnaName RocksDB table identifier.
+     * @param vulnerabilitySource
      * @param package Struct with package data.
      * @param callback Store vulnerability data.
      */
     void getVulnerabilitiesCandidates(
-        const std::string& cnaName,
+        ScanContext::VulnerabilitySource& vulnerabilitySource,
         const PackageData& package,
         const std::function<bool(const std::string& cnaName,
                                  const PackageData& package,
                                  const NSVulnerabilityScanner::ScanVulnerabilityCandidate&)>& callback)
     {
-        if (package.name.empty() || cnaName.empty())
+        if (package.name.empty() || vulnerabilitySource.getCnaBaseName().empty() ||
+            vulnerabilitySource.getCnaExpandedName().empty())
         {
-            throw std::runtime_error("Invalid package/cna name.");
+            throw std::invalid_argument("Package name or vulnerability source not set.");
         }
+
+        const auto& cnaName = vulnerabilitySource.getCnaExpandedName();
 
         std::string packageNameWithSeparator;
         packageNameWithSeparator.append(package.name);
@@ -620,9 +622,11 @@ public:
         }
 
         // If no CVEs are found and we were using the default CNA, attempt to find it with the fallback CNA.
-        if (cnaName == DEFAULT_CNA && cnaName != FALLBACK_CNA && !cvesFound)
+        if (cnaName == DEFAULT_CNA && !cvesFound)
         {
-            getVulnerabilitiesCandidates(FALLBACK_CNA, package, callback);
+            // Update the vulnerability source
+            vulnerabilitySource.setFromCna(FALLBACK_CNA);
+            getVulnerabilitiesCandidates(vulnerabilitySource, package, callback);
         }
     }
 
@@ -681,98 +685,6 @@ public:
             NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
 
         return true;
-    }
-
-    /**
-     * @brief Get CNA/ADP name based on the package source.
-     *
-     * @param source Package source.
-     * @return std::string CNA/ADP name. Empty string otherwise.
-     */
-    std::string getCnaNameBySource(std::string_view source) const
-    {
-        if (const auto& vendorMap = GlobalData::instance().vendorMaps(); vendorMap.contains("source"))
-        {
-            for (const auto& item : vendorMap.at("source"))
-            {
-                if (source == item.begin().key())
-                {
-                    return item.begin().value();
-                }
-            }
-        }
-
-        return {};
-    }
-
-    /**
-     * @brief Get CNA/ADP name based on the package format.
-     * @param format Package format.
-     * @return CNA/ADP name. Empty string otherwise.
-     */
-    std::string getCnaNameByFormat(std::string_view format) const
-    {
-        if (const auto& vendorMap = GlobalData::instance().vendorMaps(); vendorMap.contains("format"))
-        {
-            for (const auto& item : vendorMap.at("format"))
-            {
-                if (format == item.begin().key())
-                {
-                    return item.begin().value();
-                }
-            }
-        }
-
-        return {};
-    }
-
-    /**
-     * @brief Get CNA/ADP name based on the package vendor when it contains a specific word.
-     * @param vendor Package vendor.
-     * @param platform Os platform.
-     * @return CNA/ADP name. Empty string otherwise.
-     */
-    std::string getCnaNameByContains(std::string_view vendor, std::string_view platform) const
-    {
-        if (const auto& vendorMap = GlobalData::instance().vendorMaps(); vendorMap.contains("contains"))
-        {
-            for (const auto& item : vendorMap.at("contains"))
-            {
-                if (const auto& platforms = item.begin().value().at("platforms");
-                    vendor.find(item.begin().key()) != std::string::npos &&
-                    std::find(platforms.begin(), platforms.end(), platform) != platforms.end())
-                {
-                    return item.begin().value().at("cna");
-                }
-            }
-        }
-
-        return {};
-    }
-
-    /**
-     * @brief Get CNA/ADP name based on the package vendor when it starts with a specific word.
-     * @param vendor Package vendor.
-     * @param platform Os platform.
-     *
-     * @return CNA/ADP name. Empty string otherwise.
-     */
-    std::string getCnaNameByPrefix(std::string_view vendor, std::string_view platform) const
-    {
-        if (const auto& vendorMap = GlobalData::instance().vendorMaps(); vendorMap.contains("prefix"))
-        {
-            for (const auto& item : vendorMap.at("prefix"))
-            {
-                if (const auto& platforms = item.begin().value().at("platforms");
-                    Utils::startsWith(vendor.data(), item.begin().key()) &&
-                    std::find(platforms.begin(), platforms.end(), platform) != platforms.end())
-                {
-                    return item.begin().value().at("cna");
-                }
-            }
-        }
-
-        return {};
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -315,6 +315,19 @@ public:
             // We disable the automatic repair of the DB in case it's corrupted.
             m_feedDatabase = std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false, false);
 
+            //! Note: Because the CISA feed is not available yet in the feed,
+            //! we need to create the candidate and description columns.
+            if (!m_feedDatabase->columnExists(DEFAULT_CNA))
+            {
+                m_feedDatabase->createColumn(DEFAULT_CNA);
+            }
+
+            if (const auto column = std::string(DESCRIPTIONS_COLUMN) + "_" + DEFAULT_CNA;
+                !m_feedDatabase->columnExists(column))
+            {
+                m_feedDatabase->createColumn(column);
+            }
+
             // This initializes the vendor and os cpe maps and should be called before any scan or message processing.
             if (reloadGlobalMapsStartup)
             {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -613,7 +613,7 @@ public:
                     if (callback(cnaName, package, *candidate))
                     {
                         // If the candidate is vulnerable, we stop looking for more candidates.
-                        return;
+                        break;
                     }
                 }
             }
@@ -670,7 +670,7 @@ public:
             m_feedDatabase->get(cveId, resultContainer.slice, descriptionColumn) == false)
         {
             logDebug2(WM_VULNSCAN_LOGTAG,
-                      "Vulnerability description not found for %s in %s.",
+                      "Vulnerability descriptive information not found for %s in %s.",
                       cveId.c_str(),
                       descriptionColumn.c_str());
             resultContainer.data = nullptr;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -315,19 +315,6 @@ public:
             // We disable the automatic repair of the DB in case it's corrupted.
             m_feedDatabase = std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false, false);
 
-            //! Note: Because the CISA feed is not available yet in the feed,
-            //! we need to create the candidate and description columns.
-            if (!m_feedDatabase->columnExists(DEFAULT_CNA))
-            {
-                m_feedDatabase->createColumn(DEFAULT_CNA);
-            }
-
-            if (const auto column = std::string(DESCRIPTIONS_COLUMN) + "_" + DEFAULT_CNA;
-                !m_feedDatabase->columnExists(column))
-            {
-                m_feedDatabase->createColumn(column);
-            }
-
             // This initializes the vendor and os cpe maps and should be called before any scan or message processing.
             if (reloadGlobalMapsStartup)
             {
@@ -633,7 +620,7 @@ public:
         }
 
         // If no CVEs are found and we were using the default CNA, attempt to find it with the fallback CNA.
-        if (cnaName == DEFAULT_CNA && !cvesFound)
+        if (cnaName == DEFAULT_CNA && cnaName != FALLBACK_CNA && !cvesFound)
         {
             getVulnerabilitiesCandidates(FALLBACK_CNA, package, callback);
         }
@@ -847,6 +834,19 @@ private:
             throw std::runtime_error("Error getting CNA Mapping content from rocksdb.");
         }
         GlobalData::instance().cnaMappings(nlohmann::json::parse(queryResult.ToString()));
+
+        //! Note: Because the CISA feed is not available yet in the feed,
+        //! we need to create the candidate and description columns.
+        if (!m_feedDatabase->columnExists(DEFAULT_CNA))
+        {
+            m_feedDatabase->createColumn(DEFAULT_CNA);
+        }
+
+        if (const auto column = std::string(DESCRIPTIONS_COLUMN) + "_" + DEFAULT_CNA;
+            !m_feedDatabase->columnExists(column))
+        {
+            m_feedDatabase->createColumn(column);
+        }
 
         // Load translations into the Level 2 cache
         fillL2CacheTranslations();

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -18,8 +18,6 @@
 #include "vulnerabilityScanner.hpp"
 #include <variant>
 
-constexpr auto DEFAULT_ADP_SUBSHORT_NAME {"nvd"};
-
 /**
  * @brief UpdateCVEDescription class.
  *

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -210,7 +210,7 @@ public:
             if (!descriptionIsReliable())
             {
                 databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, descriptionData);
-            }                        
+            }
         }
 
         // Get CVSS data
@@ -240,7 +240,7 @@ public:
             // If the sources are the same, cvssData will be the same as descriptionData
             cvssData.data = descriptionData.data;
         }
-        
+
         // Check if the CVSS is reliable
         // 1. If its not, try with the default CNA
         // 2. If its still not reliable, try with the fallback CNA

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -138,8 +138,8 @@ private:
         }
         else
         {
-            // Fallback to default ADP
-            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
+            // Fallback to the default CNA
+            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_CNA);
         }
 
         const auto& cvssSource = vendorConfig.at(ADP_CVSS_KEY).get_ref<const std::string&>();
@@ -193,13 +193,24 @@ public:
 
         if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
         {
-            // Information not from source, try with default ADP
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+            // Information not from source, try with default CNA
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, descriptionData);
         }
 
-        if (!descriptionIsReliable() && descriptionSource != DEFAULT_ADP)
+        // Check if the description is reliable
+        // 1. If its not, try with the default CNA
+        // 2. If its still not reliable, try with the fallback CNA
+        if (!descriptionIsReliable())
         {
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+            if (descriptionSource != DEFAULT_CNA)
+            {
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, descriptionData);
+            }
+
+            if (!descriptionIsReliable())
+            {
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, descriptionData);
+            }                        
         }
 
         // Get CVSS data
@@ -220,8 +231,8 @@ public:
         {
             if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData))
             {
-                // Information not from source, try with default ADP
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+                // Information not from source, try with default CNA
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData);
             }
         }
         else
@@ -229,10 +240,21 @@ public:
             // If the sources are the same, cvssData will be the same as descriptionData
             cvssData.data = descriptionData.data;
         }
-
-        if (!cvssIsReliable() && cvssSource != DEFAULT_ADP)
+        
+        // Check if the CVSS is reliable
+        // 1. If its not, try with the default CNA
+        // 2. If its still not reliable, try with the fallback CNA
+        if (!cvssIsReliable())
         {
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+            if (cvssSource != DEFAULT_CNA)
+            {
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData);
+            }
+
+            if (!cvssIsReliable())
+            {
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, cvssData);
+            }
         }
 
         // Call the callback function with the CveDescription object

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -132,14 +132,19 @@ private:
         const auto& [adp, expandedAdp] = sources;
 
         nlohmann::json vendorConfig;
-        if (TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(adp))
+
+        const auto descriptionsMap = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY);
+        if (descriptionsMap.contains(adp))
         {
-            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adp);
+            vendorConfig = descriptionsMap.at(adp);
+        }
+        else if (descriptionsMap.contains(DEFAULT_CNA))
+        {
+            vendorConfig = descriptionsMap.at(DEFAULT_CNA);
         }
         else
         {
-            // Fallback to the default CNA
-            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_CNA);
+            vendorConfig = descriptionsMap.at(FALLBACK_CNA);
         }
 
         const auto& cvssSource = vendorConfig.at(ADP_CVSS_KEY).get_ref<const std::string&>();
@@ -194,12 +199,16 @@ public:
         if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
         {
             // Information not from source, try with default CNA
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, descriptionData);
+            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, descriptionData))
+            {
+                // Information not from default CNA, try with fallback CNA
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, descriptionData);
+            }
         }
 
         // Check if the description is reliable
-        // 1. If its not, try with the default CNA
-        // 2. If its still not reliable, try with the fallback CNA
+        // 1. If it's not, try with the default CNA
+        // 2. If it's still not reliable, try with the fallback CNA
         if (!descriptionIsReliable())
         {
             if (descriptionSource != DEFAULT_CNA)
@@ -232,7 +241,11 @@ public:
             if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData))
             {
                 // Information not from source, try with default CNA
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData);
+                if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData))
+                {
+                    // Information not from default CNA, try with fallback CNA
+                    databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, cvssData);
+                }
             }
         }
         else
@@ -242,7 +255,7 @@ public:
         }
 
         // Check if the CVSS is reliable
-        // 1. If its not, try with the default CNA
+        // 1. If it's not, try with the default CNA
         // 2. If its still not reliable, try with the fallback CNA
         if (!cvssIsReliable())
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -126,10 +126,11 @@ class DescriptionsHelper final
 private:
     template<typename TGlobalData = GlobalData>
     static std::pair<const std::string, const std::string>
-    cvssAndDescriptionSources(const std::pair<std::string, std::string>& sources)
+    cvssAndDescriptionSources(const ScanContext::VulnerabilitySource& sources)
     {
         // Ex. sources = {"redhat", "redhat_8"}
-        const auto& [adp, expandedAdp] = sources;
+        const auto& adp = sources.getCnaBaseName();
+        const auto& expandedAdp = sources.getCnaExpandedName();
 
         nlohmann::json vendorConfig;
 
@@ -165,14 +166,14 @@ public:
      * @tparam TGlobalData Global data type.
      *
      * @param cve CVE identifier.
-     * @param sources Pair of sources (ADP and expanded ADP).
+     * @param sources Vulnerability source information.
      * @param databaseFeedManager Database feed manager instance.
      * @param callback Callback function to call with the retrieved CveDescription object.
      *
      */
     template<typename TDatabaseFeedManager = DatabaseFeedManager, typename TGlobalData = GlobalData>
     static void vulnerabilityDescription(const std::string& cve,
-                                         const std::pair<std::string, std::string>& sources,
+                                         const ScanContext::VulnerabilitySource& sources,
                                          std::shared_ptr<TDatabaseFeedManager>& databaseFeedManager,
                                          const std::function<void(const CveDescription&)>& callback)
     {
@@ -188,12 +189,8 @@ public:
         // The description information is considered unreliable if the description is empty or "not defined"
         const auto descriptionIsReliable = [&descriptionData]()
         {
-            if (descriptionData.data == nullptr)
-            {
-                return false;
-            }
-
-            if (!descriptionData.data->description() || descriptionData.data->description()->str() == "not defined")
+            if (!descriptionData.data || !descriptionData.data->description() ||
+                descriptionData.data->description()->str() == "not defined")
             {
                 return false;
             }
@@ -219,12 +216,7 @@ public:
         // The CVSS information is considered unreliable if the score is near 0 or the severity is empty
         const auto cvssIsReliable = [&cvssData]()
         {
-            if (cvssData.data == nullptr)
-            {
-                return false;
-            }
-
-            if (cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
+            if (!cvssData.data || cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
             {
                 return false;
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -237,19 +237,19 @@ public:
             // If the sources are the same, cvssData will be the same as descriptionData
             cvssData.data = descriptionData.data;
         }
-        else
-        {
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData);
-        }
 
         if (!cvssIsReliable())
         {
-            // Information not from source, try with default CNA
-            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData) ||
+            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData) ||
                 !cvssIsReliable())
             {
-                // Information not from default CNA, try with fallback CNA
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, cvssData);
+                // Information not from source, try with default CNA
+                if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData) ||
+                    !cvssIsReliable())
+                {
+                    // Information not from default CNA, try with fallback CNA
+                    databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, cvssData);
+                }
             }
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -188,6 +188,11 @@ public:
         // The description information is considered unreliable if the description is empty or "not defined"
         const auto descriptionIsReliable = [&descriptionData]()
         {
+            if (descriptionData.data == nullptr)
+            {
+                return false;
+            }
+
             if (!descriptionData.data->description() || descriptionData.data->description()->str() == "not defined")
             {
                 return false;
@@ -196,28 +201,14 @@ public:
             return true;
         };
 
-        if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
+        if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData) ||
+            !descriptionIsReliable())
         {
             // Information not from source, try with default CNA
-            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, descriptionData))
+            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, descriptionData) ||
+                !descriptionIsReliable())
             {
                 // Information not from default CNA, try with fallback CNA
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, descriptionData);
-            }
-        }
-
-        // Check if the description is reliable
-        // 1. If it's not, try with the default CNA
-        // 2. If it's still not reliable, try with the fallback CNA
-        if (!descriptionIsReliable())
-        {
-            if (descriptionSource != DEFAULT_CNA)
-            {
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, descriptionData);
-            }
-
-            if (!descriptionIsReliable())
-            {
                 databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, descriptionData);
             }
         }
@@ -226,8 +217,13 @@ public:
 
         // Check if the CVSS information is reliable
         // The CVSS information is considered unreliable if the score is near 0 or the severity is empty
-        const auto cvssIsReliable = [&cvssData, &cvssSource]()
+        const auto cvssIsReliable = [&cvssData]()
         {
+            if (cvssData.data == nullptr)
+            {
+                return false;
+            }
+
             if (cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
             {
                 return false;
@@ -236,36 +232,23 @@ public:
             return true;
         };
 
-        if (cvssSource != descriptionSource)
-        {
-            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData))
-            {
-                // Information not from source, try with default CNA
-                if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData))
-                {
-                    // Information not from default CNA, try with fallback CNA
-                    databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, cvssData);
-                }
-            }
-        }
-        else
+        if (cvssSource == descriptionSource)
         {
             // If the sources are the same, cvssData will be the same as descriptionData
             cvssData.data = descriptionData.data;
         }
+        else
+        {
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData);
+        }
 
-        // Check if the CVSS is reliable
-        // 1. If it's not, try with the default CNA
-        // 2. If its still not reliable, try with the fallback CNA
         if (!cvssIsReliable())
         {
-            if (cvssSource != DEFAULT_CNA)
+            // Information not from source, try with default CNA
+            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData) ||
+                !cvssIsReliable())
             {
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_CNA, cvssData);
-            }
-
-            if (!cvssIsReliable())
-            {
+                // Information not from default CNA, try with fallback CNA
                 databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, FALLBACK_CNA, cvssData);
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -260,7 +260,7 @@ public:
                             TGlobalData::instance()
                                 .vendorMaps()
                                 .at("adp_descriptions")
-                                .at(std::get<VulnerabilitySource::ADP_BASE>(context->m_vulnerabilitySource))
+                                .at(context->m_vulnerabilitySource.getCnaBaseName())
                                 .at("adp");
                         ecsData["vulnerability"]["under_evaluation"] = isUnderEvaluation();
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
@@ -19,7 +19,7 @@
 #include "versionMatcher/versionMatcher.hpp"
 #include "wdbDataException.hpp"
 
-auto constexpr OS_SCANNER_CNA {"nvd"};
+auto constexpr OS_SCANNER_CNA {"cisa"};
 
 /**
  * @brief OsScanner class.

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
@@ -81,15 +81,12 @@ public:
 
         const auto osCPE = ScannerHelper::parseCPE(data->osCPEName().data());
 
-        auto vulnerabilityScan = [&](const std::string& cnaName,
-                                     const PackageData& package,
+        auto vulnerabilityScan = [&](std::string_view cnaName,
+                                     [[maybe_unused]] const PackageData& package,
                                      const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
             try
             {
-                // Update the vulnerability source.
-                data->m_vulnerabilitySource.first = cnaName;
-
                 VersionObjectType objectType = VersionObjectType::DPKG;
                 for (const auto& version : *callbackData.versions())
                 {
@@ -260,7 +257,7 @@ public:
                 logDebug1(WM_VULNSCAN_LOGTAG,
                           "Failed to scan OS: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'",
                           osCPE.product.c_str(),
-                          cnaName.c_str(),
+                          cnaName.data(),
                           e.what());
 
                 return false;
@@ -282,9 +279,10 @@ public:
                 {
                     PackageData package = {.name = osCPE.product};
 
-                    data->m_vulnerabilitySource = std::make_pair(OS_SCANNER_CNA, OS_SCANNER_CNA);
+                    data->m_vulnerabilitySource.setFromCna(OS_SCANNER_CNA);
 
-                    m_databaseFeedManager->getVulnerabilitiesCandidates(OS_SCANNER_CNA, package, vulnerabilityScan);
+                    m_databaseFeedManager->getVulnerabilitiesCandidates(
+                        data->m_vulnerabilitySource, package, vulnerabilityScan);
 
                     if (data->osPlatform() == "windows")
                     {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
@@ -87,6 +87,9 @@ public:
         {
             try
             {
+                // Update the vulnerability source.
+                data->m_vulnerabilitySource.first = cnaName;
+
                 VersionObjectType objectType = VersionObjectType::DPKG;
                 for (const auto& version : *callbackData.versions())
                 {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -22,7 +22,7 @@
 #include <unordered_set>
 #include <variant>
 
-auto constexpr DEFAULT_CNA {"nvd"};
+auto constexpr PACKAGE_SCANNER_CNA {"cisa"};
 auto constexpr L1_CACHE_SIZE {2048};
 
 /**
@@ -216,7 +216,7 @@ private:
                                                                           ctx->osPlatform().data());
                     if (cnaName.empty())
                     {
-                        return {DEFAULT_CNA, DEFAULT_CNA};
+                        return {PACKAGE_SCANNER_CNA, PACKAGE_SCANNER_CNA};
                     }
                 }
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -647,6 +647,9 @@ public:
         {
             try
             {
+                // Update the vulnerability source.
+                data->m_vulnerabilitySource.first = cnaName;
+
                 /* Preliminary verifications before version matching. We return if the basic conditions are not met. */
 
                 // If the candidate contains platforms, verify if agent OS is in the list.

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -252,8 +252,7 @@ private:
         return true;
     }
 
-    bool vendorVerify(const std::string& cnaName,
-                      const PackageData& package,
+    bool vendorVerify(const PackageData& package,
                       const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
                       std::shared_ptr<TScanContext> contextData)
     {
@@ -300,8 +299,7 @@ private:
         return true;
     }
 
-    bool versionMatch(const std::string& cnaName,
-                      const PackageData& package,
+    bool versionMatch(const PackageData& package,
                       const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
                       std::shared_ptr<TScanContext> contextData)
     {
@@ -477,8 +475,7 @@ private:
         return false;
     }
 
-    bool packageHotfixSolved(const std::string& cnaName,
-                             const PackageData& package,
+    bool packageHotfixSolved(const PackageData& package,
                              const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
                              std::shared_ptr<TScanContext> contextData)
     {
@@ -571,24 +568,24 @@ public:
                 /* Preliminary verifications before version matching. We return if the basic conditions are not met. */
 
                 // If the candidate contains platforms, verify if agent OS is in the list.
-                if (!platformVerify(cnaName, package, callbackData, data))
+                if (!platformVerify(package, callbackData, data))
                 {
                     return false;
                 }
 
                 // If the candidate contains a vendor, verify if package vendor matches.
-                if (!vendorVerify(cnaName, package, callbackData, data))
+                if (!vendorVerify(package, callbackData, data))
                 {
                     return false;
                 }
 
                 /* Real version analysis of the candidate. */
-                if (versionMatch(cnaName, package, callbackData, data))
+                if (versionMatch(package, callbackData, data))
                 {
                     // The candidate version matches the package. Post-match filtering.
                     if (data->osPlatform().compare("windows") == 0)
                     {
-                        if (packageHotfixSolved(cnaName, package, callbackData, data))
+                        if (packageHotfixSolved(package, callbackData, data))
                         {
                             // An installed hotfix solves the vulnerability.
                             return false;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -22,7 +22,6 @@
 #include <unordered_set>
 #include <variant>
 
-auto constexpr PACKAGE_SCANNER_CNA {"cisa"};
 auto constexpr L1_CACHE_SIZE {2048};
 
 /**
@@ -81,7 +80,6 @@ private:
      * data.
      */
     bool scanPackageTranslation(
-        const std::string& cnaName,
         const PackageData& packageToTranslate,
         const std::shared_ptr<TScanContext> data,
         const std::function<bool(const std::string& cnaName,
@@ -121,7 +119,8 @@ private:
                     translatedPackage.version = translation.translatedVersion;
                 }
 
-                m_databaseFeedManager->getVulnerabilitiesCandidates(cnaName, translatedPackage, vulnerabilityScan);
+                m_databaseFeedManager->getVulnerabilitiesCandidates(
+                    data->m_vulnerabilitySource, translatedPackage, vulnerabilityScan);
             }
             return true;
         }
@@ -161,12 +160,13 @@ private:
                               translatedPackage.name.c_str(),
                               translatedPackage.format.c_str(),
                               translatedPackage.vendor.c_str(),
-                              cnaName.c_str(),
+                              data->m_vulnerabilitySource.getCnaExpandedName().data(),
                               data->agentName().data(),
                               data->agentId().data(),
                               data->agentVersion().data());
 
-                    m_databaseFeedManager->getVulnerabilitiesCandidates(cnaName, translatedPackage, vulnerabilityScan);
+                    m_databaseFeedManager->getVulnerabilitiesCandidates(
+                        data->m_vulnerabilitySource, translatedPackage, vulnerabilityScan);
                 }
                 // Store translations in Level 1 cache
                 m_translationL1Cache.insertKey(cacheKey, std::move(L2Translations));
@@ -182,88 +182,7 @@ private:
         return false;
     }
 
-    /**
-     * @brief Define what CNA will be used to read the data.
-     *
-     * @param ctx Scan context.
-     * @return std::pair<std::string, std::string> CNA pair.
-     */
-    std::pair<std::string, std::string> getCNA(std::shared_ptr<TScanContext> ctx)
-    {
-        auto cnaName {m_databaseFeedManager->getCnaNameByFormat(ctx->packageFormat().data())};
-
-        if (cnaName.empty())
-        {
-            cnaName = m_databaseFeedManager->getCnaNameBySource(ctx->packageSource().data());
-            if (cnaName.empty())
-            {
-                cnaName =
-                    m_databaseFeedManager->getCnaNameByPrefix(ctx->packageVendor().data(), ctx->osPlatform().data());
-                if (cnaName.empty())
-                {
-                    cnaName = m_databaseFeedManager->getCnaNameByContains(ctx->packageVendor().data(),
-                                                                          ctx->osPlatform().data());
-                    if (cnaName.empty())
-                    {
-                        return {PACKAGE_SCANNER_CNA, PACKAGE_SCANNER_CNA};
-                    }
-                }
-            }
-        }
-        const auto mapping = TGlobalData::instance().cnaMappings();
-
-        const auto& cnaMapping = mapping.at("cnaMapping");
-        const auto platformEquivalence = [&](const std::string& platform) -> const std::string&
-        {
-            const auto& platformMapping = mapping.at("platformEquivalence");
-            if (const auto it = platformMapping.find(platform); it == platformMapping.end())
-            {
-                return platform;
-            }
-            else
-            {
-                return it->template get_ref<const std::string&>();
-            }
-        };
-
-        const auto majorVersionEquivalence = [&](const std::string& platform,
-                                                 const std::string& majorVersion) -> const std::string&
-        {
-            const auto& majorVersionMapping = mapping.at("majorVersionEquivalence");
-            if (const auto itPlatform = majorVersionMapping.find(platform); itPlatform == majorVersionMapping.end())
-            {
-                return majorVersion;
-            }
-            else
-            {
-                if (const auto itMajorVersion = itPlatform->find(majorVersion); itMajorVersion == itPlatform->end())
-                {
-                    return majorVersion;
-                }
-                else
-                {
-                    return itMajorVersion->template get_ref<const std::string&>();
-                }
-            }
-        };
-
-        if (const auto it = cnaMapping.find(cnaName); it == cnaMapping.end())
-        {
-            return {cnaName, cnaName};
-        }
-        else
-        {
-            std::string base = it->template get<std::string>();
-            Utils::replaceAll(base, "$(PLATFORM)", platformEquivalence(ctx->osPlatform().data()));
-            Utils::replaceAll(base,
-                              "$(MAJOR_VERSION)",
-                              majorVersionEquivalence(ctx->osPlatform().data(), ctx->osMajorVersion().data()));
-            return {cnaName, base};
-        }
-    }
-
-    bool platformVerify(const std::string& cnaName,
-                        const PackageData& package,
+    bool platformVerify(const PackageData& package,
                         const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
                         std::shared_ptr<TScanContext> contextData)
     {
@@ -630,7 +549,7 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
-        auto vulnerabilityScan = [&](const std::string& cnaName,
+        auto vulnerabilityScan = [&](std::string_view cnaName,
                                      const PackageData& package,
                                      const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
@@ -644,13 +563,10 @@ public:
                           package.name.c_str(),
                           package.format.c_str(),
                           package.vendor.c_str(),
-                          cnaName.c_str(),
+                          cnaName.data(),
                           data->agentName().data(),
                           data->agentId().data(),
                           data->agentVersion().data());
-
-                // Update the vulnerability source.
-                data->m_vulnerabilitySource.first = cnaName;
 
                 /* Preliminary verifications before version matching. We return if the basic conditions are not met. */
 
@@ -691,31 +607,31 @@ public:
                 logDebug1(WM_VULNSCAN_LOGTAG,
                           "Failed to scan package: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'",
                           package.name.c_str(),
-                          cnaName.c_str(),
+                          cnaName.data(),
                           e.what());
 
                 return false;
             }
         };
 
-        data->m_vulnerabilitySource = getCNA(data);
-
-        const auto& CNAValue = data->m_vulnerabilitySource.second;
-
         try
         {
+            // Set the vulnerability source from the package information
+            data->m_vulnerabilitySource.setFromContext();
+
             // Grouping all package related data in one single structure
             PackageData package = {.name = data->packageName().data(),
                                    .vendor = data->packageVendor().data(),
                                    .format = data->packageFormat().data(),
                                    .version = data->packageVersion().data()};
 
-            if (!scanPackageTranslation(CNAValue, package, data, vulnerabilityScan))
+            if (!scanPackageTranslation(package, data, vulnerabilityScan))
             {
                 package.name = Utils::toLowerCase(std::string(data->packageName()));
                 package.vendor = Utils::toLowerCase(std::string(data->packageVendor()));
 
-                m_databaseFeedManager->getVulnerabilitiesCandidates(CNAValue, package, vulnerabilityScan);
+                m_databaseFeedManager->getVulnerabilitiesCandidates(
+                    data->m_vulnerabilitySource, package, vulnerabilityScan);
             }
         }
         catch (const std::exception& e)
@@ -723,7 +639,7 @@ public:
             logWarn(WM_VULNSCAN_LOGTAG,
                     "Failed to scan package: '%s', CVE Numbering Authorities (CNA): '%s', Error: '%s'.",
                     data->packageName().data(),
-                    CNAValue.c_str(),
+                    data->m_vulnerabilitySource.getCnaExpandedName().data(),
                     e.what());
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -121,17 +121,6 @@ private:
                     translatedPackage.version = translation.translatedVersion;
                 }
 
-                logDebug1(WM_VULNSCAN_LOGTAG,
-                          "Initiating a vulnerability scan for package '%s' (%s) (%s) with CVE Numbering "
-                          "Authorities (CNA) '%s' on Agent '%s' (ID: '%s', Version: '%s').",
-                          translatedPackage.name.c_str(),
-                          translatedPackage.format.c_str(),
-                          translatedPackage.vendor.c_str(),
-                          cnaName.c_str(),
-                          data->agentName().data(),
-                          data->agentId().data(),
-                          data->agentVersion().data());
-
                 m_databaseFeedManager->getVulnerabilitiesCandidates(cnaName, translatedPackage, vulnerabilityScan);
             }
             return true;
@@ -647,6 +636,19 @@ public:
         {
             try
             {
+                logDebug1(WM_VULNSCAN_LOGTAG,
+                          "Initiating a vulnerability scan for package '%s' (%s) (%s) with CVE Numbering "
+                          "Authorities (CNA) "
+                          "'%s' on Agent "
+                          "'%s' (ID: '%s', Version: '%s').",
+                          package.name.c_str(),
+                          package.format.c_str(),
+                          package.vendor.c_str(),
+                          cnaName.c_str(),
+                          data->agentName().data(),
+                          data->agentId().data(),
+                          data->agentVersion().data());
+
                 // Update the vulnerability source.
                 data->m_vulnerabilitySource.first = cnaName;
 
@@ -712,19 +714,6 @@ public:
             {
                 package.name = Utils::toLowerCase(std::string(data->packageName()));
                 package.vendor = Utils::toLowerCase(std::string(data->packageVendor()));
-
-                logDebug1(WM_VULNSCAN_LOGTAG,
-                          "Initiating a vulnerability scan for package '%s' (%s) (%s) with CVE Numbering "
-                          "Authorities (CNA) "
-                          "'%s' on Agent "
-                          "'%s' (ID: '%s', Version: '%s').",
-                          package.name.c_str(),
-                          package.format.c_str(),
-                          package.vendor.c_str(),
-                          CNAValue.c_str(),
-                          data->agentName().data(),
-                          data->agentId().data(),
-                          data->agentVersion().data());
 
                 m_databaseFeedManager->getVulnerabilitiesCandidates(CNAValue, package, vulnerabilityScan);
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -26,11 +26,8 @@
 #include <variant>
 #include <vector>
 
-enum VulnerabilitySource
-{
-    ADP_BASE = 0,
-    ADP_EXPANDED = 1
-};
+constexpr auto DEFAULT_CNA {"cisa"};
+constexpr auto FALLBACK_CNA {"nvd"};
 
 enum class MessageType
 {
@@ -222,7 +219,10 @@ public:
      * @brief Class constructor.
      *
      */
-    TScanContext() = default;
+    TScanContext()
+        : m_vulnerabilitySource(*this)
+    {
+    }
     // LCOV_EXCL_STOP
 
     /**
@@ -233,6 +233,7 @@ public:
     explicit TScanContext(std::variant<const SyscollectorDeltas::Delta*,
                                        const SyscollectorSynchronization::SyncMsg*,
                                        const nlohmann::json*> data)
+        : m_vulnerabilitySource(*this)
     {
         std::visit(
             [this](auto&& arg)
@@ -1475,15 +1476,6 @@ public:
     }
 
     /**
-     * @brief Feed source information.
-     *
-     * @note Use @see VulnerabilitySource enum to access each field
-     *
-     * @return Pair with CNA/ADP base name and CNA/ADP expanded name.
-     */
-    std::pair<std::string, std::string> m_vulnerabilitySource;
-
-    /**
      * @brief Gets the affected component type.
      *
      * @return AffectedComponentType The type of component that is affected in the event.
@@ -1542,6 +1534,212 @@ public:
      */
     bool m_noIndex = false;
     // LCOV_EXCL_STOP
+
+    /**
+     * @brief Represents feed source information with a CNA base name and an expanded name.
+     *
+     * @example Base name: redhat, Expanded name: redhat_8
+     */
+    class VulnerabilitySource
+    {
+    private:
+        std::string m_cnaBaseName;     ///< The CNA base name
+        std::string m_cnaExpandedName; ///< The CNA expanded name
+        TScanContext& m_scanContext;   ///< The scan context
+
+        /**
+         * @brief Get CNA/ADP name based on the package source.
+         *
+         * @param source Package source.
+         * @return std::string CNA/ADP name. Empty string otherwise.
+         */
+        std::string getCnaNameBySource(std::string_view source) const
+        {
+            if (const auto& vendorMap = TGlobalData::instance().vendorMaps(); vendorMap.contains("source"))
+            {
+                for (const auto& item : vendorMap.at("source"))
+                {
+                    if (source == item.begin().key())
+                    {
+                        return item.begin().value();
+                    }
+                }
+            }
+
+            return {};
+        }
+
+        /**
+         * @brief Get CNA/ADP name based on the package format.
+         * @param format Package format.
+         * @return CNA/ADP name. Empty string otherwise.
+         */
+        std::string getCnaNameByFormat(std::string_view format) const
+        {
+            if (const auto& vendorMap = TGlobalData::instance().vendorMaps(); vendorMap.contains("format"))
+            {
+                for (const auto& item : vendorMap.at("format"))
+                {
+                    if (format == item.begin().key())
+                    {
+                        return item.begin().value();
+                    }
+                }
+            }
+
+            return {};
+        }
+
+        /**
+         * @brief Get CNA/ADP name based on the package vendor when it contains a specific word.
+         * @param vendor Package vendor.
+         * @param platform Os platform.
+         * @return CNA/ADP name. Empty string otherwise.
+         */
+        std::string getCnaNameByContains(std::string_view vendor, std::string_view platform) const
+        {
+            if (const auto& vendorMap = TGlobalData::instance().vendorMaps(); vendorMap.contains("contains"))
+            {
+                for (const auto& item : vendorMap.at("contains"))
+                {
+                    if (const auto platforms = item.begin().value().at("platforms");
+                        vendor.find(item.begin().key()) != std::string::npos &&
+                        std::find(platforms.begin(), platforms.end(), platform) != platforms.end())
+                    {
+                        return item.begin().value().at("cna");
+                    }
+                }
+            }
+
+            return {};
+        }
+
+        /**
+         * @brief Get CNA/ADP name based on the package vendor when it starts with a specific word.
+         * @param vendor Package vendor.
+         * @param platform Os platform.
+         *
+         * @return CNA/ADP name. Empty string otherwise.
+         */
+        std::string getCnaNameByPrefix(std::string_view vendor, std::string_view platform) const
+        {
+            if (const auto& vendorMap = TGlobalData::instance().vendorMaps(); vendorMap.contains("prefix"))
+            {
+                for (const auto& item : vendorMap.at("prefix"))
+                {
+                    if (const auto platforms = item.begin().value().at("platforms");
+                        Utils::startsWith(vendor.data(), item.begin().key()) &&
+                        std::find(platforms.begin(), platforms.end(), platform) != platforms.end())
+                    {
+                        return item.begin().value().at("cna");
+                    }
+                }
+            }
+
+            return {};
+        }
+
+        std::string expandCnaName() const
+        {
+            const auto mapping = TGlobalData::instance().cnaMappings();
+
+            const auto platformEquivalence = [&mapping](const std::string& platform) -> const std::string&
+            {
+                const auto& platformMapping = mapping.at("platformEquivalence");
+                if (const auto it = platformMapping.find(platform); it != platformMapping.end())
+                {
+                    return it->template get_ref<const std::string&>();
+                }
+                return platform; // Not in the mapping
+            };
+
+            const auto majorVersionEquivalence = [&mapping](const std::string& platform,
+                                                            const std::string& majorVersion) -> const std::string&
+            {
+                const auto& majorVersionMapping = mapping.at("majorVersionEquivalence");
+                if (const auto itPlatform = majorVersionMapping.find(platform); itPlatform != majorVersionMapping.end())
+                {
+                    if (const auto itMajorVersion = itPlatform->find(majorVersion); itMajorVersion != itPlatform->end())
+                    {
+                        return itMajorVersion->template get_ref<const std::string&>();
+                    }
+                }
+                return majorVersion;
+            };
+
+            const auto& cnaMapping = mapping.at("cnaMapping");
+            if (const auto it = cnaMapping.find(m_cnaBaseName); it != cnaMapping.end())
+            {
+                const auto platform = m_scanContext.osPlatform().data();
+                const auto majorVersion = m_scanContext.osMajorVersion().data();
+
+                std::string cnaExpandedName = it->template get<std::string>();
+                Utils::replaceAll(cnaExpandedName, "$(PLATFORM)", platformEquivalence(platform));
+                Utils::replaceAll(cnaExpandedName, "$(MAJOR_VERSION)", majorVersionEquivalence(platform, majorVersion));
+
+                return cnaExpandedName;
+            }
+            return m_cnaBaseName; // Not in the mapping
+        }
+
+    public:
+        VulnerabilitySource(TScanContext& scanContext)
+            : m_scanContext(scanContext)
+        {
+        }
+
+        void setFromContext()
+        {
+            m_cnaBaseName = getCnaNameByFormat(m_scanContext.packageFormat().data());
+
+            if (m_cnaBaseName.empty())
+            {
+                m_cnaBaseName = getCnaNameBySource(m_scanContext.packageSource().data());
+                if (m_cnaBaseName.empty())
+                {
+                    m_cnaBaseName =
+                        getCnaNameByPrefix(m_scanContext.packageVendor().data(), m_scanContext.osPlatform().data());
+                    if (m_cnaBaseName.empty())
+                    {
+                        m_cnaBaseName = getCnaNameByContains(m_scanContext.packageVendor().data(),
+                                                             m_scanContext.osPlatform().data());
+                        if (m_cnaBaseName.empty())
+                        {
+                            m_cnaBaseName = DEFAULT_CNA;
+                        }
+                    }
+                }
+            }
+
+            m_cnaExpandedName = expandCnaName();
+        }
+
+        void setFromCna(std::string_view cnaName)
+        {
+            m_cnaBaseName = std::string(cnaName);
+            m_cnaExpandedName = expandCnaName();
+        }
+
+        std::string getCnaBaseName() const
+        {
+            return m_cnaBaseName;
+        }
+
+        std::string getCnaExpandedName() const
+        {
+            return m_cnaExpandedName;
+        }
+    };
+
+    /**
+     * @brief Feed source information.
+     *
+     * @note Use @see VulnerabilitySource enum to access each field
+     *
+     * @return Pair with CNA/ADP base name and CNA/ADP expanded name.
+     */
+    VulnerabilitySource m_vulnerabilitySource;
+
 private:
     /**
      * @brief Scan type.

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -261,17 +261,21 @@ void DatabaseFeedManagerTest::SetUp()
                    "format": [],
                    "source": [],
                    "adp_descriptions" : {
+                        "cisa": {
+                            "cvss" : "cisa",
+                            "description" : "cisa"
+                        },
                         "nvd" : {
                             "cvss" : "nvd",
                             "description" : "nvd"
                         },
                         "canonical" : {
                             "cvss" : "canonical",
-                            "description" : "nvd"
+                            "description" : "cisa"
                         },
                         "vendor" : {
                             "cvss" : "vendor",
-                            "description" : "nvd",
+                            "description" : "cisa",
                             "reference" : "vendor"
                         },
                         "incomplete_vendor" : {
@@ -325,7 +329,7 @@ void DatabaseFeedManagerTest::SetUp()
 
     fbBuilder.Finish(nvdDescriptionOffset);
 
-    auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + DEFAULT_ADP;
+    auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + DEFAULT_CNA;
     if (!rocksDBWrapper.columnExists(descriptionColumn))
     {
         rocksDBWrapper.createColumn(descriptionColumn);
@@ -380,7 +384,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation)
     FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> container;
 
     // Retrieve from existing source
-    EXPECT_TRUE(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, container));
+    EXPECT_TRUE(spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_CNA, container));
     EXPECT_STREQ(container.data->accessComplexity()->c_str(), "AccessComplexityStrNvd");
     EXPECT_STREQ(container.data->assignerShortName()->c_str(), "AssignerStr");
     EXPECT_STREQ(container.data->attackVector()->c_str(), "AttackVectorStrNvd");
@@ -407,7 +411,7 @@ TEST_F(DatabaseFeedManagerTest, getVulnerabiltyDescriptiveInformation)
 
     // Retrieve from non-existing CVE
     EXPECT_FALSE(
-        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("non_existing_cve", DEFAULT_ADP, container));
+        spDatabaseFeedManager->getVulnerabiltyDescriptiveInformation("non_existing_cve", DEFAULT_CNA, container));
     EXPECT_EQ(container.data, nullptr);
 
     // Retrieve from non-existing source

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -34,6 +34,10 @@ namespace
             "nvd": {
                 "description": "nvd",
                 "cvss": "nvd"
+            },
+            "cisa": {
+                "description": "cisa",
+                "cvss": "cisa"
             }
         }
     }
@@ -134,7 +138,7 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
             }));
 
     // We don't expect the database manager to be called with the default ADP
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_CNA, testing::_))
         .Times(0);
 
     // The global data should be called to retrieve the ADP descriptions map
@@ -189,7 +193,7 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSource)
             }));
 
     // We don't expect the database manager to be called with the default ADP
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_CNA, testing::_))
         .Times(0);
 
     // The global data should be called to retrieve the ADP descriptions map
@@ -214,7 +218,7 @@ TEST_F(DescriptionsHelperTest, nonExistentAdp)
     const auto sources = std::make_pair(ADP_INEXISTENT, ADP_INEXISTENT + ADP_EXPANDED_POSTFIX);
 
     const auto expectedAdpDescriptionSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_CNA).at("description").get<std::string>();
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
 
@@ -257,7 +261,7 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
     const auto adpCvssSource =
         ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION).at("cvss").get<std::string>();
     const auto defaultAdpSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_CNA).at("description").get<std::string>();
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
 
@@ -324,7 +328,7 @@ TEST_F(DescriptionsHelperTest, notReliableCvssInformationNoScore)
     const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
     const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
     const auto defaultAdpCvssSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_CNA).at("cvss").get<std::string>();
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
 
@@ -388,7 +392,7 @@ TEST_F(DescriptionsHelperTest, notReliableCvssInformationEmptySeverity)
     const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
     const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
     const auto defaultAdpCvssSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_CNA).at("cvss").get<std::string>();
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
 
@@ -453,7 +457,7 @@ TEST_F(DescriptionsHelperTest, notReliableDescriptionInformation)
     const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
     const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
     const auto defaultAdpDescriptionSource =
-        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_CNA).at("description").get<std::string>();
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -102,7 +102,8 @@ namespace NSEventPackageAlertDetailsBuilderTest
 
     const std::string CVEID {"CVE-2024-1234"};
 
-    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
+    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_cisa"};
+    const std::string DESCRIPTIONS_COLUMN_FALLBACK {"descriptions_nvd"};
 
     const nlohmann::json ADP_DESCRIPTIONS =
         R"#(
@@ -110,7 +111,7 @@ namespace NSEventPackageAlertDetailsBuilderTest
             "adp_descriptions": {
     "alas": {
       "adp": "Amazon Linux Security Center",
-      "description": "nvd",
+      "description": "cisa",
       "cvss": "alas"
     },
     "alma": {
@@ -120,17 +121,17 @@ namespace NSEventPackageAlertDetailsBuilderTest
     },
     "arch": {
       "adp": "Arch Linux Security Tracker",
-      "description": "nvd",
-      "cvss": "nvd"
+      "description": "cisa",
+      "cvss": "cisa"
     },
     "debian": {
       "adp": "Debian Security Tracker",
       "description": "debian",
-      "cvss": "nvd"
+      "cvss": "cisa"
     },
     "oracle": {
       "adp": "Oracle Linux Security",
-      "description": "nvd",
+      "description": "cisa",
       "cvss": "oracle"
     },
     "npm": {
@@ -176,10 +177,15 @@ namespace NSEventPackageAlertDetailsBuilderTest
     "homebrew": {
       "adp": "Homebrew Security Audit",
       "description": "homebrew",
-      "cvss": "nvd"
+      "cvss": "cisa"
+    },
+    "cisa": {
+      "adp": "Cybersecurity and Infrastructure Security Agency",
+      "description": "cisa",
+      "cvss": "cisa"
     }
   }
-        }
+}
     )#"_json;
 } // namespace NSEventPackageAlertDetailsBuilderTest
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
@@ -63,7 +63,8 @@ namespace NSScanOsAlertDetailsBuilderTest
 
     const std::string CVEID {"CVE-2024-1234"};
 
-    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
+    const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_cisa"};
+    const std::string DESCRIPTIONS_COLUMN_FALLBACK {"descriptions_nvd"};
 
     const nlohmann::json ADP_DESCRIPTIONS =
         R"#(
@@ -71,7 +72,7 @@ namespace NSScanOsAlertDetailsBuilderTest
             "adp_descriptions": {
     "alas": {
       "adp": "Amazon Linux Security Center",
-      "description": "nvd",
+      "description": "cisa",
       "cvss": "alas"
     },
     "alma": {
@@ -81,17 +82,17 @@ namespace NSScanOsAlertDetailsBuilderTest
     },
     "arch": {
       "adp": "Arch Linux Security Tracker",
-      "description": "nvd",
-      "cvss": "nvd"
+      "description": "cisa",
+      "cvss": "cisa"
     },
     "debian": {
       "adp": "Debian Security Tracker",
       "description": "debian",
-      "cvss": "nvd"
+      "cvss": "cisa"
     },
     "oracle": {
       "adp": "Oracle Linux Security",
-      "description": "nvd",
+      "description": "cisa",
       "cvss": "oracle"
     },
     "npm": {
@@ -137,7 +138,12 @@ namespace NSScanOsAlertDetailsBuilderTest
     "homebrew": {
       "adp": "Homebrew Security Audit",
       "description": "homebrew",
-      "cvss": "nvd"
+      "cvss": "cisa"
+    },
+    "cisa": {
+      "adp": "Cybersecurity and Infrastructure Security Agency",
+      "description": "cisa",
+      "cvss": "cisa"
     }
   }
         }


### PR DESCRIPTION
|Related issue|
|---|
| #26098 |

## Description
This PR aims to change the default CNA to **CISA**, because it is a more mature version of the **NVD**

Given that CISA doesn't contain all the CVEs yet, fallback mechanisms are implemented to use the NVD if information is not present in CISA
