### PR TITLE
Downgrade devcontainer

### DIFF
--- a/src/engine/tools/devContainer/.devcontainer/Dockerfile
+++ b/src/engine/tools/devContainer/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-22.04
 
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="3.30.5"
 


### PR DESCRIPTION
|Related issue|
|---|
|#26966|

## Description

It was found that the workflow that checks the code format has a runner based in Ubuntu 22.04
https://github.com/wazuh/wazuh/blob/b3915ae16d5fe2836b64b2d1f5209d2bc6914c9f/.github/workflows/engine_style_documentation.yml#L142-L143

This means that ` clang-format version 14.0.0-1ubuntu1.1` is used.
But the dev container is based on Ubuntu 24.04

https://github.com/wazuh/wazuh/blob/b3915ae16d5fe2836b64b2d1f5209d2bc6914c9f/src/engine/tools/devContainer/.devcontainer/Dockerfile#L1

And `clang-format version 18.1.3 (1ubuntu1)` is used instead.

This difference leads to errors and inconsistencies.

