### PR TITLE
Adds the manage session to engine-test tool

### DIFF
--- a/src/engine/tools/engine-suite/src/engine_clear/__main__.py
+++ b/src/engine/tools/engine-suite/src/engine_clear/__main__.py
@@ -1,6 +1,7 @@
 import sys
 import argparse
 from importlib.metadata import metadata
+from shared.default_settings import Constants as DefaultSettings
 
 import shared.resource_handler as rs
 
@@ -14,7 +15,7 @@ def parse_args():
     parser = argparse.ArgumentParser(prog='engine-clear')
     parser.add_argument('--version', action='version',
                         version=f'%(prog)s {meta.get("Version")}')
-    parser.add_argument('--api-sock', default='/run/wazuh-server/engine-api.socket',
+    parser.add_argument('--api-sock', default=DefaultSettings.SOCKET_PATH,
                         help='Path to the engine-api socket')
     parser.add_argument('-f, --force', action='store_true',
                         default=False, dest='force', help='Force the execution of the command')

--- a/src/engine/tools/engine-suite/src/engine_integration/cmds/add.py
+++ b/src/engine/tools/engine-suite/src/engine_integration/cmds/add.py
@@ -2,8 +2,7 @@ import shared.resource_handler as rs
 import shared.executor as exec
 from pathlib import Path
 
-DEFAULT_API_SOCK = '/run/wazuh-server/engine-api.socket'
-DEFAULT_NAMESPACE = 'user'
+from shared.default_settings import Constants as DefaultSettings
 
 
 def add_integration(api_socket, namespace, integration_path, dry_run, resource_handler):
@@ -98,8 +97,8 @@ def run(args, resource_handler):
 def configure(subparsers):
     parser_add = subparsers.add_parser(
         'add', help='Add integration components to the Engine Catalog. If a step fails it will undo the previous ones')
-    parser_add.add_argument('-a', '--api-sock', type=str, default=DEFAULT_API_SOCK, dest='api_sock',
-                            help=f'[default="{DEFAULT_API_SOCK}"] Engine instance API socket path')
+    parser_add.add_argument('-a', '--api-sock', type=str, default=DefaultSettings.SOCKET_PATH, dest='api_sock',
+                            help=f'[default="{DefaultSettings.SOCKET_PATH}"] Engine instance API socket path')
 
     parser_add.add_argument('integration-path', type=str,
                             help=f'[default=current directory] Integration directory path')
@@ -107,7 +106,7 @@ def configure(subparsers):
     parser_add.add_argument('--dry-run', dest='dry-run', action='store_true',
                             help=f'When set it will print all the steps to apply but wont affect the store')
 
-    parser_add.add_argument('-n', '--namespace', type=str, dest='namespace', default=DEFAULT_NAMESPACE,
-                            help=f'[default={DEFAULT_NAMESPACE}]    Namespace to add the integration to')
+    parser_add.add_argument('-n', '--namespace', type=str, dest='namespace', default=DefaultSettings.DEFAULT_NS,
+                            help=f'[default={DefaultSettings.DEFAULT_NS}]    Namespace to add the integration to')
 
     parser_add.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_integration/cmds/delete.py
+++ b/src/engine/tools/engine-suite/src/engine_integration/cmds/delete.py
@@ -1,10 +1,6 @@
 import shared.resource_handler as rs
-from pathlib import Path
-import sys
 import json
-
-DEFAULT_API_SOCK = '/run/wazuh-server/engine-api.socket'
-DEFAULT_NAMESPACE = 'user'
+from shared.default_settings import Constants as DefaultSettings
 
 
 def run(args, resource_handler: rs.ResourceHandler):
@@ -68,8 +64,8 @@ def run(args, resource_handler: rs.ResourceHandler):
 def configure(subparsers):
     parser_rm = subparsers.add_parser(
         'delete', help='Delete integration assets from the Engine Catalog. If a step fails it continue with the next')
-    parser_rm.add_argument('-a', '--api-sock', type=str, default=DEFAULT_API_SOCK, dest='api_sock',
-                           help=f'[default="{DEFAULT_API_SOCK}"] Engine instance API socket path')
+    parser_rm.add_argument('-a', '--api-sock', type=str, default=DefaultSettings.SOCKET_PATH, dest='api_sock',
+                           help=f'[default="{DefaultSettings.SOCKET_PATH}"] Engine instance API socket path')
 
     parser_rm.add_argument('integration-name', type=str,
                            help=f'Integration name to be deleted')
@@ -77,7 +73,7 @@ def configure(subparsers):
     parser_rm.add_argument('--dry-run', dest='dry-run', action='store_true',
                            help=f'default False, When True will print all the steps to apply without affecting the store')
 
-    parser_rm.add_argument('-n', '--namespace', type=str, dest='namespace', default=DEFAULT_NAMESPACE,
-                           help=f'[default="{DEFAULT_NAMESPACE}"] Namespace of the integration')
+    parser_rm.add_argument('-n', '--namespace', type=str, dest='namespace', default=DefaultSettings.DEFAULT_NS,
+                           help=f'[default="{DefaultSettings.DEFAULT_NS}"] Namespace of the integration')
 
     parser_rm.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_integration/cmds/update.py
+++ b/src/engine/tools/engine-suite/src/engine_integration/cmds/update.py
@@ -2,10 +2,7 @@ import shared.resource_handler as rs
 from pathlib import Path
 import json
 import shared.executor as exec
-
-DEFAULT_API_SOCK = '/run/wazuh-server/engine-api.socket'
-DEFAULT_NAMESPACE = 'user'
-
+from shared.default_settings import Constants as DefaultSettings
 
 def run(args, resource_handler: rs.ResourceHandler):
     api_socket = args['api_sock']
@@ -115,8 +112,8 @@ def run(args, resource_handler: rs.ResourceHandler):
 def configure(subparsers):
     parser_update = subparsers.add_parser(
         'update', help=f'Updates all available intgration components, deletes if no longer present, adds when new.')
-    parser_update.add_argument('-a', '--api-sock', type=str, default=DEFAULT_API_SOCK, dest='api_sock',
-                               help=f'[default="{DEFAULT_API_SOCK}"] Engine instance API socket path')
+    parser_update.add_argument('-a', '--api-sock', type=str, default=DefaultSettings.SOCKET_PATH, dest='api_sock',
+                               help=f'[default="{DefaultSettings.SOCKET_PATH}"] Engine instance API socket path')
 
     parser_update.add_argument('-p', '--integration-path', type=str, dest='integration-path',
                                help=f'[default=current directory] Integration directory path')
@@ -124,7 +121,7 @@ def configure(subparsers):
     parser_update.add_argument('--dry-run', dest='dry-run', action='store_true',
                                help=f'When set it will print all the steps to apply but wont affect the store')
 
-    parser_update.add_argument('-n', '--namespace', type=str, dest='namespace', default=DEFAULT_NAMESPACE,
+    parser_update.add_argument('-n', '--namespace', type=str, dest='namespace', default=DefaultSettings.DEFAULT_NS,
                                help=f'Namespace to add the integration to')
 
     parser_update.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_schema/cmds/integrate.py
+++ b/src/engine/tools/engine-suite/src/engine_schema/cmds/integrate.py
@@ -2,10 +2,10 @@ from engine_schema.generate import generate
 import shared.resource_handler as rs
 from ._modules import configure as modules_configure
 from ._modules import get_args as modules_get_args
+from shared.default_settings import Constants as DefaultSettings
 
 
 DEFAULT_ECS_VERSION = 'v8.8.0'
-DEFAULT_API_SOCK = '/run/wazuh-server/engine-api.socket'
 DEFAULT_INDEXER_DIR = '/etc/filebeat/'
 DEFAULT_FIELDS_DIR = '/home/vagrant/engine/wazuh/src/engine/ruleset/schemas/'
 
@@ -56,8 +56,8 @@ def configure(subparsers):
     parser_integrate.add_argument('--ecs-version', type=str, default=DEFAULT_ECS_VERSION,
                                   help=f'[default="{DEFAULT_ECS_VERSION}"] ECS version to use for the schema generation')
 
-    parser_integrate.add_argument('--api-sock', type=str, default=DEFAULT_API_SOCK,
-                                  help=f'[default="{DEFAULT_API_SOCK}"] Engine instance API socket path')
+    parser_integrate.add_argument('--api-sock', type=str, default=DefaultSettings.SOCKET_PATH,
+                                  help=f'[default="{DefaultSettings.SOCKET_PATH}"] Engine instance API socket path')
 
     parser_integrate.add_argument('--indexer-dir', type=str, default=DEFAULT_INDEXER_DIR,
                                   help=f'[default="{DEFAULT_INDEXER_DIR}"] Path to directory where the wazuh-template.json indexer file is located')

--- a/src/engine/tools/engine-suite/src/engine_test/README.md
+++ b/src/engine/tools/engine-suite/src/engine_test/README.md
@@ -12,7 +12,13 @@
     4. [engine-test run](#engine-test-run)
 
 ## Summary
-The `engine-suite` python package contains various scripts to help developing content for the Engine.
+The `engine-test` tool, is used to test integrations, it allows test a policy,
+simulate an agent and send events to the engine. The tool allows to simulate the
+data sent by an agent, for this it makes use of a specific configuration to fill
+in the agent's metadata. This configuration is called integration configuration,
+and it contains information about how the log was collected (metadata). Then the
+use of the interactive console to send logs along with that metadata, simulating
+the agent's log sending.
 
 # Directory structure
 

--- a/src/engine/tools/engine-suite/src/engine_test/__main__.py
+++ b/src/engine/tools/engine-suite/src/engine_test/__main__.py
@@ -7,8 +7,8 @@ from engine_test.cmds.add import AddCommand
 from engine_test.cmds.get import GetCommand
 from engine_test.cmds.list import ListCommand
 from engine_test.cmds.delete import DeleteCommand
-from engine_test.config import Config, DEFAULT_CONFIG_FILE
-
+from engine_test.config import DEFAULT_CONFIG_FILE
+from engine_test.cmds.session import configure as configure_session
 
 def parse_args():
     meta = metadata('engine-suite')
@@ -37,6 +37,9 @@ def parse_args():
 
     delete_command = DeleteCommand()
     delete_command.configure(subparsers)
+
+    # Session commands
+    configure_session(subparsers)
 
     return parser.parse_args()
 

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/run.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/run.py
@@ -1,16 +1,14 @@
 import pathlib
 from engine_test.command import Command
 from engine_test.integration import Integration
+from shared.default_settings import Constants as DefaultSettings
 
 DEFAULT_AGENT_ID = "001"
 DEFAULT_AGENT_NAME = "wazuh-agent-1"
 DEFAULT_AGENT_IP = "any"
-DEFAULT_NAMESPACES = ['user']
 DEFAULT_VERBOSE = False
-DEFAULT_POLICY = "policy/wazuh/0"
 DEFAULT_ASSETS = []
 DEFAULT_JSON_FORMAT = False
-DEFAULT_API_SOCKET = "/run/wazuh-server/engine-api.socket"
 
 
 class RunCommand(Command):
@@ -28,7 +26,7 @@ class RunCommand(Command):
                                 type=str, default=DEFAULT_AGENT_ID, dest='agent_id')
 
         parser_run.add_argument('--api-socket', help=f'Socket to connect to the API',
-                                type=str, default=DEFAULT_API_SOCKET, dest='api-socket')
+                                type=str, default=DefaultSettings.SOCKET_PATH, dest='api-socket')
 
         parser_run.add_argument('--agent-name', help=f'Agent name for events filling',
                                 type=str, default=DEFAULT_AGENT_NAME, dest='agent_name')
@@ -43,12 +41,12 @@ class RunCommand(Command):
                                 type=pathlib.Path, dest='output_file')
 
         parser_run.add_argument('-n', '--namespaces', nargs='+', help=f'List of namespaces to include',
-                                default=DEFAULT_NAMESPACES, dest='namespaces')
+                                default=DefaultSettings.DEFAULT_NS, dest='namespaces')
 
         group = parser_run.add_mutually_exclusive_group()
 
         group.add_argument('-p', '--policy', help=f'Policy where to run the test. A temporary test session will be created and deleted when the command is completed.',
-                           default=DEFAULT_POLICY, dest='policy')
+                           default=DefaultSettings.DEFAULT_POLICY, dest='policy')
         group.add_argument('-s', '--session-name', help=f'Session where to run the test',
                            dest='session_name')
 

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session.py
@@ -1,6 +1,11 @@
 import argparse
 from shared.default_settings import Constants as DefaultSettings
 from engine_test.cmds.session_list import configure as configure_list
