### PR TITLE
Add logic to avoid re-scanning of agents disconnected.

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -73,11 +73,45 @@ public:
         // Return elements should be one agent.
         if (response.size() == 1)
         {
-            const auto& agent = response.front();
-            data->m_agents.push_back({data->agentId().data(),
-                                      agent.at("name"),
-                                      Utils::leftTrim(agent.at("version"), "Wazuh "),
-                                      agent.at("ip")});
+            const auto clusterStatus = data->clusterStatus();
+            const auto clusterNodeName = data->clusterNodeName();
+            const auto agentId = data->agentId();
+
+            try
+            {
+                const auto& agent = response.front();
+                const auto& wdbAgentNodeName = agent.at("node_name").get_ref<const std::string&>();
+                const auto& wdbAgentConnectionStatus = agent.at("connection_status").get_ref<const std::string&>();
+                const auto& wdbAgentVersion = agent.at("version").get_ref<const std::string&>();
+                const auto& wdbAgentName = agent.at("name").get_ref<const std::string&>();
+                const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
+
+                // If the agent is not part of a cluster or the agent is part of the cluster and the current agent
+                // node_name
+                // is the same as the server node name. Add the agent to the list of agents to be scanned.
+                if (!clusterStatus || (clusterNodeName == wdbAgentNodeName && "active" == wdbAgentConnectionStatus))
+                {
+                    data->m_agents.push_back(
+                        {agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp});
+                    logDebug2(
+                        WM_VULNSCAN_LOGTAG, "Agent %s added to the list of agents to be re-scanned", agentId.data());
+                }
+                else
+                {
+                    logDebug2(WM_VULNSCAN_LOGTAG,
+                              "Agent %s not added to the list of agents to be re-scanned (cluster status: %s) (cluster "
+                              "node_name: %s) (connection_status: %s) (agent node_name: %s)",
+                              agentId.data(),
+                              clusterStatus ? "true" : "false",
+                              clusterNodeName.data(),
+                              wdbAgentConnectionStatus.c_str(),
+                              wdbAgentNodeName.c_str());
+                }
+            }
+            catch (const std::exception& e)
+            {
+                throw std::runtime_error("Invalid agent-info response format");
+            }
         }
         return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -86,9 +86,9 @@ public:
                 const auto& wdbAgentName = agent.at("name").get_ref<const std::string&>();
                 const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
 
-                // If the agent is not part of a cluster or the agent is part of the cluster and the current agent
-                // node_name
-                // is the same as the server node name. Add the agent to the list of agents to be scanned.
+                // Add the agent to the scan list if one of the conditions is met:
+                //   - It's not in a cluster 
+                //   - It's in the cluster and matches the server node name.
                 if (!clusterStatus || (clusterNodeName == wdbAgentNodeName && "active" == wdbAgentConnectionStatus))
                 {
                     data->m_agents.push_back(

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -63,11 +63,8 @@ public:
         }
         catch (std::exception& e)
         {
-            logError(WM_VULNSCAN_LOGTAG,
-                     "Unable to retrieve agent-info (agent %s). Reason: %s.",
-                     data->agentId().data(),
-                     e.what());
-            return nullptr;
+            throw std::runtime_error(std::string("Unable to retrieve agent-info (agent ") + data->agentId().data() +
+                                     "). Reason: " + e.what() + ".");
         }
 
         // Return elements should be one agent.
@@ -87,8 +84,8 @@ public:
                 const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
 
                 // Add the agent to the scan list if one of the conditions is met:
-                //   - It's not in a cluster 
-                //   - It's in the cluster and matches the server node name.
+                //   - It's not in a cluster
+                //   - It's in the cluster and matches the server node name and the connection status is active.
                 if (!clusterStatus || (clusterNodeName == wdbAgentNodeName && "active" == wdbAgentConnectionStatus))
                 {
                     data->m_agents.push_back(

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockScanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockScanContext.hpp
@@ -1,0 +1,38 @@
+/*
+ * Wazuh report dispatcher mock
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 3, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#ifndef _MOCK_SCAN_CONTEXT_HPP
+#define _MOCK_SCAN_CONTEXT_HPP
+
+#include "scanContext.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+/**
+ * @class MockScanContext
+ *
+ * @brief Mock class for simulating a scan context object.
+ *
+ */
+class MockScanContext
+{
+public:
+    MockScanContext() = default;
+
+    virtual ~MockScanContext() = default;
+
+    MOCK_METHOD(std::string, agentId, (), ());
+    MOCK_METHOD(bool, clusterStatus, (), ());
+    MOCK_METHOD(std::string, clusterNodeName, (), ());
+
+    std::vector<AgentData> m_agents;
+};
+
+#endif // _MOCK_SCAN_CONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockScanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockScanContext.hpp
@@ -24,15 +24,41 @@
 class MockScanContext
 {
 public:
+    /**
+     * @brief Mock Constructor
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
     MockScanContext() = default;
 
+    /**
+     * @brief Mock Destructor
+     *
+     */
     virtual ~MockScanContext() = default;
 
+    /**
+     * @brief Mock method for agentId.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
     MOCK_METHOD(std::string, agentId, (), ());
+
+    /**
+     * @brief Mock method for clusterStatus.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
     MOCK_METHOD(bool, clusterStatus, (), ());
+
+    /**
+     * @brief Mock method for clusterNodeName.
+     *
+     * @note This method is intended for testing purposes and does not perform any real action.
+     */
     MOCK_METHOD(std::string, clusterNodeName, (), ());
 
-    std::vector<AgentData> m_agents;
+    std::vector<AgentData> m_agents; ///< Agent data list.
 };
 
 #endif // _MOCK_SCAN_CONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
@@ -114,6 +114,26 @@ TEST_F(BuildSingleAgentListContextTest, ExceptionOnDB)
     spSocketDBWrapperMock.reset();
 }
 
+TEST_F(BuildSingleAgentListContextTest, ExceptionOnDBRuntimeError)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::Throw(std::runtime_error("Error on DB")));
+
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<MockScanContext>();
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+
+    // Context is not used
+    EXPECT_THROW(singleAgentContext->handleRequest(scanContext), std::runtime_error);
+
+    spSocketDBWrapperMock.reset();
+}
+
 TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterOff)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
