### PR TITLE
Add APIs logs tags

### DIFF
--- a/api/api/alogging.py
+++ b/api/api/alogging.py
@@ -21,7 +21,7 @@ WARNING = 'WARNING'
 INFO = 'INFO'
 
 
-def set_logging(logging_config: APILoggingConfig) -> dict:
+def set_logging(logging_config: APILoggingConfig, tag: str) -> dict:
     """Set up logging for API.
     
     This function creates a logging configuration dictionary, configure the wazuh-api logger
@@ -32,6 +32,8 @@ def set_logging(logging_config: APILoggingConfig) -> dict:
     ----------
     logging_config :  APILoggingConfig
         Logger configuration.
+    tag : str
+        Logger tag.
 
     Raises
     ------
@@ -66,7 +68,7 @@ def set_logging(logging_config: APILoggingConfig) -> dict:
             },
             "log": {
                 "()": "uvicorn.logging.DefaultFormatter",
-                "fmt": "%(asctime)s %(levelname)s: %(message)s",
+                "fmt": f"%(asctime)s %(levelname)s: [{tag}] %(message)s",
                 "datefmt": "%Y/%m/%d %H:%M:%S",
                 "use_colors": None,
             },
@@ -94,8 +96,8 @@ def set_logging(logging_config: APILoggingConfig) -> dict:
             },
         },
         "loggers": {
+            "wazuh": {"handlers": hdls, "level": log_level, "propagate": False},
             "wazuh-api": {"handlers": hdls, "level": log_level, "propagate": False},
-            "start-stop-api": {"handlers": hdls, "level": INFO, "propagate": False},
             "wazuh-comms-api": {"handlers": hdls, "level": log_level, "propagate": False}
         }
     }

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -46,7 +46,6 @@ xfo = XFrameOptions().deny()
 secure_headers = Secure(server=server, csp=csp, xfo=xfo)
 
 logger = logging.getLogger('wazuh-api')
-start_stop_logger = logging.getLogger('start-stop-api')
 
 ip_stats = dict()
 ip_block = set()

--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -56,6 +56,7 @@ API_MAIN_PROCESS = 'wazuh-apid'
 API_LOCAL_REQUEST_PROCESS = 'wazuh-apid_exec'
 API_AUTHENTICATION_PROCESS = 'wazuh-apid_auth'
 API_SECURITY_EVENTS_PROCESS = 'wazuh-apid_events'
+LOGGING_TAG = 'Management API'
 
 logger = None
 
@@ -318,7 +319,7 @@ if __name__ == '__main__':
 
     # Set up logger file
     try:
-        uvicorn_params['log_config'] = set_logging(logging_config=management_config.logging)
+        uvicorn_params['log_config'] = set_logging(logging_config=management_config.logging, tag=LOGGING_TAG)
     except APIError as api_log_error:
         print(f"Error when trying to start the Wazuh API. {api_log_error}")
         sys.exit(1)

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -44,6 +44,7 @@ from wazuh.core.config.models.logging import APILoggingConfig
 from wazuh.core.config.models.comms_api import CommsAPIConfig
 
 MAIN_PROCESS = 'wazuh-comms-apid'
+LOGGING_TAG = 'Communications API'
 
 
 def create_app(batcher_queue: MuxDemuxQueue, commands_manager: CommandsManager) -> FastAPI:
@@ -90,7 +91,7 @@ def setup_logging(logging_config: APILoggingConfig) -> dict:
     dict
         Logging configuration dictionary.
     """
-    log_config = set_logging(logging_config=logging_config)
+    log_config = set_logging(logging_config=logging_config, tag=LOGGING_TAG)
 
     logging.config.dictConfig(log_config)
 

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -16,7 +16,7 @@ import time
 
 from wazuh.core import pyDaemonModule
 from wazuh.core.authentication import generate_keypair, keypair_exists
-from wazuh.core.common import WAZUH_SHARE, WAZUH_LOG, wazuh_gid, wazuh_uid, CONFIG_SERVER_SOCKET_PATH
+from wazuh.core.common import WAZUH_SHARE, wazuh_gid, wazuh_uid, CONFIG_SERVER_SOCKET_PATH
 from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.config.models.server import NodeType
 from wazuh.core.cluster.cluster import clean_up
@@ -381,7 +381,7 @@ def start():
     server_pid = os.getpid()
     pyDaemonModule.create_pid(SERVER_DAEMON_NAME, server_pid)
     if not args.daemon:
