### PR TITLE
Check Wazuh files ownership

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -4,8 +4,8 @@
 #
 # Syntax: make [ all | backup | install | restore | service ]
 
-WAZUH_USER        = wazuh
-WAZUH_GROUP       = wazuh
+WAZUH_USER        = wazuh-server
+WAZUH_GROUP       = wazuh-server
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
 ETC_INSTALLDIR    ?= /etc/${WAZUH_SERVER}

--- a/apis/comms_api/Makefile
+++ b/apis/comms_api/Makefile
@@ -4,8 +4,8 @@
 #
 # Syntax: make [ all | install | service ]
 
-WAZUH_USER        = wazuh
-WAZUH_GROUP       = wazuh
+WAZUH_USER        = wazuh-server
+WAZUH_GROUP       = wazuh-server
 WAZUH_SERVER      = wazuh-server
 SHARE_INSTALLDIR  ?= /usr/share/${WAZUH_SERVER}
 ETC_INSTALLDIR    ?= /etc/${WAZUH_SERVER}

--- a/apis/tools/env/wazuh-server/Dockerfile
+++ b/apis/tools/env/wazuh-server/Dockerfile
@@ -53,8 +53,8 @@ RUN /tmp/build.sh
 
 FROM ubuntu:24.04 AS server
 
-ENV USER=wazuh
-ENV GROUP=wazuh
+ENV USER=wazuh-server
+ENV GROUP=wazuh-server
 
 # Add group and user
 RUN groupadd -f "$GROUP" && useradd "$USER" -d "/" -s "/sbin/nologin" -g "$GROUP"

--- a/apis/tools/env/wazuh-server/Dockerfile
+++ b/apis/tools/env/wazuh-server/Dockerfile
@@ -60,15 +60,15 @@ ENV GROUP=wazuh-server
 RUN groupadd -f "$GROUP" && useradd "$USER" -d "/" -s "/sbin/nologin" -g "$GROUP"
 
 # Copy directories from builder
-COPY --from=builder /etc/wazuh-server /etc/wazuh-server
+COPY --from=builder --chown=${USER}:${GROUP} /etc/wazuh-server /etc/wazuh-server
 
-COPY --from=builder /run/wazuh-server /run/wazuh-server
+COPY --from=builder --chown=${USER}:${GROUP} /run/wazuh-server /run/wazuh-server
 
-COPY --from=builder /var/log/wazuh-server /var/log/wazuh-server
+COPY --from=builder --chown=${USER}:${GROUP} /var/log/wazuh-server /var/log/wazuh-server
 
-COPY --from=builder /var/lib/wazuh-server /var/lib/wazuh-server
+COPY --from=builder --chown=${USER}:${GROUP} /var/lib/wazuh-server /var/lib/wazuh-server
 
-COPY --from=builder /usr/share/wazuh-server /usr/share/wazuh-server
+COPY --from=builder --chown=${USER}:${GROUP} /usr/share/wazuh-server /usr/share/wazuh-server
 
 # Install debugging tools
 RUN apt update && apt install -y vim curl sqlite3

--- a/apis/tools/env/wazuh-server/scripts/entrypoint.sh
+++ b/apis/tools/env/wazuh-server/scripts/entrypoint.sh
@@ -19,6 +19,6 @@ then
     sed -i "s:type\: master:type\: worker:g" /etc/wazuh-server/wazuh-server.yml
 fi
 
-/usr/share/wazuh-server/bin/wazuh-server start -r &
+/usr/share/wazuh-server/bin/wazuh-server start &
 
 wait $!

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -4,8 +4,8 @@
 #
 # Syntax: make [ all | build | install | examples | clean ]
 
-WAZUH_USER        = wazuh
-WAZUH_GROUP       = wazuh
+WAZUH_USER        = wazuh-server
+WAZUH_GROUP       = wazuh-server
 WAZUH_SERVER	  = wazuh-server
 
 SHARE_INSTALLDIR       ?= /usr/share/${WAZUH_SERVER}

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -189,8 +189,8 @@ _context_cache = dict()
 cache_event = Event()
 _WAZUH_UID = None
 _WAZUH_GID = None
-GROUP_NAME = 'wazuh'
-USER_NAME = 'wazuh'
+GROUP_NAME = 'wazuh-server'
+USER_NAME = 'wazuh-server'
 
 # TODO: Keep until we remove the different deprecated functionalities that are importing it.
 WAZUH_PATH = ''

