### PR TITLE
Add server configuration endpoint check

### DIFF
--- a/apis/comms_api/core/unix_server/server.py
+++ b/apis/comms_api/core/unix_server/server.py
@@ -8,9 +8,6 @@ from comms_api.core.commands import CommandsManager
 from wazuh.core import common
 
 
-UNIX_SOCKET_PATH = common.WAZUH_SOCKET / 'comms-api.sock'
-
-
 def start_unix_server(commands_manager: CommandsManager):
     """Start the local server using HTTP over a unix socket.
 
@@ -26,5 +23,5 @@ def start_unix_server(commands_manager: CommandsManager):
     app.include_router(router)
     app.state.commands_manager = commands_manager
 
-    t = Thread(target=uvicorn.run, kwargs={'app': app, 'uds': UNIX_SOCKET_PATH}, daemon=True)
+    t = Thread(target=uvicorn.run, kwargs={'app': app, 'uds': common.COMMS_API_SOCKET_PATH}, daemon=True)
     t.start()

--- a/apis/comms_api/core/unix_server/test/test_server.py
+++ b/apis/comms_api/core/unix_server/test/test_server.py
@@ -3,7 +3,7 @@ from unittest.mock import call, patch, MagicMock
 import uvicorn
 
 from comms_api.core.unix_server.commands import post_commands
-from comms_api.core.unix_server.server import start_unix_server, UNIX_SOCKET_PATH
+from comms_api.core.unix_server.server import start_unix_server, common
 
 
 @patch('comms_api.core.unix_server.server.FastAPI')
@@ -19,6 +19,6 @@ def test_start_unix_server(mock_thread, router_mock, fastapi_mock):
         call().add_api_route('/commands', post_commands, methods=['POST'])
     ])
     mock_thread.assert_has_calls([
-        call(target=uvicorn.run, kwargs={'app': fastapi_mock(), 'uds': UNIX_SOCKET_PATH}, daemon=True),
+        call(target=uvicorn.run, kwargs={'app': fastapi_mock(), 'uds': common.COMMS_API_SOCKET_PATH}, daemon=True),
         call().start()
     ])

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -976,7 +976,7 @@ class Handler(asyncio.Protocol):
         """
         self.logger.info('Sending orders to the Communications API')
 
-        transport = httpx.AsyncHTTPTransport(uds=common.WAZUH_SOCKET / 'comms-api.sock')
+        transport = httpx.AsyncHTTPTransport(uds=common.COMMS_API_SOCKET)
         client = httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(10))
 
         orders_list = json.loads(orders)

--- a/framework/wazuh/core/cluster/local_client.py
+++ b/framework/wazuh/core/cluster/local_client.py
@@ -144,7 +144,7 @@ class LocalClient(client.AbstractClientManager):
                                                     loop=loop, on_con_lost=on_con_lost, name=self.name, 
                                                     logger=self.logger, manager=self, server_config=self.server_config
                                                     ),
-                                                path=common.WAZUH_SOCKET / common.LOCAL_SERVER_SOCKET
+                                                path=common.LOCAL_SERVER_SOCKET_PATH
                                             )
         except (ConnectionRefusedError, FileNotFoundError):
             raise exception.WazuhInternalError(3012)

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -210,7 +210,7 @@ class LocalServer(server.AbstractServer):
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         loop = asyncio.get_running_loop()
         loop.set_exception_handler(c_common.asyncio_exception_handler)
