### PR TITLE
Framework indexer client improvements

### DIFF
--- a/framework/wazuh/core/config/models/indexer.py
+++ b/framework/wazuh/core/config/models/indexer.py
@@ -18,10 +18,10 @@ class IndexerConfig(WazuhConfigBaseModel):
     password : str
         The password for indexer authentication.
     ssl : IndexerSSLConfig, optional
-        SSL configuration for the indexer. Default is an instance of IndexerSSLConfig.
+        SSL configuration for the indexer. Default is None.
     """
     host: str
     port: PositiveInt
     user: str
     password: str
-    ssl: IndexerSSLConfig = IndexerSSLConfig()
+    ssl: IndexerSSLConfig = None

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -39,18 +39,18 @@ class IndexerSSLConfig(WazuhConfigBaseModel):
     use_ssl : bool
         Whether to use SSL for the indexer. Default is False.
     key : str
-        The path to the SSL key file. Default is an empty string.
+        The path to the SSL key file.
     cert : str
-        The path to the SSL certificate file. Default is an empty string.
+        The path to the SSL certificate file.
     ca : str
-        The path to the CA certificate file. Default is an empty string.
+        The path to the CA certificate file.
     verify_certificates : bool
         Whether to verify the server TLS certificates or not. Default is True.
     """
     use_ssl: bool = False
-    key: str = ""
-    cert: str = ""
-    ca: str = ""
+    key: str
+    cert: str
+    ca: str
     verify_certificates: bool = True
 
 

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -43,18 +43,18 @@ class IndexerSSLConfig(WazuhConfigBaseModel):
     use_ssl : bool
         Whether to use SSL for the indexer. Default is False.
     key : str
-        The path to the SSL key file.
+        The path to the SSL key file. Default is an empty string.
     cert : str
-        The path to the SSL certificate file.
+        The path to the SSL certificate file. Default is an empty string.
     ca : str
-        The path to the CA certificate file.
+        The path to the CA certificate file. Default is an empty string.
     verify_certificates : bool
         Whether to verify the server TLS certificates or not. Default is True.
     """
     use_ssl: bool = False
-    key: str
-    cert: str
-    ca: str
+    key: str = ''
+    cert: str = ''
+    ca: str = ''
     verify_certificates: bool = True
 
     @field_validator('key', 'cert', 'ca')
@@ -80,7 +80,7 @@ class IndexerSSLConfig(WazuhConfigBaseModel):
             SSL certificate/key path.
         """
         if info.data['use_ssl']:
-            if path is None or path == '':
+            if path == '':
                 raise ValueError(f'{info.field_name}: missing certificate file')
 
             if not os.path.isfile(path):

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -44,11 +44,14 @@ class IndexerSSLConfig(WazuhConfigBaseModel):
         The path to the SSL certificate file. Default is an empty string.
     ca : str
         The path to the CA certificate file. Default is an empty string.
