### PR TITLE
Change compressed vuldet database path

### DIFF
--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -19,6 +19,7 @@ constexpr std::string_view INDEXER_PASSWORD = "/indexer/password";
 constexpr std::string_view INDEXER_SSL_CA_LIST = "/indexer/ssl/certificate_authorities";
 constexpr std::string_view INDEXER_SSL_CERTIFICATE = "/indexer/ssl/certificate";
 constexpr std::string_view INDEXER_SSL_KEY = "/indexer/ssl/key";
+constexpr std::string_view MERGED_CA_PATH = "/var/lib/wazuh-server/tmp/root-ca-merged.pem";
 constexpr std::string_view INDEXER_SSL_USE_SSL = "/indexer/ssl/use_ssl";
 constexpr std::string_view INDEXER_SSL_VERIFY_CERTS = "/indexer/ssl/verify_certificates";
 

--- a/src/engine/source/feedmanager/src/databaseFeedManager.cpp
+++ b/src/engine/source/feedmanager/src/databaseFeedManager.cpp
@@ -19,11 +19,11 @@
 #include "eventDecoder.hpp"
 #include "storeModel.hpp"
 
-const std::string CONTENT_NAME {"vd_1.0.0_vd_4.10.0"};                            // Content name.
-const std::filesystem::path WAZUH_LIB_PATH {"/var/lib/wazuh-server/"};            //< Path to the lib server files.
-const std::filesystem::path TMP_PATH {"/tmp/wazuh-server"};                       //< Path to the tmp files.
-const std::filesystem::path WAZUH_LIB_TMP_PATH {WAZUH_LIB_PATH / "tmp/"};         //< Path to the lib server tmp files.
-const std::filesystem::path XZ_FILE_PATH {TMP_PATH / (CONTENT_NAME + ".tar.xz")}; //< Path of the compressed db
+const std::string CONTENT_NAME {"vd_1.0.0_vd_4.10.0"};                    // Content name.
+const std::filesystem::path WAZUH_LIB_PATH {"/var/lib/wazuh-server/"};    //< Path to the lib server files.
+const std::filesystem::path WAZUH_LIB_TMP_PATH {WAZUH_LIB_PATH / "tmp/"}; //< Path to the lib server tmp files.
+const std::filesystem::path XZ_FILE_PATH {WAZUH_LIB_TMP_PATH
+                                          / (CONTENT_NAME + ".tar.xz")};                  //< Path of the compressed db
 const std::filesystem::path TAR_FILE_PATH {WAZUH_LIB_TMP_PATH / (CONTENT_NAME + ".tar")}; //< Path to the tar db.
 const std::filesystem::path LEGACY_DB_PATH {WAZUH_LIB_TMP_PATH / "queue/"};           //< Path to the legacy database.
 const std::filesystem::path VD_FEED_DB_BASE_PATH {WAZUH_LIB_PATH / "vd/"};            //< Path to the current database.
@@ -60,10 +60,6 @@ DatabaseFeedManager::DatabaseFeedManager(std::shared_mutex& mutex)
             if (std::filesystem::remove_all(VD_UPDATER_DB_BASE_PATH))
             {
                 LOG_DEBUG("Removing existent {} folder.", VD_UPDATER_DB_BASE_PATH.c_str());
-            }
-            if (!std::filesystem::exists(WAZUH_LIB_TMP_PATH))
-            {
-                std::filesystem::create_directories(WAZUH_LIB_TMP_PATH);
             }
 
             LOG_DEBUG("Starting XZ file decompression");

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -45,6 +45,7 @@ struct IndexerConnectorOptions
         std::string cert;                ///< The certificate to connect to OpenSearch.
         std::string key;                 ///< The key to connect to OpenSearch.
         bool skipVerifyPeer;             ///< Skip peer verification. (insecure mode)
