### PR TITLE
Remove redundant 'kill' commands for daemons

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/prerm
+++ b/packages/debs/SPECS/wazuh-agent/debian/prerm
@@ -95,51 +95,6 @@ case "$1" in
       fi
       ${DIR}/bin/wazuh-control stop > /dev/null 2>&1
 
-      # Process: wazuh-execd
-      if pgrep -f "wazuh-execd" > /dev/null 2>&1; then
-        kill -15 $(pgrep -f "wazuh-execd") > /dev/null 2>&1
-      fi
-
-      if pgrep -f "wazuh-execd" > /dev/null 2>&1; then
-        kill -9 $(pgrep -f "wazuh-execd") > /dev/null 2>&1
-      fi
-
-      # Process: wazuh-agentd
-      if pgrep -f "wazuh-agentd" > /dev/null 2>&1; then
-        kill -15 $(pgrep -f "wazuh-agentd") > /dev/null 2>&1
-      fi
-
-      if pgrep -f "wazuh-agentd" > /dev/null 2>&1; then
-        kill -9 $(pgrep -f "wazuh-agentd") > /dev/null 2>&1
-      fi
-
-      # Process: wazuh-syscheckd
-      if pgrep -f "wazuh-syscheckd" > /dev/null 2>&1; then
-        kill -15 $(pgrep -f "wazuh-syscheckd") > /dev/null 2>&1
-      fi
-
-      if pgrep -f "wazuh-syscheckd" > /dev/null 2>&1; then
-        kill -9 $(pgrep -f "wazuh-syscheckd") > /dev/null 2>&1
-      fi
-
-      # Process: wazuh-logcollector
-      if pgrep -f "wazuh-logcollector" > /dev/null 2>&1; then
-        kill -15 $(pgrep -f "wazuh-logcollector") > /dev/null 2>&1
-      fi
-
-      if pgrep -f "wazuh-logcollector" > /dev/null 2>&1; then
-        kill -9 $(pgrep -f "wazuh-logcollector") > /dev/null 2>&1
-      fi
-
-      # Process: wazuh-modulesd
-      if pgrep -f "wazuh-modulesd" > /dev/null 2>&1; then
-        kill -15 $(pgrep -f "wazuh-modulesd") > /dev/null 2>&1
-      fi
-
-      if pgrep -f "wazuh-modulesd" > /dev/null 2>&1; then
-        kill -9 $(pgrep -f "wazuh-modulesd") > /dev/null 2>&1
-      fi
-
     ;;
 
     remove)


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent/issues/233|

## Description

The previous approach of using 'kill' commands with pgrep to stop Wazuh daemons by name risked terminating other unrelated processes with the same name, such as Wazuh agents running in Docker.

Additionally, `wazuh-control stop` already handles the shutdown of these daemons by PID, making these manual kills unnecessary. This change improves portability by removing reliance on pgrep, which is not universally available.