+from engine_test.cmds.session_get import configure as configure_get
+from engine_test.cmds.session_add import configure as configure_add
+from engine_test.cmds.session_delete import configure as configure_delete
+from engine_test.cmds.session_delete_all import configure as configure_delete_all
+from engine_test.cmds.session_reload import configure as configure_reload
 
 
 def configure(subparsers):
@@ -12,8 +17,14 @@ def configure(subparsers):
                                 help='Path to the Wazuh API socket (default: %(default)s)')
 
     # add session subparsers
-    session_subparsers = session_parser.add_subparsers(title='session commands', required=True, dest='session_command')
+    session_subparsers = session_parser.add_subparsers(
+        title='session commands', required=True, dest='session_command')
     configure_list(session_subparsers)
+    configure_get(session_subparsers)
+    configure_add(session_subparsers)
+    configure_delete(session_subparsers)
+    configure_reload(session_subparsers)
+    configure_delete_all(session_subparsers)
 
 
 def run(args):

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session.py
@@ -1,0 +1,20 @@
+import argparse
+from shared.default_settings import Constants as DefaultSettings
+from engine_test.cmds.session_list import configure as configure_list
+
+
+def configure(subparsers):
+
+    # add session subcommand
+    session_parser = subparsers.add_parser('session', help='Session commands')
+
+    session_parser.add_argument('--api-socket', type=str, default=DefaultSettings.SOCKET_PATH,
+                                help='Path to the Wazuh API socket (default: %(default)s)')
+
+    # add session subparsers
+    session_subparsers = session_parser.add_subparsers(title='session commands', required=True, dest='session_command')
+    configure_list(session_subparsers)
+
+
+def run(args):
+    args.func(vars(args))

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session_add.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session_add.py
@@ -1,0 +1,49 @@
+import sys
+import argparse
+from google.protobuf.json_format import ParseDict
+from shared.dumpers import dict_to_yml
+
+from api_communication.client import APIClient
+import api_communication.proto.engine_pb2 as engine
+import api_communication.proto.tester_pb2 as etester
+
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+    name: str = args['name']
+    policy: str = args['policy']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = etester.SessionPost_Request()
+    request.session.name = name
+    request.session.policy = policy
+    if args['description']:
+        request.session.description = args['description']
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        sys.exit(f'Error adding session: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, engine.GenericStatus_Response())
+    if parsed_response.status == engine.ERROR:
+        sys.exit(f'Error adding session: {parsed_response.error}')
+
+    return 0
+
+
+def configure(subparsers):
+    parser = subparsers.add_parser(
+        'add', help='Add a new session for testing')
+    parser.add_argument(
+        'name', type=str, help='Name of the session to add')
+    parser.add_argument('policy', type=str, help='Policy to use for the session')
+    parser.add_argument('description', type=str, help='Description of the session, optional', default=None, nargs='?')
+    parser.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session_delete.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session_delete.py
@@ -4,39 +4,40 @@ from google.protobuf.json_format import ParseDict
 from shared.dumpers import dict_to_yml
 
 from api_communication.client import APIClient
-import api_communication.proto.tester_pb2 as etester
 import api_communication.proto.engine_pb2 as engine
+import api_communication.proto.tester_pb2 as etester
+
 
 
 def run(args):
 
     # Get the params
     api_socket: str = args['api_socket']
+    name: str = args['name']
 
     # Create API client
     client = APIClient(api_socket)
 
     # Create the request
-    request = etester.TableGet_Request()
+    request = etester.SessionDelete_Request()
+    request.name = name
 
     # Send the request
     error, response = client.send_recv(request)
     if error:
-        sys.exit(f'Error getting session list: {error}')
+        sys.exit(f'Error deleting session: {error}')
 
     # Parse the response
-    parsed_response = ParseDict(response, etester.TableGet_Response())
+    parsed_response = ParseDict(response, engine.GenericStatus_Response())
     if parsed_response.status == engine.ERROR:
-        sys.exit(f'Error getting session list: {parsed_response.error}')
-
-    # Print the response
-    data: str = dict_to_yml(response)
-
-    print(data)
+        sys.exit(f'Error deleting session: {parsed_response.error}')
 
     return 0
 
 
 def configure(subparsers):
-    parser = subparsers.add_parser('list', help='List all sessions')
+    parser = subparsers.add_parser(
+        'delete', help='Delete a session for testing')
+    parser.add_argument(
+        'name', type=str, help='Name of the session to delete')
     parser.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session_delete_all.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session_delete_all.py
@@ -1,0 +1,62 @@
+import sys
+import argparse
+from google.protobuf.json_format import ParseDict
+from shared.dumpers import dict_to_yml
+
+from api_communication.client import APIClient
+import api_communication.proto.tester_pb2 as etester
+import api_communication.proto.engine_pb2 as engine
+
+
+def run(args):
+
+    # Get the params
+    api_socket: str = args['api_socket']
+
+    # Create API client
+    client = APIClient(api_socket)
+
+    # Create the request
+    request = etester.TableGet_Request()
+
+    # Send the request
+    error, response = client.send_recv(request)
+    if error:
+        sys.exit(f'Error getting session list: {error}')
+
+    # Parse the response
+    parsed_response = ParseDict(response, etester.TableGet_Response())
+    if parsed_response.status == engine.ERROR:
+        sys.exit(f'Error getting session list: {parsed_response.error}')
+
+    # Create the list of sessions to delete
+    sessions_to_delete = []
+    for session in parsed_response.sessions:
+        if args['only_engine_tests'] and not session.name.startswith('engine_test_'):
+            continue
+        sessions_to_delete.append(session.name)
+
+    # Delete the sessions
+    for session in sessions_to_delete:
+        request = etester.SessionDelete_Request()
+        request.name = session
+
+        error, response = client.send_recv(request)
+        if error:
+            sys.exit(f'Error deleting session: {error}')
+
+        parsed_response = ParseDict(response, engine.GenericStatus_Response())
+        if parsed_response.status == engine.ERROR:
+            print(f'Error deleting session: {parsed_response.error}')
+        else:
+            print(f'Session {session} deleted')
+
+
+    return 0
+
+
+def configure(subparsers):
+    parser = subparsers.add_parser('delete-all', help='Delete all sessions')
+    parser.add_argument(
+        '-o', '--only-engine-tests', help='Delete the session starting with "engine_test_"', action='store_true', default=False)
+    parser.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session_get.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session_get.py
@@ -4,20 +4,23 @@ from google.protobuf.json_format import ParseDict
 from shared.dumpers import dict_to_yml
 
 from api_communication.client import APIClient
-import api_communication.proto.tester_pb2 as etester
 import api_communication.proto.engine_pb2 as engine
+import api_communication.proto.tester_pb2 as etester
+
 
 
 def run(args):
 
     # Get the params
     api_socket: str = args['api_socket']
+    name: str = args['name']
 
     # Create API client
     client = APIClient(api_socket)
 
     # Create the request
-    request = etester.TableGet_Request()
+    request = etester.SessionGet_Request()
+    request.name = name
 
     # Send the request
     error, response = client.send_recv(request)
@@ -25,12 +28,12 @@ def run(args):
         sys.exit(f'Error getting session list: {error}')
 
     # Parse the response
-    parsed_response = ParseDict(response, etester.TableGet_Response())
+    parsed_response = ParseDict(response, etester.SessionGet_Response())
     if parsed_response.status == engine.ERROR:
         sys.exit(f'Error getting session list: {parsed_response.error}')
 
     # Print the response
-    data: str = dict_to_yml(response)
+    data: str = dict_to_yml(response['session'])
 
     print(data)
 
@@ -38,5 +41,8 @@ def run(args):
 
 
 def configure(subparsers):
-    parser = subparsers.add_parser('list', help='List all sessions')
+    parser = subparsers.add_parser(
+        'get', help='Get information about a session')
+    parser.add_argument(
+        'name', type=str, help='Name of the session to get information about')
     parser.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session_list.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session_list.py
@@ -30,7 +30,7 @@ def run(args):
         sys.exit(f'Error getting session list: {parsed_response.error}')
 
     # Print the response
-    data: str = dict_to_yml(response)
+    data: str = dict_to_yml(response['sessions'])
 
     print(data)
 

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session_list.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session_list.py
@@ -1,0 +1,15 @@
+import sys
+import argparse
+from google.protobuf.json_format import ParseDict
+from shared.dumpers import dict_to_yml
+
+from api_communication.client import APIClient
+import api_communication.proto.tester_pb2 as etester
+
+def run(args):
+    print ("List all sessions")
+    return 0
+
+def configure(subparsers):
+    list_parser = subparsers.add_parser('list', help='List all sessions')
+    list_parser.set_defaults(func=run)

--- a/src/engine/tools/engine-suite/src/engine_test/cmds/session_reload.py
+++ b/src/engine/tools/engine-suite/src/engine_test/cmds/session_reload.py
@@ -4,39 +4,40 @@ from google.protobuf.json_format import ParseDict
 from shared.dumpers import dict_to_yml
 
 from api_communication.client import APIClient
-import api_communication.proto.tester_pb2 as etester
 import api_communication.proto.engine_pb2 as engine
+import api_communication.proto.tester_pb2 as etester
+
 
 
 def run(args):
 
     # Get the params
     api_socket: str = args['api_socket']
+    name: str = args['name']
 
     # Create API client
     client = APIClient(api_socket)
 
     # Create the request
-    request = etester.TableGet_Request()
+    request = etester.SessionReload_Request()
+    request.name = name
 
     # Send the request
     error, response = client.send_recv(request)
     if error:
-        sys.exit(f'Error getting session list: {error}')
+        sys.exit(f'Error reloading session: {error}')
 
     # Parse the response
-    parsed_response = ParseDict(response, etester.TableGet_Response())
+    parsed_response = ParseDict(response, engine.GenericStatus_Response())
     if parsed_response.status == engine.ERROR:
-        sys.exit(f'Error getting session list: {parsed_response.error}')
-
-    # Print the response
-    data: str = dict_to_yml(response)
-
-    print(data)
+        sys.exit(f'Error reloading session: {parsed_response.error}')
 
     return 0
 
 
 def configure(subparsers):
-    parser = subparsers.add_parser('list', help='List all sessions')
+    parser = subparsers.add_parser(
+        'reload', help='Reload a session for testing (rebuild the policy)')
+    parser.add_argument(
+        'name', type=str, help='Name of the session to reload')
     parser.set_defaults(func=run)


### PR DESCRIPTION
Closes #25949

This PR adds the sesion manager feature engine-test python tool that remplace the `wazuh-engine tester session` cli command.