### PR TITLE
Fix CVSS version priority issue

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -124,11 +124,13 @@ public:
             if (metricsArray)
             {
                 // We only extract one CVSS metric type. Priority is V3.1, then V3.0, and finally V2.0.
+                cve_v5::Metric::FlatBuffersVTableOffset metricCVSSVersion;
                 for (const auto& field : *metricsArray)
                 {
                     auto metricCVSSV3_1 = field->cvssV3_1();
                     if (metricCVSSV3_1)
                     {
+                        metricCVSSVersion = field->VT_CVSSV3_1;
                         vulnDescFBScoreBase = metricCVSSV3_1->baseScore();
                         vulnDescFBSeverityStr =
                             (metricCVSSV3_1->baseSeverity()) ? metricCVSSV3_1->baseSeverity()->str() : "";
@@ -146,12 +148,14 @@ public:
                         vulnDescFBScopeStr = (metricCVSSV3_1->scope()) ? metricCVSSV3_1->scope()->str() : "";
                         vulnDescFBUserInteractionStr =
                             (metricCVSSV3_1->userInteraction()) ? metricCVSSV3_1->userInteraction()->str() : "";
+                        // If the higher version is found we do not need to continue the loop.
                         break;
                     }
 
                     auto metricCVSSV3_0 = field->cvssV3_0();
-                    if (metricCVSSV3_0)
+                    if (metricCVSSV3_0 && metricCVSSVersion != field->VT_CVSSV3_1)
                     {
+                        metricCVSSVersion = field->VT_CVSSV3_0;
                         vulnDescFBScoreBase = metricCVSSV3_0->baseScore();
                         vulnDescFBSeverityStr =
                             (metricCVSSV3_0->baseSeverity()) ? metricCVSSV3_0->baseSeverity()->str() : "";
@@ -171,11 +175,11 @@ public:
                         vulnDescFBScopeStr = (metricCVSSV3_0->scope()) ? metricCVSSV3_0->scope()->str() : "";
                         vulnDescFBUserInteractionStr =
                             (metricCVSSV3_0->userInteraction()) ? metricCVSSV3_0->userInteraction()->str() : "";
-                        break;
                     }
 
                     auto metricCVSSV2_0 = field->cvssV2_0();
-                    if (metricCVSSV2_0)
+                    if (metricCVSSV2_0 && metricCVSSVersion != field->VT_CVSSV3_1 &&
+                        metricCVSSVersion != field->VT_CVSSV3_0)
                     {
                         vulnDescFBScoreBase = metricCVSSV2_0->baseScore();
                         vulnDescFBSeverityStr = (vulnDescFBScoreBase < 4.0)   ? "LOW"
@@ -194,7 +198,6 @@ public:
                                                                  : "";
                         vulnDescFBIntegrityImpactStr =
                             (metricCVSSV2_0->integrityImpact()) ? metricCVSSV2_0->integrityImpact()->str() : "";
-                        break;
                     }
                 }
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVEDescription.hpp
@@ -136,6 +136,8 @@ public:
                             (metricCVSSV3_1->baseSeverity()) ? metricCVSSV3_1->baseSeverity()->str() : "";
                         vulnDescFBScoreVersionStr = (metricCVSSV3_1->version()) ? metricCVSSV3_1->version()->str() : "";
                         vulnDescFBClassificationStr = (field->format()) ? field->format()->str() : "";
+                        vulnDescFBAttackVectorStr =
+                            (metricCVSSV3_1->attackVector()) ? metricCVSSV3_1->attackVector()->str() : "";
                         vulnDescFBAvailabilityStr =
                             (metricCVSSV3_1->availabilityImpact()) ? metricCVSSV3_1->availabilityImpact()->str() : "";
                         vulnDescFBConfidentialityImpactStr = (metricCVSSV3_1->confidentialityImpact())

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -423,6 +423,298 @@ namespace NSUpdateCVEDescriptionTest
             }
         )"};
 
