### PR TITLE
Add delete operation errors parsing support

### DIFF
--- a/apis/comms_api/core/events.py
+++ b/apis/comms_api/core/events.py
@@ -175,9 +175,18 @@ def parse_tasks_results(tasks_results: List[dict]) -> List[TaskResult]:
         for r in result:
             status = r[IndexerKey.STATUS]
             if status >= HTTP_STATUS_OK and status <= HTTP_STATUS_PARTIAL_CONTENT:
-                task_result = TaskResult(id=r[IndexerKey._ID], result=r[IndexerKey.RESULT], status=status)
+                task_result = TaskResult(
+                    id=r[IndexerKey._ID],
+                    result=r[IndexerKey.RESULT],
+                    status=status
+                )
             else:
-                task_result = TaskResult(id='', result=r[IndexerKey.ERROR][IndexerKey.REASON], status=status)
+                if IndexerKey.ERROR not in r:
+                    error_reason = r[IndexerKey.RESULT]
+                else:
+                    error_reason = r[IndexerKey.ERROR][IndexerKey.REASON]
+                    
+                task_result = TaskResult(id=r[IndexerKey._ID], result=error_reason, status=status)
 
             results.append(task_result)
 

--- a/apis/comms_api/core/events.py
+++ b/apis/comms_api/core/events.py
@@ -176,6 +176,7 @@ def parse_tasks_results(tasks_results: List[dict]) -> List[TaskResult]:
             status = r[IndexerKey.STATUS]
             if status >= HTTP_STATUS_OK and status <= HTTP_STATUS_PARTIAL_CONTENT:
                 task_result = TaskResult(
+                    index=r[IndexerKey._INDEX],
                     id=r[IndexerKey._ID],
                     result=r[IndexerKey.RESULT],
                     status=status
@@ -186,7 +187,12 @@ def parse_tasks_results(tasks_results: List[dict]) -> List[TaskResult]:
                 else:
                     error_reason = r[IndexerKey.ERROR][IndexerKey.REASON]
                     
-                task_result = TaskResult(id=r[IndexerKey._ID], result=error_reason, status=status)
+                task_result = TaskResult(
+                    index=r[IndexerKey._INDEX],
+                    id=r[IndexerKey._ID],
+                    result=error_reason,
+                    status=status,
+                )
 
             results.append(task_result)
 

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -250,17 +250,33 @@ def test_parse_tasks_results():
 
         }],
         [{
+            '_id': '3',
             'status': 400,
             'error': {
                 'reason': 'invalid field `scan_time`'
             },
+        }],
+        [{
+            '_id': '4',
+            'status': 404,
+            'error': {
+                'reason': '[4]: document missing'
+            },
+        }],
+        [{
+            '_index': 'wazuh-states-inventory-processes',
+            '_id': '5',
+            'result': 'not_found',
+            'status': 404
         }]
     ]
     expected = [
         TaskResult(id='1', result='created', status=201),
         TaskResult(id='1', result='updated', status=200),
         TaskResult(id='2', result='updated', status=200),
-        TaskResult(id='', result='invalid field `scan_time`', status=400),
+        TaskResult(id='3', result='invalid field `scan_time`', status=400),
+        TaskResult(id='4', result='[4]: document missing', status=404),
+        TaskResult(id='5', result='not_found', status=404),
     ]
     results = parse_tasks_results(tasks_results)
 

--- a/apis/comms_api/core/test/test_events.py
+++ b/apis/comms_api/core/test/test_events.py
@@ -12,7 +12,9 @@ from wazuh.core.batcher.client import BatcherClient
 from wazuh.core.exception import WazuhError
 from wazuh.core.indexer.bulk import Operation
 from wazuh.core.indexer.models.agent import Host, OS
-from wazuh.core.indexer.models.events import Agent, AgentMetadata, Header, Module, TaskResult
+from wazuh.core.indexer.models.events import Agent, AgentMetadata, Header, Module, TaskResult, SCA_INDEX, FIM_INDEX, \
+    VULNERABILITY_INDEX, INVENTORY_PORTS_INDEX, INVENTORY_PROCESSES_INDEX, INVENTORY_NETWORKS_INDEX
+from wazuh.core.indexer.commands import CommandsManager
 
 
 @patch('wazuh.core.engine.events.EventsModule.send', new_callable=AsyncMock)
