### PR TITLE
Fix logging arguments

### DIFF
--- a/src/engine/source/api/include/api/api.hpp
+++ b/src/engine/source/api/include/api/api.hpp
@@ -120,7 +120,7 @@ public:
         }
         catch (const std::exception& e)
         {
-            LOG_DEBUG("Exception in Api::processRequest: %s", e.what());
+            LOG_DEBUG("Exception in Api::processRequest: {}", e.what());
             wresponse = base::utils::wazuhProtocol::WazuhResponse::unknownError();
             callbackFn(wresponse);
         }

--- a/src/engine/source/builder/src/builders/optransform/sca.cpp
+++ b/src/engine/source/builder/src/builders/optransform/sca.cpp
@@ -689,7 +689,7 @@ void updatePolicyInfo(const DecodeCxt& ctx, const std::string& policyId)
             }
             else
             {
-                LOG_DEBUG("Engine SCA decoder builder: Hash file is the same for policy '%s'.", policyId);
+                LOG_DEBUG("Engine SCA decoder builder: Hash file is the same for policy '{}'.", policyId);
             }
             break;
         }
@@ -718,8 +718,8 @@ void checkResultsAndDump(const DecodeCxt& ctx,
             if (oldEventHash != eventHash)
             {
                 doPushDumpRequest = true;
-                LOG_DEBUG("Engine SCA decoder builder: Scan result integrity failed for policy '%s'. Hash from DB: "
-                          "'%s', hash from summary: '%s'. Requesting DB dump.",
+                LOG_DEBUG("Engine SCA decoder builder: Scan result integrity failed for policy '{}'. Hash from DB: "
+                          "'{}', hash from summary: '{}'. Requesting DB dump.",
                           policyId,
                           oldEventHash,
                           eventHash);
@@ -729,7 +729,7 @@ void checkResultsAndDump(const DecodeCxt& ctx,
         case SearchResult::NOT_FOUND:
             /* Empty DB */
             doPushDumpRequest = true;
-            LOG_DEBUG("Engine SCA decoder builder: Check results DB empty for policy '%s'. Requesting DB dump.",
+            LOG_DEBUG("Engine SCA decoder builder: Check results DB empty for policy '{}'. Requesting DB dump.",
                       policyId);
             break;
         default:


### PR DESCRIPTION
|Related issue|
|---|
|#26867|

# Objective

This PR aims to fix the argument passing to the logging function

## Testing

> [!NOTE]
> `sca` could not be tested, it requires connecting an agent

![2024-11-19_17-45](https://github.com/user-attachments/assets/cbc972ec-749c-4013-a898-7ecd6b306eed)
 