### PR TITLE
Sanitising path to avoid references to parent folders

### DIFF
--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -218,6 +218,11 @@ int receive_msg()
                     continue;
                 }
 
+                if (w_ref_parent_folder(validate_file)) {
+                    mwarn("Invalid file '%s', vulnerable to directory traversal attack. Ignoring.", validate_file);
+                    continue;
+                }
+
                 *validate_file = '\0';
 
                 /* Copy the file sum */


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/internal-devel-requests/issues/1796|

## Description

With this PR we sanitise the paths that the manager sends to the agent, so we avoid problems due to possible references to parent folders.

Now, in the case of finding a reference to the parent folder, a _`Warning`_ message appears and discards it, continuing with the rest of the files that the manager tries to send.

### Tests

In the following case we can see a real case, where we can see how it is avoided, appearing also the _`warning`_.
```
2024/11/21 12:31:32 wazuh-agent: WARNING: Invalid file ' \\..\local_internal_options.conf
', vulnerable to directory traversal attack. Ignoring.
2024/11/21 12:31:32 wazuh-agent: WARNING: Unknown message received. No action defined.
2024/11/21 12:31:32 wazuh-agent: WARNING: Invalid file ' \\..\dummy_file.txt
', vulnerable to directory traversal attack. Ignoring.
```
