### PR TITLE
Update 0245-web_rules.xml

### DIFF
--- a/ruleset/rules/0245-web_rules.xml
+++ b/ruleset/rules/0245-web_rules.xml
@@ -62,7 +62,7 @@
     </mitre>
     <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
-
+  
   <rule id="31105" level="6">
     <if_sid>31100</if_sid>
     <url>%3Cscript|%3C%2Fscript|script>|script%3E|SRC=javascript|IMG%20|</url>
@@ -353,4 +353,11 @@
    <group>attack,sqlinjection,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,</group>
   </rule>
 
+ 
+  <rule id="31172" level="5">
+    <if_sid>31100</if_sid>
+    <match>] "POST /?wordfence_syncAttackData</match>
+    <description>Web attack detected and blocked by Wordfence.</description>
+    <group>attack,pci_dss_6.5,pci_dss_11.4,pci_dss_6.5.1,gdpr_IV_35.7.d,nist_800_53_SA.11,nist_800_53_SI.4,tsc_CC6.6,tsc_CC7.1,tsc_CC8.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
 </group>


### PR DESCRIPTION
## Description

A rule to handle attack detection by Wordfence WAF on WordPress applications, without this rule, Wazuh will trigger an alert for 400 error code when there is an attack detected by Wordfence.

## Logs/Alerts example

Without the rule:
![wazuh-400](https://github.com/user-attachments/assets/a346e577-a6b4-4c77-96ce-865b21b091c9)  

With the rule:  
![wazuh-wordfence](https://github.com/user-attachments/assets/637d25e3-bdd5-494c-9b66-0495afb39897)


## Tests
<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [x] runtests.py executed without errors