### PR TITLE
Create `/run/wazuh-server` directory at server startup

### DIFF
--- a/apis/tools/env/wazuh-server/Dockerfile
+++ b/apis/tools/env/wazuh-server/Dockerfile
@@ -62,8 +62,6 @@ RUN groupadd -f "$GROUP" && useradd "$USER" -d "/" -s "/sbin/nologin" -g "$GROUP
 # Copy directories from builder
 COPY --from=builder --chown=${USER}:${GROUP} /etc/wazuh-server /etc/wazuh-server
 
-COPY --from=builder --chown=${USER}:${GROUP} /run/wazuh-server /run/wazuh-server
-
 COPY --from=builder --chown=${USER}:${GROUP} /var/log/wazuh-server /var/log/wazuh-server
 
 COPY --from=builder --chown=${USER}:${GROUP} /var/lib/wazuh-server /var/lib/wazuh-server

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -12,7 +12,6 @@ SHARE_INSTALLDIR       ?= /usr/share/${WAZUH_SERVER}
 LOG_INSTALLDIR         ?= /var/log/${WAZUH_SERVER}
 LIB_INSTALLDIR         ?= /var/lib/${WAZUH_SERVER}
 ETC_INSTALLDIR         ?= /etc/${WAZUH_SERVER}
-RUN_INSTALLDIR         ?= /run/${WAZUH_SERVER}
 BIN_INSTALLDIR         ?= ${SHARE_INSTALLDIR}/bin
 
 CC           = gcc
@@ -54,11 +53,6 @@ install:
 	$(INSTALL_DIR) $(ETC_INSTALLDIR)/cluster
 	$(INSTALL_DIR) $(ETC_INSTALLDIR)/certs
 	$(INSTALL_DIR) $(ETC_INSTALLDIR)/groups