--- a/packages/debs/SPECS/debian/preinst
+++ b/packages/debs/SPECS/debian/preinst
@@ -8,7 +8,7 @@ DIR="/var/wazuh-server"
 WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
 VERSION="$2"
 MAJOR=$(echo "$VERSION" | cut -dv -f2 | cut -d. -f1)
-WAZUH_USER="wazuh"
+WAZUH_USER="wazuh-server"
 
 # environment configuration
 if [ ! -d ${WAZUH_TMP_DIR} ]; then

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -89,25 +89,25 @@ override_dh_install:
 override_dh_fixperms:
 	dh_fixperms
 	# Folders
-	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
+	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
+	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server
+	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
+	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
+	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 	# Binaries
-	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
+	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
-	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
+	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
-	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
+	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
-	chown wazuh:wazuh $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
+	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
 
 

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -25,6 +25,8 @@ export JOBS="5"
 export DEBUG_ENABLED="no"
 export PATH="${PATH}"
 export LD_LIBRARY_PATH=""
+export WAZUH_USER="wazuh-server"
+export WAZUH_GROUP="wazuh-server"
 
 %:
 	dh $@
@@ -89,25 +91,25 @@ override_dh_install:
 override_dh_fixperms:
 	dh_fixperms
 	# Folders
-	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
+	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
+	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server
+	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
+	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
+	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 	# Binaries
-	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
+	chown $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
-	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
+	chown $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-engine
-	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
+	chown $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid
-	chown wazuh-server:wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
+	chown $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
 
 

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -27,6 +27,9 @@ ExclusiveOS: linux
 %define _source_payload w9.xzdio
 %define _binary_payload w9.xzdio
 
+%define _wazuh_user wazuh-server
+%define _wazuh_group wazuh-server
+
 %description
 Wazuh helps you to gain security visibility into your infrastructure by monitoring
 hosts at an operating system and application level. It provides the following capabilities:
@@ -105,15 +108,15 @@ install -m 0644 src/init/templates/wazuh-server.service ${RPM_BUILD_ROOT}/usr/li
 %pre
 
 # Create the wazuh group if it doesn't exists
-if command -v getent > /dev/null 2>&1 && ! getent group wazuh-server > /dev/null 2>&1; then
-  groupadd -r wazuh-server
-elif ! getent group wazuh-server > /dev/null 2>&1; then
-  groupadd -r wazuh-server
+if command -v getent > /dev/null 2>&1 && ! getent group %{_wazuh_user} > /dev/null 2>&1; then
+  groupadd -r %{_wazuh_user}
+elif ! getent group %{_wazuh_user} > /dev/null 2>&1; then
+  groupadd -r %{_wazuh_user}
 fi
 
 # Create the wazuh user if it doesn't exists
-if ! getent passwd wazuh-server > /dev/null 2>&1; then
-  useradd -g wazuh-server -G wazuh-server -d %{_localstatedir} -r -s /sbin/nologin wazuh-server
+if ! getent passwd %{_wazuh_user} > /dev/null 2>&1; then
+  useradd -g %{_wazuh_user} -G %{_wazuh_user} -d %{_localstatedir} -r -s /sbin/nologin %{_wazuh_user}
 fi
 
 # Stop the services to upgrade the package
@@ -159,14 +162,14 @@ fi
 # If the package is been uninstalled
 if [ $1 = 0 ];then
   # Remove the wazuh user if it exists
-  if getent passwd wazuh > /dev/null 2>&1; then
-    userdel wazuh >/dev/null 2>&1
+  if getent passwd %{_wazuh_user} > /dev/null 2>&1; then
+    userdel %{_wazuh_user} >/dev/null 2>&1
   fi
   # Remove the wazuh group if it exists
-  if command -v getent > /dev/null 2>&1 && getent group wazuh > /dev/null 2>&1; then
-    groupdel wazuh >/dev/null 2>&1
-  elif getent group wazuh > /dev/null 2>&1; then
-    groupdel wazuh >/dev/null 2>&1
+  if command -v getent > /dev/null 2>&1 && getent group %{_wazuh_group} > /dev/null 2>&1; then
+    groupdel %{_wazuh_group} >/dev/null 2>&1
+  elif getent group %{_wazuh_group} > /dev/null 2>&1; then
+    groupdel %{_wazuh_group} >/dev/null 2>&1
   fi
 
   # Remove lingering folders and files
