### PR TITLE
Delete daemon flag from server binaries

### DIFF
--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -289,7 +289,6 @@ def get_script_arguments() -> Namespace:
         Arguments passed to the script.
     """
     parser = ArgumentParser()
-    parser.add_argument('-d', '--daemon', action='store_true', dest='daemon', help='Run as a daemon')
     parser.add_argument('-r', '--root', action='store_true', dest='root', help='Run as root')
     parser.add_argument('-v', '--version', action='store_true', dest='version', help='Print version')
     return parser.parse_args()
@@ -334,14 +333,9 @@ if __name__ == '__main__':
     # Check for unused PID files
     utils.clean_pid_files(API_MAIN_PROCESS)
 
-    # Foreground/Daemon
-    if args.daemon:
-        pyDaemonModule.pyDaemon()
-    else:
-        logger.info('Starting API in foreground')
-
     # Drop privileges to wazuh
     if not args.root:
+        logger.info('Starting API')
         if management_config.drop_privileges:
             os.setgid(common.wazuh_gid())
             os.setuid(common.wazuh_uid())

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -40,16 +40,10 @@ def test_print_version(print_mock):
             'Free Software Foundation. For more details, go to \nhttps://www.gnu.org/licenses/gpl.html\n')
 
 
-@pytest.mark.parametrize("daemon, root", [
-    (True, True),
-    (True, False),
-    (False, True),
-    (False, False),
-])
+@pytest.mark.parametrize("root", [True, False])
 @patch('subprocess.Popen')
-def test_start_daemons(mock_popen, daemon, root):
+def test_start_daemons(mock_popen, root):
     """Validate that `start_daemons` works as expected."""
-    from wazuh.core import pyDaemonModule
 
     class LoggerMock:
         def __init__(self):
@@ -70,23 +64,20 @@ def test_start_daemons(mock_popen, daemon, root):
     with patch.object(wazuh_server, 'main_logger') as main_logger_mock, \
         patch.object(wazuh_server.pyDaemonModule, 'get_parent_pid', return_value=pid), \
         patch.object(wazuh_server.pyDaemonModule, 'create_pid'):
-        wazuh_server.start_daemons(daemon, root)
+        wazuh_server.start_daemons(root)
 
     mock_popen.assert_has_calls([
         call([wazuh_server.ENGINE_BINARY_PATH, 'server', '-l', 'info','start']),
         call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.MANAGEMENT_API_SCRIPT_PATH] + \
-              (['-r'] if root else []) + (['-d'] if daemon else [])),
+              (['-r'] if root else [])),
         call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.COMMS_API_SCRIPT_PATH] + \
-              (['-r'] if root else []) + (['-d'] if daemon else [])),
+              (['-r'] if root else [])),
     ], any_order=True)
-
-    if daemon:
-        pid = mock_popen().pid
 
     main_logger_mock.info.assert_has_calls([
         call('Starting wazuh-engined'),
-        call('Starting wazuh-apid'),
         call('Starting wazuh-comms-apid'),
+        call('Starting wazuh-apid'),
     ])
 
 
@@ -109,7 +100,7 @@ def test_start_daemons_ko(mock_popen):
 
     with patch.object(wazuh_server, 'main_logger') as main_logger_mock, \
         patch.object(wazuh_server.pyDaemonModule, 'get_parent_pid', return_value=pid):
-        wazuh_server.start_daemons(False, False)
+        wazuh_server.start_daemons(False)
 
     mock_popen.assert_has_calls([
         call([wazuh_server.ENGINE_BINARY_PATH, 'server', '-l', 'info', 'start']),
@@ -420,7 +411,6 @@ def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock
                 patch('scripts.wazuh_server.start_daemons') as start_daemons_mock, \
                 patch.object(wazuh_server.pyDaemonModule, 'get_parent_pid', return_value=999), \
                 patch('os.kill') as os_kill_mock, \
-                patch.object(wazuh_server.pyDaemonModule, 'pyDaemon') as pyDaemon_mock, \
                 patch.object(wazuh_server.pyDaemonModule, 'create_pid') as create_pid_mock, \
                 patch.object(wazuh_server.pyDaemonModule, 'delete_child_pids'), \
                 patch.object(wazuh_server.pyDaemonModule,'delete_pid') as delete_pid_mock:
@@ -430,7 +420,6 @@ def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock
                 main_logger_mock.reset_mock()
                 clean_up_mock.assert_called_once()
                 clean_pid_files_mock.assert_called_once_with('wazuh-server')
-                pyDaemon_mock.assert_called_once()
                 setuid_mock.assert_called_once_with('uid_test')
                 setgid_mock.assert_called_once_with('gid_test')
                 getpid_mock.assert_called()

--- a/framework/wazuh/core/pyDaemonModule.py
+++ b/framework/wazuh/core/pyDaemonModule.py
@@ -6,55 +6,11 @@ import logging
 import psutil
 import os
 import re
-import sys
 from os import path
 from pathlib import Path
 
 from wazuh.core import common
 from wazuh.core.exception import WazuhInternalError
-
-
-def pyDaemon():
-    """
-    Do the UNIX double-fork magic, see Stevens' "Advanced
-    Programming in the UNIX Environment" for details (ISBN 0201563177)
-    http://www.erlenstar.demon.co.uk/unix/faq_2.html#SEC16
-    """
-    try:
-        pid = os.fork()
-        if pid > 0:
-            # Exit first parent
-            sys.exit(0)
-    except OSError as e:
-        sys.stderr.write(
-            "fork #1 failed: %d (%s)\n" % (e.errno, e.strerror))
-        sys.exit(1)
-
-    os.setsid()
-
-    # Do second fork
-    try:
-        pid = os.fork()
-        if pid > 0:
-            # Exit from second parent
-            sys.exit(0)
-    except OSError as e:
-        sys.stderr.write(
-            "fork #2 failed: %d (%s)\n" % (e.errno, e.strerror))
-        sys.exit(1)
-
-    # Redirect standard file descriptors
-    sys.stdout.flush()
-    sys.stderr.flush()
-    si = open('/dev/null', 'r')
-    so = open('/dev/null', 'a+')
-    se = open('/dev/null', 'ab+', 0)
-    os.dup2(si.fileno(), sys.stdin.fileno())
-    os.dup2(so.fileno(), sys.stdout.fileno())
-    os.dup2(se.fileno(), sys.stderr.fileno())
-
-    # Decouple from parent environment
-    os.chdir('/')
 
 
 def create_pid(name: str, pid: int):

--- a/framework/wazuh/core/tests/test_pyDaemonModule.py
+++ b/framework/wazuh/core/tests/test_pyDaemonModule.py
@@ -11,30 +11,6 @@ from wazuh.core.exception import WazuhException
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 
-@pytest.mark.parametrize('effect', [
-   None,
-   OSError(10000, 'Error')
-])
-@patch('wazuh.core.pyDaemonModule.sys.exit')
-@patch('wazuh.core.pyDaemonModule.os.setsid')
-@patch('wazuh.core.pyDaemonModule.sys.stderr.write')
-@patch('wazuh.core.pyDaemonModule.sys.stdin.fileno')
-@patch('wazuh.core.pyDaemonModule.os.dup2')
-@patch('wazuh.core.pyDaemonModule.os.chdir')
-def test_pyDaemon(mock_chdir, mock_dup, mock_fileno, mock_write, mock_setsid, mock_exit, effect):
-    """Tests pyDaemon function works"""
-
-    with patch('wazuh.core.pyDaemonModule.os.fork', return_value=255, side_effect=effect):
-        pyDaemon()
-
-    if effect == None:
-        mock_exit.assert_called_with(0)
-    else:
-        mock_exit.assert_called_with(1)
-    mock_setsid.assert_called_once_with()
-    mock_chdir.assert_called_once_with('/')
-
-
 @patch('wazuh.core.pyDaemonModule.common.WAZUH_RUN', new=Path('/tmp'))
 def test_create_pid():
     """Tests create_pid function works"""


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27247 |

## Description

Removes the `-d/--daemon` flag from the server, management API and comms API binaries.

## Tests

<details><summary>Server start</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ docker logs -f wazuh-manager
2024/12/10 19:13:35 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2024/12/10 19:13:35 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
2024/12/10 19:13:35 INFO: [Cluster] [Main] Starting server (pid: 14)
2024/12/10 19:13:35 INFO: [Cluster] [Main] Generating JWT signing key pair
2024/12/10 19:13:36 INFO: [Master] [Main] Configuration server is not available, retrying...
2024/12/10 19:13:36 INFO: [Master] [Config Server] Started server process [14]
2024/12/10 19:13:36 INFO: [Master] [Config Server] Waiting for application startup.
2024/12/10 19:13:36 INFO: [Master] [Config Server] Application startup complete.
2024/12/10 19:13:36 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2024/12/10 19:13:37 INFO: [Local Server] [Main] Starting wazuh-engined
2024-12-10 19:13:37.129 20:20 info: Logging initialized.
2024/12/10 19:13:37 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2024-12-10 19:13:37.164 20:20 info: Store initialized.
2024-12-10 19:13:37.165 20:20 info: RBAC initialized.
2024-12-10 19:13:37.168 20:20 info: MetricsManager: Created new scope: (KVDB)
2024-12-10 19:13:37.372 20:20 info: KVDB initialized.
2024-12-10 19:13:37.372 20:20 info: Geo initialized.
2024-12-10 19:13:37.389 20:20 info: Schema initialized.
2024-12-10 19:13:37.403 20:20 info: Loaded timezone database version: '2024a'
2024-12-10 19:13:37.407 20:20 info: HLP initialized.
2024-12-10 19:13:37.453 20:20 info: Indexer Connector initialized.
2024-12-10 19:13:37.459 20:20 info: Builder initialized.
2024-12-10 19:13:37.459 20:20 info: Catalog initialized.
2024-12-10 19:13:37.459 20:20 info: Policy manager initialized.
2024-12-10 19:13:37.459 20:20 info: MetricsManager: Created new scope: (EventQueue)
2024-12-10 19:13:37.459 20:20 info: MetricsManager: Created new scope: (EventQueueDelta)
2024-12-10 19:13:37.460 20:20 info: No flooding file provided, the queue will not be flooded.
2024-12-10 19:13:37.460 20:20 info: MetricsManager: Created new scope: (TestQueue)
2024-12-10 19:13:37.460 20:20 info: MetricsManager: Created new scope: (TestQueueDelta)
2024-12-10 19:13:37.467 20:20 info: No flooding file provided, the queue will not be flooded.
2024-12-10 19:13:37.468 20:20 warning: Router: router/tester/0 table is empty
2024-12-10 19:13:37.601 20:20 info: Router initialized.
2024-12-10 19:13:37.648 20:20 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2024-12-10 19:13:37.649 20:20 info: MetricsManager: Created new scope: (endpointAPI)
2024-12-10 19:13:37.649 20:20 info: MetricsManager: Created new scope: (endpointAPIRate)
2024-12-10 19:13:37.649 20:20 info: MetricsManager: Created new scope: (endpointEvent)
2024-12-10 19:13:37.649 20:20 info: MetricsManager: Created new scope: (endpointEventRate)
2024-12-10 19:13:37.651 20:20 info: Starting the server...
2024/12/10 19:13:39 INFO: [Local Server] [Main] Started wazuh-engined (pid: 20)
2024/12/10 19:13:39 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2024/12/10 19:13:40 INFO: [Communications API] Starting API as root
2024/12/10 19:13:40 INFO: [Communications API] Listening on 0.0.0.0:27000
2024/12/10 19:13:40 INFO: [Communications API] Generated private key file in /etc/wazuh-server/api/configuration/ssl/server.key
2024/12/10 19:13:40 INFO: [Communications API] Generated certificate file in /etc/wazuh-server/api/configuration/ssl/server.crt
2024/12/10 19:13:40 INFO: [Communications API] Starting gunicorn 22.0.0
2024/12/10 19:13:40 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (476)
2024/12/10 19:13:40 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2024/12/10 19:13:40 INFO: [Communications API] Booting worker with pid: 522
2024/12/10 19:13:40 INFO: [Communications API] Started server process [522]
2024/12/10 19:13:40 INFO: [Communications API] Waiting for application startup.
2024/12/10 19:13:40 INFO: [Communications API] Application startup complete.
2024/12/10 19:13:40 INFO: [Communications API] Booting worker with pid: 527
2024/12/10 19:13:40 INFO: [Communications API] Started server process [527]
2024/12/10 19:13:40 INFO: [Communications API] Waiting for application startup.
2024/12/10 19:13:40 INFO: [Communications API] Application startup complete.
2024/12/10 19:13:40 INFO: [Communications API] Booting worker with pid: 528
2024/12/10 19:13:40 INFO: [Communications API] Started server process [528]
2024/12/10 19:13:40 INFO: [Communications API] Waiting for application startup.
2024/12/10 19:13:40 INFO: [Communications API] Application startup complete.
2024/12/10 19:13:40 INFO: [Communications API] Booting worker with pid: 529
2024/12/10 19:13:40 INFO: [Communications API] Started server process [529]
2024/12/10 19:13:40 INFO: [Communications API] Waiting for application startup.
2024/12/10 19:13:40 INFO: [Communications API] Application startup complete.
2024/12/10 19:13:41 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 476)
2024/12/10 19:13:41 INFO: [Local Server] [Main] Starting wazuh-apid
2024/12/10 19:13:41 INFO: [Management API] Starting API as root
2024/12/10 19:13:41 INFO: [Management API] Checking RBAC database integrity...
2024/12/10 19:13:41 INFO: [Management API] RBAC database not found. Initializing
2024/12/10 19:13:43 INFO: [Local Server] [Main] Started wazuh-apid (pid: 534)
2024/12/10 19:13:43 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2024/12/10 19:13:43 DEBUG: [Local Server] [Keep alive] Calculating.
2024/12/10 19:13:43 DEBUG: [Local Server] [Keep alive] Calculated.
2024/12/10 19:13:43 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2024/12/10 19:13:43 DEBUG: [Master] [Keep alive] Calculating.
2024/12/10 19:13:43 DEBUG: [Master] [Keep alive] Calculated.
2024/12/10 19:13:43 INFO: [Master] [Local integrity] Starting.
2024/12/10 19:13:43 INFO: [Worker] [Main] Connection from ('172.18.0.5', 57320)
2024/12/10 19:13:43 DEBUG: [Worker] [Main] Command received: b'hello'
2024/12/10 19:13:43 INFO: [Worker] [Main] Connection from ('172.18.0.4', 44256)
2024/12/10 19:13:43 DEBUG: [Worker] [Main] Command received: b'hello'
2024/12/10 19:13:43 INFO: [Master] [Local integrity] Finished in 0.018s. Calculated metadata of 2 files.
2024/12/10 19:13:43 INFO: [Management API] /var/lib/wazuh-server/rbac.db database created successfully
2024/12/10 19:13:43 INFO: [Management API] RBAC database integrity check finished successfully
2024/12/10 19:13:44 INFO: [Management API] Listening on ['0.0.0.0', '::']:55000.
2024/12/10 19:13:44 INFO: [Management API] Populating installation UID...
2024/12/10 19:13:44 INFO: [Management API] Getting updates information...
2024/12/10 19:13:44 INFO: [Management API] None 172.18.0.7 "HEAD /" with parameters {} and body {} done in 0.001s: 401
```

</details>

<details><summary>Binaries help</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/5.0$ docker exec -it wazuh-manager bash
root@wazuh-manager:/# /usr/share/wazuh-server/bin/wazuh-server --help
usage: wazuh_server.py [-h] [-v] {start,stop,status} ...

options:
  -h, --help           show this help message and exit
  -v, --version        Print version

subcommands:
  {start,stop,status}  Management operations
    start              Start Wazuh server
    stop               Stop Wazuh server
    status             Show the Wazuh server status
root@wazuh-manager:/# /usr/share/wazuh-server/bin/wazuh-apid --help
usage: wazuh_apid.py [-h] [-r] [-v]

options:
  -h, --help     show this help message and exit
  -r, --root     Run as root
  -v, --version  Print version
root@wazuh-manager:/# /usr/share/wazuh-server/bin/wazuh-comms-apid --help
usage: wazuh_comms_apid.py [-h] [-r] [-v]

options:
  -h, --help     show this help message and exit
  -r, --root     Run as root
  -v, --version  Print version
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/scripts/tests/test_wazuh_server.py::test_start_daemons
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 2 items                                                                                                                                                                                                                            

framework/scripts/tests/test_wazuh_server.py ..                                                                                                                                                                                        [100%]

============================================================================================================= 2 passed in 0.56s ==============================================================================================================
```

</details>