### PR TITLE
Fix comms api socket path typo

### DIFF
--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -964,7 +964,7 @@ class Handler(asyncio.Protocol):
 
         Raises
         ------
-        WazuhError(3041)
+        WazuhError(3050)
             Connection or timeout error.
 
         Returns
@@ -996,7 +996,7 @@ class Handler(asyncio.Protocol):
 
             self.logger.debug(f'Orders send response: {response}')
         except (httpx.ConnectError, httpx.TimeoutException) as e:
-            raise exception.WazuhError(3041, extra_message=str(e))
+            raise exception.WazuhError(3050, extra_message=str(e))
 
         await client.aclose()
 

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -976,7 +976,7 @@ class Handler(asyncio.Protocol):
         """
         self.logger.info('Sending orders to the Communications API')
 
-        transport = httpx.AsyncHTTPTransport(uds=common.COMMS_API_SOCKET)
+        transport = httpx.AsyncHTTPTransport(uds=common.COMMS_API_SOCKET_PATH)
         client = httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(10))
 
         orders_list = json.loads(orders)

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -942,7 +942,7 @@ async def test_handler_send_orders(json_loads_mock, close_mock, post_mock):
 async def test_handler_send_orders_ko(json_loads_mock, close_mock, post_mock):
     """Check if `send_orders` is called with expected parameters."""
     handler = cluster_common.Handler(cluster_items)
-    with pytest.raises(exception.WazuhError, match=r'.*3041.*'):
+    with pytest.raises(exception.WazuhError, match=r'.*3050.*'):
         await handler.send_orders(b'[{"source": "Users/Services", "user": "Management API"}]')
 
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -311,7 +311,6 @@ class WazuhException(Exception):
         3038: "Error while processing extra-valid files",
         3039: "Timeout while waiting to receive a file",
         3040: "Error while waiting to receive a file",
-        3041: 'Error while sending orders to the Communications API unix server',
 
         # HAProxy Helper exceptions
         3041: "Server status check timed out after adding new servers",
@@ -323,6 +322,9 @@ class WazuhException(Exception):
         3047: "Invalid HAProxy Dataplane API specification configured",
         3048: "Could not detect a valid HAProxy process linked to the Dataplane API",
         3049: "Unexpected response from HAProxy Dataplane API",
+
+        # Orders distribution exceptions
+        3050: 'Error while sending orders to the Communications API unix server',
 
         # RBAC exceptions
         # The messages of these exceptions are provisional until the RBAC documentation is published.


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27367 |

## Description

Fixes a typo in the Communications API socket path used when distributing orders and updated the error code to avoid interference with the ones from HAProxy helper.

## Tests

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_orders --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/cluster/tests/test_common.py .                                                                                                                                                                                    [100%]

======================================================================================================= 1 passed, 2 warnings in 0.36s ========================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/cluster/tests/test_common.py::test_handler_send_orders_ko --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/cluster/tests/test_common.py .                                                                                                                                                                                    [100%]

============================================================================================================= 1 passed in 0.49s ==============================================================================================================
```

</details>