### PR TITLE
Update stateful events models

### DIFF
--- a/apis/comms_api/core/events.py
+++ b/apis/comms_api/core/events.py
@@ -2,7 +2,6 @@ from typing import List
 
 from comms_api.models.events import StatefulEvents, StatelessEvents
 from wazuh.core.engine import get_engine_client
-from wazuh.core.exception import WazuhError
 from wazuh.core.indexer import get_indexer_client
 from wazuh.core.batcher.client import BatcherClient
 from wazuh.core.batcher.mux_demux import MuxDemuxQueue
@@ -46,38 +45,3 @@ async def send_stateless_events(events: StatelessEvents) -> None:
     """
     async with get_engine_client() as engine_client:
         await engine_client.events.send(events.events)
-
-
-def parse_agent_metadata(agent_id: str, user_agent: str, agent_groups: str) -> AgentMetadata:
-    """Parse the agent metadata from the different HTTP headers values.
-    
-    Parameters
-    ----------
-    agent_id : str
-        Agent ID.
-    user_agent : str
-        User-Agent HTTP header value.
-    agent_groups : str
-        Agent-Groups HTTP header value.
-
-    Returns
-    -------
-    AgentMetadata
-        Agent metadata.    
-    """
-    values = user_agent.split(' ', 2)
-    if len(values) != 3:
-        raise WazuhError(1764)
-    
-    name = values[0]
-    type = values[1]
-    version = values[2]
-    groups = agent_groups.split(',') if agent_groups != '' else []
-
-    return AgentMetadata(
-        id=agent_id,
-        groups=groups,
-        name=name,
-        type=type,
-        version=version
-    )

--- a/apis/comms_api/core/events.py
+++ b/apis/comms_api/core/events.py
@@ -2,17 +2,24 @@ from typing import List
 
 from comms_api.models.events import StatefulEvents, StatelessEvents
 from wazuh.core.engine import get_engine_client
+from wazuh.core.exception import WazuhError
 from wazuh.core.indexer import get_indexer_client
 from wazuh.core.batcher.client import BatcherClient
 from wazuh.core.batcher.mux_demux import MuxDemuxQueue
-from wazuh.core.indexer.models.events import TaskResult
+from wazuh.core.indexer.models.events import AgentMetadata, TaskResult
 
 
-async def create_stateful_events(events: StatefulEvents, batcher_queue: MuxDemuxQueue) -> List[TaskResult]:
+async def create_stateful_events(
+    agent_metadata: AgentMetadata,
+    events: StatefulEvents,
+    batcher_queue: MuxDemuxQueue
+) -> List[TaskResult]:
     """Post new events to the indexer.
 
     Parameters
     ----------
+    agent_metadata : AgentMetadata
+        Agent metadata. 
     events : Events
         List of events to be posted.
 
@@ -26,7 +33,7 @@ async def create_stateful_events(events: StatefulEvents, batcher_queue: MuxDemux
     """
     async with get_indexer_client() as indexer_client:
         batcher_client = BatcherClient(queue=batcher_queue)
-        return await indexer_client.events.create(events.events, batcher_client)
+        return await indexer_client.events.create(agent_metadata, events.events, batcher_client)
 
 
 async def send_stateless_events(events: StatelessEvents) -> None:
@@ -39,3 +46,38 @@ async def send_stateless_events(events: StatelessEvents) -> None:
     """
     async with get_engine_client() as engine_client:
         await engine_client.events.send(events.events)
+
+
+def parse_agent_metadata(agent_id: str, user_agent: str, agent_groups: str) -> AgentMetadata:
+    """Parse the agent metadata from the different HTTP headers values.
+    
+    Parameters
+    ----------
+    agent_id : str
+        Agent ID.
+    user_agent : str
+        User-Agent HTTP header value.
+    agent_groups : str
+        Agent-Groups HTTP header value.
+
+    Returns
+    -------
+    AgentMetadata
+        Agent metadata.    
+    """
+    values = user_agent.split(' ', 2)
+    if len(values) != 3:
+        raise WazuhError(1764)
+    
+    name = values[0]
+    type = values[1]
+    version = values[2]
+    groups = agent_groups.split(',') if agent_groups != '' else []
+
+    return AgentMetadata(
+        id=agent_id,
+        groups=groups,
+        name=name,
+        type=type,
+        version=version
+    )

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -5,7 +5,7 @@ from comms_api.core.events import create_stateful_events, send_stateless_events
 from comms_api.models.events import StatefulEvents, StatelessEvents
 from wazuh.core.engine.models.events import StatelessEvent, Event, WazuhLocation
 from wazuh.core.indexer import Indexer
-from wazuh.core.indexer.models.events import SCAEvent, TaskResult
+from wazuh.core.indexer.models.events import SCAEvent, TaskResult, StatefulEvent, ModuleType
 
 INDEXER = Indexer(host='host', user='wazuh', password='wazuh')
 
@@ -36,7 +36,10 @@ async def test_create_stateful_events(create_indexer_mock):
     create_indexer_mock.return_value.events.create.return_value = expected
     batcher_queue = AsyncMock()
 
-    events = StatefulEvents(events=[SCAEvent(), SCAEvent()])
+    events = StatefulEvents(events=[
+        StatefulEvent(data=SCAEvent(), module=ModuleType.SCA),
+        StatefulEvent(data=SCAEvent(), module=ModuleType.SCA)
+    ])
     result = await create_stateful_events(events, batcher_queue)
 
     create_indexer_mock.assert_called_once()

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest.mock import patch, AsyncMock
 
-from comms_api.core.events import create_stateful_events, send_stateless_events
+from comms_api.core.events import create_stateful_events, send_stateless_events, parse_agent_metadata
 from comms_api.models.events import StatefulEvents, StatelessEvents
 from wazuh.core.engine.models.events import StatelessEvent, Event, WazuhLocation
 from wazuh.core.indexer import Indexer
-from wazuh.core.indexer.models.events import SCAEvent, TaskResult, StatefulEvent, ModuleType
+from wazuh.core.indexer.models.events import AgentMetadata, SCAEvent, TaskResult, StatefulEvent, ModuleName
 
 INDEXER = Indexer(host='host', user='wazuh', password='wazuh')
 
@@ -33,15 +33,55 @@ async def test_create_stateful_events(create_indexer_mock):
         TaskResult(id='1', result='created', status=201),
         TaskResult(id='2', result='created', status=201),
     ]
