### PR TITLE
Adjustment of vulnerability descriptions

### DIFF
--- a/src/engine/source/feedmanager/include/databaseFeedManager.hpp
+++ b/src/engine/source/feedmanager/include/databaseFeedManager.hpp
@@ -211,7 +211,7 @@ public:
      *
      * @return true if the information was successfully retrieved, false otherwise.
      */
-    bool getVulnerabiltyDescriptiveInformation(
+    bool getVulnerabilityDescriptiveInformation(
         const std::string& cveId,
         const std::string& subShortName,
         FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer);

--- a/src/engine/source/feedmanager/include/databaseFeedManager.hpp
+++ b/src/engine/source/feedmanager/include/databaseFeedManager.hpp
@@ -29,6 +29,11 @@
 #include "vulnerabilityDescription_generated.h"
 #include "vulnerabilityRemediations_generated.h"
 
+constexpr auto DEFAULT_ADP {"nvd"};
+constexpr auto ADP_CVSS_KEY {"cvss"};
+constexpr auto ADP_DESCRIPTION_KEY {"description"};
+constexpr auto ADP_DESCRIPTIONS_MAP_KEY {"adp_descriptions"};
+
 /**
  * @brief Scanning package data struct.
  */
@@ -198,13 +203,18 @@ public:
     // LCOV_EXCL_STOP
 
     /**
-     * @brief Gets descriptive information for a cveid.
+     * @brief Gets descriptive information for a given CVE ID and CNA/ADP.
      *
-     * @param cveId cveid to search.
+     * @param cveId CVE ID to get the information.
+     * @param subShortName Expanded CNA/ADP name (Ex. nvd, suse_server_15, redhat_8)
      * @param resultContainer container struct to store the result.
+     *
+     * @return true if the information was successfully retrieved, false otherwise.
      */
-    void getVulnerabiltyDescriptiveInformation(
-        std::string_view cveId, FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer);
+    bool getVulnerabiltyDescriptiveInformation(
+        const std::string& cveId,
+        const std::string& subShortName,
+        FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer);
 
     /**
      * @brief Get CNA/ADP name based on the package source.

--- a/src/engine/source/feedmanager/src/databaseFeedManager.cpp
+++ b/src/engine/source/feedmanager/src/databaseFeedManager.cpp
@@ -407,26 +407,23 @@ utils::rocksdb::RocksDBWrapper& DatabaseFeedManager::getCVEDatabase()
 
 // LCOV_EXCL_STOP
 
-void DatabaseFeedManager::getVulnerabiltyDescriptiveInformation(
-    const std::string_view cveId, FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+bool DatabaseFeedManager::getVulnerabiltyDescriptiveInformation(
+    const std::string& cveId,
+    const std::string& subShortName,
+    FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
 {
-    if (m_feedDatabase->get(std::string(cveId), resultContainer.slice, DESCRIPTIONS_COLUMN) == false)
+    if (const auto descriptionColumn = std::string(DESCRIPTIONS_COLUMN) + "_" + subShortName;
+        m_feedDatabase->get(cveId, resultContainer.slice, descriptionColumn) == false)
     {
-        throw std::runtime_error(
-            "Error getting VulnerabilityDescription object from rocksdb. Object not found for cveId: "
-            + std::string(cveId));
-    }
-
-    if (flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(resultContainer.slice.data()),
-                                       resultContainer.slice.size());
-        NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifier) == false)
-    {
-        throw std::runtime_error(
-            "Error getting VulnerabilityDescription object from rocksdb. FlatBuffers verifier failed");
+        LOG_DEBUG("Vulnerability description not found for {} in {}.", cveId.c_str(), descriptionColumn.c_str());
+        resultContainer.data = nullptr;
+        return false;
     }
 
     resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
         NSVulnerabilityScanner::GetVulnerabilityDescription(resultContainer.slice.data()));
+
+    return true;
 }
 
 std::string DatabaseFeedManager::getCnaNameBySource(std::string_view source) const

--- a/src/engine/source/feedmanager/src/databaseFeedManager.cpp
+++ b/src/engine/source/feedmanager/src/databaseFeedManager.cpp
@@ -407,7 +407,7 @@ utils::rocksdb::RocksDBWrapper& DatabaseFeedManager::getCVEDatabase()
 
 // LCOV_EXCL_STOP
 
-bool DatabaseFeedManager::getVulnerabiltyDescriptiveInformation(
+bool DatabaseFeedManager::getVulnerabilityDescriptiveInformation(
     const std::string& cveId,
     const std::string& subShortName,
     FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)

--- a/src/engine/source/feedmanager/src/updateCVEDescription.hpp
+++ b/src/engine/source/feedmanager/src/updateCVEDescription.hpp
@@ -16,7 +16,7 @@
 #include "cve5_generated.h"
 #include "vulnerabilityDescription_generated.h"
 
-constexpr auto DESCRIPTIONS_COLUMN {"descriptions_nvd"};
+constexpr auto DESCRIPTIONS_COLUMN {"descriptions"};
 /**
  * @brief UpdateCVEDescription class.
  *

--- a/src/engine/source/feedmanager/test/mocks/feedmanager/mockDatabaseFeedManager.hpp
+++ b/src/engine/source/feedmanager/test/mocks/feedmanager/mockDatabaseFeedManager.hpp
@@ -95,12 +95,12 @@ public:
                 ());
 
     /**
-     * @brief Mock method for getVulnerabiltyDescriptiveInformation.
+     * @brief Mock method for getVulnerabilityDescriptiveInformation.
      *
      * @note This method is intended for testing purposes and does not perform any real action.
      */
     MOCK_METHOD(bool,
-                getVulnerabiltyDescriptiveInformation,
+                getVulnerabilityDescriptiveInformation,
                 (const std::string& cveId,
                  const std::string& subShortName,
                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer),

--- a/src/engine/source/feedmanager/test/mocks/feedmanager/mockDatabaseFeedManager.hpp
+++ b/src/engine/source/feedmanager/test/mocks/feedmanager/mockDatabaseFeedManager.hpp
@@ -99,9 +99,10 @@ public:
      *
      * @note This method is intended for testing purposes and does not perform any real action.
      */
-    MOCK_METHOD(void,
+    MOCK_METHOD(bool,
                 getVulnerabiltyDescriptiveInformation,
-                (const std::string_view cveId,
+                (const std::string& cveId,
+                 const std::string& subShortName,
                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer),
                 ());
 

--- a/src/engine/source/feedmanager/test/mocks/feedmanager/mockDatabaseFeedManager.hpp
+++ b/src/engine/source/feedmanager/test/mocks/feedmanager/mockDatabaseFeedManager.hpp
@@ -139,6 +139,12 @@ public:
      *
      */
     MOCK_METHOD(const nlohmann::json&, cnaMappings, (), ());
+
+    /**
+     * @brief Mock method for vendorsMap.
+     *
+     */
+    MOCK_METHOD(const nlohmann::json&, vendorsMap, (), ());
 };
 
 #endif // _MOCK_DATABASEFEEDMANAGER_HPP

--- a/src/engine/source/vdscanner/CMakeLists.txt
+++ b/src/engine/source/vdscanner/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(vdscanner_utest
     ${UNIT_SRC_DIR}/factoryOrchestrator_test.cpp
     ${UNIT_SRC_DIR}/responseBuilder_test.cpp
     ${UNIT_SRC_DIR}/scanContext_test.cpp
+    ${UNIT_SRC_DIR}/descriptionsHelper_test.cpp
 )
 target_compile_definitions(vdscanner_utest PUBLIC FLATBUFFER_SCHEMAS_DIR="${CMAKE_CURRENT_LIST_DIR}/../feedmanager/schemas/")
 target_link_libraries(vdscanner_utest GTest::gmock GTest::gtest_main vdscanner feedmanager::mocks)

--- a/src/engine/source/vdscanner/src/descriptionsHelper.hpp
+++ b/src/engine/source/vdscanner/src/descriptionsHelper.hpp
@@ -1,0 +1,261 @@
+/*
+ * Wazuh Vulnerability scanner
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 22, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#ifndef _DESCRIPTIONS_HELPER_HPP
+#define _DESCRIPTIONS_HELPER_HPP
+
+#include <databaseFeedManager.hpp>
+#include <base/json.hpp>
+#include <string>
+
+/**
+ * @brief Holds information about a vulnerability's CVSS metrics and related data.
+ */
+struct CveDescription final
+{
+    /**
+     * @brief Complexity of access required to exploit the vulnerability (CVSS metric).
+     */
+    std::string_view accessComplexity;
+
+    /**
+     * @brief Short name of the entity that assigned the CVE.
+     */
+    std::string_view assignerShortName;
+
+    /**
+     * @brief The context by which vulnerability exploitation is possible (CVSS metric).
+     */
+    std::string_view attackVector;
+
+    /**
+     * @brief Level of authentication needed to exploit the vulnerability (CVSS metric).
+     */
+    std::string_view authentication;
+
+    /**
+     * @brief Impact on the availability of the target system (CVSS metric).
+     */
+    std::string_view availabilityImpact;
+
+    /**
+     * @brief The classification or category of the vulnerability.
+     */
+    std::string_view classification;
+
+    /**
+     * @brief Impact on the confidentiality of the target system (CVSS metric).
+     */
+    std::string_view confidentialityImpact;
+
+    /**
+     * @brief Common Weakness Enumeration (CWE) identifier for the vulnerability.
+     */
+    std::string_view cweId;
+
+    /**
+     * @brief Date when the vulnerability was first published.
+     */
+    std::string_view datePublished;
+
+    /**
+     * @brief Date when the vulnerability was last updated.
+     */
+    std::string_view dateUpdated;
+
+    /**
+     * @brief Detailed description of the vulnerability.
+     */
+    std::string_view description;
+
+    /**
+     * @brief Impact on the integrity of the target system (CVSS metric).
+     */
+    std::string_view integrityImpact;
+
+    /**
+     * @brief Level of privileges required to exploit the vulnerability (CVSS metric).
+     */
+    std::string_view privilegesRequired;
+
+    /**
+     * @brief Reference URL or document related to the vulnerability.
+     */
+    std::string_view reference;
+
+    /**
+     * @brief Scope of impact once the vulnerability is exploited (CVSS metric).
+     */
+    std::string_view scope;
+
+    /**
+     * @brief Base CVSS score indicating the severity of the vulnerability.
+     * @details Initialized to 0.0 by default.
+     */
+    float scoreBase = 0.0f;
+
+    /**
+     * @brief The version of the CVSS scoring system used.
+     */
+    std::string_view scoreVersion;
+
+    /**
+     * @brief Severity level of the vulnerability (e.g., Low, Medium, High).
+     */
+    std::string_view severity;
+
+    /**
+     * @brief Indicates if user interaction is required to exploit the vulnerability (CVSS metric).
+     */
+    std::string_view userInteraction;
+};
+
+/**
+ * @brief Descriptions helper class.
+ */
+class DescriptionsHelper final
+{
+private:
+    template<typename TDatabaseFeedManager = DatabaseFeedManager>
+    static std::pair<const std::string, const std::string>
+    cvssAndDescriptionSources(const std::pair<std::string, std::string>& sources,
+                              std::shared_ptr<TDatabaseFeedManager>& databaseFeedManager)
+    {
+        // Ex. sources = {"redhat", "redhat_8"}
+        const auto& [adp, expandedAdp] = sources;
+        const auto& vendorsMap = databaseFeedManager->vendorsMap();
+
+        nlohmann::json vendorConfig;
+        if (vendorsMap.at(ADP_DESCRIPTIONS_MAP_KEY).contains(adp))
+        {
+            vendorConfig = vendorsMap.at(ADP_DESCRIPTIONS_MAP_KEY).at(adp);
+        }
+        else
+        {
+            // Fallback to default ADP
+            vendorConfig = vendorsMap.at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
+        }
+
+        const auto& cvssSource = vendorConfig.at(ADP_CVSS_KEY).get_ref<const std::string&>();
+        const auto& descriptionSource = vendorConfig.at(ADP_DESCRIPTION_KEY).get_ref<const std::string&>();
+
+        return {cvssSource == adp ? expandedAdp : cvssSource,
+                descriptionSource == adp ? expandedAdp : descriptionSource};
+    }
+
+public:
+    /**
+     * @brief Get the vulnerability description and CVSS metrics for a given CVE.
+     *
+     * @note Attempt to retrieve the information from the specified sources. If the information is not available (or it
+     * is not reliable), it uses the default ADP information instead.
+     *
+     * @tparam TDatabaseFeedManager Database feed manager type.
+     *
+     * @param cve CVE identifier.
+     * @param sources Pair of sources (ADP and expanded ADP).
+     * @param databaseFeedManager Database feed manager instance.
+     * @param callback Callback function to call with the retrieved CveDescription object.
+     *
+     */
+    template<typename TDatabaseFeedManager = DatabaseFeedManager>
+    static void vulnerabilityDescription(const std::string& cve,
+                                         const std::pair<std::string, std::string>& sources,
+                                         std::shared_ptr<TDatabaseFeedManager>& databaseFeedManager,
+                                         const std::function<void(const CveDescription&)>& callback)
+    {
+        FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> descriptionData;
+        FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> cvssData;
+
+        const auto [cvssSource, descriptionSource] =
+            DescriptionsHelper::cvssAndDescriptionSources(sources, databaseFeedManager);
+
+        // Get description data
+
+        // Check if the description information is reliable
+        // The description information is considered unreliable if the description is empty or "not defined"
+        const auto descriptionIsReliable = [&descriptionData]()
+        {
+            if (!descriptionData.data->description() || descriptionData.data->description()->str() == "not defined")
+            {
+                return false;
+            }
+
+            return true;
+        };
+
+        if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
+        {
+            // Information not from source, try with default ADP
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+        }
+
+        if (!descriptionIsReliable() && descriptionSource != DEFAULT_ADP)
+        {
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+        }
+
+        // Get CVSS data
+
+        // Check if the CVSS information is reliable
+        // The CVSS information is considered unreliable if the score is near 0 or the severity is empty
+        const auto cvssIsReliable = [&cvssData, &cvssSource]()
+        {
+            if (cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
+            {
+                return false;
+            }
+
+            return true;
+        };
+
+        if (cvssSource != descriptionSource)
+        {
+            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData))
+            {
+                // Information not from source, try with default ADP
+                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+            }
+        }
+        else
+        {
+            // If the sources are the same, cvssData will be the same as descriptionData
+            cvssData.data = descriptionData.data;
+        }
+
+        if (!cvssIsReliable() && cvssSource != DEFAULT_ADP)
+        {
+            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+        }
+
+        // Call the callback function with the CveDescription object
+        callback(CveDescription {cvssData.data->accessComplexity()->string_view(),
+                                 descriptionData.data->assignerShortName()->string_view(),
+                                 cvssData.data->attackVector()->string_view(),
+                                 cvssData.data->authentication()->string_view(),
+                                 cvssData.data->availabilityImpact()->string_view(),
+                                 cvssData.data->classification()->string_view(),
+                                 cvssData.data->confidentialityImpact()->string_view(),
+                                 descriptionData.data->cweId()->string_view(),
+                                 descriptionData.data->datePublished()->string_view(),
+                                 descriptionData.data->dateUpdated()->string_view(),
+                                 descriptionData.data->description()->string_view(),
+                                 cvssData.data->integrityImpact()->string_view(),
+                                 cvssData.data->privilegesRequired()->string_view(),
+                                 descriptionData.data->reference()->string_view(),
+                                 cvssData.data->scope()->string_view(),
+                                 cvssData.data->scoreBase(),
+                                 cvssData.data->scoreVersion()->string_view(),
+                                 cvssData.data->severity()->string_view(),
+                                 cvssData.data->userInteraction()->string_view()});
+    }
+};
+
+#endif // _DESCRIPTIONS_HELPER_HPP

--- a/src/engine/source/vdscanner/src/descriptionsHelper.hpp
+++ b/src/engine/source/vdscanner/src/descriptionsHelper.hpp
@@ -11,8 +11,9 @@
 #ifndef _DESCRIPTIONS_HELPER_HPP
 #define _DESCRIPTIONS_HELPER_HPP
 
-#include <databaseFeedManager.hpp>
 #include <base/json.hpp>
+#include <base/logging.hpp>
+#include <databaseFeedManager.hpp>
 #include <string>
 
 /**
@@ -20,101 +21,105 @@
  */
 struct CveDescription final
 {
+    static constexpr const char* DEFAULT_STR_VALUE = "";                     ///< Default value for strings.
+    static constexpr float DEFAULT_FLOAT_VALUE = 0.0f;                       ///< Default value for floats.
+    static constexpr const char* DEFAULT_TIMESTAMP = "0000-01-01T00:00:00Z"; ///< Default value for timestamps.
+
     /**
      * @brief Complexity of access required to exploit the vulnerability (CVSS metric).
      */
-    std::string_view accessComplexity;
+    std::string_view accessComplexity = DEFAULT_STR_VALUE;
 
     /**
      * @brief Short name of the entity that assigned the CVE.
      */
-    std::string_view assignerShortName;
+    std::string_view assignerShortName = DEFAULT_STR_VALUE;
 
     /**
      * @brief The context by which vulnerability exploitation is possible (CVSS metric).
      */
-    std::string_view attackVector;
+    std::string_view attackVector = DEFAULT_STR_VALUE;
 
     /**
      * @brief Level of authentication needed to exploit the vulnerability (CVSS metric).
      */
-    std::string_view authentication;
+    std::string_view authentication = DEFAULT_STR_VALUE;
 
     /**
      * @brief Impact on the availability of the target system (CVSS metric).
      */
-    std::string_view availabilityImpact;
+    std::string_view availabilityImpact = DEFAULT_STR_VALUE;
 
     /**
      * @brief The classification or category of the vulnerability.
      */
-    std::string_view classification;
+    std::string_view classification = DEFAULT_STR_VALUE;
 
     /**
      * @brief Impact on the confidentiality of the target system (CVSS metric).
      */
-    std::string_view confidentialityImpact;
+    std::string_view confidentialityImpact = DEFAULT_STR_VALUE;
 
     /**
      * @brief Common Weakness Enumeration (CWE) identifier for the vulnerability.
      */
-    std::string_view cweId;
+    std::string_view cweId = DEFAULT_STR_VALUE;
 
     /**
      * @brief Date when the vulnerability was first published.
      */
-    std::string_view datePublished;
+    std::string_view datePublished = DEFAULT_TIMESTAMP;
 
     /**
      * @brief Date when the vulnerability was last updated.
      */
-    std::string_view dateUpdated;
+    std::string_view dateUpdated = DEFAULT_TIMESTAMP;
 
     /**
      * @brief Detailed description of the vulnerability.
      */
-    std::string_view description;
+    std::string_view description = DEFAULT_STR_VALUE;
 
     /**
      * @brief Impact on the integrity of the target system (CVSS metric).
      */
-    std::string_view integrityImpact;
+    std::string_view integrityImpact = DEFAULT_STR_VALUE;
 
     /**
      * @brief Level of privileges required to exploit the vulnerability (CVSS metric).
      */
-    std::string_view privilegesRequired;
+    std::string_view privilegesRequired = DEFAULT_STR_VALUE;
 
     /**
      * @brief Reference URL or document related to the vulnerability.
      */
-    std::string_view reference;
+    std::string_view reference = DEFAULT_STR_VALUE;
 
     /**
      * @brief Scope of impact once the vulnerability is exploited (CVSS metric).
      */
-    std::string_view scope;
+    std::string_view scope = DEFAULT_STR_VALUE;
 
     /**
      * @brief Base CVSS score indicating the severity of the vulnerability.
      * @details Initialized to 0.0 by default.
      */
-    float scoreBase = 0.0f;
+    float scoreBase = DEFAULT_FLOAT_VALUE;
 
     /**
      * @brief The version of the CVSS scoring system used.
      */
-    std::string_view scoreVersion;
+    std::string_view scoreVersion = DEFAULT_STR_VALUE;
 
     /**
      * @brief Severity level of the vulnerability (e.g., Low, Medium, High).
      */
-    std::string_view severity;
+    std::string_view severity = DEFAULT_STR_VALUE;
 
     /**
      * @brief Indicates if user interaction is required to exploit the vulnerability (CVSS metric).
      */
-    std::string_view userInteraction;
+    std::string_view userInteraction = DEFAULT_STR_VALUE;
 };
 
 /**
@@ -177,51 +182,66 @@ public:
         const auto [cvssSource, descriptionSource] =
             DescriptionsHelper::cvssAndDescriptionSources(sources, databaseFeedManager);
 
-        // Get description data
+        bool defaultADPRetrievalFailed = false;
 
+        // Get description data
         // Check if the description information is reliable
         // The description information is considered unreliable if the description is empty or "not defined"
-        const auto descriptionIsReliable = [&descriptionData]()
+        const auto descriptionIsReliable = [&descriptionData, &descriptionSource, &cve]()
         {
-            if (!descriptionData.data->description() || descriptionData.data->description()->str() == "not defined")
+            if (!descriptionData.data || descriptionData.data->description()->str() == "not defined")
             {
+                LOG_DEBUG("Unreliable description information for '{}' from '{}' source.",
+                          cve.c_str(),
+                          descriptionSource.c_str());
                 return false;
             }
 
             return true;
         };
 
-        if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, descriptionSource, descriptionData))
+        // Get vulnerability descriptive information using the description source specified for the feed vendor.
+        if (!databaseFeedManager->getVulnerabilityDescriptiveInformation(cve, descriptionSource, descriptionData))
         {
-            // Information not from source, try with default ADP
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+            LOG_DEBUG("Description information could not be obtained for '{}' from '{}' source.",
+                      cve.c_str(),
+                      descriptionSource.c_str());
         }
 
+        // Only attempt to retrieve the descriptive information if the source differs from the DEFAULT_ADP
         if (!descriptionIsReliable() && descriptionSource != DEFAULT_ADP)
         {
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, descriptionData);
+            if (!databaseFeedManager->getVulnerabilityDescriptiveInformation(cve, DEFAULT_ADP, descriptionData))
+            {
+                LOG_DEBUG("Description information could not be obtained for '{}' from '{}' source.",
+                          cve.c_str(),
+                          DEFAULT_ADP);
+                defaultADPRetrievalFailed = true;
+            }
         }
 
         // Get CVSS data
-
         // Check if the CVSS information is reliable
         // The CVSS information is considered unreliable if the score is near 0 or the severity is empty
-        const auto cvssIsReliable = [&cvssData, &cvssSource]()
+        const auto cvssIsReliable = [&cvssData, &cvssSource, &cve]()
         {
-            if (cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
+            if (!cvssData.data || cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
             {
+                LOG_DEBUG("Unreliable information for '{}' from %s source.", cve.c_str(), cvssSource.c_str());
                 return false;
             }
 
             return true;
         };
 
+        // Only if cvssSource is not the same as the previous one.
         if (cvssSource != descriptionSource)
         {
-            if (!databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, cvssSource, cvssData))
+            if (!databaseFeedManager->getVulnerabilityDescriptiveInformation(cve, cvssSource, cvssData))
             {
-                // Information not from source, try with default ADP
-                databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+                LOG_DEBUG("CVSS information could not be obtained for '{}' from '{}' source.",
+                          cve.c_str(),
+                          cvssSource.c_str());
             }
         }
         else
@@ -230,31 +250,60 @@ public:
             cvssData.data = descriptionData.data;
         }
 
+        // Attempt with default ADP if the information is not reliable.
         if (!cvssIsReliable() && cvssSource != DEFAULT_ADP)
         {
-            databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, DEFAULT_ADP, cvssData);
+            if (!defaultADPRetrievalFailed)
+            {
+                if (!databaseFeedManager->getVulnerabilityDescriptiveInformation(cve, DEFAULT_ADP, cvssData))
+                {
+                    LOG_DEBUG(
+                        "CVSS information could not be obtained for '{}' from '{}' source.", cve.c_str(), DEFAULT_ADP);
+                }
+            }
+        }
+
+        // Assign a value to the target variable if the value is not empty
+        const auto assignValue = [](std::string_view& target, const flatbuffers::string_view& value)
+        {
+            if (!value.empty())
+            {
+                target = value;
+            }
+        };
+
+        // Creating struct with default values.
+        CveDescription cveDescription {};
+
+        if (cvssData.data)
+        {
+            assignValue(cveDescription.accessComplexity, cvssData.data->accessComplexity()->string_view());
+            assignValue(cveDescription.attackVector, cvssData.data->attackVector()->string_view());
+            assignValue(cveDescription.authentication, cvssData.data->authentication()->string_view());
+            assignValue(cveDescription.availabilityImpact, cvssData.data->availabilityImpact()->string_view());
+            assignValue(cveDescription.classification, cvssData.data->classification()->string_view());
+            assignValue(cveDescription.confidentialityImpact, cvssData.data->confidentialityImpact()->string_view());
+            assignValue(cveDescription.integrityImpact, cvssData.data->integrityImpact()->string_view());
+            assignValue(cveDescription.privilegesRequired, cvssData.data->privilegesRequired()->string_view());
+            assignValue(cveDescription.scope, cvssData.data->scope()->string_view());
+            assignValue(cveDescription.scoreVersion, cvssData.data->scoreVersion()->string_view());
+            assignValue(cveDescription.severity, cvssData.data->severity()->string_view());
+            assignValue(cveDescription.userInteraction, cvssData.data->userInteraction()->string_view());
+            cveDescription.scoreBase = cvssData.data->scoreBase();
+        }
+
+        if (descriptionData.data)
+        {
+            assignValue(cveDescription.assignerShortName, descriptionData.data->assignerShortName()->string_view());
+            assignValue(cveDescription.cweId, descriptionData.data->cweId()->string_view());
+            assignValue(cveDescription.datePublished, descriptionData.data->datePublished()->string_view());
+            assignValue(cveDescription.dateUpdated, descriptionData.data->dateUpdated()->string_view());
+            assignValue(cveDescription.description, descriptionData.data->description()->string_view());
+            assignValue(cveDescription.reference, descriptionData.data->reference()->string_view());
         }
 
         // Call the callback function with the CveDescription object
-        callback(CveDescription {cvssData.data->accessComplexity()->string_view(),
-                                 descriptionData.data->assignerShortName()->string_view(),
-                                 cvssData.data->attackVector()->string_view(),
-                                 cvssData.data->authentication()->string_view(),
-                                 cvssData.data->availabilityImpact()->string_view(),
-                                 cvssData.data->classification()->string_view(),
-                                 cvssData.data->confidentialityImpact()->string_view(),
-                                 descriptionData.data->cweId()->string_view(),
-                                 descriptionData.data->datePublished()->string_view(),
-                                 descriptionData.data->dateUpdated()->string_view(),
-                                 descriptionData.data->description()->string_view(),
-                                 cvssData.data->integrityImpact()->string_view(),
-                                 cvssData.data->privilegesRequired()->string_view(),
-                                 descriptionData.data->reference()->string_view(),
-                                 cvssData.data->scope()->string_view(),
-                                 cvssData.data->scoreBase(),
-                                 cvssData.data->scoreVersion()->string_view(),
-                                 cvssData.data->severity()->string_view(),
-                                 cvssData.data->userInteraction()->string_view()});
+        callback(cveDescription);
     }
 };
 

--- a/src/engine/source/vdscanner/src/descriptionsHelper.hpp
+++ b/src/engine/source/vdscanner/src/descriptionsHelper.hpp
@@ -227,7 +227,7 @@ public:
         {
             if (!cvssData.data || cvssData.data->scoreBase() < 0.01f || cvssData.data->severity()->str().empty())
             {
-                LOG_DEBUG("Unreliable information for '{}' from %s source.", cve.c_str(), cvssSource.c_str());
+                LOG_DEBUG("Unreliable information for '{}' from {} source.", cve.c_str(), cvssSource.c_str());
                 return false;
             }
 

--- a/src/engine/source/vdscanner/src/fieldAlertHelper.hpp
+++ b/src/engine/source/vdscanner/src/fieldAlertHelper.hpp
@@ -30,8 +30,8 @@ namespace FieldAlertHelper
 template<typename T>
 nlohmann::json fillEmptyOrNegative(T&& field)
 {
-    if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string_view>
-                  || std::is_same_v<T, std::string>)
+    if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>,
+                                 std::string_view> || std::is_same_v<T, std::string>)
     {
         // Return "-" if the string is empty, otherwise return the original string
         return field.empty() ? "-" : std::forward<T>(field);
@@ -55,8 +55,8 @@ nlohmann::json fillEmptyOrNegative(T&& field)
     else
     {
         // Compile-time check to ensure unsupported types are caught early
-        static_assert(std::is_arithmetic_v<std::remove_cv_t<std::remove_reference_t<T>>>
-                          || std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string>,
+        static_assert(std::is_arithmetic_v<std::remove_cv_t<std::remove_reference_t<
+                              T>>> || std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string>,
                       "Unsupported type for fillEmptyOrNegative");
     }
 }

--- a/src/engine/source/vdscanner/src/fieldAlertHelper.hpp
+++ b/src/engine/source/vdscanner/src/fieldAlertHelper.hpp
@@ -1,0 +1,66 @@
+#ifndef FIELD_ALERT_HELPER_HPP
+#define FIELD_ALERT_HELPER_HPP
+
+#include <base/json.hpp>
+#include <string>
+#include <type_traits>
+
+namespace FieldAlertHelper
+{
+
+/**
+ * @brief High-performance utility function to replace empty strings or zero/negative numeric values with
+ * placeholders.
+ *
+ * This function ensures fields such as strings and numeric values are not left empty or with undesired values.
+ * It either returns the original value or a default placeholder based on the input type and its value:
+ *
+ * - For `std::string` types, it returns `"-"` if the string is empty, otherwise it returns the original string.
+ * - For numeric types (`double`, `int`, etc.), it returns `-1` if the value is zero or negative, otherwise it
+ * returns the original value.
+ *
+ * The function is optimized for performance with minimal branching and efficient memory management.
+ *
+ * @tparam T The type of the field being processed (`std::string`, `double`, `int`, etc.).
+ * @param field The field value to check and potentially replace.
+ * @return nlohmann::json A JSON-compatible value, either the original value or a placeholder.
+ *
+ * @throws std::runtime_error If the field type is unsupported.
+ */
+template<typename T>
+nlohmann::json fillEmptyOrNegative(T&& field)
+{
+    if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string_view>
+                  || std::is_same_v<T, std::string>)
+    {
+        // Return "-" if the string is empty, otherwise return the original string
+        return field.empty() ? "-" : std::forward<T>(field);
+    }
+    else if constexpr (std::is_arithmetic_v<std::remove_cv_t<std::remove_reference_t<T>>>)
+    {
+        // Use a small epsilon value for floating-point comparisons
+        constexpr double epsilon = 1e-9;
+
+        // Handle floating-point numbers
+        if constexpr (std::is_floating_point_v<std::remove_cv_t<std::remove_reference_t<T>>>)
+        {
+            return (std::abs(field) < epsilon) ? -1.0 : std::forward<T>(field);
+        }
+        else
+        {
+            // Handle integral numbers: return -1 for negatives
+            return (field < 0) ? -1 : std::forward<T>(field);
+        }
+    }
+    else
+    {
+        // Compile-time check to ensure unsupported types are caught early
+        static_assert(std::is_arithmetic_v<std::remove_cv_t<std::remove_reference_t<T>>>
+                          || std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, std::string>,
+                      "Unsupported type for fillEmptyOrNegative");
+    }
+}
+
+} // namespace FieldAlertHelper
+
+#endif // FIELD_ALERT_HELPER_HPP

