### PR TITLE
Retag 4.10.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Prevented an infinite loop when indexing events in the Vulnerability Detector. ([#26922](https://github.com/wazuh/wazuh/pull/26922))
 - Fixed segmentation fault in `DescriptionsHelper::vulnerabilityDescription`. ([#26842](https://github.com/wazuh/wazuh/pull/26842))
 - Fixed vulnerability scanner re-scan triggers in cluster environment. ([#24034](https://github.com/wazuh/wazuh/pull/24034))
+- Fixed an issue where elements in the delayed list were not purged when changing nodes. ([#27145](https://github.com/wazuh/wazuh/pull/27145))
 
 #### Changed
 - Added self-recovery mechanism for rocksDB databases. ([#24333](https://github.com/wazuh/wazuh/pull/24333))


### PR DESCRIPTION
|Related issue|
|---|
|#27132|

This PR updates the changelog to create the new 4.10.0 tag.