### PR TITLE
added palo alto globalprotect decoders

### DIFF
--- a/ruleset/decoders/0505-paloalto_decoders.xml
+++ b/ruleset/decoders/0505-paloalto_decoders.xml
@@ -4,6 +4,7 @@
 
 <!--
   Palo Alto v8.X - v10.X decoders.
+  The log messages sent from the firewalls need to be in IETF format instad of the default BSD.
 -->
 
 <!-- 
@@ -180,6 +181,25 @@
   <parent>paloalto</parent>
   <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
   <order>application_subcategory, application_category, application_technology, application_risk, application_characteristic, application_container, application_saas, application_sanctioned_state</order>
+</decoder>
+
+<!-- Palo Alto GlobalProtect decoders -->
+<!-- Supported versions
+  10.1: Format: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Virtual System, Event ID, Stage, Authentication Method, Tunnel Type, Source User, Source Region, Machine Name, Public IP, Public IPv6, Private IP, Private IPv6, Host ID, Serial Number, Client Version, Client OS, Client OS Version, Repeat Count, Reason, Error, Description, Status, Location, Login Duration, Connect Method, Error Code, Portal, Sequence Number, Action Flags, High Res Timestamp, Selection Type, Response Time, Priority, Attempted Gateways, Gateway, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Virtual System ID
+  10.2: Format: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Virtual System, Event ID, Stage, Authentication Method, Tunnel Type, Source User, Source Region, Machine Name, Public IP, Public IPv6, Private IP, Private IPv6, Host ID, Serial Number, Client Version, Client OS, Client OS Version, Repeat Count, Reason, Error, Description, Status, Location, Login Duration, Connect Method, Error Code, Portal, Sequence Number, Action Flags, High Res Timestamp, Selection Type, Response Time, Priority, Attempted Gateways, Gateway, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Virtual System ID
+  -->
+
+<decoder name="paloalto-globalprotect-fields">
+  <parent>paloalto</parent>
+  <prematch type="pcre2">^[^,]*,\d+\/\d+\/\d+\s\d+:\d+:\d+,\d+,GLOBALPROTECT,</prematch>
+  <regex type="pcre2">^[^,]*,(\d+\/\d+\/\d+\s\d+:\d+:\d+),(\d+),(GLOBALPROTECT)</regex>
+  <order>receive_time, serial_number, type</order>
+</decoder>
+
+<decoder name="paloalto-globalprotect-fields">
+  <parent>paloalto</parent>
+  <regex type="pcre2" offset="after_regex">^,[^,]*,[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),(\"[^\"]*\"|[^,]*),([^,]*),([^,]*),([^,]*),(\"[^\"]*\"|[^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
+  <order>generated_time, virtual_system, event_id, stage, authentication_method, tunnel_type, source_user, source_region, machine_name, public_ip, public_ipv6, private_ip, private_ipv6, host_id, machine_serial, client_version, client_os, client_os_version, repeat_count, reason, error, description, login_status, location, login_duration, connect_method, error_code, portal, sequence_number, action_flags, high_res_timestamp, selection_type, response_time, priority, attempted_gateways, gateway, device_group_hierarchy_level_1, device_group_hierarchy_level_2, device_group_hierarchy_level_3, device_group_hierarchy_level_4, virtual_system_name, device_name, virtual_system_id</order>
 </decoder>
 
 <!-- Generic decoder for others modules not decoded further-->


### PR DESCRIPTION
## Description

Decoders for the GlobalProtect related syslog messages sent from Palo Alto firewalls are currently missing.


## Logs/Alerts example

Failed authentication:

`1,2024/11/28 12:34:03,082301217853,GLOBALPROTECT,0,2561,2024/11/28 12:34:03,vsys1,portal-auth,login,Other,,fail@test.com,FR,,1.1.1.1,0.0.0.0,0.0.0.0,0.0.0.0,,,,Browser,,1,,Invalid username or password,,failure,,0,,1,GPPortal,1234551586902315277,0x0,2024-11-28T12:34:04.787+00:00,,,,,,0,0,0,0,,TEST-FW01,1
`

**Phase 2: Completed decoding.
	name: 'paloalto'
	parent: 'paloalto'
	action_flags: '0x0'
	authentication_method: 'Other'
	client_os: 'Browser'
	device_group_hierarchy_level_1: '0'
	device_group_hierarchy_level_2: '0'
	device_group_hierarchy_level_3: '0'
	device_group_hierarchy_level_4: '0'
	device_name: 'TEST-FW01'
	error: 'Invalid username or password'
	error_code: '1'
	event_id: 'portal-auth'
	generated_time: '2024/11/28 12:34:03'
	high_res_timestamp: '2024-11-28T12:34:04.787+00:00'
	login_duration: '0'
	login_status: 'failure'
	portal: 'GPPortal'
	private_ip: '0.0.0.0'
	private_ipv6: '0.0.0.0'
	public_ipv6: '0.0.0.0'
	receive_time: '2024/11/28 12:34:03'
	repeat_count: '1'
	sequence_number: '1234551586902315277'
	serial_number: '082301217853'
	source_region: 'FR'
	source_user: 'fail@test.com'
	srcip: '1.1.1.1'
	stage: 'login'
	type: 'GLOBALPROTECT'
	virtual_system: 'vsys1'
	virtual_system_id: '1'

Successful authentication:

`1,2024/11/28 12:09:03,082301217853,GLOBALPROTECT,0,2561,2024/11/28 12:09:15,vsys1,gateway-connected,connected,Other,IPSec,success@test.com,FR,test-laptop,1.1.1.1,0.0.0.0,172.16.10.1,0.0.0.0,5987a6fe-75a9-14376-0aab-931a019ae1f2,DFGD123124,6.2.5,Windows,"Microsoft Windows 10 Pro , 64-bit",1,,,,success,,0,,0,GPGateway,1234551586902315277,0x0,2024-11-28T12:09:15.545+00:00,,,,,,0,0,0,0,,HBCC-FW01,1`

**Phase 2: Completed decoding.
	name: 'paloalto'
	parent: 'paloalto'
	action_flags: '0x0'
	authentication_method: 'Other'
	client_os: 'Windows'
	client_os_version: '"Microsoft Windows 10 Pro , 64-bit"'
	client_version: '6.2.5'
	device_group_hierarchy_level_1: '0'
	device_group_hierarchy_level_2: '0'
	device_group_hierarchy_level_3: '0'
	device_group_hierarchy_level_4: '0'
	device_name: 'HBCC-FW01'
	error_code: '0'
	event_id: 'gateway-connected'
	generated_time: '2024/11/28 12:09:15'
	high_res_timestamp: '2024-11-28T12:09:15.545+00:00'
	host_id: '5987a6fe-75a9-14376-0aab-931a019ae1f2'
	login_duration: '0'
	login_status: 'success'
	machine_name: 'test-laptop'
	machine_serial: 'DFGD123124'
	portal: 'GPGateway'
	private_ip: '172.16.10.1'
	private_ipv6: '0.0.0.0'
	public_ipv6: '0.0.0.0'
	receive_time: '2024/11/28 12:09:03'
	repeat_count: '1'
	sequence_number: '1234551586902315277'
	serial_number: '082301217853'
	source_region: 'FR'
	source_user: 'success@test.com'
	srcip: '1.1.1.1'
	stage: 'connected'
	tunnel_type: 'IPSec'
	type: 'GLOBALPROTECT'
	virtual_system: 'vsys1'
	virtual_system_id: '1'


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors