### PR TITLE
Rellocate Wazuh Server binaries

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -8,7 +8,7 @@ WAZUH_GROUP       = wazuh
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
 ETC_INSTALLDIR    ?= /etc/${WAZUH_SERVER}
-BIN_INSTALLDIR    ?= /bin
+BIN_INSTALLDIR    ?= /usr/share/wazuh-server/bin
 
 
 MV_FILE        = mv -f

--- a/api/Makefile
+++ b/api/Makefile
@@ -8,7 +8,7 @@ WAZUH_GROUP       = wazuh
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
 ETC_INSTALLDIR    ?= /etc/${WAZUH_SERVER}
-BIN_INSTALLDIR    ?= /usr/share/wazuh-server/bin
+BIN_INSTALLDIR    ?= ${SHARE_INSTALLDIR}/bin
 
 
 MV_FILE        = mv -f

--- a/apis/comms_api/Makefile
+++ b/apis/comms_api/Makefile
@@ -8,7 +8,7 @@ WAZUH_GROUP       = wazuh
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
 ETC_INSTALLDIR    ?= /etc/${WAZUH_SERVER}
-BIN_INSTALLDIR    ?= /usr/share/wazuh-server/bin
+BIN_INSTALLDIR    ?= ${SHARE_INSTALLDIR}/bin
 
 MV_FILE        = mv -f
 INSTALL_DIR    = install -o root -g ${WAZUH_GROUP} -m 0750 -d

--- a/apis/comms_api/Makefile
+++ b/apis/comms_api/Makefile
@@ -8,7 +8,7 @@ WAZUH_GROUP       = wazuh
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
 ETC_INSTALLDIR    ?= /etc/${WAZUH_SERVER}
-BIN_INSTALLDIR    ?= /bin
+BIN_INSTALLDIR    ?= /usr/share/wazuh-server/bin
 
 MV_FILE        = mv -f
 INSTALL_DIR    = install -o root -g ${WAZUH_GROUP} -m 0750 -d

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -37,6 +37,7 @@ all: build
 
 install:
 	# SHARE
+	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/bin
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/scripts
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/wazuh

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -12,7 +12,7 @@ LOG_INSTALLDIR         ?= /var/log/${WAZUH_SERVER}
 LIB_INSTALLDIR         ?= /var/lib/${WAZUH_SERVER}
 ETC_INSTALLDIR         ?= /etc/${WAZUH_SERVER}
 RUN_INSTALLDIR         ?= /run/${WAZUH_SERVER}
-BIN_INSTALLDIR         ?= /bin
+BIN_INSTALLDIR         ?= /usr/share/wazuh-server/bin
 
 CC           = gcc
 CFLAGS       = -pipe -Wall -Wextra

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -12,7 +12,7 @@ LOG_INSTALLDIR         ?= /var/log/${WAZUH_SERVER}
 LIB_INSTALLDIR         ?= /var/lib/${WAZUH_SERVER}
 ETC_INSTALLDIR         ?= /etc/${WAZUH_SERVER}
 RUN_INSTALLDIR         ?= /run/${WAZUH_SERVER}
-BIN_INSTALLDIR         ?= /usr/share/wazuh-server/bin
+BIN_INSTALLDIR         ?= ${SHARE_INSTALLDIR}/bin
 
 CC           = gcc
 CFLAGS       = -pipe -Wall -Wextra
@@ -37,7 +37,7 @@ all: build
 
 install:
 	# SHARE
-	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/bin
+	$(INSTALL_DIR) $(BIN_INSTALLDIR)
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/scripts
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/wazuh

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from wazuh.core.common import BIN_ROOT, WAZUH_SHARE, WAZUH_LOG
+from wazuh.core.common import WAZUH_SHARE, WAZUH_LOG
 from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.utils import clean_pid_files
 from wazuh.core.wlogging import WazuhLogger
