### PR TITLE
Fix vulnerability scanner compilation warnings

### DIFF
--- a/src/shared_modules/router/src/publisher.hpp
+++ b/src/shared_modules/router/src/publisher.hpp
@@ -89,11 +89,17 @@ public:
         m_msgDispatcher->push(data);
     }
 
+    /**
+     * @brief Destroy the Publisher object
+     *
+     */
+    // LCOV_EXCL_START
     ~Publisher() override
     {
         m_socketServer.reset();
         m_msgDispatcher->rundown();
     }
+    // LCOV_EXCL_START
 };
 
 #endif // _PUBLISHER_HPP

--- a/src/shared_modules/router/src/publisher.hpp
+++ b/src/shared_modules/router/src/publisher.hpp
@@ -99,7 +99,7 @@ public:
         m_socketServer.reset();
         m_msgDispatcher->rundown();
     }
-    // LCOV_EXCL_START
+    // LCOV_EXCL_STOP
 };
 
 #endif // _PUBLISHER_HPP

--- a/src/shared_modules/router/src/subscriber.hpp
+++ b/src/shared_modules/router/src/subscriber.hpp
@@ -39,7 +39,13 @@ public:
     {
     }
 
+    /**
+     * @brief Destroy the Subscriber object
+     *
+     */
+    // LCOV_EXCL_START
     ~Subscriber() = default;
+    // LCOV_EXCL_STOP
 
     /**
      * @brief Executes update callback.

--- a/src/shared_modules/utils/observer.hpp
+++ b/src/shared_modules/utils/observer.hpp
@@ -36,6 +36,7 @@ public:
     }
 
     virtual void update(T data) = 0;
+    virtual ~Observer() = default;
 };
 
 template<typename T>

--- a/src/shared_modules/utils/observer.hpp
+++ b/src/shared_modules/utils/observer.hpp
@@ -36,7 +36,9 @@ public:
     }
 
     virtual void update(T data) = 0;
+    // LCOV_EXCL_START
     virtual ~Observer() = default;
+    // LCOV_EXCL_STOP
 };
 
 template<typename T>

--- a/src/wazuh_modules/vulnerability_scanner/include/vulnerability_scanner.h
+++ b/src/wazuh_modules/vulnerability_scanner/include/vulnerability_scanner.h
@@ -34,8 +34,6 @@ extern "C"
 
     EXPORTED void vulnerability_scanner_stop();
 
-    EXPORTED bool vulnerability_scanner_policy_change_event(const char* data);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -167,6 +167,7 @@ public:
         {
             auto eventContext = std::make_shared<EventContext>(EventContext {.message = message,
                                                                              .resource = resource,
+                                                                             .cve5Buffer = {},
                                                                              .feedDatabase = database,
                                                                              .resourceType = ResourceType::UNKNOWN});
 
@@ -479,7 +480,9 @@ public:
             // Initialize Translation object to store translation data
             Translation translationQuery = {.productRegex = createRegex(queryData->source()->product()),
                                             .vendorRegex = createRegex(queryData->source()->vendor()),
-                                            .versionRegex = createRegex(queryData->source()->version())};
+                                            .versionRegex = createRegex(queryData->source()->version()),
+                                            .translation = {},
+                                            .target = {}};
 
             // Load target platforms into the Translation object
             for (const auto& target : *queryData->target())
@@ -544,7 +547,8 @@ public:
                 for (const auto& translatedPackage : cacheData.translation)
                 {
                     TranslatedData translatedResult {.translatedProduct = translatedPackage.translatedProduct,
-                                                     .translatedVendor = translatedPackage.translatedVendor};
+                                                     .translatedVendor = translatedPackage.translatedVendor,
+                                                     .translatedVersion = {}};
                     // Search for version regex or use translated version
                     std::smatch stringFound;
                     if (cacheData.versionRegex.has_value() &&

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanAgentInventory.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanAgentInventory.hpp
@@ -48,8 +48,8 @@ public:
      */
     explicit TCleanAgentInventory(Utils::RocksDBWrapper& inventoryDatabase,
                                   std::shared_ptr<TAbstractHandler> subOrchestration)