+        std::string merged_ca_path;      ///< The path containing the merged ca.
     } sslOptions;                        ///< The SSL options to connect to OpenSearch.
 
     uint32_t timeout = 60000u;  ///< The timeout in milliseconds to connect to OpenSearch.

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -45,7 +45,7 @@ struct IndexerConnectorOptions
         std::string cert;                ///< The certificate to connect to OpenSearch.
         std::string key;                 ///< The key to connect to OpenSearch.
         bool skipVerifyPeer;             ///< Skip peer verification. (insecure mode)
-        std::string merged_ca_path;      ///< The path containing the merged ca.
+        std::string mergedCAPath;        ///< The path containing the merged certificate authority.
     } sslOptions;                        ///< The SSL options to connect to OpenSearch.
 
     uint32_t timeout = 60000u;  ///< The timeout in milliseconds to connect to OpenSearch.

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -94,7 +94,7 @@ static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, c
 
 static void initConfiguration(SecureCommunication& secureCommunication, const IndexerConnectorOptions& config)
 {
-    std::string caRootCertificate = config.sslOptions.merged_ca_path;
+    std::string caRootCertificate = config.sslOptions.mergedCAPath;
     std::string sslCertificate;
     std::string sslKey;
     std::string username;

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -30,7 +30,7 @@ constexpr auto PASSWORD_KEY {"password"};
 constexpr auto ELEMENTS_PER_BULK {1000};
 constexpr auto WAZUH_OWNER {"wazuh"};
 constexpr auto WAZUH_GROUP {"wazuh"};
-constexpr auto MERGED_CA_PATH {"/tmp/wazuh-server/root-ca-merged.pem"};
+constexpr auto MERGED_CA_PATH {"/var/lib/wazuh-server/tmp/root-ca-merged.pem"};
 
 // Single thread in case the events needs to be processed in order.
 constexpr auto SINGLE_ORDERED_DISPATCHING = 1;

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -30,7 +30,6 @@ constexpr auto PASSWORD_KEY {"password"};
 constexpr auto ELEMENTS_PER_BULK {1000};
 constexpr auto WAZUH_OWNER {"wazuh"};
 constexpr auto WAZUH_GROUP {"wazuh"};
-constexpr auto MERGED_CA_PATH {"/var/lib/wazuh-server/tmp/root-ca-merged.pem"};
 
 // Single thread in case the events needs to be processed in order.
 constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
@@ -42,7 +41,7 @@ constexpr auto SINGLE_ORDERED_DISPATCHING = 1;
  * @throws std::runtime_error If the CA root certificate file does not exist, could not be opened, written or the
  * ownership could not be changed.
  */
-static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, std::string& caRootCertificate)
+static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, const std::string& caRootCertificate)
 {
     std::string caRootCertificateContentMerged;
 
@@ -61,8 +60,6 @@ static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, s
 
         caRootCertificateContentMerged.append((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     }
-
-    caRootCertificate = MERGED_CA_PATH;
 
     if (std::filesystem::path dirPath = std::filesystem::path(caRootCertificate).parent_path();
         !std::filesystem::exists(dirPath) && !std::filesystem::create_directories(dirPath))
@@ -97,7 +94,7 @@ static void mergeCaRootCertificates(const std::vector<std::string>& filePaths, s
 
 static void initConfiguration(SecureCommunication& secureCommunication, const IndexerConnectorOptions& config)
 {
-    std::string caRootCertificate;
+    std::string caRootCertificate = config.sslOptions.merged_ca_path;
     std::string sslCertificate;
     std::string sslKey;
     std::string username;

--- a/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
+++ b/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
@@ -207,7 +207,7 @@ extern "C" struct group* __wrap_getgrnam(const char* name)
 extern "C" int __wrap_chown(const char* path, uid_t owner, gid_t group)
 {
     // Simulate a successful chown operation for the "/tmp/success" file
-    if (strcmp(path, "/tmp/wazuh-server/root-ca-merged.pem") == 0)
+    if (strcmp(path, "/var/lib/wazuh-server/tmp/root-ca-merged.pem") == 0)
     {
         return 0; // Return success
     }
@@ -265,7 +265,7 @@ TEST_F(IndexerConnectorTest, ConnectionWithCertsArray)
     // Setup for the test
     const std::string certFileOne = "./root-ca-one.pem";
     const std::string certFileTwo = "./root-ca-two.pem";
-    const std::string mergedCertFile = "/tmp/wazuh-server/root-ca-merged.pem";
+    const std::string mergedCertFile = "/var/lib/wazuh-server/tmp/root-ca-merged.pem";
 
     // Create the first certificate file
     std::ofstream outputFile(certFileOne);

--- a/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
+++ b/src/engine/source/indexerconnector/test/component/indexerConnector_test.cpp
@@ -284,7 +284,7 @@ TEST_F(IndexerConnectorTest, ConnectionWithCertsArray)
                                            .sslOptions = {.cacert = {certFileOne, certFileTwo},
                                                           .cert = "/etc/filebeat/certs/filebeat.pem",
                                                           .key = "/etc/filebeat/certs/filebeat-key.pem",
-                                                          .merged_ca_path = MERGED_CA_PATH},
+                                                          .mergedCAPath = MERGED_CA_PATH},
                                            .timeout = INDEXER_TIMEOUT};
 
     // Attempt to create the connector and expect no exceptions for valid certificates

--- a/src/engine/source/indexerconnector/tool/main.cpp
+++ b/src/engine/source/indexerconnector/tool/main.cpp
@@ -7,6 +7,7 @@
 
 static std::random_device RD;
 static std::mt19937 ENG(RD());
+const std::string MERGED_CA_DEFAULT_PATH = "/var/lib/wazuh-server/tmp/root-ca-merged.pem";
 
 std::string generateRandomString(size_t length)
 {
@@ -119,6 +120,16 @@ void fillConfiguration(IndexerConnectorOptions& indexerConnectorOptions, const n
         {
             indexerConnectorOptions.sslOptions.key = config.at("ssl").at("key").get_ref<const std::string&>();
         }
+
+        if (config.at("ssl").contains("merged_ca_path"))
+        {
+            indexerConnectorOptions.sslOptions.merged_ca_path =
+                config.at("ssl").at("merged_ca_path").get_ref<const std::string&>();
+        }
+        else
+        {
+            indexerConnectorOptions.sslOptions.merged_ca_path = MERGED_CA_DEFAULT_PATH;
+        }
     }
 
     if (config.contains("username"))
@@ -139,7 +150,6 @@ int main(const int argc, const char* argv[])
 
         CmdLineArgs cmdArgParser(argc, argv);
         logging::start({cmdArgParser.getLogFilePath(), logging::Level::Debug});
-
         // Read configuration file.
         std::ifstream configurationFile(cmdArgParser.getConfigurationFilePath());
         if (!configurationFile.is_open())
@@ -153,7 +163,6 @@ int main(const int argc, const char* argv[])
 
         // Create indexer connector.
         IndexerConnector indexerConnector(indexerConnectorOptions);
-
         // Read events file.
         // If the events file path is empty, then the events are generated
         // automatically.

--- a/src/engine/source/indexerconnector/tool/main.cpp
+++ b/src/engine/source/indexerconnector/tool/main.cpp
@@ -123,12 +123,12 @@ void fillConfiguration(IndexerConnectorOptions& indexerConnectorOptions, const n
 
         if (config.at("ssl").contains("merged_ca_path"))
         {
-            indexerConnectorOptions.sslOptions.merged_ca_path =
+            indexerConnectorOptions.sslOptions.mergedCAPath =
                 config.at("ssl").at("merged_ca_path").get_ref<const std::string&>();
         }
         else
         {
-            indexerConnectorOptions.sslOptions.merged_ca_path = MERGED_CA_DEFAULT_PATH;
+            indexerConnectorOptions.sslOptions.mergedCAPath = MERGED_CA_DEFAULT_PATH;
         }
     }
 

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -299,6 +299,7 @@ int main(int argc, char* argv[])
                 icConfig.sslOptions.cert = confManager.get<std::string>(conf::key::INDEXER_SSL_CERTIFICATE);
                 icConfig.sslOptions.key = confManager.get<std::string>(conf::key::INDEXER_SSL_KEY);
                 icConfig.sslOptions.skipVerifyPeer = !confManager.get<bool>(conf::key::INDEXER_SSL_VERIFY_CERTS);
+                icConfig.sslOptions.key = confManager.get<std::string>(conf::key::MERGED_CA_PATH);
             }
             else
             {

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -81,13 +81,13 @@ InstallServer()
 checkDownloadContent()
 {
     VD_FILENAME='vd_1.0.0_vd_4.10.0.tar.xz'
-    VD_FULL_PATH=${INSTALLDIR}var/lib/wazuh-server/tmp/${VD_FILENAME}
+    VD_BASE_PATH=${INSTALLDIR}var/lib/wazuh-server/tmp/
+    VD_FULL_PATH=${VD_BASE_PATH}${VD_FILENAME}
 
     if [ "X${DOWNLOAD_CONTENT}" = "Xy" ]; then
         echo "Download ${VD_FILENAME} file"
-        mkdir -p ${INSTALLDIR}var/lib/wazuh-server/tmp/
+        mkdir -p ${VD_BASE_PATH}
         wget -O ${VD_FULL_PATH} http://packages.wazuh.com/deps/vulnerability_model_database/${VD_FILENAME}
-
         chmod 640 ${VD_FULL_PATH}
         chown ${WAZUH_USER}:${WAZUH_GROUP} ${VD_FULL_PATH}
     fi

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -81,13 +81,13 @@ InstallServer()
 checkDownloadContent()
 {
     VD_FILENAME='vd_1.0.0_vd_4.10.0.tar.xz'
-    VD_BASE_PATH=${INSTALLDIR}var/lib/wazuh-server/tmp/
-    VD_FULL_PATH=${VD_BASE_PATH}${VD_FILENAME}
+    VD_FULL_PATH=${INSTALLDIR}var/lib/wazuh-server/tmp/${VD_FILENAME}
 
     if [ "X${DOWNLOAD_CONTENT}" = "Xy" ]; then
         echo "Download ${VD_FILENAME} file"
-        mkdir -p ${VD_BASE_PATH}
+        mkdir -p ${INSTALLDIR}var/lib/wazuh-server/tmp/
         wget -O ${VD_FULL_PATH} http://packages.wazuh.com/deps/vulnerability_model_database/${VD_FILENAME}
+
         chmod 640 ${VD_FULL_PATH}
         chown ${WAZUH_USER}:${WAZUH_GROUP} ${VD_FULL_PATH}
     fi
@@ -160,6 +160,7 @@ installEngineStore()
     fi
 
     echo "Engine store installed successfully."
+
 }
 
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -160,7 +160,6 @@ installEngineStore()
     fi
 
     echo "Engine store installed successfully."
-
 }
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#27229|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Changed vd compressed database path to `/var/lib/wazuh-server/tmp`

## DoD

<details><summary>Outdated</summary>

### Using test tool 
![image](https://github.com/user-attachments/assets/686da331-dd7a-422d-893c-c02f20be9796)
![image](https://github.com/user-attachments/assets/909149f2-d129-404e-a83a-ebe7d7c45b48)
![image](https://github.com/user-attachments/assets/a97f909d-3554-4d85-ae9e-319df6dbaa7f)
### Packages
- deb
https://github.com/wazuh/wazuh/actions/runs/12263277598
![image](https://github.com/user-attachments/assets/3bce8cb6-c319-4c4a-9e62-e4c757050ecf)

- rpm
https://github.com/wazuh/wazuh/actions/runs/12263274247
![image](https://github.com/user-attachments/assets/bfa23700-81fc-4614-a689-7710ca01dd6d)

</details>

### Using test tool 
```console
root@jammy:/home/vagrant/wazuh-5.0.0# bash test_decompression.sh
+ mkdir -p /var/lib/wazuh-server/tmp
+ cp ../updated_db/vd_1.0.0_vd_4.10.0.tar.xz /var/lib/wazuh-server/tmp
+ ls /var/lib/wazuh-server/tmp/
vd_1.0.0_vd_4.10.0.tar.xz
+ rm -rf test.log
+ src/engine/build/source/vdscanner/tools/scanner/vdscanner_tool -s test.sock -l test.log
```
![image](https://github.com/user-attachments/assets/7a0bf469-eb6f-4daa-a4b0-e4c19cf7a230)
![image](https://github.com/user-attachments/assets/d3e865d7-c11b-4001-8bea-d45cb9a79792)
### Packages 
- DEB
https://github.com/wazuh/wazuh/actions/runs/12361294649
![image](https://github.com/user-attachments/assets/1ccb86f8-4616-4921-8ddc-fb0705b9381c)

- RPM
https://github.com/wazuh/wazuh/actions/runs/12361295437
![image](https://github.com/user-attachments/assets/53ed4160-0052-48e5-9865-a9cf74824e51)

> [!NOTE]
> Some warnings that should be related to this https://github.com/wazuh/wazuh/commit/f8451c2673f4679a302a5c8208fe073a4fc95a18

## Update  01/06/25

```console
root@jammy:/home/vagrant/wazuh-5.0.0/src/engine/build/source/indexerconnector/test# ctest
Test project /home/vagrant/wazuh-5.0.0/src/engine/build/source/indexerconnector/test
      Start  1: MonitoringTest.TestCheckIfAnUnregisteredServerIsAvailable
 1/25 Test  #1: MonitoringTest.TestCheckIfAnUnregisteredServerIsAvailable .......   Passed    0.01 sec
      Start  2: MonitoringTest.TestInstantiationWithGreenRedServers
 2/25 Test  #2: MonitoringTest.TestInstantiationWithGreenRedServers .............   Passed    0.01 sec
      Start  3: MonitoringTest.TestInstantiationWithoutServers
 3/25 Test  #3: MonitoringTest.TestInstantiationWithoutServers ..................   Passed    0.00 sec
      Start  4: ServerSelectorTest.TestInstantiation
 4/25 Test  #4: ServerSelectorTest.TestInstantiation ............................   Passed    0.00 sec
      Start  5: ServerSelectorTest.TestInstantiationWithoutServers
 5/25 Test  #5: ServerSelectorTest.TestInstantiationWithoutServers ..............   Passed    0.00 sec
      Start  6: ServerSelectorTest.TestGetNextBeforeHealthCheck
 6/25 Test  #6: ServerSelectorTest.TestGetNextBeforeHealthCheck .................   Passed    0.00 sec
      Start  7: ServerSelectorTest.TestGetNextBeforeAndAfterHealthCheck
 7/25 Test  #7: ServerSelectorTest.TestGetNextBeforeAndAfterHealthCheck .........   Passed    0.01 sec
      Start  8: ServerSelectorTest.TestGextNextWhenThereAreNoAvailableServers
 8/25 Test  #8: ServerSelectorTest.TestGextNextWhenThereAreNoAvailableServers ...   Passed    0.01 sec
      Start  9: IndexerConnectorTest.ConnectionWithUserAndPassword
 9/25 Test  #9: IndexerConnectorTest.ConnectionWithUserAndPassword ..............   Passed    0.02 sec
      Start 10: IndexerConnectorTest.ConnectionWithSslCredentials
10/25 Test #10: IndexerConnectorTest.ConnectionWithSslCredentials ...............   Passed    0.02 sec
      Start 11: IndexerConnectorTest.ConnectionWithCertsArray
11/25 Test #11: IndexerConnectorTest.ConnectionWithCertsArray ...................   Passed    0.02 sec
      Start 12: IndexerConnectorTest.ConnectionWithCertsArrayNoFiles
12/25 Test #12: IndexerConnectorTest.ConnectionWithCertsArrayNoFiles ............   Passed    0.01 sec
      Start 13: IndexerConnectorTest.ConnectionUnavailableServer
13/25 Test #13: IndexerConnectorTest.ConnectionUnavailableServer ................   Passed    2.13 sec
      Start 14: IndexerConnectorTest.ConnectionMultipleServers
14/25 Test #14: IndexerConnectorTest.ConnectionMultipleServers ..................   Passed    0.03 sec
      Start 15: IndexerConnectorTest.ConnectionInvalidServer
15/25 Test #15: IndexerConnectorTest.ConnectionInvalidServer ....................   Passed    2.22 sec
      Start 16: IndexerConnectorTest.Publish
16/25 Test #16: IndexerConnectorTest.Publish ....................................   Passed    5.99 sec
      Start 17: IndexerConnectorTest.PublishDeleted
17/25 Test #17: IndexerConnectorTest.PublishDeleted .............................   Passed    5.11 sec
      Start 18: IndexerConnectorTest.PublishWithoutId
18/25 Test #18: IndexerConnectorTest.PublishWithoutId ...........................   Passed    5.32 sec
      Start 19: IndexerConnectorTest.PublishUnavailableServer
19/25 Test #19: IndexerConnectorTest.PublishUnavailableServer ...................   Passed    8.60 sec
      Start 20: IndexerConnectorTest.PublishInvalidData
20/25 Test #20: IndexerConnectorTest.PublishInvalidData .........................   Passed    7.69 sec
      Start 21: IndexerConnectorTest.DiscardInvalidJSON
21/25 Test #21: IndexerConnectorTest.DiscardInvalidJSON .........................   Passed   10.26 sec
      Start 22: IndexerConnectorTest.PublishTwoIndexes
22/25 Test #22: IndexerConnectorTest.PublishTwoIndexes ..........................   Passed   10.06 sec
      Start 23: IndexerConnectorTest.PublishErrorFromServer
23/25 Test #23: IndexerConnectorTest.PublishErrorFromServer .....................   Passed    5.03 sec
      Start 24: IndexerConnectorTest.UpperCaseCharactersIndexName
24/25 Test #24: IndexerConnectorTest.UpperCaseCharactersIndexName ...............   Passed    0.01 sec
      Start 25: IndexerConnectorTest.PublishDatePlaceholder
25/25 Test #25: IndexerConnectorTest.PublishDatePlaceholder .....................   Passed    5.20 sec

100% tests passed, 0 tests failed out of 25

Total Test time (real) =  67.79 sec
```

Failing tests are not related to this implementation 

![image](https://github.com/user-attachments/assets/e5955612-9d73-4c2a-a58f-55417494ade6)
![image](https://github.com/user-attachments/assets/f887ea44-2458-42ac-9df1-2abe4bc48733)

### Test tool indexer connector
![image](https://github.com/user-attachments/assets/43cb40d0-7164-41e8-99ad-d702acf8ef47)

- config.json 
```json
{
  "name": "wazuh-states-vulnerabilities-cluster",
  "enabled": "yes",
  "hosts": ["http://0.0.0.0:9200"],
  "ssl": {
    "certificate_authorities": [
      "/home/vagrant/INDEXER/root-ca.pem",
      "/home/vagrant/INDEXER/admin.pem"
    ],
    "merged_ca_path": "./merged_ca.pem"
  }
}
```

- config2.json 
```json
{
  "name": "wazuh-states-vulnerabilities-cluster",
  "enabled": "yes",
  "hosts": ["http://0.0.0.0:9200"],
  "ssl": {
    "certificate_authorities": [
      "/home/vagrant/INDEXER/root-ca.pem"
    ],
    "merged_ca_path": "./merged_ca.pem"
  }
}
```

- config3.json 
```json
{
  "name": "wazuh-states-vulnerabilities-cluster",
  "enabled": "yes",
  "hosts": ["http://0.0.0.0:9200"],
  "ssl": {
    "certificate_authorities": [
      "/home/vagrant/INDEXER/root-ca.pem",
      "/home/vagrant/INDEXER/admin.pem"
    ]
  }
}
```

![image](https://github.com/user-attachments/assets/ea0999c0-d721-4389-9aeb-39f425bbfdb6)
![image](https://github.com/user-attachments/assets/d51169fd-544d-4736-93a6-383b06065638)