--- a/src/engine/source/vdscanner/src/osScanner.hpp
+++ b/src/engine/source/vdscanner/src/osScanner.hpp
@@ -18,6 +18,8 @@
 #include "scannerHelper.hpp"
 #include "versionMatcher/versionMatcher.hpp"
 
+auto constexpr OS_SCANNER_CNA {"nvd"};
+
 /**
  * @brief OsScanner class.
  * This class is in charge of scanning the OS for vulnerabilities.
@@ -254,7 +256,9 @@ public:
                 {
                     PackageData package = {.name = osCPE.product};
 
-                    m_databaseFeedManager->getVulnerabilitiesCandidates("nvd", package, vulnerabilityScan);
+                    data->m_vulnerabilitySource = std::make_pair(OS_SCANNER_CNA, OS_SCANNER_CNA);
+
+                    m_databaseFeedManager->getVulnerabilitiesCandidates(OS_SCANNER_CNA, package, vulnerabilityScan);
 
                     if (data->osPlatform() == "windows")
                     {

--- a/src/engine/source/vdscanner/src/packageScanner.hpp
+++ b/src/engine/source/vdscanner/src/packageScanner.hpp
@@ -22,7 +22,6 @@
 #include <memory>
 #include <variant>
 
-auto constexpr DEFAULT_CNA {"nvd"};
 auto constexpr L1_CACHE_SIZE {2048};
 
 /**
@@ -126,9 +125,10 @@ private:
      * @brief Define what CNA will be used to read the data.
      *
      * @param ctx Scan context.
-     * @return std::string CNA name.
+     * @return std::pair<std::string, std::string> CNA pair.
+     *
      */
