### PR TITLE
Update commands manager `POST /commands` request body

### DIFF
--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -31,16 +31,16 @@ class CommandsManager(BaseIndex):
         CreateCommandResponse
             Indexer command manager response.
         """
-        command_list = []
+        commands_to_send = []
         for command in commands:
-            command_dict = asdict(command, dict_factory=convert_enums)
-            command_list.append(command_dict)
+            command_body = asdict(command, dict_factory=convert_enums)
+            commands_to_send.append(command_body)
 
         try:
             response = await self._client.transport.perform_request(
                 method=POST_METHOD,
                 url=f'{self.PLUGIN_URL}/commands',
-                body={'commands': command_list},
+                body={'commands': commands_to_send},
             )
         except exceptions.RequestError as e:
             raise WazuhError(1761, extra_message=str(e))

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -39,13 +39,17 @@ class TestCommandsManager:
         }
         client_mock.transport.perform_request.return_value = return_value
 
-        response = await index_instance.create(self.create_command)
+        response = await index_instance.create([self.create_command])
 
         assert isinstance(response, CreateCommandResponse)
         client_mock.transport.perform_request.assert_called_once_with(
             method=POST_METHOD,
             url=f'{index_instance.PLUGIN_URL}/commands',
-            body=asdict(self.create_command, dict_factory=convert_enums),
+            body={
+                'commands': [
+                    asdict(self.create_command, dict_factory=convert_enums),
+                ]
+            },
         )
 
         document_ids = [document.get(IndexerKey._ID) for document in return_value.get(IndexerKey._DOCUMENTS)]
@@ -57,7 +61,7 @@ class TestCommandsManager:
         """Check the error handling of the `create` method."""
         client_mock.transport.perform_request.side_effect = exceptions.RequestError(400, 'error')
         with pytest.raises(WazuhError, match='.*1761.*'):
-            await index_instance.create(self.create_command)
+            await index_instance.create([self.create_command])
 
 
 def test_create_restart_command():

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -317,7 +317,7 @@ async def test_agent_add_agent(
     )
     agents_create_mock = AsyncMock(return_value=new_agent)
     create_indexer_mock.return_value.agents.create = agents_create_mock
-    create_response = CreateCommandResponse(index='.commands', document_id='pwrD5Ddf', result=ResponseResult.CREATED)
+    create_response = CreateCommandResponse(index='.commands', document_ids=['pwrD5Ddf'], result=ResponseResult.CREATED)
     commands_create_mock = AsyncMock(return_value=create_response)
     create_indexer_mock.return_value.commands_manager.create = commands_create_mock
 
@@ -555,7 +555,7 @@ async def test_agent_remove_agents_from_group(mock_get_groups, create_indexer_mo
     search_mock = AsyncMock(return_value=[IndexerAgent(id='0191c7fa-26d5-705f-bc3c-f54810d30d79')])
     create_indexer_mock.return_value.agents.search = search_mock
 
-    create_response = CreateCommandResponse(index='.commands', document_id='pwrD5Ddf', result=ResponseResult.CREATED)
+    create_response = CreateCommandResponse(index='.commands', document_ids=['pwrD5Ddf'], result=ResponseResult.CREATED)
     commands_create_mock = AsyncMock(return_value=create_response)
     create_indexer_mock.return_value.commands_manager.create = commands_create_mock
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27150 |

## Description

Updates the commands manager `POST /commands` request body and the way we create agent commands to leverage batching.

### Tests

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py 
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 5 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py .....                                                                                                                                                                              [100%]

============================================================================================================= 5 passed in 0.24s ==============================================================================================================
```

</details>