### PR TITLE
Add check to avoid pop behavior if the queue is empty.

### DIFF
--- a/src/shared_modules/utils/benchmark/rocksdbqueue_test.cpp
+++ b/src/shared_modules/utils/benchmark/rocksdbqueue_test.cpp
@@ -1,7 +1,7 @@
+#include "rocksDBQueue.hpp"
 #include <benchmark/benchmark.h>
 #include <filesystem>
 #include <system_error>
-#include "rocksDBQueue.hpp"
 
 constexpr auto TEST_DB = "test.db";
 
@@ -32,13 +32,12 @@ static void popBenchmark(benchmark::State& state)
     std::filesystem::remove_all(TEST_DB, ec);
 
     RocksDBQueue<std::string> queue(TEST_DB);
-    for (int i = 0; i < 100000; i++)
-    {
-        queue.push("test");
-    }
 
     for (auto _ : state)
     {
+        state.PauseTiming();
+        queue.push("test");
+        state.ResumeTiming();
         queue.pop();
     }
 }

--- a/src/shared_modules/utils/rocksDBQueue.hpp
+++ b/src/shared_modules/utils/rocksDBQueue.hpp
@@ -138,16 +138,29 @@ public:
 
     void pop()
     {
+        // If the queue is empty, nothing to do.
+        if (m_size == 0)
+        {
+            return;
+        }
+
         auto index = m_first;
         std::string value;
 
         // Find the first element in the queue from m_first (included).
-        while (!m_db->KeyMayExist(rocksdb::ReadOptions(), m_db->DefaultColumnFamily(), std::to_string(index), &value))
+        while (index <= m_last &&
+               !m_db->KeyMayExist(rocksdb::ReadOptions(), m_db->DefaultColumnFamily(), std::to_string(index), &value))
         {
             // If the key does not exist, it means that the queue is not continuous.
             // This incremental is only for the head, because this is a part of recovery algorithm when the queue
             // not is continuous.
             ++index;
+        }
+
+        // If the index is greater than the last element, the queue status is invalid.
+        if (index > m_last)
+        {
+            throw std::runtime_error("Failed to dequeue element, queue is empty");
         }
 
         // RocksDB dequeue element.

--- a/src/shared_modules/utils/rocksDBQueueCF.hpp
+++ b/src/shared_modules/utils/rocksDBQueueCF.hpp
@@ -161,18 +161,30 @@ public:
     {
         if (const auto it {m_queueMetadata.find(id.data())}; it != m_queueMetadata.end())
         {
+            // If the queue is empty, nothing to do.
+            if (it->second.size == 0)
+            {
+                return;
+            }
+
             std::string value;
             auto index = it->second.head;
 
-            while (!m_db->KeyMayExist(rocksdb::ReadOptions(),
-                                      m_db->DefaultColumnFamily(),
-                                      std::string(id) + "_" + std::to_string(index),
-                                      &value))
+            while (index <= it->second.tail && !m_db->KeyMayExist(rocksdb::ReadOptions(),
+                                                                  m_db->DefaultColumnFamily(),
+                                                                  std::string(id) + "_" + std::to_string(index),
+                                                                  &value))
             {
                 // If the key does not exist, it means that the queue is not continuous.
                 // This incremental is only for the head, because this is a part of recovery algorithm when the
                 // queue not is continuous.
                 ++index;
+            }
+
+            // If the index is greater than the last element, the queue status is invalid.
+            if (index > it->second.tail)
+            {
+                throw std::runtime_error("Failed to dequeue element, queue is empty");
             }
 
             // RocksDB dequeue element.


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27157|

## Description
This PR aims to fix the benchmarks tests for the queue, basically avoid the pop behavior when the queue is empty.
```bash
 src git:(bug/27157-add-cutoff-when-the-queue-is-empty) ✗ ./build/shared_modules/utils/benchmark/utils_benchmark_test                                 
2024-12-04T16:40:37-03:00
Running ./build/shared_modules/utils/benchmark/utils_benchmark_test
Run on (24 X 5100 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x12)
  L1 Instruction 32 KiB (x12)
  L2 Unified 1280 KiB (x12)
  L3 Unified 30720 KiB (x1)
Load Average: 1.42, 2.12, 1.55
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
---------------------------------------------------------
Benchmark               Time             CPU   Iterations
---------------------------------------------------------
pushBenchmark        1557 ns         1557 ns       450496
popBenchmark         2116 ns         2117 ns       330703
frontBenchmark        226 ns          226 ns      3114890
```