### PR TITLE
Added Engine httpsrv module and interface

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -219,6 +219,7 @@ add_subdirectory(${ENGINE_SOURCE_DIR}/metrics)
 add_subdirectory(${ENGINE_SOURCE_DIR}/geo)
 add_subdirectory(${ENGINE_SOURCE_DIR}/queue)
 add_subdirectory(${ENGINE_SOURCE_DIR}/apiserver)
+add_subdirectory(${ENGINE_SOURCE_DIR}/httpsrv)
 
 #TODO isolate rxcpp
 target_link_libraries(main base cmds api CLI11::CLI11)

--- a/src/engine/source/geo/CMakeLists.txt
+++ b/src/engine/source/geo/CMakeLists.txt
@@ -23,7 +23,7 @@ set(PUBLIC_LINKS
 )
 
 # Patch the maxminddb target
-set_target_properties(maxminddb::maxminddb 
+set_target_properties(maxminddb::maxminddb
   PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ""
 )
@@ -81,6 +81,7 @@ target_link_libraries(geo_utest
     GTest::gtest_main
     store::mocks
 )
+gtest_discover_tests(geo_utest)
 target_compile_definitions(geo_utest PRIVATE MMDB_PATH_TEST="${MMDB_PATH_TEST}")
 
 add_executable(geo_ctest

--- a/src/engine/source/httpsrv/CMakeLists.txt
+++ b/src/engine/source/httpsrv/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
+set(INC_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
+set(IFACE_DIR ${CMAKE_CURRENT_LIST_DIR}/interface)
+
+add_library(httpsrv_ihttpsrv INTERFACE)
+target_include_directories(httpsrv_ihttpsrv INTERFACE ${IFACE_DIR})
+target_link_libraries(httpsrv_ihttpsrv INTERFACE base)
+add_library(httpsrv::ihttpsrv ALIAS httpsrv_ihttpsrv)

--- a/src/engine/source/httpsrv/interface/httpsrv/iserver.hpp
+++ b/src/engine/source/httpsrv/interface/httpsrv/iserver.hpp
@@ -1,0 +1,119 @@
+#ifndef _HTTPSRV_ISERVER_HPP
+#define _HTTPSRV_ISERVER_HPP
+
+#include <filesystem>
+#include <functional>
+#include <string>
+
+#include <fmt/format.h>
+
+namespace httpsrv
+{
+enum class Method
+{
+    GET,
+    POST,
+    PUT,
+    DELETE,
+    ERROR_METHOD
+};
+
+constexpr auto methodToStr(Method method)
+{
+    switch (method)
+    {
+        case Method::GET: return "GET";
+        case Method::POST: return "POST";
+        case Method::PUT: return "PUT";
+        case Method::DELETE: return "DELETE";
+        default: return "ERROR_METHOD";
+    }
+}
+
+constexpr auto strToMethod(const char* str)
+{
+    if (methodToStr(Method::GET) == str)
+    {
+        return Method::GET;
+    }
+    else if (methodToStr(Method::POST) == str)
+    {
+        return Method::POST;
+    }
+    else if (methodToStr(Method::PUT) == str)
+    {
+        return Method::PUT;
+    }
+    else if (methodToStr(Method::DELETE) == str)
+    {
+        return Method::DELETE;
+    }
+    else
+    {
+        return Method::ERROR_METHOD;
+    }
+}
+
+template<class ServerImpl>
+class IServer
+{
+private:
+    ServerImpl m_server;
+
+public:
+    virtual ~IServer() = default;
+
+    /**
+     * @brief Starts the server with the specified socket path.
+     *
+     * @param socketPath The path to the socket file.
+     */
+    void start(const std::filesystem::path& socketPath)
+    {
+        try
+        {
+            m_server.start(socketPath);
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error(fmt::format("Failed to start server at {}: {}", socketPath, e.what()));
+        }
+    }
+
+    /**
+     * Stops the server.
+     */
+    void stop() { m_server.stop(); }
+
+    /**
+     * @brief Adds a route to the server.
+     *
+     * This function adds a route to the server based on the specified HTTP method, route path, and handler
+     * function. The handler function is called when a request matching the specified method and route is received by
+     * the server.
+     *
+     * @param method The HTTP method for the route (GET, POST, PUT, DELETE).
+     * @param route The route path.
+     * @param handler The handler function to be called when a request is received. The handler function must take
+     * two parameters: a const reference to the request object and a reference to the response object.
+     * The request and response objects must be of google::protobuf::Message type or httplib::Request and
+     * httplib::Response respectively.
+     */
+    template<typename Request, typename Response>
+    void
+    addRoute(Method method, const std::string& route, const std::function<void(const Request&, Response&)>& handler)
+    {
+        try
+        {
+            m_server.addRoute(method, route, handler);
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error(
+                fmt::format("Failed to add route {}:{} error: {}", methodToStr(method), route, e.what()));
+        }
+    }
+};
+} // namespace httpsrv
+
+#endif // _HTTPSRV_ISERVER_HPP


### PR DESCRIPTION
|Related issue|
|---|
|#26371|

Added httpsrv module and iserver interface using CRTP. Add route method is templated on request and response types, so it can be implemented with protobuff or httplib::Request/Response.
