### PR TITLE
Global-data performance improvements

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -64,6 +64,9 @@ runs:
           done
           arguments+="$include_files"
 
+          # Exclude scanContext.hpp
+          arguments+="--exclude=*/scanContext.hpp "
+
           echo "Executing: lcov $arguments"
           lcov $arguments
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/globalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/globalData.hpp
@@ -14,15 +14,12 @@
 
 #include "json.hpp"
 #include "singleton.hpp"
-#include <mutex>
-#include <shared_mutex>
 
 /**
  * @brief Class to manage global maps data.
  */
 class GlobalData final : public Singleton<GlobalData>
 {
-    mutable std::shared_mutex m_mutex;
     nlohmann::json m_vendorMaps;
     nlohmann::json m_osCpeMaps;
     nlohmann::json m_cnaMappings;
@@ -35,7 +32,6 @@ public:
      */
     void vendorMaps(const nlohmann::json& vendor)
     {
-        std::unique_lock lock(m_mutex);
         m_vendorMaps = vendor;
     }
 
@@ -45,7 +41,6 @@ public:
      */
     void osCpeMaps(const nlohmann::json& osCpe)
     {
-        std::unique_lock lock(m_mutex);
         m_osCpeMaps = osCpe;
     }
 
@@ -55,8 +50,7 @@ public:
      */
     void managerName(std::string_view name)
     {
-        std::unique_lock lock(m_mutex);
-        m_managerName = name;
+        m_managerName = name.empty() ? "manager" : name;
     }
 
     /**
@@ -65,7 +59,6 @@ public:
      */
     void cnaMappings(const nlohmann::json& cnaMappings)
     {
-        std::unique_lock lock(m_mutex);
         m_cnaMappings = cnaMappings;
     }
 
@@ -73,9 +66,8 @@ public:
      * @brief Get vendor map data.
      * @return vendor map data.
      */
-    nlohmann::json vendorMaps() const
+    const nlohmann::json& vendorMaps() const
     {
-        std::shared_lock lock(m_mutex);
         return m_vendorMaps;
     }
 
@@ -83,9 +75,8 @@ public:
      * @brief Get OS CPE map data.
      * @return OS CPE data.
      */
-    nlohmann::json osCpeMaps() const
+    const nlohmann::json& osCpeMaps() const
     {
-        std::shared_lock lock(m_mutex);
         return m_osCpeMaps;
     }
 
@@ -93,9 +84,8 @@ public:
      * @brief Get CNA mappings.
      * @return CNA mappings.
      */
-    nlohmann::json cnaMappings() const
+    const nlohmann::json& cnaMappings() const
     {
-        std::shared_lock lock(m_mutex);
         return m_cnaMappings;
     }
 
@@ -103,10 +93,9 @@ public:
      * @brief Get manager name.
      * @return Manager name.
      */
-    std::string managerName() const
+    const std::string& managerName() const
     {
-        std::shared_lock lock(m_mutex);
-        return m_managerName.empty() ? "manager" : m_managerName;
+        return m_managerName;
     }
 };
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/descriptionsHelper.hpp
@@ -145,16 +145,9 @@ public:
         // Ex. sources = {"redhat", "redhat_8"}
         const auto& [adp, expandedAdp] = sources;
 
-        nlohmann::json vendorConfig;
-        if (TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).contains(adp))
-        {
-            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(adp);
-        }
-        else
-        {
-            // Fallback to default ADP
-            vendorConfig = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY).at(DEFAULT_ADP);
-        }
+        const auto& adpMap = TGlobalData::instance().vendorMaps().at(ADP_DESCRIPTIONS_MAP_KEY);
+
+        const nlohmann::json& vendorConfig = adpMap.contains(adp) ? adpMap.at(adp) : adpMap.at(DEFAULT_ADP);
 
         const auto& cvssSource = vendorConfig.at(ADP_CVSS_KEY).get_ref<const std::string&>();
         const auto& descriptionSource = vendorConfig.at(ADP_DESCRIPTION_KEY).get_ref<const std::string&>();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/packageScanner.hpp
@@ -221,7 +221,7 @@ private:
                 }
             }
         }