-    std::string getCNA(std::shared_ptr<TScanContext> ctx)
+    std::pair<std::string, std::string> getCNA(std::shared_ptr<TScanContext> ctx)
     {
         auto cnaName {m_databaseFeedManager->getCnaNameByFormat(ctx->packageFormat().data())};
 
@@ -145,7 +145,7 @@ private:
                                                                           ctx->osPlatform().data());
                     if (cnaName.empty())
                     {
-                        return DEFAULT_CNA;
+                        return {DEFAULT_CNA, DEFAULT_CNA};
                     }
                 }
             }
@@ -190,7 +190,7 @@ private:
 
         if (const auto it = cnaMapping.find(cnaName); it == cnaMapping.end())
         {
-            return cnaName;
+            return {cnaName, cnaName};
         }
         else
         {
@@ -200,7 +200,7 @@ private:
                 base,
                 "$(MAJOR_VERSION)",
                 majorVersionEquivalence(ctx->osPlatform().data(), ctx->osMajorVersion().data()));
-            return base;
+            return {cnaName, base};
         }
     }
 
@@ -609,7 +609,8 @@ public:
             }
         };
 
-        const auto CNAValue = getCNA(data);
+        data->m_vulnerabilitySource = getCNA(data);
+        const auto& CNAValue = data->m_vulnerabilitySource.second;
 
         try
         {

--- a/src/engine/source/vdscanner/src/responseBuilder.hpp
+++ b/src/engine/source/vdscanner/src/responseBuilder.hpp
@@ -18,6 +18,7 @@
 #include "base/utils/stringUtils.hpp"
 #include "base/utils/timeUtils.hpp"
 #include "databaseFeedManager.hpp"
+#include "descriptionsHelper.hpp"
 #include "scanContext.hpp"
 
 /**
@@ -37,42 +38,40 @@ class TResponseBuilder final : public utils::patterns::AbstractHandler<std::shar
 private:
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
 
-    void buildUnderEvaluation(nlohmann::json& json, const NSVulnerabilityScanner::VulnerabilityDescription* data)
+    void buildUnderEvaluation(nlohmann::json& json, CveDescription description)
     {
-        json["under_evaluation"] = base::utils::numeric::floatToDoubleRound(data->scoreBase(), 2) == 0
-                                   || data->classification()->str().empty() || data->severity()->str().empty();
+        json["under_evaluation"] = base::utils::numeric::floatToDoubleRound(description.scoreBase, 2) == 0
+                                   || description.classification.empty() || description.severity.empty();
     }
 
-    void buildScore(const std::string& cveId,
-                    nlohmann::json& json,
-                    const NSVulnerabilityScanner::VulnerabilityDescription* data)
+    void buildScore(const std::string& cveId, nlohmann::json& json, CveDescription description)
     {
-        const auto cvssVersion {data->scoreVersion()->str()};
-        const auto scoreVersion {"cvss" + cvssVersion.substr(0, 1)};
+        const auto cvssVersion {description.scoreVersion};
+        const auto scoreVersion {std::string("cvss") + cvssVersion.front()};
 
         if (!cvssVersion.empty())
         {
             nlohmann::json vectorObj;
             if (scoreVersion.compare("cvss2") == 0)
             {
-                vectorObj["access_complexity"] = data->accessComplexity()->str();
-                vectorObj["authentication"] = data->authentication()->str();
+                vectorObj["access_complexity"] = description.accessComplexity;
+                vectorObj["authentication"] = description.authentication;
             }
             else if (scoreVersion.compare("cvss3") == 0)
             {
-                vectorObj["attack_vector"] = data->attackVector()->str();
-                vectorObj["privileges_required"] = data->privilegesRequired()->str();
-                vectorObj["scope"] = data->scope()->str();
-                vectorObj["user_interaction"] = data->userInteraction()->str();
+                vectorObj["attack_vector"] = description.attackVector;
+                vectorObj["privileges_required"] = description.privilegesRequired;
+                vectorObj["scope"] = description.scope;
+                vectorObj["user_interaction"] = description.userInteraction;
             }
             else
             {
                 LOG_DEBUG("CVSS version not supported: {}", cvssVersion);
             }
 
-            vectorObj["availability"] = data->availabilityImpact()->str();
-            vectorObj["confidentiality_impact"] = data->confidentialityImpact()->str();
-            vectorObj["integrity_impact"] = data->integrityImpact()->str();
+            vectorObj["availability"] = description.availabilityImpact;
+            vectorObj["confidentiality_impact"] = description.confidentialityImpact;
+            vectorObj["integrity_impact"] = description.integrityImpact;
 
             json["cvss"][scoreVersion]["vector"] = std::move(vectorObj);
         }
@@ -159,54 +158,64 @@ public:
         // For each element, we get the vulnerability descriptive information and build the event details.
         for (auto& [cve, json] : data->m_elements)
         {
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription> returnData;
-            m_databaseFeedManager->getVulnerabiltyDescriptiveInformation(cve, returnData);
-            if (returnData.data)
+            try
             {
-                switch (data->scannerType())
-                {
-                    case ScannerType::Package:
-                        json["category"] = "Packages";
-                        json["item_id"] = data->packageItemId();
-                        break;
+                DescriptionsHelper::vulnerabilityDescription(
+                    cve,
+                    data->m_vulnerabilitySource,
+                    m_databaseFeedManager,
+                    [&](const CveDescription& description)
+                    {
+                        switch (data->scannerType())
+                        {
+                            case ScannerType::Package:
+                                json["category"] = "Packages";
+                                json["item_id"] = data->packageItemId();
+                                break;
 
-                    case ScannerType::Os: json["category"] = "OS"; break;
+                            case ScannerType::Os: json["category"] = "OS"; break;
 
-                    default: throw std::invalid_argument("Invalid scanner type"); break;
-                }
+                            default: throw std::invalid_argument("Invalid scanner type"); break;
+                        }
 
-                // Status date
-                json["classification"] = returnData.data->classification()->str();
-                json["description"] = returnData.data->description()->str();
-                json["detected_at"] = base::utils::time::getCurrentISO8601();
-                json["enumeration"] = "CVE";
-                json["id"] = cve;
-                json["published_at"] = returnData.data->datePublished()->str();
-                json["reference"] = returnData.data->reference()->str();
-                json["score"]["base"] = base::utils::numeric::floatToDoubleRound(returnData.data->scoreBase(), 2);
-                json["score"]["version"] = returnData.data->scoreVersion()->str();
-                json["severity"] = base::utils::string::toSentenceCase(returnData.data->severity()->str());
-                json["source"] = vulnerabilitySource;
+                        // Status date
+                        json["classification"] = description.classification;
+                        json["description"] = description.description;
+                        json["detected_at"] = base::utils::time::getCurrentISO8601();
+                        json["enumeration"] = "CVE";
+                        json["id"] = cve;
+                        json["published_at"] = description.datePublished;
+                        json["reference"] = description.reference;
+                        json["score"]["base"] = base::utils::numeric::floatToDoubleRound(description.scoreBase, 2);
+                        json["score"]["version"] = description.scoreVersion;
+                        json["severity"] = base::utils::string::toSentenceCase(
+                            std::string(description.severity.data(), description.severity.size()));
+                        json["source"] = vulnerabilitySource;
 
-                // Alert data
-                json["assigner"] = returnData.data->assignerShortName()->str();
-                json["cwe_reference"] = returnData.data->cweId()->str();
-                json["updated"] = returnData.data->dateUpdated()->str();
+                        // Alert data
+                        json["assigner"] = description.assignerShortName;
+                        json["cwe_reference"] = description.cweId;
+                        json["updated"] = description.dateUpdated;
 
-                if (const auto it = data->m_matchConditions.find(cve); it != data->m_matchConditions.end())
-                {
-                    buildMatchCondition(json, it->second);
-                }
-                else
-                {
-                    // If we dont have a match condition, we dont have a CVE match, and this is an error.
-                    throw std::invalid_argument("Match condition not found for CVE: " + cve);
-                }
+                        if (const auto it = data->m_matchConditions.find(cve); it != data->m_matchConditions.end())
+                        {
+                            buildMatchCondition(json, it->second);
+                        }
+                        else
+                        {
+                            // If we dont have a match condition, we dont have a CVE match, and this is an error.
+                            throw std::invalid_argument("Match condition not found for CVE: " + cve);
+                        }
 
-                buildScore(cve, json, returnData.data);
-                buildUnderEvaluation(json, returnData.data);
+                        buildScore(cve, json, description);
+                        buildUnderEvaluation(json, description);
 
-                data->moveResponseData(json);
+                        data->moveResponseData(json);
+                    });
+            }
+            catch (const std::exception& e)
+            {
+                LOG_ERROR("Error building event details for CVE: {}. Error message: {}", cve, e.what());
             }
         }
 

--- a/src/engine/source/vdscanner/src/responseBuilder.hpp
+++ b/src/engine/source/vdscanner/src/responseBuilder.hpp
@@ -37,6 +37,12 @@ class TResponseBuilder final : public utils::patterns::AbstractHandler<std::shar
 private:
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
 
+    void buildUnderEvaluation(nlohmann::json& json, const NSVulnerabilityScanner::VulnerabilityDescription* data)
+    {
+        json["under_evaluation"] = base::utils::numeric::floatToDoubleRound(data->scoreBase(), 2) == 0
+                                   || data->classification()->str().empty() || data->severity()->str().empty();
+    }
+
     void buildScore(const std::string& cveId,
                     nlohmann::json& json,
                     const NSVulnerabilityScanner::VulnerabilityDescription* data)
@@ -198,6 +204,7 @@ public:
                 }
 
                 buildScore(cve, json, returnData.data);
+                buildUnderEvaluation(json, returnData.data);
 
                 data->moveResponseData(json);
             }

--- a/src/engine/source/vdscanner/src/responseBuilder.hpp
+++ b/src/engine/source/vdscanner/src/responseBuilder.hpp
@@ -19,6 +19,7 @@
 #include "base/utils/timeUtils.hpp"
 #include "databaseFeedManager.hpp"
 #include "descriptionsHelper.hpp"
+#include "fieldAlertHelper.hpp"
 #include "scanContext.hpp"
 
 /**
@@ -179,17 +180,18 @@ public:
                         }
 
                         // Status date
-                        json["classification"] = description.classification;
+                        json["classification"] = FieldAlertHelper::fillEmptyOrNegative(description.classification);
                         json["description"] = description.description;
                         json["detected_at"] = base::utils::time::getCurrentISO8601();
                         json["enumeration"] = "CVE";
                         json["id"] = cve;
                         json["published_at"] = description.datePublished;
                         json["reference"] = description.reference;
-                        json["score"]["base"] = base::utils::numeric::floatToDoubleRound(description.scoreBase, 2);
-                        json["score"]["version"] = description.scoreVersion;
-                        json["severity"] = base::utils::string::toSentenceCase(
-                            std::string(description.severity.data(), description.severity.size()));
+                        json["score"]["base"] = FieldAlertHelper::fillEmptyOrNegative(
+                            base::utils::numeric::floatToDoubleRound(description.scoreBase, 2));
+                        json["score"]["version"] = FieldAlertHelper::fillEmptyOrNegative(description.scoreVersion);
+                        json["severity"] = FieldAlertHelper::fillEmptyOrNegative(base::utils::string::toSentenceCase(
+                            std::string(description.severity.data(), description.severity.size())));
                         json["source"] = vulnerabilitySource;
 
                         // Alert data

--- a/src/engine/source/vdscanner/src/responseBuilder.hpp
+++ b/src/engine/source/vdscanner/src/responseBuilder.hpp
@@ -126,7 +126,7 @@ public:
      * @param data Scan context.
      * @return std::shared_ptr<ScanContext> Abstract handler.
      */
-    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
+    std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<ScanContext> data) override
     {
         LOG_DEBUG("Building event details for component type: {}", static_cast<int>(data->scannerType()));
 
@@ -144,6 +144,11 @@ public:
         }
 
         nlohmann::json dataElements = nlohmann::json::array();