+    verify_certificates : bool
+        Whether to verify the server TLS certificates or not. Default is True.
     """
     use_ssl: bool = False
     key: str = ""
     cert: str = ""
     ca: str = ""
+    verify_certificates: bool = True
 
 
 class APISSLConfig(WazuhConfigBaseModel):

--- a/framework/wazuh/core/config/models/tests/test_engine.py
+++ b/framework/wazuh/core/config/models/tests/test_engine.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 from pydantic import ValidationError
 from pathlib import PosixPath
 
-from wazuh.core.config.models.engine import EngineClientConfig, EngineConfig, DEFAULT_ENGINE_SOCKET_PATH
+from wazuh.core.common import ENGINE_SOCKET
+from wazuh.core.config.models.engine import EngineClientConfig, EngineConfig
 
 valid_socket_path = "/var/wazuh/queue/example.sock"
 valid_retries = 5
@@ -13,7 +14,7 @@ valid_timeout = 20.0
 @pytest.mark.parametrize("init_values, expected", [
     ({"api_socket_path": valid_socket_path, "retries": valid_retries, "timeout": valid_timeout},
      {"api_socket_path": valid_socket_path, "retries": valid_retries, "timeout": valid_timeout}),
-    ({}, {"api_socket_path": DEFAULT_ENGINE_SOCKET_PATH, "retries": 3, "timeout": 10.0}),
+    ({}, {"api_socket_path": ENGINE_SOCKET, "retries": 3, "timeout": 10.0}),
 ])
 @patch('pathlib.Path.is_file', return_value=True)
 def test_engine_client_config_default_values(mock_is_file, init_values, expected):

--- a/framework/wazuh/core/config/models/tests/test_indexer.py
+++ b/framework/wazuh/core/config/models/tests/test_indexer.py
@@ -1,8 +1,13 @@
+from unittest.mock import patch
+
 import pytest
 from pydantic import ValidationError
 
 from wazuh.core.config.models.indexer import IndexerConfig
 from wazuh.core.config.models.ssl_config import IndexerSSLConfig
+
+with patch('os.path.isfile', return_value=True):
+    SSL_CONFIG = IndexerSSLConfig(use_ssl=True, key='key_example', cert='cert_example', ca='ca_example')
 
 
 @pytest.mark.parametrize('init_values,expected', [
@@ -26,14 +31,14 @@ from wazuh.core.config.models.ssl_config import IndexerSSLConfig
             'port': 9300,
             'user': 'another_user',
             'password': 'another_password',
-            'ssl': IndexerSSLConfig(use_ssl=True, key='key_example', cert='cert_example', ca='ca_example')
+            'ssl': SSL_CONFIG
         },
         {
             'host': 'example.com',
             'port': 9300,
             'user': 'another_user',
             'password': 'another_password',
-            'ssl': IndexerSSLConfig(use_ssl=True, key='key_example', cert='cert_example', ca='ca_example')
+            'ssl': SSL_CONFIG
         }
     )
 ])

--- a/framework/wazuh/core/config/models/tests/test_indexer.py
+++ b/framework/wazuh/core/config/models/tests/test_indexer.py
@@ -5,36 +5,35 @@ from wazuh.core.config.models.indexer import IndexerConfig
 from wazuh.core.config.models.ssl_config import IndexerSSLConfig
 
 
-@pytest.mark.parametrize("init_values,expected", [
+@pytest.mark.parametrize('init_values,expected', [
     (
         {
-            "host": "localhost",
-            "port": 9200,
-            "user": "user_example",
-            "password": "password_example"
+            'host': 'localhost',
+            'port': 9200,
+            'user': 'user_example',
+            'password': 'password_example'
         },
         {
-            "host": "localhost",
-            "port": 9200,
-            "user": "user_example",
-            "password": "password_example",
-            "ssl": IndexerSSLConfig()
+            'host': 'localhost',
+            'port': 9200,
+            'user': 'user_example',
+            'password': 'password_example',
         }
     ),
     (
         {
-            "host": "example.com",
-            "port": 9300,
-            "user": "another_user",
-            "password": "another_password",
-            "ssl": IndexerSSLConfig(use_ssl=True, key="key_example", cert="cert_example")
+            'host': 'example.com',
+            'port': 9300,
+            'user': 'another_user',
+            'password': 'another_password',
+            'ssl': IndexerSSLConfig(use_ssl=True, key='key_example', cert='cert_example', ca='ca_example')
         },
         {
-            "host": "example.com",
-            "port": 9300,
-            "user": "another_user",
-            "password": "another_password",
-            "ssl": IndexerSSLConfig(use_ssl=True, key="key_example", cert="cert_example")
+            'host': 'example.com',
+            'port': 9300,
+            'user': 'another_user',
+            'password': 'another_password',
+            'ssl': IndexerSSLConfig(use_ssl=True, key='key_example', cert='cert_example', ca='ca_example')
         }
     )
 ])
@@ -42,18 +41,19 @@ def test_indexer_config_default_values(init_values, expected):
     """Check the correct initialization of the `IndexerConfig` class."""
     config = IndexerConfig(**init_values)
 
-    assert config.host == expected["host"]
-    assert config.port == expected["port"]
-    assert config.user == expected["user"]
-    assert config.password == expected["password"]
-    assert config.ssl == expected["ssl"]
+    assert config.host == expected['host']
+    assert config.port == expected['port']
+    assert config.user == expected['user']
+    assert config.password == expected['password']
+    if config.ssl:
+        assert config.ssl == expected['ssl']
 
 
-@pytest.mark.parametrize("init_values", [
+@pytest.mark.parametrize('init_values', [
     ({}),
-    ({"host": "localhost"}),
-    ({"host": "localhost", "port": 9200}),
-    ({"host": "localhost", "port": 9200, "user": "user_example"}),
+    ({'host': 'localhost'}),
+    ({'host': 'localhost', 'port': 9200}),
+    ({'host': 'localhost', 'port': 9200, 'user': 'user_example'}),
 ])
 def test_indexer_config_fails_without_values(init_values):
     """Check the correct behavior of the `IndexerConfig` class validations."""

--- a/framework/wazuh/core/config/models/tests/test_ssl_config.py
+++ b/framework/wazuh/core/config/models/tests/test_ssl_config.py
@@ -52,6 +52,10 @@ def test_ssl_config_fails_without_values(init_values):
     (
         {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example"},
         {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example"}
+    ),
+    (
+        {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example", "verify_certificates": True},
+        {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example", "verify_certificates": True}
     )
 ])
 def test_indexer_ssl_config_default_values(init_values, expected):
@@ -62,6 +66,7 @@ def test_indexer_ssl_config_default_values(init_values, expected):
     assert ssl_config.key == expected["key"]
     assert ssl_config.cert == expected["cert"]
     assert ssl_config.ca == expected["ca"]
+    assert ssl_config.verify_certificates == expected["verify_certificates"]
 
 
 @pytest.mark.parametrize("init_values,expected", [

--- a/framework/wazuh/core/config/models/tests/test_ssl_config.py
+++ b/framework/wazuh/core/config/models/tests/test_ssl_config.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from pydantic import ValidationError
 
@@ -42,7 +44,8 @@ def test_ssl_config_fails_without_values(init_values):
         {'use_ssl': True, 'key': 'key_example', 'cert': 'cert_example', 'ca': 'ca_example', 'verify_certificates': True}
     )
 ])
-def test_indexer_ssl_config_default_values(init_values, expected):
+@patch('os.path.isfile', return_value=True)
+def test_indexer_ssl_config_default_values(file_exists_mock, init_values, expected):
     """Check the correct initialization of the `IndexerSSLConfig` class."""
     ssl_config = IndexerSSLConfig(**init_values)
 

--- a/framework/wazuh/core/config/models/tests/test_ssl_config.py
+++ b/framework/wazuh/core/config/models/tests/test_ssl_config.py
@@ -4,14 +4,14 @@ from pydantic import ValidationError
 from wazuh.core.config.models.ssl_config import SSLConfig, IndexerSSLConfig, SSLProtocol, APISSLConfig
 
 
-@pytest.mark.parametrize("init_values,expected", [
+@pytest.mark.parametrize('init_values,expected', [
     (
-        {"key": "key_example", "cert": "cert_example", "ca": "ca_example"},
-        ""
+        {'key': 'key_example', 'cert': 'cert_example', 'ca': 'ca_example'},
+        ''
     ),
     (
-        {"key": "key_example", "cert": "cert_example", "ca": "ca_example", "keyfile_password": "example"},
-        "example"
+        {'key': 'key_example', 'cert': 'cert_example', 'ca': 'ca_example', 'keyfile_password': 'example'},
+        'example'
     )
 ])
 def test_ssl_config_default_values(init_values, expected):
@@ -21,90 +21,74 @@ def test_ssl_config_default_values(init_values, expected):
     assert ssl_config.keyfile_password == expected
 
 
-@pytest.mark.parametrize("init_values", [
+@pytest.mark.parametrize('init_values', [
     {},
-    {"key": "key_example"},
-    {"key": "key_example", "cert": "cert_example"},
+    {'key': 'key_example'},
+    {'key': 'key_example', 'cert': 'cert_example'},
 ])
 def test_ssl_config_fails_without_values(init_values):
-    """Check the correct behavior of the `SSLConfig` class validations."""
+    'Check the correct behavior of the `SSLConfig` class validations.'
     with pytest.raises(ValidationError):
         _ = SSLConfig(**init_values)
 
 
-@pytest.mark.parametrize("init_values,expected", [
+@pytest.mark.parametrize('init_values,expected', [
     (
-        {},
-        {"use_ssl": False, "key": "", "cert": "", "ca": ""}
+        {'use_ssl': True, 'key': 'key_example', 'cert': 'cert_example', 'ca': 'ca_example', 'verify_certificates': False},
+        {'use_ssl': True, 'key': 'key_example', 'cert': 'cert_example', 'ca': 'ca_example', 'verify_certificates': False}
     ),
     (
-        {"use_ssl": True},
-        {"use_ssl": True, "key": "", "cert": "", "ca": ""}
-    ),
-    (
-        {"use_ssl": True, "key": "key_example"},
-        {"use_ssl": True, "key": "key_example", "cert": "", "ca": ""}
-    ),
-    (
-        {"use_ssl": True, "key": "key_example", "cert": "cert_example"},
-        {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": ""}
-    ),
-    (
-        {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example"},
-        {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example"}
-    ),
-    (
-        {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example", "verify_certificates": True},
-        {"use_ssl": True, "key": "key_example", "cert": "cert_example", "ca": "ca_example", "verify_certificates": True}
+        {'use_ssl': True, 'key': 'key_example', 'cert': 'cert_example', 'ca': 'ca_example', 'verify_certificates': True},
+        {'use_ssl': True, 'key': 'key_example', 'cert': 'cert_example', 'ca': 'ca_example', 'verify_certificates': True}
     )
 ])
 def test_indexer_ssl_config_default_values(init_values, expected):
     """Check the correct initialization of the `IndexerSSLConfig` class."""
     ssl_config = IndexerSSLConfig(**init_values)
 
-    assert ssl_config.use_ssl == expected["use_ssl"]
-    assert ssl_config.key == expected["key"]
-    assert ssl_config.cert == expected["cert"]
-    assert ssl_config.ca == expected["ca"]
-    assert ssl_config.verify_certificates == expected["verify_certificates"]
+    assert ssl_config.use_ssl == expected['use_ssl']
+    assert ssl_config.key == expected['key']
+    assert ssl_config.cert == expected['cert']
+    assert ssl_config.ca == expected['ca']
+    assert ssl_config.verify_certificates == expected['verify_certificates']
 
 
-@pytest.mark.parametrize("init_values,expected", [
+@pytest.mark.parametrize('init_values,expected', [
     (
-        {"key": "key_example", "cert": "cert_example"},
-        {"use_ca": False, "ca": "", "ssl_protocol": SSLProtocol.auto, "ssl_ciphers": ""}
+        {'key': 'key_example', 'cert': 'cert_example'},
+        {'use_ca': False, 'ca': '', 'ssl_protocol': SSLProtocol.auto, 'ssl_ciphers': ''}
     ),
     (
-        {"key": "key_example", "cert": "cert_example", "use_ca": True},
-        {"use_ca": True, "ca": "", "ssl_protocol": SSLProtocol.auto, "ssl_ciphers": ""}
+        {'key': 'key_example', 'cert': 'cert_example', 'use_ca': True},
+        {'use_ca': True, 'ca': '', 'ssl_protocol': SSLProtocol.auto, 'ssl_ciphers': ''}
     ),
     (
-        {"key": "key_example", "cert": "cert_example", "use_ca": True, "ca": "ca_example"},
-        {"use_ca": True, "ca": "ca_example", "ssl_protocol": SSLProtocol.auto, "ssl_ciphers": ""}
+        {'key': 'key_example', 'cert': 'cert_example', 'use_ca': True, 'ca': 'ca_example'},
+        {'use_ca': True, 'ca': 'ca_example', 'ssl_protocol': SSLProtocol.auto, 'ssl_ciphers': ''}
     ),
     (
-        {"key": "key_example", "cert": "cert_example", "use_ca": True, "ca": "ca_example", "ssl_protocol": SSLProtocol.tls},
-        {"use_ca": True, "ca": "ca_example", "ssl_protocol": SSLProtocol.tls, "ssl_ciphers": ""}
+        {'key': 'key_example', 'cert': 'cert_example', 'use_ca': True, 'ca': 'ca_example', 'ssl_protocol': SSLProtocol.tls},
+        {'use_ca': True, 'ca': 'ca_example', 'ssl_protocol': SSLProtocol.tls, 'ssl_ciphers': ''}
     ),
     (
-        {"key": "key_example", "cert": "cert_example", "use_ca": True, "ca": "ca_example", "ssl_protocol": SSLProtocol.tls, "ssl_ciphers": "cipher_example"},
-        {"use_ca": True, "ca": "ca_example", "ssl_protocol": SSLProtocol.tls, "ssl_ciphers": "cipher_example"}
+        {'key': 'key_example', 'cert': 'cert_example', 'use_ca': True, 'ca': 'ca_example', 'ssl_protocol': SSLProtocol.tls, 'ssl_ciphers': 'cipher_example'},
+        {'use_ca': True, 'ca': 'ca_example', 'ssl_protocol': SSLProtocol.tls, 'ssl_ciphers': 'cipher_example'}
     )
 ])
 def test_api_ssl_config_default_values(init_values, expected):
     """Check the correct initialization of the `APISSLConfig` class."""
     ssl_config = APISSLConfig(**init_values)
 
-    assert ssl_config.use_ca == expected["use_ca"]
-    assert ssl_config.ca == expected["ca"]
-    assert ssl_config.ssl_protocol == expected["ssl_protocol"]
-    assert ssl_config.ssl_ciphers == expected["ssl_ciphers"]
+    assert ssl_config.use_ca == expected['use_ca']
+    assert ssl_config.ca == expected['ca']
+    assert ssl_config.ssl_protocol == expected['ssl_protocol']
+    assert ssl_config.ssl_ciphers == expected['ssl_ciphers']
 
 
-@pytest.mark.parametrize("init_values", [
+@pytest.mark.parametrize('init_values', [
     {},
-    {"key": "key_example"},
-    {"cert": "cert_example"}
+    {'key': 'key_example'},
+    {'cert': 'cert_example'}
 ])
 def test_api_ssl_config_fails_without_values(init_values):
     """Check the correct behavior of the `APISSLConfig` class validations."""

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -303,7 +303,7 @@ class WazuhException(Exception):
 
         # Indexer
         2200: {'message': 'Could not connect to the indexer'},
-        2201: {'message': 'Indexer credentials not provided'},
+        2201: {'message': 'Invalid indexer credentials'},
         2202: {'message': 'Command does not exist'},
 
         # Communications API

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -127,6 +127,7 @@ async def create_indexer(
     user: str = '',
     password: str = '',
     port: int = 9200,
+    verify_certs: bool = True,
     retries: int = 5,
     backoff_in_seconds: int = 1,
     **kwargs,
@@ -142,7 +143,9 @@ async def create_indexer(
     password : str, optional
         Password of the Wazuh Indexer to authenticate with.
     port : int, optional
-        Port of the Wazuh Indexer to connect with, by default 9200
+        Port of the Wazuh Indexer to connect with, by default 9200.
+    verify_certs : bool
+        Verify server TLS certificates.
     retries : int, optional
         Number of retries, by default 5.
     backoff_in_seconds : int, optional
@@ -154,7 +157,7 @@ async def create_indexer(
         The new Indexer instance.
     """
 