+    // Source:  CNA:Microsoft Corporation &  ADP:CISA-ADP
+    const std::string JSON_STR_CVSS_MULTIPLE_SOURCES_NO_NVD {
+        R"(
+        {
+    "containers": {
+      "cna": {
+        "affected": [
+          {
+            "cpes": [
+              "cpe:2.3:o:microsoft:windows_10_21h2:*:*:*:*:*:*:*:*"
+            ],
+            "defaultStatus": "unaffected",
+            "product": "windows_10_21h2",
+            "vendor": "microsoft",
+            "versions": [
+              {
+                "lessThan": "10.0.19044.4291",
+                "status": "affected",
+                "version": "0",
+                "versionType": "custom"
+              }
+            ]
+          }
+        ],
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Windows Storage Elevation of Privilege Vulnerability"
+          }
+        ],
+        "metrics": [
+          {
+            "cvssV3_1": {
+              "attackComplexity": "LOW",
+              "attackVector": "LOCAL",
+              "availabilityImpact": "HIGH",
+              "baseScore": 7.8,
+              "baseSeverity": "HIGH",
+              "confidentialityImpact": "HIGH",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "LOW",
+              "scope": "UNCHANGED",
+              "userInteraction": "NONE",
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "version": "3.1"
+            },
+            "format": "CVSS"
+          }
+        ],
+        "problemTypes": [
+          {
+            "descriptions": [
+              {
+                "cweId": "CWE-269",
+                "description": "CWE-269",
+                "lang": "en"
+              }
+            ]
+          }
+        ],
+        "providerMetadata": {
+          "dateUpdated": "2024-08-15T19:35:09Z",
+          "orgId": "00000000-0000-4000-A000-000000000003",
+          "shortName": "nvd",
+          "x_subShortName": "nvd"
+        },
+        "references": [
+          {
+            "tags": [
+              "patch",
+              "vendor-advisory"
+            ],
+            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-29052"
+          }
+        ]
+      }
+    },
+    "cveMetadata": {
+      "assignerOrgId": "f38d906d-7342-40ea-92c1-6c4a2c6478c8",
+      "assignerShortName": "microsoft",
+      "cveId": "CVE-2024-29052",
+      "datePublished": "2024-04-09T17:15:58Z",
+      "dateUpdated": "2024-08-15T19:35:09Z",
+      "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+  }
+        )"};
+
+    // Source: CNA:Adobe Systems Incorporated
+    const std::string JSON_STR_CVSS_SINGLE_SOURCE_NO_NVD {
+        R"(
+        {
+    "containers": {
+      "cna": {
+        "affected": [
+          {
+            "cpes": [
+              "cpe:2.3:a:adobe:experience_manager:*:*:*:*:*:*:*:*",
+              "cpe:2.3:a:adobe:experience_manager:*:*:*:*:aem_cloud_service:*:*:*"
+            ],
+            "defaultStatus": "unaffected",
+            "product": "experience_manager",
+            "vendor": "adobe",
+            "versions": [
+              {
+                "lessThan": "2024.5",
+                "status": "affected",
+                "version": "0",
+                "versionType": "custom"
+              },
+              {
+                "lessThan": "6.5.21",
+                "status": "affected",
+                "version": "0",
+                "versionType": "custom"
+              }
+            ]
+          }
+        ],
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Adobe Experience Manager versions 6.5.20 and earlier are affected by a stored Cross-Site Scripting (XSS) vulnerability that could be abused by an attacker to inject malicious scripts into vulnerable form fields. Malicious JavaScript may be executed in a victim’s browser when they browse to the page containing the vulnerable field."
+          }
+        ],
+        "metrics": [
+          {
+            "cvssV3_1": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "availabilityImpact": "NONE",
+              "baseScore": 5.4,
+              "baseSeverity": "MEDIUM",
+              "confidentialityImpact": "LOW",
+              "integrityImpact": "LOW",
+              "privilegesRequired": "LOW",
+              "scope": "CHANGED",
+              "userInteraction": "REQUIRED",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+              "version": "3.1"
+            },
+            "format": "CVSS"
+          }
+        ],
+        "problemTypes": [
+          {
+            "descriptions": [
+              {
+                "cweId": "CWE-79",
+                "description": "CWE-79",
+                "lang": "en"
+              }
+            ]
+          }
+        ],
+        "providerMetadata": {
+          "dateUpdated": "2024-06-17T19:22:41Z",
+          "orgId": "00000000-0000-4000-A000-000000000003",
+          "shortName": "nvd",
+          "x_subShortName": "nvd"
+        },
+        "references": [
+          {
+            "tags": [
+              "vendor-advisory"
+            ],
+            "url": "https://helpx.adobe.com/security/products/experience-manager/apsb24-28.html"
+          }
+        ]
+      }
+    },
+    "cveMetadata": {
+      "assignerOrgId": "078d4453-3bcd-4900-85e6-15281da43538",
+      "assignerShortName": "adobe",
+      "cveId": "CVE-2024-36207",
+      "datePublished": "2024-06-13T08:16:16Z",
+      "dateUpdated": "2024-06-17T19:22:41Z",
+      "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+  }
+        )"};
+
+    // Sources:  NIST:NVD &  CNA:Patchstack
+    const std::string JSON_STR_CVSS_MULTIPLE_SOURCES_WITH_NVD {
+        R"(
+        {
+    "containers": {
+      "cna": {
+        "affected": [
+          {
+            "cpes": [
+              "cpe:2.3:a:wishlist_member:wishlist_member:*:*:*:*:*:*:*:*"
+            ],
+            "defaultStatus": "unaffected",
+            "product": "wishlist_member",
+            "vendor": "wishlist_member",
+            "versions": [
+              {
+                "lessThan": "3.26.7",
+                "status": "affected",
+                "version": "0",
+                "versionType": "custom"
+              }
+            ]
+          }
+        ],
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') vulnerability in Membership Software WishList Member X.This issue affects WishList Member X: from n/a before 3.26.7."
+          }
+        ],
+        "metrics": [
+          {
+            "cvssV3_1": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "availabilityImpact": "HIGH",
+              "baseScore": 9.8,
+              "baseSeverity": "CRITICAL",
+              "confidentialityImpact": "HIGH",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "NONE",
+              "scope": "UNCHANGED",
+              "userInteraction": "NONE",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "version": "3.1"
+            },
+            "format": "CVSS"
+          },
+          {
+            "cvssV3_1": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "availabilityImpact": "HIGH",
+              "baseScore": 10,
+              "baseSeverity": "CRITICAL",
+              "confidentialityImpact": "HIGH",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "NONE",
+              "scope": "CHANGED",
+              "userInteraction": "NONE",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+              "version": "3.1"
+            },
+            "format": "CVSS"
+          }
+        ],
+        "problemTypes": [
+          {
+            "descriptions": [
+              {
+                "cweId": "CWE-89",
+                "description": "CWE-89",
+                "lang": "en"
+              }
+            ]
+          }
+        ],
+        "providerMetadata": {
+          "dateUpdated": "2024-08-02T20:56:35Z",
+          "orgId": "00000000-0000-4000-A000-000000000003",
+          "shortName": "nvd",
+          "x_subShortName": "nvd"
+        },
+        "references": [
+          {
+            "tags": [
+              "third-party-advisory"
+            ],
+            "url": "https://patchstack.com/database/vulnerability/wishlist-member-x/wordpress-wishlist-member-x-plugin-3-25-1-unauthenticated-arbitrary-sql-query-execution-vulnerability?_s_id=cve"
+          }
+        ]
+      }
+    },
+    "cveMetadata": {
+      "assignerOrgId": "21595511-bba5-4825-b968-b78d1f9984a3",
+      "assignerShortName": "Patchstack",
+      "cveId": "CVE-2024-37112",
+      "datePublished": "2024-07-09T09:15:02Z",
+      "dateUpdated": "2024-08-02T20:56:35Z",
+      "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+  }
+        )"};
+
     const std::string CVE_JSON_STR_MISSING_METRICS {"CVE-2022-1154"};
     const std::string JSON_STR_MISSING_METRICS {
         R"({
@@ -698,20 +990,20 @@ namespace NSUpdateCVEDescriptionTest
 
 using namespace NSUpdateCVEDescriptionTest;
 
-TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
+void processMetricHelper(const std::string& jsonStrData,
+                         const std::string& descriptionColumn,
+                         std::string& vulnerabilityDescriptionFBStr)
 {
-    std::string cve5FlatbufferSchemaStr;
-
     // Read schemas from filesystem.
+    std::string cve5FlatbufferSchemaStr;
     bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
-    ASSERT_EQ(valid, true);
-    ASSERT_EQ(JSON_STR_CVSS_V3_1.empty(), false);
+    EXPECT_EQ(valid, true);
+    EXPECT_EQ(jsonStrData.empty(), false);
 
     // Parse schemas and JSON example.
     flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
-             parser.Parse(JSON_STR_CVSS_V3_1.c_str()));
-    ASSERT_EQ(valid, true);
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) && parser.Parse(jsonStrData.c_str()));
+    EXPECT_EQ(valid, true);
 
     // Get flatbuffer pointer
     uint8_t* buf = parser.builder_.GetBufferPointer();
