### PR TITLE
Added certificate verification for wazuh-engine indexer connector

### DIFF
--- a/.github/workflows/engine_coverage.yml
+++ b/.github/workflows/engine_coverage.yml
@@ -19,7 +19,7 @@ on:
         type: string
         description: 'Modules to exclude, separated by commas'
         required: false
-        default: "feedmanager,proto"
+        default: "feedmanager,proto,wazuh-http-request"
       min_coverage:
         type: number
         description: 'Minimum coverage required'
@@ -40,7 +40,7 @@ env:
   BUILD_PATH: src/engine/build
   BUILD_MODULES_PATH: src/engine/build/source
   FULL_COVERAGE: ${{ inputs.full_coverage }}
-  EXCLUDE_MODULES: ${{ inputs.exlude_modules || 'feedmanager,proto' }}
+  EXCLUDE_MODULES: ${{ inputs.exlude_modules || 'feedmanager,proto,wazuh-http-request' }}
   MIN_COVERAGE: ${{ inputs.min_coverage || 80 }}
 
 jobs:

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -56,7 +56,7 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
     addUnit<std::string>(key::INDEXER_SSL_CERTIFICATE, "WAZUH_INDEXER_SSL_CERTIFICATE", "");
     addUnit<std::string>(key::INDEXER_SSL_KEY, "WAZUH_INDEXER_SSL_KEY", "");
     addUnit<bool>(key::INDEXER_SSL_USE_SSL, "WAZUH_INDEXER_SSL_USE_SSL", false);
-    addUnit<bool>(key::INDEXER_SSL_VERIFY_CERTS, "WAZUH_INDEXER_SSL_VERIFY_CERTS", false);
+    addUnit<bool>(key::INDEXER_SSL_VERIFY_CERTS, "WAZUH_INDEXER_SSL_VERIFY_CERTS", true);
     addUnit<int>(key::INDEXER_TIMEOUT, "WAZUH_INDEXER_TIMEOUT", 60000);
     addUnit<int>(key::INDEXER_THREADS, "WAZUH_INDEXER_THREADS", 1);
     addUnit<std::string>(key::INDEXER_DB_PATH, "WAZUH_INDEXER_DB_PATH", "/var/lib/wazuh-server/indexer-connector/");

--- a/src/engine/source/geo/src/downloader.cpp
+++ b/src/engine/source/geo/src/downloader.cpp
@@ -28,6 +28,7 @@ bool isMD5Hash(const std::string& str)
 namespace geo
 {
 // Function to download content of the URL into a std::string in memory
+// TODO: Should use http-request library instead of libcurl
 base::RespOrError<std::string> Downloader::downloadHTTPS(const std::string& url) const
 {
     CURL* curl;

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -44,6 +44,7 @@ struct IndexerConnectorOptions
         std::vector<std::string> cacert; ///< The list of CA certificates to trust.
         std::string cert;                ///< The certificate to connect to OpenSearch.
         std::string key;                 ///< The key to connect to OpenSearch.
+        bool skipVerifyPeer;             ///< Skip peer verification. (insecure mode)
     } sslOptions;                        ///< The SSL options to connect to OpenSearch.
 
     uint32_t timeout = 60000u;  ///< The timeout in milliseconds to connect to OpenSearch.

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -136,7 +136,8 @@ static void initConfiguration(SecureCommunication& secureCommunication, const In
     secureCommunication.basicAuth(username + ":" + password)
         .sslCertificate(sslCertificate)
         .sslKey(sslKey)
-        .caRootCertificate(caRootCertificate);
+        .caRootCertificate(caRootCertificate)
+        .skipPeerVerification(config.sslOptions.skipVerifyPeer);
 }
 
 static void builderBulkDelete(std::string& bulkData, std::string_view id, std::string_view index)

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -242,6 +242,21 @@ int main(int argc, char* argv[])
                 icConfig.sslOptions.cacert = confManager.get<std::vector<std::string>>(conf::key::INDEXER_SSL_CA_LIST);
                 icConfig.sslOptions.cert = confManager.get<std::string>(conf::key::INDEXER_SSL_CERTIFICATE);
                 icConfig.sslOptions.key = confManager.get<std::string>(conf::key::INDEXER_SSL_KEY);
+                icConfig.sslOptions.skipVerifyPeer = !confManager.get<bool>(conf::key::INDEXER_SSL_VERIFY_CERTS);
+            }
+            else
+            {
+                // If not use SSL, check if url start with https
+                for (const auto& host : icConfig.hosts)
+                {
+                    if (base::utils::string::startsWith(host, "https://"))
+                    {
+                        throw std::runtime_error(fmt::format(
+                            "The host '{}' for indexer connector is using HTTPS but the SSL options are not "
+                            "enabled.",
+                            host));
+                    }
+                }
             }
 
             icConfig.databasePath = confManager.get<std::string>(conf::key::INDEXER_DB_PATH);


### PR DESCRIPTION
Closes  #27174 

Add the option to verify the certificate in the indexer connector. Also set the global default setting to verify. 