### PR TITLE
Update groups queries and scripts

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -561,7 +561,7 @@ async def add_agent(
             key=key,
             type=type,
             version=version,
-            groups=','.join(groups) if groups else None,
+            groups=groups,
             host=IndexerAgentHost(
                 architecture=host['architecture'],
                 ip=host['ip'],

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -542,6 +542,8 @@ async def add_agent(
     ------
     WazuhError(1738)
         Name length is greater than 128 characters.
+    WazuhError(1710)
+        Group doesn't exist.
     WazuhError(1762)
         Failed while creating the update-group order.
     
@@ -553,6 +555,10 @@ async def add_agent(
     # Check length of agent name
     if len(name) > common.AGENT_NAME_LEN_LIMIT:
         raise WazuhError(1738)
+
+    for group in groups:
+        if not Agent.group_exists(group):
+            raise WazuhError(1710, extra_message=group)
 
     async with get_indexer_client() as indexer_client:
         new_agent = await indexer_client.agents.create(
@@ -687,9 +693,10 @@ async def create_group(group_id: str) -> WazuhResult:
         raise WazuhError(1711, extra_message=group_id)
 
     # Create group in /etc/shared
-    agent_conf_template = path.join(common.WAZUH_SHARED, 'agent-template.conf')
     try:
-        full_copy(agent_conf_template, group_path)
+        with open(group_path, 'w') as f:
+            # TODO(#25121): Write group configuration template
+            f.write('# Group configuration')
 
         chown(group_path, common.wazuh_uid(), common.wazuh_gid())
         chmod(group_path, 0o660)
@@ -734,8 +741,8 @@ async def delete_groups(group_list: list = None) -> AffectedItemsWazuhResult:
 
                 # Reuse command object
                 command = create_update_group_command(agent_id='')
-                for agent_id in agent_list:
-                    command.target.id = agent_id
+                for agent in agent_list:
+                    command.target.id = agent.id
 
                     response = await indexer_client.commands_manager.create(command)
                     if response.result is not ResponseResult.CREATED:
@@ -800,15 +807,26 @@ async def assign_agents_to_group(group_list: list = None, agent_list: list = Non
         query = {IndexerKey.MATCH_ALL: {}}
 
     async with get_indexer_client() as indexer_client:
-        available_agents = [item.id for item in
-            await indexer_client.agents.search(query={IndexerKey.QUERY: query}, select='agent.id')
-        ]
+        available_agents = await indexer_client.agents.search(
+            query={IndexerKey.QUERY: query},
+            select='agent.id,agent.groups',
+        )
 
-        for not_found_id in set(agent_list) - set(available_agents):
+        available_agents_ids = []
+        for i, agent in enumerate(available_agents):
+            if group_id in agent.groups:
+                result.add_failed_item(id_=agent.id, error=WazuhError(1766))
+                available_agents.pop(i)
+                agent_list.remove(agent.id)
+                continue
+
+            available_agents_ids.append(agent.id)
+
+        for not_found_id in set(agent_list) - set(available_agents_ids):
             result.add_failed_item(not_found_id, error=WazuhResourceNotFound(1701))
             agent_list.remove(not_found_id)
 
-        await indexer_client.agents.add_agents_to_group(group_name=group_id, agent_ids=agent_list)
+        await indexer_client.agents.add_agents_to_group(group_name=group_id, agent_ids=agent_list, override=replace)
 
         # Reuse command object
         command = create_set_group_command(agent_id='', groups=[group_id])

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1182,7 +1182,7 @@ async def get_agents_info() -> set:
     """
     async with get_indexer_client() as indexer_client:
         query = {IndexerKey.MATCH_ALL: {}}
-        agents = await indexer_client.agents.search(query={IndexerKey.QUERY: query}, select='id')
+        agents = await indexer_client.agents.search(query={IndexerKey.QUERY: query}, select='agent.id')
         return set([agent.id for agent in agents])
 
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -366,7 +366,7 @@ class WazuhException(Exception):
         1763: "Invalid inventory module type. It must be 'network', 'package', 'process' or 'system'",
         1764: "Invalid User-Agent HTTP header value. It must follow the format '<name> <type> <version>'",
         1765: "Invalid module name. It must be 'fim', 'sca', 'inventory', 'command' or 'vulnerability'",
-
+        1766: {'message': 'The agent already belongs to the group'},
 
         # CDB List: 1800 - 1899
         1800: {'message': 'Bad format in CDB list {path}'},

--- a/framework/wazuh/core/indexer/agent.py
+++ b/framework/wazuh/core/indexer/agent.py
@@ -43,7 +43,7 @@ class AgentsIndex(BaseIndex):
         key: str,
         type: str,
         version: str,
-        groups: str = None,
+        groups: List[str] = None,
         host: Host = None,
     ) -> Agent:
         """Create a new agent.
@@ -75,13 +75,17 @@ class AgentsIndex(BaseIndex):
         Agent : dict
             The created agent instance.
         """
+        group_list = [DEFAULT_GROUP]
+        if groups is not None:
+            group_list.extend(groups)
+
         agent = Agent(
             id=id,
             name=name,
             raw_key=key,
             type=type,
             version=version,
-            groups=DEFAULT_GROUP + f',{groups}' if groups else DEFAULT_GROUP,
+            groups=group_list,
             host=host if host else None
         )
         try:

--- a/framework/wazuh/core/indexer/models/agent.py
+++ b/framework/wazuh/core/indexer/models/agent.py
@@ -73,7 +73,7 @@ class Agent:
     key: str = None
     type: str = None
     version: str = None
-    groups: str = None
+    groups: List[str] = None
     last_login: datetime = None
     status: Status = None
     host: Host = None
@@ -83,8 +83,6 @@ class Agent:
     def __post_init__(self, raw_key: str | None):
         if raw_key is not None:
             self.key = self.hash_key(raw_key).decode('latin-1')
-        if self.groups is not None:
-            self.groups = self.groups.split(',')
 
     @staticmethod
     def hash_key(raw_key: str) -> bytes:
@@ -130,9 +128,4 @@ class Agent:
         dict
             The translated data.
         """
-        ret_val = {}
-        for k, v in asdict(self, dict_factory=convert_enums).items():
-            if k == 'groups':
-                v = ','.join(v)
-            ret_val[k] = v
-        return ret_val
+        return asdict(self, dict_factory=convert_enums)

--- a/framework/wazuh/core/indexer/tests/test_agent.py
+++ b/framework/wazuh/core/indexer/tests/test_agent.py
@@ -108,8 +108,8 @@ class TestAgentIndex:
             IndexerKey.QUERY: {
                 IndexerKey.BOOL: {
                     IndexerKey.FILTER: [{
-                        IndexerKey.QUERY_STRING: {
-                            IndexerKey.QUERY: f'agent.groups: *{group_name}*'
+                        IndexerKey.TERM: {
+                            'agent.groups': group_name
                         }
                     }]
                 }
@@ -138,8 +138,8 @@ class TestAgentIndex:
             IndexerKey.QUERY: {
                 IndexerKey.BOOL: {
                     IndexerKey.FILTER: [{
-                        IndexerKey.QUERY_STRING: {
-                            IndexerKey.QUERY: f'agent.groups: *{group_name}*'
+                        IndexerKey.TERM: {
+                            'agent.groups': group_name
                         }
                     }]
                 }
@@ -178,13 +178,14 @@ class TestAgentIndex:
         await index_instance._update_groups(group_name=group_name, agent_ids=agent_ids, override=override)
 
         if override:
-            source = 'ctx._source.agent.groups = params.group'
+            source = 'ctx._source.agent.groups = new String[] {params.group};'
         else:
+            # Changing the indentation makes the test to fail
             source = """
                 if (ctx._source.agent.groups == null) {
-                    ctx._source.agent.groups = params.group;
+                    ctx._source.agent.groups = new String[] {params.group};
                 } else {
-                    ctx._source.agent.groups += ","+params.group;
+                    ctx._source.agent.groups.add(params.group);
                 }
                 """
 

--- a/framework/wazuh/core/indexer/tests/test_agent.py
+++ b/framework/wazuh/core/indexer/tests/test_agent.py
@@ -180,7 +180,7 @@ class TestAgentIndex:
         if override:
             source = 'ctx._source.agent.groups = new String[] {params.group};'
         else:
-            # Changing the indentation makes the test to fail
+            # Changing the indentation makes the test fail
             source = """
                 if (ctx._source.agent.groups == null) {
                     ctx._source.agent.groups = new String[] {params.group};

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -488,7 +488,8 @@ async def test_agent_add_agent(
     ]
 )
 @patch('wazuh.core.indexer.create_indexer')
-async def test_agent_add_agent_ko(create_indexer_mock, name, id, key, type, version):
+@patch('wazuh.core.agent.Agent.group_exists', return_value=True)
+async def test_agent_add_agent_ko(mock_group_exists, create_indexer_mock, name, id, key, type, version):
     """Test `add_agent` from agent module.
 
     Parameters

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -438,7 +438,9 @@ async def test_agent_delete_agents(
     ),
 ])
 @patch('wazuh.core.indexer.create_indexer')
+@patch('wazuh.core.agent.Agent.group_exists', return_value=True)
 async def test_agent_add_agent(
+    mock_group_exists,
     create_indexer_mock,
     name,
     id,
@@ -454,7 +456,7 @@ async def test_agent_add_agent(
         raw_key=key,
         type=type,
         version=version,
-        groups=','.join(groups),
+        groups=groups,
     )
     agents_create_mock = AsyncMock(return_value=new_agent)
     create_indexer_mock.return_value.agents.create = agents_create_mock
@@ -500,7 +502,6 @@ async def test_agent_add_agent_ko(create_indexer_mock, name, id, key, type, vers
     """
     with pytest.raises(WazuhError, match='.* 1738 .*'):
         await add_agent(name=name*128, id=id, key=key, type=type, version=version)
-
 
 
 @pytest.mark.parametrize('group_list, q, expected_result', [


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/26847 |

## Description

Updates agent groups queries and scripts to manipulate a string array instead of a string with values separated by commas.

### Tests

<details><summary>Create group</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks -X POST https://localhost:55000/groups -d '{
  "group_id": "group1"
}' | jq
{
  "message": "Group 'group1' created.",
  "error": 0
}
root@wazuh-master:/# ls -la /etc/wazuh-server/shared/
total 16
drwxr-x--- 1 root  wazuh 4096 Nov 15 15:13 .
drwxr-x--- 1 root  wazuh 4096 Nov 15 14:58 ..
-rw-rw---- 1 wazuh wazuh   21 Nov 15 15:13 group1.conf
```

</details>

<details><summary>Get groups</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks https://localhost:55000/groups | jq
{
  "data": {
    "affected_items": [
      {
        "name": "group1",
        "configSum": "65e363d76ef3e3b76f87b8eaa24cbff9"
      },
      {
        "name": "group2",
        "configSum": "65e363d76ef3e3b76f87b8eaa24cbff9"
      },
      {
        "name": "group3",
        "configSum": "65e363d76ef3e3b76f87b8eaa24cbff9"
      }
    ],
    "total_affected_items": 3,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected groups information was returned",
  "error": 0
}
```

</details>


<details><summary>Register an agent</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -k https://localhost:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0",
  "groups": ["group1", "group2"]
}
'
```

</details>

<details><summary>Get agents</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks https://localhost:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "k/uAXddaPrK2I/3MSNC6q1TAUaS4juj3oX2v2KO299Gpy8bBrYPjxCnERLSeyrJ4",
        "type": "endpoint",
        "version": "5.0.0",
        "groups": [
          "default",
          "group1",
          "group2"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

<details><summary>Assign agent to group</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks -X PUT "https://localhost:55000/agents/group?agents_list=0a96a0ab-5bef-415c-bb3c-ea3e294215a0&group_id=group3" | jq
{
  "data": {
    "affected_items": [
      "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were assigned to group3",
  "error": 0
}
```

</details>

<details><summary>Get agents in group</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks https://localhost:55000/groups/group3/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "k/uAXddaPrK2I/3MSNC6q1TAUaS4juj3oX2v2KO299Gpy8bBrYPjxCnERLSeyrJ4",
        "type": "endpoint",
        "version": "5.0.0",
        "groups": [
          "default",
          "group1",
          "group2",
          "group3"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected groups information was returned",
  "error": 0
}
```

</details>

<details><summary>Remove agent from group</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks -X DELETE "https://localhost:55000/agents/group?agents_list=0a96a0ab-5bef-415c-bb3c-ea3e294215a0&group_id=group3" | jq
{
  "data": {
    "affected_items": [
      "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were removed from group group3",
  "error": 0
}
```

</details>

<details><summary>Get agents</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks https://localhost:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "k/uAXddaPrK2I/3MSNC6q1TAUaS4juj3oX2v2KO299Gpy8bBrYPjxCnERLSeyrJ4",
        "type": "endpoint",
        "version": "5.0.0",
        "groups": [
          "default",
          "group1",
          "group2"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

<details><summary>Delete a group</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks -X DELETE "https://localhost:55000/groups?groups_list=group2" | jq
{
  "data": {
    "affected_items": [
      "group2"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected groups were deleted",
  "error": 0
}
```

</details>

<details><summary>Get agents</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks https://localhost:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "k/uAXddaPrK2I/3MSNC6q1TAUaS4juj3oX2v2KO299Gpy8bBrYPjxCnERLSeyrJ4",
        "type": "endpoint",
        "version": "5.0.0",
        "groups": [
          "default",
          "group1"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

<details><summary>Get groups</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks https://localhost:55000/groups | jq
{
  "data": {
    "affected_items": [
      {
        "name": "group1",
        "configSum": "65e363d76ef3e3b76f87b8eaa24cbff9"
      },
      {
        "name": "group3",
        "configSum": "65e363d76ef3e3b76f87b8eaa24cbff9"
      }
    ],
    "total_affected_items": 2,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected groups information was returned",
  "error": 0
}
```

</details>

<details><summary>Get agent group commands</summary>

> The `agent.groups=groups000` is added by the commands manager. The reason is unknown to me.

```console
gasti@gasti:~/work/wazuh-tools/framework/environments/dev$ curl -X POST -H "Content-Type: application/json" -ku admin:SecretPassword1% http://localhost:9200/.commands/_search?pretty -d'
{
   "query": {
      "match_all": {}
   }
}'
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 4,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : ".commands",
        "_id" : "U4VXMJMB3yN8yd0jCi4u",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "command" : {
            "source" : "Users/Services",
            "user" : "Management API",
            "target" : {
              "type" : "agent",
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
            },
            "action" : {
              "name" : "update-group",
              "args" : [ ],
              "version" : "5.0.0"
            },
            "timeout" : 100,
            "status" : "PENDING",
            "order_id" : "UoVXMJMB3yN8yd0jCi4t",
            "request_id" : "UYVXMJMB3yN8yd0jCi4t"
          }
        }
      },
      {
        "_index" : ".commands",
        "_id" : "VoVmMJMB3yN8yd0jGy4E",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "command" : {
            "source" : "Users/Services",
            "user" : "Management API",
            "target" : {
              "type" : "agent",
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
            },
            "action" : {
              "name" : "set-group",
              "args" : [
                "group3"
              ],
              "version" : "5.0.0"
            },
            "timeout" : 100,
            "status" : "PENDING",
            "order_id" : "VYVmMJMB3yN8yd0jGy4E",
            "request_id" : "VIVmMJMB3yN8yd0jGy4E"
          }
        }
      },
      {
        "_index" : ".commands",
        "_id" : "XIVvMJMB3yN8yd0j7S6I",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "command" : {
            "source" : "Users/Services",
            "user" : "Management API",
            "target" : {
              "type" : "agent",
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
            },
            "action" : {
              "name" : "update-group",
              "args" : [ ],
              "version" : "5.0.0"
            },
            "timeout" : 100,
            "status" : "PENDING",
            "order_id" : "W4VvMJMB3yN8yd0j7S6I",
            "request_id" : "WoVvMJMB3yN8yd0j7S6I"
          }
        }
      },
      {
        "_index" : ".commands",
        "_id" : "ZYWAMJMB3yN8yd0j0S6G",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "command" : {
            "source" : "Users/Services",
            "user" : "Management API",
            "target" : {
              "type" : "agent",
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
            },
            "action" : {
              "name" : "update-group",
              "args" : [ ],
              "version" : "5.0.0"
            },
            "timeout" : 100,
            "status" : "PENDING",
            "order_id" : "ZIWAMJMB3yN8yd0j0S6G",
            "request_id" : "Y4WAMJMB3yN8yd0j0S6G"
          }
        }
      }
    ]
  }
}
```

</details>

<details><summary>Assing agent to group forcing single group</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks -X PUT "https://localhost:55000/agents/group?agents_list=0a96a0ab-5bef-415c-bb3c-ea3e294215a0&group_id=group3&force_single_group=true" | jq
{
  "data": {
    "affected_items": [
      "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were assigned to group3 and removed from the other groups",
  "error": 0
}
```

</details>

<details><summary>Get agents</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks https://localhost:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "k/uAXddaPrK2I/3MSNC6q1TAUaS4juj3oX2v2KO299Gpy8bBrYPjxCnERLSeyrJ4",
        "type": "endpoint",
        "version": "5.0.0",
        "groups": [
          "group3"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

<details><summary>Try to create an agent with a group that doesn't exist</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://localhost:55000/agents -d '
{
  "id": "1e80ccba-dfe0-44ea-bbfb-b2e59181960b",
  "name": "test2",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0",
  "groups": ["group1", "group2"]
}
' | jq
{
  "title": "Bad Request",
  "detail": "The group does not exist: group2",
  "remediation": "Please, use `GET /agents/groups` to find all available groups",
  "dapi_errors": {
    "master": {
      "error": "The group does not exist: group2"
    }
  },
  "error": 1710
}
```

</details>

<details><summary>Try to assign an agent to a group that it already belongs to</summary>

```console
root@wazuh-master:/# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -ks -X PUT "https://localhost:55000/agents/group?agents_list=0a96a0ab-5bef-415c-bb3c-ea3e294215a0&group_id=group3" | jq
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 1,
    "failed_items": [
      {
        "error": {
          "code": 1766,
          "message": "The agent already belongs to the group"
        },
        "id": [
          "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
        ]
      }
    ]
  },
  "message": "No agents were assigned to group3",
  "error": 1
}
```

</details>

> [!Note]
> Unit tests are expected to fail and will be fixed in https://github.com/wazuh/wazuh/issues/26725.