### PR TITLE
Fix agent commands exception

### DIFF
--- a/apis/comms_api/core/commands.py
+++ b/apis/comms_api/core/commands.py
@@ -6,8 +6,7 @@ from fastapi import status
 from uuid6 import UUID
 
 from comms_api.routers.exceptions import HTTPError
-from wazuh.core.indexer import get_indexer_client
-from wazuh.core.indexer.models.commands import Command, Status
+from wazuh.core.indexer.models.commands import Command
 
 
 class CommandsManager():
@@ -103,11 +102,5 @@ async def pull_commands(commands_manager: CommandsManager, agent_id: UUID) -> Li
             message='Request exceeded the processing time limit',
             status_code=status.HTTP_408_REQUEST_TIMEOUT,
         )
-
-    for command in commands:
-        command.status = Status.SENT
-
-    async with get_indexer_client() as indexer_client:
-        await indexer_client.commands_manager.update(commands)
     
     return commands

--- a/apis/comms_api/core/test/test_commands.py
+++ b/apis/comms_api/core/test/test_commands.py
@@ -1,17 +1,14 @@
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import call, patch
 from multiprocessing import Event
 
 import pytest
 
 from comms_api.core.commands import CommandsManager, pull_commands
-from wazuh.core.indexer import Indexer
 from wazuh.core.indexer.models.commands import Command, Status, Target, TargetType
 
 ORDER_ID = 'UB2jVpEBYSr9jxqDgXAD'
 AGENT_ID = '01915801-4b34-7131-9d88-ff06ff05aefd'
 COMMAND = Command(order_id=ORDER_ID, status=Status.PENDING, target=Target(id=AGENT_ID, type=TargetType.AGENT))
-UPDATED_COMMAND = Command(order_id=ORDER_ID, status=Status.SENT, target=Target(id=AGENT_ID, type=TargetType.AGENT))
-INDEXER = Indexer(host='host', user='wazuh', password='wazuh')
 
 
 @patch('comms_api.core.commands.SyncManager')
@@ -77,12 +74,8 @@ def test_commands_manager_shutdown(sync_manager_mock):
 
 @pytest.mark.asyncio
 @patch('comms_api.core.commands.CommandsManager')
-@patch('wazuh.core.indexer.create_indexer', return_value=INDEXER)
-@patch('wazuh.core.indexer.commands.CommandsManager.update', new_callable=AsyncMock)
-async def test_pull_commands(commands_update_mock, create_indexer_mock, commands_manager_mock):
+async def test_pull_commands(commands_manager_mock):
     commands_manager_mock.get_commands.return_value = [COMMAND]
     commands = await pull_commands(commands_manager_mock, AGENT_ID)
 
-    assert commands == [UPDATED_COMMAND]
-    create_indexer_mock.assert_called_once()
-    commands_update_mock.assert_called_once_with([UPDATED_COMMAND])
+    assert commands == [COMMAND]

--- a/apis/comms_api/routers/router.py
+++ b/apis/comms_api/routers/router.py
@@ -10,7 +10,7 @@ from comms_api.routers.vulnerability import post_scan_request
 
 router = APIRouter(prefix='/api/v1')
 router.add_api_route('/authentication', authentication, methods=['POST'])
-router.add_api_route('/commands', get_commands, methods=['GET'])
+router.add_api_route('/commands', get_commands, methods=['GET'], response_model_exclude_none=True)
 router.include_router(events_router)
 router.add_api_route('/files', get_files, methods=['GET'], dependencies=[Depends(JWTBearer())])
 router.add_api_route('/vulnerability/scan', post_scan_request, methods=['POST'], dependencies=[Depends(JWTBearer())],

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -50,43 +50,6 @@ class CommandsManager(BaseIndex):
             result=ResponseResult(response.get(IndexerKey.RESULT)),
         )
 
-    async def get(self, uuid: UUID, status: Status) -> Optional[List[Command]]:
-        """Get commands with the provided status from an specific agent.
-
-        Parameters
-        ----------
-        uuid : UUID
-            Agent universally unique identifier.
-        status: Status
-            Command execution status.
-
-        Returns
-        -------
-        Optional[ListCommand]
-            Commands list or None.
-        """
-        body = {
-            IndexerKey.QUERY: {
-                IndexerKey.BOOL: {
-                    IndexerKey.MUST: [
-                        {IndexerKey.MATCH: {TARGET_ID_KEY: uuid}},
-                        {IndexerKey.MATCH: {STATUS_KEY: status}},
-                    ]
-                }
-            }
-        }
-
-        response = await self._client.search(index=self.INDEX, body=body)
-        hits = response[IndexerKey.HITS][IndexerKey.HITS]
-        if len(hits) == 0:
-            return None
-
-        commands = []
-        for data in hits:
-            commands.append(Command.from_dict(data[IndexerKey._ID], data[IndexerKey._SOURCE]))
-
-        return commands
-
 
 def create_restart_command(agent_id: str) -> Command:
     """Create a restart command for an agent with the ID specified.

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -87,33 +87,6 @@ class CommandsManager(BaseIndex):
 
         return commands
 
-    async def update(self, items: List[Union[Command, Result]]) -> None:
-        """Update commands.
-        
-        Parameters
-        ----------
-        items : List[Union[Command, Result]]
-            List of commands or results to update.
-
-        Raises
-        ------
-        WazuhResourceNotFound(2202)
-            If no document exists with the id provided.
-        """
-        actions = []
-        for item in items:
-            actions.append({IndexerKey.UPDATE: {IndexerKey._INDEX: self.INDEX, IndexerKey._ID: item.id}})
-            item_dict = asdict(item, dict_factory=remove_empty_values)
-            # The document ID shouldn't be part of the value
-            item_dict.pop(DOC_ID_KEY, None)
-            actions.append({IndexerKey.DOC: item_dict})
-
-        # TODO(25121): Create an internal library to build opensearch requests and parse responses
-        response = await self._client.bulk(actions, self.INDEX)
-        for item in response[IndexerKey.ITEMS]:
-            if item[IndexerKey.UPDATE][STATUS_KEY] == 404:
-                raise WazuhResourceNotFound(2202)
-
 
 def create_restart_command(agent_id: str) -> Command:
     """Create a restart command for an agent with the ID specified.

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -53,10 +53,8 @@ class Target:
 @dataclass
 class Command:
     """Command data model."""