-    indexer = Indexer(host, user, password, port, **kwargs)
+    indexer = Indexer(host, user, password, port, verify_certs=verify_certs, **kwargs)
     retries_count = 0
     while True:
         try:
@@ -191,6 +194,7 @@ async def get_indexer_client() -> AsyncIterator[Indexer]:
         client_cert_path=indexer_config.ssl.cert,
         client_key_path=indexer_config.ssl.key,
         ca_certs_path=indexer_config.ssl.ca,
+        verify_certs=indexer_config.ssl.verify_certificates,
         retries=1
     )
 

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -150,7 +150,7 @@ async def create_indexer(
         The new Indexer instance.
     """
     if ssl is None:
-        ssl = IndexerSSLConfig(use_ssl=False, cert='', key='', ca='')
+        ssl = IndexerSSLConfig(use_ssl=False)
 
     indexer = Indexer(
         host=host,

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -149,6 +149,9 @@ async def create_indexer(
     Indexer
         The new Indexer instance.
     """
+    if ssl is None:
+        ssl = IndexerSSLConfig(use_ssl=False, cert='', key='', ca='')
+
     indexer = Indexer(
         host=host,
         user=user,
@@ -181,15 +184,13 @@ async def create_indexer(
 async def get_indexer_client() -> AsyncIterator[Indexer]:
     """Create and return the indexer client."""
     indexer_config = CentralizedConfig.get_indexer_config()
-    if indexer_config.ssl is None:
-        indexer_config.ssl = IndexerSSLConfig(use_ssl=False, cert='', key='', ca='')
 
     client = await create_indexer(
         host=indexer_config.host,
         port=indexer_config.port,
         user=indexer_config.user,
         password=indexer_config.password,
-        ssl=indexer_config.ssl,
+        ssl=indexer_config.ssl if indexer_config.ssl else None,
         retries=1
     )
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27048 |

## Description

Introduces quality of life improvements to the framework indexer client and its configuration.

## Tests

<details><summary>New error message</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55050/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
' | jq
{
  "title": "Wazuh Indexer Error",
  "detail": "Could not connect to the indexer: Server disconnected",
  "dapi_errors": {
    "server_01": {
      "error": "Could not connect to the indexer: Server disconnected",
      "logfile": "WAZUH_LOG/api.log"
    }
  },
  "error": 2200
}
```

</details>

<details><summary>SSL file does not exist error</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55050/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
' | jq
{
  "title": "Wazuh Indexer Error",
  "detail": "Could not connect to the indexer: The file '/etc/wazuh-server/indexer-key.pem' does not exist",
  "dapi_errors": {
    "server_01": {
      "error": "Could not connect to the indexer: The file '/etc/wazuh-server/indexer-key.pem' does not exist",
      "logfile": "WAZUH_LOG/api.log"
    }
  },
  "error": 2200
}
```

</details>

<details><summary>Invalid SSL files error</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55050/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
' | jq
{
  "title": "Wazuh Indexer Error",
  "detail": "Could not connect to the indexer: No connections were configured. Check your configuration and SSL certificates",
  "dapi_errors": {
    "server_01": {
      "error": "Could not connect to the indexer: No connections were configured. Check your configuration and SSL certificates",
      "logfile": "WAZUH_LOG/api.log"
    }
  },
  "error": 2200
}
```

</details>

<details><summary>SSL certificate validation error</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55050/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a1",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
' | jq
{
  "title": "Wazuh Indexer Error",
  "detail": "Could not connect to the indexer: Cannot connect to host wazuh-indexer:9200 ssl:True [SSLCertVerificationError: (1, \"[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'wazuh-indexer'. (_ssl.c:1007)\")]",
  "dapi_errors": {
    "server_01": {
      "error": "Could not connect to the indexer: Cannot connect to host wazuh-indexer:9200 ssl:True [SSLCertVerificationError: (1, \"[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'wazuh-indexer'. (_ssl.c:1007)\")]",
      "logfile": "WAZUH_LOG/api.log"
    }
  },
  "error": 2200
}
```

</details>

<details><summary>Invalid user or password error</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55050/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a1",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
' | jq
{
  "title": "Wazuh Indexer Error",
  "detail": "Could not connect to the indexer: Unauthorized",
  "dapi_errors": {
    "server_01": {
      "error": "Could not connect to the indexer: Unauthorized",
      "logfile": "WAZUH_LOG/api.log"
    }
  },
  "error": 2200
}
```

</details>

<details><summary>Missing certificate error</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55050/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a1",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
' | jq
{
  "title": "Wazuh Indexer Error",
  "detail": "Invalid indexer credentials: Empty file path",
  "dapi_errors": {
    "server_01": {
      "error": "Invalid indexer credentials: Empty file path",
      "logfile": "WAZUH_LOG/api.log"
    }
  },
  "error": 2201
}
```

</details>

<details><summary>use_ssl true and no path specified error</summary>

```console
root@wazuh-master:/etc/wazuh-server# wazuh-server start -rf
2024/11/26 16:01:52 ERROR: [Cluster] [Main] 1 validation error for Config
indexer.ssl.ca
  Field required [type=missing, input_value={'use_ssl': True, 'key': ...fy_certificates': False}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.9/v/missing
```

</details>


<details><summary>Invalid certificate file path error</summary>

```console
root@wazuh-master:/etc/wazuh-server# wazuh-server start -rf
2024/11/26 16:02:10 ERROR: [Cluster] [Main] 1 validation error for Config
indexer.ssl.ca
  Value error, ca: the file '/etc/wazuh-server/root-ca1.pem' does not exist [type=value_error, input_value='/etc/wazuh-server/root-ca1.pem', input_type=str]
    For further information visit https://errors.pydantic.dev/2.9/v/value_error
```

</details>

<details><summary>Successful request</summary>

```console
gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ksi https://0.0.0.0:55050/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a3",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Tue, 26 Nov 2024 16:05:53 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
gasti@gasti:~/work/wazuh$ curl -ksu admin:SecretPassword1% https://localhost:9200/.agents/_doc/0a96a0ab-5bef-415c-bb3c-ea3e294215a3 | jq
{
  "_index": ".agents",
  "_id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a3",
  "_version": 1,
  "_seq_no": 2,
  "_primary_term": 1,
  "found": true,
  "_source": {
    "agent": {
      "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a3",
      "name": "test",
      "key": "eWd8RKjCU+XWx90JVYhIrAQuHubdVYSAymc7iXAsRqiTWZNMm7q4vKoXmTW7/dvb",
      "type": "endpoint",
      "version": "5.0.0",
      "groups": [
        "default"
      ]
    }
  }
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/config/models --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 162 items                                                                                                                                                                                                                          

framework/wazuh/core/config/models/tests/test_central_config.py .                                                                                                                                                                      [  0%]
framework/wazuh/core/config/models/tests/test_comms_api.py ..............                                                                                                                                                              [  9%]
framework/wazuh/core/config/models/tests/test_engine.py ..........                                                                                                                                                                     [ 15%]
framework/wazuh/core/config/models/tests/test_indexer.py ......                                                                                                                                                                        [ 19%]
framework/wazuh/core/config/models/tests/test_logging.py ........................                                                                                                                                                      [ 33%]
framework/wazuh/core/config/models/tests/test_management_api.py ..........................                                                                                                                                             [ 50%]
framework/wazuh/core/config/models/tests/test_server.py ..................................................................                                                                                                             [ 90%]
framework/wazuh/core/config/models/tests/test_ssl_config.py ...............                                                                                                                                                            [100%]

============================================================================================================ 162 passed in 0.35s =============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 67 items                                                                                                                                                                                                                           

framework/wazuh/core/indexer/models/test/test_agent.py ......                                                                                                                                                                          [  8%]
framework/wazuh/core/indexer/models/test/test_commands.py .                                                                                                                                                                            [ 10%]
framework/wazuh/core/indexer/models/test/test_event.py ..........                                                                                                                                                                      [ 25%]
framework/wazuh/core/indexer/tests/test_agent.py .............                                                                                                                                                                         [ 44%]
framework/wazuh/core/indexer/tests/test_base.py ...                                                                                                                                                                                    [ 49%]
framework/wazuh/core/indexer/tests/test_bulk.py ..........                                                                                                                                                                             [ 64%]
framework/wazuh/core/indexer/tests/test_commands.py ......                                                                                                                                                                             [ 73%]
framework/wazuh/core/indexer/tests/test_init.py .............F                                                                                                                                                                         [ 94%]
framework/wazuh/core/indexer/tests/test_utils.py ....                                                                                                                                                                                  [100%]

================================================================================================================== FAILURES ==================================================================================================================
...
FAILED framework/wazuh/core/indexer/tests/test_init.py::test_get_indexer_client - FileNotFoundError: Configuration file not found: /etc/wazuh-server/wazuh-server.yml
======================================================================================================== 1 failed, 66 passed in 0.67s ========================================================================================================
```

> The failed test is expected and will be fixed in https://github.com/wazuh/wazuh/issues/26725

</details>