### PR TITLE
CLI usage improvements

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -85,7 +85,7 @@ class WazuhJsonFormatter(jsonlogger.JsonFormatter):
         log_record['data'] = record.message
 
 
-def set_logging(log_filepath, logging_config: RotatedLoggingConfig, foreground_mode: bool = False) -> dict:
+def set_logging(log_filepath, logging_config: RotatedLoggingConfig, background_mode: bool = False) -> dict:
     """Set up logging for API.
     
     This function creates a logging configuration dictionary, configure the wazuh-api logger
@@ -98,9 +98,8 @@ def set_logging(log_filepath, logging_config: RotatedLoggingConfig, foreground_m
         Log file path.
     logging_config :  RotatedLoggingConfig
         Logger configuration.
-    foreground_mode : bool
-        Log output to console streams when true
-        else Log output to file.
+    background_mode : bool
+        Log output to file when true, else log output to standard streams.
 
     Raise
     -----
@@ -115,9 +114,10 @@ def set_logging(log_filepath, logging_config: RotatedLoggingConfig, foreground_m
     handlers = {
         'plainfile': None, 
         'jsonfile': None,
+        'console': {}
     }
-    if foreground_mode:
-        handlers.update({'console': {}})
+    if background_mode:
+        handlers.pop('console')
 
     if 'json' in logging_config.format:
         handlers["jsonfile"] = {

--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -289,9 +289,9 @@ def get_script_arguments() -> Namespace:
         Arguments passed to the script.
     """
     parser = ArgumentParser()
-    parser.add_argument('-d', action='store_true', dest='daemon', help='Run as a daemon.')
-    parser.add_argument('-r', action='store_true', dest='root', help='Run as root')
-    parser.add_argument('-V', action='store_true', dest='version', help='Print version')
+    parser.add_argument('-d', '--daemon', action='store_true', dest='daemon', help='Run as a daemon')
+    parser.add_argument('-r', '--root', action='store_true', dest='root', help='Run as root')
+    parser.add_argument('-V', '--version', action='store_true', dest='version', help='Print version')
     return parser.parse_args()
 
 

--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -4,16 +4,50 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import argparse
+import asyncio
+import logging
+import logging.config
 import os
 import signal
+import ssl
 import sys
 import warnings
+from argparse import ArgumentParser, Namespace
 from functools import partial
 
+import uvicorn
+from connexion import AsyncApp
+from connexion.exceptions import HTTPException, ProblemException, Unauthorized
+from connexion.middleware import MiddlewarePosition
+from connexion.options import SwaggerUIOptions
+from content_size_limit_asgi import ContentSizeLimitMiddleware
+from content_size_limit_asgi.errors import ContentSizeExceeded
+from starlette.middleware.cors import CORSMiddleware
+
+from api import __path__ as api_path
+from api import error_handler
+from api.alogging import set_logging
+from api.api_exception import APIError, ExpectFailedException
+from api.configuration import generate_private_key, generate_self_signed_certificate
+from api.constants import API_LOG_PATH
+from api.middlewares import (
+    CheckBlockedIP,
+    CheckRateLimitsMiddleware,
+    SecureHeadersMiddleware,
+    WazuhAccessLoggerMiddleware,
+    CheckExpectHeaderMiddleware,
+)
+from api.signals import lifespan_handler
+from api.uri_parser import APIUriParser
+from wazuh.core import common, pyDaemonModule, utils
 from wazuh.core.common import WAZUH_SERVER_YML
+from wazuh.core.cluster.utils import print_version
 from wazuh.core.config.models.central_config import ManagementAPIConfig
 from wazuh.core.config.models.ssl_config import APISSLConfig
+from wazuh.rbac.orm import check_database_integrity
+from wazuh.core.config.client import CentralizedConfig
+from wazuh.core.config.models.management_api import ManagementAPIConfig
+
 
 SSL_DEPRECATED_MESSAGE = 'The `{ssl_protocol}` SSL protocol is deprecated.'
 CACHE_DELETED_MESSAGE = 'The `cache` API configuration option no longer takes effect since {release} and will ' \
@@ -204,14 +238,12 @@ def start(params: dict, config: ManagementAPIConfig):
             allow_credentials=config.cors.allow_credentials,
         )
 
-
     # Add error handlers to format exceptions
     app.add_error_handler(ExpectFailedException, error_handler.expect_failed_error_handler)
     app.add_error_handler(Unauthorized, error_handler.unauthorized_error_handler)
     app.add_error_handler(HTTPException, error_handler.http_error_handler)
     app.add_error_handler(ProblemException, error_handler.problem_error_handler)
     app.add_error_handler(403, error_handler.problem_error_handler)
-
 
     # Start uvicorn server
     try:
@@ -225,18 +257,6 @@ def start(params: dict, config: ManagementAPIConfig):
         else:
             logger.error(exc)
             raise exc
-
-
-def print_version():
-    from wazuh.core.cluster import __author__, __licence__, __version__, __wazuh_name__
-    print('\n{} {} - {}\n\n{}'.format(__wazuh_name__, __version__, __author__, __licence__))
-
-
-
-def version():
-    """Print API version and exits with 0 code. """
-    print_version()
-    sys.exit(0)
 
 
 def add_debug2_log_level_and_error():
@@ -260,65 +280,34 @@ def add_debug2_log_level_and_error():
     logging.Logger.error = error
 
 
-if __name__ == '__main__':
+def get_script_arguments() -> Namespace:
+    """Get script arguments.
 
-    parser = argparse.ArgumentParser()
-    #########################################################################################
-    parser.add_argument('-f', help="Run in foreground",
-                        action='store_true', dest='foreground')
-    parser.add_argument('-V', help="Print version",
-                        action='store_true', dest="version")
-    parser.add_argument('-r', help="Run as root",
-                        action='store_true', dest='root')
-    parser.add_argument('-d', help="Enable debug messages. Use twice to increase verbosity.",
-                        action='count',
-                        dest='debug_level')
-    args = parser.parse_args()
+    Returns
+    -------
+    argparse.Namespace
+        Arguments passed to the script.
+    """
+    parser = ArgumentParser()
+    parser.add_argument('-d', action='store_true', dest='daemon', help='Run as a daemon.')
+    parser.add_argument('-r', action='store_true', dest='root', help='Run as root')
+    parser.add_argument('-V', action='store_true', dest='version', help='Print version')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = get_script_arguments()
 
     if args.version:
-        version()
+        print_version()
         sys.exit(0)
