### PR TITLE
Link statically libstdc++ and libgcc_s

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -222,6 +222,7 @@ add_subdirectory(${ENGINE_SOURCE_DIR}/apiserver)
 
 #TODO isolate rxcpp
 target_link_libraries(main base cmds api CLI11::CLI11)
+target_link_options(main PRIVATE -static-libgcc -static-libstdc++)
 
 # Build benchmark
 if(ENGINE_BUILD_BENCHMARK)

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -222,7 +222,10 @@ add_subdirectory(${ENGINE_SOURCE_DIR}/apiserver)
 
 #TODO isolate rxcpp
 target_link_libraries(main base cmds api CLI11::CLI11)
-target_link_options(main PRIVATE -static-libgcc -static-libstdc++)
+# If ASAN, UBSAN or any other sanitizers are enabled do not link with static libraries
+if(NOT CMAKE_CXX_FLAGS MATCHES "-fsanitize=.*")
+    target_link_libraries(main -static-libgcc -static-libstdc++)
+endif()
 
 # Build benchmark
 if(ENGINE_BUILD_BENCHMARK)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #26525 |

This PR aims to link statically the libstdc++ to avoid shared libraries dependencies.