-        print(f'Starting server in foreground (pid: {server_pid})')
+        main_logger.info(f'Starting server in foreground (pid: {server_pid})')
 
     if server_config.node.type == NodeType.MASTER:
         main_function = master_main

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -98,6 +98,7 @@ class Indexer(MixinBulk):
         WazuhIndexerError(2200)
             In case of errors communicating with the Wazuh Indexer.
         """
+        logger.debug('Connecting to the indexer client.')
         try:
             return await self._client.info()
         except ssl.SSLError as e:
@@ -110,7 +111,7 @@ class Indexer(MixinBulk):
 
     async def close(self) -> None:
         """Close the Wazuh Indexer client."""
-        logger.warning('Closing the indexer client session.')
+        logger.debug('Closing the indexer client session.')
         await self._client.close()
 
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27226 |

## Description

Adds tags to the API loggers to make it easier to identify their logs.

## Tests

<details><summary>Logs</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ docker logs -f wazuh-manager
2024/12/06 18:28:57 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2024/12/06 18:28:57 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
2024/12/06 18:28:57 INFO: [Cluster] [Main] Generating JWT signing key pair
2024/12/06 18:28:57 INFO: [Master] [Main] Configuration server is not available, retrying...
2024/12/06 18:28:57 INFO: [Master] [Config Server] Started server process [14]
2024/12/06 18:28:57 INFO: [Master] [Config Server] Waiting for application startup.
2024/12/06 18:28:57 INFO: [Master] [Config Server] Application startup complete.
2024/12/06 18:28:57 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2024/12/06 18:28:57 INFO: [Cluster] [Main] Starting server in foreground (pid: 14)
2024/12/06 18:28:58 INFO: [Local Server] [Main] Starting wazuh-engined
2024-12-06 18:28:58.738 20:20 info: Logging initialized.
2024/12/06 18:28:58 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2024-12-06 18:28:58.743 20:20 info: Store initialized.
2024-12-06 18:28:58.743 20:20 info: RBAC initialized.
2024-12-06 18:28:58.743 20:20 info: MetricsManager: Created new scope: (KVDB)
2024-12-06 18:28:58.900 20:20 info: KVDB initialized.
2024-12-06 18:28:58.900 20:20 info: Geo initialized.
2024-12-06 18:28:58.911 20:20 info: Schema initialized.
2024-12-06 18:28:58.919 20:20 info: Loaded timezone database version: '2024a'
2024-12-06 18:28:58.923 20:20 info: HLP initialized.
2024-12-06 18:28:58.980 20:20 info: Indexer Connector initialized.
2024-12-06 18:28:58.980 20:20 info: Builder initialized.
2024-12-06 18:28:58.980 20:20 info: Catalog initialized.
2024-12-06 18:28:58.980 20:20 info: Policy manager initialized.
2024-12-06 18:28:58.980 20:20 info: MetricsManager: Created new scope: (EventQueue)
2024-12-06 18:28:58.980 20:20 info: MetricsManager: Created new scope: (EventQueueDelta)
2024-12-06 18:28:58.982 20:20 info: No flooding file provided, the queue will not be flooded.
2024-12-06 18:28:58.983 20:20 info: MetricsManager: Created new scope: (TestQueue)
2024-12-06 18:28:58.983 20:20 info: MetricsManager: Created new scope: (TestQueueDelta)
2024-12-06 18:28:58.989 20:20 info: No flooding file provided, the queue will not be flooded.
2024-12-06 18:28:58.990 20:20 warning: Router: router/tester/0 table is empty
2024-12-06 18:28:59.106 20:20 info: Router initialized.
2024-12-06 18:28:59.178 20:20 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2024-12-06 18:28:59.178 20:20 info: MetricsManager: Created new scope: (endpointAPI)
2024-12-06 18:28:59.178 20:20 info: MetricsManager: Created new scope: (endpointAPIRate)
2024-12-06 18:28:59.179 20:20 info: MetricsManager: Created new scope: (endpointEvent)
2024-12-06 18:28:59.179 20:20 info: MetricsManager: Created new scope: (endpointEventRate)
2024-12-06 18:28:59.180 20:20 info: Starting the server...
2024/12/06 18:29:00 INFO: [Local Server] [Main] Started wazuh-engined (pid: 20)
2024/12/06 18:29:00 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2024/12/06 18:29:01 INFO: [Communications API] Starting API in foreground
2024/12/06 18:29:01 INFO: [Communications API] Starting API as root
2024/12/06 18:29:01 INFO: [Communications API] Listening on 0.0.0.0:27000
2024/12/06 18:29:01 INFO: [Communications API] Generated private key file in /etc/wazuh-server/api/configuration/ssl/server.key
2024/12/06 18:29:01 INFO: [Communications API] Generated certificate file in /etc/wazuh-server/api/configuration/ssl/server.crt
2024/12/06 18:29:02 INFO: [Communications API] Starting gunicorn 22.0.0
2024/12/06 18:29:02 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (460)
2024/12/06 18:29:02 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2024/12/06 18:29:02 INFO: [Communications API] Booting worker with pid: 526
2024/12/06 18:29:02 INFO: [Communications API] Started server process [460]
2024/12/06 18:29:02 INFO: [Communications API] Waiting for application startup.
2024/12/06 18:29:02 INFO: [Communications API] Application startup complete.
2024/12/06 18:29:02 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2024/12/06 18:29:02 INFO: [Communications API] Booting worker with pid: 527
2024/12/06 18:29:02 INFO: [Communications API] Started server process [527]
2024/12/06 18:29:02 INFO: [Communications API] Waiting for application startup.
2024/12/06 18:29:02 INFO: [Communications API] Application startup complete.
2024/12/06 18:29:02 INFO: [Communications API] Booting worker with pid: 528
2024/12/06 18:29:02 INFO: [Communications API] Started server process [528]
2024/12/06 18:29:02 INFO: [Communications API] Waiting for application startup.
2024/12/06 18:29:02 INFO: [Communications API] Application startup complete.
2024/12/06 18:29:02 INFO: [Communications API] Booting worker with pid: 529
2024/12/06 18:29:02 INFO: [Communications API] Started server process [529]
2024/12/06 18:29:02 INFO: [Communications API] Waiting for application startup.
2024/12/06 18:29:02 INFO: [Communications API] Application startup complete.
2024/12/06 18:29:02 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 460)
2024/12/06 18:29:02 INFO: [Local Server] [Main] Starting wazuh-apid
2024/12/06 18:29:03 INFO: [Management API] Starting API in foreground
2024/12/06 18:29:03 INFO: [Management API] Starting API as root
2024/12/06 18:29:03 INFO: [Management API] Checking RBAC database integrity...
2024/12/06 18:29:03 INFO: [Management API] RBAC database not found. Initializing
2024/12/06 18:29:04 INFO: [Local Server] [Main] Started wazuh-apid (pid: 534)
2024/12/06 18:29:04 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2024/12/06 18:29:04 DEBUG: [Local Server] [Keep alive] Calculating.
2024/12/06 18:29:04 DEBUG: [Local Server] [Keep alive] Calculated.
2024/12/06 18:29:04 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/12/06 18:29:04 DEBUG: [Master] [Keep alive] Calculating.
2024/12/06 18:29:04 DEBUG: [Master] [Keep alive] Calculated.
2024/12/06 18:29:04 INFO: [Master] [Local integrity] Starting.
2024/12/06 18:29:04 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 2 files.
2024/12/06 18:29:05 INFO: [Worker] [Main] Connection from ('172.18.0.5', 52330)
2024/12/06 18:29:05 DEBUG: [Worker] [Main] Command received: b'hello'
2024/12/06 18:29:05 INFO: [Worker] [Main] Connection from ('172.18.0.4', 34496)
2024/12/06 18:29:05 DEBUG: [Worker] [Main] Command received: b'hello'
2024/12/06 18:29:05 INFO: [Management API] /var/lib/wazuh-server/rbac.db database created successfully
2024/12/06 18:29:05 INFO: [Management API] RBAC database integrity check finished successfully
2024/12/06 18:29:06 INFO: [Management API] Listening on ['0.0.0.0', '::']:55000.
2024/12/06 18:29:06 INFO: [Management API] Populating installation UID...
2024/12/06 18:29:06 INFO: [Management API] Getting updates information...
2024/12/06 18:29:06 INFO: [Management API] None 172.18.0.7 "HEAD /" with parameters {} and body {} done in 0.001s: 401
```

> Engine logs continue to be untagged, this should be addressed once we decide how to manage logs in the feature complete implementation.

</details>