@@ -719,26 +1011,27 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
-    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    EXPECT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
     const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
 
     // Call function.
-    std::shared_ptr<Utils::RocksDBWrapper> rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
-    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
-    {
-        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
-    }
+    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
     UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
 
     // Get flatbuffer from vulnerability description database.
-    std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(
-        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
+    EXPECT_TRUE(rocksDBWrapper->get(
+        cve5Flatbuffer->cveMetadata()->cveId()->str(), vulnerabilityDescriptionFBStr, descriptionColumn));
 
     // Verify flatbuffer.
     flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
                                            vulnerabilityDescriptionFBStr.size());
     EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+}
+
+TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
+{
+    std::string vulnerabilityDescriptionFBStr;
+    processMetricHelper(JSON_STR_CVSS_V3_1, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
 
     // Read flatbuffer values.
     auto vulnerabilityDescription =
@@ -759,45 +1052,8 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_1)
 
 TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
 {
-    std::string cve5FlatbufferSchemaStr;
-
-    // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
-    ASSERT_EQ(valid, true);
-    ASSERT_EQ(JSON_STR_CVSS_V3_0.empty(), false);
-
-    // Parse schemas and JSON example.
-    flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
-             parser.Parse(JSON_STR_CVSS_V3_0.c_str()));
-    ASSERT_EQ(valid, true);
-
-    // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
-    size_t flatbufferSize = parser.builder_.GetSize();
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
-    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
-    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
-
-    // Call function.
-    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
-    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
-    {
-        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
-    }
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
-
-    // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(
-        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
-                                           vulnerabilityDescriptionFBStr.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+    processMetricHelper(JSON_STR_CVSS_V3_0, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
 
     // Read flatbuffer values.
     auto vulnerabilityDescription =
@@ -816,45 +1072,8 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV3_0)
 
 TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
 {
-    std::string cve5FlatbufferSchemaStr;
-
-    // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
-    ASSERT_EQ(valid, true);
-    ASSERT_EQ(JSON_STR_CVSS_V2_0.empty(), false);
-
-    // Parse schemas and JSON example.
-    flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
-             parser.Parse(JSON_STR_CVSS_V2_0.c_str()));
-    ASSERT_EQ(valid, true);
-
-    // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
-    size_t flatbufferSize = parser.builder_.GetSize();
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
-    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
-    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
-
-    // Call function.
-    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
-    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
-    {
-        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
-    }
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
-
-    // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(
-        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V2_0, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
-                                           vulnerabilityDescriptionFBStr.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+    processMetricHelper(JSON_STR_CVSS_V2_0, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
 
     // Read flatbuffer values.
     auto vulnerabilityDescription =
@@ -879,45 +1098,8 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
 
 TEST_F(UpdateCVEDescriptionTest, StoreNewestCVEDescriptionCVSSVersion)
 {
-    std::string cve5FlatbufferSchemaStr;
-
-    // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
-    ASSERT_EQ(valid, true);
-    ASSERT_EQ(JSON_STR_CVSS_VX_UNORDERED.empty(), false);
-
-    // Parse schemas and JSON example.
-    flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
-             parser.Parse(JSON_STR_CVSS_VX_UNORDERED.c_str()));
-    ASSERT_EQ(valid, true);
-
-    // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
-    size_t flatbufferSize = parser.builder_.GetSize();
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
-    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
-    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
-
-    // Call function.
-    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
-    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
-    {
-        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
-    }
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
-
-    // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper->get(
-        CVE_JSON_STR_CVSS_VX_UNORDERED, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
-                                           vulnerabilityDescriptionFBStr.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+    processMetricHelper(JSON_STR_CVSS_VX_UNORDERED, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
 
     // Read flatbuffer values.
     auto vulnerabilityDescription =
@@ -935,43 +1117,8 @@ TEST_F(UpdateCVEDescriptionTest, StoreNewestCVEDescriptionCVSSVersion)
 
 TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
 {
-    std::string cve5FlatbufferSchemaStr;
-
-    // Read schemas from filesystem.
-    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
-    ASSERT_EQ(valid, true);
-    ASSERT_EQ(JSON_STR_MISSING_METRICS.empty(), false);
-
-    // Parse schemas and JSON example.
-    flatbuffers::Parser parser;
-    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
-             parser.Parse(JSON_STR_MISSING_METRICS.c_str()));
-    ASSERT_EQ(valid, true);
-
-    // Get flatbuffer pointer
-    uint8_t* buf = parser.builder_.GetBufferPointer();
-    size_t flatbufferSize = parser.builder_.GetSize();
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
-    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
-    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
-
-    // Key
-    auto key = cve5Flatbuffer->cveMetadata()->cveId()->str();
-
-    // Call function.
-    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
-    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
-
-    // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    ASSERT_TRUE(rocksDBWrapper->get(key, vulnerabilityDescriptionFBStr, "descriptions_arch"));
-
-    // Verify flatbuffer.
-    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
-                                           vulnerabilityDescriptionFBStr.size());
-    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+    processMetricHelper(JSON_STR_MISSING_METRICS, "descriptions_arch", vulnerabilityDescriptionFBStr);
 
     // Read flatbuffer values.
     auto vulnerabilityDescription =
@@ -983,6 +1130,67 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
     EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
     EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1154");
+}
+
+TEST_F(UpdateCVEDescriptionTest, MetricsMultipleSourcesNoNVD)
+{
+    std::string vulnerabilityDescriptionFBStr;
+    processMetricHelper(
+        JSON_STR_CVSS_MULTIPLE_SOURCES_NO_NVD, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    // TODO: Define whether or not the metrics is added if no NVD source exists.
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), 0);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
+              "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-29052");
+}
+
+TEST_F(UpdateCVEDescriptionTest, MetricsSingleSourceNoNVD)
+{
+    std::string vulnerabilityDescriptionFBStr;
+    processMetricHelper(JSON_STR_CVSS_SINGLE_SOURCE_NO_NVD, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    // TODO: Define whether or not the metrics is added if no NVD source exists.
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), 0);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
+              "https://helpx.adobe.com/security/products/experience-manager/apsb24-28.html");
+}
+
+TEST_F(UpdateCVEDescriptionTest, MetricsMultipleSourcesWithNVD)
+{
+    std::string vulnerabilityDescriptionFBStr;
+    processMetricHelper(
+        JSON_STR_CVSS_MULTIPLE_SOURCES_WITH_NVD, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    // If NVD source exists use it regardless CVSS version.
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), 0);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
+              "https://patchstack.com/database/vulnerability/wishlist-member-x/"
+              "wordpress-wishlist-member-x-plugin-3-25-1-unauthenticated-arbitrary-sql-query-execution-vulnerability?_"
+              "s_id=cve");
 }
 
 TEST_F(UpdateCVEDescriptionTest, RejectedCVE5Entry)