@@ -25,7 +25,7 @@ SERVER_DAEMON_NAME = 'wazuh-server'
 COMMS_API_SCRIPT_PATH = WAZUH_SHARE / 'apis' / 'scripts' / 'wazuh_comms_apid.py'
 COMMS_API_DAEMON_NAME = 'wazuh-comms-apid'
 EMBEDDED_PYTHON_PATH = WAZUH_SHARE / 'framework' / 'python' / 'bin' / 'python3'
-ENGINE_BINARY_PATH = BIN_ROOT / 'wazuh-engine'
+ENGINE_BINARY_PATH = WAZUH_SHARE / 'bin' / 'wazuh-engine'
 ENGINE_DAEMON_NAME = 'wazuh-engined'
 MANAGEMENT_API_SCRIPT_PATH = WAZUH_SHARE / 'api' / 'scripts' / 'wazuh_apid.py'
 MANAGEMENT_API_DAEMON_NAME = 'wazuh-apid'

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -58,17 +58,17 @@ override_dh_install:
 
 	# Copying to target
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/tmp
-	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/bin
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/run
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/etc
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/var/lib
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/var/log
-	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/usr/share
+	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/usr/share/wazuh-server/bin
 
-	cp -p $(INSTALLATION_DIR)bin/wazuh-engine $(TARGET_DIR)$(INSTALLATION_DIR)bin/
-	cp -p $(INSTALLATION_DIR)bin/wazuh-apid $(TARGET_DIR)$(INSTALLATION_DIR)bin/
-	cp -p $(INSTALLATION_DIR)bin/wazuh-comms-apid $(TARGET_DIR)$(INSTALLATION_DIR)bin/
-	cp -p $(INSTALLATION_DIR)bin/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)bin/
+
+	cp -p $(INSTALLATION_DIR)bin/wazuh-engine $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
+	cp -p $(INSTALLATION_DIR)bin/wazuh-apid $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
+	cp -p $(INSTALLATION_DIR)bin/wazuh-comms-apid $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
+	cp -p $(INSTALLATION_DIR)bin/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
 
 	cp -pr $(INSTALLATION_DIR)tmp/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)tmp/
 	cp -pr $(INSTALLATION_DIR)run/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)run/
@@ -104,14 +104,15 @@ override_dh_fixperms:
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 	# Binaries
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
-	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-apid
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-apid
-	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
-	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
-	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
+	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
+	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
+	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
+	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
+
 
 	# Services
 	chown root:root $(TARGET_DIR)/etc/init.d/wazuh-server

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -65,10 +65,10 @@ override_dh_install:
 	mkdir -p $(TARGET_DIR)$(INSTALLATION_DIR)/usr/share/wazuh-server/bin
 
 
-	cp -p $(INSTALLATION_DIR)bin/wazuh-engine $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
-	cp -p $(INSTALLATION_DIR)bin/wazuh-apid $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
-	cp -p $(INSTALLATION_DIR)bin/wazuh-comms-apid $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
-	cp -p $(INSTALLATION_DIR)bin/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
+	cp -p $(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
+	cp -p $(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
+	cp -p $(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
+	cp -p $(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
 
 	cp -pr $(INSTALLATION_DIR)tmp/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)tmp/
 	cp -pr $(INSTALLATION_DIR)run/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)run/

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -80,12 +80,13 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}var/lib/wazuh-server
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}var/log
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}etc/wazuh-server
 
-cp -p %{_localstatedir}usr/bin/wazuh-engine ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin/
-cp -p %{_localstatedir}usr/bin/wazuh-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin/
-cp -p %{_localstatedir}usr/bin/wazuh-comms-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin/
-cp -p %{_localstatedir}usr/bin/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin/
+cp -p %{_localstatedir}usr/bin/wazuh-engine ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
+cp -p %{_localstatedir}usr/bin/wazuh-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
+cp -p %{_localstatedir}usr/bin/wazuh-comms-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
+cp -p %{_localstatedir}usr/bin/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
 
 cp -pr %{_localstatedir}tmp/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}tmp/
 cp -pr %{_localstatedir}run/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}run/
