### PR TITLE
Fix handleleak found in FIM

### DIFF
--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -135,7 +135,7 @@
 #define FIM_PROCESS_PRIORITY                "(6320): Setting process priority to: '%d'"
 #define FIM_SEND                            "(6321): Sending FIM event: %s"
 #define FIM_AUDIT_ALREADY_ADDED             "(6322): Already added audit rule for monitoring directory: '%s'"
-#define FIM_REALTIME_DIRECTORYCHANGES       "(6323): Unable to set 'ReadDirectoryChangesW' for directory: '%s'. Error(%lu): '%s'"
+#define FIM_REALTIME_DIRECTORYCHANGES       "(6323): Unable to set 'ReadDirectoryChangesW' for path: '%s'. Error(%lu): '%s'"
 #define FIM_HASHES_FAIL                     "(6324): Couldn't generate hashes for '%s'"
 #define FIM_EXTRACT_PERM_FAIL               "(6325): It was not possible to extract the permissions of '%s'. Error: %d"
 #define FIM_RBTREE_DUPLICATE_INSERT         "(6326): Couldn't insert entry, duplicate path: '%s'"

--- a/src/error_messages/debug_messages.h
+++ b/src/error_messages/debug_messages.h
@@ -135,7 +135,7 @@
 #define FIM_PROCESS_PRIORITY                "(6320): Setting process priority to: '%d'"
 #define FIM_SEND                            "(6321): Sending FIM event: %s"
 #define FIM_AUDIT_ALREADY_ADDED             "(6322): Already added audit rule for monitoring directory: '%s'"
-#define FIM_REALTIME_DIRECTORYCHANGES       "(6323): Unable to set 'ReadDirectoryChangesW' for directory: '%s'"
+#define FIM_REALTIME_DIRECTORYCHANGES       "(6323): Unable to set 'ReadDirectoryChangesW' for directory: '%s'. Error(%lu): '%s'"
 #define FIM_HASHES_FAIL                     "(6324): Couldn't generate hashes for '%s'"
 #define FIM_EXTRACT_PERM_FAIL               "(6325): It was not possible to extract the permissions of '%s'. Error: %d"
 #define FIM_RBTREE_DUPLICATE_INSERT         "(6326): Couldn't insert entry, duplicate path: '%s'"

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -73,6 +73,7 @@
 #define FIM_EMPTY_CHANGED_ATTRIBUTES            "(6954): Entry '%s' does not have any modified fields. No event will be generated."
 #define FIM_INVALID_FILE_NAME                   "(6955): Ignoring file '%s' due to unsupported name (non-UTF8)."
 #define FIM_FULL_AUDIT_QUEUE                    "(6956): Internal audit queue is full. Some events may be lost. Next scheduled scan will recover lost data."
