### PR TITLE
Fix empty commands creation

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -146,17 +146,18 @@ async def restart_agents(agent_list: list) -> AffectedItemsWazuhResult:
                 result.add_failed_item(not_found_id, error=WazuhResourceNotFound(1701))
                 agent_list.remove(not_found_id)
 
-        commands = []
-        for agent_id in agent_list:
-            command = create_restart_command(agent_id=agent_id)
-            commands.append(command)
-
-        response = await indexer_client.commands_manager.create(commands)
-        if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
-            result.affected_items.extend(agent_list)
-        else:
+        if len(agent_list) > 0:
+            commands = []
             for agent_id in agent_list:
-                result.add_failed_item(id_=agent_id, error=WazuhError(1762, extra_message=response.result.value))
+                command = create_restart_command(agent_id=agent_id)
+                commands.append(command)
+
+            response = await indexer_client.commands_manager.create(commands)
+            if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
+                result.affected_items.extend(agent_list)
+            else:
+                for agent_id in agent_list:
+                    result.add_failed_item(id_=agent_id, error=WazuhError(1762, extra_message=response.result.value))
 
     result.total_affected_items = len(agent_list)
 
@@ -547,16 +548,17 @@ async def delete_groups(group_list: list = None) -> AffectedItemsWazuhResult:
 
             async with get_indexer_client() as indexer_client:
                 # Get the list of agents belonging to the group to send them the update-group command
-                agent_list = await indexer_client.agents.get_group_agents(group_name=group_id)
+                agents = await indexer_client.agents.get_group_agents(group_name=group_id)
 
-                commands = []
-                for agent_id in agent_list:
-                    command = create_update_group_command(agent_id=agent_id)
-                    commands.append(command)
+                if len(agents) > 0:
+                    commands = []
+                    for agent in agents:
+                        command = create_update_group_command(agent_id=agent.id)
+                        commands.append(command)
 
-                response = await indexer_client.commands_manager.create(commands)
-                if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
-                    raise WazuhError(1762, extra_message=response.result.value)
+                    response = await indexer_client.commands_manager.create(commands)
+                    if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
+                        raise WazuhError(1762, extra_message=response.result.value)
 
                 await indexer_client.agents.delete_group(group_name=group_id)
 