+    agent_metadata = AgentMetadata(
+        id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+        groups=[],
+        name='test',
+        type='endpoint',
+        version='v5.0.0'
+    )
     create_indexer_mock.return_value.events.create.return_value = expected
     batcher_queue = AsyncMock()
 
     events = StatefulEvents(events=[
-        StatefulEvent(data=SCAEvent(), module=ModuleType.SCA),
-        StatefulEvent(data=SCAEvent(), module=ModuleType.SCA)
+        StatefulEvent(data=SCAEvent(), module=ModuleName.SCA),
+        StatefulEvent(data=SCAEvent(), module=ModuleName.SCA)
     ])
-    result = await create_stateful_events(events, batcher_queue)
+    result = await create_stateful_events(agent_metadata, events, batcher_queue)
 
     create_indexer_mock.assert_called_once()
     create_indexer_mock.return_value.events.create.assert_called_once()
     assert result == expected
+
+
+@pytest.mark.parametrize('agent_id, user_agent, agent_groups, expected', [
+    (
+        'ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+        'test endpoint v5.0.0',
+        '',
+        AgentMetadata(
+            id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+            groups=[],
+            name='test',
+            type='endpoint',
+            version='v5.0.0'
+        )
+    ),
+    (
+        'ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+        'test2 lambda v5.0.1',
+        'default,group1,group2',
+        AgentMetadata(
+            id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+            groups=['default', 'group1', 'group2'],
+            name='test2',
+            type='lambda',
+            version='v5.0.1'
+        )
+    ),
+])
+def test_parse_agent_metadata(agent_id, user_agent, agent_groups, expected):
+    """Check that the `parse_agent_metadata` function works as expected."""
+    agent_metadata = parse_agent_metadata(agent_id, user_agent, agent_groups)
+
+    assert agent_metadata == expected

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, AsyncMock
 
-from comms_api.core.events import create_stateful_events, send_stateless_events, parse_agent_metadata
+from comms_api.core.events import create_stateful_events, send_stateless_events
 from comms_api.models.events import StatefulEvents, StatelessEvents
 from wazuh.core.engine.models.events import StatelessEvent, Event, WazuhLocation
 from wazuh.core.indexer import Indexer
@@ -52,36 +52,3 @@ async def test_create_stateful_events(create_indexer_mock):
     create_indexer_mock.assert_called_once()
     create_indexer_mock.return_value.events.create.assert_called_once()
     assert result == expected
-
-
-@pytest.mark.parametrize('agent_id, user_agent, agent_groups, expected', [
-    (
-        'ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
-        'test endpoint v5.0.0',
-        '',
-        AgentMetadata(
-            id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
-            groups=[],
-            name='test',
-            type='endpoint',
-            version='v5.0.0'
-        )
-    ),
-    (
-        'ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
-        'test2 lambda v5.0.1',
-        'default,group1,group2',
-        AgentMetadata(
-            id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
-            groups=['default', 'group1', 'group2'],
-            name='test2',
-            type='lambda',
-            version='v5.0.1'
-        )
-    ),
-])
-def test_parse_agent_metadata(agent_id, user_agent, agent_groups, expected):
-    """Check that the `parse_agent_metadata` function works as expected."""
-    agent_metadata = parse_agent_metadata(agent_id, user_agent, agent_groups)
-
-    assert agent_metadata == expected

--- a/apis/comms_api/core/test/test_utils.py
+++ b/apis/comms_api/core/test/test_utils.py
@@ -1,0 +1,37 @@
+import pytest
+
+from comms_api.core.utils import parse_agent_metadata
+from wazuh.core.indexer.models.events import AgentMetadata
+
+
+@pytest.mark.parametrize('agent_id, user_agent, agent_groups, expected', [
+    (
+        'ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+        'test endpoint v5.0.0',
+        '',
+        AgentMetadata(
+            id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+            groups=[],
+            name='test',
+            type='endpoint',
+            version='v5.0.0'
+        )
+    ),
+    (
+        'ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+        'test2 lambda v5.0.1',
+        'default,group1,group2',
+        AgentMetadata(
+            id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+            groups=['default', 'group1', 'group2'],
+            name='test2',
+            type='lambda',
+            version='v5.0.1'
+        )
+    ),
+])
+def test_parse_agent_metadata(agent_id, user_agent, agent_groups, expected):
+    """Check that the `parse_agent_metadata` function works as expected."""
+    agent_metadata = parse_agent_metadata(agent_id, user_agent, agent_groups)
+
+    assert agent_metadata == expected

--- a/apis/comms_api/core/utils.py
+++ b/apis/comms_api/core/utils.py
@@ -1,0 +1,38 @@
+
+from wazuh.core.exception import WazuhError
+from wazuh.core.indexer.models.events import AgentMetadata
+
+
+def parse_agent_metadata(agent_id: str, user_agent: str, agent_groups: str) -> AgentMetadata:
+    """Parse the agent metadata from the different HTTP headers values.
+    
+    Parameters
+    ----------
+    agent_id : str
+        Agent ID.
+    user_agent : str
+        User-Agent HTTP header value.
+    agent_groups : str
+        Agent-Groups HTTP header value.
+
+    Returns
+    -------
+    AgentMetadata
+        Agent metadata.    
+    """
+    values = user_agent.split(' ', 2)
+    if len(values) != 3:
+        raise WazuhError(1764)
+    
+    name = values[0]
+    type = values[1]
+    version = values[2]
+    groups = agent_groups.split(',') if agent_groups != '' else []
+
+    return AgentMetadata(
+        id=agent_id,
+        groups=groups,
+        name=name,
+        type=type,
+        version=version
+    )

