### PR TITLE
Add special testing case for arm32 rpm packages

### DIFF
--- a/.github/actions/test-install-components/install_component.sh
+++ b/.github/actions/test-install-components/install_component.sh
@@ -22,8 +22,19 @@ else
     exit 1
 fi
 
-if [ "${ARCH}" = "i386" ] || [ "${ARCH}" = "armv7hl" ]; then
+if [ "${ARCH}" = "i386" ] || [ "${ARCH}" = "armhf" ]; then
     linux="linux32"
+    if [ "${ARCH}" = "armhf" ] && [ "${SYSTEM}" = "rpm" ]; then
+        install="rpm -ivh --force --ignorearch"
+        WAZUH_MANAGER="10.0.0.2" $linux $install "/packages/$package_name"| tee /packages/status.log
+        if [ "$(rpm -qa | grep wazuh-agent)" ]; then
+            echo " installed wazuh-agent" >> /packages/status.log
+            exit 0
+        else
+            echo "Package could not be installed."
+            exit 1
+        fi
+    fi
 fi
 
 WAZUH_MANAGER="10.0.0.2" $linux $install "/packages/$package_name"| tee /packages/status.log


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26400|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team,

The smoke test for the `arm32` packages in the rpm systems needed a special testing case since the package is built in a `arm32` docker hosted in a `arm64` machine.

This PR updates the command needed to install the generated package under its circumstances and makes the smoke test work as spected.

## Tests
The following jobs have been triggered to test it works both for `arm32` and `arm64` rpm packages.

Command: 
```
gh workflow run packages-build-linux-agent-arm.yml -r bug/26400-fix-armv7hl-compilation-workflow -f architecture=armv7hl -f system=rpm -f source_reference=fix/26400-compilation-errors-for-armhf-and-armv7hl-rpm -f id=test_armv7hl_rpm
```
:green_circle: Triggered job: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11516709980/job/32059915905

Command: 
```
gh workflow run packages-build-linux-agent-arm.yml -r bug/26400-fix-armv7hl-compilation-workflow -f architecture=armhf -f system=rpm -f source_reference=fix/26400-compilation-errors-for-armhf-and-armv7hl-rpm -f id=test_armhf_rpm
```
:green_circle: Triggered job: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11516715585/job/32059930222

Command: 
```
gh workflow run packages-build-linux-agent-arm.yml -r bug/26400-fix-armv7hl-compilation-workflow -f architecture=aarch64 -f system=rpm -f source_reference=fix/26400-compilation-errors-for-armhf-and-armv7hl-rpm -f id=test_aarch64_rpm
```
:green_circle: Triggered job: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11516720828/job/32059946248

Command: 
```
gh workflow run packages-build-linux-agent-arm.yml -r bug/26400-fix-armv7hl-compilation-workflow -f architecture=arm64 -f system=rpm -f source_reference=fix/26400-compilation-errors-for-armhf-and-armv7hl-rpm -f id=test_arm64_rpm
```
:green_circle: Triggered job: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11516724672/job/32059957222

Command: 
```
gh workflow run packages-build-linux-agent-arm.yml -r bug/26400-fix-armv7hl-compilation-workflow -f architecture=arm64 -f system=deb -f source_reference=fix/26400-compilation-errors-for-armhf-and-armv7hl-rpm -f id=test_arm64_deb
```
:green_circle: Triggered job: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11516728341/job/32059969342

Command: 
```
gh workflow run packages-build-linux-agent-arm.yml -r bug/26400-fix-armv7hl-compilation-workflow -f architecture=armhf -f system=deb -f source_reference=fix/26400-compilation-errors-for-armhf-and-armv7hl-rpm -f id=test_armhf_deb
```
:green_circle: Triggered job: https://github.com/wazuh/wazuh-agent-packages/actions/runs/11516731519/job/32059977475