-
-    import asyncio
-    import logging
-    import logging.config
-    import ssl
-
-    import uvicorn
-    from connexion import AsyncApp
-    from connexion.exceptions import HTTPException, ProblemException, Unauthorized
-    from connexion.middleware import MiddlewarePosition
-    from connexion.options import SwaggerUIOptions
-    from content_size_limit_asgi import ContentSizeLimitMiddleware
-    from content_size_limit_asgi.errors import ContentSizeExceeded
-    from starlette.middleware.cors import CORSMiddleware
-    from wazuh.core import common, pyDaemonModule, utils
-    from wazuh.rbac.orm import check_database_integrity
-    from wazuh.core.config.client import CentralizedConfig
-    from wazuh.core.config.models.management_api import ManagementAPIConfig
-
-    from api import __path__ as api_path
-    from api import error_handler
-    from api.alogging import set_logging
-    from api.api_exception import APIError, ExpectFailedException
-    from api.configuration import generate_private_key, generate_self_signed_certificate
-    from api.constants import API_LOG_PATH
-    from api.middlewares import (
-        CheckBlockedIP,
-        CheckRateLimitsMiddleware,
-        SecureHeadersMiddleware,
-        WazuhAccessLoggerMiddleware,
-        CheckExpectHeaderMiddleware,
-    )
-    from api.signals import lifespan_handler
-    from api.uri_parser import APIUriParser
-    from api.util import to_relative_path
 
     try:
         CentralizedConfig.load()
     except Exception as e:
         print(f"Error when trying to load the configuration. {e}")
         sys.exit(1)
+
     management_config = CentralizedConfig.get_management_api_config()
 
     # Configure uvicorn parameters dictionary
@@ -332,7 +321,7 @@ if __name__ == '__main__':
     try:
         uvicorn_params['log_config'] = set_logging(log_filepath=API_LOG_PATH,
                                                    logging_config=management_config.logging,
-                                                   foreground_mode=args.foreground)
+                                                   background_mode=args.daemon)
     except APIError as api_log_error:
         print(f"Error when trying to start the Wazuh API. {api_log_error}")
         sys.exit(1)
@@ -354,7 +343,7 @@ if __name__ == '__main__':
     utils.clean_pid_files(API_MAIN_PROCESS)
 
     # Foreground/Daemon
-    if not args.foreground:
+    if args.daemon:
         pyDaemonModule.pyDaemon()
     else:
         logger.info('Starting API in foreground')

--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -291,7 +291,7 @@ def get_script_arguments() -> Namespace:
     parser = ArgumentParser()
     parser.add_argument('-d', '--daemon', action='store_true', dest='daemon', help='Run as a daemon')
     parser.add_argument('-r', '--root', action='store_true', dest='root', help='Run as root')
-    parser.add_argument('-V', '--version', action='store_true', dest='version', help='Print version')
+    parser.add_argument('-v', '--version', action='store_true', dest='version', help='Print version')
     return parser.parse_args()
 
 

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -205,9 +205,9 @@ def get_script_arguments() -> Namespace:
         Arguments passed to the script.
     """
     parser = ArgumentParser()
-    parser.add_argument('-d', action='store_true', dest='daemon', help='Run as a daemon.')
-    parser.add_argument('-r', action='store_true', dest='root', help='Run as root')
-    parser.add_argument('-V', action='store_true', dest='version', help='Print version')
+    parser.add_argument('-d', '--daemon', action='store_true', dest='daemon', help='Run as a daemon')
+    parser.add_argument('-r', '--root', action='store_true', dest='root', help='Run as root')
+    parser.add_argument('-V', '--version', action='store_true', dest='version', help='Print version')
     return parser.parse_args()
 
 

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -207,7 +207,7 @@ def get_script_arguments() -> Namespace:
     parser = ArgumentParser()
     parser.add_argument('-d', '--daemon', action='store_true', dest='daemon', help='Run as a daemon')
     parser.add_argument('-r', '--root', action='store_true', dest='root', help='Run as root')
-    parser.add_argument('-V', '--version', action='store_true', dest='version', help='Print version')
+    parser.add_argument('-v', '--version', action='store_true', dest='version', help='Print version')
     return parser.parse_args()
 
 

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -26,7 +26,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from api.alogging import set_logging
 from api.configuration import generate_private_key, generate_self_signed_certificate
-from api.constants import API_SSL_PATH, COMMS_API_LOG_PATH
+from api.constants import COMMS_API_LOG_PATH
 from api.middlewares import SecureHeadersMiddleware
 from comms_api.core.batcher import create_batcher_process
 from comms_api.core.commands import CommandsManager
@@ -39,7 +39,7 @@ from wazuh.core import common, pyDaemonModule, utils
 from wazuh.core.exception import WazuhCommsAPIError
 from wazuh.core.batcher.config import BatcherConfig
 from wazuh.core.batcher.mux_demux import MuxDemuxQueue, MuxDemuxManager
-
+from wazuh.core.cluster.utils import print_version
 from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.config.models.logging import RotatedLoggingConfig
 from wazuh.core.config.models.comms_api import CommsAPIConfig
@@ -78,13 +78,13 @@ def create_app(batcher_queue: MuxDemuxQueue, commands_manager: CommandsManager) 
     return app
 
 
-def setup_logging(foreground_mode: bool, logging_config: RotatedLoggingConfig) -> dict:
+def setup_logging(daemon: bool, logging_config: RotatedLoggingConfig) -> dict:
     """Set up the logging module and returns the configuration used.
 
     Parameters
     ----------
-    foreground_mode : bool
-        Whether to execute the script in foreground mode or not.
+    daemon : bool
+        Whether to execute the script as a daemon or in foreground.
     logging_config :  RotatedLoggingConfig
         Logger configuration.
 
@@ -95,7 +95,7 @@ def setup_logging(foreground_mode: bool, logging_config: RotatedLoggingConfig) -
     """
     log_config_dict = set_logging(log_filepath=COMMS_API_LOG_PATH,
                                   logging_config=logging_config,
-                                  foreground_mode=foreground_mode)
+                                  background_mode=daemon)
 
     for handler in log_config_dict['handlers'].values():
         if 'filename' in handler:
@@ -153,15 +153,15 @@ def post_worker_init(worker):
     atexit.unregister(_exit_function)
 
 
-def get_gunicorn_options(pid: int, foreground_mode: bool, log_config_dict: dict, config: CommsAPIConfig) -> dict:
+def get_gunicorn_options(pid: int, daemon: bool, log_config_dict: dict, config: CommsAPIConfig) -> dict:
     """Get the gunicorn app configuration options.
 
     Parameters
     ----------
     pid : int
         Main process ID.