@@ -54,8 +56,8 @@ async def test_send_stateless_events_ko(mock_engine_config, mock_engine_client, 
 async def test_send_stateful_events(send_events_mock, batcher_client_mock):
     """Check that the `send_stateful_events` function works as expected."""
     expected = [
-        TaskResult(id='1', result='created', status=201),
-        TaskResult(id='2', result='created', status=201),
+        TaskResult(index=CommandsManager.INDEX, id='1', result='created', status=201),
+        TaskResult(index=CommandsManager.INDEX, id='2', result='created', status=201),
     ]
     agent_metadata = AgentMetadata(agent=Agent(
         id='ac5f7bed-363a-4095-bc19-5c1ebffd1be0',
@@ -233,23 +235,27 @@ def test_parse_tasks_results():
     tasks_results = [
         [
             {
+                '_index': SCA_INDEX,
                 '_id': '1',
                 'status': 201,
                 'result': 'created',
             },
             {
+                '_index': VULNERABILITY_INDEX,
                 '_id': '1',
                 'status': 200,
                 'result': 'updated',
             }
         ],
         [{
+            '_index': FIM_INDEX,
             '_id': '2',
             'status': 200,
             'result': 'updated',
 
         }],
         [{
+            '_index': INVENTORY_PORTS_INDEX,
             '_id': '3',
             'status': 400,
             'error': {
@@ -257,6 +263,7 @@ def test_parse_tasks_results():
             },
         }],
         [{
+            '_index': INVENTORY_NETWORKS_INDEX,
             '_id': '4',
             'status': 404,
             'error': {
@@ -264,19 +271,19 @@ def test_parse_tasks_results():
             },
         }],
         [{
-            '_index': 'wazuh-states-inventory-processes',
+            '_index': INVENTORY_PROCESSES_INDEX,
             '_id': '5',
             'result': 'not_found',
             'status': 404
         }]
     ]
     expected = [
-        TaskResult(id='1', result='created', status=201),
-        TaskResult(id='1', result='updated', status=200),
-        TaskResult(id='2', result='updated', status=200),
-        TaskResult(id='3', result='invalid field `scan_time`', status=400),
-        TaskResult(id='4', result='[4]: document missing', status=404),
-        TaskResult(id='5', result='not_found', status=404),
+        TaskResult(index=SCA_INDEX, id='1', result='created', status=201),
+        TaskResult(index=VULNERABILITY_INDEX, id='1', result='updated', status=200),
+        TaskResult(index=FIM_INDEX, id='2', result='updated', status=200),
+        TaskResult(index=INVENTORY_PORTS_INDEX, id='3', result='invalid field `scan_time`', status=400),
+        TaskResult(index=INVENTORY_NETWORKS_INDEX, id='4', result='[4]: document missing', status=404),
+        TaskResult(index=INVENTORY_PROCESSES_INDEX, id='5', result='not_found', status=404),
     ]
     results = parse_tasks_results(tasks_results)
 

--- a/apis/comms_api/routers/test/test_events.py
+++ b/apis/comms_api/routers/test/test_events.py
@@ -8,7 +8,7 @@ from comms_api.models.events import StatefulEventsResponse
 from comms_api.routers.events import post_stateful_events, post_stateless_events
 from comms_api.routers.exceptions import HTTPError
 from wazuh.core.exception import WazuhEngineError, WazuhError
-from wazuh.core.indexer.models.events import TaskResult
+from wazuh.core.indexer.models.events import TaskResult, FIM_INDEX
 
 
 @pytest.mark.asyncio
@@ -22,7 +22,7 @@ async def test_post_stateful_events(parse_stateful_events_mock, send_stateful_ev
     })
     request.app.state.batcher_queue = AsyncMock()
 
-    results = [TaskResult(id='123', result='created', status=201)]
+    results = [TaskResult(index=FIM_INDEX, id='123', result='created', status=201)]
     events = []
     parse_stateful_events_mock.return_value = events
     send_stateful_events_mock.return_value = results

--- a/framework/wazuh/core/indexer/models/events.py
+++ b/framework/wazuh/core/indexer/models/events.py
@@ -37,6 +37,7 @@ class AgentMetadata(BaseModel):
 
 class TaskResult(BaseModel):
     """Stateful event bulk task result data model."""
+    index: str
     id: str
     result: str
     status: int


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27197 |

## Description

Adds support for parsing opensearch responses on failed `delete` operations.

### Tests

<details><summary>Try to index events that do not exist or are invalid</summary>

```json
{
  "results": [
    {
      "index": "wazuh-states-inventory-hardware",
      "id": "aW52ZW50b3J5OmhhcmR3YXJlOjA=",
      "result": "[aW52ZW50b3J5OmhhcmR3YXJlOjA=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczox",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczox]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczoy",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczoy]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoxNg==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoxNg==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoxNw==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoxNw==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoxOA==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoxOA==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoyNA==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoyNA==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoyNQ==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoyNQ==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczozMg==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczozMg==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczozNg==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczozNg==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczozOA==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczozOA==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo0OA==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo0OA==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoyNTA=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoyNTA=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo1MTQ=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo1MTQ=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo1ODk=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo1ODk=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo1OTA=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo1OTA=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo2ODY=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo2ODY=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo2ODc=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo2ODc=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo2OTE=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo2OTE=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo2OTk=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo2OTk=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4Mzk=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo4Mzk=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NTY=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo4NTY=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo5ODM=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo5ODM=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoxMDMx",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoxMDMx]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoxMzk0",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoxMzk0]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo0NjI2",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo0NjI2]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo3ODAw",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo3ODAw]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo3ODU0",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo3ODU0]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MDEw",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo4MDEw]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MDMw",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo4MDMw]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MTY4",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo4MTY4]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MTk0",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo4MTk0]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MjIw",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo4MjIw]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MjU1",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MjU2",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4Mjk5",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MzA3",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MzEw",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MzQz",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MzQ2",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MzQ3",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MzUx",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MzY5",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4Mzcx",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4Mzcy",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4Mzkx",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4Mzky",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4Mzk5",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo2NQ==",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MTY5",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MTcx",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MTk5",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MjM5",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MjQy",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMDY0OnVkcDowLjAuMC4wOjI3MDAw",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMDY1OnVkcDY6Ojo6MjcwMDA=",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwOTgwOnRjcDowLjAuMC4wOjI3MDAw",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjM4ODk5OnRjcDoxMC4wLjIuMTU6MjI=",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjUxODM4",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMDgxOnRjcDoxOTIuMTY4LjU2LjEwNDo1MTg1NA==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMDgzOnRjcDoxOTIuMTY4LjU2LjEwNDo1MTg1OA==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMDgyOnRjcDoxOTIuMTY4LjU2LjEwNDo1MTg1Ng==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwOTgxOnRjcDY6Ojo6MjcwMDA=",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjM3MDg4",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjM3MTAy",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjQzMDcw",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjM4NDExOnRjcDoxOTIuMTY4LjU2LjEwNDo0MzA3Mg==",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjM4NDEyOnRjcDoxOTIuMTY4LjU2LjEwNDo0MzA3Ng==",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjM5MzkzOnRjcDoxOTIuMTY4LjU2LjEwNDo0MzA4MA==",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-networks",
      "id": "aW52ZW50b3J5Om5ldHdvcmtzOmV0aDA6OmlwdjQ6OjEwLjAuMi4xNQ==",
      "result": "[aW52ZW50b3J5Om5ldHdvcmtzOmV0aDA6OmlwdjQ6OjEwLjAuMi4xNQ==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-networks",
      "id": "aW52ZW50b3J5Om5ldHdvcmtzOmV0aDE6OmlwdjQ6OjE5Mi4xNjguNTYuMTA0",
      "result": "[aW52ZW50b3J5Om5ldHdvcmtzOmV0aDE6OmlwdjQ6OjE5Mi4xNjguNTYuMTA0]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-networks",
      "id": "aW52ZW50b3J5Om5ldHdvcmtzOmV0aDE6OmlwdjY6OmZlODA6OmEwMDoyN2ZmOmZlZTI6N2JjNA==",
      "result": "[aW52ZW50b3J5Om5ldHdvcmtzOmV0aDE6OmlwdjY6OmZlODA6OmEwMDoyN2ZmOmZlZTI6N2JjNA==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczozMQ==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczozMQ==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo2NjU=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo2NjU=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo3MTQ=",
      "result": "[aW52ZW50b3J5OnByb2Nlc3Nlczo3MTQ=]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDEx",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDI5",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDMz",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDQ2",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDQ3",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDQ4",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDU1",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4MDgx",
      "result": "not_found",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMjk3OnVkcDowLjAuMC4wOjI3MDAw",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMjk4OnVkcDY6Ojo6MjcwMDA=",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQxMzQzOnRjcDowLjAuMC4wOjI3MDAw",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjQ5NjIy",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjQ5NjE2",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjM5NDQw",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjU0MDYy",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTozNTczMA==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMToyNzAwMA==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQxMzQyOnRjcDY6Ojo6MjcwMDA=",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3NlczoxNQ==",
      "result": "[aW52ZW50b3J5OnByb2Nlc3NlczoxNQ==]: document missing",
      "status": 404
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDY5",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDcw",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDcz",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDc0",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDk2",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDk4",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NDk5",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-processes",
      "id": "aW52ZW50b3J5OnByb2Nlc3Nlczo4NTky",
      "result": "mapping set to strict, dynamic introduction of [tty] within [process] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwNjQ1OnRjcDoxOTIuMTY4LjU2LjEwNDozODI2NA==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjEyNy4wLjAuMTo0MzgxOA==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQxNzgxOnRjcDoxOTIuMTY4LjU2LjEwNDozODI5Ng==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjM4MjU0",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjA6dGNwOjE5Mi4xNjguNTYuMTA0OjUyNTQ2",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwMzY2OnRjcDoxMC4wLjIuMTU6MjI=",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    },
    {
      "index": "wazuh-states-inventory-ports",
      "id": "aW52ZW50b3J5OnBvcnRzOjQwNjQ2OnRjcDoxOTIuMTY4LjU2LjEwNDozODI4MA==",
      "result": "mapping set to strict, dynamic introduction of [interface] within [_doc] is not allowed",
      "status": 400
    }
  ]
}
```

</details>


<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest apis/comms_api/core/test/test_events.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis/comms_api/core/test
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 8 items                                                                                                                                                                                                                            

apis/comms_api/core/test/test_events.py ........                                                                                                                                                                                       [100%]

============================================================================================================= 8 passed in 0.60s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest apis/comms_api/routers/test/test_events.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 4 items                                                                                                                                                                                                                            

apis/comms_api/routers/test/test_events.py ....                                                                                                                                                                                        [100%]

======================================================================================================== 4 passed, 1 warning in 0.64s ========================================================================================================
```

</details>