+#define FIM_REALTIME_FILE_NOT_SUPPORTED         "(6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: '%s'"
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/src/run_realtime.c
+++ b/src/syscheckd/src/run_realtime.c
@@ -689,7 +689,15 @@ int realtime_adddir(const char *dir, directory_t *configuration) {
 
     /* Add directory to be monitored */
     if(realtime_win32read(rtlocald) == 0) {
-        mdebug1(FIM_REALTIME_DIRECTORYCHANGES, rtlocald->dir);
+        DWORD last_error = GetLastError();
+        mdebug1(FIM_REALTIME_DIRECTORYCHANGES, rtlocald->dir, last_error, win_strerror(last_error));
+        CloseHandle(rtlocald->h);
+        rtlocald->watch_status = FIM_RT_HANDLE_CLOSED;
+        if (!w_directory_exists(rtlocald->dir)) {
+            mwarn(FIM_REALTIME_FILE_NOT_SUPPORTED, rtlocald->dir);
+            configuration->options &= ~REALTIME_ACTIVE;
+            configuration->options |= SCHEDULED_ACTIVE;
+        }
         free_win32rtfim_data(rtlocald);
 
         w_mutex_unlock(&syscheck.fim_realtime_mutex);

--- a/src/syscheckd/src/run_realtime.c
+++ b/src/syscheckd/src/run_realtime.c
@@ -23,6 +23,7 @@
 #include "../../unit_tests/wrappers/windows/handleapi_wrappers.h"
 #include "../../unit_tests/wrappers/windows/synchapi_wrappers.h"
 #include "../../unit_tests/wrappers/windows/winbase_wrappers.h"
+#include "../../unit_tests/wrappers/windows/errhandlingapi_wrappers.h"
 #endif
 #endif
 

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -175,7 +175,7 @@ if(${TARGET} STREQUAL "winagent")
 
   # Create event channel tests for run_realtime
   list(APPEND syscheckd_event_tests_names "test_run_realtime_event")
-  list(APPEND syscheckd_event_tests_flags "${RUN_REALTIME_BASE_FLAGS} -Wl,--wrap=whodata_audit_start \
+  list(APPEND syscheckd_event_tests_flags "${RUN_REALTIME_BASE_FLAGS} -Wl,--wrap=whodata_audit_start -Wl,--wrap=win_strerror \
                                            -Wl,--wrap=check_path_type,--wrap=set_winsacl,--wrap=w_directory_exists \
                                            -Wl,--wrap,fim_sync_push_msg -Wl,--wrap=fim_db_get_count_registry_data \
                                            -Wl,--wrap=fim_db_get_count_registry_key -Wl,--wrap=syscom_dispatch

--- a/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
+++ b/tests/integration/test_fim/test_files/test_report_changes/test_report_changes_and_diff.py
@@ -171,7 +171,7 @@ def test_reports_file_and_nodiff(test_configuration, test_metadata, configure_lo
         - diff
         - scheduled
     '''
-    if test_metadata.get('fim_mode') == 'whodata' and sys.platform == WINDOWS:
+    if (test_metadata.get('fim_mode') == 'whodata' or test_metadata.get('fim_mode') == 'realtime') and sys.platform == WINDOWS:
         time.sleep(5)
     is_truncated = 'testdir_nodiff' in test_metadata.get('folder')
     folder = test_metadata.get('folder')


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26741#top|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Fix handleleak found in FIM realtime mode:
- It only happens when configuring files in realtime (which is not allowed because we use `ReadDirectoryChanges`).
- In addition to fix the leak using CloseHandle(), we have added the swap derealtime to schedulefor that path, otherwise, it would be opening and closing that handle every second (I have commented several options in the issue [comment](https://github.com/wazuh/wazuh/issues/26741#issuecomment-2476990127) ).
- When this happened, we had a mdebug1that we have left and improved:
```
2024/11/14 09:15:13 wazuh-agent[6132] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for directory: 'c:\test text document.txt'. Error(87): 'The parameter is incorrect.'
```
- And we have added a warning when the mode swap is done:
```
2024/11/14 09:15:13 wazuh-agent[6132] run_realtime.c:698 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test text document.txt'.
```

## Configuration options
Syscheck block:
```
    <directories realtime="yes">C:\test\New Text Document - Copy (10).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (11).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (12).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (13).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (14).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (15).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (16).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (17).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (18).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (19).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (2).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (3).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (4).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (5).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (6).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (7).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (8).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy (9).txt</directories>
    <directories realtime="yes">C:\test\New Text Document - Copy.txt</directories>
    <directories realtime="yes">C:\test\New Text Document.txt</directories>
    <directories realtime="yes">C:\test\dir1</directories>
```


Using handle.exe after a while, we can see no leak occurs:
```
PS C:\> ./handle.exe -p wazuh-agent

Nthandle v5.0 - Handle viewer
Copyright (C) 1997-2022 Mark Russinovich
Sysinternals - www.sysinternals.com

------------------------------------------------------------------------------
wazuh-agent.exe pid: 3840 NT AUTHORITY\SYSTEM
   4C: File  (RW-)   C:\Windows
  1BC: File  (RW-)   C:\Program Files (x86)\ossec-agent
  3E0: File  (R-D)   C:\Windows\System32\en-US\KernelBase.dll.mui
  3F8: File  (R-D)   C:\Windows\System32\en-US\crypt32.dll.mui
  484: File  (RW-)   C:\Program Files (x86)\ossec-agent\queue\fim\db\fim.db
  4A0: File  (RW-)   C:\Program Files (x86)\ossec-agent\queue\fim\db\fim.db-journal
  584: File  (RWD)   C:\Program Files (x86)\ossec-agent\rids\sender_counter
  5D4: File  (RWD)   C:\test\dir1
```

## Logs/Alerts example

```
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:711 at realtime_adddir(): DEBUG: (6227): Directory added for real time monitoring: 'c:\test\dir1'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (10).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (10).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (11).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (11).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (12).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (12).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (13).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (13).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (14).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (14).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (15).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (15).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (16).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (16).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (17).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (17).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (18).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (18).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (19).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (19).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (2).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (2).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (3).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (3).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (4).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (4).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (5).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (5).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (6).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (6).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (7).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (7).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (8).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (8).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy (9).txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy (9).txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document - copy.txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document - copy.txt'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:693 at realtime_adddir(): DEBUG: (6323): Unable to set 'ReadDirectoryChangesW' for path: 'c:\test\new text document.txt'. Error(87): 'The parameter is incorrect.'
2024/11/15 05:55:32 wazuh-agent[840] run_realtime.c:697 at realtime_adddir(): WARNING: (6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: 'c:\test\new text document.txt'
2024/11/15 05:55:32 wazuh-agent[840] run_check.c:424 at fim_run_realtime(): DEBUG: (6345): Folders monitored with real-time engine: 1
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
- [x] Source installation
- [x] Review logs syntax and correct language
