### PR TITLE
Set rpm packages vendor and set it to UNKNOWN_VALUE if it's empty

### DIFF
--- a/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelper.h
@@ -49,7 +49,7 @@ namespace PackageLinuxHelper
             ret["architecture"] = package.architecture;
             ret["source"]       = UNKNOWN_VALUE;
             ret["format"]       = "rpm";
-            ret["vendor"]       = package.vendor;
+            ret["vendor"]       = package.vendor.empty() ? UNKNOWN_VALUE : package.vendor;
             ret["description"]  = package.description;
             // The multiarch field won't have a default value
         }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/26953|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hello team, 

This PR add's a verification of the retrieved vendor value from an RPM package, and sets it to `UNKNOWN_VALUE` in case it's empty.