### PR TITLE
Run `wazuh-server` without `root` flag

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -4,6 +4,7 @@
 #
 # Syntax: make [ all | backup | install | restore | service ]
 
+WAZUH_USER        = wazuh
 WAZUH_GROUP       = wazuh
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
@@ -13,11 +14,11 @@ BIN_INSTALLDIR    ?= /bin
 
 MV_FILE        = mv -f
 RM_FILE        = rm -f
-INSTALL_DIR    = install -o root -g ${WAZUH_GROUP} -m 0750 -d
-INSTALL_RW_DIR = install -o root -g ${WAZUH_GROUP} -m 0770 -d
-INSTALL_EXEC   = install -o root -g ${WAZUH_GROUP} -m 0750
-INSTALL_FILE   = install -o root -g ${WAZUH_GROUP} -m 0640
-INSTALL_CONFIG_FILE   = install -o root -g ${WAZUH_GROUP} -m 0660
+INSTALL_DIR    = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750 -d
+INSTALL_RW_DIR = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0770 -d
+INSTALL_EXEC   = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750
+INSTALL_FILE   = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0640
+INSTALL_CONFIG_FILE   = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0660
 PYTHON_BIN     = $(SHARE_INSTALLDIR)/framework/python/bin/python3
 
 

--- a/apis/comms_api/Makefile
+++ b/apis/comms_api/Makefile
@@ -4,6 +4,7 @@
 #
 # Syntax: make [ all | install | service ]
 
+WAZUH_USER        = wazuh
 WAZUH_GROUP       = wazuh
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
@@ -11,9 +12,9 @@ ETC_INSTALLDIR    ?= /etc/${WAZUH_SERVER}
 BIN_INSTALLDIR    ?= /bin
 
 MV_FILE        = mv -f
-INSTALL_DIR    = install -o root -g ${WAZUH_GROUP} -m 0750 -d
-INSTALL_EXEC   = install -o root -g ${WAZUH_GROUP} -m 0750
-INSTALL_FILE   = install -o root -g ${WAZUH_GROUP} -m 0640
+INSTALL_DIR    = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750 -d
+INSTALL_EXEC   = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750
+INSTALL_FILE   = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0640
 
 
 .PHONY: all install

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -4,6 +4,7 @@
 #
 # Syntax: make [ all | build | install | examples | clean ]
 
+WAZUH_USER        = wazuh
 WAZUH_GROUP       = wazuh
 WAZUH_SERVER	  = wazuh-server
 
@@ -19,9 +20,9 @@ CFLAGS       = -pipe -Wall -Wextra
 THREAD_FLAGS = -pthread
 MV_FILE      = mv -f
 RM_FILE      = rm -f
-INSTALL_DIR  = install -o root -g ${WAZUH_GROUP} -m 0750  -d
-INSTALL_EXEC = install -o root -g ${WAZUH_GROUP} -m 0750
-INSTALL_FILE = install -o root -g ${WAZUH_GROUP} -m 0640
+INSTALL_DIR  = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750  -d
+INSTALL_EXEC = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750
+INSTALL_FILE = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0640
 
 ifdef DEBUG
 	CFLAGS+=-g -I ../src

--- a/packages/debs/SPECS/debian/preinst
+++ b/packages/debs/SPECS/debian/preinst
@@ -8,6 +8,7 @@ DIR="/var/wazuh-server"
 WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 VERSION="$2"
 MAJOR=$(echo "$VERSION" | cut -dv -f2 | cut -d. -f1)
+WAZUH_USER="wazuh"
 
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then
@@ -19,6 +20,18 @@ fi
 
 case "$1" in
     install|upgrade)
+        if [ "$1" = "install" ]; then
+            # Create wazuh group if not exists
+            if ! getent group $WAZUH_USER > /dev/null 2>&1; then
+                groupadd -r $WAZUH_USER
+            fi
+
+            # Create wazuh user if not exists
+            if ! getent passwd ${WAZUH_USER} > /dev/null 2>&1; then
+                useradd ${WAZUH_USER} -d / -s /sbin/nologin -g ${WAZUH_USER}
+            fi
+        fi
+
         if [ "$1" = "upgrade" ]; then
             if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1 && systemctl is-active --quiet wazuh-server > /dev/null 2>&1; then
                 systemctl stop wazuh-server.service > /dev/null 2>&1

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -90,27 +90,27 @@ override_dh_install:
 override_dh_fixperms:
 	dh_fixperms
 	# Folders
