### PR TITLE
Allow unknown syslog identifier at Logcollector's journald reader

### DIFF
--- a/src/logcollector/journal_log.c
+++ b/src/logcollector/journal_log.c
@@ -148,11 +148,11 @@ STATIC INLINE char * find_library_path(const char * library_name) {
     while (getline(&line, &len, maps_file) != -1) {
         if (strstr(line, library_name) != NULL) {
             char * path_start = strchr(line, '/');
-            if (path_start == NULL) {                
+            if (path_start == NULL) {
                 break; // Never happens
             }
             char * path_end = strchr(path_start, '\n');
-            if (path_end == NULL) {                
+            if (path_end == NULL) {
                 break; // Never happens
             }
             *path_end = '\0';
@@ -310,8 +310,8 @@ void w_journal_context_update_timestamp(w_journal_context_t * ctx) {
     }
 }
 
-int w_journal_context_seek_most_recent(w_journal_context_t * ctx) {  
-    
+int w_journal_context_seek_most_recent(w_journal_context_t * ctx) {
+
     if (ctx == NULL) {
         return -1;
     }
@@ -330,7 +330,7 @@ int w_journal_context_seek_most_recent(w_journal_context_t * ctx) {
 }
 
 int w_journal_context_seek_timestamp(w_journal_context_t * ctx, uint64_t timestamp) {
-    
+
     if (ctx == NULL) {
         return -1;
     }
@@ -366,7 +366,7 @@ int w_journal_context_seek_timestamp(w_journal_context_t * ctx, uint64_t timesta
 }
 
 int w_journal_context_next_newest(w_journal_context_t * ctx) {
-    
+
     if (ctx == NULL) {
         return -1;
     }
@@ -553,7 +553,7 @@ STATIC INLINE char * entry_as_syslog(w_journal_context_t * ctx) {
     }
     char * timestamp = w_timestamp_to_string(ctx->timestamp);
 
-    if (!hostname || !syslog_identifier || !message || !timestamp) {
+    if (!hostname || !message || !timestamp) {
         mdebug2(LOGCOLLECTOR_JOURNAL_LOG_NOT_SYSLOG, ctx->timestamp);
         os_free(hostname);
         os_free(syslog_identifier);
@@ -561,6 +561,10 @@ STATIC INLINE char * entry_as_syslog(w_journal_context_t * ctx) {
         os_free(pid);
         os_free(timestamp);
         return NULL;
+    }
+
+    if (syslog_identifier == NULL) {
+        syslog_identifier = strdup("unknown");
     }
 
     char * syslog_msg = create_plain_syslog(timestamp, hostname, syslog_identifier, pid, message);

--- a/src/logcollector/read_journald.c
+++ b/src/logcollector/read_journald.c
@@ -92,7 +92,7 @@ bool w_journald_can_read(unsigned long owner_id) {
     if (gs_journald_global.owner_id == 0) {
 
         gs_journald_global.owner_id = owner_id;
- 
+
         if (gs_journald_global.journal_ctx == NULL && w_journal_context_create(&gs_journald_global.journal_ctx) != 0) {
             merror(LOGCOLLECTOR_JOURNAL_LOG_DISABLING);
             gs_journald_global.is_disabled = true;
@@ -150,7 +150,7 @@ void * read_journald(logreader * lf, int * rc, __attribute__((unused)) int drop_
         w_journal_entry_free(entry);
 
         if (entry_str == NULL) {
-            merror(LOGCOLLECTOR_JOURNAL_LOG_FAIL_GET);
+            mdebug1(LOGCOLLECTOR_JOURNAL_LOG_FAIL_GET);
             break;
         }
 

--- a/src/unit_tests/logcollector/test_journal_log.c
+++ b/src/unit_tests/logcollector/test_journal_log.c
@@ -3760,14 +3760,11 @@ void test_entry_as_syslog_missing_tag(void ** state) {
     // Get timestamp
     will_return(__wrap_gmtime_r, timestamp);
 
-    // Debug msg
-    expect_string(__wrap__mdebug2,
-                  formatted_msg,
-                  "(9002): Failed to get the required fields, discarted log with timestamp '1618849174000000'");
-
     // Check the result
     char * retval = entry_as_syslog(ctx);
-    assert_null(retval);
+    assert_non_null(retval);
+    assert_string_equal(retval, "Apr 19 16:19:34 <hostname> unknown[<spid>]: <message>");
+    os_free(retval);
 
     // >>>> Start context free
     expect_value(__wrap_dlclose, handle, (void *) 0x123456);

--- a/src/unit_tests/logcollector/test_read_journal.c
+++ b/src/unit_tests/logcollector/test_read_journal.c
@@ -243,7 +243,7 @@ void test_read_journald_dump_entry_error(void ** state) {
     will_return(__wrap_w_journal_entry_to_string, NULL);
     expect_function_call(__wrap_w_journal_entry_free);
 
-    expect_string(__wrap__merror, formatted_msg, "(1611): Failed to get the message from the journal");
+    expect_string(__wrap__mdebug1, formatted_msg, "(1611): Failed to get the message from the journal");
 
     assert_null(read_journald(&lf, &rc, 0));
     assert_false(journald_isDisabled());


### PR DESCRIPTION
|Related issue|
|---|
|Closes #25534|

## Description

This PR aims to fix an issue in Logcollector that sometimes made it produce this log:
> 2024/11/05 11:19:01 wazuh-logcollector: ERROR: (1611): Failed to get the message from the journal

**This happens when logs have no identifier (tag).**

### Rationale

The Logcollector's journald format reader gathers logs from _journald_ and tries to format them into the _syslog_ format, like this:

```
Nov 05 11:46:14 localhost run-parts(/etc/cron.daily)[30856]: starting mlocate
--------------- --------- -------------------------- -----   ----------------
Timestamp       Hostname  Identifier (tag)           PID     Message
```

For that, the agent needs to catch the following data:

- **Timestamp**:
   This field belongs to the log's metadata.
- **`_HOSTNAME`**:
   This is a **trusted field**, meaning that it's implicitly added by the journal.
- **`SYSLOG_IDENTIFIER`**:
   This is the log's tag, usually the program name.
- **`SYSLOG_PID` or `_PID`**:
   This is the PID of the log source.
- **`MESSAGE`**:
   Body of the log.

**Reference:** [systemd.journal-fields(3)](https://man7.org/linux/man-pages/man7/systemd.journal-fields.7.html)

In other words, we can expect the timestamp and the hostname to be included in every log. On the other hand:
- `SYSLOG_IDENTIFIER` may be missing. In this case, `journalctl` inserts "unknown" in its place.
- If `SYSLOG_PID` is missing, Logcollector gets `_PID` instead (which should always exist).
- If `MESSAGE` is missing, the log has no sense.

## Change proposal

We propose a behavior similar to what we have noticed in the `journalctl` tool:

1. If the identifier (or tag) is missing, silently replace it with `"unknown"` and send the log.
2. If the message is missing, print a debug log and discard the log.

## Tests

- [X] Push a log with a missing tag → Logcollector inserts `"unknown"` in its place.
- [X] Push a log with a missing message → Logcollector skips it.
- [X] No error logs in any case.
- [X] Unit tests.

### Testing tool

<details><summary>logger.py</summary>

```python
#! /usr/bin/env python3

import socket
from sys import argv

JOURNAL_SOCKET = '/run/systemd/journal/socket'

def format_log(message: str, tag: str):
    if tag is None:
        return f'MESSAGE={message}\n'
    else:
        return f"SYSLOG_IDENTIFIER={tag}\nMESSAGE={message}\n"

def log_to_journald(message: str, tag: str = None):
    log_message = format_log(message, tag)

    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
        sock.connect(JOURNAL_SOCKET)
        sock.sendall(log_message.encode('utf-8'))

if __name__ == '__main__':
    if len(argv) == 1:
        print('Syntax: ./logger.py [TAG] <MESSAGE>')
    elif len(argv) == 2:
        log_to_journald(argv[1])
    else:
        log_to_journald(argv[2], argv[1])
```

</details>

### Results (archives)

- Push a log with a tag:
```bash
python3 logger.py 'Test' 'Hello World'
```
> 2024 Nov 05 13:10:27 (amazon2) any->journald Nov 05 12:10:25 localhost Test[31016]: Hello World
- Push a log without a tag:
```bash
python3 logger.py 'Hello World'
```
> 2024 Nov 05 13:09:50 (amazon2) any->journald Nov 05 12:09:49 localhost unknown[31009]: Hello World