### PR TITLE
Make services only log to stdout

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -8,7 +8,7 @@ import re
 
 from api.api_exception import APIError
 
-from wazuh.core.config.models.logging import RotatedLoggingConfig
+from wazuh.core.config.models.logging import APILoggingConfig
 
 # Compile regex when the module is imported so it's not necessary to compile it everytime log.info is called
 request_pattern = re.compile(r'\[.+]|\s+\*\s+')
@@ -21,7 +21,7 @@ WARNING = 'WARNING'
 INFO = 'INFO'
 
 
-def set_logging(logging_config: RotatedLoggingConfig) -> dict:
+def set_logging(logging_config: APILoggingConfig) -> dict:
     """Set up logging for API.
     
     This function creates a logging configuration dictionary, configure the wazuh-api logger
@@ -30,7 +30,7 @@ def set_logging(logging_config: RotatedLoggingConfig) -> dict:
     
     Parameters
     ----------
-    logging_config :  RotatedLoggingConfig
+    logging_config :  APILoggingConfig
         Logger configuration.
 
     Raises
@@ -73,7 +73,7 @@ def set_logging(logging_config: RotatedLoggingConfig) -> dict:
         },
         "filters": {
             'plain-filter': {'()': 'wazuh.core.wlogging.CustomFilter',
-                             'log_type': 'log' }
+                             'log_type': 'log'}
         },
         "handlers": {
             "default": {

--- a/api/api/constants.py
+++ b/api/api/constants.py
@@ -11,8 +11,6 @@ CONFIG_FILE_PATH = CONFIG_PATH / 'api.yaml'
 SECURITY_PATH = CONFIG_PATH / 'security'
 SECURITY_CONFIG_PATH = SECURITY_PATH / 'security.yaml'
 
-API_LOG_PATH = common.WAZUH_LOG / API
-COMMS_API_LOG_PATH = common.WAZUH_LOG / 'comms_api'
 API_SSL_PATH = CONFIG_PATH / 'ssl'
 INSTALLATION_UID_PATH = common.WAZUH_LIB / 'installation_uid'
 INSTALLATION_UID_KEY = 'installation_uid'

--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -29,7 +29,6 @@ from api import error_handler
 from api.alogging import set_logging
 from api.api_exception import APIError, ExpectFailedException
 from api.configuration import generate_private_key, generate_self_signed_certificate
-from api.constants import API_LOG_PATH
 from api.middlewares import (
     CheckBlockedIP,
     CheckRateLimitsMiddleware,
@@ -319,18 +318,10 @@ if __name__ == '__main__':
 
     # Set up logger file
     try:
-        uvicorn_params['log_config'] = set_logging(log_filepath=API_LOG_PATH,
-                                                   logging_config=management_config.logging,
-                                                   background_mode=args.daemon)
+        uvicorn_params['log_config'] = set_logging(logging_config=management_config.logging)
     except APIError as api_log_error:
         print(f"Error when trying to start the Wazuh API. {api_log_error}")
         sys.exit(1)
-
-    # set permission on log files
-    for handler in uvicorn_params['log_config']['handlers'].values():
-        if 'filename' in handler:
-            utils.assign_wazuh_ownership(handler['filename'])
-            os.chmod(handler['filename'], 0o660)
 
     # Configure and create the wazuh-api logger
     add_debug2_log_level_and_error()

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -14,7 +14,7 @@ import atexit
 from argparse import ArgumentParser, Namespace
 from functools import partial
 from sys import exit
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 from multiprocessing import Process
 from multiprocessing.util import _exit_function
 
@@ -40,7 +40,7 @@ from wazuh.core.batcher.config import BatcherConfig
 from wazuh.core.batcher.mux_demux import MuxDemuxQueue, MuxDemuxManager
 from wazuh.core.cluster.utils import print_version
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.logging import RotatedLoggingConfig
+from wazuh.core.config.models.logging import APILoggingConfig
 from wazuh.core.config.models.comms_api import CommsAPIConfig
 
 MAIN_PROCESS = 'wazuh-comms-apid'
@@ -77,12 +77,12 @@ def create_app(batcher_queue: MuxDemuxQueue, commands_manager: CommandsManager) 
     return app
 
 
-def setup_logging(logging_config: RotatedLoggingConfig) -> dict:
+def setup_logging(logging_config: APILoggingConfig) -> dict:
     """Set up the logging module and returns the configuration used.
 
     Parameters
     ----------
-    logging_config :  RotatedLoggingConfig
+    logging_config :  APILoggingConfig
         Logger configuration.
 
     Returns
@@ -202,7 +202,7 @@ def get_script_arguments() -> Namespace:
 
 
 class StandaloneApplication(BaseApplication):
-    def __init__(self, app: Callable, options: Dict[str, Any] = None):
+    def __init__(self, app: Callable, options: dict[str, Any] = None):
         self.options = options or {}
         self.app = app
         super().__init__()

--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -19,7 +19,6 @@ opensearch-py==2.6.0
 psutil==5.9.0
 PyJWT==2.8.0
 python-dateutil==2.8.1
