### PR TITLE
Fix uptime for route with disable state

### DIFF
--- a/src/engine/source/api/src/router/handlers.cpp
+++ b/src/engine/source/api/src/router/handlers.cpp
@@ -126,7 +126,15 @@ eRouter::Entry eRouteEntryFromEntry(const ::router::prod::Entry& entry,
     eEntry.set_entry_status(state);
 
     // Calculate the uptime
-    eEntry.set_uptime(static_cast<uint32_t>(currentTime() - entry.lastUpdate()));
+    if (state == eRouter::State::DISABLED)
+    {
+        eEntry.set_uptime(entry.lastUpdate());
+    }
+    else
+    {
+        eEntry.set_uptime(static_cast<uint32_t>(currentTime() - entry.lastUpdate()));
+    }
+
     return eEntry;
 }
 } // namespace

--- a/src/engine/source/router/src/router.cpp
+++ b/src/engine/source/router/src/router.cpp
@@ -38,9 +38,9 @@ base::OptError Router::addEntry(const prod::EntryPost& entryPost, bool ignoreFai
         }
         entry.environment() = nullptr;
         entry.hash("");
+        entry.lastUpdate(0);
     }
     entry.status(env::State::DISABLED); // It is disabled until all routes are ready
-    entry.lastUpdate(getStartTime());
 
     // Add the entry to the table
     {
@@ -109,6 +109,7 @@ base::OptError Router::enableEntry(const std::string& name)
         return base::Error {"The route is not buided"};
     }
     entry.status(env::State::ENABLED);
+    entry.lastUpdate(getStartTime());
     return {};
 }
 

--- a/src/engine/test/integration_tests/router/environment.py
+++ b/src/engine/test/integration_tests/router/environment.py
@@ -5,7 +5,9 @@ engine_handler = EngineHandler(
     os.getenv('BINARY_DIR', ""), os.getenv('CONF_FILE', ""))
 
 def before_all(context):
+    context.shared_data = {}
     engine_handler.start()
+    context.shared_data['engine_instance'] = engine_handler
 
 def after_all(context):
     engine_handler.stop()

--- a/src/engine/test/integration_tests/router/features/api.feature
+++ b/src/engine/test/integration_tests/router/features/api.feature
@@ -77,6 +77,22 @@ Feature: Router Routes API Management
     And I send a request to get the list of routes
     Then I should receive a list with size equal to "3"
 
+  Scenario: Check that last update is zero when state is disabled
+    Given I have a policy "policy/wazuh/0" that has an integration called "wazuh-core-test" loaded
+    And I create a "default" route with priority "255" that uses the filter "filter/allow-all/0" and points to policy "policy/wazuh/0"
+    When I send a request to get the route "default"
+    Then I should receive a route with state "ENABLED"
+    AND I should receive a route with last update different to 0
+    When I send a request to delete the filter "filter/allow-all/0"
+    Then I send a restart to server
+    When I send a request to get the route "default"
+    Then I should receive a route with state "DISABLED"
+    AND I should receive a route with last update equal to 0
+    When I send a request to create the filter "filter/allow-all/0"
+    Then I send a restart to server
+    When I send a request to get the route "default"
+    Then I should receive a route with state "ENABLED"
+
   Scenario: Change sync of specific route via API
     Given I have a policy "policy/wazuh/0" that has an integration called "wazuh-core-test" loaded
     And I create a "default" route with priority "255" that uses the filter "filter/allow-all/0" and points to policy "policy/wazuh/0"

--- a/src/engine/test/integration_tests/router/steps/api_steps.py
+++ b/src/engine/test/integration_tests/router/steps/api_steps.py
@@ -12,7 +12,7 @@ from api_communication.proto import kvdb_pb2 as api_kvdb
 from api_communication.proto import policy_pb2 as api_policy
 from api_communication.proto import engine_pb2 as api_engine
 from api_utils.commands import engine_clear
-
+import time
 
 ENV_DIR = os.environ.get("ENV_DIR", "")
 SOCKET_PATH = ENV_DIR + "/queue/sockets/engine-api"
@@ -122,6 +122,14 @@ def create_filter(filter_name: str):
     assert error is None, f"{error}"
 
 
+def delete_filter(filter_name: str):
+    request = api_catalog.ResourceDelete_Request()
+    request.name = filter_name
+    request.namespaceid = "system"
+    error, response = send_recv(request, api_engine.GenericStatus_Response())
+    assert error is None, f"{error}"
+
+
 def create_route(route_name: str, policy_name: str, filter_name: str, priority: int) -> api_engine.GenericStatus_Response:
     request = api_router.RoutePost_Request()
     request.route.name = route_name
@@ -196,6 +204,7 @@ def step_impl(context, route_name: str):
 def step_impl(context, route_name: str):
     request = api_router.RouteGet_Request()
     request.name = route_name
+    time.sleep(1) # need for uptime
     error, context.result = send_recv(request, api_router.RouteGet_Response())
     assert error is None, f"{error}"
 
@@ -225,6 +234,21 @@ def step_impl(context, event: str, route_name: str):
     request.wazuh_event = event
     error, context.result = send_recv(
         request, api_engine.GenericStatus_Response())
+
+
+@when('I send a request to {request} the filter "{filter_name}"')
+def step_impl(context, request: str, filter_name: str):
+    if request == 'create':
+        create_filter(filter_name)
+    elif request == 'delete':
+        delete_filter(filter_name)
+    else:
+        assert f"The request {request} is not allowed."
+
+@then('I send a restart to server')
+def step_impl(context):
+    context.shared_data['engine_instance'].stop()
+    context.shared_data['engine_instance'].start()
 
 
 @then('I should receive an {status} response indicating "{response}"')
@@ -307,6 +331,15 @@ def step_impl(context, state: str):
     assert state_to_string[
         context.result.route.entry_status] == state, f"{context.result.route}"
 
+
+@then('I should receive a route with last update {request} to {last_update}')
+def step_impl(context, request: str, last_update: str):
+    if request == 'equal':
+        assert context.result.route.uptime == int(last_update), f"{context.result.route}"
+    elif request == 'different':
+        assert context.result.route.uptime != int(last_update), f"{context.result.route}"
+    else:
+        assert f"The request {request} is not allowed."
 
 @then('I send a request to the router to reload the "{route_name}"')
 def step_impl(context, route_name: str):


### PR DESCRIPTION
|Related issue|
|---|
|#26678|


### Description:

There is a bug in the router API of Wazuh-Engine where the `uptime` for disabled routes is incorrectly returned. Instead of showing the expected `uptime: 0` for disabled routes, the API currently returns the actual uptime since the route was last created. This issue may cause confusion for users monitoring the status of routes through the API.