-	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)tmp/wazuh-server
+	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)tmp/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)tmp/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
+	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
+	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server
+	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
+	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
+	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 	# Binaries
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
+	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-apid
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-apid
+	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
+	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
-	chown root:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
+	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
 
 	# Services

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -104,14 +104,14 @@ override_dh_fixperms:
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 	# Binaries
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
 	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-apid
 	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-apid
-	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-engine
-	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
-	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
+	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-comms-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
+	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)bin/wazuh-server
 
 	# Services
 	chown root:root $(TARGET_DIR)/etc/init.d/wazuh-server

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -199,14 +199,28 @@ if [ -f %{_localstatedir}/tmp/wazuh.restart ]; then
   fi
 fi
 
-chown -R root:wazuh %{_localstatedir}var/lib/wazuh-server
+chown -R wazuh:wazuh %{_localstatedir}tmp/wazuh-server
+find %{_localstatedir}tmp/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+chown -R wazuh:wazuh %{_localstatedir}tmp/wazuh-server
+find %{_localstatedir}tmp/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+chown -R wazuh:wazuh %{_localstatedir}var/lib/wazuh-server
 find %{_localstatedir}var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-chown -R root:wazuh %{_localstatedir}var/log/wazuh-server
+chown -R wazuh:wazuh %{_localstatedir}var/log/wazuh-server
 find %{_localstatedir}var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
-chown -R root:wazuh %{_localstatedir}usr/share/wazuh-server
+chown -R wazuh:wazuh %{_localstatedir}usr/share/wazuh-server
 find %{_localstatedir}usr/share/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
-chown -R root:wazuh %{_localstatedir}etc/wazuh-server
+chown -R wazuh:wazuh %{_localstatedir}etc/wazuh-server
 find %{_localstatedir}etc/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
+
+# Binaries
+chmod 750 %{_localstatedir}bin/wazuh-engine
+chown wazuh:wazuh %{_localstatedir}bin/wazuh-engine
+chmod 750 %{_localstatedir}bin/wazuh-apid
+chown wazuh:wazuh %{_localstatedir}bin/wazuh-apid
+chmod 750 %{_localstatedir}bin/wazuh-comms-apid
+chown wazuh:wazuh %{_localstatedir}bin/wazuh-comms-apid
+chmod 750 %{_localstatedir}bin/wazuh-server
+chown wazuh:wazuh %{_localstatedir}bin/wazuh-server
 
 # Fix Python permissions
 chmod -R 0750 %{_localstatedir}usr/share/wazuh-server/framework/python/bin
@@ -217,42 +231,42 @@ chmod -R 0750 %{_localstatedir}usr/share/wazuh-server/framework/python/bin
 rm -fr %{buildroot}
 
 %files