-        const auto mapping = TGlobalData::instance().cnaMappings();
+        const auto& mapping = TGlobalData::instance().cnaMappings();
 
         const auto& cnaMapping = mapping.at("cnaMapping");
         const auto platformEquivalence = [&](const std::string& platform) -> const std::string&

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -1185,8 +1185,7 @@ public:
     {
         if (agentId() == "000")
         {
-            static std::string managerName = TGlobalData::instance().managerName();
-            return managerName;
+            return TGlobalData::instance().managerName();
         }
 
         return extractData<std::string_view>(

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -1185,7 +1185,7 @@ public:
     {
         if (agentId() == "000")
         {
-            static std::string managerName = GlobalData::instance().managerName();
+            static std::string managerName = TGlobalData::instance().managerName();
             return managerName;
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockGlobalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockGlobalData.hpp
@@ -51,28 +51,28 @@ public:
      *
      * @return nlohmann::json
      */
-    MOCK_METHOD(nlohmann::json, vendorMaps, (), (const));
+    MOCK_METHOD(const nlohmann::json&, vendorMaps, (), (const));
 
     /**
      * @brief Mock method
      *
      * @return nlohmann::json
      */
-    MOCK_METHOD(nlohmann::json, osCpeMaps, (), (const));
+    MOCK_METHOD(const nlohmann::json&, osCpeMaps, (), (const));
 
     /**
      * @brief Mock method
      *
      * @return nlohmann::json
      */
-    MOCK_METHOD(nlohmann::json, cnaMappings, (), (const));
+    MOCK_METHOD(const nlohmann::json&, cnaMappings, (), (const));
 
     /**
      * @brief Mock method
      *
      * @return std::string
      */
-    MOCK_METHOD(std::string, managerName, (), (const));
+    MOCK_METHOD(const std::string&, managerName, (), (const));
 };
 
 #endif // _MOCK_GLOBAL_DATA_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockGlobalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockGlobalData.hpp
@@ -66,6 +66,13 @@ public:
      * @return nlohmann::json
      */
     MOCK_METHOD(nlohmann::json, cnaMappings, (), (const));
+
+    /**
+     * @brief Mock method
+     *
+     * @return std::string
+     */
+    MOCK_METHOD(std::string, managerName, (), (const));
 };
 
 #endif // _MOCK_GLOBAL_DATA_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineGlobalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineGlobalData.hpp
@@ -87,6 +87,16 @@ public:
     {
         return spGlobalDataMock->cnaMappings();
     }
+
+    /**
+     * @brief Trampoline to method agentName.
+     *
+     * @return std::string
+     */
+    std::string managerName() const
+    {
+        return spGlobalDataMock->managerName();
+    }
 };
 
 #endif // _TRAMPOLINE_GLOBAL_DATA_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineGlobalData.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineGlobalData.hpp
@@ -53,7 +53,7 @@ public:
      *
      * @return nlohmann::json
      */
-    nlohmann::json vendorMaps() const
+    const nlohmann::json& vendorMaps() const
     {
         return spGlobalDataMock->vendorMaps();
     }
@@ -63,7 +63,7 @@ public:
      *
      * @return nlohmann::json
      */
-    nlohmann::json osCpeMaps() const
+    const nlohmann::json& osCpeMaps() const
     {
         return spGlobalDataMock->osCpeMaps();
     }
@@ -83,7 +83,7 @@ public:
      *
      * @return nlohmann::json
      */
-    nlohmann::json cnaMappings() const
+    const nlohmann::json& cnaMappings() const
     {
         return spGlobalDataMock->cnaMappings();
     }
@@ -93,7 +93,7 @@ public:
      *
      * @return std::string
      */
-    std::string managerName() const
+    const std::string& managerName() const
     {
         return spGlobalDataMock->managerName();
     }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/descriptionsHelper_test.cpp
@@ -145,6 +145,10 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSource)
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
         .Times(0);
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
 
@@ -188,6 +192,10 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSource)
     EXPECT_CALL(*spDatabaseFeedManagerMock, getVulnerabilityDescriptiveInformation(CVE_ID, DEFAULT_ADP, testing::_))
         .Times(0);
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
 
@@ -218,6 +226,10 @@ TEST_F(DescriptionsHelperTest, nonExistentAdp)
         .WillOnce(::testing::Invoke(
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBuffer); }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
@@ -268,6 +280,10 @@ TEST_F(DescriptionsHelperTest, informationNotFoundOnDB)
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss); }));
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
 
@@ -315,6 +331,10 @@ TEST_F(DescriptionsHelperTest, notReliableCvssInformationNoScore)
         .WillOnce(::testing::Invoke(
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss); }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
@@ -377,6 +397,10 @@ TEST_F(DescriptionsHelperTest, notReliableCvssInformationEmptySeverity)
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferDefaultCvss); }));
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
 
@@ -428,6 +452,10 @@ TEST_F(DescriptionsHelperTest, notReliableDescriptionInformation)
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss); }));
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     DescriptionsHelper::vulnerabilityDescription<MockDatabaseFeedManager, TrampolineGlobalData>(
         CVE_ID, sources, spDatabaseFeedManagerMock, validateVulnerabilityDescriptiveInformation);
 