@@ -197,24 +200,24 @@ if [ -f %{_localstatedir}/tmp/wazuh.restart ]; then
   fi
 fi
 
-chown -R wazuh-server:wazuh-server %{_localstatedir}var/lib/wazuh-server
+chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}var/lib/wazuh-server
 find %{_localstatedir}var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-chown -R wazuh-server:wazuh-server %{_localstatedir}var/log/wazuh-server
+chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}var/log/wazuh-server
 find %{_localstatedir}var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
-chown -R wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server
+chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server
 find %{_localstatedir}usr/share/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
-chown -R wazuh-server:wazuh-server %{_localstatedir}etc/wazuh-server
+chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}etc/wazuh-server
 find %{_localstatedir}etc/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 # Binaries
 chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
-chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
+chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
 chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
-chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
+chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
 chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
-chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
+chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
 chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
-chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
+chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
 
 # Fix Python permissions
 chmod -R 0750 %{_localstatedir}usr/share/wazuh-server/framework/python/bin
@@ -228,44 +231,44 @@ chmod -R 0750 %{_localstatedir}usr/share/wazuh-server/bin
 rm -fr %{buildroot}
 
 %files
-%defattr(-,wazuh-server,wazuh-server)
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}run/wazuh-server
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/vd
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/tmp
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/log/wazuh-server
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/log/wazuh-server/engine
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server/certs
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server/cluster
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server/groups
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}run/wazuh-server/cluster
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}run/wazuh-server/socket
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/lib
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/framework
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/api
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/apis
+%defattr(-, %{_wazuh_user}, %{_wazuh_group})
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}run/wazuh-server
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/vd
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/tmp
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server/engine
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/cluster
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/groups
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}run/wazuh-server/cluster
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}run/wazuh-server/socket
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/lib
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/framework
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/api
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/apis
 %{_localstatedir}var/lib/wazuh-server/engine/tzdb/*
 %{_localstatedir}etc/wazuh-server/*
 %{_localstatedir}usr/share/wazuh-server/lib/*
 %{_localstatedir}usr/share/wazuh-server/framework/*
 %{_localstatedir}usr/share/wazuh-server/api/*
 %{_localstatedir}usr/share/wazuh-server/apis/*
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine/store
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/store
 %{_localstatedir}var/lib/wazuh-server/engine/store/*
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
 %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
-%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/indexer-connector
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
-%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
-%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
-%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
-%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
+%attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
+%attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
+%attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
+%attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
 # This will be correctly added in #26936
-%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/rbac_control
-%attr(640, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/tmp/vd_1.0.0_vd_4.10.0.tar.xz
+%attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/rbac_control
+%attr(640, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/tmp/vd_1.0.0_vd_4.10.0.tar.xz
 
 %config(missingok) %{_initrddir}/wazuh-server
 /usr/lib/systemd/system/wazuh-server.service

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -105,15 +105,15 @@ install -m 0644 src/init/templates/wazuh-server.service ${RPM_BUILD_ROOT}/usr/li
 %pre
 
 # Create the wazuh group if it doesn't exists
-if command -v getent > /dev/null 2>&1 && ! getent group wazuh > /dev/null 2>&1; then
-  groupadd -r wazuh
-elif ! getent group wazuh > /dev/null 2>&1; then
-  groupadd -r wazuh
+if command -v getent > /dev/null 2>&1 && ! getent group wazuh-server > /dev/null 2>&1; then
+  groupadd -r wazuh-server
+elif ! getent group wazuh-server > /dev/null 2>&1; then
+  groupadd -r wazuh-server
 fi
 
 # Create the wazuh user if it doesn't exists
-if ! getent passwd wazuh > /dev/null 2>&1; then
-  useradd -g wazuh -G wazuh -d %{_localstatedir} -r -s /sbin/nologin wazuh
+if ! getent passwd wazuh-server > /dev/null 2>&1; then
+  useradd -g wazuh-server -G wazuh-server -d %{_localstatedir} -r -s /sbin/nologin wazuh-server
 fi
 
 # Stop the services to upgrade the package
@@ -197,24 +197,24 @@ if [ -f %{_localstatedir}/tmp/wazuh.restart ]; then
   fi
 fi
 
-chown -R wazuh:wazuh %{_localstatedir}var/lib/wazuh-server
+chown -R wazuh-server:wazuh-server %{_localstatedir}var/lib/wazuh-server
 find %{_localstatedir}var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-chown -R wazuh:wazuh %{_localstatedir}var/log/wazuh-server
+chown -R wazuh-server:wazuh-server %{_localstatedir}var/log/wazuh-server
 find %{_localstatedir}var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
-chown -R wazuh:wazuh %{_localstatedir}usr/share/wazuh-server
+chown -R wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server
 find %{_localstatedir}usr/share/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
-chown -R wazuh:wazuh %{_localstatedir}etc/wazuh-server
+chown -R wazuh-server:wazuh-server %{_localstatedir}etc/wazuh-server
 find %{_localstatedir}etc/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 # Binaries
-chmod 750 %{_localstatedir}bin/wazuh-engine
-chown wazuh:wazuh %{_localstatedir}bin/wazuh-engine
-chmod 750 %{_localstatedir}bin/wazuh-apid
-chown wazuh:wazuh %{_localstatedir}bin/wazuh-apid
-chmod 750 %{_localstatedir}bin/wazuh-comms-apid
-chown wazuh:wazuh %{_localstatedir}bin/wazuh-comms-apid
-chmod 750 %{_localstatedir}bin/wazuh-server
-chown wazuh:wazuh %{_localstatedir}bin/wazuh-server
+chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
+chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
+chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
+chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
+chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
+chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
+chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
+chown wazuh-server:wazuh-server %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
 
 # Fix Python permissions
 chmod -R 0750 %{_localstatedir}usr/share/wazuh-server/framework/python/bin
@@ -228,44 +228,44 @@ chmod -R 0750 %{_localstatedir}usr/share/wazuh-server/bin
 rm -fr %{buildroot}
 
 %files
-%defattr(-,wazuh,wazuh)
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}run/wazuh-server
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/vd
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/tmp
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/log/wazuh-server
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/log/wazuh-server/engine
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server/certs
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server/cluster
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}etc/wazuh-server/groups
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}run/wazuh-server/cluster
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}run/wazuh-server/socket
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/lib
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/framework
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/api
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/apis
+%defattr(-,wazuh-server,wazuh-server)
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}run/wazuh-server
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/vd
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/tmp
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/log/wazuh-server
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/log/wazuh-server/engine
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server/certs
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server/cluster
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}etc/wazuh-server/groups
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}run/wazuh-server/cluster
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}run/wazuh-server/socket
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/lib
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/framework
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/api
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/apis
 %{_localstatedir}var/lib/wazuh-server/engine/tzdb/*
 %{_localstatedir}etc/wazuh-server/*
 %{_localstatedir}usr/share/wazuh-server/lib/*
 %{_localstatedir}usr/share/wazuh-server/framework/*
 %{_localstatedir}usr/share/wazuh-server/api/*
 %{_localstatedir}usr/share/wazuh-server/apis/*
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/store
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine/store
 %{_localstatedir}var/lib/wazuh-server/engine/store/*
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
 %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
-%dir %attr(750, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/indexer-connector
+%dir %attr(750, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
-%attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
-%attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
-%attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
-%attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
+%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
+%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid
+%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid
+%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
 # This will be correctly added in #26936
-%attr(750, wazuh, wazuh) %{_localstatedir}usr/share/wazuh-server/bin/rbac_control
-%attr(640, wazuh, wazuh) %{_localstatedir}var/lib/wazuh-server/tmp/vd_1.0.0_vd_4.10.0.tar.xz
+%attr(750, wazuh-server, wazuh-server) %{_localstatedir}usr/share/wazuh-server/bin/rbac_control
+%attr(640, wazuh-server, wazuh-server) %{_localstatedir}var/lib/wazuh-server/tmp/vd_1.0.0_vd_4.10.0.tar.xz
 
 %config(missingok) %{_initrddir}/wazuh-server
 /usr/lib/systemd/system/wazuh-server.service

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -24,8 +24,8 @@ GenerateService()
 
 InstallCommon()
 {
-  WAZUH_GROUP='wazuh'
-  WAZUH_USER='wazuh'
+  WAZUH_GROUP='wazuh-server'
+  WAZUH_USER='wazuh-server'
   INSTALL="install"
   WAZUH_CONTROL_SRC='./init/wazuh-server.sh'
 

--- a/src/init/templates/wazuh-server-debian.init
+++ b/src/init/templates/wazuh-server-debian.init
@@ -22,8 +22,7 @@ WAZUH_HOME=WAZUH_HOME_TMP
 WAZUH_SERVER="${WAZUH_HOME}usr/share/wazuh-server/bin/wazuh-server"
 
 start() {
-    # TODO: Remove root flag
-    ${WAZUH_SERVER} start -r
+    ${WAZUH_SERVER} start
 }
 
 stop() {

--- a/src/init/templates/wazuh-server-rh.init
+++ b/src/init/templates/wazuh-server-rh.init
@@ -20,8 +20,7 @@ WAZUH_SERVER="${WAZUH_HOME}/usr/share/wazuh-server/bin/wazuh-server"
 
 start() {
     echo -n "Starting Wazuh: "
-    # TODO: Remove root flag
-    ${WAZUH_SERVER} start -r > /dev/null
+    ${WAZUH_SERVER} start > /dev/null
     RETVAL=$?
     if [ $RETVAL -eq 0 ]; then
         success

--- a/src/init/templates/wazuh-server.init
+++ b/src/init/templates/wazuh-server.init
@@ -9,8 +9,7 @@ WAZUH_HOME=WAZUH_HOME_TMP
 WAZUH_SERVER="${WAZUH_HOME}/usr/share/wazuh-server/bin/wazuh-server"
 
 start() {
-    # TODO: Remove root flag
-    ${WAZUH_SERVER} start -r
+    ${WAZUH_SERVER} start
 }
 
 stop() {

--- a/src/init/templates/wazuh-server.service
+++ b/src/init/templates/wazuh-server.service
@@ -5,8 +5,7 @@ After=network.target network-online.target
 
 [Service]
 LimitNOFILE=65536
-# TODO: Remove root flag
-ExecStart=/usr/bin/env WAZUH_HOME_TMPusr/share/wazuh-server/bin/wazuh-server start -r
+ExecStart=/usr/bin/env WAZUH_HOME_TMPusr/share/wazuh-server/bin/wazuh-server start
 Type=exec
 KillSignal=SIGINT
 RemainAfterExit=yes


### PR DESCRIPTION
|Related issue|
|---|
|#27263|

## Description

This PR closes #27263. Renames the default user and group to `wazuh-server` and removes the `-r` flag from the init templates. 

## Logs/Alerts example

<details><summary>Installed from sources</summary>
<p>

```console
root@dde7d4951b11:/pkg# apt info wazuh-server
N: Unable to locate package wazuh-server
N: Unable to locate package wazuh-server
E: No packages found
root@dde7d4951b11:/pkg# ll /etc/wazuh-server/
total 28
drwxr-x--- 5 wazuh-server wazuh-server 4096 Dec 13 13:11 ./
drwxr-xr-x 1 root         root         4096 Dec 13 13:11 ../
drwxr-x--- 3 wazuh-server wazuh-server 4096 Dec 13 13:11 api/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 13:11 cluster/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 13:11 shared/
-rw-r----- 1 wazuh-server wazuh-server  887 Dec 13 13:11 wazuh-server.yml
root@dde7d4951b11:/pkg# ll /run/wazuh-server/
total 16
drwxr-x--- 4 wazuh-server wazuh-server 4096 Dec 13 13:11 ./
drwxr-xr-x 1 root         root         4096 Dec 13 13:10 ../
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 13:11 cluster/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 13:11 socket/
root@dde7d4951b11:/pkg# ll /var/lib/wazuh-server/
total 24
drwxr-x--- 5 wazuh-server wazuh-server 4096 Dec 13 13:10 ./
drwxr-xr-x 1 root         root         4096 Dec 13 13:10 ../
drwxr-x--- 4 root                  110 4096 Oct 18 12:28 engine/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 13:10 indexer-connector/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 13:10 vd/
root@dde7d4951b11:/pkg# ll /var/log/wazuh-server/
total 16
drwxr-x--- 3 wazuh-server wazuh-server 4096 Dec 13 13:10 ./
drwxr-xr-x 1 root         root         4096 Dec 13 13:10 ../
drwxr-xr-x 2 wazuh-server wazuh-server 4096 Dec 13 13:10 engine/
```

</p>
</details> 

<details><summary>DEB Package</summary>
<p>

```console
root@3357aa93e3ef:/pkg# apt info wazuh-server
Package: wazuh-server
Version: 5.0.0-test
Status: install ok installed
Priority: extra
Section: admin
Maintainer: Wazuh, Inc <info@wazuh.com>
Installed-Size: 546 MB
Depends: libc6 (>= 2.7), lsb-release, debconf, adduser
Suggests: expect
Replaces: wazuh-api
Homepage: http://www.wazuh.com
Download-Size: unknown
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: Wazuh server
 Wazuh helps you to gain security visibility into your infrastructure by monitoring
 hosts at an operating system and application level. It provides the following
 capabilities: log analysis, file integrity monitoring, intrusions detection
 and policy and compliance monitoring.

root@3357aa93e3ef:/pkg# ll /etc/wazuh-server/
total 28
drwxr-x--- 5 wazuh-server wazuh-server 4096 Dec 13 10:15 ./
drwxr-xr-x 1 root         root         4096 Dec 13 10:15 ../
drwxr-x--- 3 wazuh-server wazuh-server 4096 Dec 13 10:15 api/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 15:27 cluster/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 15:27 shared/
-rw-r----- 1 wazuh-server wazuh-server  887 Dec 12 15:27 wazuh-server.yml
root@3357aa93e3ef:/pkg# ll /run/wazuh-server/
total 16
drwxr-x--- 4 wazuh-server wazuh-server 4096 Dec 13 10:15 ./
drwxr-xr-x 1 root         root         4096 Dec 13 10:15 ../
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 15:27 cluster/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 15:27 socket/
root@3357aa93e3ef:/pkg# ll /var/lib/wazuh-server/
total 28
drwxr-x--- 6 wazuh-server wazuh-server 4096 Dec 13 10:15 ./
drwxr-xr-x 1 root         root         4096 Dec 13 10:15 ../
drwxr-x--- 5 wazuh-server wazuh-server 4096 Dec 13 10:15 engine/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 15:26 indexer-connector/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 10:15 tmp/
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 15:26 vd/
root@3357aa93e3ef:/pkg# ll /var/log/wazuh-server/
total 16
drwxr-xr-x 3 wazuh-server wazuh-server 4096 Dec 13 10:15 ./
drwxr-xr-x 1 root         root         4096 Dec 13 10:15 ../
drwxr-xr-x 2 wazuh-server wazuh-server 4096 Dec 12 15:26 engine/
```

</p>
</details> 

<details><summary>RPM Package</summary>
<p>

```console
[root@08f8285f603d pkg]# yum info wazuh-server
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
Installed Packages
Name        : wazuh-server
Arch        : x86_64
Version     : 5.0.0
Release     : test
Size        : 529 M
Repo        : installed
From repo   : /wazuh-server_5.0.0-test_x86_64_5ad2395492
Summary     : Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file
            : integrity monitoring, intrusions detection and policy and compliance monitoring
URL         : https://www.wazuh.com/
License     : GPL
Description : Wazuh helps you to gain security visibility into your infrastructure by monitoring
            : hosts at an operating system and application level. It provides the following capabilities:
            : log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring

[root@08f8285f603d pkg]# ll /etc/wazuh-server/
total 16
drwxr-xr-x 3 wazuh-server wazuh-server 4096 Dec 13 13:21 api
drwxr-xr-x 2 wazuh-server wazuh-server 4096 Dec 12 20:36 cluster
drwxr-xr-x 2 wazuh-server wazuh-server 4096 Dec 12 20:36 shared
-rw-r--r-- 1 wazuh-server wazuh-server  887 Dec 12 20:36 wazuh-server.yml
[root@08f8285f603d pkg]# ll /run/wazuh-server/
total 8
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 20:36 cluster
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 20:36 socket
[root@08f8285f603d pkg]# ll /var/lib/wazuh-server/
total 16
drwxr-x--- 5 wazuh-server wazuh-server 4096 Dec 13 13:21 engine
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 20:35 indexer-connector
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 13 13:21 tmp
drwxr-x--- 2 wazuh-server wazuh-server 4096 Dec 12 20:35 vd
[root@08f8285f603d pkg]# ll /var/log/wazuh-server/
total 4
drwxr-xr-x 2 wazuh-server wazuh-server 4096 Dec 12 20:35 engine
```

</p>
</details> 