-    document_id: str = None
     request_id: str = None
     order_id: str = None
-    groups: str = None
     source: Source = None
     user: str = None
     target: Target = None
@@ -72,24 +70,6 @@ class Command:
             self.action = Action(**self.action)
         if isinstance(self.result, dict):
             self.result = Result(**self.result)
-
-    @classmethod
-    def from_dict(cls, document_id: str, data: dict):
-        """Create an object instance from a dictionary.
-        
-        Parameters
-        ----------
-        document_id : str
-            Document ID.
-        data : dict
-            Command data.
-        
-        Returns
-        -------
-        Command
-            Object instance with its fields initialized.
-        """
-        return cls(document_id=document_id, **data)
 
 
 class ResponseResult(str, Enum):

--- a/framework/wazuh/core/indexer/models/test/test_commands.py
+++ b/framework/wazuh/core/indexer/models/test/test_commands.py
@@ -2,7 +2,7 @@ from wazuh.core.indexer.models.commands import Action, Command, Result, Status, 
 
 
 def test_command_post_init():
-    """Validate the correct functionality of the `Command.__post_init` method."""
+    """Validate the correct functionality of the `Command.__post_init__` method."""
     status = 'pending'
     timeout = 100
     data = {

--- a/framework/wazuh/core/indexer/models/test/test_commands.py
+++ b/framework/wazuh/core/indexer/models/test/test_commands.py
@@ -1,9 +1,8 @@
 from wazuh.core.indexer.models.commands import Action, Command, Result, Status, Source, Target, TargetType
 
 
-def test_command_from_dict():
-    """Validate the correct functionality of the `Command.from_dict` method."""
-    document_id = 'id'
+def test_command_post_init():
+    """Validate the correct functionality of the `Command.__post_init` method."""
     status = 'pending'
     timeout = 100
     data = {
@@ -14,9 +13,8 @@ def test_command_from_dict():
         'timeout': timeout,
         'source': Source.SERVICES.value,
     }
-    command = Command().from_dict(document_id, data)
+    command = Command(**data)
 
-    assert command.document_id == document_id
     assert command.target == Target(**data['target'])
     assert command.action == Action(**data['action'])
     assert command.result == Result(**data['result'])


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27113 |

## Description

Removes the commands status updates, methods from the indexer module that won't be used and fields from the command class that are now managed by the Indexer's command manager.

## Tests

<details><summary>Post order</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ curl -H "Authorization: Bearer $TOKEN" -X POST -H "Content-Type: application/json" -ks https://0.0.0.0:55000/orders -d '
{
  "orders": [
    {
      "source" : "Users/Services",
      "user" : "Management API",
      "target" : {
        "type" : "agent",
        "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
      },
      "action" : {
        "name" : "restart",
        "args" : [],
        "version" : "v5.0.0"
      },
      "timeout" : 100,
      "status" : "pending",
      "order_id" : "auyvlZIBRVsFNWNvvj6f",
      "request_id" : "aeyvlZIBRVsFNWNvvj6f"
    }
  ]
}' | jq
{
  "data": {
    "affected_items": [
      "auyvlZIBRVsFNWNvvj6f"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All orders were published",
  "error": 0
}
```

</details>

<details><summary>Get commands</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:27000/api/v1/commands | jq
{
  "commands": [
    {
      "request_id": "aeyvlZIBRVsFNWNvvj6f",
      "order_id": "auyvlZIBRVsFNWNvvj6f",
      "source": "Users/Services",
      "user": "Management API",
      "target": {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "type": "agent"
      },
      "action": {
        "name": "restart",
        "version": "v5.0.0",
        "args": []
      },
      "timeout": 100,
      "status": "pending"
    }
  ]
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest apis/comms_api/core/test/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 6 items                                                                                                                                                                                                                            

apis/comms_api/core/test/test_commands.py ......                                                                                                                                                                                       [100%]

======================================================================================================== 6 passed, 1 warning in 0.58s ========================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/models/test/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/indexer/models/test/test_commands.py .                                                                                                                                                                            [100%]

============================================================================================================= 1 passed in 0.23s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 5 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py .....                                                                                                                                                                              [100%]

============================================================================================================= 5 passed in 0.26s ==============================================================================================================
```

</details>