-        : m_subOrchestration(std::move(subOrchestration))
-        , TInventorySync<TScanContext>(inventoryDatabase)
+        : TInventorySync<TScanContext>(inventoryDatabase)
+        , m_subOrchestration(std::move(subOrchestration))
     {
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanInventory.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/cleanInventory.hpp
@@ -49,8 +49,8 @@ public:
      */
     explicit TCleanInventory(Utils::RocksDBWrapper& inventoryDatabase,
                              std::shared_ptr<TAbstractHandler> subOrchestration)
-        : m_subOrchestration(std::move(subOrchestration))
-        , TInventorySync<TScanContext>(inventoryDatabase)
+        : TInventorySync<TScanContext>(inventoryDatabase)
+        , m_subOrchestration(std::move(subOrchestration))
     {
     }
     // LCOV_EXCL_STOP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osScanner.hpp
@@ -82,7 +82,7 @@ public:
         const auto osCPE = ScannerHelper::parseCPE(data->osCPEName().data());
 
         auto vulnerabilityScan = [&](const std::string& cnaName,
-                                     const PackageData& package,
+                                     [[maybe_unused]] const PackageData& package,
                                      const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
         {
             try
@@ -277,7 +277,7 @@ public:
                 }
                 else
                 {
-                    PackageData package = {.name = osCPE.product};
+                    PackageData package = {.name = osCPE.product, .vendor = {}, .format = {}, .version = {}};
 
                     data->m_vulnerabilitySource = std::make_pair(OS_SCANNER_CNA, OS_SCANNER_CNA);
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -273,8 +273,7 @@ private:
         }
     }
 
-    bool platformVerify(const std::string& cnaName,
-                        const PackageData& package,
+    bool platformVerify(const PackageData& package,
                         const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
                         std::shared_ptr<TScanContext> contextData)
     {
@@ -344,10 +343,8 @@ private:
         return true;
     }
 
-    bool vendorVerify(const std::string& cnaName,
-                      const PackageData& package,
-                      const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
-                      std::shared_ptr<TScanContext> contextData)
+    bool vendorVerify(const PackageData& package,
+                      const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData)
     {
         if (callbackData.vendor())
         {
@@ -392,8 +389,7 @@ private:
         return true;
     }
 
-    bool versionMatch(const std::string& cnaName,
-                      const PackageData& package,
+    bool versionMatch(const PackageData& package,
                       const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
                       std::shared_ptr<TScanContext> contextData)
     {
@@ -569,8 +565,7 @@ private:
         return false;
     }
 
-    bool packageHotfixSolved(const std::string& cnaName,
-                             const PackageData& package,
+    bool packageHotfixSolved(const PackageData& package,
                              const NSVulnerabilityScanner::ScanVulnerabilityCandidate& callbackData,
                              std::shared_ptr<TScanContext> contextData)
     {
@@ -650,24 +645,24 @@ public:
                 /* Preliminary verifications before version matching. We return if the basic conditions are not met. */
 
                 // If the candidate contains platforms, verify if agent OS is in the list.
-                if (!platformVerify(cnaName, package, callbackData, data))
+                if (!platformVerify(package, callbackData, data))
                 {
                     return false;
                 }
 
                 // If the candidate contains a vendor, verify if package vendor matches.
-                if (!vendorVerify(cnaName, package, callbackData, data))
+                if (!vendorVerify(package, callbackData))
                 {
                     return false;
                 }
 
                 /* Real version analysis of the candidate. */
-                if (versionMatch(cnaName, package, callbackData, data))
+                if (versionMatch(package, callbackData, data))
                 {
                     // The candidate version matches the package. Post-match filtering.
                     if (data->osPlatform().compare("windows") == 0)
                     {
-                        if (packageHotfixSolved(cnaName, package, callbackData, data))
+                        if (packageHotfixSolved(package, callbackData, data))
                         {
                             // An installed hotfix solves the vulnerability.
                             return false;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scannerHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scannerHelper.hpp
@@ -87,12 +87,12 @@ public:
         // Check if is 2.2 or 2.3
         // If is 2.2, the first part is "cpe"
         // If is 2.3, the first part is "cpe" and the second part is "2.3"
-        const auto offset = Utils::startsWith(cpeString, "cpe:2.3") ? 1 : 0;
+        const size_t offset = Utils::startsWith(cpeString, "cpe:2.3") ? 1 : 0;
 
         cpe.cpeVersion = offset == 0 ? "2.2" : cpeParts[CPE_VERSION_INDEX];
         cpe.indexQuantity = cpeParts.size() - offset - 1; // -1 because the first part is "cpe"
 
-        const auto maxAvailableIndex {cpeParts.empty() ? 0 : cpeParts.size() - 1};
+        const size_t maxAvailableIndex {cpeParts.empty() ? 0 : cpeParts.size() - 1};
 
         if (maxAvailableIndex >= CPEFIELDS::product + offset)
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
@@ -65,11 +65,6 @@ extern "C"
     {
         VulnerabilityScanner::instance().stop();
     }
-
-    bool vulnerability_scanner_policy_change_event(const char* data)
-    {
-        return true;
-    }
 #ifdef __cplusplus
 }
 #endif

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -32,7 +32,7 @@ public:
      *
      * @param message
      */
-    void publish(const std::string& message) {}
+    void publish([[maybe_unused]] const std::string& message) {}
 };
 
 /**
@@ -112,7 +112,9 @@ public:
      * @param obj2 Not used.
      * @param fileProcessingCallback Callback function in charge of the file processing task.
      */
-    DummyContentRegister(std::string obj1, const nlohmann::json& obj2, FileProcessingCallback fileProcessingCallback)
+    DummyContentRegister([[maybe_unused]] std::string obj1,
+                         [[maybe_unused]] const nlohmann::json& obj2,
+                         FileProcessingCallback fileProcessingCallback)
     {
 
         fileProcessingCallback(g_message, g_shouldStop);
@@ -123,7 +125,7 @@ public:
      *
      * @param interval Not used.
      */
-    void changeSchedulerInterval(long unsigned int interval) {}
+    void changeSchedulerInterval([[maybe_unused]] long unsigned int interval) {}
 };
 
 int main(const int argc, const char* argv[])

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
@@ -33,7 +33,7 @@ int main(const int argc, const char** argv)
         auto requestedKey = cmdLineArgs.getKey();
         auto seekKey = cmdLineArgs.getSeekKey();
         auto columnFamily = cmdLineArgs.getColumnFamily();
-        auto value = cmdLineArgs.getValue();
+        auto requestedValue = cmdLineArgs.getValue();
 
         flatbuffers::IDLOptions options;
         options.strict_json = true;
@@ -73,7 +73,7 @@ int main(const int argc, const char** argv)
                 printValue(key, value);
             }
         }
-        else if (!value.empty() && !requestedKey.empty())
+        else if (!requestedValue.empty() && !requestedKey.empty())
         {
             if (!rocksDB.columnExists(columnFamily))
             {
@@ -82,7 +82,7 @@ int main(const int argc, const char** argv)
 
             if (!fbs.empty())
             {
-                if (!parser.Parse(value.c_str()))
+                if (!parser.Parse(requestedValue.c_str()))
                 {
                     throw std::runtime_error("Unable to parse value.");
                 }
@@ -92,7 +92,7 @@ int main(const int argc, const char** argv)
             }
             else
             {
-                rocksDB.put(requestedKey, value, columnFamily);
+                rocksDB.put(requestedKey, requestedValue, columnFamily);
             }
 
             std::cout << "Value inserted." << std::endl;

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/argsParser.hpp
@@ -274,13 +274,13 @@ private:
     const std::string m_waitTime;
     const std::vector<std::string> m_inputFiles;
     const bool m_onlyDownloadContent;
+    const bool m_disableContentUpdater;
     const bool m_fakeReportServer;
     const std::string m_fakeDBServer;
+    const std::string m_logFilePath;
     const std::string m_fakeDBGlobal;
     const std::string m_fakeDBPkgs;
     const std::string m_fakeDBHotfixes;
-    const std::string m_logFilePath;
-    const bool m_disableContentUpdater;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/main.cpp
@@ -50,7 +50,7 @@ private:
     };
     struct sockaddr_un m_serverAddr
     {
-        .sun_family = AF_UNIX
+        .sun_family = AF_UNIX, .sun_path = {}
     };
     socklen_t m_clientSize;
 
@@ -147,7 +147,6 @@ public:
             m_fakeServerThread.join();
         }
 
-        constexpr auto INVALID_SOCKET {-1};
         if (m_socketServer != INVALID_SOCKET)
         {
             close(m_socketServer);
@@ -456,10 +455,12 @@ int main(const int argc, const char* argv[])
             auto tempSocketClient =
                 std::make_shared<SocketClient<Socket<OSPrimitives, NoHeaderProtocol>, EpollWrapper>>(
                     DEFAULT_QUEUE_PATH);
-            tempSocketClient->connect(
-                [](const char* data, uint32_t size, const char* dataHeader, uint32_t sizeHeader) {},
-                []() {},
-                SOCK_DGRAM);
+            tempSocketClient->connect([]([[maybe_unused]] const char* data,
+                                         [[maybe_unused]] uint32_t size,
+                                         [[maybe_unused]] const char* dataHeader,
+                                         [[maybe_unused]] uint32_t sizeHeader) {},
+                                      []() {},
+                                      SOCK_DGRAM);
             tempSocketClient->send("stop", 4);
 
             fakeReportServer.waitForStop();


### PR DESCRIPTION
|Related issue|
|---|
|#26580|

## Description 

Compilation warnings fixed:
- Unused variables.
- Initialization order.
- Shadowed variables.
- Missing struct member initialization.
- Accessible non-virtual destructor.
- Comparison integer expression different signedness.
