### PR TITLE
Print the scan details with the right types

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -265,7 +265,7 @@ private:
         if (!isDelayed && type != ScannerType::CleanupAllAgentData && type != ScannerType::ReScanAllAgents &&
             type != ScannerType::CleanupSingleAgentData && m_eventDelayedDispatcher->size(context->agentId()))
         {
-            logDebug2(WM_VULNSCAN_LOGTAG, "Postponing event '%s' for agent '%s'", type, context->agentId().data());
+            logDebug2(WM_VULNSCAN_LOGTAG, "Postponing event '%d' for agent '%s'", type, context->agentId().data());
             m_eventDelayedDispatcher->push(context->agentId(), rawData);
         }
         else


### PR DESCRIPTION
|Related issue|
|---|
|Closes #26494 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes a wrong variable type that generates a segmentation fault in v4.10.0.
The proposed approach tries to be simple to expand and concise, without the risk of making the same mistake again.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

This is the log that shows the failure

<details><summary>Details</summary>
<p>

```
2024/10/24 00:12:52 wazuh-modulesd:vulnerability-scanner[5397] scanOrchestrator.hpp:268 at run(): DEBUG: Postponing event '(null)' for agent '001'
```

</p>
</details> 

This is the segmentation fault message

<details><summary>Details</summary>
<p>

```
Thread 233 "wazuh-modulesd" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffd2de1640 (LWP 8409)]
__strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
74	../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
#1  0x00007ffff6e4dd31 in __vfprintf_internal (s=0x7fffdea13200, format=0x7fffdea18840 "Postponing event '%s' for agent '%s'", ap=0x7fffd2ddeda8, mode_flags=0) at ./stdio-common/vfprintf-internal.c:1517
#2  0x000055555556711b in _log_function (level=0, tag=0x7fffdea187b0 "wazuh-modulesd:vulnerability-scanner", file=0x7fffdea3904f "scanOrchestrator.hpp", line=268, func=0x7fffd2ddee10 "run", 
    msg=0x7fffdea18840 "Postponing event '%s' for agent '%s'", plain_only=false, args=0x7fffd2ddeda8) at shared/debug_op.c:244
#3  0x0000555555566559 in _log (level=0, tag=0x7fffdea187b0 "wazuh-modulesd:vulnerability-scanner", 
    file=0x7fffdea39000 "/workspaces/wazuh/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp", line=268, func=0x7fffd2ddee10 "run", 
    msg=0x7fffdea18840 "Postponing event '%s' for agent '%s'", args=0x7fffd2ddeda8) at shared/debug_op.c:37
#4  0x0000555555569089 in mtLoggingFunctionsWrapper (level=5, tag=0x7fffdea187b0 "wazuh-modulesd:vulnerability-scanner", 
    file=0x7fffdea39000 "/workspaces/wazuh/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp", line=268, func=0x7fffd2ddee10 "run", 
    msg=0x7fffdea18840 "Postponing event '%s' for agent '%s'", args=0x7fffd2ddeda8) at shared/debug_op.c:704
#5  0x00007ffff010c7da in operator()(int, const std::string &, const std::string &, int, const std::string &, const std::string &, typedef __va_list_tag __va_list_tag *) const (
    __closure=0x7ffff03f9c00 <Log::GLOBAL_LOG_FUNCTION[abi:cxx11]>, logLevel=5, tag=..., file=..., line=268, func=..., logMessage=..., args=0x7fffd2ddeda8)
    at /workspaces/wazuh/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp:60
```

</p>
</details> 

This is an example of the new generated logs (WIP)

<details><summary>Details</summary>
<p>

```

```

</p>
</details> 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
 
 ## Update
 
 It was found that the test `TestRunScannerTypePackageInsertInDelayed` should cover this, but not all the tests have a logging method assigned, so the bug in a message isn't tested.