-python-json-logger==2.0.2
 pytz==2020.1
 rsa==4.7.2
 secure==0.3.0

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -57,7 +57,6 @@ def set_logging(debug_mode=0) -> WazuhLogger:
         Cluster logger.
     """
     cluster_logger = ClusterLogger(
-        log_path='cluster.log',
         debug_level=debug_mode,
         tag='%(asctime)s %(levelname)s: [%(tag)s] [%(subtag)s] %(message)s',
     )

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -34,7 +34,6 @@ ENGINE_BINARY_PATH = WAZUH_SHARE / 'bin' / 'wazuh-engine'
 ENGINE_DAEMON_NAME = 'wazuh-engined'
 MANAGEMENT_API_SCRIPT_PATH = WAZUH_SHARE / 'api' / 'scripts' / 'wazuh_apid.py'
 MANAGEMENT_API_DAEMON_NAME = 'wazuh-apid'
-CLUSTER_LOG = WAZUH_LOG / 'cluster.log'
 
 
 #
@@ -42,7 +41,7 @@ CLUSTER_LOG = WAZUH_LOG / 'cluster.log'
 #
 
 
-def set_logging(foreground_mode=False, debug_mode=0) -> WazuhLogger:
+def set_logging(debug_mode=0) -> WazuhLogger:
     """Set cluster logger.
 
     Parameters
@@ -58,7 +57,6 @@ def set_logging(foreground_mode=False, debug_mode=0) -> WazuhLogger:
         Cluster logger.
     """
     cluster_logger = ClusterLogger(
-        foreground_mode=foreground_mode,
         log_path='cluster.log',
         debug_level=debug_mode,
         tag='%(asctime)s %(levelname)s: [%(tag)s] [%(subtag)s] %(message)s',
@@ -369,11 +367,6 @@ def start():
     except StopIteration:
         pass
 
-    # Set correct permissions on cluster.log file
-    if os.path.exists(CLUSTER_LOG):
-        os.chown(CLUSTER_LOG, wazuh_uid(), wazuh_gid())
-        os.chmod(CLUSTER_LOG, 0o660)
-
     try:
         server_config = CentralizedConfig.get_server_config()
     except Exception as e:
@@ -460,7 +453,7 @@ if __name__ == '__main__':
     except Exception:
         debug_mode_ = 0
 
-    main_logger = set_logging(foreground_mode=not getattr(args, 'daemon', False), debug_mode=debug_mode_)
+    main_logger = set_logging(debug_mode=debug_mode_)
 
     if hasattr(args, 'func'):
         args.func()

--- a/framework/wazuh/core/config/models/comms_api.py
+++ b/framework/wazuh/core/config/models/comms_api.py
@@ -4,7 +4,7 @@ from pydantic import PositiveInt, PositiveFloat
 from api.constants import API_SSL_PATH
 from wazuh.core.config.models.base import WazuhConfigBaseModel
 from wazuh.core.config.models.ssl_config import APISSLConfig
-from wazuh.core.config.models.logging import RotatedLoggingConfig
+from wazuh.core.config.models.logging import APILoggingConfig
 
 DEFAULT_COMMUNICATIONS_API_KEY_PATH = os.path.join(API_SSL_PATH, 'server.key')
 DEFAULT_COMMUNICATIONS_API_CERT_PATH = os.path.join(API_SSL_PATH, 'server.crt')
@@ -38,7 +38,7 @@ class CommsAPIConfig(WazuhConfigBaseModel):
         The port number for the communications API. Default: 27000.
     workers : PositiveInt
         The number of worker threads for the communications API. Default: 4.
-    logging : RotatedLoggingConfig
+    logging : APILoggingConfig
         Logging configuration for the communications API. Default is an instance of LoggingWithRotationConfig.
     batcher : BatcherConfig
         Configuration for the batcher. Default is an instance of BatcherConfig.
@@ -51,7 +51,7 @@ class CommsAPIConfig(WazuhConfigBaseModel):
     port: PositiveInt = 27000
     workers: PositiveInt = 4
 
-    logging: RotatedLoggingConfig = RotatedLoggingConfig()
+    logging: APILoggingConfig = APILoggingConfig()
     batcher: BatcherConfig = BatcherConfig()
     ssl: APISSLConfig = APISSLConfig(
         key=DEFAULT_COMMUNICATIONS_API_KEY_PATH,

--- a/framework/wazuh/core/config/models/logging.py
+++ b/framework/wazuh/core/config/models/logging.py
@@ -10,7 +10,6 @@ from wazuh.core.config.models.base import WazuhConfigBaseModel
 class LoggingFormat(str, Enum):
     """Enum representing the available logging formats."""
     plain = 'plain'
-    json = 'json'
 
 
 class LoggingLevel(str, Enum):
@@ -79,20 +78,6 @@ class LoggingConfig(WazuhConfigBaseModel):
         return 2
 
 
-class LogFileMaxSizeConfig(WazuhConfigBaseModel):
-    """Configuration for maximum log file size.
-
-    Parameters
-    ----------
-    enabled : bool
-        Whether the maximum file size feature is enabled. Default is False.
-    size : str
-        The maximum size of the log file. Supports 'M' for megabytes and 'K' for kilobytes. Default is "1M".
-    """
-    enabled: bool = False
-    size: str = Field(default="1M", pattern=r"^([1-9]\d*)([KM])$")
-
-
 class RotatedLoggingConfig(WazuhConfigBaseModel):
     """Configuration for logging with rotation.
 
