### PR TITLE
Change to type the agent's os

### DIFF
--- a/api/api/models/agent_registration_model.py
+++ b/api/api/models/agent_registration_model.py
@@ -93,21 +93,21 @@ class AgentForce(Model):
 class OS(Model):
     """Agent OS model."""
 
-    def __init__(self, name: str = None, platform: str = None, version: str = None):
+    def __init__(self, name: str = None, type: str = None, version: str = None):
         self.swagger_types = {
             'name': str,
-            'platform': str,
+            'type': str,
             'version': str
         }
 
         self.attribute_map = {
             'name': 'name',
-            'platform': 'platform',
+            'type': 'type',
             'version': 'version'
         }
 
         self._name = name
-        self._platform = platform
+        self._type = type
         self._version = version
 
     @property
@@ -119,12 +119,12 @@ class OS(Model):
         self._name = name
 
     @property
-    def platform(self) -> str:
-        return self._platform
+    def type(self) -> str:
+        return self._type
 
-    @platform.setter
-    def platform(self, platform: str):
-        self._platform = platform
+    @type.setter
+    def type(self, type: str):
+        self._type = type
         
     @property
     def version(self) -> str:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -785,7 +785,7 @@ components:
               properties:
                 name:
                   type: string
-                platform:
+                type:
                   type: string
                 version:
                   type: string
@@ -2666,7 +2666,7 @@ paths:
                   - 127.0.0.1
                 os:
                   name: Debian
-                  platform: Linux
+                  type: Linux
                   version: 12 "Bookworm"
       responses:
         '201':

--- a/apis/comms_api/core/test/pytest.ini
+++ b/apis/comms_api/core/test/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode=auto

--- a/framework/wazuh/core/batcher/tests/test_client.py
+++ b/framework/wazuh/core/batcher/tests/test_client.py
@@ -23,7 +23,7 @@ def test_send_event(queue_mock):
             ip='127.0.0.1',
             os=OS(
                 name='Debian 12',
-                platform='Linux'
+                type='Linux'
             )
         ),
     ))

--- a/framework/wazuh/core/indexer/models/agent.py
+++ b/framework/wazuh/core/indexer/models/agent.py
@@ -52,7 +52,7 @@ class Status(str, Enum):
 class OS:
     """Agent operating system information."""
     name: str = None
-    platform: str = None
+    type: str = None
     version: str = None
 
 


### PR DESCRIPTION
|Related issue|
|---|
| #27119  |


## Description

The agent's header section was modified by replacing `os.platform` with `os.type`.

```console
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "groups": [],
  "version": "5.0.0",
  "host": {
        "architecture": "x86_64",
        "hostname": "wazuh-agent",
        "ip": ["127.0.0.1"],
        "os": {
        "name": "Debian 12 bookworm",
        "type": "Linux",
        "version": "tests"
        }
  }
}
'
```
```console
       "os": {
        "name": "Debian 12 bookworm",
        "type": "Linux",
        "version": "tests"
        }
```