--- a/apis/comms_api/routers/events.py
+++ b/apis/comms_api/routers/events.py
@@ -14,9 +14,9 @@ from wazuh.core.exception import WazuhEngineError, WazuhError, WazuhCommsAPIErro
 async def post_stateful_events(
     token: Annotated[str, Depends(JWTBearer())],
     user_agent: Annotated[str, Header()],
-    agent_groups: Annotated[str, Header()],
     request: Request,
     events: StatefulEvents,
+    agent_groups: Annotated[str, Header()] = '',
 ) -> StatefulEventsResponse:
     """Handle posting stateful events.
 
@@ -26,12 +26,12 @@ async def post_stateful_events(
         JWT token.
     user_agent : str
         User-Agent header value.
-    agent_groups : str
-        Agent-Groups header value.
     request : Request
         Incoming HTTP request.
     events : StatefulEvents
         Events to post.
+    agent_groups : str
+        Agent-Groups header value. Default value is an emtpy string.
 
     Raises
     ------

--- a/apis/comms_api/routers/events.py
+++ b/apis/comms_api/routers/events.py
@@ -3,7 +3,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Header, Request, Response, status
 
 from comms_api.authentication.authentication import decode_token, JWTBearer
-from comms_api.core.events import create_stateful_events, send_stateless_events, parse_agent_metadata
+from comms_api.core.events import create_stateful_events, send_stateless_events
+from comms_api.core.utils import parse_agent_metadata
 from comms_api.models.events import StatefulEvents, StatefulEventsResponse, StatelessEvents
 from comms_api.routers.exceptions import HTTPError
 from comms_api.routers.utils import timeout

--- a/apis/comms_api/routers/test/test_events.py
+++ b/apis/comms_api/routers/test/test_events.py
@@ -7,12 +7,13 @@ from comms_api.models.events import StatefulEventsResponse
 from comms_api.routers.events import post_stateful_events, post_stateless_events
 from comms_api.routers.exceptions import HTTPError
 from wazuh.core.exception import WazuhEngineError, WazuhError
-from wazuh.core.indexer.models.events import TaskResult
+from wazuh.core.indexer.models.events import AgentMetadata, TaskResult
 
 
 @pytest.mark.asyncio
 @patch('comms_api.routers.events.create_stateful_events')
-async def test_post_stateful_events(create_stateful_events_mock):
+@patch('comms_api.routers.events.decode_token')
+async def test_post_stateful_events(decode_token_mock, create_stateful_events_mock):
     """Verify that the `post_stateful_events` handler works as expected."""
     request = MagicMock()
     request.app.state.batcher_queue = AsyncMock()  # Mock the batcher_queue
@@ -21,16 +22,30 @@ async def test_post_stateful_events(create_stateful_events_mock):
     results = [TaskResult(id='123', result='created', status=201)]
     create_stateful_events_mock.return_value = results
 
-    response = await post_stateful_events(request, events)
+    agent_id = '01929571-49b5-75e8-a3f6-1d2b84f4f71a'
+    decode_token_mock.return_value = {'uuid': agent_id}
+    token = 'token'
+    user_agent = 'test endpoint v5.0.0'
+    agent_groups = 'group1,group2'
+    agent_metadata = AgentMetadata(
+        id=agent_id,
+        groups=['group1', 'group2'],
+        name='test',
+        type='endpoint',
+        version='v5.0.0'
+    )
 
-    create_stateful_events_mock.assert_called_once_with(events, request.app.state.batcher_queue)
+    response = await post_stateful_events(token, user_agent, request, events, agent_groups)
+
+    create_stateful_events_mock.assert_called_once_with(agent_metadata, events, request.app.state.batcher_queue)
 
     assert isinstance(response, StatefulEventsResponse)
     assert response.results == results
 
 
 @pytest.mark.asyncio
-async def test_post_stateful_events_ko():
+@patch('comms_api.routers.events.decode_token')
+async def test_post_stateful_events_ko(decode_token_mock):
     """Verify that the `post_stateful_events` handler catches exceptions successfully."""
     request = MagicMock()
     request.app.state.batcher_queue = AsyncMock()  # Mock the batcher_queue
@@ -41,7 +56,7 @@ async def test_post_stateful_events_ko():
 
     with patch('comms_api.routers.events.create_stateful_events', MagicMock(side_effect=exception)):
         with pytest.raises(HTTPError, match=f'{code}: {exception.message}'):
-            await post_stateful_events(request, events)
+            await post_stateful_events('', 'test endpoint v5.0.0', request, events)
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/batcher/client.py
+++ b/framework/wazuh/core/batcher/client.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from wazuh.core.batcher.mux_demux import MuxDemuxQueue, Item
 from wazuh.core.indexer.base import remove_empty_values
-from wazuh.core.indexer.models.events import StatefulEvent
+from wazuh.core.indexer.models.events import StatefulEvent, get_module_index_name
 
 
 class BatcherClient:
@@ -38,8 +38,8 @@ class BatcherClient:
         """
         item = Item(
             id=id(event),
-            content=asdict(event, dict_factory=remove_empty_values),
-            index_name=event.get_index_name()
+            content=asdict(event.data, dict_factory=remove_empty_values),
+            index_name=get_module_index_name(event.module)
         )
         self.queue.send_to_mux(item)
         return item.id