@@ -107,7 +92,6 @@ class RotatedLoggingConfig(WazuhConfigBaseModel):
     """
     level: APILoggingLevel = APILoggingLevel.debug
     format: List[LoggingFormat] = Field(default=[LoggingFormat.plain], min_length=1)
-    max_size: LogFileMaxSizeConfig = LogFileMaxSizeConfig()
 
     def get_level(self) -> int:
         """Returns the integer value corresponding to the logging level.

--- a/framework/wazuh/core/config/models/logging.py
+++ b/framework/wazuh/core/config/models/logging.py
@@ -87,8 +87,6 @@ class RotatedLoggingConfig(WazuhConfigBaseModel):
          The logging level. Default is "debug".
      format : List[Literal["plain", "json"]]
          The format for logging output. Default is ["plain"].
-     max_size : LogFileMaxSizeConfig
-         Configuration for the maximum log file size. Default is an instance of LogFileMaxSizeConfig.
     """
     level: APILoggingLevel = APILoggingLevel.debug
     format: List[LoggingFormat] = Field(default=[LoggingFormat.plain], min_length=1)

--- a/framework/wazuh/core/config/models/logging.py
+++ b/framework/wazuh/core/config/models/logging.py
@@ -1,7 +1,6 @@
 import logging
 
 from pydantic import Field
-from typing import List
 from enum import Enum
 
 from wazuh.core.config.models.base import WazuhConfigBaseModel
@@ -78,18 +77,18 @@ class LoggingConfig(WazuhConfigBaseModel):
         return 2
 
 
-class RotatedLoggingConfig(WazuhConfigBaseModel):
-    """Configuration for logging with rotation.
+class APILoggingConfig(WazuhConfigBaseModel):
+    """Configuration for API logging.
 
      Parameters
      ----------
      level : Literal["debug", "info", "warning", "error", "critical"]
          The logging level. Default is "debug".
-     format : List[Literal["plain", "json"]]
+     format : list[Literal["plain"]]
          The format for logging output. Default is ["plain"].
     """
     level: APILoggingLevel = APILoggingLevel.debug
-    format: List[LoggingFormat] = Field(default=[LoggingFormat.plain], min_length=1)
+    format: list[LoggingFormat] = Field(default=[LoggingFormat.plain], min_length=1)
 
     def get_level(self) -> int:
         """Returns the integer value corresponding to the logging level.

--- a/framework/wazuh/core/config/models/management_api.py
+++ b/framework/wazuh/core/config/models/management_api.py
@@ -7,7 +7,7 @@ from enum import Enum
 from api.constants import API_SSL_PATH
 from wazuh.core.config.models.base import WazuhConfigBaseModel
 from wazuh.core.config.models.ssl_config import APISSLConfig
-from wazuh.core.config.models.logging import RotatedLoggingConfig
+from wazuh.core.config.models.logging import APILoggingConfig
 
 DEFAULT_MANAGEMENT_API_KEY_PATH = os.path.join(API_SSL_PATH, 'server.key')
 DEFAULT_MANAGEMENT_API_CERT_PATH = os.path.join(API_SSL_PATH, 'server.crt')
@@ -95,6 +95,8 @@ class ManagementAPIConfig(WazuhConfigBaseModel):
         CORS configuration for the management API. Default is an instance of CorsConfig.
     access : AccessConfig
         Access configuration for the management API. Default is an instance of AccessConfig.
+    logging : APILoggingConfig
+        Logging configuration for the management API. Default is an instance of APILoggingConfig.
     """
     host: List[str] = Field(default=["localhost", "::1"], min_length=2)
     port: PositiveInt = 55000
@@ -108,7 +110,6 @@ class ManagementAPIConfig(WazuhConfigBaseModel):
         key=DEFAULT_MANAGEMENT_API_KEY_PATH,
         cert=DEFAULT_MANAGEMENT_API_CERT_PATH
     )
-    # TODO: review this config
-    logging: RotatedLoggingConfig = RotatedLoggingConfig()
+    logging: APILoggingConfig = APILoggingConfig()
     cors: CorsConfig = CorsConfig()
     access: AccessConfig = AccessConfig()

--- a/framework/wazuh/core/config/models/management_api.py
+++ b/framework/wazuh/core/config/models/management_api.py
@@ -91,8 +91,6 @@ class ManagementAPIConfig(WazuhConfigBaseModel):
         Configuration for management API intervals. Default is an instance of ManagementAPIIntervals.
     ssl : APISSLConfig
         SSL configuration for the management API. Default is an instance of APISSLConfig.
-    logging : RotatedLoggingConfig
-        Logging configuration for the management API. Default is an instance of LoggingWithRotationConfig.
     cors : CorsConfig
         CORS configuration for the management API. Default is an instance of CorsConfig.
     access : AccessConfig
@@ -110,6 +108,7 @@ class ManagementAPIConfig(WazuhConfigBaseModel):
         key=DEFAULT_MANAGEMENT_API_KEY_PATH,
         cert=DEFAULT_MANAGEMENT_API_CERT_PATH
     )
+    # TODO: review log rotation
     logging: RotatedLoggingConfig = RotatedLoggingConfig()
     cors: CorsConfig = CorsConfig()
     access: AccessConfig = AccessConfig()

