### PR TITLE
Improve the signal handling to avoid crashes during stop

### DIFF
--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -16,13 +16,21 @@ static void wm_help();                  // Print help.
 static void wm_setup();                 // Setup function. Exits on error.
 static void wm_cleanup();               // Cleanup function, called on exiting.
 static void wm_handler(int signum);     // Action on signal.
+static void wm_signals_ignore();        // Ignore signals until the modules have started.
+static void wm_signals_configure();     // Configure signal handling.
 
 static int flag_foreground = 0;         // Running in foreground.
+
+static bool wm_sig_received = false;   // Flag to indicate if a signal is being handled.
+static pthread_mutex_t sig_lock = PTHREAD_MUTEX_INITIALIZER;
 
 // Main function
 
 int main(int argc, char **argv)
 {
+    // Ignore signals until the modules have started
+    wm_signals_ignore();
+
     int c;
     int wm_debug = 0;
     int test_config = 0;
@@ -98,8 +106,13 @@ int main(int argc, char **argv)
     // Start com request thread
     w_create_thread(wmcom_main, NULL);
 
-    // Wait for threads
+    mdebug2("Waiting for modules to start.");
+    sleep(1);
 
+    // Signal management
+    wm_signals_configure();
+
+    // Wait for threads
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
         pthread_join(cur_module->thread, NULL);
     }
@@ -127,8 +140,6 @@ void wm_help()
 
 void wm_setup()
 {
-    struct sigaction action = { .sa_handler = wm_handler };
-
     // Read XML settings and internal options
 
     if (wm_config() < 0) {
@@ -153,19 +164,6 @@ void wm_setup()
         minfo("No configuration defined. Exiting...");
         exit(EXIT_SUCCESS);
     }
-
-    // Signal management
-
-    atexit(wm_cleanup);
-    sigaction(SIGTERM, &action, NULL);
-
-    if (flag_foreground) {
-        sigaction(SIGHUP, &action, NULL);
-        sigaction(SIGINT, &action, NULL);
-    }
-
-    action.sa_handler = SIG_IGN;
-    sigaction(SIGPIPE, &action, NULL);
 
     // Create PID file
 
@@ -192,8 +190,40 @@ void wm_cleanup()
 
 // Action on signal
 
+void wm_signals_ignore()
+{
+    struct sigaction action = { .sa_handler = SIG_IGN };
+
+    sigaction(SIGTERM, &action, NULL);
+    sigaction(SIGPIPE, &action, NULL);
+}
+
+void wm_signals_configure()
+{
+    struct sigaction action = { .sa_handler = wm_handler };
+
+    atexit(wm_cleanup);
+    sigaction(SIGTERM, &action, NULL);
+
+    if (flag_foreground) {
+        sigaction(SIGHUP, &action, NULL);
+        sigaction(SIGINT, &action, NULL);
+    }
+}
+
 void wm_handler(int signum)
 {
+    w_mutex_lock(&sig_lock);
+    if (wm_sig_received) {
+        mdebug2("Signal received: %d, ignoring.", signum);
+        w_mutex_unlock(&sig_lock);
+        return;
+    } else {
+        wm_sig_received = true;
+        mdebug2("Signal received: %d, handling.", signum);
+    }
+    w_mutex_unlock(&sig_lock);
+
     wmodule * cur_module;
     switch (signum) {
     case SIGHUP:
@@ -201,6 +231,7 @@ void wm_handler(int signum)
     case SIGTERM:
         // For the moment only gracefull shutdown will be for syscollector, in the future
         // it will be modified for all wmodules, modifying the mainloop of each thread.
+        minfo("Shutting down Wazuh modules.");
         for (cur_module = wmodules; cur_module && cur_module->context && cur_module->context->name; cur_module = cur_module->next) {
             if (cur_module->context->stop) {
                 cur_module->context->stop(cur_module->data);


### PR DESCRIPTION
|Related issue|
|---|
|Closes #26536|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

To avoid the crash of the `wazuh-modulesd` during the shutdown, some improvements were added:
- The signals are ignored at startup and until the modules have started. This avoids the termination of the module during the `sleep()` calls.
- There is a wait time of 1 second after the modules have started to allow them settle.
- The signal handling setup was moved after the added wait time to avoid calling a stop before the start has finished.
- The signal handling now has a mutex, it will only process one signal and will ignore the rest

**Update**

The original proposal described above might have many changes. A simplified one is under analysis, where the sleep occurs at the stop method and no sig-ignore is configured at startup. 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

The reproduction steps now don't cause crashes.

![2024-11-01_11-37](https://github.com/user-attachments/assets/5748c5e7-4600-4521-90ca-9422a700e39a)


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  
