### PR TITLE
Changed ubuntu version in integration test

### DIFF
--- a/.github/workflows/integration-tests-agentd-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-agentd-tier-0-1-lin.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-enrollment-tier-0-1-lin.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-execd-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-execd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-win.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-fim-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-fim-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-fim-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-0-1-win.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-github-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-github-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-github-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-github-tier-0-1-win.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-logcollector-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-msgraph-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-office365-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-office365-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-office365-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-office365-tier-0-1-win.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-sca-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-sca-tier-0-1-lin.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-sca-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-sca-tier-0-1-win.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-lin.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   # Build the winagent on linux.
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/27296|

## Description
This PR change ubuntu-latest to ubuntu-22.04 in GHA for this tests:
- [Integration tests for Agentd on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255244/job/34379352991?pr=27292)
- [Integration tests for enrollment on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255313/job/34379348922?pr=27292)
- [Integration tests for Execd on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255302/job/34379348364?pr=27292)
- [Integration tests for FIM on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255311/job/34379352982?pr=27292)
- [Integration tests for GitHub on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255290/job/34379345331?pr=27292)
- [Integration tests for logcollector on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255284/job/34379348116?pr=27292)
- [Integration tests for MsGraph on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255297/job/34379348657?pr=27292)
- [Integration tests for Office365 on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255301/job/34379351031?pr=27292)
- [Integration tests for SCA on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255256/job/34379345360?pr=27292)
- [Integration tests for Syscollector on Linux - Tier 0 and 1 / build (pull_request)](https://github.com/wazuh/wazuh/actions/runs/12317255246/job/34379349414?pr=27292)