### PR TITLE
Remove all wazuh-server resources after unistalling it

### DIFF
--- a/packages/debs/SPECS/debian/postinst
+++ b/packages/debs/SPECS/debian/postinst
@@ -7,11 +7,7 @@ case "$1" in
 
         OS=$(lsb_release -si)
         VER=$(lsb_release -sr)
-        DIR="/var/wazuh-server"
-        USER="wazuh"
-        GROUP="wazuh"
-        WAZUH_GLOBAL_TMP_DIR="${DIR}/packages_files"
-        WAZUH_TMP_DIR="${WAZUH_GLOBAL_TMP_DIR}/manager_config_files"
+        WAZUH_TMP_DIR="/tmp"
         OSMYSHELL="/sbin/nologin"
 
         if [ -d /run/systemd/system ]; then
@@ -22,13 +18,6 @@ case "$1" in
             if [ -f "/bin/false" ]; then
                 OSMYSHELL="/bin/false"
             fi
-        fi
-
-        if ! getent group ${GROUP} > /dev/null 2>&1; then
-            addgroup --system ${GROUP}  > /dev/null 2>&1
-        fi
-        if ! getent passwd ${USER} > /dev/null 2>&1; then
-            adduser --system --home ${DIR} --shell ${OSMYSHELL} --ingroup ${GROUP} ${USER} > /dev/null 2>&1
         fi
 
         # Remove old service file /etc/systemd/system/wazuh-server.service if present

--- a/packages/debs/SPECS/debian/postrm
+++ b/packages/debs/SPECS/debian/postrm
@@ -3,18 +3,21 @@
 # Wazuh, Inc 2015
 set -e
 
+WAZUH_USER="wazuh-server"
+WAZUH_GROUP="wazuh-server"
+
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)
 
     ;;
 
     purge)
-        if getent passwd wazuh > /dev/null 2>&1 ; then
-            deluser wazuh  > /dev/null 2>&1
+        if getent passwd $WAZUH_USER > /dev/null 2>&1 ; then
+            deluser $WAZUH_USER  > /dev/null 2>&1
         fi
 
-        if getent group wazuh > /dev/null 2>&1; then
-            delgroup wazuh  > /dev/null 2>&1
+        if getent group $WAZUH_GROUP > /dev/null 2>&1; then
+            delgroup $WAZUH_GROUP  > /dev/null 2>&1
         fi
 
         if [ -d "/var/lib/wazuh-server/" ]; then

--- a/packages/debs/SPECS/debian/postrm
+++ b/packages/debs/SPECS/debian/postrm
@@ -24,6 +24,14 @@ case "$1" in
         if [ -d "/run/wazuh-server" ]; then
             rm -rf /run/wazuh-server || true
         fi
+
+        if [ -d "/etc/wazuh-server" ]; then
+            rm -rf /etc/wazuh-server || true
+        fi
+
+        if [ -d "/var/log/wazuh-server" ]; then
+            rm -rf /var/log/wazuh-server || true
+        fi
     ;;
 
     upgrade)

--- a/packages/debs/SPECS/debian/preinst
+++ b/packages/debs/SPECS/debian/preinst
@@ -4,8 +4,7 @@
 set -e
 
 # configuration variables
-DIR="/var/wazuh-server"
-WAZUH_TMP_DIR="${DIR}/packages_files/manager_config_files"
+WAZUH_TMP_DIR="/tmp"
 VERSION="$2"
 MAJOR=$(echo "$VERSION" | cut -dv -f2 | cut -d. -f1)
 WAZUH_USER="wazuh-server"

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -172,12 +172,9 @@ if [ $1 = 0 ];then
   fi
 
   # Remove lingering folders and files
-  rm -rf %{_localstatedir}usr/bin/wazuh-engine
-  rm -rf %{_localstatedir}usr/bin/wazuh-keystore
-  rm -rf %{_localstatedir}usr/bin/wazuh-apid
-  rm -rf %{_localstatedir}usr/bin/wazuh-comms-apid
-  rm -rf %{_localstatedir}usr/bin/wazuh-server
+  rm -rf %{_localstatedir}run/wazuh-server
   rm -rf %{_localstatedir}var/lib/wazuh-server
+  rm -rf %{_localstatedir}var/log/wazuh-server
   rm -rf %{_localstatedir}usr/share/wazuh-server
   rm -rf %{_localstatedir}etc/wazuh-server
 fi


### PR DESCRIPTION
|Related issue|
|---|
|#27318|

## Description

This PR closes #27318. Modify the post-remove scripts to delete all the resources installed with `wazuh-server`.

## Logs/Alerts example

<details><summary>DEB remove</summary>
<p>

```console
root@aaa6a3606c50:/pkg# find / -name wazuh-server
/etc/init.d/wazuh-server
/etc/wazuh-server
/var/log/wazuh-server
/var/lib/wazuh-server
/usr/share/doc/wazuh-server
/usr/share/wazuh-server
/usr/share/wazuh-server/bin/wazuh-server
/run/wazuh-server
root@aaa6a3606c50:/pkg# apt purge wazuh-server
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-server*
0 upgraded, 0 newly installed, 1 to remove and 11 not upgraded.
After this operation, 542 MB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 26288 files and directories currently installed.)
Removing wazuh-server (5.0.0-test) ...
Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
(Reading database ... 8582 files and directories currently installed.)
Purging configuration files for wazuh-server (5.0.0-test) ...
root@aaa6a3606c50:/pkg# find / -name wazuh-server
root@aaa6a3606c50:/pkg#
```

</p>
</details>

<details><summary>RPM remove</summary>
<p>

```console
[root@6669951c480f pkg]# find / -name wazuh-server
/etc/rc.d/init.d/wazuh-server
/etc/wazuh-server
/var/log/wazuh-server
/var/lib/wazuh-server
/usr/share/wazuh-server
/usr/share/wazuh-server/bin/wazuh-server
/run/wazuh-server
[root@6669951c480f pkg]# yum remove wazuh-server
Loaded plugins: fastestmirror, ovl
Resolving Dependencies
--> Running transaction check
---> Package wazuh-server.x86_64 0:5.0.0-test will be erased
--> Finished Dependency Resolution

Dependencies Resolved

=====================================================================================================================================================================================================================
 Package                                      Arch                                   Version                                       Repository                                                                   Size
=====================================================================================================================================================================================================================
Removing:
 wazuh-server                                 x86_64                                 5.0.0-test                                    @/wazuh-server_5.0.0-test_x86_64_f48d159ca4                                 529 M

Transaction Summary
=====================================================================================================================================================================================================================
Remove  1 Package

Installed size: 529 M
Is this ok [y/N]: y
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Unable to stop wazuh-server. Neither systemctl nor service are available.
  Erasing    : wazuh-server-5.0.0-test.x86_64                                                                                                                                                                    1/1
warning: file /var/lib/wazuh-server/engine/kvdb/kvdb/OPTIONS-000053: remove failed: No such file or directory
warning: file /var/lib/wazuh-server/engine/kvdb/kvdb/MANIFEST-000005: remove failed: No such file or directory
warning: file /var/lib/wazuh-server/engine/kvdb/kvdb/000004.log: remove failed: No such file or directory
  Verifying  : wazuh-server-5.0.0-test.x86_64                                                                                                                                                                    1/1

Removed:
  wazuh-server.x86_64 0:5.0.0-test

Complete!
[root@6669951c480f pkg]# find / -name wazuh-server
[root@6669951c480f pkg]#
```

As we can see, some warnings are thrown during the uninstall process, but all the resources are deleted. We have #27115 to check them.

</p>
</details> 

