### PR TITLE
Fix shared modules compilation warnings

### DIFF
--- a/src/shared_modules/router/include/iRouterProvider.hpp
+++ b/src/shared_modules/router/include/iRouterProvider.hpp
@@ -44,6 +44,12 @@ public:
      * @param data Data to be sent
      */
     virtual void send(const std::vector<char>& data) = 0;
+
+    /**
+     * @brief Destroy the IRouterProvider object
+     *
+     */
+    virtual ~IRouterProvider() = default;
 };
 
 #endif //_IROUTER_PROVIDER_HPP

--- a/src/shared_modules/router/include/iRouterProvider.hpp
+++ b/src/shared_modules/router/include/iRouterProvider.hpp
@@ -49,7 +49,9 @@ public:
      * @brief Destroy the IRouterProvider object
      *
      */
+    // LCOV_EXCL_START
     virtual ~IRouterProvider() = default;
+    // LCOV_EXCL_STOP
 };
 
 #endif //_IROUTER_PROVIDER_HPP

--- a/src/shared_modules/router/include/routerProvider.hpp
+++ b/src/shared_modules/router/include/routerProvider.hpp
@@ -47,7 +47,9 @@ public:
         , m_isLocal {isLocal}
     {
     }
-    virtual ~RouterProvider() = default;
+    // LCOV_EXCL_START
+    ~RouterProvider() = default;
+    // LCOV_EXCL_STOP
     void stop();
     void start();
     void start(const std::function<void()>& onConnect);

--- a/src/shared_modules/router/src/publisher.hpp
+++ b/src/shared_modules/router/src/publisher.hpp
@@ -89,11 +89,17 @@ public:
         m_msgDispatcher->push(data);
     }
 
+    /**
+     * @brief Destroy the Publisher object
+     *
+     */
+    // LCOV_EXCL_START
     ~Publisher() override
     {
         m_socketServer.reset();
         m_msgDispatcher->rundown();
     }
+    // LCOV_EXCL_START
 };
 
 #endif // _PUBLISHER_HPP

--- a/src/shared_modules/router/src/publisher.hpp
+++ b/src/shared_modules/router/src/publisher.hpp
@@ -99,7 +99,7 @@ public:
         m_socketServer.reset();
         m_msgDispatcher->rundown();
     }
-    // LCOV_EXCL_START
+    // LCOV_EXCL_STOP
 };
 
 #endif // _PUBLISHER_HPP

--- a/src/shared_modules/router/src/subscriber.hpp
+++ b/src/shared_modules/router/src/subscriber.hpp
@@ -39,7 +39,13 @@ public:
     {
     }
 
+    /**
+     * @brief Destroy the Subscriber object
+     *
+     */
+    // LCOV_EXCL_START
     ~Subscriber() = default;
+    // LCOV_EXCL_STOP
 
     /**
      * @brief Executes update callback.

--- a/src/shared_modules/utils/observer.hpp
+++ b/src/shared_modules/utils/observer.hpp
@@ -36,6 +36,7 @@ public:
     }
 
     virtual void update(T data) = 0;
+    virtual ~Observer() = default;
 };
 
 template<typename T>

--- a/src/shared_modules/utils/observer.hpp
+++ b/src/shared_modules/utils/observer.hpp
@@ -36,7 +36,9 @@ public:
     }
 
     virtual void update(T data) = 0;
+    // LCOV_EXCL_START
     virtual ~Observer() = default;
+    // LCOV_EXCL_STOP
 };
 
 template<typename T>

--- a/src/shared_modules/utils/packet.hpp
+++ b/src/shared_modules/utils/packet.hpp
@@ -18,16 +18,16 @@ class Packet final
 {
 public:
     Packet(char* data, uint32_t size)
-        : data {std::make_unique<char[]>(size + 1)}
-        , size(size)
-        , offset(0)
+        : m_data {std::make_unique<char[]>(size + 1)}
+        , m_size(size)
+        , m_offset(0)
     {
-        std::copy(data, data + size, this->data.get());
+        std::copy(data, data + size, this->m_data.get());
     }
     virtual ~Packet() = default;
-    std::unique_ptr<char[]> data;
-    uint32_t size;
-    uint32_t offset;
+    std::unique_ptr<char[]> m_data;
+    uint32_t m_size;
+    uint32_t m_offset;
 };
 
 #endif // _PACKET_HPP

--- a/src/shared_modules/utils/socketWrapper.hpp
+++ b/src/shared_modules/utils/socketWrapper.hpp
@@ -633,7 +633,8 @@ public:
         while (!m_unsentPacketList.empty())
         {
             auto& packet = m_unsentPacketList.front();
-            auto ret = T::send(m_sock, packet.data.get() + packet.offset, packet.size - packet.offset, MSG_NOSIGNAL);
+            auto ret =
+                T::send(m_sock, packet.m_data.get() + packet.m_offset, packet.m_size - packet.m_offset, MSG_NOSIGNAL);
             if (ret <= 0)
             {
                 if (errno == EAGAIN || errno == EWOULDBLOCK)
@@ -647,10 +648,10 @@ public:
             }
             else
             {
-                if (ret != packet.size)
+                if (ret != packet.m_size)
                 {
                     // In this case we need to send the rest of the data, when the next send is called.
-                    packet.offset += ret;
+                    packet.m_offset += ret;
                 }
                 else
                 {

--- a/src/shared_modules/utils/socketWrapper.hpp
+++ b/src/shared_modules/utils/socketWrapper.hpp
@@ -232,8 +232,8 @@ public:
                             uint32_t& bufferSize,
                             const char* dataBody,
                             uint32_t sizeBody,
-                            const char* dataHeader = nullptr,
-                            uint32_t sizeHeader = 0)
+                            [[maybe_unused]] const char* dataHeader = nullptr,
+                            [[maybe_unused]] uint32_t sizeHeader = 0)
     {
         if (sizeof(Header) + sizeBody > BUFFER_MAX_SIZE)
         {
@@ -255,7 +255,7 @@ public:
      * @param buffer Buffer to obtain the header size from.
      * @return auto Header size.
      */
