### PR TITLE
Start the agent service back after upgrade via DEB package

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/preinst
+++ b/packages/debs/SPECS/wazuh-agent/debian/preinst
@@ -8,12 +8,7 @@ DIR="/var/ossec"
 WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
 
 # environment configuration
-if [ ! -d ${WAZUH_TMP_DIR} ]; then
-    mkdir -p ${WAZUH_TMP_DIR}
-else
-    rm -rf ${WAZUH_TMP_DIR}
-    mkdir -p ${WAZUH_TMP_DIR}
-fi
+mkdir -p ${WAZUH_TMP_DIR}
 
 case "$1" in
     install|upgrade)
@@ -37,11 +32,11 @@ case "$1" in
                 touch ${WAZUH_TMP_DIR}/wazuh.restart
             fi
             ${DIR}/bin/ossec-control stop > /dev/null 2>&1 || ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
-            
+
             if [ -d ${DIR}/logs/ossec ]; then
                 mv ${DIR}/logs/ossec ${DIR}/logs/wazuh
             fi
-            
+
             if [ -d ${DIR}/queue/ossec ]; then
                 mv ${DIR}/queue/ossec ${DIR}/queue/sockets
             fi

--- a/packages/debs/SPECS/wazuh-agent/debian/prerm
+++ b/packages/debs/SPECS/wazuh-agent/debian/prerm
@@ -4,6 +4,15 @@
 set -e
 
 DIR="/var/ossec"
+WAZUH_TMP_DIR="${DIR}/packages_files/agent_config_files"
+
+# environment configuration
+if [ ! -d ${WAZUH_TMP_DIR} ]; then
+    mkdir -p ${WAZUH_TMP_DIR}
+else
+    rm -rf ${WAZUH_TMP_DIR}
+    mkdir -p ${WAZUH_TMP_DIR}
+fi
 
 # Function to extract package_uninstallation value from XML
 get_package_uninstallation_value() {
@@ -77,8 +86,12 @@ case "$1" in
       # Stop the services before uninstalling the package
       if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-agent > /dev/null 2>&1; then
           systemctl stop wazuh-agent > /dev/null 2>&1
+          touch ${WAZUH_TMP_DIR}/wazuh.restart
       elif command -v service > /dev/null 2>&1 && service wazuh-agent status 2>/dev/null | grep "running" > /dev/null 2>&1; then
           service wazuh-agent stop > /dev/null 2>&1
+          touch ${WAZUH_TMP_DIR}/wazuh.restart
+      elif ${DIR}/bin/ossec-control status 2>/dev/null | grep "is running" > /dev/null 2>&1; then
+          touch ${WAZUH_TMP_DIR}/wazuh.restart
       fi
       ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh-agent/issues/237 |

This PR proposes a solution to the problem of the agent always being stopped after an upgrade.

## Expected behavior

- If the agent was stopped before the upgrade, it should remain stopped afterwards.
- If the agent was active before the upgrade, it should remain active afterwards.

## How it works

The upgrade of a DEB package has three important phases (among others):
- Pre-remove (old version): stops the service, if it was active.
- Pre-install (new version): also checks the service (which should be stopped).
- Post-install (new version): starts the service, if it was active before.

The pre-install phase creates a "flag file" to mark that the agent was active before the upgrade. However, the pre-remove phase would have already stopped it.

## Fix proposal

So, the fix proposal is that, during the pre-remove phase, the system also creates that "flag file" to indicate that the service is active. In this way, post-install could start the service again.

> [!NOTE]
It should be noted that, due to the architecture of the DEB packaging system, since the pre-remove phase is being modified, the fix would **apply to the versions immediately after the one it is applied to**. That is, if we apply the fix in 4.10.0, the solution would be noticeable in upgrades from 4.10.0 to a later version.

## Tests

We've created a 4.10.0 package with this fix applied:

- [wazuh-agent_4.10.0-0_amd64_cc33727.deb.gz](https://github.com/user-attachments/files/17571431/wazuh-agent_4.10.0-0_amd64_cc33727.deb.gz)

### Test cases

- [x] If the agent was stopped before the upgrade, it remains stopped afterwards:
```shell
dpkg -i wazuh-agent_4.10.0-0_amd64_cc33727.deb
sed -i'' 's/MANAGER_IP/192.168.1.8/' /var/ossec/etc/ossec.conf
dpkg -i wazuh-agent_4.10.0-0_amd64_cc33727.deb
systemctl is-active wazuh-agent
```
> inactive
- [x] If the agent was active before the upgrade, it remains active afterwards:
```shell
dpkg -i wazuh-agent_4.10.0-0_amd64_cc33727.deb
sed -i'' 's/MANAGER_IP/192.168.1.8/' /var/ossec/etc/ossec.conf
systemctl start wazuh-agent
dpkg -i wazuh-agent_4.10.0-0_amd64_cc33727.deb
systemctl is-active wazuh-agent
```
> active