+
+        const auto vulnerabilitySource = m_databaseFeedManager->vendorsMap()
+                                             .at("adp_descriptions")
+                                             .at(std::get<VulnerabilitySource::ADP_BASE>(data->m_vulnerabilitySource))
+                                             .at("adp");
 
         // For each element, we get the vulnerability descriptive information and build the event details.
         for (auto& [cve, json] : data->m_elements)
@@ -175,6 +180,7 @@ public:
                 json["score"]["base"] = base::utils::numeric::floatToDoubleRound(returnData.data->scoreBase(), 2);
                 json["score"]["version"] = returnData.data->scoreVersion()->str();
                 json["severity"] = base::utils::string::toSentenceCase(returnData.data->severity()->str());
+                json["source"] = vulnerabilitySource;
 
                 // Alert data
                 json["assigner"] = returnData.data->assignerShortName()->str();

--- a/src/engine/source/vdscanner/src/scanContext.hpp
+++ b/src/engine/source/vdscanner/src/scanContext.hpp
@@ -536,7 +536,7 @@ public:
      *
      * @note Use @see VulnerabilitySource enum to access each field
      *
-     * @return Pair with CNA base name and CNA expanded name.
+     * @return Pair with CNA/ADP base name and CNA/ADP expanded name.
      */
     std::pair<std::string, std::string> m_vulnerabilitySource = std::make_pair(DEFAULT_CNA, DEFAULT_CNA);
 

--- a/src/engine/source/vdscanner/src/scanContext.hpp
+++ b/src/engine/source/vdscanner/src/scanContext.hpp
@@ -16,6 +16,14 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
+auto constexpr DEFAULT_CNA {"nvd"};
+
+enum VulnerabilitySource
+{
+    ADP_BASE = 0,
+    ADP_EXPANDED = 1
+};
+
 enum class ScannerType
 {
     Unknown = 0,
@@ -52,9 +60,6 @@ struct MatchCondition
 /**
  * @brief ScanContext structure.
  *
- * @tparam TOsDataCache os data cache type.
- * @tparam TGlobalData global data type.
- * @tparam TRemediationDataCache remediation data cache type.
  */
 struct ScanContext final
 {
@@ -525,6 +530,15 @@ public:
      *
      */
     std::unordered_map<std::string, MatchCondition> m_matchConditions;
+
+    /**
+     * @brief Feed source information.
+     *
+     * @note Use @see VulnerabilitySource enum to access each field
+     *
+     * @return Pair with CNA base name and CNA expanded name.
+     */
+    std::pair<std::string, std::string> m_vulnerabilitySource = std::make_pair(DEFAULT_CNA, DEFAULT_CNA);
 
     ScannerType scannerType() const { return m_type; }
 

--- a/src/engine/source/vdscanner/test/src/unit/descriptionsHelper_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/descriptionsHelper_test.cpp
@@ -57,6 +57,13 @@ const std::string ADP_CVSS_EQUALS_DESCRIPTION = "ADP_1";
 const std::string ADP_CVSS_DIFFERS_DESCRIPTION = "ADP_2";
 const std::string ADP_EXPANDED_POSTFIX = "_expanded";
 
+const auto createVulnerabilityDescriptiveInformationFail =
+    [](FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+{
+    resultContainer.data = nullptr;
+    return false;
+};
+
 const auto createVulnerabilityDescriptiveInformation =
     [](FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer,
        flatbuffers::DetachedBuffer& detachedBuffer,
@@ -90,6 +97,8 @@ const auto createVulnerabilityDescriptiveInformation =
     fbBuilder.Finish(vulnerabilityDescriptiveInformation);
     detachedBuffer = fbBuilder.Release();
     resultContainer.data = NSVulnerabilityScanner::GetVulnerabilityDescription(detachedBuffer.data());
+
+    return true;
 };
 
 const auto validateVulnerabilityDescriptiveInformation = [](const CveDescription& description)
@@ -137,18 +146,15 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
 
     // We expect one call to the database manager for both the CVSS and description
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
-        .WillOnce(::testing::Invoke(
-            [&](const std::string&,
-                const std::string&,
-                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
-                return true;
-            }));
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer); }));
 
     // We don't expect the database manager to be called with the default ADP
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
         .Times(0);
 
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -182,18 +188,15 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSource)
 
     // Expect two calls to the database manager, one for the description and one for the CVSS
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
@@ -204,7 +207,7 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSource)
             }));
 
     // We don't expect the database manager to be called with the default ADP
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
         .Times(0);
 
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -235,15 +238,12 @@ TEST_F(DescriptionsHelperTest, nonExistentAdp)
 
     // We get the information from the default ADP
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
-        .WillOnce(::testing::Invoke(
-            [&](const std::string&,
-                const std::string&,
-                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
-                return true;
-            }));
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
@@ -274,49 +274,42 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
 
     // Two calls to the default ADP fail, so we fallback to the default ADP
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, adpDescriptionSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, adpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
             {
                 flatbuffers::DetachedBuffer detachedBuffer;
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
-                return false;
+                return createVulnerabilityDescriptiveInformationFail(resultContainer);
             }));
 
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, adpCvssSource, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, adpCvssSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
             {
                 flatbuffers::DetachedBuffer detachedBuffer;
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
-                return false;
+                return createVulnerabilityDescriptiveInformationFail(resultContainer);
             }));
 
     // Create two detached buffers to store the vulnerability descriptive information for the test duration
     flatbuffers::DetachedBuffer detachedBufferDescription;
     flatbuffers::DetachedBuffer detachedBufferCvss;
 
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpSource, testing::_))
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, defaultAdpSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription);
-                return true;
-            }))
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription); }))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
@@ -352,37 +345,28 @@ TEST_F(DescriptionsHelperTest, notReliableCvssInformationNoScore)
     // Expect three calls to the database manager, one for the description and two for the CVSS (one for the unreliable
     // ADP and one for the default ADP)
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription, 0.0f);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription, 0.0f); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss, 0.0f);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss, 0.0f); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
@@ -419,39 +403,40 @@ TEST_F(DescriptionsHelperTest, notReliableCvssInformationEmptySeverity)
     // Expect three calls to the database manager, one for the description and two for the CVSS (one for the unreliable
     // ADP and one for the default ADP)
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
             {
-                createVulnerabilityDescriptiveInformation(
-                    resultContainer, detachedBufferDescription, 3.0f, "descriptionData.description", "");
-                return true;
+                return createVulnerabilityDescriptiveInformation(resultContainer,
+                                                                 detachedBufferDescription,
+                                                                 3.0f,
+                                                                 "descriptionData.description",
+                                                                 CveDescription::DEFAULT_STR_VALUE);
             }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
             {
-                createVulnerabilityDescriptiveInformation(
-                    resultContainer, detachedBufferCvss, 3.0f, "descriptionData.description", "");
-                return true;
+                return createVulnerabilityDescriptiveInformation(resultContainer,
+                                                                 detachedBufferCvss,
+                                                                 3.0f,
+                                                                 "descriptionData.description",
+                                                                 CveDescription::DEFAULT_STR_VALUE);
             }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
@@ -487,43 +472,331 @@ TEST_F(DescriptionsHelperTest, notReliableDescriptionInformation)
     // Expect three calls to the database manager, one for the CVSS and two for the description (one for the unreliable
     // ADP and one for the default ADP)
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
             {
-                createVulnerabilityDescriptiveInformation(
+                return createVulnerabilityDescriptiveInformation(
                     resultContainer, detachedBufferDescription, 3.0f, "not defined");
-                return true;
             }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpDescriptionSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, defaultAdpDescriptionSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultDescription);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultDescription); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock,
