### PR TITLE
Update commands manager `POST /commands` response model

### DIFF
--- a/framework/wazuh/core/indexer/base.py
+++ b/framework/wazuh/core/indexer/base.py
@@ -12,6 +12,7 @@ class IndexerKey(str, Enum):
     _INDEX = '_index'
     _ID = '_id'
     _SOURCE = '_source'
+    _DOCUMENTS = '_documents'
     ID = 'id'
     DOC = 'doc'
     MATCH = 'match'

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -44,9 +44,13 @@ class CommandsManager(BaseIndex):
         except exceptions.RequestError as e:
             raise WazuhError(1761, extra_message=str(e))
 
+        document_ids = []
+        for document in response.get(IndexerKey._DOCUMENTS):
+            document_ids.append(document.get(IndexerKey._ID))
+
         return CreateCommandResponse(
             index=response.get(IndexerKey._INDEX),
-            document_id=response.get(IndexerKey._ID),
+            document_ids=document_ids,
             result=ResponseResult(response.get(IndexerKey.RESULT)),
         )
 

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -85,5 +85,5 @@ class ResponseResult(str, Enum):
 class CreateCommandResponse:
     """Create command response data model."""
     index: str
-    document_id: str
+    document_ids: List[str]
     result: ResponseResult

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -139,10 +139,9 @@ async def test_agent_restart_agents(create_indexer_mock, agent_list, expected_it
     agents_search_mock = AsyncMock(return_value=[Agent(id=agent_id) for agent_id in all_agent_ids])
     create_indexer_mock.return_value.agents.search = agents_search_mock
 
-    document_id = 'pBjePGfvgm'
     create_response = CreateCommandResponse(
         index='.commands',
-        document_id=document_id,
+        document_ids=['pBjePGfvgm'],
         result=ResponseResult.INTERNAL_ERROR if fail else ResponseResult.CREATED,
     )
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27140 |

## Description

Updates the commands manager `POST /commands` endpoint response parsing.

## Tests

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py 
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 5 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py .....                                                                                                                                                                              [100%]

============================================================================================================= 5 passed in 0.24s ==============================================================================================================
```

</details>