### PR TITLE
Add document_id field to orders and commands

### DIFF
--- a/api/api/models/order_model.py
+++ b/api/api/models/order_model.py
@@ -99,6 +99,7 @@ class Order(Model):
         status: str = None,
         order_id: str = None,
         request_id: str = None,
+        document_id: str = None,
     ):
         self.swagger_types = {
             'source': str,
@@ -109,6 +110,7 @@ class Order(Model):
             'status': str,
             'order_id': str,
             'request_id': str,
+            'document_id': str,
         }
 
         self.attribute_map = {
@@ -120,6 +122,7 @@ class Order(Model):
             'status': 'status',
             'order_id': 'order_id',
             'request_id': 'request_id',
+            'document_id': 'document_id',
         }
 
         self._source = source
@@ -130,6 +133,7 @@ class Order(Model):
         self._status = status
         self._order_id = order_id
         self._request_id = request_id
+        self._document_id = document_id
 
     @property
     def source(self) -> str:
@@ -194,6 +198,14 @@ class Order(Model):
     @request_id.setter
     def request_id(self, request_id: str):
         self._request_id = request_id
+    
+    @property
+    def document_id(self) -> str:
+        return self._document_id
+
+    @document_id.setter
+    def document_id(self, document_id: str):
+        self._document_id = document_id
 
 
 class Orders(Body):

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1627,6 +1627,7 @@ components:
         - status
         - order_id
         - request_id
+        - document_id
       properties:
         source:
           type: string
@@ -1682,6 +1683,9 @@ components:
           type: string
           format: alphanumeric_symbols
         request_id:
+          type: string
+          format: alphanumeric_symbols
+        document_id:
           type: string
           format: alphanumeric_symbols
 
@@ -6027,6 +6031,7 @@ paths:
                   status: PENDING
                   order_id: l8nhoJIBerRY2Wz26Je8
                   request_id: lsnhoJIBerRY2Wz26Je7
+                  document_id: SuyTlZIBRVsFsWNvvx6f
       responses:
         '200':
           description: "Orders sent"

--- a/apis/comms_api/core/test/test_commands.py
+++ b/apis/comms_api/core/test/test_commands.py
@@ -6,9 +6,9 @@ import pytest
 from comms_api.core.commands import CommandsManager, pull_commands
 from wazuh.core.indexer.models.commands import Command, Status, Target, TargetType
 
-ORDER_ID = 'UB2jVpEBYSr9jxqDgXAD'
+DOCUMENT_ID = 'UB2jVpEBYSr9jxqDgXAD'
 AGENT_ID = '01915801-4b34-7131-9d88-ff06ff05aefd'
-COMMAND = Command(order_id=ORDER_ID, status=Status.PENDING, target=Target(id=AGENT_ID, type=TargetType.AGENT))
+COMMAND = Command(document_id=DOCUMENT_ID, status=Status.PENDING, target=Target(id=AGENT_ID, type=TargetType.AGENT))
 
 
 @patch('comms_api.core.commands.SyncManager')

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -159,10 +159,11 @@ async def test_distribute_orders(read_config_mock, get_cluster_items_mock):
     local_client = LocalClient()
     with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client) as execute_mock:
         with patch('json.loads'):
-            await control.distribute_orders(lc=local_client, orders=[Order(status='pending').to_dict()])
+            order = Order(document_id='1', status='pending').to_dict()
+            await control.distribute_orders(lc=local_client, orders=[order])
 
         data = b'[{"source": null, "user": null, "target": null, "action": null, "timeout": null, ' \
-            b'"status": "pending", "order_id": null, "request_id": null}]'
+            b'"status": "pending", "order_id": null, "request_id": null, "document_id": "1"}]'
         execute_mock.assert_called_once_with(command=b'dist_orders', data=data)
 
         with patch('json.loads', return_value=KeyError(1)):

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -53,6 +53,7 @@ class Target:
 @dataclass
 class Command:
     """Command data model."""
+    document_id: str = None
     request_id: str = None
     order_id: str = None
     source: Source = None

--- a/framework/wazuh/core/indexer/models/test/test_commands.py
+++ b/framework/wazuh/core/indexer/models/test/test_commands.py
@@ -12,6 +12,9 @@ def test_command_post_init():
         'status': status,
         'timeout': timeout,
         'source': Source.SERVICES.value,
+        'request_id': 'lsnhoJIBerRY2Wz26Je7',
+        'order_id': 'lsnhoJIBerRY2Wz26Je7',
+        'document_id': 'UB2jVpEBYSr9jxqDgXAD'
     }
     command = Command(**data)
 

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -84,6 +84,7 @@ def test_create_restart_command():
     command = create_restart_command(agent_id=agent_id)
 
     assert command == expected_command
+    assert command.document_id is None
 
 
 def test_create_set_group_command():
@@ -108,6 +109,7 @@ def test_create_set_group_command():
     command = create_set_group_command(agent_id=agent_id, groups=groups)
 
     assert command == expected_command
+    assert command.document_id is None
 
 
 def test_create_update_group_command():
@@ -130,3 +132,4 @@ def test_create_update_group_command():
     command = create_update_group_command(agent_id=agent_id)
 
     assert command == expected_command
+    assert command.document_id is None


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27155 |

## Description

Adds the `document_id` field to the `Order` and `Command` structures so the agents can receive it on the `GET /commands` response and use it in the `POST /events/stateful` request body. 

## Tests

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/models/test/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/indexer/models/test/test_commands.py .                                                                                                                                                                            [100%]

============================================================================================================= 1 passed in 0.23s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest apis/comms_api/core/test/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis/comms_api/core/test
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 6 items                                                                                                                                                                                                                            

apis/comms_api/core/test/test_commands.py ......                                                                                                                                                                                       [100%]

============================================================================================================= 6 passed in 0.52s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 5 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py .....                                                                                                                                                                              [100%]

============================================================================================================= 5 passed in 0.25s ==============================================================================================================
```

</details>