### PR TITLE
Update 0800-sysmon_id_1.xml

### DIFF
--- a/ruleset/rules/0800-sysmon_id_1.xml
+++ b/ruleset/rules/0800-sysmon_id_1.xml
@@ -817,8 +817,8 @@
 
   <rule id="92076" level="6">
     <if_group>sysmon_event1</if_group>
-    <field name="win.eventdata.originalFileName" type="pcre2">(?i)RUNDLL32.EXE</field>
-    <field name="win.eventdata.commandLine" type="pcre2">(?i).lock</field>
+    <field name="win.eventdata.originalFileName" type="pcre2">(?i)RUNDLL32\.EXE</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)\.lock</field>
     <options>no_full_log</options>
     <description>Rundll32 executing suspicious .lock file, possible persistence tactic</description>
     <mitre>


### PR DESCRIPTION
Rule 92076 needs the dot to be a literal.  The current rule is missing the backslash prior to the dot on both field name lines.

The rule, as it stands, is matching any substring that includes the word "lock", like "overclock" and needs to be further restricted to limit false positives.

## Description

Rule 92076 needs the dot to be a literal.  The current rule is missing the backslash prior to the dot on both field name lines.

The rule, as it stands, is matching any substring that includes the word "lock", like "overclock" and needs to be further restricted to limit false positives.

## Configuration options

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors