### PR TITLE
Preserve permissions when updating to same version

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -151,10 +151,9 @@ function install {
 
         if ($msi_new_version -ne $null -and $msi_new_version -eq $current_version) {
             write-output "$(Get-Date -format u) - Reinstalling the same version." >> .\upgrade\upgrade.log
-            Start-Process -FilePath "msiexec.exe" -ArgumentList @("/i", $msiPath, '-quiet', '-norestart', '-log', 'installer.log', 'REINSTALL=ALL', 'REINSTALLMODE=vomus') -Wait -NoNewWindow
-        } else {
-            Start-Process -FilePath "msiexec.exe" -ArgumentList @("/i", $msiPath, '-quiet', '-norestart', '-log', 'installer.log') -Wait -NoNewWindow
         }
+        
+        Start-Process -FilePath "msiexec.exe" -ArgumentList @("/i", $msiPath, '-quiet', '-norestart', '-log', 'installer.log') -Wait -NoNewWindow
 
     } catch {
         write-output "$(Get-Date -format u) - Installation failed: $($_.Exception.Message)" >> .\upgrade\upgrade.log


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26856|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team, 

this PR makes the Windows WPK agent upgrade preserve the expected permissions when an upgrade occurs.

The problematic line was the following:

```
Start-Process -FilePath "msiexec.exe" -ArgumentList @("/i", $msiPath, '-quiet', '-norestart', '-log', 'installer.log', 'REINSTALL=ALL', 'REINSTALLMODE=vomus') -Wait -NoNewWindow
```

Requesting the reinstall this way was modifying the files permissions while not remaining the same due to the combination of `REINSTALL=ALL` and `REINSTALLMODE=vomus`. Some additional combinations of the mentioned configuration were tested, but the final installation remained broken leaving the agent in a not working state. 

The proposed solution uses the same command to reinstall the agent when it's a new version or the same version, which homogenizes the way we install a new version of the agent and preserve the permissions as they are expected.
<!--
Add a clear description of how the problem has been solved.
-->


## Test

The following `4.10.0` server is deployed, and the used agents will be `013`, which is initially a `4.9.2` version, and `013`, which is initially a `4.10.0` version.

```
root@server-ubu22:/home/vagrant# /var/ossec/bin/agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: server-ubu22 (server), IP: 127.0.0.1, Active/Local
   ID: 003, Name: WIN-SRUDH9K27MT, IP: any, Disconnected
   ID: 004, Name: WIN-UM7GIDHEOJ1, IP: any, Disconnected
   ID: 013, Name: windows11, IP: any, Active
   ID: 014, Name: windows11-1, IP: any, Active
```

Both agents are requested to be updated using a custom WPK implementing the proposed change, and the reported results seem to be the expected:

```
root@server-ubu22:/home/vagrant# /var/ossec/bin/agent_upgrade -a 013 -f /vagrant/wpk_tests/wazuh-agent_4.10.0-0_windows_c6e21e6.msi.wpk

Upgrading...

Upgraded agents:
	Agent 013 upgraded: Wazuh v4.9.2 -> Wazuh v4.10.0
root@server-ubu22:/home/vagrant# /var/ossec/bin/agent_upgrade -a 014 -f /vagrant/wpk_tests/wazuh-agent_4.10.0-0_windows_c6e21e6.msi.wpk

Upgrading...

Upgraded agents:
	Agent 014 upgraded: Wazuh v4.10.0 -> Wazuh v4.10.0
```

In the server logs the result is still reported as a successful execution:

```
2024/11/19 07:55:27 wazuh-modulesd:agent-upgrade: INFO: (8164): Received upgrade notification from agent '13'. Error code: '0', message: 'Upgrade was successful'
2024/11/19 07:57:38 wazuh-modulesd:agent-upgrade: INFO: (8164): Received upgrade notification from agent '14'. Error code: '0', message: 'Upgrade was successful'
```

The `upgrade.log` for the initial `4.9.2` version agent looks as follows:

```
2024-11-18 23:54:34Z - Sysnative Powershell will be used to access the registry.
2024-11-18 23:54:37Z - Current version: v4.9.2.
2024-11-18 23:54:37Z - Extracting the version from MSI file.
2024-11-18 23:54:40Z - MSI new version: v4.10.0.
2024-11-18 23:54:40Z - Starting upgrade process.
2024-11-18 23:55:01Z - Starting Wazuh-Agent service.
2024-11-18 23:55:01Z - Installation finished.
2024-11-18 23:55:01Z - Process ID: 7260.
2024-11-18 23:55:11Z - Reading status file: status='connected'.
2024-11-18 23:55:11Z - Upgrade finished successfully.
2024-11-18 23:55:11Z - New version: v4.10.0.
```


The `upgrade.log` for the initial `4.10.0` version agent looks as follows:

```
2024-11-18 23:56:49Z - Sysnative Powershell will be used to access the registry.
2024-11-18 23:56:52Z - Current version: v4.10.0.
2024-11-18 23:56:52Z - Extracting the version from MSI file.
2024-11-18 23:56:54Z - MSI new version: v4.10.0.
2024-11-18 23:56:54Z - Starting upgrade process.
2024-11-18 23:56:54Z - Reinstalling the same version.
2024-11-18 23:57:12Z - Waiting for the Wazuh-Agent installation to end.
2024-11-18 23:57:14Z - Waiting for the Wazuh-Agent installation to end.
2024-11-18 23:57:16Z - Waiting for the Wazuh-Agent installation to end.
2024-11-18 23:57:18Z - Waiting for the Wazuh-Agent installation to end.
2024-11-18 23:57:20Z - Waiting for the Wazuh-Agent installation to end.
2024-11-18 23:57:22Z - Starting Wazuh-Agent service.
2024-11-18 23:57:22Z - Installation finished.
2024-11-18 23:57:22Z - Process ID: 2032.
2024-11-18 23:57:32Z - Reading status file: status='connected'.
2024-11-18 23:57:32Z - Upgrade finished successfully.
2024-11-18 23:57:32Z - New version: v4.10.0.
```


Checking the affected permissions we see the following behavior:

Initial permissions for the `v4.9.2` agent in the `win32ui.exe`:

```
File: C:\Program Files (x86)\ossec-agent\win32ui.exe
  User/Group: WINDOWS11\vagrant
  Permissions: ReadAndExecute, Synchronize
  Inherited: True
  Access Type: Allow

  User/Group: NT AUTHORITY\SYSTEM
  Permissions: FullControl
  Inherited: True
  Access Type: Allow

  User/Group: BUILTIN\Administrators
  Permissions: FullControl
  Inherited: True
  Access Type: Allow
```

Permissions after WPK upgrade for `v4.9.2` agent in the `win32ui.exe`:

```
File: C:\Program Files (x86)\ossec-agent\win32ui.exe
  User/Group: NT AUTHORITY\Authenticated Users
  Permissions: ReadAndExecute, Synchronize
  Inherited: False
  Access Type: Allow

  User/Group: NT AUTHORITY\SYSTEM
  Permissions: FullControl
  Inherited: True
  Access Type: Allow

  User/Group: BUILTIN\Administrators
  Permissions: FullControl
  Inherited: True
  Access Type: Allow
```

Initial permissions for the `v4.10.0` agent in the `win32ui.exe`:

```
File: C:\Program Files (x86)\ossec-agent\win32ui.exe
  User/Group: NT AUTHORITY\Authenticated Users
  Permissions: ReadAndExecute, Synchronize
  Inherited: False
  Access Type: Allow

  User/Group: NT AUTHORITY\SYSTEM
  Permissions: FullControl
  Inherited: True
  Access Type: Allow

  User/Group: BUILTIN\Administrators
  Permissions: FullControl
  Inherited: True
  Access Type: Allow
```

Permissions after WPK upgrade for `v4.10.0` agent in the `win32ui.exe`:

```
File: C:\Program Files (x86)\ossec-agent\win32ui.exe
  User/Group: NT AUTHORITY\Authenticated Users
  Permissions: ReadAndExecute, Synchronize
  Inherited: False
  Access Type: Allow

  User/Group: NT AUTHORITY\SYSTEM
  Permissions: FullControl
  Inherited: True
  Access Type: Allow

  User/Group: BUILTIN\Administrators
  Permissions: FullControl
  Inherited: True
  Access Type: Allow
```

After the updates, both agents are requested to restart and both are restarted smoothly and the expected alerts are generated


```
** Alert 1732005520.6382061: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2024 Nov 19 08:38:40 (windows11) any->wazuh-remoted
Rule: 506 (level 3) -> 'Wazuh agent stopped.'
ossec: Agent stopped: 'windows11->any'.

** Alert 1732005522.6382392: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2024 Nov 19 08:38:42 (windows11) any->wazuh-agent
Rule: 503 (level 3) -> 'Wazuh agent started.'
ossec: Agent started: 'windows11->any'.

** Alert 1732005523.6382721: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2024 Nov 19 08:38:43 (windows11-1) any->wazuh-remoted
Rule: 506 (level 3) -> 'Wazuh agent stopped.'
ossec: Agent stopped: 'windows11-1->any'.

** Alert 1732005525.6383056: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2024 Nov 19 08:38:45 (windows11-1) any->wazuh-agent
Rule: 503 (level 3) -> 'Wazuh agent started.'
ossec: Agent started: 'windows11-1->any'.
```