@@ -461,6 +489,10 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromSameSourceCouldNotBeObtaine
         .WillOnce(::testing::Invoke(
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
+
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     // Information couldn't be retrieved. Default values asigned.
     const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
@@ -532,6 +564,10 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSourceCDescription
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformation(resultContainer, detachedBufferCvss); }));
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     // Only information from description is set to default values.
     const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
     {
@@ -601,6 +637,10 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSourceCVSSFails)
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
     {
         EXPECT_EQ(description.accessComplexity, CveDescription::DEFAULT_STR_VALUE);
@@ -666,6 +706,10 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionFromDifferentSourceBothFails)
             [&](const std::string&, const std::string&, FlatbufferDataPair<VulnerabilityDescription>& resultContainer)
             { return createVulnerabilityDescriptiveInformationFail(resultContainer); }));
 
+    // The global data should be called to retrieve the ADP descriptions map
+    spGlobalDataMock = std::make_shared<MockGlobalData>();
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+
     const auto validateVulnerabilityDescriptiveInformationFail = [](const CveDescription& description)
     {
         EXPECT_EQ(description.accessComplexity, CveDescription::DEFAULT_STR_VALUE);
@@ -704,7 +748,7 @@ TEST_F(DescriptionsHelperTest, cvssAndDescriptionSources)
 {
     // The global data should be called to retrieve the ADP descriptions map
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(::testing::Invoke([]() { return ADP_DESCRIPTIONS; }));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     const auto sourcesAdp1 = DescriptionsHelper::cvssAndDescriptionSources<TrampolineGlobalData>(
         {ADP_CVSS_EQUALS_DESCRIPTION, ADP_CVSS_EQUALS_DESCRIPTION + ADP_EXPANDED_POSTFIX});

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -156,6 +156,8 @@ namespace NSEventDetailsBuilderTest
             }
         )";
 
+    const std::string MANAGER_NAME {"manager_name"};
+
     const std::string CVEID {"CVE-2024-1234"};
 
     const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
@@ -362,7 +364,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
                          TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -562,8 +564,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
-    EXPECT_CALL(*spGlobalDataMock, managerName()).WillRepeatedly(testing::Return("manager_name"));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, managerName()).WillRepeatedly(testing::ReturnRef(MANAGER_NAME));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
                          TScanContext<TrampolineOsDataCache, TrampolineGlobalData, TrampolineRemediationDataCache>,
@@ -763,7 +765,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
     scanContext->m_vulnerabilitySource = {"suse", "suse"};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
                          TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -868,7 +870,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
                          TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -1053,7 +1055,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
     scanContext->m_vulnerabilitySource = {"suse", "suse"};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
                          TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -1254,7 +1256,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
                          TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -1481,7 +1483,7 @@ void EventDetailsBuilderAdpTest::TearDown()
 void EventDetailsBuilderAdpTest::TestingAdpDescription(const std::string& adp)
 {
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
                          TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -553,7 +553,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
         syscollectorDelta = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContext =
-        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
+        std::make_shared<TScanContext<TrampolineOsDataCache, TrampolineGlobalData, TrampolineRemediationDataCache>>(
             syscollectorDelta);
     scanContext->m_elements[CVEID] =
         R"({"operation":"INSERTED", "id":"000_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2024-1234"})"_json;
@@ -563,9 +563,10 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, managerName()).WillRepeatedly(testing::Return("manager_name"));
 
     TEventDetailsBuilder<MockDatabaseFeedManager,