@@ -247,10 +248,10 @@ rm -fr %{buildroot}
 %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
 %dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-engine
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-apid
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-comms-apid
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-server
+%attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
+%attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
+%attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
+%attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
 %attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/vd_1.0.0_vd_4.10.0.tar.xz
 %attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/engine_store_0.0.2_5.0.0.tar.gz
 

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -83,10 +83,10 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}etc/wazuh-server
 
-cp -p %{_localstatedir}usr/bin/wazuh-engine ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
-cp -p %{_localstatedir}usr/bin/wazuh-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
-cp -p %{_localstatedir}usr/bin/wazuh-comms-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
-cp -p %{_localstatedir}usr/bin/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
+cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
+cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
+cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
+cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
 
 cp -pr %{_localstatedir}tmp/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}tmp/
 cp -pr %{_localstatedir}run/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}run/

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -130,7 +130,8 @@ InstallEngine()
 {
   # Check if the content needs to be downloaded.
   checkDownloadContent
-  ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} engine/build/main ${INSTALLDIR}bin/wazuh-engine
+  mkdir -p ${INSTALLDIR}usr/share/wazuh-server/bin
+  ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} engine/build/main ${INSTALLDIR}usr/share/wazuh-server/bin/wazuh-engine
 
   # Folder for the engine socket.
   ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}run/wazuh-server/

--- a/src/init/templates/wazuh-server-debian.init
+++ b/src/init/templates/wazuh-server-debian.init
@@ -19,7 +19,7 @@
 ### END INIT INFO
 
 WAZUH_HOME=WAZUH_HOME_TMP
-WAZUH_SERVER="${WAZUH_HOME}bin/wazuh-server"
+WAZUH_SERVER="${WAZUH_HOME}usr/share/wazuh-server/bin/wazuh-server"
 
 start() {
     # TODO: Remove root flag

--- a/src/init/templates/wazuh-server-rh.init
+++ b/src/init/templates/wazuh-server-rh.init
@@ -16,7 +16,7 @@ export LANG=C
 . /etc/init.d/functions
 
 WAZUH_HOME=WAZUH_HOME_TMP
-WAZUH_SERVER="${WAZUH_HOME}/bin/wazuh-server"
+WAZUH_SERVER="${WAZUH_HOME}/usr/share/wazuh-server/bin/wazuh-server"
 
 start() {
     echo -n "Starting Wazuh: "

--- a/src/init/templates/wazuh-server.init
+++ b/src/init/templates/wazuh-server.init
@@ -6,7 +6,7 @@
 # Modified for slackware by Jack S. Lai
 
 WAZUH_HOME=WAZUH_HOME_TMP
-WAZUH_SERVER="${WAZUH_HOME}/bin/wazuh-server"
+WAZUH_SERVER="${WAZUH_HOME}/usr/share/wazuh-server/bin/wazuh-server"
 
 start() {
     # TODO: Remove root flag

--- a/src/init/templates/wazuh-server.service
+++ b/src/init/templates/wazuh-server.service
@@ -8,8 +8,8 @@ Type=forking
 LimitNOFILE=65536
 
 # TODO: Remove root flag
-ExecStart=/usr/bin/env WAZUH_HOME_TMPbin/wazuh-server start -r
-ExecStop=/usr/bin/env WAZUH_HOME_TMPbin/wazuh-server stop
+ExecStart=/usr/bin/env WAZUH_HOME_TMPusr/share/wazuh-server/bin/wazuh-server start -r
+ExecStop=/usr/bin/env WAZUH_HOME_TMPusr/share/wazuh-server/bin/wazuh-server stop
 
 KillMode=process
 RemainAfterExit=yes


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26905|


## Description

Moves the Wazuh Server binaries from `/bin` to `/usr/share/wazuh-server/bin`.

