### PR TITLE
get_date helper function added

### DIFF
--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.cpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.cpp
@@ -1582,6 +1582,36 @@ MapOp opBuilderHelperDateFromEpochTime(const std::vector<OpArg>& opArgs,
     };
 }
 
+// field:  get_date
+MapOp opBuilderHelperGetDate(const std::vector<OpArg>& opArgs, const std::shared_ptr<const IBuildCtx>& buildCtx)
+{
+    // Check parameters
+    utils::assertSize(opArgs, 0);
+
+    // Tracing
+    const auto name = buildCtx->context().opName;
+    const auto successTrace = fmt::format("{} -> Success", name);
+    const auto failureTrace = fmt::format("{} -> Failed to generate current date", name);
+
+    // Return Op
+    return [=, runState = buildCtx->runState()](base::ConstEvent event) -> MapResult
+    {
+        // Get the current time point
+        auto now = std::chrono::system_clock::now();
+        auto tp = date::floor<std::chrono::seconds>(now);
+        auto result = date::format("%Y-%m-%dT%H:%M:%SZ", tp);
+
+        if (result.empty())
+        {
+            RETURN_FAILURE(runState, json::Json {}, failureTrace);
+        }
+
+        json::Json resultJson;
+        resultJson.setString(result);
+        RETURN_SUCCESS(runState, resultJson, successTrace);
+    };
+}
+
 //*************************************************
 //*              Checksum and hash                *
 //*************************************************

--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
@@ -298,6 +298,19 @@ MapOp opBuilderHelperEpochTimeFromSystem(const std::vector<OpArg>& opArgs,
 MapOp opBuilderHelperDateFromEpochTime(const std::vector<OpArg>& opArgs,
                                        const std::shared_ptr<const IBuildCtx>& buildCtx);
 
+/**
+ * @brief Builds an operation to generate the current date in ISO 8601 format.
+ *
+ * This function returns a callable operation that produces the current date
+ * in the format "%Y-%m-%dT%H:%M:%SZ". The date is generated in UTC time zone.
+ *
+ * @param opArgs Vector of operation arguments containing numeric values to be converted.
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @throw std::runtime when type of number of paramter missmatch
+ * @return base::Expression
+ */
+MapOp opBuilderHelperGetDate(const std::vector<OpArg>& opArgs, const std::shared_ptr<const IBuildCtx>& buildCtx);
+
 //*************************************************
 //*              Checksum and hash                *
 //*************************************************

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -183,8 +183,7 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
         "date_from_epoch",
         {schemf::STypeToken::create(schemf::Type::DATE), builders::opBuilderHelperDateFromEpochTime});
     registry->template add<builders::OpBuilderEntry>(
-        "date_from_epoch",
-        {schemf::STypeToken::create(schemf::Type::DATE), builders::opBuilderHelperGetDate});
+        "get_date", {schemf::STypeToken::create(schemf::Type::DATE), builders::opBuilderHelperGetDate});
 
     // Transform builders
     registry->template add<builders::OpBuilderEntry>(

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -182,6 +182,9 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
     registry->template add<builders::OpBuilderEntry>(
         "date_from_epoch",
         {schemf::STypeToken::create(schemf::Type::DATE), builders::opBuilderHelperDateFromEpochTime});
+    registry->template add<builders::OpBuilderEntry>(
+        "date_from_epoch",
+        {schemf::STypeToken::create(schemf::Type::DATE), builders::opBuilderHelperGetDate});
 
     // Transform builders
     registry->template add<builders::OpBuilderEntry>(

--- a/src/engine/source/builder/test/src/unit/builders/opmap/time_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/time_test.cpp
@@ -51,6 +51,10 @@ INSTANTIATE_TEST_SUITE_P(
         MapT({}, opBuilderHelperEpochTimeFromSystem, SUCCESS()),
         MapT({makeValue(R"("value")")}, opBuilderHelperEpochTimeFromSystem, FAILURE()),
         MapT({makeRef("ref")}, opBuilderHelperEpochTimeFromSystem, FAILURE()),
+        /*** Get Date ***/
+        MapT({}, opBuilderHelperGetDate, SUCCESS()),
+        MapT({makeValue(R"("value")")}, opBuilderHelperGetDate, FAILURE()),
+        MapT({makeRef("ref")}, opBuilderHelperGetDate, FAILURE()),
         /*** Date From Epoch ***/
         MapT({}, opBuilderHelperDateFromEpochTime, FAILURE()),
         MapT({makeValue(R"("value")")}, opBuilderHelperDateFromEpochTime, FAILURE()),
@@ -74,6 +78,8 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values(
         /*** Epoch From System ***/
         MapT("{}", opBuilderHelperEpochTimeFromSystem, {}, SUCCESS(IGNORE_MAP_RESULT)),
+        /*** Get date ***/
+        MapT("{}", opBuilderHelperGetDate, {}, SUCCESS(IGNORE_MAP_RESULT)),
         /*** Date From Epoch ***/
         MapT(R"({"ref": 1706172785})",
              opBuilderHelperDateFromEpochTime,

--- a/src/engine/test/helper_tests/helpers_description/map/get_date.yml
+++ b/src/engine/test/helper_tests/helpers_description/map/get_date.yml
@@ -1,0 +1,17 @@
+# Name of the helper function
+name: get_date
+
+metadata:
+  description: |
+    Get the current date in the format "%Y-%m-%dT%H:%M:%SZ". The date is generated in UTC time zone.
+  keywords:
+    - time
+
+helper_type: map
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: False
+
+output:
+  type: string
+  subset: string


### PR DESCRIPTION
|Related issue|
|---|
|#27289|

## Description

A new helper function named get_date is required in Wazuh-Engine. This helper will not accept any arguments and should map the current date and time into a specified field in the format '%Y-%m-%dT%H:%M:%SZ'. This function aims to standardize date handling within the engine, ensuring consistent formatting for date/time values.