### PR TITLE
Remove agent agnostic commands from orders

### DIFF
--- a/api/api/models/order_model.py
+++ b/api/api/models/order_model.py
@@ -95,10 +95,6 @@ class Order(Model):
         user: str = None,
         target: Target = None,
         action: Action = None,
-        timeout: int = None,
-        status: str = None,
-        order_id: str = None,
-        request_id: str = None,
         document_id: str = None,
     ):
         self.swagger_types = {
@@ -106,10 +102,6 @@ class Order(Model):
             'user': str,
             'target': Target,
             'action': Action,
-            'timeout': int,
-            'status': str,
-            'order_id': str,
-            'request_id': str,
             'document_id': str,
         }
 
@@ -118,10 +110,6 @@ class Order(Model):
             'user': 'user',
             'target': 'target',
             'action': 'action',
-            'timeout': 'timeout',
-            'status': 'status',
-            'order_id': 'order_id',
-            'request_id': 'request_id',
             'document_id': 'document_id',
         }
 
@@ -129,10 +117,6 @@ class Order(Model):
         self._user = user
         self._target = target
         self._action = action
-        self._timeout = timeout
-        self._status = status
-        self._order_id = order_id
-        self._request_id = request_id
         self._document_id = document_id
 
     @property
@@ -167,38 +151,6 @@ class Order(Model):
     def action(self, action: Action):
         self._action = action
 
-    @property
-    def timeout(self) -> int:
-        return self._timeout
-
-    @timeout.setter
-    def timeout(self, timeout: int):
-        self._timeout = timeout
-
-    @property
-    def status(self) -> str:
-        return self._status
-
-    @status.setter
-    def status(self, status: str):
-        self._status = status
-
-    @property
-    def order_id(self) -> str:
-        return self._order_id
-
-    @order_id.setter
-    def order_id(self, order_id: str):
-        self._order_id = order_id
-
-    @property
-    def request_id(self) -> str:
-        return self._request_id
-
-    @request_id.setter
-    def request_id(self, request_id: str):
-        self._request_id = request_id
-    
     @property
     def document_id(self) -> str:
         return self._document_id

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1623,10 +1623,6 @@ components:
         - user
         - target
         - action
-        - timeout
-        - status
-        - order_id
-        - request_id
         - document_id
       properties:
         source:
@@ -1668,23 +1664,6 @@ components:
               description: "Order action arguments"
               items:
                 type: string
-        timeout:
-          type: integer
-          format: int32
-        status:
-          type: string
-          description: "Order status"
-          enum:
-            - pending
-            - sent
-            - success
-            - failure
-        order_id:
-          type: string
-          format: alphanumeric_symbols
-        request_id:
-          type: string
-          format: alphanumeric_symbols
         document_id:
           type: string
           format: alphanumeric_symbols
@@ -6027,10 +6006,6 @@ paths:
                     name: set-group
                     args: ['group1']
                     version: v5.0.0
-                  timeout: 60
-                  status: PENDING
-                  order_id: l8nhoJIBerRY2Wz26Je8
-                  request_id: lsnhoJIBerRY2Wz26Je7
                   document_id: SuyTlZIBRVsFsWNvvx6f
       responses:
         '200':

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -162,8 +162,7 @@ async def test_distribute_orders(read_config_mock, get_cluster_items_mock):
             order = Order(document_id='1', status='pending').to_dict()
             await control.distribute_orders(lc=local_client, orders=[order])
 
-        data = b'[{"source": null, "user": null, "target": null, "action": null, "timeout": null, ' \
-            b'"status": "pending", "order_id": null, "request_id": null, "document_id": "1"}]'
+        data = b'[{"source": null, "user": null, "target": null, "action": null, "document_id": "1"}]'
         execute_mock.assert_called_once_with(command=b'dist_orders', data=data)
 
         with patch('json.loads', return_value=KeyError(1)):

--- a/framework/wazuh/order.py
+++ b/framework/wazuh/order.py
@@ -28,13 +28,13 @@ async def send_orders(orders: List[Order]) -> AffectedItemsWazuhResult:
         none_msg="No orders were published"
     )
 
-    order_ids = [item['order_id'] for item in orders]
+    document_ids = [item['document_id'] for item in orders]
     try:
         lc = local_client.LocalClient()
         await distribute_orders(lc, orders)
-        result.affected_items.extend(order_ids)
+        result.affected_items.extend(document_ids)
     except (WazuhError, WazuhClusterError) as e:
-        for id_ in order_ids:
+        for id_ in document_ids:
             result.add_failed_item(id_=id_, error=e)
 
     result.total_affected_items = len(result.affected_items)


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27264 |

## Description

Removes the fields that are irrelevant to the agents from the Management API orders.

## Tests

> Will be performed after the changes in https://github.com/wazuh/wazuh/issues/27277.