-                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
         .WillOnce(::testing::Invoke(
             [&](const std::string&,
                 const std::string&,
                 FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
-            {
-                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
-                return true;
-            }));
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss); }));
 
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from the same
+ * source but fails.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSourceCouldNotBeObtained)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_EQUALS_DESCRIPTION, ADP_CVSS_EQUALS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // We expect a call to the database manager to retrieve description information but fails.
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    // We expect the database manager to be called with the default ADP because no information could be found with the
+    // specific ADP and also fails.
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    // Information couldn't be retrieved. Default values asigned.
+    const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
+    {
+        EXPECT_EQ(description.accessComplexity, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.assignerShortName, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.attackVector, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.authentication, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.availabilityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.classification, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.confidentialityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.cweId, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.datePublished, CveDescription::DEFAULT_TIMESTAMP);
+        EXPECT_EQ(description.dateUpdated, CveDescription::DEFAULT_TIMESTAMP);
+        EXPECT_EQ(description.description, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.integrityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.privilegesRequired, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.reference, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.scope, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.scoreBase, 0);
+        EXPECT_EQ(description.scoreVersion, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.severity, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.userInteraction, CveDescription::DEFAULT_STR_VALUE);
+    };
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformationFail);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from different
+ * sources. Description information retrieval fails.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSourceCDescriptionFails)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create a detached buffer to store the CVSS descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+
+    // We expect a call to retrieve the description information but fails.
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    // We expect the database manager to be called with the default ADP but fails.
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    // We expect a call to retrieve information from CVSS source.
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss); }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    // Only information from description is set to default values.
+    const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
+    {
+        EXPECT_EQ(description.accessComplexity, "cvssData.accessComplexity");
+        EXPECT_EQ(description.assignerShortName, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.attackVector, "cvssData.attackVector");
+        EXPECT_EQ(description.authentication, "cvssData.authentication");
+        EXPECT_EQ(description.availabilityImpact, "cvssData.availabilityImpact");
+        EXPECT_EQ(description.classification, "cvssData.classification");
+        EXPECT_EQ(description.confidentialityImpact, "cvssData.confidentialityImpact");
+        EXPECT_EQ(description.cweId, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.datePublished, CveDescription::DEFAULT_TIMESTAMP);
+        EXPECT_EQ(description.dateUpdated, CveDescription::DEFAULT_TIMESTAMP);
+        EXPECT_EQ(description.description, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.integrityImpact, "cvssData.integrityImpact");
+        EXPECT_EQ(description.privilegesRequired, "cvssData.privilegesRequired");
+        EXPECT_EQ(description.reference, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.scope, "cvssData.scope");
+        EXPECT_EQ(description.scoreBase, 3.0f);
+        EXPECT_EQ(description.scoreVersion, "cvssData.scoreVersion");
+        EXPECT_EQ(description.severity, "cvssData.severity");
+        EXPECT_EQ(description.userInteraction, "cvssData.userInteraction");
+    };
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformationFail);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from different
+ * sources. CVSS information fails.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSourceCVSSFails)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create a detached buffer to store the vulnerability description information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+
+    // Expect a calls to the database manager to retrieve the description information.
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription); }));
+
+    // Couldn't retrieve information from CVSS source.
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    // We expect the database manager to be called with the default ADP but fails.
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
+    {
+        EXPECT_EQ(description.accessComplexity, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.assignerShortName, "descriptionData.assignerShortName");
+        EXPECT_EQ(description.attackVector, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.authentication, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.availabilityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.classification, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.confidentialityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.cweId, "descriptionData.cweId");
+        EXPECT_EQ(description.datePublished, "descriptionData.datePublished");
+        EXPECT_EQ(description.dateUpdated, "descriptionData.dateUpdated");
+        EXPECT_EQ(description.description, "descriptionData.description");
+        EXPECT_EQ(description.integrityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.privilegesRequired, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.reference, "descriptionData.reference");
+        EXPECT_EQ(description.scope, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.scoreBase, 0);
+        EXPECT_EQ(description.scoreVersion, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.severity, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.userInteraction, CveDescription::DEFAULT_STR_VALUE);
+    };
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformationFail);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from different
+ * sources. Both fails.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSourceBothFails)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // We expect a call to retrieve the description information but fails.
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    // We expect the database manager to be called with the default ADP but fails.
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    // Couldn't retrieve information from CVSS source.
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabilityDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(
+            ::testing::Invoke([&](const std::string&,
+                                  const std::string&,
+                                  FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+                              { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
+    {
+        EXPECT_EQ(description.accessComplexity, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.assignerShortName, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.attackVector, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.authentication, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.availabilityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.classification, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.confidentialityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.cweId, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.datePublished, CveDescription::DEFAULT_TIMESTAMP);
+        EXPECT_EQ(description.dateUpdated, CveDescription::DEFAULT_TIMESTAMP);
+        EXPECT_EQ(description.description, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.integrityImpact, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.privilegesRequired, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.reference, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.scope, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.scoreBase, 0);
+        EXPECT_EQ(description.scoreVersion, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.severity, CveDescription::DEFAULT_STR_VALUE);
+        EXPECT_EQ(description.userInteraction, CveDescription::DEFAULT_STR_VALUE);
+    };
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformationFail);
 
     // Reset the mocks
     spDatabaseFeedManagerMock.reset();

--- a/src/engine/source/vdscanner/test/src/unit/descriptionsHelper_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/descriptionsHelper_test.cpp
@@ -1,0 +1,530 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * September 25, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "../../../vdscanner/src/descriptionsHelper.hpp"
+#include "feedmanager/mockDatabaseFeedManager.hpp"
+#include "vulnerabilityDescription_generated.h"
+#include <base/json.hpp>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+/**
+ * @brief Runs unit tests for the DescriptionsHelper class.
+ *
+ */
+class DescriptionsHelperTest : public ::testing::Test
+{
+protected:
+    // LCOV_EXCL_START
+    DescriptionsHelperTest() = default;
+    ~DescriptionsHelperTest() override = default;
+    // LCOV_EXCL_STOP
+};
+
+namespace
+{
+const nlohmann::json ADP_DESCRIPTIONS =
+    R"#(
+    {
+        "adp_descriptions": {
+            "ADP_1": {
+                "description": "A",
+                "cvss": "A"
+            },
+            "ADP_2": {
+                "description": "A",
+                "cvss": "B"
+            },
+            "nvd": {
+                "description": "nvd",
+                "cvss": "nvd"
+            }
+        }
+    }
+)#"_json;
+
+const std::string CVE_ID = "CVE-1234-1234";
+const std::string ADP_INEXISTENT = "non_existent";
+const std::string ADP_CVSS_EQUALS_DESCRIPTION = "ADP_1";
+const std::string ADP_CVSS_DIFFERS_DESCRIPTION = "ADP_2";
+const std::string ADP_EXPANDED_POSTFIX = "_expanded";
+
+const auto createVulnerabilityDescriptiveInformation =
+    [](FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer,
+       flatbuffers::DetachedBuffer& detachedBuffer,
+       float scoreBase = 3.0f,
+       const char* description = "descriptionData.description",
+       const char* severity = "cvssData.severity")
+{
+    flatbuffers::FlatBufferBuilder fbBuilder;
+    const auto vulnerabilityDescriptiveInformation =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
+                                                                     "cvssData.accessComplexity",
+                                                                     "descriptionData.assignerShortName",
+                                                                     "cvssData.attackVector",
+                                                                     "cvssData.authentication",
+                                                                     "cvssData.availabilityImpact",
+                                                                     "cvssData.classification",
+                                                                     "cvssData.confidentialityImpact",
+                                                                     "descriptionData.cweId",
+                                                                     "descriptionData.datePublished",
+                                                                     "descriptionData.dateUpdated",
+                                                                     description,
+                                                                     "cvssData.integrityImpact",
+                                                                     "cvssData.privilegesRequired",
+                                                                     "descriptionData.reference",
+                                                                     "cvssData.scope",
+                                                                     scoreBase,
+                                                                     "cvssData.scoreVersion",
+                                                                     severity,
+                                                                     "cvssData.userInteraction");
+
+    fbBuilder.Finish(vulnerabilityDescriptiveInformation);
+    detachedBuffer = fbBuilder.Release();
+    resultContainer.data = NSVulnerabilityScanner::GetVulnerabilityDescription(detachedBuffer.data());
+};
+
+const auto validateVulnerabilityDescriptiveInformation = [](const CveDescription& description)
+{
+    EXPECT_EQ(description.accessComplexity, "cvssData.accessComplexity");
+    EXPECT_EQ(description.assignerShortName, "descriptionData.assignerShortName");
+    EXPECT_EQ(description.attackVector, "cvssData.attackVector");
+    EXPECT_EQ(description.authentication, "cvssData.authentication");
+    EXPECT_EQ(description.availabilityImpact, "cvssData.availabilityImpact");
+    EXPECT_EQ(description.classification, "cvssData.classification");
+    EXPECT_EQ(description.confidentialityImpact, "cvssData.confidentialityImpact");
+    EXPECT_EQ(description.cweId, "descriptionData.cweId");
+    EXPECT_EQ(description.datePublished, "descriptionData.datePublished");
+    EXPECT_EQ(description.dateUpdated, "descriptionData.dateUpdated");
+    EXPECT_EQ(description.description, "descriptionData.description");
+    EXPECT_EQ(description.integrityImpact, "cvssData.integrityImpact");
+    EXPECT_EQ(description.privilegesRequired, "cvssData.privilegesRequired");
+    EXPECT_EQ(description.reference, "descriptionData.reference");
+    EXPECT_EQ(description.scope, "cvssData.scope");
+    EXPECT_EQ(description.scoreBase, 3.0f);
+    EXPECT_EQ(description.scoreVersion, "cvssData.scoreVersion");
+    EXPECT_EQ(description.severity, "cvssData.severity");
+    EXPECT_EQ(description.userInteraction, "cvssData.userInteraction");
+};
+
+} // namespace
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from the same
+ * source.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_EQUALS_DESCRIPTION, ADP_CVSS_EQUALS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_EQUALS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create a detached buffer to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBuffer;
+
+    // We expect one call to the database manager for both the CVSS and description
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return true;
+            }));
+
+    // We don't expect the database manager to be called with the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .Times(0);
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP in which the CVSS and description are obtained from the same
+ * source.
+ *
+ */
+TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSource)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create two detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+
+    // Expect two calls to the database manager, one for the description and one for the CVSS
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
+                return true;
+            }));
+
+    // We don't expect the database manager to be called with the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
+        .Times(0);
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief Attempt to retrieve the information from an ADP that is not present in the ADP descriptions map. We should
+ * fallback to the default ADP.
+ *
+ */
+TEST_F(DescriptionsHelperTest, nonExistentAdp)
+{
+    const auto sources = std::make_pair(ADP_INEXISTENT, ADP_INEXISTENT + ADP_EXPANDED_POSTFIX);
+
+    const auto expectedAdpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create a detached buffer to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBuffer;
+
+    // We get the information from the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The database doesn't contain the information for the requested ADP, so we fallback to the default ADP.
+ *
+ */
+TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto adpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION).at("description").get<std::string>();
+    const auto adpCvssSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION).at("cvss").get<std::string>();
+    const auto defaultAdpSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Two calls to the default ADP fail, so we fallback to the default ADP
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, adpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                flatbuffers::DetachedBuffer detachedBuffer;
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return false;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, adpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                flatbuffers::DetachedBuffer detachedBuffer;
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer);
+                return false;
+            }));
+
+    // Create two detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription);
+                return true;
+            }))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The CVSS information is not reliable, so we fallback to the default ADP (due to the CVSS score being near 0).
+ *
+ */
+TEST_F(DescriptionsHelperTest, notReliableCvssInformationNoScore)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+    const auto defaultAdpCvssSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create three detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+    flatbuffers::DetachedBuffer detachedBufferDefaultCvss;
+
+    // Expect three calls to the database manager, one for the description and two for the CVSS (one for the unreliable
+    // ADP and one for the default ADP)
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDescription, 0.0f);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss, 0.0f);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The CVSS information is not reliable, so we fallback to the default ADP (due to the CVSS severity being
+ * empty).
+ *
+ */
+TEST_F(DescriptionsHelperTest, notReliableCvssInformationEmptySeverity)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+    const auto defaultAdpCvssSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("cvss").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create three detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+    flatbuffers::DetachedBuffer detachedBufferDefaultCvss;
+
+    // Expect three calls to the database manager, one for the description and two for the CVSS (one for the unreliable
+    // ADP and one for the default ADP)
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(
+                    resultContainer, detachedBufferDescription, 3.0f, "descriptionData.description", "");
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(
+                    resultContainer, detachedBufferCvss, 3.0f, "descriptionData.description", "");
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}
+
+/**
+ * @brief The Description information is not reliable, so we fallback to the default ADP.
+ *
+ */
+TEST_F(DescriptionsHelperTest, notReliableDescriptionInformation)
+{
+    const auto sources =
+        std::make_pair(ADP_CVSS_DIFFERS_DESCRIPTION, ADP_CVSS_DIFFERS_DESCRIPTION + ADP_EXPANDED_POSTFIX);
+
+    const auto& adpDescriptionsData = ADP_DESCRIPTIONS.at("adp_descriptions").at(ADP_CVSS_DIFFERS_DESCRIPTION);
+    const auto expectedAdpDescriptionSource = adpDescriptionsData.at("description").get<std::string>();
+    const auto expectedAdpCvssSource = adpDescriptionsData.at("cvss").get<std::string>();
+    const auto defaultAdpDescriptionSource =
+        ADP_DESCRIPTIONS.at("adp_descriptions").at(DEFAULT_ADP).at("description").get<std::string>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    // Create three detached buffers to store the vulnerability descriptive information for the test duration
+    flatbuffers::DetachedBuffer detachedBufferDescription;
+    flatbuffers::DetachedBuffer detachedBufferDefaultDescription;
+    flatbuffers::DetachedBuffer detachedBufferCvss;
+
+    // Expect three calls to the database manager, one for the CVSS and two for the description (one for the unreliable
+    // ADP and one for the default ADP)
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(
+                    resultContainer, detachedBufferDescription, 3.0f, "not defined");
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, defaultAdpDescriptionSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultDescription);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock,
+                getVulnerabiltyDescriptiveInformation(CVE_ID, expectedAdpCvssSource, testing::_))
+        .WillOnce(::testing::Invoke(
+            [&](const std::string&,
+                const std::string&,
+                FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+            {
+                createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss);
+                return true;
+            }));
+
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
+    DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager>(
+        CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
+
+    // Reset the mocks
+    spDatabaseFeedManagerMock.reset();
+}

--- a/src/engine/source/vdscanner/test/src/unit/descriptionsHelper_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/descriptionsHelper_test.cpp
@@ -26,8 +26,18 @@ protected:
     // LCOV_EXCL_START
     DescriptionsHelperTest() = default;
     ~DescriptionsHelperTest() override = default;
+    /**
+     * @brief Set the environment for testing.
+     *
+     */
+    void SetUp() override;
     // LCOV_EXCL_STOP
 };
+
+void DescriptionsHelperTest::SetUp()
+{
+    logging::testInit();
+}
 
 namespace
 {

--- a/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
@@ -291,7 +291,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS2)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto mockGetVulnerabiltyDescriptiveInformation =
+    auto mockgetVulnerabilityDescriptiveInformation =
         [&](const std::string& cveId,
             const std::string& subShortName,
             FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
@@ -304,8 +304,8 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS2)
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(mockgetVulnerabilityDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
@@ -387,7 +387,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto mockGetVulnerabiltyDescriptiveInformation =
+    auto mockgetVulnerabilityDescriptiveInformation =
         [&](const std::string& cveId,
             const std::string& subShortName,
             FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
@@ -400,8 +400,8 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(mockgetVulnerabilityDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
@@ -522,7 +522,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto mockGetVulnerabiltyDescriptiveInformation =
+    auto mockgetVulnerabilityDescriptiveInformation =
         [&](const std::string& cveId,
             const std::string& subShortName,
             FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
@@ -535,8 +535,8 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(mockgetVulnerabilityDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
@@ -545,8 +545,6 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
     // Mock one vulnerability
     scanContext->m_elements[CVEID] = R"({})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
-
-    std::cout << scanContext->m_vulnerabilitySource.first << std::endl;
 
     TResponseBuilder<MockDatabaseFeedManager, ScanContext> responseBuilder(spDatabaseFeedManagerMock);
 
@@ -620,7 +618,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseNonDefaultCna)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto mockGetVulnerabiltyDescriptiveInformation =
+    auto mockgetVulnerabilityDescriptiveInformation =
         [&](const std::string& cveId,
             const std::string& subShortName,
             FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
@@ -633,8 +631,8 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseNonDefaultCna)
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(mockgetVulnerabilityDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
@@ -717,7 +715,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseUnderEvaluation)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto mockGetVulnerabiltyDescriptiveInformation =
+    auto mockgetVulnerabilityDescriptiveInformation =
         [&](const std::string& cveId,
             const std::string& subShortName,
             FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
@@ -730,8 +728,8 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseUnderEvaluation)
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(mockgetVulnerabilityDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
@@ -811,7 +809,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseDefaultValues)
                                                                      "userInteraction_test_string");
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
-    auto mockGetVulnerabiltyDescriptiveInformation =
+    auto mockgetVulnerabilityDescriptiveInformation =
         [&](const std::string& cveId,
             const std::string& subShortName,
             FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
@@ -824,8 +822,8 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseDefaultValues)
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
-        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(mockgetVulnerabilityDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;

--- a/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
@@ -292,16 +292,19 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS2)
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view /*cveId*/,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+        [&](const std::string& cveId,
+            const std::string& subShortName,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
     {
         rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
             NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+
+        return true;
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
@@ -385,16 +388,19 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view /*cveId*/,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+        [&](const std::string& cveId,
+            const std::string& subShortName,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
     {
         rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
             NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+
+        return true;
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
@@ -517,16 +523,19 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view /*cveId*/,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+        [&](const std::string& cveId,
+            const std::string& subShortName,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
     {
         rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
             NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+
+        return true;
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
@@ -612,16 +621,19 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseNonDefaultCna)
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view /*cveId*/,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+        [&](const std::string& cveId,
+            const std::string& subShortName,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
     {
         rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
             NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+
+        return true;
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
@@ -706,16 +718,19 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseUnderEvaluation)
     fbBuilder.Finish(vulnerabilityDescriptionData);
 
     auto mockGetVulnerabiltyDescriptiveInformation =
-        [&](const std::string_view /*cveId*/,
-            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+        [&](const std::string& cveId,
+            const std::string& subShortName,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
     {
         rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
         resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
             NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+
+        return true;
     };
 
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
-    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
     EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 

--- a/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
@@ -355,6 +355,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS2)
                      .at("adp")
                      .get_ref<const std::string&>()
                      .c_str());
+    EXPECT_FALSE(elementData.at("under_evaluation").get_ref<const bool&>());
 }
 
 TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
@@ -448,6 +449,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
                      .at("adp")
                      .get_ref<const std::string&>()
                      .c_str());
+    EXPECT_FALSE(elementData.at("under_evaluation").get_ref<const bool&>());
 }
 
 TEST_F(ResponseBuilderTest, TestEmptyResponse)
@@ -580,6 +582,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
                      .at("adp")
                      .get_ref<const std::string&>()
                      .c_str());
+    EXPECT_FALSE(elementData.at("under_evaluation").get_ref<const bool&>());
 }
 
 TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseNonDefaultCna)
@@ -673,4 +676,99 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseNonDefaultCna)
                      .at("adp")
                      .get_ref<const std::string&>()
                      .c_str());
+    EXPECT_FALSE(elementData.at("under_evaluation").get_ref<const bool&>());
+}
+
+TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseUnderEvaluation)
+{
+    flatbuffers::FlatBufferBuilder fbBuilder;
+    auto vulnerabilityDescriptionData =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
+                                                                     "accessComplexity_test_string",
+                                                                     "assignerShortName_test_string",
+                                                                     "attackVector_test_string",
+                                                                     "authentication_test_string",
+                                                                     "availabilityImpact_test_string",
+                                                                     "classification_test_string",
+                                                                     "confidentialityImpact_test_string",
+                                                                     "cweId_test_string",
+                                                                     "datePublished_test_string",
+                                                                     "dateUpdated_test_string",
+                                                                     "description_test_string",
+                                                                     "integrityImpact_test_string",
+                                                                     "privilegesRequired_test_string",
+                                                                     "reference_test_string",
+                                                                     "scope_test_string",
+                                                                     0,
+                                                                     "3",
+                                                                     "severity_test_string",
+                                                                     "userInteraction_test_string");
+    fbBuilder.Finish(vulnerabilityDescriptionData);
+
+    auto mockGetVulnerabiltyDescriptiveInformation =
+        [&](const std::string_view /*cveId*/,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    {
+        rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
+        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+    };
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
+
+    nlohmann::json response;
+    auto scanContext = std::make_shared<ScanContext>(
+        ScannerType::Package, AGENT_001_MSG, OS_001_MSG, PACKAGES_001_MSG, "{}"_json, response);
+    // Mock one vulnerability
+    scanContext->m_elements[CVEID] = R"({})"_json;
+    scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
+    scanContext->m_vulnerabilitySource = {"redhat", "redhat"};
+
+    TResponseBuilder<MockDatabaseFeedManager, ScanContext> responseBuilder(spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(responseBuilder.handleRequest(scanContext));
+
+    EXPECT_EQ(response.size(), 1);
+
+    auto& elementData = *response.begin();
+
+    EXPECT_STREQ(elementData.at("category").get_ref<const std::string&>().c_str(), "Packages");
+    EXPECT_STREQ(
+        elementData.at("classification").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->classification()->c_str());
+    EXPECT_STREQ(
+        elementData.at("description").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
+    EXPECT_STREQ(elementData.at("enumeration").get_ref<const std::string&>().c_str(), "CVE");
+    EXPECT_STREQ(elementData.at("id").get_ref<const std::string&>().c_str(), CVEID.c_str());
+    EXPECT_STREQ(
+        elementData.at("reference").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->reference()->c_str());
+    EXPECT_DOUBLE_EQ(
+        elementData.at("score").at("base").get_ref<const double&>(),
+        base::utils::numeric::floatToDoubleRound(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreBase(), 2));
+    EXPECT_STREQ(
+        elementData.at("score").at("version").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreVersion()->c_str());
+    EXPECT_STREQ(
+        elementData.at("severity").get_ref<const std::string&>().c_str(),
+        base::utils::string::toSentenceCase(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->severity()->str())
+            .c_str());
+    EXPECT_STREQ(
+        elementData.at("published_at").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
+    EXPECT_TRUE(elementData.at("detected_at").get_ref<const std::string&>() <= base::utils::time::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("source").get_ref<const std::string&>().c_str(),
+                 spDatabaseFeedManagerMock->vendorsMap()
+                     .at("adp_descriptions")
+                     .at(scanContext->m_vulnerabilitySource.first)
+                     .at("adp")
+                     .get_ref<const std::string&>()
+                     .c_str());
+    EXPECT_TRUE(elementData.at("under_evaluation").get_ref<const bool&>());
 }

--- a/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
@@ -348,6 +348,13 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS2)
         elementData.at("published_at").get_ref<const std::string&>().c_str(),
         NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("detected_at").get_ref<const std::string&>() <= base::utils::time::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("source").get_ref<const std::string&>().c_str(),
+                 spDatabaseFeedManagerMock->vendorsMap()
+                     .at("adp_descriptions")
+                     .at(scanContext->m_vulnerabilitySource.first)
+                     .at("adp")
+                     .get_ref<const std::string&>()
+                     .c_str());
 }
 
 TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
@@ -434,6 +441,13 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
         elementData.at("published_at").get_ref<const std::string&>().c_str(),
         NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("detected_at").get_ref<const std::string&>() <= base::utils::time::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("source").get_ref<const std::string&>().c_str(),
+                 spDatabaseFeedManagerMock->vendorsMap()
+                     .at("adp_descriptions")
+                     .at(scanContext->m_vulnerabilitySource.first)
+                     .at("adp")
+                     .get_ref<const std::string&>()
+                     .c_str());
 }
 
 TEST_F(ResponseBuilderTest, TestEmptyResponse)
@@ -559,4 +573,104 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
         elementData.at("published_at").get_ref<const std::string&>().c_str(),
         NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("detected_at").get_ref<const std::string&>() <= base::utils::time::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("source").get_ref<const std::string&>().c_str(),
+                 spDatabaseFeedManagerMock->vendorsMap()
+                     .at("adp_descriptions")
+                     .at(scanContext->m_vulnerabilitySource.first)
+                     .at("adp")
+                     .get_ref<const std::string&>()
+                     .c_str());
+}
+
+TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseNonDefaultCna)
+{
+    flatbuffers::FlatBufferBuilder fbBuilder;
+    auto vulnerabilityDescriptionData =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
+                                                                     "accessComplexity_test_string",
+                                                                     "assignerShortName_test_string",
+                                                                     "attackVector_test_string",
+                                                                     "authentication_test_string",
+                                                                     "availabilityImpact_test_string",
+                                                                     "classification_test_string",
+                                                                     "confidentialityImpact_test_string",
+                                                                     "cweId_test_string",
+                                                                     "datePublished_test_string",
+                                                                     "dateUpdated_test_string",
+                                                                     "description_test_string",
+                                                                     "integrityImpact_test_string",
+                                                                     "privilegesRequired_test_string",
+                                                                     "reference_test_string",
+                                                                     "scope_test_string",
+                                                                     8.3,
+                                                                     "3",
+                                                                     "severity_test_string",
+                                                                     "userInteraction_test_string");
+    fbBuilder.Finish(vulnerabilityDescriptionData);
+
+    auto mockGetVulnerabiltyDescriptiveInformation =
+        [&](const std::string_view /*cveId*/,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer)
+    {
+        rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
+        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+    };
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
+        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
+
+    nlohmann::json response;
+    auto scanContext = std::make_shared<ScanContext>(
+        ScannerType::Package, AGENT_001_MSG, OS_001_MSG, PACKAGES_001_MSG, "{}"_json, response);
+    // Mock one vulnerability
+    scanContext->m_elements[CVEID] = R"({})"_json;
+    scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
+    scanContext->m_vulnerabilitySource = {"redhat", "redhat"};
+
+    TResponseBuilder<MockDatabaseFeedManager, ScanContext> responseBuilder(spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(responseBuilder.handleRequest(scanContext));
+
+    EXPECT_EQ(response.size(), 1);
+
+    auto& elementData = *response.begin();
+
+    EXPECT_STREQ(elementData.at("category").get_ref<const std::string&>().c_str(), "Packages");
+    EXPECT_STREQ(
+        elementData.at("classification").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->classification()->c_str());
+    EXPECT_STREQ(
+        elementData.at("description").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
+    EXPECT_STREQ(elementData.at("enumeration").get_ref<const std::string&>().c_str(), "CVE");
+    EXPECT_STREQ(elementData.at("id").get_ref<const std::string&>().c_str(), CVEID.c_str());
+    EXPECT_STREQ(
+        elementData.at("reference").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->reference()->c_str());
+    EXPECT_DOUBLE_EQ(
+        elementData.at("score").at("base").get_ref<const double&>(),
+        base::utils::numeric::floatToDoubleRound(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreBase(), 2));
+    EXPECT_STREQ(
+        elementData.at("score").at("version").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreVersion()->c_str());
+    EXPECT_STREQ(
+        elementData.at("severity").get_ref<const std::string&>().c_str(),
+        base::utils::string::toSentenceCase(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->severity()->str())
+            .c_str());
+    EXPECT_STREQ(
+        elementData.at("published_at").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
+    EXPECT_TRUE(elementData.at("detected_at").get_ref<const std::string&>() <= base::utils::time::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("source").get_ref<const std::string&>().c_str(),
+                 spDatabaseFeedManagerMock->vendorsMap()
+                     .at("adp_descriptions")
+                     .at(scanContext->m_vulnerabilitySource.first)
+                     .at("adp")
+                     .get_ref<const std::string&>()
+                     .c_str());
 }

--- a/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
@@ -762,10 +762,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseUnderEvaluation)
     EXPECT_STREQ(
         elementData.at("reference").get_ref<const std::string&>().c_str(),
         NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->reference()->c_str());
-    EXPECT_DOUBLE_EQ(
-        elementData.at("score").at("base").get_ref<const double&>(),
-        base::utils::numeric::floatToDoubleRound(
-            NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreBase(), 2));
+    EXPECT_DOUBLE_EQ(elementData.at("score").at("base").get_ref<const double&>(), -1);
     EXPECT_STREQ(
         elementData.at("score").at("version").get_ref<const std::string&>().c_str(),
         NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->scoreVersion()->c_str());
@@ -774,6 +771,92 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseUnderEvaluation)
         base::utils::string::toSentenceCase(
             NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->severity()->str())
             .c_str());
+    EXPECT_STREQ(
+        elementData.at("published_at").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
+    EXPECT_TRUE(elementData.at("detected_at").get_ref<const std::string&>() <= base::utils::time::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("source").get_ref<const std::string&>().c_str(),
+                 spDatabaseFeedManagerMock->vendorsMap()
+                     .at("adp_descriptions")
+                     .at(scanContext->m_vulnerabilitySource.first)
+                     .at("adp")
+                     .get_ref<const std::string&>()
+                     .c_str());
+    EXPECT_TRUE(elementData.at("under_evaluation").get_ref<const bool&>());
+}
+
+TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseDefaultValues)
+{
+    flatbuffers::FlatBufferBuilder fbBuilder;
+    auto vulnerabilityDescriptionData =
+        NSVulnerabilityScanner::CreateVulnerabilityDescriptionDirect(fbBuilder,
+                                                                     "accessComplexity_test_string",
+                                                                     "assignerShortName_test_string",
+                                                                     "attackVector_test_string",
+                                                                     "authentication_test_string",
+                                                                     "availabilityImpact_test_string",
+                                                                     "",
+                                                                     "confidentialityImpact_test_string",
+                                                                     "cweId_test_string",
+                                                                     "datePublished_test_string",
+                                                                     "dateUpdated_test_string",
+                                                                     "description_test_string",
+                                                                     "integrityImpact_test_string",
+                                                                     "privilegesRequired_test_string",
+                                                                     "reference_test_string",
+                                                                     "scope_test_string",
+                                                                     0,
+                                                                     "",
+                                                                     "",
+                                                                     "userInteraction_test_string");
+    fbBuilder.Finish(vulnerabilityDescriptionData);
+
+    auto mockGetVulnerabiltyDescriptiveInformation =
+        [&](const std::string& cveId,
+            const std::string& subShortName,
+            FlatbufferDataPair<NSVulnerabilityScanner::VulnerabilityDescription>& resultContainer) -> bool
+    {
+        rocksdb::Slice value(reinterpret_cast<const char*>(fbBuilder.GetBufferPointer()), fbBuilder.GetSize());
+        resultContainer.data = const_cast<NSVulnerabilityScanner::VulnerabilityDescription*>(
+            NSVulnerabilityScanner::GetVulnerabilityDescription(value.data()));
+
+        return true;
+    };
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+    EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _, _))
+        .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
+
+    nlohmann::json response;
+    auto scanContext = std::make_shared<ScanContext>(
+        ScannerType::Package, AGENT_001_MSG, OS_001_MSG, PACKAGES_001_MSG, "{}"_json, response);
+    // Mock one vulnerability
+    scanContext->m_elements[CVEID] = R"({})"_json;
+    scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
+    scanContext->m_vulnerabilitySource = {"redhat", "redhat"};
+
+    TResponseBuilder<MockDatabaseFeedManager, ScanContext> responseBuilder(spDatabaseFeedManagerMock);
+
+    EXPECT_NO_THROW(responseBuilder.handleRequest(scanContext));
+
+    EXPECT_EQ(response.size(), 1);
+
+    auto& elementData = *response.begin();
+
+    EXPECT_STREQ(elementData.at("category").get_ref<const std::string&>().c_str(), "Packages");
+    EXPECT_STREQ(elementData.at("classification").get_ref<const std::string&>().c_str(), "-");
+    EXPECT_STREQ(
+        elementData.at("description").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->description()->c_str());
+    EXPECT_STREQ(elementData.at("enumeration").get_ref<const std::string&>().c_str(), "CVE");
+    EXPECT_STREQ(elementData.at("id").get_ref<const std::string&>().c_str(), CVEID.c_str());
+    EXPECT_STREQ(
+        elementData.at("reference").get_ref<const std::string&>().c_str(),
+        NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->reference()->c_str());
+    EXPECT_DOUBLE_EQ(elementData.at("score").at("base").get_ref<const double&>(), -1);
+    EXPECT_STREQ(elementData.at("score").at("version").get_ref<const std::string&>().c_str(), "-");
+    EXPECT_STREQ(elementData.at("severity").get_ref<const std::string&>().c_str(), "-");
     EXPECT_STREQ(
         elementData.at("published_at").get_ref<const std::string&>().c_str(),
         NSVulnerabilityScanner::GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());

