### PR TITLE
Deleted temporary files from the engine store

### DIFF
--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -252,7 +252,6 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-comms-apid
 %attr(750, root, wazuh) %{_localstatedir}usr/bin/wazuh-server
 %attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/vd_1.0.0_vd_4.10.0.tar.xz
-%attr(640, root, wazuh) %{_localstatedir}tmp/wazuh-server/engine_store_0.0.2_5.0.0.tar.gz
 
 %config(missingok) %{_initrddir}/wazuh-server
 /usr/lib/systemd/system/wazuh-server.service

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -112,19 +112,42 @@ installEngineStore()
     STORE_URL=https://packages.wazuh.com/deps/engine_store_model_database/${STORE_FILENAME}
     DEST_FULL_PATH=${INSTALLDIR}var/lib/wazuh-server
 
-    echo "Download ${STORE_FILENAME} file"
+    echo "Downloading ${STORE_FILENAME} file..."
     mkdir -p ${INSTALLDIR}tmp/wazuh-server
-    wget -O ${STORE_FULL_PATH} ${STORE_URL}
+    if ! wget -O ${STORE_FULL_PATH} ${STORE_URL}; then
+        echo "Error: Failed to download ${STORE_FILENAME} from ${STORE_URL}"
+        exit 1
+    fi
 
     chmod 640 ${STORE_FULL_PATH}
     chown ${WAZUH_USER}:${WAZUH_GROUP} ${STORE_FULL_PATH}
 
-    tar -xzf ${STORE_FULL_PATH} -C ${DEST_FULL_PATH}
+    echo "Extracting ${STORE_FILENAME} to ${DEST_FULL_PATH}..."
+    if ! tar -xzf ${STORE_FULL_PATH} -C ${DEST_FULL_PATH}; then
+        echo "Error: Failed to extract ${STORE_FILENAME} to ${DEST_FULL_PATH}"
+        exit 1
+    fi
+
+    echo "Removing tar file ${STORE_FULL_PATH}..."
+    if ! rm -f ${STORE_FULL_PATH}; then
+        echo "Warning: Failed to remove tar file ${STORE_FULL_PATH}."
+    fi
+
     chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${DEST_FULL_PATH}/engine/store
     chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${DEST_FULL_PATH}/engine/kvdb
     find ${DEST_FULL_PATH}/engine/store -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
     find ${DEST_FULL_PATH}/engine/kvdb -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+    
+    echo "Verifying store installation..."
+    if [ ! -d "${DEST_FULL_PATH}/engine/store" ] || [ ! -d "${DEST_FULL_PATH}/engine/kvdb" ]; then
+        echo "Error: Store installation verification failed. Required directories are missing."
+        exit 1
+    fi
+
+    echo "Engine store installed successfully."
+
 }
+
 
 InstallEngine()
 {


### PR DESCRIPTION
|Related issue|
|---|
|#26947|

This PR deletes the temporary file from the engine store once it has been downloaded, unzipped and copied correctly.