### PR TITLE
Introducing Wazuh Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Coverity](https://scan.coverity.com/projects/10992/badge.svg)](https://scan.coverity.com/projects/wazuh-wazuh)
 [![Twitter](https://img.shields.io/twitter/follow/wazuh?style=social)](https://twitter.com/wazuh)
 [![YouTube](https://img.shields.io/youtube/views/peTSzcAueEc?style=social)](https://www.youtube.com/watch?v=peTSzcAueEc)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Wazuh%20Guru-006BFF)](https://gurubase.io/g/wazuh)
 
 
 Wazuh is a free and open source platform used for threat prevention, detection, and response. It is capable of protecting workloads across on-premises, virtualized, containerized, and cloud-based environments.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Wazuh Guru](https://gurubase.io/g/wazuh) to Gurubase. Wazuh Guru uses the data from this repo and data from the [docs](http://documentation.wazuh.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "Wazuh Guru", which highlights that Wazuh now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Wazuh Guru in Gurubase, just let me know that's totally fine.