--- a/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
+++ b/src/engine/source/vdscanner/test/src/unit/responseBuilder_test.cpp
@@ -137,6 +137,119 @@ const auto OS_001_MSG =
             "kernel_release":"osdata_kernelRelease"
     })"_json;
 
+const auto FEED_GLOBAL_MOCK =
+    R"(
+  {
+    "prefix": [
+      {"Canonical": {"cna":"canonical", "platforms":["ubuntu","linuxmint","pop"]}},
+      {"Ubuntu":  {"cna":"canonical", "platforms":["ubuntu","linuxmint","pop"]}},
+      {"Debian": {"cna":"debian", "platforms":["debian","linuxmint","pop"]}},
+      {"Red Hat, Inc.": {"cna":"redhat", "platforms":["rhel","centos"]}},
+      {"CentOS": {"cna":"redhat", "platforms":["centos","rhel"]}},
+      {"Amazon Linux": {"cna":"alas", "platforms":["amzn"]}},
+      {"Amazon.com": {"cna":"alas", "platforms":["amzn"]}},
+      {"Amazon AWS": {"cna":"alas", "platforms":["amzn"]}},
+      {"Arch Linux": {"cna":"arch", "platforms":["arch"]}},
+      {"suse": {"cna":"suse", "platforms":["sles","sled"]}},
+      {"SUSE": {"cna":"suse", "platforms":["sles","sled"]}},
+      {"openSUSE": {"cna":"opensuse", "platforms":["opensuse-leap","opensuse-tumbleweed"]}},
+      {"AlmaLinux": {"cna":"alma", "platforms":["almalinux"]}},
+      {"CloudLinux": {"cna":"alma", "platforms":["almalinux"]}},
+      {"Rocky": {"cna": "rocky","platforms": ["rocky"]}}
+    ],
+    "contains": [
+      {"@ubuntu.com":  {"cna":"canonical", "platforms":["ubuntu","linuxmint","pop"]}},
+      {"@canonical.com":  {"cna":"canonical", "platforms":["ubuntu","linuxmint","pop"]}},
+      {"debian.org": {"cna":"debian", "platforms":["debian","linuxmint","pop"]}},
+      {"debian.net": {"cna":"debian", "platforms":["debian","linuxmint","pop"]}}
+    ],
+    "format": [
+      {"pypi": "pypi"},
+      {"npm": "npm"},
+      {"snap": "nvd"}
+    ],
+    "source": [
+      {"homebrew": "homebrew"}
+    ],
+    "adp_descriptions": {
+      "alas": {
+        "adp": "Amazon Linux Security Center",
+        "description": "cisa",
+        "cvss": "alas"
+      },
+      "alma": {
+        "adp": "Alma Linux Security Oval",
+        "description": "alma",
+        "cvss": "alma"
+      },
+      "arch": {
+        "adp": "Arch Linux Security Tracker",
+        "description": "cisa",
+        "cvss": "cisa"
+      },
+      "debian": {
+        "adp": "Debian Security Tracker",
+        "description": "debian",
+        "cvss": "cisa"
+      },
+      "oracle": {
+        "adp": "Oracle Linux Security",
+        "description": "cisa",
+        "cvss": "oracle"
+      },
+      "npm": {
+        "adp": "Open Source Vulnerabilities",
+        "description": "npm",
+        "cvss": "npm"
+      },
+      "nvd": {
+        "adp": "National Vulnerability Database",
+        "description": "nvd",
+        "cvss": "nvd"
+      },
+      "pypi": {
+        "adp": "Open Source Vulnerabilities",
+        "description": "pypi",
+        "cvss": "pypi"
+      },
+      "redhat": {
+        "adp": "Red Hat CVE Database",
+        "description": "redhat",
+        "cvss": "redhat"
+      },
+      "rocky": {
+        "adp": "Rocky Enterprise Product Errata",
+        "description": "rocky",
+        "cvss": "rocky"
+      },
+      "suse": {
+        "adp": "SUSE CVE Database",
+        "description": "suse",
+        "cvss": "suse"
+      },
+      "opensuse": {
+        "adp": "SUSE CVE Database",
+        "description": "suse",
+        "cvss": "suse"
+      },
+      "canonical": {
+        "adp": "Canonical Security Tracker",
+        "description": "canonical",
+        "cvss": "canonical"
+      },
+      "homebrew": {
+        "adp": "Homebrew Security Audit",
+        "description": "homebrew",
+        "cvss": "nvd"
+      },
+      "cisa": {
+          "adp": "Cybersecurity and Infrastructure Security Agency",
+          "description": "cisa",
+          "cvss": "cisa"
+      }
+    }
+  })"_json;
+
 const std::string CVEID {"CVE-2024-1234"};
 } // namespace NSresponseBuilderTest
 
@@ -190,6 +303,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS2)
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
     auto scanContext = std::make_shared<ScanContext>(
@@ -274,6 +388,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
     auto scanContext = std::make_shared<ScanContext>(
@@ -281,6 +396,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulPackageResponseCVSS3)
     // Mock one vulnerability
     scanContext->m_elements[CVEID] = R"({})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
+    scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
 
     TResponseBuilder<MockDatabaseFeedManager, ScanContext> responseBuilder(spDatabaseFeedManagerMock);
 
@@ -396,6 +512,7 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
     auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabiltyDescriptiveInformation(_, _))
         .WillRepeatedly(testing::Invoke(mockGetVulnerabiltyDescriptiveInformation));
+    EXPECT_CALL(*spDatabaseFeedManagerMock, vendorsMap()).WillRepeatedly(testing::ReturnRef(FEED_GLOBAL_MOCK));
 
     nlohmann::json response;
     auto scanContext =
@@ -403,6 +520,8 @@ TEST_F(ResponseBuilderTest, TestSuccessfulOSResponseCVSS3)
     // Mock one vulnerability
     scanContext->m_elements[CVEID] = R"({})"_json;
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
+
+    std::cout << scanContext->m_vulnerabilitySource.first << std::endl;
 
     TResponseBuilder<MockDatabaseFeedManager, ScanContext> responseBuilder(spDatabaseFeedManagerMock);
 


### PR DESCRIPTION
|Related issue|
|---|
| #26130 |

## Description

This PR takes the following changes to `master` (5.x)
- https://github.com/wazuh/wazuh/issues/25480
- https://github.com/wazuh/wazuh/issues/25482
- https://github.com/wazuh/wazuh/issues/25481
- https://github.com/wazuh/wazuh/issues/25484
- https://github.com/wazuh/wazuh/issues/26823

The UT were adapted and in some cases, the changes were omitted because not all functionalities/class have its counterpart in `master` branch. 

## Testing

### QA efficacy tests

I generated the tools and run the test workflow. The tests pass 
<details><summary>Details</summary>
<p>