--- a/framework/wazuh/core/batcher/client.py
+++ b/framework/wazuh/core/batcher/client.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from wazuh.core.batcher.mux_demux import MuxDemuxQueue, Item
 from wazuh.core.indexer.base import remove_empty_values
-from wazuh.core.indexer.models.events import StatefulEvent, get_module_index_name
+from wazuh.core.indexer.models.events import AgentMetadata, ModuleName, StatefulEvent, get_module_index_name
 
 
 class BatcherClient:
@@ -23,11 +23,13 @@ class BatcherClient:
         self.queue = queue
         self.wait_frequency = wait_frequency
 
-    def send_event(self, event: StatefulEvent) -> int:
+    def send_event(self, agent_metadata: AgentMetadata, event: StatefulEvent) -> int:
         """Send an event through the RouterQueue.
 
         Parameters
         ----------
+        agent_metadata : AgentMetadata
+            Agent metadata.
         event : StatefulEvent
             Event to send.
 
@@ -36,9 +38,21 @@ class BatcherClient:
         int
             Unique identifier assigned to the event.
         """
+        metadata = {}
+        if event.module.name is ModuleName.VULNERABILITY:
+            metadata = {'agent': asdict(agent_metadata)}
+        else:
+            metadata = {
+                'agent': {
+                    'id': agent_metadata.id,
+                    'groups': agent_metadata.groups
+                }
+            }
+
+        content = metadata | asdict(event.data, dict_factory=remove_empty_values)
         item = Item(
             id=id(event),
-            content=asdict(event.data, dict_factory=remove_empty_values),
+            content=content,
             index_name=get_module_index_name(event.module)
         )
         self.queue.send_to_mux(item)

--- a/framework/wazuh/core/batcher/client.py
+++ b/framework/wazuh/core/batcher/client.py
@@ -39,7 +39,7 @@ class BatcherClient:
             Unique identifier assigned to the event.
         """
         metadata = {}
-        if event.module.name is ModuleName.VULNERABILITY:
+        if event.module.name == ModuleName.VULNERABILITY:
             metadata = {'agent': asdict(agent_metadata)}
         else:
             metadata = {

--- a/framework/wazuh/core/batcher/tests/test_client.py
+++ b/framework/wazuh/core/batcher/tests/test_client.py
@@ -23,7 +23,7 @@ def test_send_event(id_mock, queue_mock):
 
     id_mock.return_value = expected_item_id
 
-    item_id = batcher.send_event(event)
+    item_id = batcher.send_event(agent_metadata, event)
     assert item_id == expected_item_id
     queue_mock.send_to_mux.assert_called_once()
 

--- a/framework/wazuh/core/batcher/tests/test_client.py
+++ b/framework/wazuh/core/batcher/tests/test_client.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, AsyncMock, call
 import pytest
 
 from framework.wazuh.core.batcher.client import BatcherClient
-from wazuh.core.indexer.models.events import SCAEvent
+from wazuh.core.indexer.models.events import AgentMetadata, SCAEvent, StatefulEvent, Module, ModuleName
 
 
 @patch("wazuh.core.batcher.mux_demux.MuxDemuxQueue")
@@ -11,7 +11,14 @@ from wazuh.core.indexer.models.events import SCAEvent
 def test_send_event(id_mock, queue_mock):
     """Check that the `send_event` method works as expected."""
     batcher = BatcherClient(queue=queue_mock)
-    event = SCAEvent()
+    agent_metadata = AgentMetadata(
+        id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
+        groups=[],
+        name='test',
+        type='endpoint',
+        version='v5.0.0'
+    )
+    event = StatefulEvent(data=SCAEvent(), module=Module(name=ModuleName.SCA))
     expected_item_id = 1234
 
     id_mock.return_value = expected_item_id

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -366,9 +366,9 @@ class WazuhException(Exception):
                'remediation': 'Please check the request body and try again'
                },
         1762: 'Error sending command to the commands manager',
-        1763: "Invalid inventory module type. It must be 'network', 'package', 'process' or 'system'.",
+        1763: "Invalid inventory module type. It must be 'network', 'package', 'process' or 'system'",
         1764: "Invalid User-Agent HTTP header value. It must follow the format '<name> <type> <version>'",
-        1765: "Invalid module name. It must be 'fim', 'sca', 'inventory', 'command' or 'vulnerability'.",
+        1765: "Invalid module name. It must be 'fim', 'sca', 'inventory', 'command' or 'vulnerability'",
 
 
         # CDB List: 1800 - 1899

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -366,6 +366,10 @@ class WazuhException(Exception):
                'remediation': 'Please check the request body and try again'
                },
         1762: 'Error sending command to the commands manager',
+        1763: "Invalid inventory module type. It must be 'network', 'package', 'process' or 'system'.",
+        1764: "Invalid User-Agent HTTP header value. It must follow the format '<name> <type> <version>'",
+        1765: "Invalid module name. It must be 'fim', 'sca', 'inventory', 'command' or 'vulnerability'.",
+
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/core/indexer/base.py
+++ b/framework/wazuh/core/indexer/base.py
@@ -41,6 +41,8 @@ class IndexerKey(str, Enum):
     FILTER = 'filter'
     RESULT = 'result'
     STATUS = 'status'
+    ERROR = 'error'
+    REASON = 'reason'
 
 
 class BaseIndex:

--- a/framework/wazuh/core/indexer/events.py
+++ b/framework/wazuh/core/indexer/events.py
@@ -10,6 +10,9 @@ from wazuh.core.batcher.client import BatcherClient
 
 from opensearchpy import AsyncOpenSearch
 
+HTTP_STATUS_OK = 200
+HTTP_STATUS_PARTIAL_CONTENT = 206
+
 
 class EventsIndex(BaseIndex, MixinBulk):
     """Set of methods to interact with the stateful events indices."""
@@ -60,7 +63,7 @@ class EventsIndex(BaseIndex, MixinBulk):
         results: List[TaskResult] = []
         for result in tasks_results:
             status = result[IndexerKey.STATUS]
-            if status < 300:
+            if status >= HTTP_STATUS_OK and status <= HTTP_STATUS_PARTIAL_CONTENT:
                 task_result = TaskResult(
                     id=result[IndexerKey._ID],
                     result=result[IndexerKey.RESULT],

--- a/framework/wazuh/core/indexer/events.py
+++ b/framework/wazuh/core/indexer/events.py
@@ -3,7 +3,7 @@ from typing import List
 from uuid import UUID
 
 from .base import BaseIndex
-from wazuh.core.indexer.models.events import StatefulEvent, TaskResult
+from wazuh.core.indexer.models.events import AgentMetadata, StatefulEvent, TaskResult
 from wazuh.core.indexer.base import IndexerKey
 from wazuh.core.indexer.bulk import MixinBulk
 from wazuh.core.batcher.client import BatcherClient
@@ -17,11 +17,18 @@ class EventsIndex(BaseIndex, MixinBulk):
     def __init__(self, client: AsyncOpenSearch):
         super().__init__(client)
 
-    async def create(self, events: List[StatefulEvent], batcher_client: BatcherClient) -> List[TaskResult]:
+    async def create(
+        self,
+        agent_metadata: AgentMetadata,
+        events: List[StatefulEvent],
+        batcher_client: BatcherClient
+    ) -> List[TaskResult]:
         """Post new events to the indexer.
 
         Parameters
         ----------