@@ -636,19 +638,20 @@ async def assign_agents_to_group(group_list: list = None, agent_list: list = Non
             result.add_failed_item(not_found_id, error=WazuhResourceNotFound(1701))
             agent_list.remove(not_found_id)
 
-        await indexer_client.agents.add_agents_to_group(group_name=group_id, agent_ids=agent_list, override=replace)
+        if len(agent_list) > 0:
+            await indexer_client.agents.add_agents_to_group(group_name=group_id, agent_ids=agent_list, override=replace)
 
-        commands = []
-        for agent_id in agent_list:
-            command = create_set_group_command(agent_id=agent_id, groups=[group_id])
-            commands.append(command)
-
-        response = await indexer_client.commands_manager.create(commands)
-        if response.result in (ResponseResult.OK, ResponseResult.CREATED):
-            result.affected_items.extend(agent_list)
-        else:
+            commands = []
             for agent_id in agent_list:
-                result.add_failed_item(id_=agent_id, error=WazuhError(1762, extra_message=response.result.value))
+                command = create_set_group_command(agent_id=agent_id, groups=[group_id])
+                commands.append(command)
+
+            response = await indexer_client.commands_manager.create(commands)
+            if response.result in (ResponseResult.OK, ResponseResult.CREATED):
+                result.affected_items.extend(agent_list)
+            else:
+                for agent_id in agent_list:
+                    result.add_failed_item(id_=agent_id, error=WazuhError(1762, extra_message=response.result.value))
 
     result.total_affected_items = len(result.affected_items)
 
@@ -702,19 +705,20 @@ async def remove_agents_from_group(agent_list: list = None, group_list: list = N
             result.add_failed_item(not_found_id, error=WazuhResourceNotFound(1701))
             agent_list.remove(not_found_id)
 
-        await indexer_client.agents.remove_agents_from_group(group_name=group_id, agent_ids=agent_list)
+        if len(agent_list) > 0:
+            await indexer_client.agents.remove_agents_from_group(group_name=group_id, agent_ids=agent_list)
 
-        commands = []
-        for agent_id in agent_list:
-            command = create_update_group_command(agent_id=agent_id)
-            commands.append(command)
-
-        response = await indexer_client.commands_manager.create(commands)
-        if response.result in (ResponseResult.OK, ResponseResult.CREATED):
-            result.affected_items.extend(agent_list)
-        else:
+            commands = []
             for agent_id in agent_list:
-                result.add_failed_item(id_=agent_id, error=WazuhError(1762, extra_message=response.result.value))
+                command = create_update_group_command(agent_id=agent_id)
+                commands.append(command)
+
+            response = await indexer_client.commands_manager.create(commands)
+            if response.result in (ResponseResult.OK, ResponseResult.CREATED):
+                result.affected_items.extend(agent_list)
+            else:
+                for agent_id in agent_list:
+                    result.add_failed_item(id_=agent_id, error=WazuhError(1762, extra_message=response.result.value))
 
     result.total_affected_items = len(result.affected_items)
 

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -42,7 +42,7 @@ class CommandsManager(BaseIndex):
                 url=f'{self.PLUGIN_URL}/commands',
                 body={'commands': commands_to_send},
             )
-        except exceptions.RequestError as e:
+        except (exceptions.RequestError, exceptions.TransportError) as e:
             raise WazuhError(1761, extra_message=str(e))
 
         document_ids = []

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -57,9 +57,13 @@ class TestCommandsManager:
         assert response.document_ids == document_ids
         assert response.result == return_value.get(IndexerKey.RESULT)
     
-    async def test_create_ko(self, index_instance: CommandsManager, client_mock: mock.AsyncMock):
+    @pytest.mark.parametrize("exc", [
+        exceptions.RequestError,
+        exceptions.TransportError
+    ])
+    async def test_create_ko(self, index_instance: CommandsManager, client_mock: mock.AsyncMock, exc):
         """Check the error handling of the `create` method."""
-        client_mock.transport.perform_request.side_effect = exceptions.RequestError(400, 'error')
+        client_mock.transport.perform_request.side_effect = exc(400, 'error')
         with pytest.raises(WazuhError, match='.*1761.*'):
             await index_instance.create([self.create_command])
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27274 |

## Description

Introduces changes to avoid sending an empty list of commands to the commands manager.

## Tests

<details><summary>Create group</summary>

POST /groups
```json
{
  "group_id": "group1"
}
```

```json
{
    "message": "Group 'group1' created.",
    "error": 0
}
```

</details>

<details><summary>Get agents in group</summary>

GET /groups/group1/agents

```json
{
    "data": {
        "affected_items": [],
        "total_affected_items": 0,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "No group information was returned",
    "error": 0
}
```

</details>

<details><summary>Delete group</summary>

DELETE /groups?groups_list=group1

```json
{
    "data": {
        "affected_items": [
            "group1"
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected groups were deleted",
    "error": 0
}
```

</details>

<details><summary>Get update-group command</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Content-Type: application/json" -ksu admin:admin https://localhost:9200/.commands/_doc/RY5Su5MBqibDFTuvtw2U | jq
{
  "_index": ".commands",
  "_id": "RY5Su5MBqibDFTuvtw2U",
  "_version": 1,
  "_seq_no": 0,
  "_primary_term": 1,
  "found": true,
  "_source": {
    "agent": {
      "groups": [
        "groups000"
      ]
    },
    "command": {
      "source": "Users/Services",
      "user": "Management API",
      "target": {
        "type": "agent",
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
      },
      "action": {
        "name": "update-group",
        "args": [],
        "version": "5.0.0"
      },
      "timeout": 100,
      "status": "PENDING",
      "order_id": "RI5Su5MBqibDFTuvtw2T",
      "request_id": "Q45Su5MBqibDFTuvtw2T"
    },
    "@timestamp": "2024-12-12T14:43:00Z",
    "delivery_timestamp": "2024-12-12T14:44:40Z"
  }
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 6 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py ......                                                                                                                                                                             [100%]

============================================================================================================= 6 passed in 0.26s ==============================================================================================================
```

</details>