-    foreground_mode : bool
-        Whether to execute the script in foreground mode or not.
+    daemon : bool
+        Whether to execute the script as a daemon or in foreground.
     log_config_dict : dict
         Logging configuration dictionary.
     config : CommsAPIConfig
@@ -172,7 +172,6 @@ def get_gunicorn_options(pid: int, foreground_mode: bool, log_config_dict: dict,
     dict
         Gunicorn configuration options.
     """
-
     configure_ssl(config.ssl.key, config.ssl.cert)
 
     pidfile = common.WAZUH_RUN / f'{MAIN_PROCESS}-{pid}.pid'
@@ -180,7 +179,7 @@ def get_gunicorn_options(pid: int, foreground_mode: bool, log_config_dict: dict,
     return {
         'proc_name': MAIN_PROCESS,
         'pidfile': str(pidfile),
-        'daemon': not foreground_mode,
+        'daemon': daemon,
         'bind': f'{config.host}:{config.port}',
         'workers': config.workers,
         'worker_class': 'uvicorn.workers.UvicornWorker',
@@ -206,11 +205,9 @@ def get_script_arguments() -> Namespace:
         Arguments passed to the script.
     """
     parser = ArgumentParser()
-    parser.add_argument('--host', type=str, default='0.0.0.0', help='API host.')
-    parser.add_argument('-p', '--port', type=int, default=27000, help='API port.')
-    parser.add_argument('-f', action='store_true', dest='foreground', help='Run API in foreground mode.')
+    parser.add_argument('-d', action='store_true', dest='daemon', help='Run as a daemon.')
     parser.add_argument('-r', action='store_true', dest='root', help='Run as root')
-
+    parser.add_argument('-V', action='store_true', dest='version', help='Print version')
     return parser.parse_args()
 
 
@@ -291,25 +288,27 @@ def terminate_processes(
 if __name__ == '__main__':
     args = get_script_arguments()
 
-    # The bash script that starts all services first executes them using the `-t` flag to check the configuration.
-    # We don't have a configuration yet, but it will be added in the future, so we just exit successfully for now.
-    #
+    if args.version:
+        print_version()
+        sys.exit(0)
+
     try:
         CentralizedConfig.load()
     except Exception as e:
         print(f"Error when trying to load the configuration. {e}")
         sys.exit(1)
+
     comms_api_config = CentralizedConfig.get_comms_api_config()
 
     utils.clean_pid_files(MAIN_PROCESS)
     
-    log_config_dict = setup_logging(args.foreground, comms_api_config.logging)
+    log_config_dict = setup_logging(daemon=args.daemon, logging_config=comms_api_config.logging)
     logger = logging.getLogger('wazuh-comms-api')
 
-    if args.foreground:
-        logger.info('Starting API in foreground')
-    else:
+    if args.daemon:
         pyDaemonModule.pyDaemon()
+    else:
+        logger.info('Starting API in foreground')
 
     if not args.root:
         # Drop privileges to wazuh
@@ -339,11 +338,11 @@ if __name__ == '__main__':
     )
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-    logger.info(f'Listening on {args.host}:{args.port}')
-    
+    logger.info(f'Listening on {comms_api_config.host}:{comms_api_config.port}')
+
     try:
         app = create_app(mux_demux_manager.get_queue(), commands_manager)
-        options = get_gunicorn_options(pid, args.foreground, log_config_dict, comms_api_config)
+        options = get_gunicorn_options(pid, args.daemon, log_config_dict, comms_api_config)
         StandaloneApplication(app, options).run()
     except WazuhCommsAPIError as e:
         logger.error(f'Error when trying to start the Wazuh Communications API. {e}')

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -423,8 +423,8 @@ def test_get_script_arguments(command, expected_args):
 @patch('scripts.wazuh_server.os.chown')
 @patch('scripts.wazuh_server.os.path.exists', return_value=True)
 @patch('builtins.print')
-def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock, setgid_mock, getpid_mock, exit_mock):
-    """Check and set the behavior of wazuh_server main function."""
+def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock, setgid_mock, getpid_mock, exit_mock):
+    """Check and set the behavior of the `start` function."""
     import wazuh.core.cluster.utils as cluster_utils
     from wazuh.core import common, pyDaemonModule
 
@@ -458,7 +458,7 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
 
         with patch.object(wazuh_server.cluster_utils, 'read_config', side_effect=Exception):
             with pytest.raises(SystemExit):
-                wazuh_server.main()
+                wazuh_server.start()
             main_logger_mock.assert_called_once()
             main_logger_mock.reset_mock()
             path_exists_mock.assert_any_call(wazuh_server.CLUSTER_LOG)
@@ -469,14 +469,14 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
 
         with patch('wazuh.core.cluster.cluster.check_cluster_config', side_effect=IndexError):
             with pytest.raises(SystemExit):
-                wazuh_server.main()
+                wazuh_server.start()
             main_logger_mock.assert_called_once()
             exit_mock.assert_called_once_with(1)
             exit_mock.reset_mock()
 
         with patch('wazuh.core.cluster.cluster.check_cluster_config', return_value=None):
             with pytest.raises(SystemExit):
-                wazuh_server.main()
+                wazuh_server.start()
             main_logger_mock.assert_called_once()
             exit_mock.assert_called_once_with(0)
             main_logger_mock.reset_mock()
@@ -495,7 +495,7 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
                 patch.object(wazuh_server.pyDaemonModule, 'create_pid') as create_pid_mock, \
                 patch.object(wazuh_server.pyDaemonModule, 'delete_child_pids'), \
                 patch.object(wazuh_server.pyDaemonModule,'delete_pid') as delete_pid_mock:
-                wazuh_server.main()
+                wazuh_server.start()
                 main_logger_mock.assert_any_call(
                     "Unhandled exception: name 'cluster_items' is not defined")
                 main_logger_mock.reset_mock()