+        agent_metadata : AgentMetadata
+            Agent metadata.
         events : List[StatefulEvent]
             List of events.
         batcher_client : BatcherClient
@@ -36,7 +43,7 @@ class EventsIndex(BaseIndex, MixinBulk):
 
         # Sends the events to the batcher
         for event in events:
-            item_id = batcher_client.send_event(event)
+            item_id = batcher_client.send_event(agent_metadata, event)
             item_ids.append(item_id)
 
         # Create tasks using a lambda function to obtain the result of each one

--- a/framework/wazuh/core/indexer/events.py
+++ b/framework/wazuh/core/indexer/events.py
@@ -52,10 +52,20 @@ class EventsIndex(BaseIndex, MixinBulk):
 
         results: List[TaskResult] = []
         for result in tasks_results:
-            results.append(TaskResult(
-                id=result[IndexerKey._ID],
-                result=result[IndexerKey.RESULT],
-                status=result[IndexerKey.STATUS]
-            ))
+            status = result[IndexerKey.STATUS]
+            if status < 300:
+                task_result = TaskResult(
+                    id=result[IndexerKey._ID],
+                    result=result[IndexerKey.RESULT],
+                    status=status
+                )
+            else:
+                task_result = TaskResult(
+                    id='',
+                    result=result[IndexerKey.ERROR][IndexerKey.REASON],
+                    status=status
+                )
+
+            results.append(task_result)
 
         return results

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -14,7 +14,6 @@ class Action:
 @dataclass
 class Result:
     """Command result data model."""
-    info: str = None
     code: int = None
     message: str = None
     data: str = None

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -10,7 +10,7 @@ from wazuh.core.indexer.commands import CommandsManager
 FIM_INDEX = 'wazuh-states-fim'
 INVENTORY_INDEX = 'stateful-inventory'
 SCA_INDEX = 'stateful-sca'
-VULNERABILITY_INDEX = 'stateful-vulnerability'
+VULNERABILITY_INDEX = 'wazuh-states-vulnerabilities'
 
 
 @dataclass
@@ -88,7 +88,6 @@ class OS:
     platform: str
     version: str
     type: str
-    family: str
 
 
 @dataclass
@@ -144,20 +143,19 @@ class SCAEvent(BaseModel):
 
 
 @dataclass
-class BuildInfo:
-    """Agent build information data model."""
-    original: str
-
-
-@dataclass
 class VulnerabilityEventAgent:
     """Agent data model in relation to vulnerability events."""
-    build: BuildInfo
-    ephemeral_id: str
     id: str
+    groups: str
     name: str
     type: str
     version: str
+
+
+@dataclass
+class VulnerabilityEventHost:
+    """Host data model in relation to vulnerability events."""
+    os: OS
 
 
 @dataclass
@@ -186,12 +184,6 @@ class Cluster:
 
 
 @dataclass
-class Manager:
-    """Wazuh manager data model."""
-    name: str
-
-
-@dataclass
 class Schema:
     """Wazuh schema data model."""
     version: str
@@ -201,18 +193,44 @@ class Schema:
 class Wazuh:
     """Wazuh instance information data model."""
     cluster: Cluster
-    manager: Manager
     schema: Schema
+
+
+@dataclass
+class Scanner:
+    """Scanner data model."""
+    source: str
+    vendor: str
+
+
+@dataclass
+class Score:
+    """Score data model."""
+    base: float
+    environmental: float
+    temporal: float
+    version: str
 
 
 @dataclass
 class VulnerabilityEvent(BaseModel):
     """Vulnerability events data model."""
     agent: VulnerabilityEventAgent
-    host: Host
-    message: str
+    host: VulnerabilityEventHost
     package: Package