-                         TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
+                         TScanContext<TrampolineOsDataCache, TrampolineGlobalData, TrampolineRemediationDataCache>,
                          TrampolineGlobalData>
         eventDetailsBuilder(spDatabaseFeedManagerMock);
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -300,7 +300,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Equal};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
                                      TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -497,7 +497,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::LessThan};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
                                      TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -698,7 +698,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::DefaultStatus};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
                                      TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -802,7 +802,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::LessThanOrEqual};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
                                      TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -906,7 +906,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::Unknown};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
                                      TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -1043,7 +1043,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
     scanContext->m_elements[CVEID] = R"({"operation":"invalid"})"_json;
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
                                      TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -1143,7 +1143,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
     scanContext->m_matchConditions[CVEID] = {"1.0.0", MatchRuleCondition::LessThan};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TEventPackageAlertDetailsBuilder<MockDatabaseFeedManager,
                                      TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -462,7 +462,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualTo)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -561,7 +561,7 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedEqualTo)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -650,7 +650,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThan)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -749,7 +749,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMissing)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -838,7 +838,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMismatch)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -927,7 +927,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMatch)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1026,7 +1026,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanOrEqual)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1125,7 +1125,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanWithVersionNotZero)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1224,7 +1224,7 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedLessThan)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1313,7 +1313,7 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusAffected)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1411,7 +1411,7 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusUnaffected)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1474,7 +1474,7 @@ TEST_F(PackageScannerTest, TestPackageGetVulnerabilitiesCandidatesGeneratesExcep
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1525,7 +1525,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlma8)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1573,7 +1573,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas1)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1621,7 +1621,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1669,7 +1669,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2022)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1717,7 +1717,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToRedHat7)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1765,7 +1765,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLED)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1813,7 +1813,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLES)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -1902,7 +1902,7 @@ TEST_F(PackageScannerTest, TestGetTranslationFromL2)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -2007,7 +2007,7 @@ TEST_F(PackageScannerTest, TestVersionTranslation)
             syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -2111,7 +2111,7 @@ TEST_F(PackageScannerTest, TestVendorTranslation)
             syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -2215,7 +2215,7 @@ TEST_F(PackageScannerTest, TestVendorAndVersionTranslation)
             syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -2278,7 +2278,7 @@ TEST_F(PackageScannerTest, TestGetCnaNameByPrefix)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -2329,7 +2329,7 @@ TEST_F(PackageScannerTest, TestGetCnaNameByContains)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,
@@ -2380,7 +2380,7 @@ TEST_F(PackageScannerTest, TestGetCnaNameBySource)
     auto scanContextOriginal = std::make_shared<TrampolineScanContext>(syscollectorDelta);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::Return(CNA_MAPPINGS));
+    EXPECT_CALL(*spGlobalDataMock, cnaMappings()).WillOnce(testing::ReturnRef(CNA_MAPPINGS));
 
     TPackageScanner<MockDatabaseFeedManager,
                     TrampolineScanContext,

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
@@ -1166,7 +1166,7 @@ TEST_F(ScanContextTest, TestBuildCPEWindows10)
     const nlohmann::json osCpeMap = nlohmann::json::parse(osCpeRules);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::Return(osCpeMap));
+    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::ReturnRef(osCpeMap));
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
@@ -1229,7 +1229,7 @@ TEST_F(ScanContextTest, TestBuildCPECentos)
     const nlohmann::json osCpeMap = nlohmann::json::parse(osCpeRules);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::Return(osCpeMap));
+    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::ReturnRef(osCpeMap));
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
@@ -1292,7 +1292,7 @@ TEST_F(ScanContextTest, TestBuildCPERedHat)
     const nlohmann::json osCpeMap = nlohmann::json::parse(osCpeRules);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::Return(osCpeMap));
+    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::ReturnRef(osCpeMap));
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
@@ -1350,7 +1350,7 @@ TEST_F(ScanContextTest, TestBuildCPEOpensuseTumbleweed)
     const nlohmann::json osCpeMap = nlohmann::json::parse(osCpeRules);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::Return(osCpeMap));
+    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::ReturnRef(osCpeMap));
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
@@ -1408,7 +1408,7 @@ TEST_F(ScanContextTest, TestBuildCPEOpensuseLeap)
     const nlohmann::json osCpeMap = nlohmann::json::parse(osCpeRules);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::Return(osCpeMap));
+    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::ReturnRef(osCpeMap));
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
@@ -1468,7 +1468,7 @@ TEST_F(ScanContextTest, TestBuildCPENameFedora)
     const nlohmann::json osCpeMap = nlohmann::json::parse(osCpeRules);
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::Return(osCpeMap));
+    EXPECT_CALL(*spGlobalDataMock, osCpeMaps()).WillOnce(testing::ReturnRef(osCpeMap));
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
@@ -255,7 +255,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
             }));
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -401,7 +401,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
     scanContext->m_matchConditions[CVEID] = {"version", MatchRuleCondition::DefaultStatus};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
                                TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -534,7 +534,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
     scanContext->m_matchConditions[CVEID] = {"version", MatchRuleCondition::LessThan};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
                                TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -667,7 +667,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
     scanContext->m_matchConditions[CVEID] = {"version", MatchRuleCondition::Equal};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
                                TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
@@ -772,7 +772,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
     scanContext->m_isFirstScan = false;
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
-    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::Return(ADP_DESCRIPTIONS));
+    EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
 
     TScanOsAlertDetailsBuilder<MockDatabaseFeedManager,
                                TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27316|

This PR aims to enhance `global-data` performance by avoiding unnecessary return statements and optimizing access to the singleton instance. These improvements reduce overhead and ensure more efficient data retrieval and usage.






