### PR TITLE
Update configuration server error response

### DIFF
--- a/framework/wazuh/core/cluster/unix_server/config.py
+++ b/framework/wazuh/core/cluster/unix_server/config.py
@@ -1,4 +1,4 @@
-from fastapi import Response, status, HTTPException
+from fastapi import Response, status
 from starlette.responses import JSONResponse
 from typing import Optional
 
@@ -24,9 +24,12 @@ async def get_config(sections: Optional[str] = None) -> Response:
         try:
             validated_sections = [ConfigSections(section) for section in section_list]
         except ValueError as e:
-            raise HTTPException(
+            return JSONResponse(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail={'code': status.HTTP_400_BAD_REQUEST, 'message': f"Invalid section(s): {str(e)}"},
+                content={
+                    'message': f"Invalid configuration section: '{e.args[0]}'",
+                    'code': status.HTTP_400_BAD_REQUEST,
+                },
             )
     else:
         validated_sections = None

--- a/framework/wazuh/core/config/models/central_config.py
+++ b/framework/wazuh/core/config/models/central_config.py
@@ -17,7 +17,19 @@ class ConfigSections(str, Enum):
     COMMUNICATIONS_API = 'communications_api'
 
     @classmethod
-    def _missing_(cls, value: str):
+    def _missing_(cls, value: str) -> None:
+        """Missing enum value handler.
+        
+        Parameters
+        ----------
+        value : str
+            Enum value.
+        
+        Raises
+        ------
+        ValueError
+            Invalid value error.
+        """
         raise ValueError(value)
 
 

--- a/framework/wazuh/core/config/models/central_config.py
+++ b/framework/wazuh/core/config/models/central_config.py
@@ -16,6 +16,10 @@ class ConfigSections(str, Enum):
     MANAGEMENT_API = 'management_api'
     COMMUNICATIONS_API = 'communications_api'
 
+    @classmethod
+    def _missing_(cls, value: str):
+        raise ValueError(value)
+
 
 class Config(WazuhConfigBaseModel):
     """Main configuration class for the application.

--- a/framework/wazuh/core/config/models/tests/test_central_config.py
+++ b/framework/wazuh/core/config/models/tests/test_central_config.py
@@ -1,6 +1,14 @@
 import pytest
 
-from wazuh.core.config.models.central_config import Config, EngineConfig, ManagementAPIConfig, CommsAPIConfig, IndexerConfig
+from wazuh.core.config.models.central_config import Config, EngineConfig, ManagementAPIConfig, CommsAPIConfig, \
+    IndexerConfig, ConfigSections
+
+
+def test_config_sections_ko():
+    """Validate that the `ConfigSections` class instantiation with an invalid value raises an error."""
+    value = 'test'
+    with pytest.raises(ValueError, match=rf'.*{value}.*'):
+        ConfigSections(value)
 
 
 @pytest.mark.parametrize('init_values, expected', [


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27266 |

## Description

Updates the error returned by the configuration server when an invalid section is requested.

## Tests

<details><summary>Get one section</summary>

```console
root@wazuh-manager:/# curl --unix-socket /run/wazuh-server/config-server.sock -s http://localhost/api/v1/config?sections=indexer | jq
{
  "indexer": {
    "hosts": [
      "https://wazuh-indexer:9200"
    ],
    "username": "admin",
    "password": "admin",
    "ssl": {
      "use_ssl": true,
      "key": "/etc/wazuh-server/indexer-key.pem",
      "certificate": "/etc/wazuh-server/indexer.pem",
      "certificate_authorities": [
        "/etc/wazuh-server/root-ca.pem"
      ],
      "verify_certificates": true
    }
  }
}
```

</details>

<details><summary>Get multiple sections</summary>

```console
root@wazuh-manager:/# curl --unix-socket /run/wazuh-server/config-server.sock -s http://localhost/api/v1/config?sections=engine,indexer | jq
{
  "indexer": {
    "hosts": [
      "https://wazuh-indexer:9200"
    ],
    "username": "admin",
    "password": "admin",
    "ssl": {
      "use_ssl": true,
      "key": "/etc/wazuh-server/indexer-key.pem",
      "certificate": "/etc/wazuh-server/indexer.pem",
      "certificate_authorities": [
        "/etc/wazuh-server/root-ca.pem"
      ],
      "verify_certificates": true
    }
  },
  "engine": {
    "logging": {
      "level": "info"
    }
  }
}
```

</details>

<details><summary>Get invalid section</summary>

```console
root@wazuh-manager:/# curl --unix-socket /run/wazuh-server/config-server.sock -si http://localhost/api/v1/config?sections=test
HTTP/1.1 400 Bad Request
date: Fri, 13 Dec 2024 17:57:43 GMT
server: uvicorn
content-length: 62
content-type: application/json

{
  "message": "Invalid configuration section: 'test'",
  "code": 400
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/config/models/tests/test_central_config.py::test_config_sections_ko --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/config/models/tests/test_central_config.py .                                                                                                                                                                      [100%]

============================================================================================================= 1 passed in 0.13s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/cluster/unix_server/tests/test_config.py::test_get_config_invalid_sections --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 2 items                                                                                                                                                                                                                            

framework/wazuh/core/cluster/unix_server/tests/test_config.py ..                                                                                                                                                                       [100%]

============================================================================================================= 2 passed in 0.43s ==============================================================================================================
```

</details>