### PR TITLE
PEP440 performance improvement

### DIFF
--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -470,6 +470,44 @@ namespace Utils
         out += str;
         return out;
     }
+    /**
+     * @brief Split a string into a vector of numbers.
+     *
+     * @param str Original string.
+     * @param delimiter Delimiter character.
+     * @return std::vector<uint32_t> Vector of numbers.
+     */
+    static std::vector<uint32_t> splitToNumbers(const std::string& str, const char delimiter)
+    {
+        std::vector<uint32_t> tokens;
+        tokens.reserve(10);
+
+        auto start = str.begin();
+        auto end = str.begin();
+
+        while ((end = std::find(start, str.end(), delimiter)) != str.end())
+        {
+            uint32_t num = 0;
+            for (auto it = start; it != end; ++it)
+            {
+                num = num * 10 + (*it - '0');
+            }
+            tokens.push_back(num);
+            start = end + 1;
+        }
+
+        if (start != str.end())
+        {
+            uint32_t num = 0;
+            for (auto it = start; it != str.end(); ++it)
+            {
+                num = num * 10 + (*it - '0');
+            }
+            tokens.push_back(num);
+        }
+
+        return tokens;
+    }
 
 } // namespace Utils
 

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -490,6 +490,10 @@ namespace Utils
             uint32_t num = 0;
             for (auto it = start; it != end; ++it)
             {
+                if (*it < '0' || *it > '9')
+                {
+                    throw std::runtime_error("Invalid number.");
+                }
                 num = num * 10 + (*it - '0');
             }
             tokens.push_back(num);
@@ -501,6 +505,10 @@ namespace Utils
             uint32_t num = 0;
             for (auto it = start; it != str.end(); ++it)
             {
+                if (*it < '0' || *it > '9')
+                {
+                    throw std::runtime_error("Invalid number.");
+                }
                 num = num * 10 + (*it - '0');
             }
             tokens.push_back(num);

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -611,3 +611,32 @@ TEST_F(StringUtilsTest, haveUpperCaseCharacters)
     EXPECT_FALSE(Utils::haveUpperCaseCharacters("test"));
     EXPECT_FALSE(Utils::haveUpperCaseCharacters(""));
 }
+
+TEST_F(StringUtilsTest, splitToNumbers)
+{
+    auto ret = Utils::splitToNumbers("1.2.3.4.5.6.7.8.9.0", '.');
+    EXPECT_EQ(ret.size(), 10);
+    EXPECT_EQ(ret[0], 1);
+    EXPECT_EQ(ret[1], 2);
+    EXPECT_EQ(ret[2], 3);
+    EXPECT_EQ(ret[3], 4);
+    EXPECT_EQ(ret[4], 5);
+    EXPECT_EQ(ret[5], 6);
+    EXPECT_EQ(ret[6], 7);
+    EXPECT_EQ(ret[7], 8);
+    EXPECT_EQ(ret[8], 9);
+    EXPECT_EQ(ret[9], 0);
+
+    ret = Utils::splitToNumbers("1", '.');
+    EXPECT_EQ(ret.size(), 1);
+    EXPECT_EQ(ret[0], 1);
+
+    EXPECT_ANY_THROW({ ret = Utils::splitToNumbers("aaaa", '.'); });
+
+    ret = Utils::splitToNumbers("", '.');
+    EXPECT_EQ(ret.size(), 0);
+
+    EXPECT_ANY_THROW({ ret = Utils::splitToNumbers("a.a.a", '.'); });
+
+    EXPECT_ANY_THROW({ ret = Utils::splitToNumbers("1.1.1", ' '); });
+}

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.cpp
@@ -33,5 +33,3 @@
 std::regex VersionObjectPEP440::m_parserRegex(
     R"(^v?(?:(?:([0-9]+)!)?([0-9]+(?:\.[0-9]+)*)(?:[-_\.]?(a|b|c|rc|alpha|beta|pre|preview)[-_\.]?([0-9]+)?)?(?:(?:-([0-9]+))|(?:[-_\.]?(post|rev|r)[-_\.]?([0-9]+)?))?(?:[-_\.]?(dev)[-_\.]?([0-9]+)?)?)?$)",
     std::regex_constants::icase);
-
-std::regex VersionObjectPEP440::m_parserVersionStrRegex(R"(\.)");

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
@@ -13,9 +13,9 @@
 #define _VERSION_OBJECT_PEP440_HPP
 
 #include "iVersionObjectInterface.hpp"
+#include "stringHelper.h"
 #include <algorithm>
 #include <cctype>
-#include <memory>
 #include <regex>
 #include <string>
 
@@ -66,23 +66,8 @@ private:
      */
     static int compareVersionStr(const std::string& versionStrA, const std::string& versionStrB)
     {
-        std::deque<uint32_t> versionStrSplitA;
-        std::sregex_token_iterator itA(versionStrA.begin(), versionStrA.end(), m_parserVersionStrRegex, -1);
-        std::sregex_token_iterator itEndA;
-        while (itA != itEndA)
-        {
-            versionStrSplitA.push_back(static_cast<uint32_t>(std::stoul(itA->str())));
-            itA++;
-        }
-
-        std::deque<uint32_t> versionStrSplitB;
-        std::sregex_token_iterator itB(versionStrB.begin(), versionStrB.end(), m_parserVersionStrRegex, -1);
-        std::sregex_token_iterator itEndB;
-        while (itB != itEndB)
-        {
-            versionStrSplitB.push_back(static_cast<uint32_t>(std::stoul(itB->str())));
-            itB++;
-        }
+        auto versionStrSplitA = Utils::splitToNumbers(versionStrA, '.');
+        auto versionStrSplitB = Utils::splitToNumbers(versionStrB, '.');
 
         while (versionStrSplitA.size() < versionStrSplitB.size())
         {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27308|

This PR aims to improve the PEP440 version parsing by replacing regex usage with a more efficient helper function `static std::vector<uint32_t> splitToNumbers(const std::string& str, const char delimiter)`. This change enhances performance and simplifies the implementation by directly splitting the version string into numeric components.