@@ -523,16 +523,16 @@ def test_main(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock,
                 start_daemons_mock.assert_called_once()
 
                 args.foreground = True
-                wazuh_server.main()
+                wazuh_server.start()
                 print_mock.assert_called_once_with('Starting cluster in foreground (pid: 543)')
 
                 wazuh_server.cluster_items = {}
                 with patch('scripts.wazuh_server.master_main', side_effect=KeyboardInterrupt('TESTING')):
-                    wazuh_server.main()
+                    wazuh_server.start()
                     main_logger_info_mock.assert_any_call('SIGINT received. Shutting down...')
 
                 with patch('scripts.wazuh_server.master_main', side_effect=MemoryError('TESTING')):
-                    wazuh_server.main()
+                    wazuh_server.start()
                     main_logger_mock.assert_any_call(
                         "Directory '/tmp' needs read, write & execution "
                         "permission for 'wazuh' user")

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -295,11 +295,11 @@ def get_script_arguments() -> argparse.Namespace:
         Arguments passed to the script.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-V', help='Print version', action='store_true', dest='version')
+    parser.add_argument('-V', '--version', help='Print version', action='store_true', dest='version')
 
-    subparsers = parser.add_subparsers(title='subcommands', help='Management operations.')
+    subparsers = parser.add_subparsers(title='subcommands', help='Management operations')
 
-    start_parser = subparsers.add_parser('start', help='Start Wazuh server.')
+    start_parser = subparsers.add_parser('start', help='Start Wazuh server')
     ####################################################################################################################
     # Dev options - Silenced in the help message.
     ####################################################################################################################
@@ -316,15 +316,15 @@ def get_script_arguments() -> argparse.Namespace:
     # implemented in worker nodes.
     start_parser.add_argument('--file', help=argparse.SUPPRESS, type=str, dest='send_file')
     ####################################################################################################################
-    start_parser.add_argument('-d', help='Run in daemon', action='store_true', dest='daemon')
-    start_parser.add_argument('-r', help='Run as root', action='store_true', dest='root')
+    start_parser.add_argument('-d', '--daemon', help='Run as a daemon', action='store_true', dest='daemon')
+    start_parser.add_argument('-r', '--root', help='Run as root', action='store_true', dest='root')
 
     start_parser.set_defaults(func=start)
 
-    stop_parser = subparsers.add_parser('stop', help='Stop Wazuh server.')
+    stop_parser = subparsers.add_parser('stop', help='Stop Wazuh server')
     stop_parser.set_defaults(func=stop)
 
-    status_parser = subparsers.add_parser('status', help='Show the Wazuh server status.')
+    status_parser = subparsers.add_parser('status', help='Show the Wazuh server status')
     status_parser.set_defaults(func=status)
 
     return parser

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -295,7 +295,7 @@ def get_script_arguments() -> argparse.Namespace:
         Arguments passed to the script.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-V', '--version', help='Print version', action='store_true', dest='version')
+    parser.add_argument('-v', '--version', help='Print version', action='store_true', dest='version')
 
     subparsers = parser.add_subparsers(title='subcommands', help='Management operations')
 

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -11,16 +11,20 @@ import os
 import signal
 import subprocess
 import sys
-from pathlib import Path
 from typing import List
 
-from wazuh.core.common import WAZUH_SHARE, WAZUH_LOG
+from wazuh.core import pyDaemonModule
+from wazuh.core.authentication import generate_keypair, keypair_exists
+from wazuh.core.common import WAZUH_SHARE, WAZUH_LOG, wazuh_gid, wazuh_uid
 from wazuh.core.config.client import CentralizedConfig
+from wazuh.core.config.models.server import NodeType
+from wazuh.core.cluster.cluster import clean_up
+from wazuh.core.cluster.utils import ClusterLogger, context_tag, process_spawn_sleep, print_version
 from wazuh.core.utils import clean_pid_files
 from wazuh.core.wlogging import WazuhLogger
 from wazuh.core.config.models.server import ServerConfig
 
-BIN_PATH = '/bin'
+
 SERVER_DAEMON_NAME = 'wazuh-server'
 COMMS_API_SCRIPT_PATH = WAZUH_SHARE / 'apis' / 'scripts' / 'wazuh_comms_apid.py'
 COMMS_API_DAEMON_NAME = 'wazuh-comms-apid'
@@ -51,7 +55,7 @@ def set_logging(foreground_mode=False, debug_mode=0) -> WazuhLogger:
     WazuhLogger
         Cluster logger.
     """
-    cluster_logger = cluster_utils.ClusterLogger(
+    cluster_logger = ClusterLogger(
         foreground_mode=foreground_mode,
         log_path='cluster.log',
         debug_level=debug_mode,
@@ -59,13 +63,6 @@ def set_logging(foreground_mode=False, debug_mode=0) -> WazuhLogger:
     )
     cluster_logger.setup_logger()
     return cluster_logger
-
-
-def print_version():
-    """Print Wazuh metadata."""
-    from wazuh.core.cluster import __author__, __licence__, __version__, __wazuh_name__
-
-    print(f'\n{__wazuh_name__} {__version__} - {__author__}\n\n{__licence__}')
 
 
 def exit_handler(signum, frame):
@@ -82,13 +79,13 @@ def exit_handler(signum, frame):
         os.kill(os.getpid(), signum)
 
 
-def start_daemon(foreground: bool, name: str, args: List[str]):
+def start_daemon(background_mode: bool, name: str, args: List[str]):
     """Start a daemon in a subprocess and validate that there were no errors during its execution.
 
     Parameters
     ----------
-    foreground : bool
-        Whether the script is running in foreground mode or not.
+    background_mode : bool
+        Whether the script is running in background mode or not.
     name : str
         Daemon name.
     args : list
@@ -97,46 +94,54 @@ def start_daemon(foreground: bool, name: str, args: List[str]):
     try:
         p = subprocess.Popen(args)
         pid = p.pid
-        if foreground or name == ENGINE_DAEMON_NAME:
-            returncode = p.poll()
-            if returncode not in (0, None):
+        if not background_mode or name == ENGINE_DAEMON_NAME:
+            # Wait two seconds to catch any failures during the execution. If the timeout is reached we consider
+            # it successful
+            returncode = p.wait(timeout=2)
+            if returncode != 0:
                 raise Exception(f'return code {returncode}')
 
             if name == ENGINE_DAEMON_NAME:
                 pyDaemonModule.create_pid(ENGINE_DAEMON_NAME, pid)
         else:
             returncode = p.wait()
+            main_logger.info(returncode)
             if returncode != 0:
                 raise Exception(f'return code {returncode}')
 
             pid = pyDaemonModule.get_parent_pid(name)
+            if pid is None:
+                raise Exception('failed during the execution')
 
         main_logger.info(f'Started {name} (pid: {pid})')
+    except subprocess.TimeoutExpired:
+        # The command was executed without errors
+        pass
     except Exception as e:
         main_logger.error(f'Error starting {name}: {e}')
 
 
-def start_daemons(foreground: bool, root: bool):
+def start_daemons(background_mode: bool, root: bool):
     """Start the engine and the management and communications APIs daemons in subprocesses.
 
     Parameters
     ----------
-    foreground : bool
-        Whether the script is running in foreground mode or not.
+    background_mode : bool
+        Whether the script is running in background mode or not.
     root : bool
         Whether the script is running as root or not.
     """
     daemons = {
         ENGINE_DAEMON_NAME: [ENGINE_BINARY_PATH, 'server', 'start'],
         MANAGEMENT_API_DAEMON_NAME: [EMBEDDED_PYTHON_PATH, MANAGEMENT_API_SCRIPT_PATH]
-        + (['-r'] if root else [])
-        + (['-f'] if foreground else []),
+            + (['-r'] if root else [])
+            + (['-d'] if background_mode else []),
         COMMS_API_DAEMON_NAME: [EMBEDDED_PYTHON_PATH, COMMS_API_SCRIPT_PATH]
-        + (['-r'] if root else [])
-        + (['-f'] if foreground else []),
+            + (['-r'] if root else [])
+            + (['-d'] if background_mode else []),
     }
     for name, args in daemons.items():
-        start_daemon(foreground, name, args)
+        start_daemon(background_mode, name, args)
 
 
 def shutdown_daemon(name: str):
@@ -190,7 +195,7 @@ async def master_main(args: argparse.Namespace, server_config: ServerConfig, log
     """
     from wazuh.core.cluster import local_server, master
 
-    cluster_utils.context_tag.set('Master')
+    context_tag.set('Master')
 
     my_server = master.Master(
         performance_test=args.performance_test,
@@ -201,7 +206,7 @@ async def master_main(args: argparse.Namespace, server_config: ServerConfig, log
 
     # Spawn pool processes
     if my_server.task_pool is not None:
-        my_server.task_pool.map(cluster_utils.process_spawn_sleep, range(my_server.task_pool._max_workers))
+        my_server.task_pool.map(process_spawn_sleep, range(my_server.task_pool._max_workers))
 
     my_local_server = local_server.LocalServerMaster(
         performance_test=args.performance_test,
@@ -237,7 +242,7 @@ async def worker_main(args: argparse.Namespace, server_config: ServerConfig, log
 
     from wazuh.core.cluster import local_server, worker
 
-    cluster_utils.context_tag.set('Worker')
+    context_tag.set('Worker')
 
     # Pool is defined here so the child process is not recreated when the connection with master node is broken.
     try:
@@ -273,7 +278,7 @@ async def worker_main(args: argparse.Namespace, server_config: ServerConfig, log
         )
         # Spawn pool processes
         if my_client.task_pool is not None:
-            my_client.task_pool.map(cluster_utils.process_spawn_sleep, range(my_client.task_pool._max_workers))
+            my_client.task_pool.map(process_spawn_sleep, range(my_client.task_pool._max_workers))
         try:
             await asyncio.gather(my_client.start(), my_local_server.start())
         except asyncio.CancelledError:
@@ -289,16 +294,8 @@ def get_script_arguments() -> argparse.Namespace:
     argparse.Namespace
         Arguments passed to the script.
     """
-
     parser = argparse.ArgumentParser()
     parser.add_argument('-V', help='Print version', action='store_true', dest='version')
-    parser.add_argument(
-        '-d',
-        help='Enable debug messages. Use twice to increase verbosity.',
-        action='count',
-        dest='debug_level',
-        default=0
-    )
 
     subparsers = parser.add_subparsers(title='subcommands', help='Management operations.')
 
@@ -319,13 +316,13 @@ def get_script_arguments() -> argparse.Namespace:
     # implemented in worker nodes.
     start_parser.add_argument('--file', help=argparse.SUPPRESS, type=str, dest='send_file')
     ####################################################################################################################
-    start_parser.add_argument('-f', help='Run in foreground', action='store_true', dest='foreground')
+    start_parser.add_argument('-d', help='Run in daemon', action='store_true', dest='daemon')
     start_parser.add_argument('-r', help='Run as root', action='store_true', dest='root')
 
-    start_parser.set_defaults(func=main)
+    start_parser.set_defaults(func=start)
 
     stop_parser = subparsers.add_parser('stop', help='Stop Wazuh server.')
-    stop_parser.set_defaults(func=stop, foreground=True)
+    stop_parser.set_defaults(func=stop)
 
     status_parser = subparsers.add_parser('status', help='Show the Wazuh server status.')
     status_parser.set_defaults(func=status)
@@ -333,15 +330,19 @@ def get_script_arguments() -> argparse.Namespace:
     return parser
 
 
-def main():
-    """Main function of the wazuh-clusterd script in charge of starting the cluster process."""
-    import wazuh.core.cluster.cluster
-    from wazuh.core.config.client import CentralizedConfig
-    from wazuh.core.authentication import generate_keypair, keypair_exists
+def start():
+    """Start function of the wazuh-server script in charge of starting the server process."""
+    try:
+        server_pid = pyDaemonModule.get_wazuh_server_pid(SERVER_DAEMON_NAME)
+        if server_pid:
+            print(f'The server is already running on process {server_pid}')
+            sys.exit(1)
+    except StopIteration:
+        pass
 
     # Set correct permissions on cluster.log file
     if os.path.exists(CLUSTER_LOG):
-        os.chown(CLUSTER_LOG, common.wazuh_uid(), common.wazuh_gid())
+        os.chown(CLUSTER_LOG, wazuh_uid(), wazuh_gid())
         os.chmod(CLUSTER_LOG, 0o660)
 
     try:
@@ -351,25 +352,25 @@ def main():
         sys.exit(1)
 
     # Clean cluster files from previous executions
-    wazuh.core.cluster.cluster.clean_up()
+    clean_up()
     # Check for unused PID files
     clean_pid_files(SERVER_DAEMON_NAME)
 
     # Foreground/Daemon
-    if not args.foreground:
+    if args.daemon:
         pyDaemonModule.pyDaemon()
 
     # Drop privileges to wazuh
     if not args.root:
-        os.setgid(common.wazuh_gid())
-        os.setuid(common.wazuh_uid())
+        os.setgid(wazuh_gid())
+        os.setuid(wazuh_uid())
 
     cluster_pid = os.getpid()
     pyDaemonModule.create_pid(SERVER_DAEMON_NAME, cluster_pid)
-    if args.foreground:
+    if not args.daemon:
         print(f'Starting cluster in foreground (pid: {cluster_pid})')
 
-    if server_config.node.type == 'master':
+    if server_config.node.type == NodeType.MASTER:
         main_function = master_main
 
         # Generate JWT signing key pair if it doesn't exist
@@ -380,7 +381,7 @@ def main():
         main_function = worker_main
 
     try:
-        start_daemons(args.foreground, args.root)
+        start_daemons(args.daemon, args.root)
 
         asyncio.run(main_function(args, server_config, main_logger))
     except KeyboardInterrupt:
@@ -395,7 +396,6 @@ def main():
 
 def stop():
     """Stop the Wazuh server running in background."""
-
     try:
         server_pid = pyDaemonModule.get_wazuh_server_pid(SERVER_DAEMON_NAME)
     except StopIteration:
@@ -403,12 +403,11 @@ def stop():
         sys.exit(1)
 
     shutdown_cluster(server_pid)
-    os.kill(server_pid, signal.SIGKILL)
+    os.kill(server_pid, signal.SIGTERM)
 
 
 def status():
     """Show the status of the Wazuh server."""
-
     daemons = [SERVER_DAEMON_NAME, COMMS_API_DAEMON_NAME, MANAGEMENT_API_DAEMON_NAME, ENGINE_DAEMON_NAME]
     running_processes = pyDaemonModule.get_running_processes()
 
@@ -420,9 +419,6 @@ def status():
 
 
 if __name__ == '__main__':
-    import wazuh.core.cluster.utils as cluster_utils
-    from wazuh.core import common, pyDaemonModule
-
     original_sig_handler = signal.signal(signal.SIGTERM, exit_handler)
 
     parser = get_script_arguments()
@@ -437,7 +433,7 @@ if __name__ == '__main__':
     except Exception:
         debug_mode_ = 0
 
-    main_logger = set_logging(foreground_mode=getattr(args, 'foreground', False), debug_mode=debug_mode_)
+    main_logger = set_logging(foreground_mode=not getattr(args, 'daemon', False), debug_mode=debug_mode_)
 
     if hasattr(args, 'func'):
         args.func()

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -444,3 +444,8 @@ def raise_if_exc(result: object) -> None:
     """
     if isinstance(result, Exception):
         raise result
+
+
+def print_version():
+    from wazuh.core.cluster import __author__, __licence__, __version__, __wazuh_name__
+    print('\n{} {} - {}\n\n{}'.format(__wazuh_name__, __version__, __author__, __licence__))

--- a/framework/wazuh/core/config/models/server.py
+++ b/framework/wazuh/core/config/models/server.py
@@ -4,15 +4,15 @@ from enum import Enum
 
 from wazuh.core.config.models.base import WazuhConfigBaseModel
 from wazuh.core.config.models.ssl_config import SSLConfig
-from wazuh.core.config.models.logging import LoggingConfig
+from wazuh.core.config.models.logging import LoggingConfig, LoggingLevel
 
 DEFAULT_CTI_URL = "https://cti.wazuh.com"
 
 
 class NodeType(str, Enum):
     """Enum representing supported nodes types."""
-    worker = "worker"
-    master = "master"
+    WORKER = 'worker'
+    MASTER = 'master'
 
 
 class MasterIntervalsConfig(WazuhConfigBaseModel):
@@ -329,7 +329,7 @@ class ServerConfig(WazuhConfigBaseModel):
     worker: WorkerConfig = WorkerConfig()
     master: MasterConfig = MasterConfig()
     communications: CommunicationsConfig = CommunicationsConfig()
-    logging: LoggingConfig = LoggingConfig(level="debug2")
+    logging: LoggingConfig = LoggingConfig(level=LoggingLevel.info)
     cti: CTIConfig = CTIConfig()
     _internal: ServerSyncConfig = PrivateAttr(DEFAULT_SERVER_INTERNAL_CONFIG)
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/26693 |

## Description

Removes unused CLI flags and improves their behavior consistency. 

### Tests


<details><summary>wazuh-server --help</summary>

```console
root@wazuh-master:/# wazuh-server --help
usage: wazuh_server.py [-h] [-V] {start,stop,status} ...

options:
  -h, --help           show this help message and exit
  -V                   Print version

subcommands:
  {start,stop,status}  Management operations.
    start              Start Wazuh server.
    stop               Stop Wazuh server.
    status             Show the Wazuh server status.
```

</details>

<details><summary>wazuh-server -V</summary>

```console
root@wazuh-master:/# wazuh-server -V

Wazuh 5.0.0 - Wazuh Inc

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License (version 2) as 
published by the Free Software Foundation. For more details, go to 
https://www.gnu.org/licenses/gpl.html
```

</details>

<details><summary>wazuh-server start -r</summary>

```console
root@wazuh-master:/# wazuh-server start -r
2024/11/19 14:34:12 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2024/11/19 14:34:12 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
Starting cluster in foreground (pid: 4432)
2024/11/19 14:34:12 INFO: [Cluster] [Main] Started wazuh-engined (pid: 4433)
2024/11/19 14:34:12 INFO: [Cluster] [Main] Started wazuh-apid (pid: 4434)
2024/11/19 14:34:12 INFO: [Cluster] [Main] Started wazuh-comms-apid (pid: 4435)
2024/11/19 14:34:12 INFO: [Local Server] [Main] Serving on /run/wazuh-server/socket/local-server.sock
2024/11/19 14:34:12 DEBUG: [Local Server] [Keep alive] Calculating.
2024/11/19 14:34:12 DEBUG: [Local Server] [Keep alive] Calculated.
2024/11/19 14:34:12 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2024/11/19 14:34:12 DEBUG: [Master] [Keep alive] Calculating.
2024/11/19 14:34:12 DEBUG: [Master] [Keep alive] Calculated.
2024/11/19 14:34:12 INFO: [Master] [Local integrity] Starting.
2024/11/19 14:34:12 INFO: [Master] [Local integrity] Finished in 0.097s. Calculated metadata of 0 files.
2024/11/19 14:34:13 INFO: HTTPS is enabled but cannot find the private key and/or certificate. Attempting to generate them
2024/11/19 14:34:13 INFO: Starting API in foreground
2024/11/19 14:34:13 INFO: Starting API as root
2024/11/19 14:34:13 INFO: Generated private key file in /etc/wazuh-server/api/configuration/ssl/server.key
2024/11/19 14:34:13 INFO: Generated certificate file in /etc/wazuh-server/api/configuration/ssl/server.crt
2024/11/19 14:34:13 INFO: Starting API in foreground
2024/11/19 14:34:13 INFO: Starting API as root
2024/11/19 14:34:13 INFO: Checking RBAC database integrity...
2024/11/19 14:34:13 INFO: RBAC database not found. Initializing
2024/11/19 14:34:13 INFO: Listening on localhost:27000
2024/11/19 14:34:13 INFO: Starting gunicorn 22.0.0
2024/11/19 14:34:13 INFO: Listening at: https://127.0.0.1:27000 (4435)
2024/11/19 14:34:13 INFO: Using worker: uvicorn.workers.UvicornWorker
2024/11/19 14:34:13 INFO: Booting worker with pid: 4845
2024/11/19 14:34:13 INFO: Booting worker with pid: 4846
2024/11/19 14:34:13 INFO: Started server process [4435]
2024/11/19 14:34:13 INFO: Waiting for application startup.
2024/11/19 14:34:13 INFO: Application startup complete.
2024/11/19 14:34:13 INFO: Uvicorn running on unix socket /run/wazuh-server/socket/comms-api.sock (Press CTRL+C to quit)
2024/11/19 14:34:13 INFO: Booting worker with pid: 4847
2024/11/19 14:34:13 INFO: Started server process [4847]
2024/11/19 14:34:13 INFO: Waiting for application startup.
2024/11/19 14:34:13 INFO: Application startup complete.
2024/11/19 14:34:13 INFO: Booting worker with pid: 4849
2024/11/19 14:34:13 INFO: Started server process [4849]
2024/11/19 14:34:13 INFO: Waiting for application startup.
2024/11/19 14:34:13 INFO: Application startup complete.
```

</details>

<details><summary>wazuh-server start when the server is already running</summary>

```console
root@wazuh-master:/# wazuh-server start -r
The server is already running on process 5882
```

</details>

<details><summary>Show daemons execution failures</summary>

```console
root@wazuh-master:/# wazuh-server start -r
Starting cluster in foreground (pid: 13074)
--store_path: Directory does not exist: /var/lib/wazuh-server/engine/store
Run with --help for more information.
2024/11/19 15:26:26 ERROR: [Cluster] [Main] Error starting wazuh-engined: return code 105
2024/11/19 15:26:27 INFO: Starting API in foreground
2024/11/19 15:26:27 INFO: Starting API as root
2024/11/19 15:26:27 INFO: Checking RBAC database integrity...
2024/11/19 15:26:27 INFO: RBAC database not found. Initializing
2024/11/19 15:26:27 ERROR: Error during the database migration. Restoring the previous database file
2024/11/19 15:26:27 ERROR: Error details: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Error when trying to start the Wazuh API. 2012 - Error while attempting to check RBAC database integrity: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8).
2024/11/19 15:26:27 ERROR: [Cluster] [Main] Error starting wazuh-apid: return code 1
wazuh-comms-apid: Non existent process 13000, removing from /run/wazuh-server...
2024/11/19 15:26:28 INFO: Starting API in foreground
2024/11/19 15:26:28 INFO: Starting API as root
2024/11/19 15:26:28 INFO: Listening on localhost:27000
2024/11/19 15:26:28 INFO: Starting gunicorn 22.0.0
2024/11/19 15:26:28 INFO: Listening at: https://127.0.0.1:27000 (13088)
...
```

</details>

<details><summary>wazuh-server status</summary>

```console
root@wazuh-master:/# wazuh-server status
wazuh-server is running...
wazuh-comms-apid is running...
wazuh-apid is not running...
wazuh-engined is not running...
```

</details>

<details><summary>wazuh-server stop</summary>

```console
root@wazuh-master:/# wazuh-server stop
2024/11/19 15:27:55 INFO: [Cluster] [Main] Shutting down wazuh-comms-apid (pid: 13329)
```

> The other daemons are not shut down because they failed

</details>

<details><summary>wazuh-server start -rd</summary>

```console
root@wazuh-master:/# wazuh-server start -rd
root@wazuh-master:/# tail -f /var/log/wazuh-server/cluster.log 
2024/11/19 15:46:32 ERROR: [Cluster] [Main] Error starting wazuh-engined: return code 105
2024/11/19 15:46:33 ERROR: [Cluster] [Main] Error starting wazuh-apid: failed during the execution
2024/11/19 15:46:34 INFO: [Cluster] [Main] Started wazuh-comms-apid (pid: 16662)
2024/11/19 15:46:35 INFO: [Local Server] [Main] Serving on /run/wazuh-server/socket/local-server.sock
2024/11/19 15:46:35 INFO: [Master] [Main] Serving on ('127.0.0.1', 1516)
2024/11/19 15:46:35 INFO: [Master] [Local integrity] Starting.
2024/11/19 15:46:35 INFO: [Master] [Local integrity] Finished in 0.098s. Calculated metadata of 0 files.
```

</details>


<details><summary>wazuh-comms-apid --help</summary>

```console
root@wazuh-master:/# wazuh-comms-apid --help
usage: wazuh_comms_apid.py [-h] [-d] [-r] [-V]

options:
  -h, --help  show this help message and exit
  -d          Run as a daemon.
  -r          Run as root
  -V          Print version
```

</details>


<details><summary>wazuh-comms-apid -V</summary>

```console
root@wazuh-master:/# wazuh-comms-apid -V

Wazuh 5.0.0 - Wazuh Inc

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License (version 2) as 
published by the Free Software Foundation. For more details, go to 
https://www.gnu.org/licenses/gpl.html
```

</details>

<details><summary>wazuh-comms-apid -r</summary>

```console
root@wazuh-master:/# wazuh-comms-apid -r
wazuh-comms-apid: Non existent process 13538, removing from /run/wazuh-server...
2024/11/19 15:30:05 INFO: Starting API in foreground
2024/11/19 15:30:05 INFO: Starting API as root
2024/11/19 15:30:05 INFO: Listening on localhost:27000
2024/11/19 15:30:05 INFO: Starting gunicorn 22.0.0
2024/11/19 15:30:05 INFO: Listening at: https://127.0.0.1:27000 (13767)
2024/11/19 15:30:05 INFO: Using worker: uvicorn.workers.UvicornWorker
2024/11/19 15:30:05 INFO: Booting worker with pid: 13803
2024/11/19 15:30:05 INFO: Started server process [13767]
2024/11/19 15:30:05 INFO: Waiting for application startup.
2024/11/19 15:30:05 INFO: Application startup complete.
2024/11/19 15:30:05 INFO: Uvicorn running on unix socket /run/wazuh-server/socket/comms-api.sock (Press CTRL+C to quit)
2024/11/19 15:30:05 INFO: Booting worker with pid: 13804
2024/11/19 15:30:05 INFO: Started server process [13804]
2024/11/19 15:30:05 INFO: Waiting for application startup.
2024/11/19 15:30:05 INFO: Application startup complete.
2024/11/19 15:30:05 INFO: Booting worker with pid: 13805
2024/11/19 15:30:05 INFO: Started server process [13805]
2024/11/19 15:30:05 INFO: Waiting for application startup.
2024/11/19 15:30:05 INFO: Application startup complete.
2024/11/19 15:30:05 INFO: Booting worker with pid: 13806
2024/11/19 15:30:05 INFO: Started server process [13806]
2024/11/19 15:30:05 INFO: Waiting for application startup.
2024/11/19 15:30:05 INFO: Application startup complete.
^C2024/11/19 15:30:24 INFO: Handling signal: int
2024/11/19 15:30:24 ERROR: Worker (pid:13803) was sent SIGINT!
2024/11/19 15:30:24 INFO: Shutting down
2024/11/19 15:30:24 INFO: Error while closing socket [Errno 9] Bad file descriptor
2024/11/19 15:30:24 INFO: Shutting down
2024/11/19 15:30:24 INFO: Error while closing socket [Errno 9] Bad file descriptor
2024/11/19 15:30:24 INFO: Shutting down
2024/11/19 15:30:24 INFO: Error while closing socket [Errno 9] Bad file descriptor
2024/11/19 15:30:24 INFO: Waiting for application shutdown.
2024/11/19 15:30:24 INFO: Application shutdown complete.
2024/11/19 15:30:24 INFO: Finished server process [13804]
2024/11/19 15:30:24 INFO: Worker exiting (pid: 13804)
2024/11/19 15:30:24 INFO: Waiting for application shutdown.
2024/11/19 15:30:24 INFO: Application shutdown complete.
2024/11/19 15:30:24 INFO: Finished server process [13805]
2024/11/19 15:30:24 INFO: Worker exiting (pid: 13805)
2024/11/19 15:30:24 INFO: Waiting for application shutdown.
2024/11/19 15:30:24 INFO: Application shutdown complete.
2024/11/19 15:30:24 INFO: Finished server process [13806]
2024/11/19 15:30:24 INFO: Worker exiting (pid: 13806)
2024/11/19 15:30:24 INFO: Shutting down: Master
2024/11/19 15:30:24 INFO: Shutting down
2024/11/19 15:30:24 INFO: MuxDemuxQueue (pid: 13785) - Received signal SIGTERM, shutting down
2024/11/19 15:30:24 INFO: Batcher (pid: 13787) - Received signal SIGTERM, shutting down
```

</details>

<details><summary>wazuh-comms-apid -rd</summary>

```console
root@wazuh-master:/# wazuh-comms-apid -rd
root@wazuh-master:/# tail -n 20 /var/log/wazuh-server/comms_api.log 
2024/11/19 15:30:57 INFO: Starting gunicorn 22.0.0
2024/11/19 15:30:57 INFO: Listening at: https://127.0.0.1:27000 (13974)
2024/11/19 15:30:57 INFO: Using worker: uvicorn.workers.UvicornWorker
2024/11/19 15:30:57 INFO: Booting worker with pid: 14010
2024/11/19 15:30:57 INFO: Started server process [13974]
2024/11/19 15:30:57 INFO: Waiting for application startup.
2024/11/19 15:30:57 INFO: Application startup complete.
2024/11/19 15:30:57 INFO: Uvicorn running on unix socket /run/wazuh-server/socket/comms-api.sock (Press CTRL+C to quit)
2024/11/19 15:30:57 INFO: Booting worker with pid: 14011
2024/11/19 15:30:57 INFO: Started server process [14011]
2024/11/19 15:30:57 INFO: Waiting for application startup.
2024/11/19 15:30:57 INFO: Application startup complete.
2024/11/19 15:30:57 INFO: Booting worker with pid: 14012
2024/11/19 15:30:57 INFO: Started server process [14012]
2024/11/19 15:30:57 INFO: Waiting for application startup.
2024/11/19 15:30:57 INFO: Booting worker with pid: 14013
2024/11/19 15:30:57 INFO: Application startup complete.
2024/11/19 15:30:57 INFO: Started server process [14013]
2024/11/19 15:30:57 INFO: Waiting for application startup.
2024/11/19 15:30:57 INFO: Application startup complete.
```

</details>

<details><summary>wazuh-apid --help</summary>

```console
root@wazuh-master:/# wazuh-apid --help
usage: wazuh_apid.py [-h] [-d] [-r] [-V]

options:
  -h, --help  show this help message and exit
  -d          Run as a daemon.
  -r          Run as root
  -V          Print version
```

</details>

<details><summary>wazuh-apid -V</summary>

```console
root@wazuh-master:/# wazuh-apid -V

Wazuh 5.0.0 - Wazuh Inc

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License (version 2) as 
published by the Free Software Foundation. For more details, go to 
https://www.gnu.org/licenses/gpl.html
```

</details>

<details><summary>wazuh-apid -r</summary>

```console
root@wazuh-master:/# wazuh-apid -r
2024/11/19 15:33:58 INFO: Starting API in foreground
2024/11/19 15:33:58 INFO: Starting API as root
2024/11/19 15:33:58 INFO: Checking RBAC database integrity...
2024/11/19 15:33:58 INFO: RBAC database not found. Initializing
2024/11/19 15:33:58 ERROR: Error during the database migration. Restoring the previous database file
2024/11/19 15:33:58 ERROR: Error details: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Error when trying to start the Wazuh API. 2012 - Error while attempting to check RBAC database integrity: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8).
```

> The error is caused by the engine that is deleting the folder where we store RBAC

</details>

<details><summary>wazuh-apid -rd</summary>

```console
root@wazuh-master:/# tail -n 6 /var/log/wazuh-server/api.log 
2024/11/19 15:34:36 INFO: Starting API as root
2024/11/19 15:34:36 INFO: Checking RBAC database integrity...
2024/11/19 15:34:36 INFO: RBAC database not found. Initializing
2024/11/19 15:34:36 ERROR: Error during the database migration. Restoring the previous database file
2024/11/19 15:34:36 ERROR: Error details: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
```

> The error is caused by the engine that is deleting the folder where we store RBAC

</details>