### PR TITLE
Change wazuh-server.yml default values

### DIFF
--- a/etc/wazuh-server.yml
+++ b/etc/wazuh-server.yml
@@ -1,15 +1,20 @@
 server:
   nodes:
-    - 'wazuh-master'
+    - master
   node:
-    name: manager_01
-    type: "master"
+    name: server_01
+    type: master
     ssl:
       key: /etc/wazuh-server/server.key
-      cert: /etc/wazuh-server/server.cert
+      cert: /etc/wazuh-server/server.crt
       ca: /etc/wazuh-server/server.ca
 indexer:
-  host: wazuh-indexer
+  host: localhost
   port: 9200
-  user: ""
-  password: ""
+  user: admin
+  password: admin
+  ssl:
+    use_ssl: true
+    key: <PATH_TO_KEY_FILE>
+    cert: <PATH_TO_CERT_FILE>
+    ca: <PATH_TO_CA_FILE>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26904|



## Description

Change the default values of the `wazuh-server.yml` configuration file created in the Wazuh Server installation.

## Environment

After installing the package in a new environment, the following file was created:

```console
root@cd4fd231dcff:/# cat etc/wazuh-server/wazuh-server.yml 
server:
  nodes:
    - master
  node:
    name: server_01
    type: master
    ssl:
      key: /etc/wazuh-server/server.key
      cert: /etc/wazuh-server/server.crt
      ca: /etc/wazuh-server/server.ca
indexer:
  host: localhost
  port: 9200
  user: admin
  password: admin
  ssl:
    use_ssl: true
    key: <PATH_TO_KEY_FILE>
    cert: <PATH_TO_CERT_FILE>
    ca: <PATH_TO_CA_FILE>
```