-%defattr(-,root,wazuh)
-%dir %attr(750, root, wazuh) %{_localstatedir}run/wazuh-server
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/vd
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
-%dir %attr(750, root, wazuh) %{_localstatedir}var/log/wazuh-server
-%dir %attr(750, root, wazuh) %{_localstatedir}var/log/wazuh-server/engine
-%dir %attr(750, root, wazuh) %{_localstatedir}etc/wazuh-server
-%dir %attr(750, root, wazuh) %{_localstatedir}etc/wazuh-server/api
-%dir %attr(750, root, wazuh) %{_localstatedir}etc/wazuh-server/cluster
-%dir %attr(750, root, wazuh) %{_localstatedir}etc/wazuh-server/shared
-%dir %attr(750, root, wazuh) %{_localstatedir}run/wazuh-server/cluster
-%dir %attr(750, root, wazuh) %{_localstatedir}run/wazuh-server/socket
-%dir %attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/lib
-%dir %attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/framework
-%dir %attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/api
-%dir %attr(750, root, wazuh) %{_localstatedir}usr/share/wazuh-server/apis
+%defattr(-,wazuh,wazuh)
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}run/wazuh-server
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/vd
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/log/wazuh-server
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/log/wazuh-server/engine
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server/api
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server/cluster
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server/shared
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}run/wazuh-server/cluster
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}run/wazuh-server/socket
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/lib
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/framework
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/api
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/apis
 %{_localstatedir}var/lib/wazuh-server/engine/tzdb/*
 %{_localstatedir}etc/wazuh-server/*
 %{_localstatedir}usr/share/wazuh-server/lib/*
 %{_localstatedir}usr/share/wazuh-server/framework/*
 %{_localstatedir}usr/share/wazuh-server/api/*
 %{_localstatedir}usr/share/wazuh-server/apis/*
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store
 %{_localstatedir}var/lib/wazuh-server/engine/store/*
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
 %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
-%dir %attr(750, root, wazuh) %{_localstatedir}var/lib/wazuh-server/indexer-connector
+%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-engine
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-apid
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-comms-apid
-%attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-server
-%attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/vd_1.0.0_vd_4.10.0.tar.xz
-%attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/engine_store_0.0.2_5.0.0.tar.gz
+%attr(750, wazuh, wazuh) %{_localstatedir}usr/bin/wazuh-engine
+%attr(750, wazuh, wazuh) %{_localstatedir}usr/bin/wazuh-apid
+%attr(750, wazuh, wazuh) %{_localstatedir}usr/bin/wazuh-comms-apid
+%attr(750, wazuh, wazuh) %{_localstatedir}usr/bin/wazuh-server
+%attr(640, wazuh, wazuh) %{_localstatedir}tmp/wazuh-server/vd_1.0.0_vd_4.10.0.tar.xz
+%attr(640, wazuh, wazuh) %{_localstatedir}tmp/wazuh-server/engine_store_0.0.2_5.0.0.tar.gz
 
 %config(missingok) %{_initrddir}/wazuh-server
 /usr/lib/systemd/system/wazuh-server.service

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -32,15 +32,15 @@ InstallCommon()
   ./init/adduser.sh ${WAZUH_USER} ${WAZUH_GROUP} ${INSTALLDIR}
 
   # Folder for the engine api socket
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}run/wazuh-engine
+  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}run/wazuh-engine
   # Folder for persistent databases (vulnerability scanner, ruleset, connector).
-  ${INSTALL} -d -m 0660 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine
+  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine
   # Folder for persistent databases (vulnerability scanner).
-  ${INSTALL} -d -m 0660 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/vd
+  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/vd
   # Folder for persistent databases (ruleset).
-  ${INSTALL} -d -m 0660 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/ruleset
+  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/ruleset
   # Folder for persistent queues for the indexer connector.
-  ${INSTALL} -d -m 0660 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/indexer-connector
+  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/indexer-connector
 
 }
 
@@ -130,25 +130,24 @@ InstallEngine()
 {
   # Check if the content needs to be downloaded.
   checkDownloadContent
-  ${INSTALL} -m 0750 -o root -g ${WAZUH_GROUP} engine/build/main ${INSTALLDIR}bin/wazuh-engine
+  ${INSTALL} -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} engine/build/main ${INSTALLDIR}bin/wazuh-engine
 
   # Folder for the engine socket.
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}run/wazuh-server/
+  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}run/wazuh-server/
 
   # Folder for persistent databases (vulnerability scanner, ruleset, connector).
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/vd
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine
-  ${INSTALL} -d -m 0755 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server
-  ${INSTALL} -d -m 0755 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server/engine
+  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/
+  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/vd
+  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine
+  ${INSTALL} -d -m 0755 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server
+  ${INSTALL} -d -m 0755 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server/engine
 
-  #${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} engine/build/tzdb ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
   cp -rp engine/build/tzdb ${INSTALLDIR}var/lib/wazuh-server/engine/
   chown -R root:${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
   chmod 0750 ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
   chmod 0640 ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb/*
 
-  ${INSTALL} -d -m 0750 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/indexer-connector
+  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/indexer-connector
 
   # Download and extract the Engine store
   installEngineStore

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -143,7 +143,7 @@ InstallEngine()
   ${INSTALL} -d -m 0755 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server/engine
 
   cp -rp engine/build/tzdb ${INSTALLDIR}var/lib/wazuh-server/engine/
-  chown -R root:${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
+  chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
   chmod 0750 ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb
   chmod 0640 ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb/*
 


### PR DESCRIPTION
|Related issue|
|---|
|#26908|

## Description

This PR closes #26908. Sets the correct ownership for the directories to run the server without the `-r` flag.

## Logs/Alerts example

I've opened #26950 and #26948 to address problems related to the engine start. 

<details><summary>Installed from source</summary>
<p>

```console
root@wazuh-master:/# wazuh-server start -f
2024/11/21 15:45:03 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2024/11/21 15:45:03 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
Starting cluster in foreground (pid: 67)
2024/11/21 15:45:03 INFO: [Cluster] [Main] Generating JWT signing key pair
2024/11/21 15:45:03 INFO: [Cluster] [Main] Started wazuh-engined (pid: 79)
2024/11/21 15:45:03 INFO: [Cluster] [Main] Started wazuh-apid (pid: 80)
2024/11/21 15:45:03 INFO: [Cluster] [Main] Started wazuh-comms-apid (pid: 81)
2024-11-21 15:45:03.478 79:79 info: Logging initialized.
2024-11-21 15:45:03.478 79:79 info: Store initialized.
2024-11-21 15:45:03.479 79:79 info: RBAC initialized.
2024-11-21 15:45:03.479 79:79 info: MetricsManager: Created new scope: (KVDB)
2024-11-21 15:45:03.494 79:79 info: KVDB initialized.
2024-11-21 15:45:03.494 79:79 info: Geo initialized.
2024-11-21 15:45:03.509 79:79 info: Schema initialized.
2024/11/21 15:45:04 INFO: [Local Server] [Main] Serving on /run/wazuh-server/socket/local-server.sock
2024/11/21 15:45:04 DEBUG: [Local Server] [Keep alive] Calculating.
2024/11/21 15:45:04 DEBUG: [Local Server] [Keep alive] Calculated.
2024/11/21 15:45:04 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2024/11/21 15:45:04 DEBUG: [Master] [Keep alive] Calculating.
2024/11/21 15:45:04 DEBUG: [Master] [Keep alive] Calculated.
2024/11/21 15:45:04 INFO: [Master] [Local integrity] Starting.
2024/11/21 15:45:04 INFO: [Master] [Local integrity] Finished in 0.098s. Calculated metadata of 0 files.
2024/11/21 15:45:04 INFO: HTTPS is enabled but cannot find the private key and/or certificate. Attempting to generate them
2024/11/21 15:45:04 INFO: Generated private key file in /etc/wazuh-server/api/configuration/ssl/server.key
2024/11/21 15:45:04 INFO: Generated certificate file in /etc/wazuh-server/api/configuration/ssl/server.crt
2024/11/21 15:45:04 INFO: Starting API in foreground
2024/11/21 15:45:04 INFO: Checking RBAC database integrity...
2024/11/21 15:45:04 INFO: RBAC database not found. Initializing
2024-11-21 15:45:04.616 79:79 info: Loaded timezone database version: '2024a'
2024-11-21 15:45:04.620 79:79 info: HLP initialized.
2024-11-21 15:45:04.621 79:79 error: An error occurred while initializing the modules: filesystem error: cannot create directories: Permission denied [queue/indexer/test-basic-index].
2024-11-21 15:45:04.622 79:79 info: KVDB terminated.
2024/11/21 15:45:04 INFO: Starting API in foreground
2024/11/21 15:45:04 INFO: Listening on 0.0.0.0:27000
2024/11/21 15:45:04 INFO: Starting gunicorn 22.0.0
2024/11/21 15:45:04 INFO: Listening at: https://127.0.0.1:27000 (81)
2024/11/21 15:45:04 INFO: Using worker: uvicorn.workers.UvicornWorker
2024/11/21 15:45:04 INFO: Booting worker with pid: 164
2024/11/21 15:45:04 INFO: Booting worker with pid: 165
2024/11/21 15:45:04 INFO: Started server process [81]
2024/11/21 15:45:04 INFO: Waiting for application startup.
2024/11/21 15:45:04 INFO: Application startup complete.
2024/11/21 15:45:04 INFO: Uvicorn running on unix socket /run/wazuh-server/socket/comms-api.sock (Press CTRL+C to quit)
2024/11/21 15:45:04 INFO: Booting worker with pid: 166
2024/11/21 15:45:04 INFO: Started server process [166]
2024/11/21 15:45:04 INFO: Waiting for application startup.
2024/11/21 15:45:04 INFO: Application startup complete.
2024/11/21 15:45:04 INFO: Booting worker with pid: 167
2024/11/21 15:45:04 INFO: Started server process [167]
2024/11/21 15:45:04 INFO: Waiting for application startup.
2024/11/21 15:45:04 INFO: Application startup complete.
2024/11/21 15:45:05 INFO: /var/lib/wazuh-server/rbac.db database created successfully
2024/11/21 15:45:05 INFO: RBAC database integrity check finished successfully
2024/11/21 15:45:08 INFO: Listening on ['localhost', '::1']:55000.
2024/11/21 15:45:08 INFO: Populating installation UID...
2024/11/21 15:45:08 INFO: Getting updates information...
2024/11/21 15:45:12 INFO: [Master] [Local integrity] Starting.
2024/11/21 15:45:12 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
```

</p>
</details> 

<details><summary>DEB Package</summary>
<p>

```console
root@dce051f36712:/pkg# dpkg -i wazuh-server_5.0.0-test_amd64_c2bf0f0593.deb
Selecting previously unselected package wazuh-server.
(Reading database ... 7826 files and directories currently installed.)
Preparing to unpack wazuh-server_5.0.0-test_amd64_c2bf0f0593.deb ...
Unpacking wazuh-server (5.0.0-test) ...
Setting up wazuh-server (5.0.0-test) ...
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
root@dce051f36712:/pkg# cp certs/server.* /etc/wazuh-server/
root@dce051f36712:/pkg# chown wazuh:wazuh /etc/wazuh-server/server.*
root@dce051f36712:/pkg# wazuh-server start -f
2024/11/21 15:48:01 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2024/11/21 15:48:01 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
Starting cluster in foreground (pid: 1383)
2024/11/21 15:48:01 INFO: [Cluster] [Main] Generating JWT signing key pair
2024/11/21 15:48:01 INFO: [Cluster] [Main] Started wazuh-engined (pid: 1384)
2024/11/21 15:48:01 INFO: [Cluster] [Main] Started wazuh-apid (pid: 1385)
2024/11/21 15:48:01 INFO: [Cluster] [Main] Started wazuh-comms-apid (pid: 1386)
mkdir: cannot create directory ‘/usr/bin/tzdb’: Permission denied
2024-11-21 15:48:01.953 1384:1384 error: An error occurred while initializing the modules: Timezone database not found at "/usr/bin/tzdb".
2024/11/21 15:48:02 ERROR: [Master] [Main] Failed loading SSL context: [SSL] PEM lib (_ssl.c:3900). Using default one.
Traceback (most recent call last):
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 1419, in create_ssl_context
    ssl_context.load_cert_chain(
ssl.SSLError: [SSL] PEM lib (_ssl.c:3900)
2024/11/21 15:48:02 INFO: [Local Server] [Main] Serving on /run/wazuh-server/socket/local-server.sock
2024/11/21 15:48:02 DEBUG: [Local Server] [Keep alive] Calculating.
2024/11/21 15:48:02 DEBUG: [Local Server] [Keep alive] Calculated.
2024/11/21 15:48:02 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2024/11/21 15:48:02 DEBUG: [Master] [Keep alive] Calculating.
2024/11/21 15:48:02 DEBUG: [Master] [Keep alive] Calculated.
2024/11/21 15:48:02 INFO: [Master] [Local integrity] Starting.
2024/11/21 15:48:02 INFO: [Master] [Local integrity] Finished in 0.099s. Calculated metadata of 0 files.
2024/11/21 15:48:02 INFO: HTTPS is enabled but cannot find the private key and/or certificate. Attempting to generate them
2024/11/21 15:48:02 INFO: Generated private key file in /etc/wazuh-server/api/configuration/ssl/server.key
2024/11/21 15:48:02 INFO: Generated certificate file in /etc/wazuh-server/api/configuration/ssl/server.crt
2024/11/21 15:48:02 INFO: Starting API in foreground
2024/11/21 15:48:02 INFO: Checking RBAC database integrity...
2024/11/21 15:48:02 INFO: RBAC database not found. Initializing
2024/11/21 15:48:03 INFO: Starting API in foreground
2024/11/21 15:48:03 INFO: Listening on 0.0.0.0:27000
2024/11/21 15:48:03 INFO: Starting gunicorn 22.0.0
2024/11/21 15:48:03 INFO: Listening at: https://127.0.0.1:27000 (1386)
2024/11/21 15:48:03 INFO: Using worker: uvicorn.workers.UvicornWorker
2024/11/21 15:48:03 INFO: Booting worker with pid: 1798
2024/11/21 15:48:03 INFO: Booting worker with pid: 1799
2024/11/21 15:48:03 INFO: Started server process [1386]
2024/11/21 15:48:03 INFO: Waiting for application startup.
2024/11/21 15:48:03 INFO: Application startup complete.
2024/11/21 15:48:03 INFO: Uvicorn running on unix socket /run/wazuh-server/socket/comms-api.sock (Press CTRL+C to quit)
2024/11/21 15:48:03 INFO: Booting worker with pid: 1800
2024/11/21 15:48:03 INFO: Started server process [1800]
2024/11/21 15:48:03 INFO: Waiting for application startup.
2024/11/21 15:48:03 INFO: Application startup complete.
2024/11/21 15:48:03 INFO: Booting worker with pid: 1801
2024/11/21 15:48:03 INFO: Started server process [1801]
2024/11/21 15:48:03 INFO: Waiting for application startup.
2024/11/21 15:48:03 INFO: Application startup complete.
2024/11/21 15:48:04 INFO: /var/lib/wazuh-server/rbac.db database created successfully
2024/11/21 15:48:04 INFO: RBAC database integrity check finished successfully
2024/11/21 15:48:06 INFO: Listening on ['localhost', '::1']:55000.
2024/11/21 15:48:06 INFO: Populating installation UID...
2024/11/21 15:48:06 INFO: Getting updates information...
2024/11/21 15:48:10 INFO: [Master] [Local integrity] Starting.
2024/11/21 15:48:10 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
```

</p>
</details> 

<details><summary>RPM Package</summary>
<p>

```console
[root@fa4c7193889a pkg]# yum localinstall wazuh-server_5.0.0-test_x86_64_c2bf0f0593.rpm
Loaded plugins: fastestmirror, ovl
Examining wazuh-server_5.0.0-test_x86_64_c2bf0f0593.rpm: wazuh-server-5.0.0-test.x86_64
Marking wazuh-server_5.0.0-test_x86_64_c2bf0f0593.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package wazuh-server.x86_64 0:5.0.0-test will be installed
--> Finished Dependency Resolution

Dependencies Resolved

=====================================================================================================================================================================================================================
 Package                                       Arch                                    Version                                     Repository                                                                   Size
=====================================================================================================================================================================================================================
Installing:
 wazuh-server                                  x86_64                                  5.0.0-test                                  /wazuh-server_5.0.0-test_x86_64_c2bf0f0593                                  573 M

Transaction Summary
=====================================================================================================================================================================================================================
Install  1 Package

Total size: 573 M
Installed size: 573 M
Is this ok [y/d/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : wazuh-server-5.0.0-test.x86_64                                                                                                                                                                    1/1
  Verifying  : wazuh-server-5.0.0-test.x86_64                                                                                                                                                                    1/1

Installed:
  wazuh-server.x86_64 0:5.0.0-test

Complete!
[root@fa4c7193889a pkg]# cp certs/server.* /etc/wazuh-server/
[root@fa4c7193889a pkg]# chown wazuh:wazuh /etc/wazuh-server/server.*
[root@fa4c7193889a pkg]# wazuh-server start -f
2024/11/21 15:51:57 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2024/11/21 15:51:57 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
Starting cluster in foreground (pid: 23445)
2024/11/21 15:51:57 INFO: [Cluster] [Main] Generating JWT signing key pair
2024/11/21 15:51:57 INFO: [Cluster] [Main] Started wazuh-engined (pid: 23446)
2024/11/21 15:51:57 INFO: [Cluster] [Main] Started wazuh-apid (pid: 23447)
2024/11/21 15:51:57 INFO: [Cluster] [Main] Started wazuh-comms-apid (pid: 23448)
mkdir: cannot create directory '/usr/bin/tzdb': Permission denied
2024-11-21 15:51:57.176 23446:23446 error: An error occurred while initializing the modules: Timezone database not found at "/usr/bin/tzdb".
2024/11/21 15:51:57 ERROR: [Master] [Main] Failed loading SSL context: [SSL] PEM lib (_ssl.c:3900). Using default one.
Traceback (most recent call last):
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/common.py", line 1419, in create_ssl_context
    ssl_context.load_cert_chain(
ssl.SSLError: [SSL] PEM lib (_ssl.c:3900)
2024/11/21 15:51:57 INFO: [Local Server] [Main] Serving on /run/wazuh-server/socket/local-server.sock
2024/11/21 15:51:57 DEBUG: [Local Server] [Keep alive] Calculating.
2024/11/21 15:51:57 DEBUG: [Local Server] [Keep alive] Calculated.
2024/11/21 15:51:57 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2024/11/21 15:51:57 DEBUG: [Master] [Keep alive] Calculating.
2024/11/21 15:51:57 DEBUG: [Master] [Keep alive] Calculated.
2024/11/21 15:51:57 INFO: [Master] [Local integrity] Starting.
2024/11/21 15:51:57 INFO: [Master] [Local integrity] Finished in 0.097s. Calculated metadata of 0 files.
2024/11/21 15:51:58 INFO: HTTPS is enabled but cannot find the private key and/or certificate. Attempting to generate them
2024/11/21 15:51:58 INFO: Generated private key file in /etc/wazuh-server/api/configuration/ssl/server.key
2024/11/21 15:51:58 INFO: Generated certificate file in /etc/wazuh-server/api/configuration/ssl/server.crt
2024/11/21 15:51:58 INFO: Starting API in foreground
2024/11/21 15:51:58 INFO: Checking RBAC database integrity...
2024/11/21 15:51:58 INFO: RBAC database not found. Initializing
2024/11/21 15:51:58 INFO: Starting API in foreground
2024/11/21 15:51:58 INFO: Listening on 0.0.0.0:27000
2024/11/21 15:51:58 INFO: Starting gunicorn 22.0.0
2024/11/21 15:51:58 INFO: Listening at: https://127.0.0.1:27000 (23448)
2024/11/21 15:51:58 INFO: Using worker: uvicorn.workers.UvicornWorker
2024/11/21 15:51:58 INFO: Booting worker with pid: 23859
2024/11/21 15:51:58 INFO: Started server process [23448]
2024/11/21 15:51:58 INFO: Waiting for application startup.
2024/11/21 15:51:58 INFO: Application startup complete.
2024/11/21 15:51:58 INFO: Uvicorn running on unix socket /run/wazuh-server/socket/comms-api.sock (Press CTRL+C to quit)
2024/11/21 15:51:58 INFO: Booting worker with pid: 23860
2024/11/21 15:51:58 INFO: Started server process [23860]
2024/11/21 15:51:58 INFO: Waiting for application startup.
2024/11/21 15:51:58 INFO: Application startup complete.
2024/11/21 15:51:58 INFO: Booting worker with pid: 23861
2024/11/21 15:51:58 INFO: Started server process [23861]
2024/11/21 15:51:58 INFO: Waiting for application startup.
2024/11/21 15:51:58 INFO: Application startup complete.
2024/11/21 15:51:58 INFO: Booting worker with pid: 23862
2024/11/21 15:51:58 INFO: Started server process [23862]
2024/11/21 15:51:58 INFO: Waiting for application startup.
2024/11/21 15:51:58 INFO: Application startup complete.
2024/11/21 15:51:59 INFO: /var/lib/wazuh-server/rbac.db database created successfully
2024/11/21 15:51:59 INFO: RBAC database integrity check finished successfully
2024/11/21 15:52:01 INFO: Listening on ['localhost', '::1']:55000.
2024/11/21 15:52:01 INFO: Populating installation UID...
2024/11/21 15:52:01 INFO: Getting updates information...
2024/11/21 15:52:05 INFO: [Master] [Local integrity] Starting.
2024/11/21 15:52:05 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
```

</p>
</details>