### PR TITLE
Accept OK and CREATED as successful response results

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -152,7 +152,7 @@ async def restart_agents(agent_list: list) -> AffectedItemsWazuhResult:
             commands.append(command)
 
         response = await indexer_client.commands_manager.create(commands)
-        if response.result is ResponseResult.CREATED:
+        if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
             result.affected_items.extend(agent_list)
         else:
             for agent_id in agent_list:
@@ -388,7 +388,7 @@ async def add_agent(
 
         command = create_update_group_command(agent_id=id)
         response = await indexer_client.commands_manager.create([command])
-        if response.result is not ResponseResult.CREATED:
+        if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
             raise WazuhError(1762, extra_message=response.result.value)
 
     return WazuhResult({'data': new_agent})
@@ -555,7 +555,7 @@ async def delete_groups(group_list: list = None) -> AffectedItemsWazuhResult:
                     commands.append(command)
 
                 response = await indexer_client.commands_manager.create(commands)
-                if response.result is not ResponseResult.CREATED:
+                if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
                     raise WazuhError(1762, extra_message=response.result.value)
 
                 await indexer_client.agents.delete_group(group_name=group_id)
@@ -644,7 +644,7 @@ async def assign_agents_to_group(group_list: list = None, agent_list: list = Non
             commands.append(command)
 
         response = await indexer_client.commands_manager.create(commands)
-        if response.result is ResponseResult.CREATED:
+        if response.result in (ResponseResult.OK, ResponseResult.CREATED):
             result.affected_items.extend(agent_list)
         else:
             for agent_id in agent_list:
@@ -710,7 +710,7 @@ async def remove_agents_from_group(agent_list: list = None, group_list: list = N
             commands.append(command)
 
         response = await indexer_client.commands_manager.create(commands)
-        if response.result is ResponseResult.CREATED:
+        if response.result in (ResponseResult.OK, ResponseResult.CREATED):
             result.affected_items.extend(agent_list)
         else:
             for agent_id in agent_list:


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27159 |

## Description

Accepts both `OK` and `CREATED` as successful responses when creating commands. 

## Tests

<details><summary>Tests</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -k https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
```

```
2024/12/04 19:21:14 INFO: wazuh 172.18.0.1 "POST /agents" with parameters {} and body {"id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0", "name": "test", "key": "****", "type": "endpoint", "version": "5.0.0"} done in 0.963s: 201
```

```
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ curl -H "Authorization: Bearer $TOKEN" -X POST -H "Content-Type: application/json" -ks https://0.0.0.0:55000/orders -d '
{
  "orders": [
    {
      "document_id": "a-yvlZIBRVsFNWNvvj6f",
      "source" : "Users/Services",
      "user" : "Management API",
      "target" : {
        "type" : "agent",
        "id" : "01929571-49b5-75e8-a3f6-1d2b84f4f71a"
      },
      "action" : {
        "name" : "restart",
        "args" : [],
        "version" : "v5.0.0"
      },
      "timeout" : 100,
      "status" : "pending",
      "order_id" : "auyvlZIBRVsFNWNvvj6f",
      "request_id" : "aeyvlZIBRVsFNWNvvj6f"
    }
  ]
}' | jq
{
  "data": {
    "affected_items": [
      "auyvlZIBRVsFNWNvvj6f"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All orders were published",
  "error": 0
}
```

```
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ curl -X POST -H "Content-Type: application/json" -ku admin:admin https://localhost:9200/.commands/_search?pretty -d'
{
   "query": {
      "match_all": {}
   }
}'
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : ".commands",
        "_id" : "WYcqk5MBUsr920i3Ogdu",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "command" : {
            "source" : "Users/Services",
            "user" : "Management API",
            "target" : {
              "type" : "agent",
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
            },
            "action" : {
              "name" : "set-group",
              "args" : [
                "group1"
              ],
              "version" : "5.0.0"
            },
            "timeout" : 100,
            "status" : "PENDING",
            "order_id" : "WIcqk5MBUsr920i3Ogdu",
            "request_id" : "V4cqk5MBUsr920i3Ogdu"
          },
          "@timestamp" : "2024-12-04T19:33:58Z",
          "delivery_timestamp" : "2024-12-04T19:35:38Z"
        }
      },
      {
        "_index" : ".commands",
        "_id" : "Vocek5MBUsr920i3kwdJ",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "command" : {
            "source" : "Users/Services",
            "user" : "Management API",
            "target" : {
              "type" : "agent",
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
            },
            "action" : {
              "name" : "update-group",
              "args" : [ ],
              "version" : "5.0.0"
            },
            "timeout" : 100,
            "status" : "PENDING",
            "order_id" : "VYcek5MBUsr920i3kwdI",
            "request_id" : "VIcek5MBUsr920i3kwdI"
          },
          "@timestamp" : "2024-12-04T19:21:14Z",
          "delivery_timestamp" : "2024-12-04T19:22:54Z"
        }
      }
    ]
  }
}
```

</details>