@@ -1057,11 +1265,11 @@ TEST_F(UpdateCVEDescriptionTest, RemoveDescription)
 
     // Get flatbuffer from vulnerability description database.
     std::string vulnerabilityDescriptionFBStr;
-    EXPECT_TRUE(
-        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
+    EXPECT_TRUE(rocksDBWrapper->get(
+        cve5Flatbuffer->cveMetadata()->cveId()->str(), vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 
     // Remove entry and verify
     UpdateCVEDescription::removeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
-    EXPECT_FALSE(
-        rocksDBWrapper->get(CVE_JSON_STR_CVSS_V3_1, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
+    EXPECT_FALSE(rocksDBWrapper->get(
+        cve5Flatbuffer->cveMetadata()->cveId()->str(), vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -169,6 +169,20 @@ namespace NSUpdateCVEDescriptionTest
                         ],
                         "metrics": [
                             {
+                                "cvssV2_0": {
+                                    "accessComplexity": "LOW",
+                                    "accessVector": "LOCAL",
+                                    "authentication": "NONE",
+                                    "availabilityImpact": "NONE",
+                                    "baseScore": 2.1,
+                                    "confidentialityImpact": "PARTIAL",
+                                    "integrityImpact": "NONE",
+                                    "vectorString": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+                                    "version": "2.0"
+                                },
+                                "format": "CVSS"
+                            },
+                            {
                                 "cvssV3_0": {
                                     "attackComplexity": "LOW",
                                     "attackVector": "LOCAL",
@@ -182,20 +196,6 @@ namespace NSUpdateCVEDescriptionTest
                                     "userInteraction": "NONE",
                                     "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
                                     "version": "3.0"
-                                },
-                                "format": "CVSS"
-                            },
-                            {
-                                "cvssV2_0": {
-                                    "accessComplexity": "LOW",
-                                    "accessVector": "LOCAL",
-                                    "authentication": "NONE",
-                                    "availabilityImpact": "NONE",
-                                    "baseScore": 2.1,
-                                    "confidentialityImpact": "PARTIAL",
-                                    "integrityImpact": "NONE",
-                                    "vectorString": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-                                    "version": "2.0"
                                 },
                                 "format": "CVSS"
                             }
@@ -331,6 +331,97 @@ namespace NSUpdateCVEDescriptionTest
                 "dataType": "CVE_RECORD",
                 "dataVersion": "5.0"
             })"};
+
+    const std::string CVE_JSON_STR_CVSS_VX_UNORDERED {"CVE-2022-26809"};
+    const std::string JSON_STR_CVSS_VX_UNORDERED {
+        R"(
+            {
+                "containers": {
+                    "cna": {
+                        "affected": [
+                            {
+                                "cpes": [
+                                    "cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"
+                                ],
+                                "defaultStatus": "unknown",
+                                "product": "windows_10",
+                                "vendor": "microsoft"
+                            }
+                        ],
+                        "descriptions": [
+                            {
+                                "lang": "en",
+                                "value": "Remote Procedure Call Runtime Remote Code Execution Vulnerability"
+                            }
+                        ],
+                        "metrics": [
+                            {
+                                "cvssV2_0": {
+                                "accessComplexity": "LOW",
+                                "accessVector": "NETWORK",
+                                "authentication": "NONE",
+                                "availabilityImpact": "COMPLETE",
+                                "baseScore": 10,
+                                "confidentialityImpact": "COMPLETE",
+                                "integrityImpact": "COMPLETE",
+                                "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+                                "version": "2.0"
+                                },
+                                "format": "CVSS"
+                            },
+                            {
+                                "cvssV3_1": {
+                                "attackComplexity": "LOW",
+                                "attackVector": "NETWORK",
+                                "availabilityImpact": "HIGH",
+                                "baseScore": 9.8,
+                                "baseSeverity": "CRITICAL",
+                                "confidentialityImpact": "HIGH",
+                                "integrityImpact": "HIGH",
+                                "privilegesRequired": "NONE",
+                                "scope": "UNCHANGED",
+                                "userInteraction": "NONE",
+                                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                                "version": "3.1"
+                                },
+                                "format": "CVSS"
+                            }
+                        ],
+                        "problemTypes": [
+                            {
+                                "descriptions": [
+                                    {
+                                        "description": "NVD-CWE-noinfo",
+                                        "lang": "en"
+                                    }
+                                ]
+                            }
+                        ],
+                        "providerMetadata": {
+                        "dateUpdated": "2023-06-29T01:15:37Z",
+                        "orgId": "00000000-0000-4000-A000-000000000003",
+                        "shortName": "nvd",
+                        "x_subShortName": "nvd"
+                        },
+                        "references": [
+                            {
+                                "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-26809"
+                            }
+                        ]
+                    }
+                },
+                "cveMetadata": {
+                    "assignerOrgId": "f38d906d-7342-40ea-92c1-6c4a2c6478c8",
+                    "assignerShortName": "microsoft",
+                    "cveId": "CVE-2022-26809",
+                    "datePublished": "2022-04-15T19:15:13Z",
+                    "dateUpdated": "2023-06-29T01:15:37Z",
+                    "state": "PUBLISHED"
+                },
+                "dataType": "CVE_RECORD",
+                "dataVersion": "5.0"
+            }
+        )"};
 
     const std::string CVE_JSON_STR_MISSING_METRICS {"CVE-2022-1154"};
     const std::string JSON_STR_MISSING_METRICS {
@@ -784,6 +875,62 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionCVSSV2_0)
     EXPECT_EQ(vulnerabilityDescription->reference()->str(),
               "https://github.com/stripe/stripe-cli/commit/be38da5c0191adb77f661f769ffff2fbc7ddf6cd, "
               "https://github.com/stripe/stripe-cli/security/advisories/GHSA-4cx6-fj7j-pjx9");
+}
+
+TEST_F(UpdateCVEDescriptionTest, StoreNewestCVEDescriptionCVSSVersion)
+{
+    std::string cve5FlatbufferSchemaStr;
+
+    // Read schemas from filesystem.
+    bool valid = (flatbuffers::LoadFile(CVE5_FLATBUFFER_SCHEMA_PATH.c_str(), false, &cve5FlatbufferSchemaStr));
+    ASSERT_EQ(valid, true);
+    ASSERT_EQ(JSON_STR_CVSS_VX_UNORDERED.empty(), false);
+
+    // Parse schemas and JSON example.
+    flatbuffers::Parser parser;
+    valid = (parser.Parse(cve5FlatbufferSchemaStr.c_str(), INCLUDE_DIRECTORIES) &&
+             parser.Parse(JSON_STR_CVSS_VX_UNORDERED.c_str()));
+    ASSERT_EQ(valid, true);
+
+    // Get flatbuffer pointer
+    uint8_t* buf = parser.builder_.GetBufferPointer();
+    size_t flatbufferSize = parser.builder_.GetSize();
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierCVE5(buf, flatbufferSize);
+    ASSERT_EQ(cve_v5::VerifyEntryBuffer(verifierCVE5), true);
+    const cve_v5::Entry* cve5Flatbuffer = cve_v5::GetEntry(buf);
+
+    // Call function.
+    auto rocksDBWrapper = std::make_shared<Utils::RocksDBWrapper>(DATABASE_PATH);
+    if (!rocksDBWrapper->columnExists(DESCRIPTIONS_COLUMN_DEFAULT))
+    {
+        rocksDBWrapper->createColumn(DESCRIPTIONS_COLUMN_DEFAULT);
+    }
+    UpdateCVEDescription::storeVulnerabilityDescription(cve5Flatbuffer, rocksDBWrapper);
+
+    // Get flatbuffer from vulnerability description database.
+    std::string vulnerabilityDescriptionFBStr;
+    ASSERT_TRUE(rocksDBWrapper->get(
+        CVE_JSON_STR_CVSS_VX_UNORDERED, vulnerabilityDescriptionFBStr, DESCRIPTIONS_COLUMN_DEFAULT));
+
+    // Verify flatbuffer.
+    flatbuffers::Verifier verifierVulnDesc(reinterpret_cast<const uint8_t*>(vulnerabilityDescriptionFBStr.c_str()),
+                                           vulnerabilityDescriptionFBStr.size());
+    EXPECT_EQ(NSVulnerabilityScanner::VerifyVulnerabilityDescriptionBuffer(verifierVulnDesc), true);
+
+    // Read flatbuffer values.
+    auto vulnerabilityDescription =
+        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
+
+    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "3.1");
+    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "CRITICAL");
+    EXPECT_EQ(vulnerabilityDescription->scoreBase(), (float)9.8);
+    EXPECT_EQ(vulnerabilityDescription->description()->str(),
+              "Remote Procedure Call Runtime Remote Code Execution Vulnerability");
+    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "CVSS");
+    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
+              "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-26809");
 }
 
 TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/updateCVEDescription_test.cpp