-        socket_path = common.WAZUH_SOCKET / common.LOCAL_SERVER_SOCKET
+        socket_path = common.LOCAL_SERVER_SOCKET_PATH
 
         try:
             local_server = await loop.create_unix_server(

--- a/framework/wazuh/core/cluster/tests/test_local_client.py
+++ b/framework/wazuh/core/cluster/tests/test_local_client.py
@@ -116,10 +116,9 @@ def test_localclient_initialization(mock_get_running_loop, read_config_mock, get
     assert lc.transport is None
 
 
-@patch('wazuh.core.cluster.utils.get_cluster_items')
-@patch('wazuh.core.cluster.utils.read_config')
 @pytest.mark.asyncio
-async def test_localclient_start(read_config_mock, get_cluster_items_mock):
+@patch('wazuh.core.config.client.CentralizedConfig.get_server_config')
+async def test_localclient_start(mock_get_server_config):
     """Check that the start method works correctly. Exceptions are not tested."""
 
     async def create_unix_connection(protocol_factory=None, path=None):
@@ -131,17 +130,16 @@ async def test_localclient_start(read_config_mock, get_cluster_items_mock):
             lc = LocalClient()
             await lc.start()
             assert mock_create_unix_connection.call_count == 1
-            assert mock_create_unix_connection.call_args[1]["path"] == common.WAZUH_SOCKET / common.LOCAL_SERVER_SOCKET
+            assert mock_create_unix_connection.call_args[1]["path"] == common.LOCAL_SERVER_SOCKET_PATH
             assert isinstance(mock_create_unix_connection.call_args[1]["protocol_factory"], Callable)
             assert lc.protocol == "protocol"
             assert lc.transport == "transport"
 
 
 @pytest.mark.asyncio
-@patch('wazuh.core.cluster.utils.get_cluster_items')
-@patch('wazuh.core.cluster.utils.read_config')
+@patch('wazuh.core.config.client.CentralizedConfig.get_server_config')
 @patch("wazuh.core.cluster.client.asyncio.get_running_loop")
-async def test_localclient_start_ko(mock_get_running_loop, read_config_mock, get_cluster_items_mock):
+async def test_localclient_start_ko(mock_get_running_loop, mock_get_server_config):
     """Check the behavior of the start function for the different types of exceptions that may occur."""
     with pytest.raises(WazuhInternalError, match=r'.* 3009 .*'):
         await LocalClient().start()

--- a/framework/wazuh/core/cluster/tests/test_local_server.py
+++ b/framework/wazuh/core/cluster/tests/test_local_server.py
@@ -15,18 +15,16 @@ from uvloop import Loop
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):
-        # TODO: Fix in #26725
-        with patch('wazuh.core.utils.load_wazuh_xml'):
-            sys.modules['wazuh.rbac.orm'] = MagicMock()
-            import wazuh.rbac.decorators
+        sys.modules['wazuh.rbac.orm'] = MagicMock()
+        import wazuh.rbac.decorators
 
-            del sys.modules['wazuh.rbac.orm']
-            from wazuh.tests.util import RBAC_bypasser
+        del sys.modules['wazuh.rbac.orm']
+        from wazuh.tests.util import RBAC_bypasser
 
-            wazuh.rbac.decorators.expose_resources = RBAC_bypasser
-            from wazuh.core.cluster.local_server import *
-            from wazuh.core.cluster.dapi import dapi
-            from wazuh.core.exception import WazuhClusterError
+        wazuh.rbac.decorators.expose_resources = RBAC_bypasser
+        from wazuh.core.cluster.local_server import *
+        from wazuh.core.cluster.dapi import dapi
+        from wazuh.core.exception import WazuhClusterError
 
 async def wait_function_called(func_mock):
     while not func_mock.call_count:

--- a/framework/wazuh/core/cluster/unix_server/server.py
+++ b/framework/wazuh/core/cluster/unix_server/server.py
@@ -6,8 +6,6 @@ from typing import Any
 from wazuh.core.cluster.unix_server.config import get_config
 from wazuh.core import common
 
-SERVER_UNIX_SOCKET_PATH = common.WAZUH_RUN / 'config-server.sock'
-
 
 def get_log_config(node: str) -> dict[str, Any]:
     """
@@ -44,6 +42,6 @@ def start_unix_server(node: str):
 
     log_config = get_log_config(node=node)
     t = Thread(target=uvicorn.run,
-               kwargs={'app': app, 'uds': SERVER_UNIX_SOCKET_PATH, 'log_config': log_config},
+               kwargs={'app': app, 'uds': common.CONFIG_SERVER_SOCKET_PATH, 'log_config': log_config},
                daemon=True)
     t.start()

--- a/framework/wazuh/core/cluster/unix_server/tests/test_server.py
+++ b/framework/wazuh/core/cluster/unix_server/tests/test_server.py
@@ -3,7 +3,7 @@ from unittest.mock import call, patch
 
 import uvicorn
 
-from wazuh.core.cluster.unix_server.server import start_unix_server, get_log_config, SERVER_UNIX_SOCKET_PATH
+from wazuh.core.cluster.unix_server.server import start_unix_server, get_log_config, common
 from wazuh.core.cluster.unix_server.config import get_config
 
 
@@ -39,7 +39,8 @@ def test_start_unix_server(mock_thread, router_mock, fastapi_mock):
         call().add_api_route('/config', get_config, methods=['GET'])
     ])
     mock_thread.assert_has_calls([
-        call(target=uvicorn.run, kwargs={'app': fastapi_mock(), 'uds': SERVER_UNIX_SOCKET_PATH, 'log_config': logging},
+        call(target=uvicorn.run, kwargs={'app': fastapi_mock(), 'uds': common.CONFIG_SERVER_SOCKET_PATH,
+                                         'log_config': logging},
              daemon=True),
         call().start()
     ])

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -6,6 +6,7 @@ import fcntl
 import json
 import logging
 import os
+from pathlib import Path
 import re
 import signal
 import socket
@@ -66,6 +67,35 @@ HELPER_DEFAULTS = {
     IMBALANCE_TOLERANCE: 0.1,
     REMOVE_DISCONNECTED_NODE_AFTER: 240,
 }
+
+
+def ping_unix_socket(socket_path: Path, timeout: int = 1):
+    """Ping a UNIX socket to check if it's available.
+
+    Parameters
+    ----------
+    socket_path : Path
+        Path to the UNIX socket file.
+    timeout : int
+        Connection timeout in seconds.
+
+    Returns
+    -------
+    bool
+        True if the socket is reachable, False otherwise.
+    """
+    if not socket_path.exists():
+        return False
+
+    try:
+        # Create a testing UNIX socket client to connect to the server socket.
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(timeout)
+        client.connect(str(socket_path))
+        client.close()
+        return True
+    except (socket.timeout, socket.error):
+        return False
 
 
 def _parse_haproxy_helper_integer_values(helper_config: dict) -> dict:

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -213,11 +213,17 @@ WAZUH_LOG = VAR_LOG / WAZUH_SERVER
 WAZUH_LIB = VAR_LIB / WAZUH_SERVER
 
 WAZUH_QUEUE = WAZUH_RUN / 'cluster'
-WAZUH_SOCKET = WAZUH_RUN / 'socket'
 
 WAZUH_SHARED = WAZUH_ETC / 'shared'
 
 LOCAL_SERVER_SOCKET = 'local-server.sock'
+LOCAL_SERVER_SOCKET_PATH = WAZUH_RUN / LOCAL_SERVER_SOCKET
+
+CONFIG_SERVER_SOCKET = 'config-server.sock'
+CONFIG_SERVER_SOCKET_PATH = WAZUH_RUN / CONFIG_SERVER_SOCKET
+
+COMMS_API_SOCKET = 'comms-api.sock'
+COMMS_API_SOCKET_PATH = WAZUH_RUN / COMMS_API_SOCKET
 
 
 # ============================================= Wazuh constants - Commands =============================================


### PR DESCRIPTION
|Related issue|
|---|
| #27138 |

- Added a verification before initiating the server daemons so the engine has the configuration endpoint available when it starts.
- Applied the necessary modifications to have every created socket in `/var/run/wazuh-server`.
- Manual tests were carried out [here](https://github.com/wazuh/wazuh/issues/27138#issuecomment-2520652516).
> [!NOTE] 
> Took the opportunity to modify certain tests and eliminate unnecessary functions to lighten the work to be carried out in https://github.com/wazuh/wazuh/issues/26725



## Related Unit Tests

<details>

```console
(5.0-aca) fdalmau@wazuhFW:~/git/wazuh(master)$ pytest framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_orders_ko
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.16, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 1 item                                                                                                                                                

framework/wazuh/core/cluster/tests/test_common.py .                                                                                                       [100%]

======================================================================= 1 passed in 0.57s =======================================================================
(5.0-aca) fdalmau@wazuhFW:~/git/wazuh(master)$ pytest framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_orders
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.16, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 1 item                                                                                                                                                

framework/wazuh/core/cluster/tests/test_common.py .                                                                                                       [100%]

======================================================================= warnings summary ========================================================================
wazuh/core/cluster/tests/test_common.py::test_handler_send_orders
  /home/fdalmau/git/wazuh/framework/wazuh/core/cluster/common.py:1004: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.logger.error(f'Orders request failed: {response.status_code} - {response.json()}')
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

wazuh/core/cluster/tests/test_common.py::test_handler_send_orders
  /home/fdalmau/git/wazuh/framework/wazuh/core/cluster/tests/test_common.py:928: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    await handler.send_orders(orders)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================= 1 passed, 2 warnings in 0.93s =================================================================


(5.0-aca) fdalmau@wazuhFW:~/git/wazuh(master)$ pytest framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_start_ko
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.16, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 1 item                                                                                                                                                

framework/wazuh/core/cluster/tests/test_local_client.py .                                                                                                 [100%]

======================================================================= 1 passed in 0.38s =======================================================================
(5.0-aca) fdalmau@wazuhFW:~/git/wazuh(master)$ pytest framework/wazuh/core/cluster/tests/test_local_client.py::test_localclient_start
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.16, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 1 item                                                                                                                                                

framework/wazuh/core/cluster/tests/test_local_client.py .                                                                                                 [100%]

======================================================================= 1 passed in 0.43s =======================================================================

(5.0-aca) fdalmau@wazuhFW:~/git/wazuh(master)$ pytest framework/wazuh/core/tests/test_common.py 
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.16, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/fdalmau/git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, metadata-3.1.1, trio-0.8.0, tavern-1.23.5, cov-4.1.0, asyncio-0.18.1, html-2.1.1
asyncio: mode=auto
collected 8 items                                                                                                                                               

framework/wazuh/core/tests/test_common.py ........                                                                                                        [100%]

======================================================================= 8 passed in 0.07s =======================================================================

```

</details>