@@ -136,6 +156,7 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsC
     auto scanContext = std::make_shared<MockScanContext>();
 
     EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(false));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillOnce(testing::Return("node_1"));
     EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
 
     EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
@@ -148,6 +169,8 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsC
     EXPECT_EQ(agent.name, "name");
     EXPECT_EQ(agent.version, "v4.4.4");
     EXPECT_EQ(agent.ip, "192.168.0.1");
+
+    spSocketDBWrapperMock.reset();
 }
 
 TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterOnDifferentNodeName)
@@ -178,6 +201,8 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsC
     EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
 
     ASSERT_EQ(scanContext->m_agents.size(), 0);
+
+    spSocketDBWrapperMock.reset();
 }
 
 TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterDisconnected)
@@ -208,4 +233,6 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsC
     EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
 
     ASSERT_EQ(scanContext->m_agents.size(), 0);
+
+    spSocketDBWrapperMock.reset();
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
@@ -10,31 +10,9 @@
  */
 
 #include "buildSingleAgentListContext_test.hpp"
-#include "TrampolineOsDataCache.hpp"
+#include "MockScanContext.hpp"
 #include "TrampolineSocketDBWrapper.hpp"
 #include "buildSingleAgentListContext.hpp"
-
-TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContext)
-{
-    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
-    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_)).Times(1);
-
-    const auto jsonData =
-        R"({
-        "agent_info": {
-          "agent_id":"001"
-        },
-        "action":"upgradeAgentDB"})"_json;
-
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &jsonData;
-
-    auto singleAgentContext = std::make_shared<
-        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
-
-    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
-    singleAgentContext->handleRequest(scanContext);
-}
 
 TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextEmpty)
 {
@@ -46,23 +24,13 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextEmpty)
         .Times(1)
         .WillOnce(testing::SetArgReferee<1>(queryResult));
 
-    const auto jsonData =
-        R"({
-        "agent_info": {
-          "agent_id":"001"
-        },
-        "action":"upgradeAgentDB"})"_json;
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
 
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &jsonData;
+    auto scanContext = std::make_shared<MockScanContext>();
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
 
-    auto singleAgentContext = std::make_shared<
-        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
-
-    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
-
-    // Context is not used
-    singleAgentContext->handleRequest(scanContext);
+    EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
 
     EXPECT_EQ(scanContext->m_agents.size(), 0);
 }
@@ -70,35 +38,30 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextEmpty)
 TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElements)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
-    const auto jsonData =
-        R"({
-        "agent_info": {
-          "agent_id":"001"
-        },
-        "action":"upgradeAgentDB"})"_json;
 
     nlohmann::json queryResult = R"([{
         "id": 1,
         "name": "name",
         "version": "Wazuh v4.4.4",
         "ip": "192.168.0.1",
-        "node_name": "node_1"
+        "node_name": "node_1",
+        "connection_status": "active"
     }])"_json;
 
     EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
         .Times(1)
         .WillOnce(testing::SetArgReferee<1>(queryResult));
 
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &jsonData;
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
 