@@ -1132,67 +1132,6 @@ TEST_F(UpdateCVEDescriptionTest, StoreCVEDescriptionMissingMetrics)
     EXPECT_EQ(vulnerabilityDescription->reference()->str(), "https://security.archlinux.org/CVE-2022-1154");
 }
 
-TEST_F(UpdateCVEDescriptionTest, MetricsMultipleSourcesNoNVD)
-{
-    std::string vulnerabilityDescriptionFBStr;
-    processMetricHelper(
-        JSON_STR_CVSS_MULTIPLE_SOURCES_NO_NVD, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
-
-    // Read flatbuffer values.
-    auto vulnerabilityDescription =
-        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
-
-    // TODO: Define whether or not the metrics is added if no NVD source exists.
-    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->scoreBase(), 0);
-    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
-    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
-              "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-29052");
-}
-
-TEST_F(UpdateCVEDescriptionTest, MetricsSingleSourceNoNVD)
-{
-    std::string vulnerabilityDescriptionFBStr;
-    processMetricHelper(JSON_STR_CVSS_SINGLE_SOURCE_NO_NVD, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
-
-    // Read flatbuffer values.
-    auto vulnerabilityDescription =
-        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
-
-    // TODO: Define whether or not the metrics is added if no NVD source exists.
-    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->scoreBase(), 0);
-    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
-    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
-              "https://helpx.adobe.com/security/products/experience-manager/apsb24-28.html");
-}
-
-TEST_F(UpdateCVEDescriptionTest, MetricsMultipleSourcesWithNVD)
-{
-    std::string vulnerabilityDescriptionFBStr;
-    processMetricHelper(
-        JSON_STR_CVSS_MULTIPLE_SOURCES_WITH_NVD, DESCRIPTIONS_COLUMN_DEFAULT, vulnerabilityDescriptionFBStr);
-
-    // Read flatbuffer values.
-    auto vulnerabilityDescription =
-        NSVulnerabilityScanner::GetVulnerabilityDescription(vulnerabilityDescriptionFBStr.c_str());
-
-    // If NVD source exists use it regardless CVSS version.
-    EXPECT_EQ(vulnerabilityDescription->scoreVersion()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->severity()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->scoreBase(), 0);
-    EXPECT_EQ(vulnerabilityDescription->description()->str(), "not defined");
-    EXPECT_EQ(vulnerabilityDescription->classification()->str(), "");
-    EXPECT_EQ(vulnerabilityDescription->reference()->str(),
-              "https://patchstack.com/database/vulnerability/wishlist-member-x/"
-              "wordpress-wishlist-member-x-plugin-3-25-1-unauthenticated-arbitrary-sql-query-execution-vulnerability?_"
-              "s_id=cve");
-}
-
 TEST_F(UpdateCVEDescriptionTest, RejectedCVE5Entry)
 {
     std::string cve5FlatbufferSchemaStr;


### PR DESCRIPTION
|Related issue|
|---|
|#26642|


## Description

New checks and new tests were added to validate that the CVSS metric used is the one with a higher version despite the order present in the CVE5 data. 

## DoD 

### Testing with CVE-2022-26809 

Metric information.
```json
{
            "cvssV2_0": {
              "accessComplexity": "LOW",
              "accessVector": "NETWORK",
              "authentication": "NONE",
              "availabilityImpact": "COMPLETE",
              "baseScore": 10,
              "confidentialityImpact": "COMPLETE",
              "integrityImpact": "COMPLETE",
              "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
              "version": "2.0"
            },
            "format": "CVSS"
          },
          {
            "cvssV3_1": {
              "attackComplexity": "LOW",
              "attackVector": "NETWORK",
              "availabilityImpact": "HIGH",
              "baseScore": 9.8,
              "baseSeverity": "CRITICAL",
              "confidentialityImpact": "HIGH",
              "integrityImpact": "HIGH",
              "privilegesRequired": "NONE",
              "scope": "UNCHANGED",
              "userInteraction": "NONE",
              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "version": "3.1"
            },
            "format": "CVSS"
          }
```

- Testing with the compressed database
```json
{
  "agent": {
    "id": "001",
    "name": "win08r2sp1",
    "type": "Wazuh",
    "version": "v4.9.2"
  },
  "host": {
    "os": {
      "full": "Microsoft Windows Server 2008 R2 Enterprise 6.1.7601",
      "name": "Microsoft Windows Server 2008 R2 Enterprise",
      "platform": "windows",
      "type": "windows",
      "version": "6.1.7601"
    }
  },
  "package": {
    "architecture": "x86_64",
    "name": "Microsoft Windows Server 2008 R2 Enterprise 6.1.7601",
    "type": "windows",
    "version": "6.1.7601"
  },
  "vulnerability": {
    "category": "OS",
    "classification": "CVSS",
    "description": "Remote Procedure Call Runtime Remote Code Execution Vulnerability",
    "detected_at": "2024-11-19T15:13:35.279Z",
    "enumeration": "CVE",
    "id": "CVE-2022-26809",
    "published_at": "2022-04-15T19:15:13Z",
    "reference": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-26809",
    "scanner": {
      "source": "National Vulnerability Database",
      "vendor": "Wazuh"
    },
    "score": {
      "base": 10,
      "version": "2.0"
    },
    "severity": "High",
    "under_evaluation": false
  },
  "wazuh": {
    "cluster": {
      "name": "jammy"
    },
    "schema": {
      "version": "1.0.0"
    }
  }
}
```

- Testing processing the snapshot and offsets. 

![image](https://github.com/user-attachments/assets/f91690a2-885c-4bf8-b538-24c197651432)

```json
{
  "agent": {
    "id": "001",
    "name": "win08r2sp1",
    "type": "Wazuh",
    "version": "v4.9.2"
  },
  "host": {
    "os": {
      "full": "Microsoft Windows Server 2008 R2 Enterprise 6.1.7601",
      "name": "Microsoft Windows Server 2008 R2 Enterprise",
      "platform": "windows",
      "type": "windows",
      "version": "6.1.7601"
    }
  },
  "package": {
    "architecture": "x86_64",
    "name": "Microsoft Windows Server 2008 R2 Enterprise 6.1.7601",
    "type": "windows",
    "version": "6.1.7601"
  },
  "vulnerability": {
    "category": "OS",
    "classification": "CVSS",
    "description": "Remote Procedure Call Runtime Remote Code Execution Vulnerability",
    "detected_at": "2024-11-19T15:44:33.378Z",
    "enumeration": "CVE",
    "id": "CVE-2022-26809",
    "published_at": "2022-04-15T19:15:13Z",
    "reference": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2022-26809",
    "scanner": {
      "source": "National Vulnerability Database",
      "vendor": "Wazuh"
    },
    "score": {
      "base": 9.8,
      "version": "3.1"
    },
    "severity": "Critical",
    "under_evaluation": false
  },
  "wazuh": {
    "cluster": {
      "name": "jammy"
    },
    "schema": {
      "version": "1.0.0"
    }
  }
}
```

- files 

[files.tar.gz](https://github.com/user-attachments/files/17819650/files.tar.gz)

