### PR TITLE
Fix Coverity issue on shared library

### DIFF
--- a/src/shared_modules/utils/socketServer.hpp
+++ b/src/shared_modules/utils/socketServer.hpp
@@ -106,7 +106,7 @@ private:
             // If EPOLLIN is set, then we can read data, so process the read.
             if (event & EPOLLIN)
             {
-                processRead(client, onRead);
+                processRead(std::move(client), onRead);
             }
 
             // If EPOLLERR or EPOLLHUP is set, then remove the client(Close the connection). This removes is in the end


### PR DESCRIPTION
|Related issue|
|---|
|#26626|

# Objective 

This pull request addresses Coverity issue [1601408 COPY_INSTEAD_OF_MOVE](https://scan7.scan.coverity.com/doc/en/cov_checker_ref.html#static_checker_COPY_INSTEAD_OF_MOVE). The objective is to optimize by applying move semantics when passing `client` to `processRead` instead of a pass-by-value approach, enhancing efficiency by avoiding an unnecessary copy constructor call.
