### PR TITLE
Add requests debug logs

### DIFF
--- a/apis/comms_api/middlewares/logging.py
+++ b/apis/comms_api/middlewares/logging.py
@@ -55,7 +55,7 @@ async def log_request(request: Request, response: Response, start_time: time) ->
 
 
 async def log_request_debug(request: Request, path: str) -> None:
-    """Log request headers and the entire body on endpoints using JSON streaming.
+    """Log request headers and body JSON streams.
 
     Parameters
     ----------
@@ -71,7 +71,7 @@ async def log_request_debug(request: Request, path: str) -> None:
         async for chunk in request.stream():
             body += chunk
         
-        logger.debug(f'Request body: {body.decode()}',  extra={'log_type': 'log'})
+        logger.debug(f'Request body stream: {body.decode()}',  extra={'log_type': 'log'})
 
 
 class LoggingMiddleware(BaseHTTPMiddleware):

--- a/apis/comms_api/middlewares/logging.py
+++ b/apis/comms_api/middlewares/logging.py
@@ -33,6 +33,9 @@ async def log_request(request: Request, response: Response, start_time: time) ->
     if 'key' in body and '/authentication' in path:
         body['key'] = '***'
 
+    if logger.isEnabledFor(logging.DEBUG):
+        await log_request_debug(request, path)
+
     log_info = f'({agent_uuid}) ' if agent_uuid is not None else ''
     log_info += f'"{method} {path}" with parameters {json.dumps(query)} and body '
     log_info += f'{json.dumps(body)} done in {elapsed_time:.3f}s: {status_code}'
@@ -49,6 +52,26 @@ async def log_request(request: Request, response: Response, start_time: time) ->
 
     logger.info(log_info, extra={'log_type': 'log'})
     logger.info(json_info, extra={'log_type': 'json'})
+
+
+async def log_request_debug(request: Request, path: str) -> None:
+    """Log request headers and the entire body on endpoints using JSON streaming.
+
+    Parameters
+    ----------
+    request : Request
+        HTTP request received.
+    path : str
+        URL path.
+    """
+    logger.debug(f'Request headers: {dict(request.headers.items())}', extra={'log_type': 'log'})
+
+    if '/events' in path:
+        body = b''
+        async for chunk in request.stream():
+            body += chunk
+        
+        logger.debug(f'Request body: {body.decode()}',  extra={'log_type': 'log'})
 
 
 class LoggingMiddleware(BaseHTTPMiddleware):

--- a/apis/comms_api/middlewares/test/test_logging.py
+++ b/apis/comms_api/middlewares/test/test_logging.py
@@ -2,50 +2,73 @@ import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from fastapi import FastAPI, Request
 import pytest
 from freezegun import freeze_time
 from starlette.applications import Starlette
 
-from comms_api.middlewares.logging import LoggingMiddleware, log_request
+from comms_api.middlewares.logging import LoggingMiddleware, log_request, log_request_debug
 
 
-@freeze_time(datetime(1970, 1, 1, 0, 0, 0))
+@freeze_time(datetime(1970, 1, 1, 0, 0, 1))
 async def test_log_request():
     """Test log request calls."""
     expected_time = datetime(1970, 1, 1, 0, 0, 0).timestamp()
-    remote, method, path = '1.1.1.1', 'POST', '/api/v1'
-    query, elapsed_time, status_code =  {'pretty': True}, 1.01, 200
+    agent_uuid = '1'
+    method, path = 'POST', '/api/v1'
+    query, elapsed_time, status_code =  {'pretty': True}, 1.0, 200
     body = {}
     body.update({'test': 'test'})
 
     json_info = {
-        'ip': remote,
         'http_method': method,
         'uri': f'{method} {path}',
         'parameters': query,
         'body': body,
         'time': f'{elapsed_time:.3f}s',
-        'status_code': status_code
+        'status_code': status_code,
+        'agent_uuid': agent_uuid
     }
 
     mock_resp = MagicMock()
     mock_resp.status_code = status_code
     mock_req = MagicMock()
-    mock_req.client.host = remote
     mock_req.scope = {'path': path}
     mock_req.method = method
     mock_req.query_params = query
     mock_req.json = AsyncMock(return_value=body)
+    mock_req.state.agent_uuid = agent_uuid
 
