### PR TITLE
Switch PIDfile delete error to debug log

### DIFF
--- a/src/wazuh_modules/main.c
+++ b/src/wazuh_modules/main.c
@@ -186,7 +186,7 @@ void wm_cleanup()
     // Delete PID file
 
     if (DeletePID(ARGV0) < 0) {
-        merror("Couldn't delete PID file.");
+        mdebug1("Couldn't delete PID file.");
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #26827|

We've been found that _wazuh-modulesd_ may print an error when it fails to delete its PIDfile on exit:

```
rm /var/ossec/var/run/wazuh-modulesd-*.pid
pkill wazuh-modulesd
```
> 2024/11/13 10:33:07 wazuh-modulesd: ERROR: Couldn't delete PID file.

This might happen on upgrade, maybe the installer could have deleted the PÎDfile before _wazuh-modulesd_ completely exited.

Since this is not an important error, and the rest of the daemons are ignoring this situation, we're switching this log type to debug-1.

## Tests

- [x] wazuh-modulesd prints this log as debug:
   > 2024/11/13 10:44:49 wazuh-modulesd[52463] main.c:189 at wm_cleanup(): DEBUG: Couldn't delete PID file.