-    tags: List[str]
+    scanner: Scanner
+    score: Score
+    category: str
+    classification: str
+    description: str
+    detected_at: datetime
+    enumeration: str
+    id: str
+    published_at: datetime
+    reference: str
+    report_id: str
+    severity: str
+    under_evaluation: bool
 
     def get_index_name(self) -> str:
         """Get the index name for the event type.

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -9,6 +9,7 @@ from wazuh.core.indexer.commands import CommandsManager
 
 FIM_INDEX = 'wazuh-states-fim'
 INVENTORY_INDEX = 'stateful-inventory'
+INVENTORY_SYSTEM_INDEX = 'wazuh-states-inventory-system'
 SCA_INDEX = 'stateful-sca'
 VULNERABILITY_INDEX = 'wazuh-states-vulnerabilities'
 
@@ -124,6 +125,24 @@ class InventoryEvent(BaseModel):
             Index name.
         """
         return INVENTORY_INDEX
+
+
+@dataclass
+class InventorySystemEvent(BaseModel):
+    """Inventory system events data model."""
+    agent: EventAgent
+    scan_time: datetime
+    host: Host
+
+    def get_index_name(self) -> str:
+        """Get the index name for the event type.
+        
+        Returns
+        -------
+        str
+            Index name.
+        """
+        return INVENTORY_SYSTEM_INDEX
 
 
 @dataclass

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -11,7 +11,7 @@ FIM_INDEX = 'wazuh-states-fim'
 INVENTORY_PACKAGES_INDEX = 'wazuh-states-inventory-packages'
 INVENTORY_PROCESSES_INDEX = 'wazuh-states-inventory-processes'
 INVENTORY_SYSTEM_INDEX = 'wazuh-states-inventory-system'
-SCA_INDEX = 'stateful-sca'
+SCA_INDEX = 'wazuh-states-sca'
 VULNERABILITY_INDEX = 'wazuh-states-vulnerabilities'
 
 
@@ -200,7 +200,7 @@ class InventorySystemEvent(BaseModel):
 @dataclass
 class SCAEvent(BaseModel):
     """SCA events data model."""
-    # TODO(25121): Update SCA event fields
+    # TODO(25121): Add SCA event fields once they are defined
 
     def get_index_name(self) -> str:
         """Get the index name for the event type.

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -9,6 +9,7 @@ from wazuh.core.indexer.commands import CommandsManager
 
 FIM_INDEX = 'wazuh-states-fim'
 INVENTORY_PACKAGES_INDEX = 'wazuh-states-inventory-packages'
+INVENTORY_PROCESSES_INDEX = 'wazuh-states-inventory-processes'
 INVENTORY_SYSTEM_INDEX = 'wazuh-states-inventory-system'
 SCA_INDEX = 'stateful-sca'
 VULNERABILITY_INDEX = 'wazuh-states-vulnerabilities'
@@ -100,17 +101,6 @@ class Host:
 
 
 @dataclass
-class ProcessHash:
-    md5: str
-
-
-@dataclass
-class Process:
-    """Process data model."""
-    hash: ProcessHash
-
-
-@dataclass
 class Package:
     """Package data model."""
     architecture: str
@@ -139,6 +129,54 @@ class InventoryPackageEvent(BaseModel):
             Index name.
         """
         return INVENTORY_PACKAGES_INDEX
+
+
+@dataclass
+class Parent:
+    """Process parent data model."""
+    pid: float
+
+
+@dataclass
+class ID:
+    """Process users and groups ID data model."""
+    id: str
+
+
+@dataclass
+class Process:
+    """Process data model."""
+    pid: float
+    name: str
+    parent: Parent
+    command_line: str
+    args: List[str]
+    user: ID
+    real_user: ID
+    saved_user: ID
+    group: ID
+    real_group: ID
+    saved_group: ID
+    start: datetime
+    thread: ID
+
+
+@dataclass
+class InventoryProcessEvent(BaseModel):
+    """Inventory process events data model."""
+    agent: EventAgent
+    scan_time: datetime
+    process: Process
+
+    def get_index_name(self) -> str:
+        """Get the index name for the event type.
+        
+        Returns
+        -------
+        str
+            Index name.
+        """
+        return INVENTORY_PROCESSES_INDEX
 
 
 @dataclass
@@ -294,4 +332,11 @@ class CommandResult(BaseModel):
 
 
 # Stateful event type
-StatefulEvent = Union[FIMEvent, InventoryPackageEvent, InventorySystemEvent, SCAEvent, VulnerabilityEvent]
+StatefulEvent = Union[
+    FIMEvent,
+    InventoryPackageEvent,
+    InventoryProcessEvent,
+    InventorySystemEvent,
+    SCAEvent,
+    VulnerabilityEvent
+]

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -8,7 +8,7 @@ from wazuh.core.indexer.models.commands import Result
 from wazuh.core.indexer.commands import CommandsManager
 
 FIM_INDEX = 'wazuh-states-fim'
-INVENTORY_INDEX = 'stateful-inventory'
+INVENTORY_PACKAGES_INDEX = 'wazuh-states-inventory-packages'
 INVENTORY_SYSTEM_INDEX = 'wazuh-states-inventory-system'
 SCA_INDEX = 'stateful-sca'
 VULNERABILITY_INDEX = 'wazuh-states-vulnerabilities'
@@ -111,10 +111,24 @@ class Process:
 
 
 @dataclass
-class InventoryEvent(BaseModel):
-    """Inventory events data model."""
-    host: Host
-    process: Process
+class Package:
+    """Package data model."""
+    architecture: str
+    description: str
+    installed: datetime
+    name: str
+    path: str
+    size: float
+    type: str
+    version: str
+
+
+@dataclass
+class InventoryPackageEvent(BaseModel):
+    """Inventory packages events data model."""
+    agent: EventAgent
+    scan_time: datetime
+    package: Package
 
     def get_index_name(self) -> str:
         """Get the index name for the event type.
@@ -124,7 +138,7 @@ class InventoryEvent(BaseModel):
         str
             Index name.
         """