-    auto static getHeaderSize(const std::vector<char>& buffer)
+    auto static getHeaderSize([[maybe_unused]] const std::vector<char>& buffer)
     {
         return 0;
     }
@@ -266,7 +266,7 @@ public:
      * @param headerSize The size of the header.
      * @return auto Data offset.
      */
-    auto static getDataOffset(uint32_t headerSize)
+    auto static getDataOffset([[maybe_unused]] uint32_t headerSize)
     {
         return 0;
     }
@@ -312,8 +312,8 @@ public:
                             uint32_t& bufferSize,
                             const char* dataBody,
                             uint32_t sizeBody,
-                            const char* dataHeader = nullptr,
-                            uint32_t sizeHeader = 0)
+                            [[maybe_unused]] const char* dataHeader = nullptr,
+                            [[maybe_unused]] uint32_t sizeHeader = 0)
     {
         if (sizeBody > BUFFER_MAX_SIZE)
         {
@@ -331,7 +331,7 @@ public:
      * @param buffer Buffer to obtain the header size from.
      * @return auto Header size.
      */
-    auto static getHeaderSize(const std::vector<char>& buffer)
+    auto static getHeaderSize([[maybe_unused]] const std::vector<char>& buffer)
     {
         return 0;
     }
@@ -342,7 +342,7 @@ public:
      * @param headerSize The size of the header.
      * @return auto Data offset.
      */
-    auto static getDataOffset(uint32_t headerSize)
+    auto static getDataOffset([[maybe_unused]] uint32_t headerSize)
     {
         return 0;
     }

--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -217,12 +217,11 @@ private:
     }
 
     Functor m_functor;
+    const size_t m_maxQueueSize;
+    const uint64_t m_bulkSize;
     std::unique_ptr<TSafeQueueType> m_queue;
     std::thread m_thread;
     std::atomic_bool m_running = true;
-
-    const size_t m_maxQueueSize;
-    const uint64_t m_bulkSize;
 };
 
 template<typename Type, typename Functor>

--- a/src/shared_modules/utils/threadSafeMultiQueue.hpp
+++ b/src/shared_modules/utils/threadSafeMultiQueue.hpp
@@ -134,8 +134,8 @@ namespace Utils
     private:
         mutable std::mutex m_mutex;
         std::condition_variable m_cv;
-        std::atomic<bool> m_canceled {};
         Tq m_queue;
+        std::atomic<bool> m_canceled {};
     };
 } // namespace Utils
 

--- a/src/shared_modules/utils/threadSafeQueue.h
+++ b/src/shared_modules/utils/threadSafeQueue.h
@@ -121,7 +121,7 @@ namespace Utils
             // If the queue is not canceled, get the elements.
             if (!m_canceled)
             {
-                for (auto i = 0; i < elementsQuantity && i < m_queue.size(); ++i)
+                for (size_t i = 0; i < elementsQuantity && i < m_queue.size(); ++i)
                 {
                     bulkQueue.push(std::move(m_queue.at(i)));
                 }
@@ -133,7 +133,7 @@ namespace Utils
         void popBulk(const uint64_t elementsQuantity)
         {
             std::lock_guard<std::mutex> lock {m_mutex};
-            for (auto i = 0; i < elementsQuantity && !m_queue.empty(); ++i)
+            for (size_t i = 0; i < elementsQuantity && !m_queue.empty(); ++i)
             {
                 m_queue.pop();
             }

--- a/src/shared_modules/utils/threadSafeQueue.h
+++ b/src/shared_modules/utils/threadSafeQueue.h
@@ -167,8 +167,8 @@ namespace Utils
     private:
         mutable std::mutex m_mutex;
         std::condition_variable m_cv;
-        std::atomic<bool> m_canceled {};
         Tq m_queue;
+        std::atomic<bool> m_canceled {};
     };
 
     template<typename T, typename Tq = std::queue<T>>


### PR DESCRIPTION
|Related issue|
|---|
|#26579|

## Description 

Compilation warning fixed: 
- Shadowed class members in Packet class. 
- Suppress unused variable warnings.
- Avoid having accessible non-virtual destructors.
- Comparison integer different signedness. 
- -Wreorder warning.