-
-	# RUN
-	$(INSTALL_DIR) $(RUN_INSTALLDIR)
-	$(INSTALL_DIR) $(RUN_INSTALLDIR)/cluster
-	$(INSTALL_DIR) $(RUN_INSTALLDIR)/socket
 
 	# SHARE
 	$(INSTALL_FILE) scripts/*.py ${SHARE_INSTALLDIR}/framework/scripts

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -16,12 +16,12 @@ import time
 
 from wazuh.core import pyDaemonModule
 from wazuh.core.authentication import generate_keypair, keypair_exists
-from wazuh.core.common import WAZUH_SHARE, wazuh_gid, wazuh_uid, CONFIG_SERVER_SOCKET_PATH
+from wazuh.core.common import WAZUH_SHARE, wazuh_gid, wazuh_uid, CONFIG_SERVER_SOCKET_PATH, WAZUH_RUN
 from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.config.models.server import NodeType
 from wazuh.core.cluster.cluster import clean_up
 from wazuh.core.cluster.utils import ClusterLogger, context_tag, process_spawn_sleep, print_version, ping_unix_socket
-from wazuh.core.utils import clean_pid_files
+from wazuh.core.utils import clean_pid_files, create_wazuh_dir
 from wazuh.core.wlogging import WazuhLogger
 from wazuh.core.cluster.unix_server.server import start_unix_server
 from wazuh.core.config.models.server import ServerConfig
@@ -350,6 +350,10 @@ def start():
 
     # Clean cluster files from previous executions
     clean_up()
+
+    # Create /run/wazuh-server
+    create_wazuh_dir(WAZUH_RUN)
+
     # Check for unused PID files
     clean_pid_files(SERVER_DAEMON_NAME)
 

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -150,6 +150,27 @@ key: value
 '''
 
 
+@pytest.mark.parametrize('exists', [True, False])
+@patch('wazuh.core.utils.chown')
+@patch('wazuh.core.common.wazuh_uid')
+@patch('wazuh.core.common.wazuh_gid')
+def test_create_wazuh_dir(mock_gid, mock_uid, mock_chown, exists):
+    """Test create_wazuh_dir function."""
+    dirpath = MagicMock()
+    dirpath.exists = MagicMock(return_value=exists)
+
+    utils.create_wazuh_dir(dirpath)
+
+    dirpath.exists.assert_called_once()
+
+    if not exists:
+        dirpath.mkdir.assert_called_once()
+        mock_chown.assert_called_once_with(dirpath, mock_uid(), mock_gid())
+    else:
+        dirpath.mkdir.assert_not_called()
+        mock_chown.assert_not_called()
+
+
 @patch('os.chown')
 @patch('wazuh.core.common.wazuh_uid')
 @patch('wazuh.core.common.wazuh_gid')
@@ -1911,4 +1932,3 @@ def test_agents_allow_higher_versions(new_conf, agents_conf):
         else:
             with pytest.raises(exception.WazuhError, match=".* 1129 .*"):
                 utils.check_agents_allow_higher_versions(new_conf)
-

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import operator
 import os
+import psutil
 import re
 import stat
 import sys
@@ -16,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 from functools import wraps
 from itertools import groupby, chain
 from os import chmod, chown, listdir, mkdir, curdir, rename, utime, path
-import psutil
+from pathlib import Path
 from shutil import move, copy2
 from signal import signal, alarm, SIGALRM, SIGKILL
 
@@ -36,6 +37,18 @@ t_cache = TTLCache(maxsize=4500, ttl=60)
 
 GROUP_FILE_EXT = '.yml'
 
+
+def create_wazuh_dir(dirpath: Path):
+    """Create a directory if it doesn't exist and assign ownership.
+
+    Parameters
+    ----------
+    dirpath : Path
+        Directory to create.
+    """
+    if not dirpath.exists():
+        dirpath.mkdir()
+        chown(dirpath, common.wazuh_uid(), common.wazuh_gid())
 
 def assign_wazuh_ownership(filepath: str):
     """Create a file if it doesn't exist and assign ownership.

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -50,6 +50,7 @@ def create_wazuh_dir(dirpath: Path):
         dirpath.mkdir()
         chown(dirpath, common.wazuh_uid(), common.wazuh_gid())
 
+
 def assign_wazuh_ownership(filepath: str):
     """Create a file if it doesn't exist and assign ownership.
 

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -72,7 +72,6 @@ override_dh_install:
 	cp -p $(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-comms-apid $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
 	cp -p $(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
 
-	cp -pr $(INSTALLATION_DIR)run/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)run/
 	cp -pr $(INSTALLATION_DIR)var/lib/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/
 	cp -pr $(INSTALLATION_DIR)var/log/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/log/
 	cp -pr $(INSTALLATION_DIR)usr/share/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/
@@ -91,8 +90,6 @@ override_dh_install:
 override_dh_fixperms:
 	dh_fixperms
 	# Folders
-	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server
-	find $(TARGET_DIR)$(INSTALLATION_DIR)run/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -237,9 +237,9 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/api
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/cluster
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/shared
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/groups
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/lib
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/framework
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/api

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -77,7 +77,6 @@ scl enable devtoolset-11 ./install.sh
 mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
 
 # Copy the installed files into RPM_BUILD_ROOT directory
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}run/wazuh-server
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}var/lib/wazuh-server
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}usr/bin
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}var/log
@@ -90,7 +89,6 @@ cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-apid ${RPM_BUILD_ROOT}%{
 cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-comms-apid ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
 cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
 
-cp -pr %{_localstatedir}run/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}run/
 cp -pr %{_localstatedir}var/lib/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}var/lib/
 cp -pr %{_localstatedir}var/log/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}var/log/
 cp -pr %{_localstatedir}usr/share/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/
@@ -177,7 +175,6 @@ if [ $1 = 0 ];then
   rm -rf %{_localstatedir}usr/bin/wazuh-apid
   rm -rf %{_localstatedir}usr/bin/wazuh-comms-apid
   rm -rf %{_localstatedir}usr/bin/wazuh-server
-  rm -rf %{_localstatedir}run/wazuh-server
   rm -rf %{_localstatedir}var/lib/wazuh-server
   rm -rf %{_localstatedir}usr/share/wazuh-server
   rm -rf %{_localstatedir}etc/wazuh-server
@@ -232,7 +229,6 @@ rm -fr %{buildroot}
 
 %files
 %defattr(-, %{_wazuh_user}, %{_wazuh_group})
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}run/wazuh-server
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/vd
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/tmp
@@ -241,11 +237,9 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/api
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/cluster
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/groups
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}run/wazuh-server/cluster
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}run/wazuh-server/socket
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/shared
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/lib
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/framework
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/api

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -31,8 +31,6 @@ InstallCommon()
 
   ./init/adduser.sh ${WAZUH_USER} ${WAZUH_GROUP} ${INSTALLDIR}
 
-  # Folder for the engine api socket
-  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}run/wazuh-engine
   # Folder for persistent databases (vulnerability scanner, ruleset, connector).
   ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine
   # Folder for persistent databases (vulnerability scanner).
@@ -155,9 +153,6 @@ InstallEngine()
   checkDownloadContent
   mkdir -p ${INSTALLDIR}usr/share/wazuh-server/bin
   ${INSTALL} -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} engine/build/main ${INSTALLDIR}usr/share/wazuh-server/bin/wazuh-engine
-
-  # Folder for the engine socket.
-  ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}run/wazuh-server/
 
   # Folder for persistent databases (vulnerability scanner, ruleset, connector).
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/


### PR DESCRIPTION
|Related issue|
|---|
|#27258|

## Description

This PR closes #27258. Change the creation behavior of the `/run/wazuh-server` directory moving it from the installation process to the server start-up.

## Logs/Alerts example

In a freshly installed server the `/run/wazuh-server` don't exists.

```console
root@3d4c543abea8:/pkg# apt install ./wazuh-server_5.0.0-test_amd64_48f1662115.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-server' instead of './wazuh-server_5.0.0-test_amd64_48f1662115.deb'
The following additional packages will be installed:
  adduser
Suggested packages:
  liblocale-gettext-perl perl cron quota ecryptfs-utils expect
The following NEW packages will be installed:
  adduser wazuh-server
0 upgraded, 2 newly installed, 0 to remove and 11 not upgraded.
Need to get 101 kB/288 MB of archives.
After this operation, 542 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://archive.ubuntu.com/ubuntu noble/main amd64 adduser all 3.137ubuntu1 [101 kB]
Get:2 /pkg/wazuh-server_5.0.0-test_amd64_48f1662115.deb wazuh-server amd64 5.0.0-test [288 MB]
Fetched 101 kB in 2s (56.4 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package adduser.
(Reading database ... 8531 files and directories currently installed.)
Preparing to unpack .../adduser_3.137ubuntu1_all.deb ...
Unpacking adduser (3.137ubuntu1) ...
Setting up adduser (3.137ubuntu1) ...
Selecting previously unselected package wazuh-server.
(Reading database ... 8579 files and directories currently installed.)
Preparing to unpack .../wazuh-server_5.0.0-test_amd64_48f1662115.deb ...
Unpacking wazuh-server (5.0.0-test) ...
Setting up wazuh-server (5.0.0-test) ...
Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
root@3d4c543abea8:/pkg# ll /run/
total 16
drwxr-xr-x 1 root root 4096 Dec 17 11:20 ./
drwxr-xr-x 1 root root 4096 Dec 17 11:18 ../
-rw-r--r-- 1 root root    0 Dec 17 11:20 adduser
drwxrwxrwt 2 root root 4096 Aug 27 11:03 lock/
drwxr-xr-x 2 root root 4096 Aug 27 11:06 systemd/
```

At the first start, the directory will be created

```console
root@3d4c543abea8:/pkg# /usr/share/wazuh-server/bin/wazuh-server start > out.log 2>&1 &
[1] 2310
root@3d4c543abea8:/pkg# ll /run/wazuh-server/
total 44
drwxr-xr-x 2 wazuh-server wazuh-server 4096 Dec 17 11:28 ./
drwxr-xr-x 1 root         root         4096 Dec 17 11:28 ../
srw-rw-rw- 1 wazuh-server wazuh-server    0 Dec 17 11:28 comms-api.sock=
srw-rw-rw- 1 wazuh-server wazuh-server    0 Dec 17 11:28 config-server.sock=
srwxr-xr-x 1 wazuh-server wazuh-server    0 Dec 17 11:28 engine-api.socket=
srwxr-xr-x 1 wazuh-server wazuh-server    0 Dec 17 11:28 engine.socket=
srw-rw---- 1 wazuh-server wazuh-server    0 Dec 17 11:28 local-server.sock=
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-apid-2813.pid
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-apid_auth-2824.pid
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-apid_events-2827.pid
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-apid_exec-2821.pid
-rw-r--r-- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-comms-apid-2759.pid
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-engined-2321.pid
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-server-2315.pid
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-server_child_0-2317.pid
-rw-r----- 1 wazuh-server wazuh-server    5 Dec 17 11:28 wazuh-server_child_1-2318.pid
```

## Tests

```console
(framework) ➜  wazuh git:(bug/27258-run-wazuh-server-refactor) ✗ PYTHONPATH=$WAZUH_REPO/api:$WAZUH_REPO/framework:$WAZUH_REPO/apis/comms_api python -m pytest --disable-warnings framework/wazuh/core/tests/test_utils.py::test_create_wazuh_dir
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/nstefani/git/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.8.0, anyio-4.1.0, html-2.1.1, metadata-3.1.1, cov-4.1.0
asyncio: mode=auto
collected 2 items

framework/wazuh/core/tests/test_utils.py ..                                                                                                                                                                   [100%]

================================================================================================= 2 passed in 0.87s =================================================================================================
```