-    auto singleAgentContext = std::make_shared<
-        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
+    auto scanContext = std::make_shared<MockScanContext>();
 
-    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
+    EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(true));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillOnce(testing::Return("node_1"));
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
 
-    // Context is not used
-    singleAgentContext->handleRequest(scanContext);
+    EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
 
     EXPECT_EQ(scanContext->m_agents.size(), 1);
 
@@ -120,23 +83,13 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextMultiple)
         .Times(1)
         .WillOnce(testing::SetArgReferee<1>(queryResult));
 
-    const auto jsonData =
-        R"({
-        "agent_info": {
-          "agent_id":"001"
-        },
-        "action":"upgradeAgentDB"})"_json;
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
 
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &jsonData;
+    auto scanContext = std::make_shared<MockScanContext>();
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
 
-    auto singleAgentContext = std::make_shared<
-        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
-
-    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
-
-    // Context is not used
-    singleAgentContext->handleRequest(scanContext);
+    EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
 
     EXPECT_EQ(scanContext->m_agents.size(), 0);
 }
@@ -149,24 +102,110 @@ TEST_F(BuildSingleAgentListContextTest, ExceptionOnDB)
         .Times(1)
         .WillOnce(testing::Throw(SocketDbWrapperException("Error on DB")));
 
-    const auto jsonData = R"(
-        {
-            "agent_info": {
-                "agent_id":"001"
-            },
-            "action":"upgradeAgentDB"
-        })"_json;
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
 
-    std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        data = &jsonData;
-
-    auto singleAgentContext = std::make_shared<
-        TBuildSingleAgentListInfoContext<TScanContext<TrampolineOsDataCache>, TrampolineSocketDBWrapper>>();
-
-    auto scanContext = std::make_shared<TScanContext<TrampolineOsDataCache>>(data);
+    auto scanContext = std::make_shared<MockScanContext>();
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
 
     // Context is not used
     EXPECT_THROW(singleAgentContext->handleRequest(scanContext), WdbDataException);
 
     spSocketDBWrapperMock.reset();
+}
+
+TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterOff)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+    nlohmann::json queryResult = R"([{
+        "id": 1,
+        "name": "name",
+        "version": "Wazuh v4.4.4",
+        "ip": "192.168.0.1",
+        "node_name": "node_1",
+        "connection_status": "active"
+    }])"_json;
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<MockScanContext>();
+
+    EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(false));
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+
+    EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
+
+    ASSERT_EQ(scanContext->m_agents.size(), 1);
+
+    auto agent = scanContext->m_agents[0];
+
+    EXPECT_EQ(agent.id, "001");
+    EXPECT_EQ(agent.name, "name");
+    EXPECT_EQ(agent.version, "v4.4.4");
+    EXPECT_EQ(agent.ip, "192.168.0.1");
+}
+
+TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterOnDifferentNodeName)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+    nlohmann::json queryResult = R"([{
+        "id": 1,
+        "name": "name",
+        "version": "Wazuh v4.4.4",
+        "ip": "192.168.0.1",
+        "node_name": "node_1",
+        "connection_status": "active"
+    }])"_json;
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<MockScanContext>();
+
+    EXPECT_CALL(*scanContext, clusterStatus()).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillRepeatedly(testing::Return("node_2"));
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+
+    EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
+
+    ASSERT_EQ(scanContext->m_agents.size(), 0);
+}
+
+TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterDisconnected)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+    nlohmann::json queryResult = R"([{
+        "id": 1,
+        "name": "name",
+        "version": "Wazuh v4.4.4",
+        "ip": "192.168.0.1",
+        "node_name": "node_1",
+        "connection_status": "disconnected"
+    }])"_json;
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    auto singleAgentContext =
+        std::make_shared<TBuildSingleAgentListInfoContext<MockScanContext, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<MockScanContext>();
+
+    EXPECT_CALL(*scanContext, clusterStatus()).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillRepeatedly(testing::Return("node_1"));
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+
+    EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
+
+    ASSERT_EQ(scanContext->m_agents.size(), 0);
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.hpp
@@ -12,7 +12,6 @@
 #ifndef _BUILD_SINGLE_AGENT_LIST_CONTEXT_HPP
 #define _BUILD_SINGLE_AGENT_LIST_CONTEXT_HPP
 
-#include "socketServer.hpp"
 #include "gtest/gtest.h"
 
 /**


### PR DESCRIPTION
# Description

This PR Aims to solve a problem during the delayed queue processing if an agent is during a synchronization and is moved to another worker.