![2024-11-22_21-52](https://github.com/user-attachments/assets/e7f68eea-b7a7-481e-938e-01ff94407472)

</p>
</details> 

### Manual tests

Input for all the tests:

<details><summary>Details</summary>
<p>

```
curl -vsS --unix-socket test.sock --header "Content-Type: application/json"   --request POST   --data '{
  "type": "packagelist",
  "agent": {
    "id": "001"
  },
  "packages": [
    {
      "architecture": "amd64",
      "checksum": "1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
      "description": "NSS",
      "format": "rpm",
      "groups": "libs",
      "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
      "multiarch": "same",
      "name": "nss",
      "priority": "optional",
      "scan_time": "2023/08/04 19:56:11",
      "size": 72,
      "source": "nss",
      "vendor": "Red Hat, Inc.",
      "version": "3.53.1-3.el7_9"
    }
  ],
  "hotfixes": [],
  "os": {
    "architecture": "x86_64",
    "checksum": "1691178971959743855",
    "hostname": "redhat",
    "codename": "7",
    "major_version": "7",
    "minor_version": "9",
    "name": "Redhat",
    "patch": "6",
    "platform": "rhel",
    "version": "7.9",
    "scan_time": "2023/08/04 19:56:11",
    "kernel_release": "5.4.0-155-generic",
    "kernel_name": "Linux",
    "kernel_version": "#172-Ubuntu SMP Fri Jul 7 16:10:02 UTC 2023"
  }
}' http://localhost/vulnerability/scan | jq
```
</p>
</details> 

### Porting: https://github.com/wazuh/wazuh/issues/25480

<details><summary>Details</summary>
<p>

- Output
```json
  {
    "assigner": "mozilla",
    "category": "Packages",
    "classification": "",
    "condition": "Package default status",
    "cwe_reference": "",
    "description": "NSS was susceptible to a timing side-channel attack when performing RSA decryption. This attack could potentially allow an attacker to recover the private data. This vulnerability affects Firefox < 124, Firefox ESR < 115.9, and Thunderbird < 115.9.",
    "detected_at": "2024-10-25T22:59:16.965Z",
    "enumeration": "CVE",
    "id": "CVE-2023-5388",
    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
    "published_at": "2024-03-19T12:15:07Z",
    "reference": "https://bugzilla.mozilla.org/show_bug.cgi?id=1780432, https://lists.debian.org/debian-lts-announce/2024/03/msg00022.html, https://lists.debian.org/debian-lts-announce/2024/03/msg00028.html, https://www.mozilla.org/security/advisories/mfsa2024-12/, https://www.mozilla.org/security/advisories/mfsa2024-13/, https://www.mozilla.org/security/advisories/mfsa2024-14/",
    "score": {
      "base": 0.0,
      "version": ""
    },
    "severity": "",
    "source": "Red Hat CVE Database",
    "updated": "2024-03-25T17:15:51Z"
  },
```

```json
    "source": "Red Hat CVE Database",
```
</p>
</details> 


### Porting: https://github.com/wazuh/wazuh/issues/25482

<details><summary>Details</summary>
<p>

- Under evaluation CVE:
![image](https://github.com/user-attachments/assets/edddbde8-68f4-4508-be23-ae0083fd394c)
```json
  {
    "assigner": "mozilla",
    "category": "Packages",
    "classification": "",
    "condition": "Package default status",
    "cwe_reference": "",
    "description": "NSS was susceptible to a timing side-channel attack when performing RSA decryption. This attack could potentially allow an attacker to recover the private data. This vulnerability affects Firefox < 124, Firefox ESR < 115.9, and Thunderbird < 115.9.",
    "detected_at": "2024-10-28T12:15:44.509Z",
    "enumeration": "CVE",
    "id": "CVE-2023-5388",
    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
    "published_at": "2024-03-19T12:15:07Z",
    "reference": "https://bugzilla.mozilla.org/show_bug.cgi?id=1780432, https://lists.debian.org/debian-lts-announce/2024/03/msg00022.html, https://lists.debian.org/debian-lts-announce/2024/03/msg00028.html, https://www.mozilla.org/security/advisories/mfsa2024-12/, https://www.mozilla.org/security/advisories/mfsa2024-13/, https://www.mozilla.org/security/advisories/mfsa2024-14/",
    "score": {
      "base": 0.0,
      "version": ""
    },
    "severity": "",
    "source": "Red Hat CVE Database",
    "under_evaluation": true,
    "updated": "2024-03-25T17:15:51Z"
  }
```
- Evaluated CVE:
![image](https://github.com/user-attachments/assets/d41cb6af-2a2f-4d7b-bfdf-3f1a6db91202)
```json
  {
    "assigner": "mozilla",
    "category": "Packages",
    "classification": "CVSS",
    "condition": "Package default status",
    "cvss": {
      "cvss3": {
        "vector": {
          "attack_vector": "",
          "availability": "NONE",
          "confidentiality_impact": "LOW",
          "integrity_impact": "NONE",
          "privileges_required": "NONE",
          "scope": "UNCHANGED",
          "user_interaction": "REQUIRED"
        }
      }
    },
    "cwe_reference": "CWE-203",
    "description": "Multiple NSS NIST curves were susceptible to a side-channel attack known as \"Minerva\". This attack could potentially allow an attacker to recover the private key. This vulnerability affects Firefox < 121.",
    "detected_at": "2024-10-28T12:15:44.510Z",
    "enumeration": "CVE",
    "id": "CVE-2023-6135",
    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
    "published_at": "2023-12-19T14:15:07Z",
    "reference": "https://bugzilla.mozilla.org/show_bug.cgi?id=1853908, https://www.mozilla.org/security/advisories/mfsa2023-56/, https://security.gentoo.org/glsa/202401-10",
    "score": {
      "base": 4.3,
      "version": "3.1"
    },
    "severity": "Medium",
    "source": "Red Hat CVE Database",
    "under_evaluation": false,
    "updated": "2024-01-07T11:15:14Z"
  }
```

</p>
</details> 

### Porting #25681

<details><summary>Details</summary>
<p>

To verify this feature, I'll take a package from a Debian agent because this OS has different CVSS and descriptions sources

```json
"debian": {
      "adp": "Debian Security Tracker",
      "description": "debian",
      "cvss": "nvd"
    }
```

Selected package
```
curl -vsS --unix-socket test.sock --header "Content-Type: application/json"   --request POST   --data '{
  "type": "packagelist",
  "agent": {
    "id": "001"
  },
  "packages": [
    {
      "architecture": "amd64",
      "description": "Vi IMproved - enhanced vi editor",
      "format": "deb",
      "groups": "editors",
      "install_time": " ",
      "location": " ",
      "multiarch": "",
      "name": "vim",
      "priority": "optional",
      "size": 3364864,
      "source": " ",
      "vendor": "Debian Vim Maintainers <team+vim@tracker.debian.org>",
      "version": "2:8.2.2434-3+deb11u1",
      "checksum": "1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
      "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53"
    }
  ],
  "hotfixes": [],
  "os": {
    "architecture": "x86_64",
    "checksum": "1691178971959743855",
    "hostname": "a51c01971248",
    "codename": "bullseye",
    "major_version": "11",
    "name": "Debian GNU/Linux",
    "platform": "debian",
    "version": "11 (bullseye)",
    "scan_time": "2023/08/04 19:56:11",
    "kernel_release": "6.6.54-2-MANJARO",
    "kernel_name": "Linux",
    "kernel_version": "#1 SMP PREEMPT_DYNAMIC Tue Oct  8 03:11:08 UTC 2024"
  }
}' http://localhost/vulnerability/scan | jq
```

Results
```json
  {
    "assigner": "GitHub_M",
    "category": "Packages",
    "classification": "CVSS",
    "condition": "Package default status",
    "cvss": {
      "cvss3": {
        "vector": {
          "attack_vector": "",
          "availability": "HIGH",
          "confidentiality_impact": "NONE",
          "integrity_impact": "NONE",
          "privileges_required": "NONE",
          "scope": "UNCHANGED",
          "user_interaction": "REQUIRED"
        }
      }
    },
    "cwe_reference": "CWE-416",
    "description": "Vim is a UNIX editor that, prior to version 9.0.2121, has a heap-use-after-free vulnerability. When executing a `:s` command for the very first time and using a sub-replace-special atom inside the substitution part, it is possible that the recursive `:s` call causes free-ing of memory which may later then be accessed by the initial `:s` command. The user must intentionally execute the payload and the whole process is a bit tricky to do since it seems to work only reliably for the very first :s command. It may also cause a crash of Vim. Version 9.0.2121 contains a fix for this issue.",
    "detected_at": "2024-11-23T03:47:03.144Z",
    "enumeration": "CVE",
    "id": "CVE-2023-48706",
    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
    "published_at": "2023-11-22T22:15:08Z",
    "reference": "https://github.com/gandalf4a/crash_report/blob/main/vim/vim_huaf, https://github.com/vim/vim/security/advisories/GHSA-c8qm-x72m-q53q, https://github.com/vim/vim/pull/13552, http://www.openwall.com/lists/oss-security/2023/11/22/3, https://github.com/vim/vim/commit/26c11c56888d01e298cd8044caf860f3c26f57bb, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DNMFS3IH74KEMMESOA3EOB6MZ56TWGFF/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IVA7K73WHQH4KVFDJQ7ELIUD2WK5ZT5E/, https://security.netapp.com/advisory/ntap-20240105-0001/",
    "score": {
      "base": 4.7,
      "version": "3.1"
    },
    "severity": "Medium",
    "source": "Debian Security Tracker",
    "under_evaluation": false,
    "updated": "2024-01-05T18:15:29Z"
  }
```

Related logs

```
2024-11-23 03:54:37.250 157343:157381 databaseFeedManager.cpp:346 at getVulnerabilityDescriptiveInformation(): debug: Vulnerability description not found for CVE-2023-48706 in descriptions_debian.
2024-11-23 03:54:37.250 157343:157381 descriptionsHelper.hpp:206 at vulnerabilityDescription(): debug: Description information could not be obtained for 'CVE-2023-48706' from 'debian' source.
2024-11-23 03:54:37.250 157343:157381 descriptionsHelper.hpp:194 at operator()(): debug: Unreliable description information for 'CVE-2023-48706' from 'debian' source.
```

DB query

```
# ./rocksdb_tool -d /var/lib/wazuh-server/vd/feed/ -f /workspaces/5.x/wazuh/src/engine/source/feedmanager/schemas/vulnerabilityDescription.fbs -c descriptions_nvd -k CVE-2023-48706
{"CVE-2023-48706":{"accessComplexity":"","assignerShortName":"GitHub_M","attackVector":"","authentication":"","availabilityImpact":"HIGH","classification":"CVSS","confidentialityImpact":"NONE","cweId":"CWE-416","datePublished":"2023-11-22T22:15:08Z","dateUpdated":"2024-01-05T18:15:29Z","description":"Vim is a UNIX editor that, prior to version 9.0.2121, has a heap-use-after-free vulnerability. When executing a `:s` command for the very first time and using a sub-replace-special atom inside the substitution part, it is possible that the recursive `:s` call causes free-ing of memory which may later then be accessed by the initial `:s` command. The user must intentionally execute the payload and the whole process is a bit tricky to do since it seems to work only reliably for the very first :s command. It may also cause a crash of Vim. Version 9.0.2121 contains a fix for this issue.","integrityImpact":"NONE","privilegesRequired":"NONE","reference":"https://github.com/gandalf4a/crash_report/blob/main/vim/vim_huaf, https://github.com/vim/vim/security/advisories/GHSA-c8qm-x72m-q53q, https://github.com/vim/vim/pull/13552, http://www.openwall.com/lists/oss-security/2023/11/22/3, https://github.com/vim/vim/commit/26c11c56888d01e298cd8044caf860f3c26f57bb, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DNMFS3IH74KEMMESOA3EOB6MZ56TWGFF/, https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/IVA7K73WHQH4KVFDJQ7ELIUD2WK5ZT5E/, https://security.netapp.com/advisory/ntap-20240105-0001/","scope":"UNCHANGED","scoreBase":4.7,"scoreVersion":"3.1","severity":"MEDIUM","userInteraction":"REQUIRED"}}

# ./rocksdb_tool -d /var/lib/wazuh-server/vd/feed/ -f /workspaces/5.x/wazuh/src/engine/source/feedmanager/schemas/vulnerabilityDescription.fbs -c descriptions_debian -k CVE-2023-48706
Unable to find resource.
```

</p>
</details> 

<details><summary>Details</summary>
<p>

Another example with ALAS

```json
  "adp_descriptions": {
    "alas": {
      "adp": "Amazon Linux Security Center",
      "description": "nvd",
      "cvss": "alas"
    }
```

Input
```
    curl -vsS --unix-socket test.sock --header "Content-Type: application/json"   --request POST   --data '{
      "type": "packagelist",
      "agent": {
        "id": "001"
      },
      "packages": [
        {
         "architecture": "x86_64",
          "description": "Network Security Services Softoken Module",
          "format": "rpm",
          "groups": "System Environment/Libraries",
          "install_time": "1702931526",
          "location": " ",
          "name": "nss-softokn",
          "priority": " ",
          "size": 1294014,
          "source": " ",
          "vendor": "Amazon.com",
          "version": "3.53.1-6.48.amzn1",
          "checksum": "1e6ce14f97f57d1bbd46ff8e5d3e133171a1bbce",
          "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53"
        }
      ],
      "hotfixes": [],
      "os": {
        "architecture": "x86_64",
        "checksum": "1691178971959743855",
        "hostname": "a51c01971248",
        "codename": "bullseye",
        "major_version": "2018",
        "minor_version" : "03",
        "name": "Amazon Linux AMI",
        "platform": "amzn",
        "version": "2018.03",
        "scan_time": "2023/08/04 19:56:11",
        "kernel_release": "6.6.54-2-MANJARO",
        "kernel_name": "Linux",
        "kernel_version": "#1 SMP PREEMPT_DYNAMIC Tue Oct  8 03:11:08 UTC 2024"
      }
    }' http://localhost/vulnerability/scan | jq
```

Result

```json
[
  {
    "assigner": "mozilla",
    "category": "Packages",
    "classification": "CVSS",
    "condition": "Package less than 3.53.1-6.49.amzn1",
    "cvss": {
      "cvss3": {
        "vector": {
          "attack_vector": "",
          "availability": "LOW",
          "confidentiality_impact": "LOW",
          "integrity_impact": "NONE",
          "privileges_required": "NONE",
          "scope": "UNCHANGED",
          "user_interaction": "NONE"
        }
      }
    },
    "cwe_reference": "",
    "description": "NSS was susceptible to a timing side-channel attack when performing RSA decryption. This attack could potentially allow an attacker to recover the private data. This vulnerability affects Firefox < 124, Firefox ESR < 115.9, and Thunderbird < 115.9.",
    "detected_at": "2024-11-23T04:23:15.555Z",
    "enumeration": "CVE",
    "id": "CVE-2023-5388",
    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
    "published_at": "2024-03-19T12:15:07Z",
    "reference": "https://bugzilla.mozilla.org/show_bug.cgi?id=1780432, https://lists.debian.org/debian-lts-announce/2024/03/msg00022.html, https://lists.debian.org/debian-lts-announce/2024/03/msg00028.html, https://www.mozilla.org/security/advisories/mfsa2024-12/, https://www.mozilla.org/security/advisories/mfsa2024-13/, https://www.mozilla.org/security/advisories/mfsa2024-14/",
    "score": {
      "base": 6.5,
      "version": "3.1"
    },
    "severity": "Medium",
    "source": "Amazon Linux Security Center",
    "under_evaluation": false,
    "updated": "2024-11-14T22:35:01Z"
  }
]
```

Related logs
```
2024-11-23 04:41:16.542 168614:168655 descriptionsHelper.hpp:230 at operator()(): debug: Unreliable information for 'CVE-2023-5388' from alas_1 source.
```

DB query
```
# ./rocksdb_tool -d /var/lib/wazuh-server/vd/feed/ -f /workspaces/5.x/wazuh/src/engine/source/feedmanager/schemas/vulnerabilityDescription.fbs -c descriptions_alas_1 -k CVE-2023-5388
{"CVE-2023-5388":{"accessComplexity":"","assignerShortName":"mozilla","attackVector":"","authentication":"","availabilityImpact":"","classification":"","confidentialityImpact":"","cweId":"","datePublished":"2024-03-19T12:15:07Z","dateUpdated":"2024-11-14T22:35:01Z","description":"It was discovered that the numerical library used in NSS for RSA cryptography leaks information whether high order bits of the RSA decryption result are zero. This information can be used to mount a Bleichenbacher or Manger like attack against all RSA decryption operations. As the leak happens before any padding operations, it affects all padding modes: PKCS#1 v1.5, OAEP, and RSASVP. Both API level calls and TLS server operation are affected.","integrityImpact":"","privilegesRequired":"","reference":"http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-5388","scope":"","scoreVersion":"","severity":"","userInteraction":""}}

# ./rocksdb_tool -d /var/lib/wazuh-server/vd/feed/ -f /workspaces/5.x/wazuh/src/engine/source/feedmanager/schemas/vulnerabilityDescription.fbs -c descriptions_nvd -k CVE-2023-5388
{"CVE-2023-5388":{"accessComplexity":"","assignerShortName":"mozilla","attackVector":"","authentication":"","availabilityImpact":"LOW","classification":"CVSS","confidentialityImpact":"LOW","cweId":"","datePublished":"2024-03-19T12:15:07Z","dateUpdated":"2024-11-14T22:35:01Z","description":"NSS was susceptible to a timing side-channel attack when performing RSA decryption. This attack could potentially allow an attacker to recover the private data. This vulnerability affects Firefox < 124, Firefox ESR < 115.9, and Thunderbird < 115.9.","integrityImpact":"NONE","privilegesRequired":"NONE","reference":"https://bugzilla.mozilla.org/show_bug.cgi?id=1780432, https://lists.debian.org/debian-lts-announce/2024/03/msg00022.html, https://lists.debian.org/debian-lts-announce/2024/03/msg00028.html, https://www.mozilla.org/security/advisories/mfsa2024-12/, https://www.mozilla.org/security/advisories/mfsa2024-13/, https://www.mozilla.org/security/advisories/mfsa2024-14/","scope":"UNCHANGED","scoreBase":6.5,"scoreVersion":"3.1","severity":"MEDIUM","userInteraction":"NONE"}}
```


</p>
</details> 

### Porting #25711 and #26842

<details><summary>Details</summary>
<p>

Both PRs define the default values and one extends the other one, so the evidence verifies both developments.

 If we repeat the first input, we find that now the `classification` field has an hyphen as value

```json
  {
    "assigner": "mozilla",
    "category": "Packages",
    "classification": "-",
    "condition": "Package default status",
    "cvss": {
      "cvss3": {
        "vector": {
          "attack_vector": "",
          "availability": "NONE",
          "confidentiality_impact": "HIGH",
          "integrity_impact": "NONE",
          "privileges_required": "LOW",
          "scope": "UNCHANGED",
          "user_interaction": "NONE"
        }
      }
    },
    "cwe_reference": "",
    "description": "DOCUMENTATION: It was discovered that the numerical library used in NSS for RSA cryptography leaks information whether high order bits of the RSA decryption result are zero. This information can be used to mount a Bleichenbacher or Manger like attack against all RSA decryption operations. As the leak happens before any padding operations, it affects all padding modes: PKCS#1 v1.5, OAEP, and RSASVP. Both API level calls and TLS server operation are affected.",
    "detected_at": "2024-11-23T04:45:41.092Z",
    "enumeration": "CVE",
    "id": "CVE-2023-5388",
    "item_id": "ec465b7eb5fa011a336e95614072e4c7f1a65a53",
    "published_at": "2024-03-19T12:15:07Z",
    "reference": "https://access.redhat.com/security/cve/CVE-2023-5388",
    "score": {
      "base": 6.5,
      "version": "3.1"
    },
    "severity": "Medium",
    "source": "Red Hat CVE Database",
    "under_evaluation": true,
    "updated": "2024-11-14T22:35:01Z"
  }
```
</p>
</details> 