-    with patch('api.alogging.logger') as log_info_mock:
-        log_info_mock.info = MagicMock()
-        log_info_mock.level = 1
+    with patch('comms_api.middlewares.logging.logger') as logger_mock:
+        logger_mock.info = MagicMock()
+        logger_mock.level = 1
         _ = await log_request(request=mock_req, response=mock_resp, start_time=expected_time)
 
-        log_info = f'{remote} "{method} {path}" with parameters {json.dumps(query)} and body ' \
+        log_info = f'({agent_uuid}) "{method} {path}" with parameters {json.dumps(query)} and body ' \
                     f'{json.dumps(body)} done in {elapsed_time:.3f}s: {status_code}'
-        log_info_mock.info.has_calls([call(log_info, {'log_type': 'log'}),
-                                      call(json_info, {'log_type': 'json'})])
+        logger_mock.info.assert_has_calls([
+            call(log_info, extra={'log_type': 'log'}),
+            call(json_info, extra={'log_type': 'json'})
+        ])
+
+async def test_log_request_debug():
+    """Validate that the `log_request_debug` function works as expected."""
+    request = Request(scope={
+        'type': 'http',
+        'app': FastAPI(),
+        'headers': [(b'content-type', b'application/json')]
+    })
+    body = '{"id": "123"}'
+    request._body = '\n'.join([body]).encode()
+
+    with patch('comms_api.middlewares.logging.logger') as logger_mock:
+        logger_mock.debug = MagicMock()
+        _ = await log_request_debug(request=request, path='/events')
+
+        logger_mock.debug.assert_has_calls([
+            call("Request headers: {'content-type': 'application/json'}", extra={'log_type': 'log'}),
+            call(f'Request body: {body}', extra={'log_type': 'log'}),
+        ])
 
 
 @pytest.mark.asyncio

--- a/apis/comms_api/middlewares/test/test_logging.py
+++ b/apis/comms_api/middlewares/test/test_logging.py
@@ -51,6 +51,7 @@ async def test_log_request():
             call(json_info, extra={'log_type': 'json'})
         ])
 
+
 async def test_log_request_debug():
     """Validate that the `log_request_debug` function works as expected."""
     request = Request(scope={
@@ -67,7 +68,7 @@ async def test_log_request_debug():
 
         logger_mock.debug.assert_has_calls([
             call("Request headers: {'content-type': 'application/json'}", extra={'log_type': 'log'}),
-            call(f'Request body: {body}', extra={'log_type': 'log'}),
+            call(f'Request body stream: {body}', extra={'log_type': 'log'}),
         ])
 
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27088 |

## Description

Adds debug logging for the Communications API requests.

## Tests

<details><summary>Logs</summary>

```console
2024/11/29 07:39:04 DEBUG: Request headers: {'host': '0.0.0.0:27000', 'accept': '*/*', 'content-type': 'application/json', 'user-agent': 'test', 'content-length': '592'}
2024/11/29 07:39:04 DEBUG: Request body stream: 
{"agent":{"id":"2887e1cf-9bf2-431a-b066-a46860080f56","name":"javier","type":"endpoint","version":"5.0.0","groups":["group1","group2"],"host":{"hostname":"myhost","os":{"name":"Amazon Linux 2","platform":"Linux"},"ip":["192.168.1.2"],"architecture":"x86_64"}}}
{"module": "logcollector", "type": "file"}
{"log": {"file": {"path": "/var/log/apache2/access.log"}}, "base": {"tags": ["production-server"]}, "event": {"original": "::1 - - [26/Jun/2020:16:16:29 +0200] \"GET /favicon.ico HTTP/1.1\" 404 209", "ingested": "2023-12-26T09:22:14.000Z", "module": "apache-access", "provider": "file"}}
2024/11/29 07:39:04 INFO: "POST /api/v1/events/stateless" with parameters {} and body {} done in 0.025s: 204
```

</details>

<details><summary>Unit test</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest apis/comms_api/middlewares/test/test_logging.py --disable-warnings
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 3 items                                                                                                                                                         

apis/comms_api/middlewares/test/test_logging.py ...                                                                                                                 [100%]

====================================================================== 3 passed, 1 warning in 0.46s =======================================================================
```

</details>