-        return INVENTORY_INDEX
+        return INVENTORY_PACKAGES_INDEX
 
 
 @dataclass
@@ -178,8 +192,8 @@ class VulnerabilityEventHost:
 
 
 @dataclass
-class Package:
-    """Package data model."""
+class VulnerabilityEventPackage:
+    """Package data model in relation to vulnerability events."""
     architecture: str
     build_version: str
     checksum: str
@@ -236,7 +250,7 @@ class VulnerabilityEvent(BaseModel):
     """Vulnerability events data model."""
     agent: VulnerabilityEventAgent
     host: VulnerabilityEventHost
-    package: Package
+    package: VulnerabilityEventPackage
     scanner: Scanner
     score: Score
     category: str
@@ -280,4 +294,4 @@ class CommandResult(BaseModel):
 
 
 # Stateful event type
-StatefulEvent = Union[FIMEvent, InventoryEvent, SCAEvent, VulnerabilityEvent, CommandResult]
+StatefulEvent = Union[FIMEvent, InventoryPackageEvent, InventorySystemEvent, SCAEvent, VulnerabilityEvent]

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from wazuh.core.indexer.models.commands import Result
 from wazuh.core.indexer.commands import CommandsManager
 
-FIM_INDEX = 'stateful-fim'
+FIM_INDEX = 'wazuh-states-fim'
 INVENTORY_INDEX = 'stateful-inventory'
 SCA_INDEX = 'stateful-sca'
 VULNERABILITY_INDEX = 'stateful-vulnerability'
@@ -19,6 +19,12 @@ class TaskResult:
     id: str
     result: str
     status: int
+
+
+class EventAgent:
+    """Agent data model in relation to events."""
+    id: str
+    groups: str
 
 
 @dataclass
@@ -58,6 +64,7 @@ class Registry:
 @dataclass
 class FIMEvent(BaseModel):
     """FIM events data model."""
+    agent: EventAgent
     file: File
     registry: Registry
 
@@ -143,8 +150,8 @@ class BuildInfo:
 
 
 @dataclass
-class EventAgent:
-    """Agent data model in relation to events."""
+class VulnerabilityEventAgent:
+    """Agent data model in relation to vulnerability events."""
     build: BuildInfo
     ephemeral_id: str
     id: str
@@ -201,7 +208,7 @@ class Wazuh:
 @dataclass
 class VulnerabilityEvent(BaseModel):
     """Vulnerability events data model."""
-    agent: EventAgent
+    agent: VulnerabilityEventAgent
     host: Host
     message: str
     package: Package

--- a/framework/wazuh/core/indexer/models/test/test_commands.py
+++ b/framework/wazuh/core/indexer/models/test/test_commands.py
@@ -9,7 +9,7 @@ def test_command_from_dict():
     data = {
         'target': {'id': 'agent_id', 'type': TargetType.AGENT.value},
         'action': {'name': 'restart', 'args': ['/bin/bash', '-c'], 'version': 'v5.0.0'},
-        'result': {'info': 'info'},
+        'result': {'message': 'message'},
         'status': status,
         'timeout': timeout,
         'source': Source.SERVICES.value,

--- a/framework/wazuh/core/indexer/models/test/test_event.py
+++ b/framework/wazuh/core/indexer/models/test/test_event.py
@@ -1,0 +1,35 @@
+import pytest
+
+from wazuh.core.exception import WazuhError
+from wazuh.core.indexer.models.events import get_module_index_name, Module, ModuleName, FIM_INDEX, SCA_INDEX, \
+    VULNERABILITY_INDEX, INVENTORY_NETWORK_INDEX, INVENTORY_PACKAGES_INDEX, INVENTORY_PROCESSES_INDEX, \
+    INVENTORY_SYSTEM_INDEX, INVENTORY_NETWORK_TYPE, INVENTORY_PACKAGES_TYPE, INVENTORY_PROCESSES_TYPE, \
+    INVENTORY_SYSTEM_TYPE, CommandsManager
+
+
+@pytest.mark.parametrize('module, expected_name', [
+    (Module(name=ModuleName.INVENTORY, type=INVENTORY_NETWORK_TYPE), INVENTORY_NETWORK_INDEX),
+    (Module(name=ModuleName.INVENTORY, type=INVENTORY_PACKAGES_TYPE), INVENTORY_PACKAGES_INDEX),
+    (Module(name=ModuleName.INVENTORY, type=INVENTORY_PROCESSES_TYPE), INVENTORY_PROCESSES_INDEX),
+    (Module(name=ModuleName.INVENTORY, type=INVENTORY_SYSTEM_TYPE), INVENTORY_SYSTEM_INDEX),
+    (Module(name=ModuleName.SCA), SCA_INDEX),
+    (Module(name=ModuleName.FIM), FIM_INDEX),
+    (Module(name=ModuleName.VULNERABILITY), VULNERABILITY_INDEX),
+    (Module(name=ModuleName.COMMAND), CommandsManager.INDEX),
+])
+def test_get_module_index_name(module, expected_name):
+    """Validate that the `get_module_index_name` works as expected."""
+    actual_name = get_module_index_name(module)
+
+    assert actual_name == expected_name
+
+
+@pytest.mark.parametrize('name, type, exception', [
+    (ModuleName.INVENTORY, 'invalid', 1763),
+    ('test', 'package', 1765),
+])
+def test_get_module_index_name_ko(name, type, exception):
+    """Validate that the `get_module_index_name` fails if the module is not valid."""
+    module = Module(name=name, type=type)
+    with pytest.raises(WazuhError, match=rf'{exception}'):
+        get_module_index_name(module)


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/26568 |

## Description

Updates the stateful events models and index names to conform with what is defined in https://github.com/wazuh/wazuh-indexer/tree/master/ecs and https://github.com/wazuh/wazuh-indexer/issues/270.

### Tests

<details><summary>Send FIM event</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "User-Agent: test endpoint v5.0.0" -H "Agent-Groups: default,group1,group2" -H "Content-Type: application/json" -ks -X POST https://0.0.0.0:27000/api/v1/events/stateful -d '
{
  "events": [
    {
      "data": {
        "file": {
          "attributes": ["string"],
          "name": "string",
          "path": "string",
          "gid": 0,
          "group": "string",
          "inode": "string",
          "mtime": "2024-10-30T14:59:31.558Z",
          "mode": "string",
          "size": 0,
          "target_path": "string",
          "type": "string",
          "uid": 0,
          "owner": "string",
          "hash": {
            "md5": "string",
            "sha1": "string",
            "sha256": "string"
          }
        },
        "registry": {
          "key": "string",
          "value": "string"
        }
      },
      "module": {
        "name": "fim"
      }
    }
  ]
}' | jq
{
  "results": [
    {
      "id": "6xPU45IBKRnA5k4nQ6as",
      "result": "created",
      "status": 201
    }
  ]
}
{"results":[{"id":"PZf93ZIBfzyT-8mULNgI","result":"created","status":201}]}
```

</details>

<details><summary>Get FIM event</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Content-Type: application/json" -ku admin:SecretPassword1% http://localhost:9200/wazuh-states-fim/_doc/6xPU45IBKRnA5k4nQ6as?pretty=true
{
  "_index" : "wazuh-states-fim",
  "_id" : "6xPU45IBKRnA5k4nQ6as",
  "_version" : 1,
  "_seq_no" : 0,
  "_primary_term" : 1,
  "found" : true,
  "_source" : {
    "agent" : {
      "id" : "01929571-49b5-75e8-a3f6-1d2b84f4f71a",
      "groups" : [
        "default",
        "group1",
        "group2"
      ]
    },
    "file" : {
      "attributes" : [
        "string"
      ],
      "name" : "string",
      "path" : "string",
      "gid" : 0,
      "group" : "string",
      "inode" : "string",
      "mtime" : "2024-10-30T14:59:31.558000+00:00",
      "mode" : "string",
      "size" : 0.0,
      "target_path" : "string",
      "type" : "string",
      "uid" : 0,
      "owner" : "string",
      "hash" : {
        "md5" : "string",
        "sha1" : "string",
        "sha256" : "string"
      }
    },
    "registry" : {
      "key" : "string",
      "value" : "string"
    }
  }
}
```

</details>

<details><summary>Try to send an event using an invalid module name</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "User-Agent: test endpoint v5.0.0" -H "Agent-Groups: default,group1,group2" -H "Content-Type: application/json" -ks -X POST https://0.0.0.0:27000/api/v1/events/stateful -d '
{
  "events": [
    {
      "data": {},
      "module": {
        "name": "agent"
      }
    }
  ]
}' | jq
{
  "message": "('body', 'events', 0, 'module', 'name') input should be 'fim', 'inventory', 'sca', 'vulnerability' or 'command'",
  "code": 400
}
```

</details>

<details><summary>Try to send an event using an invalid module type</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "User-Agent: test endpoint v5.0.0" -H "Agent-Groups: default,group1,group2" -H "Content-Type: application/json" -ks -X POST https://0.0.0.0:27000/api/v1/events/stateful -d '
{
  "events": [
    {
      "data": {},
      "module": {
        "name": "inventory",
        "type": "test"
      }
    }
  ]
}' | jq
{
  "message": "Invalid inventory module type. It must be 'network', 'package', 'process' or 'system'",
  "code": 400
}
```

</details>

<details><summary>Try to send an event using an invalid User-Agent</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "User-Agent: test" -H "Agent-Groups: default,group1,group2" -H "Content-Type: application/json" -ks -X POST https://0.0.0.0:27000/api/v1/events/stateful -d '
{
  "events": [
    {
      "data": {},
      "module": {
        "name": "sca"
      }
    }
  ]
}' | jq
{
  "message": "Invalid User-Agent HTTP header value. It must follow the format '<name> <type> <version>'",
  "code": 400
}
```

</details>

<details><summary>Try to send an event with no User-Agent header</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Agent-Groups: default" -H "Content-Type: application/json" -ks -X POST https://0.0.0.0:27000/api/v1/events/stateful -d '
{
  "events": [
    {
      "data": {},
      "module": {
        "name": "sca"
      }
    }
  ]
}' | jq
{
  "message": "('header', 'user-agent') field required",
  "code": 400
}
```

</details>

<details><summary>Send event with no Agent-Groups header</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "User-Agent: test endpoint v5.0.0" -H "Content-Type: application/json" -ks -X POST https://0.0.0.0:27000/api/v1/events/stateful -d '
{
  "events": [
    {
      "data": {},
      "module": {
        "name": "sca"
      }
    }
  ]
}' | jq
{
  "results": [
    {
      "id": "8RPt45IBKRnA5k4n-aYD",
      "result": "created",
      "status": 201
    }
  ]
}
```

</details>

<details><summary>Get indexed event</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Content-Type: application/json" -ku admin:SecretPassword1% http://localhost:9200/wazuh-states-sca/_doc/8RPt45IBKRnA5k4n-aYD?pretty=true
{
  "_index" : "wazuh-states-sca",
  "_id" : "8RPt45IBKRnA5k4n-aYD",
  "_version" : 1,
  "_seq_no" : 1,
  "_primary_term" : 1,
  "found" : true,
  "_source" : {
    "agent" : {
      "id" : "01929571-49b5-75e8-a3f6-1d2b84f4f71a",
      "groups" : [ ]
    }
  }
}
```

</details>