### PR TITLE
Adapted blibpath variable for AIX to find the necessary paths

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -214,7 +214,11 @@ ifeq ($(INSTALLDIR),)
 	INSTALLDIR = /var/ossec
 endif
 		CMAKE_OPTS+=-DINSTALL_PREFIX=${INSTALLDIR}
+ifeq (${uname_S},AIX)
+		OSSEC_LDFLAGS+='-Wl,-blibpath:${INSTALLDIR}/lib:/opt/freeware/lib:/usr/lib:/lib'
+else
 		OSSEC_LDFLAGS+='-Wl,-blibpath:${INSTALLDIR}/lib:/usr/lib:/lib'
+endif
 		AR_LDFLAGS+=-pthread
 		AR_LDFLAGS+='-Wl,-blibpath:${INSTALLDIR}/lib:/usr/lib:/lib'
 		PATH:=${PATH}:/usr/vac/bin
@@ -1974,7 +1978,7 @@ $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
 		ar -x libwazuhext/$$lib; \
 		mv *.o libwazuhext/; \
 	done
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc -Wl,-blibpath:/opt/freeware/lib:/usr/lib:/lib -latomic
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc -latomic
 else
 ifeq (${uname_S},HP-UX)
 $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)


### PR DESCRIPTION
|Related issue|
|---|
|#26860|

## Description

With this PR we fix the problem of not finding the necessary libraries, so that the binary can be executed without any errors appearing due to the lack of libraries, nor having to adapt the environment variables to correct the error.

To do this, we have simply modified the `blibpath` flag in the compilation for the case of AIX, so that it finds first the libraries of the Wazuh binaries, and after that, the path of `/opt/freeware/lib/` where the atomic library is located by default (besides `/usr/lib` and `/lib`, which would be the alternative paths).

## Tests

> Package generated with the fix and with which the tests have been performed: [Job](https://github.com/wazuh/wazuh-agent-packages/actions/runs/11890612972)

As can be seen, with the fix, it is no longer necessary to have the environment variables set for it to find the libraries correctly:

```
bash-5.1# echo $LD_LIBRARY_PATH

bash-5.1# echo $LIBPATH

bash-5.1# /var/ossec/bin/wazuh-control start
Starting Wazuh v4.10.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
```