--- a/framework/wazuh/core/config/models/management_api.py
+++ b/framework/wazuh/core/config/models/management_api.py
@@ -108,7 +108,7 @@ class ManagementAPIConfig(WazuhConfigBaseModel):
         key=DEFAULT_MANAGEMENT_API_KEY_PATH,
         cert=DEFAULT_MANAGEMENT_API_CERT_PATH
     )
-    # TODO: review log rotation
+    # TODO: review this config
     logging: RotatedLoggingConfig = RotatedLoggingConfig()
     cors: CorsConfig = CorsConfig()
     access: AccessConfig = AccessConfig()

--- a/framework/wazuh/core/config/models/tests/test_logging.py
+++ b/framework/wazuh/core/config/models/tests/test_logging.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from wazuh.core.config.models.logging import LoggingFormat, LoggingLevel, LoggingConfig, \
-    APILoggingLevel, LogFileMaxSizeConfig, RotatedLoggingConfig, EngineLoggingLevel, EngineLoggingConfig
+    APILoggingLevel, RotatedLoggingConfig, EngineLoggingLevel, EngineLoggingConfig
 
 
 @pytest.mark.parametrize('init_values, expected', [
@@ -59,45 +59,6 @@ def test_get_level_values(value, expected):
     config = LoggingConfig(level=value)
 
     assert config.get_level_value() == expected
-
-
-@pytest.mark.parametrize('init_values, expected', [
-    ({}, {'enabled': False, 'size': '1M'}),
-    ({'enabled': True, 'size': '20K'}, {'enabled': True, 'size': '20K'})
-])
-def test_log_file_max_size_config_default_values(init_values, expected):
-    """Check the correct initialization of the `LogFileMaxSizeConfig` class."""
-    config = LogFileMaxSizeConfig(**init_values)
-
-    assert config.size == expected['size']
-    assert config.enabled == expected['enabled']
-
-
-@pytest.mark.parametrize('value', [
-    '',
-    '1MK',
-    '1',
-    '-1M',
-    '0K',
-])
-def test_log_file_max_size_config_invalid_values(value):
-    """Check the correct behavior of the `LogFileMaxSizeConfig` class validations."""
-    with pytest.raises(ValidationError):
-        _ = LogFileMaxSizeConfig(size=value)
-
-
-@pytest.mark.parametrize('init_values, expected', [
-    ({}, {'level': APILoggingLevel.debug, 'format': [LoggingFormat.plain], 'max_size': {}}),
-    ({'level': APILoggingLevel.info, 'format': [LoggingFormat.plain, LoggingFormat.json], 'max_size': {'size': '3M'}},
-     {'level': APILoggingLevel.info, 'format': [LoggingFormat.plain, LoggingFormat.json], 'max_size': {'size': '3M'}})
-])
-def test_rotated_logging_config_default_values(init_values, expected):
-    """Check the correct initialization of the `RotatedLoggingConfig` class."""
-    config = RotatedLoggingConfig(**init_values)
-
-    assert config.level == expected['level']
-    assert config.format == expected['format']
-    assert config.max_size == LogFileMaxSizeConfig(**expected['max_size'])
 
 
 @pytest.mark.parametrize('init_values', [

--- a/framework/wazuh/core/config/models/tests/test_logging.py
+++ b/framework/wazuh/core/config/models/tests/test_logging.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from wazuh.core.config.models.logging import LoggingFormat, LoggingLevel, LoggingConfig, \
-    APILoggingLevel, RotatedLoggingConfig, EngineLoggingLevel, EngineLoggingConfig
+    APILoggingLevel, APILoggingConfig, EngineLoggingLevel, EngineLoggingConfig
 
 
 @pytest.mark.parametrize('init_values, expected', [
@@ -67,10 +67,10 @@ def test_get_level_values(value, expected):
     {'format': []}
 
 ])
-def test_rotated_logging_config_invalid_values(init_values):
-    """Check the correct behavior of the `RotatedLoggingConfig` class validations."""
+def test_api_logging_config_invalid_values(init_values):
+    """Check the correct behavior of the `APILoggingConfig` class validations."""
     with pytest.raises(ValidationError):
-        _ = RotatedLoggingConfig(**init_values)
+        _ = APILoggingConfig(**init_values)
 
 
 @pytest.mark.parametrize('value, expected', [
@@ -82,6 +82,6 @@ def test_rotated_logging_config_invalid_values(init_values):
 ])
 def test_get_level(value, expected):
     """Check the correct behavior of the `get_level` method."""
-    config = RotatedLoggingConfig(level=value)
+    config = APILoggingConfig(level=value)
 
     assert config.get_level() == expected

--- a/framework/wazuh/core/tests/test_wlogging.py
+++ b/framework/wazuh/core/tests/test_wlogging.py
@@ -41,8 +41,8 @@ def test_wazuh_logger__init__(mock_lformatter, mock_formatter, mock_logger_name,
                               mock_logger, mock_tag):
     """Test if WazuhLogger __init__ method initialize all attributes properly."""
 
-    wlogging.WazuhLogger(tag=mock_tag,debug_level=mock_debug_level,
-                             logger_name=mock_logger_name, custom_formatter=mock_formatter)
+    wlogging.WazuhLogger(tag=mock_tag, debug_level=mock_debug_level,
+                         logger_name=mock_logger_name, custom_formatter=mock_formatter)
     for x in [mock_formatter, mock_logger_name, mock_debug_level, mock_logger]:
         x.assert_called()
 

--- a/framework/wazuh/core/tests/test_wlogging.py
+++ b/framework/wazuh/core/tests/test_wlogging.py
@@ -19,181 +19,42 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core import wlogging
 
 
-def test_timebasedfilerotatinghandler_dorollover():
-    """Test if method doRollover of TimeBasedFileRotatingHandler works properly."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        test_str = 'test string'
-        log_file = join(tmp_dir, 'test.log')
-        with open(log_file, 'w') as f:
-            f.write(test_str)
-
-        fh = wlogging.TimeBasedFileRotatingHandler(filename=log_file)
-        fh.doRollover()
-        today = date.today()
-        backup_file = join(tmp_dir, 'test', str(today.year),
-                           today.strftime("%b"),
-                           f"test.log-{today.day:02d}.gz")
-
-        with gzip.open(backup_file, 'r') as backup:
-            assert backup.read().decode() == test_str
-
-
-@pytest.mark.parametrize('rotated_file', ['test.log.2021-08-03', 'test.log.2019-07-04'])
-@patch('wazuh.core.utils.mkdir_with_mode')
-def test_timebasedfilerotatinghandler_compute_log_directory(mock_mkdir, rotated_file):
-    """Test if method compute_log_directory of TimeBasedFileRotatingHandler works properly.
-
-    Parameters
-    ----------
-    rotated_file : str
-        Test log file used to compute the directory.
-    """
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        log_file = join(tmp_dir, 'test.log')
-        with open(log_file, 'w') as _:
-            pass
-
-        fh = wlogging.TimeBasedFileRotatingHandler(filename=log_file)
-        year, month, day = rotated_file.split('-')
-        year = year.split('.')[2]
-        month = calendar.month_abbr[int(month)]
-        log_path = join(tmp_dir, 'test', year, month)
-        expected_name = join(log_path, f"test.log-{int(day):02d}.gz")
-        computed_name = fh.compute_log_directory(rotated_file)
-
-        assert expected_name == computed_name
-        mock_mkdir.assert_called_with(log_path, 0o750)
-
-
-def test_sizebasedfilerotatinghandler_dorollover():
-    """Test if method doRollover of SizeBasedFileRotatingHandler works properly."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        test_str = 'test string'
-        log_file = join(tmp_dir, 'test.log')
-
-        fh = wlogging.SizeBasedFileRotatingHandler(filename=log_file, maxBytes=1, backupCount=1)
-
-        with open(log_file, 'w') as f:
-            f.write(test_str)
-
-        fh.doRollover()
-        today = date.today()
-        backup_file = join(tmp_dir, 'test', str(today.year),
-                           today.strftime("%b"),
-                           f"test.log-{today.day:02d}_1.gz")
-
-        with gzip.open(backup_file, 'r') as backup:
-            assert backup.read().decode() == test_str
-
-
-@patch('wazuh.core.utils.mkdir_with_mode')
-def test_sizebasedfilerotatinghandler_compute_log_directory(mock_mkdir):
-    """Test if method compute_log_directory of SizeBasedFileRotatingHandler works properly."""
-    previous_rotated_logs = randint(2, 15)
-
-    def _mock_exists(path):
-        path_regex = re.match(r".+_(\d+)\.gz", path)
-        if path_regex is None:
-            return exists(path)
-        else:
-            return False if int(path_regex.group(1)) > previous_rotated_logs else True
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        log_file = join(tmp_dir, 'test.log')
-        with open(log_file, 'w') as _:
-            pass
-
-        fh = wlogging.SizeBasedFileRotatingHandler(filename=log_file, maxBytes=1, backupCount=1)
-        today = date.today()
-        year, month, day = today.year, today.month, today.day
-        month = calendar.month_abbr[int(month)]
-
-        log_path = join(tmp_dir, 'test', str(year), month)
-
-        # Expect the first rotated log
-        expected_name = join(log_path, f"test.log-{int(day):02d}_1.gz")
-        computed_name = fh.compute_log_directory()
-
-        assert expected_name == computed_name
-        mock_mkdir.assert_called_with(log_path, 0o750)
-
-        # Expect the 4th rotated log
-        with patch("wazuh.core.wlogging.os.path.exists", new=_mock_exists):
-            expected_name = join(log_path, f"test.log-{int(day):02d}_{previous_rotated_logs + 1}.gz")
-            computed_name = fh.compute_log_directory()
-
-            assert expected_name == computed_name
-            mock_mkdir.assert_called_with(log_path, 0o750)
-
-
-@pytest.mark.parametrize('max_size', [0, 500])
 @patch('logging.addLevelName')
 @patch('logging.Logger.addHandler')
-@patch('wazuh.core.wlogging.SizeBasedFileRotatingHandler')
-@patch('wazuh.core.wlogging.TimeBasedFileRotatingHandler')
-def test_wazuh_logger_setup_logger(mock_time_handler, mock_size_handler, mock_add_handler, mock_add_level_name,
-                                   max_size):
-    """Test if method setup_logger of WazuhLogger setups the logger attribute properly.
-
-    Parameters
-    ----------
-    max_size : int
-        `max_size` input value.
-    """
-    tmp_dir = tempfile.TemporaryDirectory()
-    # To bypass the checking of the existence of a valid Wazuh install
-    # Check time handler
-    with patch('os.path.join', return_value=tmp_dir.name):
-        w_logger = wlogging.WazuhLogger(foreground_mode=True, log_path=tmp_dir.name,
-                                        tag='%(test)s %(test)s: %(test)s',
-                                        debug_level=[0, 'test'], max_size=max_size)
+def test_wazuh_logger_setup_logger(mock_add_handler, mock_add_level_name):
+    """Test if method setup_logger of WazuhLogger setups the logger attribute properly."""
+    w_logger = wlogging.WazuhLogger(tag='%(test)s %(test)s: %(test)s',
+                                        debug_level=[0, 'test'])
     w_logger.setup_logger()
-    if max_size == 0:
-        mock_time_handler.assert_called_once_with(filename=Path(tmp_dir.name), when='midnight')
-        assert not mock_size_handler.called, "Size handler should not be called when using time based rotation"
-    else:
-        mock_size_handler.assert_called_with(filename=Path(tmp_dir.name), maxBytes=max_size, backupCount=1)
-        assert not mock_time_handler.called, "Time handler should not be called when using size based rotation"
 
     mock_add_handler.assert_called()
     mock_add_level_name.assert_called()
 
 
-@patch.object(wlogging.WazuhLogger, 'log_path', create=True, new_callable=PropertyMock(Path('test')))
 @patch.object(wlogging.WazuhLogger, 'tag', create=True, new_callable=PropertyMock)
 @patch.object(wlogging.WazuhLogger, 'logger', create=True, new_callable=PropertyMock)
-@patch.object(wlogging.WazuhLogger, 'foreground_mode', create=True, new_callable=PropertyMock)
 @patch.object(wlogging.WazuhLogger, 'debug_level', create=True, new_callable=PropertyMock)
 @patch.object(wlogging.WazuhLogger, 'logger_name', create=True, new_callable=PropertyMock)
 @patch.object(wlogging.WazuhLogger, 'custom_formatter', create=True, new_callable=PropertyMock)
-@patch.object(wlogging.WazuhLogger, 'max_size', create=True, new_callable=PropertyMock)
 @patch('logging.Formatter')
-def test_wazuh_logger__init__(mock_lformatter, mock_max_size, mock_formatter, mock_logger_name, mock_debug_level,
-                              mock_foreground_mode, mock_logger, mock_tag, mock_log_path):
+def test_wazuh_logger__init__(mock_lformatter, mock_formatter, mock_logger_name, mock_debug_level,
+                              mock_logger, mock_tag):
     """Test if WazuhLogger __init__ method initialize all attributes properly."""
-    # To bypass the checking of the existence of a valid Wazuh install
-    with patch('os.path.join'):
-        wlogging.WazuhLogger(foreground_mode=mock_foreground_mode, log_path=mock_log_path, tag=mock_tag,
-                             debug_level=mock_debug_level, logger_name=mock_logger_name,
-                             custom_formatter=mock_formatter, max_size=mock_max_size)
-    for x in [mock_formatter, mock_logger_name, mock_debug_level, mock_foreground_mode,
-              mock_logger]:
+
+    wlogging.WazuhLogger(tag=mock_tag,debug_level=mock_debug_level,
+                             logger_name=mock_logger_name, custom_formatter=mock_formatter)
+    for x in [mock_formatter, mock_logger_name, mock_debug_level, mock_logger]:
         x.assert_called()
 
 
 @pytest.mark.parametrize('attribute, expected_exception, expected_value', [
     ('level', None, 0),
-    ('foreground_mode', None, True),
     ('doesnt_exists', AttributeError, None)
 ])
-@patch('wazuh.core.wlogging.SizeBasedFileRotatingHandler')
-@patch('wazuh.core.wlogging.TimeBasedFileRotatingHandler')
-def test_wazuh_logger_getattr(mock_time_handler, mock_size_handler, attribute, expected_exception, expected_value):
+def test_wazuh_logger_getattr(attribute, expected_exception, expected_value):
     """Test if WazuhLogger __getattr__ method works properly."""
-    tmp_dir = tempfile.TemporaryDirectory()
     # To bypass the checking of the existence of a valid Wazuh install
-    with patch('os.path.join'):
-        w_logger = wlogging.WazuhLogger(foreground_mode=True, log_path=tmp_dir.name, tag='%(test)s %(test)s: %(test)s',
+    w_logger = wlogging.WazuhLogger(tag='%(test)s %(test)s: %(test)s',
                                         debug_level=[0, 'test'], logger_name='test')
     w_logger.setup_logger()
 

--- a/framework/wazuh/core/wlogging.py
+++ b/framework/wazuh/core/wlogging.py
@@ -5,8 +5,6 @@
 import logging
 import logging.handlers
 
-from wazuh.core import common, utils
-
 
 class CustomFilter:
     """
@@ -44,15 +42,13 @@ class WazuhLogger:
     """
     Define attributes of a Python Wazuh daemon's logger.
     """
-    def __init__(self, log_path: str, debug_level: [int, str], logger_name: str = 'wazuh',
+    def __init__(self, debug_level: [int, str], logger_name: str = 'wazuh',
                  custom_formatter: callable = None, tag: str = '%(asctime)s %(levelname)s: %(message)s',
                  max_size: int = 0):
         """Constructor.
 
         Parameters
         ----------
-        log_path : str
-            Filepath of the file to send logs to. Relative to the Wazuh installation path.
         debug_level : int or str
             Log level.
         logger_name : str
@@ -61,10 +57,7 @@ class WazuhLogger:
             Subclass of logging.Formatter. Allows formatting messages depending on their contents.
         tag : str
             Tag defining logging format.
-        max_size : int
-            Number of bytes the log can store at max. Once reached, the log will be rotated.
         """
-        self.log_path = common.WAZUH_LOG / log_path
         self.logger = None
         self.debug_level = debug_level
         self.logger_name = logger_name
@@ -73,7 +66,6 @@ class WazuhLogger:
             self.custom_formatter = self.default_formatter
         else:
             self.custom_formatter = custom_formatter(style='%', datefmt="%Y/%m/%d %H:%M:%S")
-        self.max_size = max_size
 
     def setup_logger(self):
         """

--- a/framework/wazuh/core/wlogging.py
+++ b/framework/wazuh/core/wlogging.py
@@ -2,98 +2,10 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import calendar
-import glob
-import gzip
 import logging
 import logging.handlers
-import os
-import re
-import shutil
-from datetime import date
 
 from wazuh.core import common, utils
-
-
-class TimeBasedFileRotatingHandler(logging.handlers.TimedRotatingFileHandler):
-    """
-    Wazuh log rotation. It rotates the log at midnight and sets the appropriate permissions to the new log file.
-    """
-
-    def doRollover(self):
-        """Override base class method to make the set the appropriate permissions to the new log file."""
-        # Rotate the file first
-        logging.handlers.TimedRotatingFileHandler.doRollover(self)
-
-        # Save rotated file in /var/logs/wazuh-server/api directory
-        rotated_file = glob.glob("{}.*".format(self.baseFilename))[0]
-
-        new_rotated_file = self.compute_log_directory(rotated_file)
-        with open(rotated_file, 'rb') as f_in, gzip.open(new_rotated_file, 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
-        os.chmod(new_rotated_file, 0o640)
-        os.unlink(rotated_file)
-
-    def compute_log_directory(self, rotated_filepath: str):
-        """Based on the name of the rotated file, compute in which directory it should be stored.
-
-        Parameters
-        ----------
-        rotated_filepath : str
-            Filepath of the rotated log.
-
-        Returns
-        -------
-        str
-            New directory path.
-        """
-        rotated_file = os.path.basename(rotated_filepath)
-        year, month, day = re.match(r'[\w.]+\.(\d+)-(\d+)-(\d+)', rotated_file).groups()
-        month = calendar.month_abbr[int(month)]
-        log_path = os.path.join(os.path.splitext(self.baseFilename)[0], year, month)
-        if not os.path.exists(log_path):
-            utils.mkdir_with_mode(log_path, 0o750)
-
-        return os.path.join(log_path, f"{os.path.basename(self.baseFilename)}-{day}.gz")
-
-
-class SizeBasedFileRotatingHandler(logging.handlers.RotatingFileHandler):
-    """Wazuh log rotation. It rotates when the logging file size exceeds the maximum number of bytes configured."""
-
-    def doRollover(self):
-        """Override base class method to make the set the appropriate permissions to the new log file.'"""
-        # Rotate the file first
-        logging.handlers.RotatingFileHandler.doRollover(self)
-
-        # Save rotated file in /var/logs/wazuh-server/api directory
-        rotated_file = glob.glob("{}.*".format(self.baseFilename))[0]
-
-        new_rotated_file = self.compute_log_directory()
-        with open(rotated_file, 'rb') as f_in, gzip.open(new_rotated_file, 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
-        os.chmod(new_rotated_file, 0o640)
-        os.unlink(rotated_file)
-
-    def compute_log_directory(self):
-        """Based on the current date and iteration of the rotated file, compute in which directory it should be stored.
-
-        Returns
-        -------
-        New directory path.
-        """
-        today = date.today()
-        year, month, day = today.year, today.month, f"{today.day:02d}"
-        month = calendar.month_abbr[int(month)]
-        iteration = 1
-
-        log_path = os.path.join(os.path.splitext(self.baseFilename)[0], str(year), month)
-        if not os.path.exists(log_path):
-            utils.mkdir_with_mode(log_path, 0o750)
-
-        while os.path.exists(os.path.join(log_path, f"{os.path.basename(self.baseFilename)}-{day}_{iteration}.gz")):
-            iteration += 1
-
-        return os.path.join(log_path, f"{os.path.basename(self.baseFilename)}-{day}_{iteration}.gz")
 
 
 class CustomFilter:
@@ -132,15 +44,13 @@ class WazuhLogger:
     """
     Define attributes of a Python Wazuh daemon's logger.
     """
-    def __init__(self, foreground_mode: bool, log_path: str, debug_level: [int, str], logger_name: str = 'wazuh',
+    def __init__(self, log_path: str, debug_level: [int, str], logger_name: str = 'wazuh',
                  custom_formatter: callable = None, tag: str = '%(asctime)s %(levelname)s: %(message)s',
                  max_size: int = 0):
         """Constructor.
 
         Parameters
         ----------
-        foreground_mode : bool
-            Enable stream handler on sys.stderr.
         log_path : str
             Filepath of the file to send logs to. Relative to the Wazuh installation path.
         debug_level : int or str
@@ -156,7 +66,6 @@ class WazuhLogger:
         """
         self.log_path = common.WAZUH_LOG / log_path
         self.logger = None
-        self.foreground_mode = foreground_mode
         self.debug_level = debug_level
         self.logger_name = logger_name
         self.default_formatter = logging.Formatter(tag, style='%', datefmt="%Y/%m/%d %H:%M:%S")
@@ -166,34 +75,21 @@ class WazuhLogger:
             self.custom_formatter = custom_formatter(style='%', datefmt="%Y/%m/%d %H:%M:%S")
         self.max_size = max_size
 
-    def setup_logger(self, handler: logging.Handler = None):
+    def setup_logger(self):
         """
         Prepare a logger with:
-            * Two rotating file handlers (time | size).
-            * A stream handler (if foreground_mode is enabled).
+            * A stream handler.
             * An additional debug level.
 
-        :param handler: custom handler that can be set instead of the default one.
         """
         logger = logging.getLogger(self.logger_name)
-        cf = CustomFilter('log') if self.log_path.suffix == '.log' else CustomFilter('json')
         logger.propagate = False
         # configure logger
-        if handler:
-            custom_handler = handler
-        else:
-            custom_handler = TimeBasedFileRotatingHandler(filename=self.log_path, when='midnight') if self.max_size == 0 \
-            else SizeBasedFileRotatingHandler(filename=self.log_path, maxBytes=self.max_size, backupCount=1)
 
-        custom_handler.setFormatter(self.custom_formatter)
-        custom_handler.addFilter(cf)
-        logger.addHandler(custom_handler)
-
-        if self.foreground_mode:
-            ch = logging.StreamHandler()
-            ch.setFormatter(self.default_formatter)
-            ch.addFilter(CustomFilter('log'))
-            logger.addHandler(ch)
+        ch = logging.StreamHandler()
+        ch.setFormatter(self.default_formatter)
+        ch.addFilter(CustomFilter('log'))
+        logger.addHandler(ch)
 
         # add a new debug level
         logging.DEBUG2 = 5


### PR DESCRIPTION
|Related issue|
|---|
| #27098 |

## Description

Removes the file loggers for the Management API, Comms API, and Cluster and makes the services only log to `stdout` avoiding race conditions from multiple processes logging to the same file.
Manual testing can be found in the [issue](https://github.com/wazuh/wazuh/issues/27098#issuecomment-2514447656).

## Unit Tests

<details><summary>Related unit tests</summary>
```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.15, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/api/api
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 6 items                                                                                                                                               

api/api/test/test_alogging.py ......                                                                                                                      [100%]

======================================================================= warnings summary ========================================================================
../../venv/5.0-aca/lib/python3.10/site-packages/connexion/json_schema.py:16
../../venv/5.0-aca/lib/python3.10/site-packages/connexion/json_schema.py:16
  /home/fdalmau/venv/5.0-aca/lib/python3.10/site-packages/connexion/json_schema.py:16: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import Draft4Validator, RefResolver

../../venv/5.0-aca/lib/python3.10/site-packages/connexion/json_schema.py:17
  /home/fdalmau/venv/5.0-aca/lib/python3.10/site-packages/connexion/json_schema.py:17: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema.exceptions import RefResolutionError, ValidationError  # noqa

../../venv/5.0-aca/lib/python3.10/site-packages/connexion/validators/form_data.py:4
../../venv/5.0-aca/lib/python3.10/site-packages/connexion/validators/form_data.py:4
  /home/fdalmau/venv/5.0-aca/lib/python3.10/site-packages/connexion/validators/form_data.py:4: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import ValidationError, draft4_format_checker

../../venv/5.0-aca/lib/python3.10/site-packages/connexion/validators/json.py:6
../../venv/5.0-aca/lib/python3.10/site-packages/connexion/validators/json.py:6
  /home/fdalmau/venv/5.0-aca/lib/python3.10/site-packages/connexion/validators/json.py:6: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import Draft4Validator, ValidationError, draft4_format_checker

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================= 6 passed, 7 warnings in 0.36s =================================================================
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.15, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 164 items                                                                                                                                             

framework/wazuh/core/config/models/tests/test_central_config.py .                                                                                         [  0%]
framework/wazuh/core/config/models/tests/test_comms_api.py ..............                                                                                 [  9%]
framework/wazuh/core/config/models/tests/test_engine.py ..........                                                                                        [ 15%]
framework/wazuh/core/config/models/tests/test_indexer.py .......                                                                                          [ 19%]
framework/wazuh/core/config/models/tests/test_logging.py .................                                                                                [ 29%]
framework/wazuh/core/config/models/tests/test_management_api.py ..........................                                                                [ 45%]
framework/wazuh/core/config/models/tests/test_server.py ..................................................................                                [ 85%]
framework/wazuh/core/config/models/tests/test_ssl_config.py ...............                                                                               [ 95%]
framework/wazuh/core/config/tests/test_client.py ........                                                                                                 [100%]

====================================================================== 164 passed in 0.32s ======================================================================
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.15, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 10 items                                                                                                                                              

framework/wazuh/core/tests/test_wlogging.py ..........                                                                                                    [100%]

====================================================================== 10 passed in 0.05s =======================================================================
```

</details>
