### PR TITLE
Exit server when a daemon fail to start

### DIFF
--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -103,15 +103,15 @@ def test_start_daemons_ko(mock_popen):
     with patch.object(wazuh_server, 'main_logger') as main_logger_mock, \
         patch.object(wazuh_server.pyDaemonModule, 'get_parent_pid', return_value=pid):
 
-        with pytest.raises(wazuh_server.DaemonStartError, match='Error starting wazuh-engined: return code 1'):
+        with pytest.raises(wazuh_server.WazuhDaemonError, match='Error starting wazuh-engined: return code 1'):
             wait_mock.side_effect = (1,)
             wazuh_server.start_daemons(False)
 
-        with pytest.raises(wazuh_server.DaemonStartError, match='Error starting wazuh-comms-apid: return code 1'):
+        with pytest.raises(wazuh_server.WazuhDaemonError, match='Error starting wazuh-comms-apid: return code 1'):
             wait_mock.side_effect = (0, 1)
             wazuh_server.start_daemons(False)
 
-        with pytest.raises(wazuh_server.DaemonStartError, match='Error starting wazuh-apid: return code 1'):
+        with pytest.raises(wazuh_server.WazuhDaemonError, match='Error starting wazuh-apid: return code 1'):
             wait_mock.side_effect = (0, 0, 1)
             wazuh_server.start_daemons(False)
 
@@ -463,7 +463,7 @@ def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock
                         "permission for 'wazuh' user")
 
                 error_message = 'Some daemon fail to start'
-                start_daemons_mock.side_effect = wazuh_server.DaemonStartError(error_message)
+                start_daemons_mock.side_effect = wazuh_server.WazuhDaemonError(error_message)
                 wazuh_server.start()
                 main_logger_mock.assert_any_call(error_message)
 

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -455,6 +455,12 @@ def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock
                         "Directory '/tmp' needs read, write & execution "
                         "permission for 'wazuh' user")
 
+                error_message = 'Some daemon fail to start'
+                start_daemons_mock.side_effect = wazuh_server.DaemonStartError(error_message)
+                wazuh_server.start()
+                main_logger_mock.assert_any_call(error_message)
+
+
 
 @patch('scripts.wazuh_server.shutdown_server')
 @patch('scripts.wazuh_server.os.kill')

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -92,27 +92,34 @@ def test_start_daemons_ko(mock_popen):
             pass
 
     wazuh_server.main_logger = LoggerMock
+    wazuh_server.debug_mode_ = 0
     pid = 2
+    wait_mock = Mock()
     process_mock = Mock()
-    attrs = {'poll.return_value': 1, 'wait.return_value': 1}
+    attrs = {'wait': wait_mock}
     process_mock.configure_mock(**attrs)
     mock_popen.return_value = process_mock
 
     with patch.object(wazuh_server, 'main_logger') as main_logger_mock, \
         patch.object(wazuh_server.pyDaemonModule, 'get_parent_pid', return_value=pid):
-        wazuh_server.start_daemons(False)
+
+        with pytest.raises(wazuh_server.DaemonStartError, match='Error starting wazuh-engined: return code 1'):
+            wait_mock.side_effect = (1,)
+            wazuh_server.start_daemons(False)
+
+        with pytest.raises(wazuh_server.DaemonStartError, match='Error starting wazuh-comms-apid: return code 1'):
+            wait_mock.side_effect = (0, 1)
+            wazuh_server.start_daemons(False)
+
+        with pytest.raises(wazuh_server.DaemonStartError, match='Error starting wazuh-apid: return code 1'):
+            wait_mock.side_effect = (0, 0, 1)
+            wazuh_server.start_daemons(False)
 
     mock_popen.assert_has_calls([
         call([wazuh_server.ENGINE_BINARY_PATH, 'server', '-l', 'info', 'start']),
         call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.MANAGEMENT_API_SCRIPT_PATH]),
         call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.COMMS_API_SCRIPT_PATH]),
     ], any_order=True)
-
-    main_logger_mock.error.assert_has_calls([
-        call('Error starting wazuh-engined: return code 1'),
-        call('Error starting wazuh-apid: return code 1'),
-        call('Error starting wazuh-comms-apid: return code 1'),
-    ])
 
 
 @patch('scripts.wazuh_server.os.kill')

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -38,6 +38,7 @@ MANAGEMENT_API_DAEMON_NAME = 'wazuh-apid'
 
 
 class DaemonStartError(Exception):
+    """Exception raised when a server daemon fails to start."""
     pass
 
 #

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -21,6 +21,7 @@ from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.config.models.server import NodeType
 from wazuh.core.cluster.cluster import clean_up
 from wazuh.core.cluster.utils import ClusterLogger, context_tag, process_spawn_sleep, print_version, ping_unix_socket
+from wazuh.core.exception import WazuhDaemonError
 from wazuh.core.utils import clean_pid_files, create_wazuh_dir
 from wazuh.core.wlogging import WazuhLogger
 from wazuh.core.cluster.unix_server.server import start_unix_server
@@ -36,10 +37,6 @@ ENGINE_DAEMON_NAME = 'wazuh-engined'
 MANAGEMENT_API_SCRIPT_PATH = WAZUH_SHARE / 'api' / 'scripts' / 'wazuh_apid.py'
 MANAGEMENT_API_DAEMON_NAME = 'wazuh-apid'
 
-
-class DaemonStartError(Exception):
-    """Exception raised when a server daemon fails to start."""
-    pass
 
 #
 # Aux functions
@@ -93,7 +90,7 @@ def start_daemon(name: str, args: List[str]):
             pyDaemonModule.create_pid(ENGINE_DAEMON_NAME, pid)
         main_logger.info(f'Started {name} (pid: {pid})')
     except Exception as e:
-        raise DaemonStartError(f'Error starting {name}: {e}')
+        raise WazuhDaemonError(f'Error starting {name}: {e}')
 
 
 def start_daemons(root: bool):
@@ -386,7 +383,7 @@ def start():
         main_logger.info('SIGINT received. Shutting down...')
     except MemoryError:
         main_logger.error("Directory '/tmp' needs read, write & execution " "permission for 'wazuh' user")
-    except DaemonStartError as e:
+    except WazuhDaemonError as e:
         main_logger.error(e)
     except Exception as e:
         main_logger.error(f'Unhandled exception: {e}')

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -37,6 +37,9 @@ MANAGEMENT_API_SCRIPT_PATH = WAZUH_SHARE / 'api' / 'scripts' / 'wazuh_apid.py'
 MANAGEMENT_API_DAEMON_NAME = 'wazuh-apid'
 
 
+class DaemonStartError(Exception):
+    pass
+
 #
 # Aux functions
 #
@@ -89,7 +92,7 @@ def start_daemon(name: str, args: List[str]):
             pyDaemonModule.create_pid(ENGINE_DAEMON_NAME, pid)
         main_logger.info(f'Started {name} (pid: {pid})')
     except Exception as e:
-        main_logger.error(f'Error starting {name}: {e}')
+        raise DaemonStartError(f'Error starting {name}: {e}')
 
 
 def start_daemons(root: bool):
@@ -382,6 +385,8 @@ def start():
         main_logger.info('SIGINT received. Shutting down...')
     except MemoryError:
         main_logger.error("Directory '/tmp' needs read, write & execution " "permission for 'wazuh' user")
+    except DaemonStartError as e:
+        main_logger.error(e)
     except Exception as e:
         main_logger.error(f'Unhandled exception: {e}')
     finally:

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -631,6 +631,14 @@ class WazuhIndexerError(WazuhInternalError):
     _default_title = "Wazuh Indexer Error"
 
 
+class WazuhDaemonError(WazuhInternalError):
+    """
+    This type of exception is raised inside the server daemons.
+    """
+    _default_type = "about:blank"
+    _default_title = "Wazuh Daemon Error"
+
+
 class WazuhError(WazuhException):
     """
     This type of exception is raised as a controlled response to a bad request from user


### PR DESCRIPTION
|Related issue|
|---|
|#27313|

## Description

This PR closes #27313. Changes the behavior of the server startup exiting when one of the daemons fails to start.

## Logs/Alerts example

<details><summary>wazuh-engined start failure</summary>
<p>

```console
root@44f96370db8a:/wazuh# vim /etc/wazuh-server/wazuh-server.yml
root@44f96370db8a:/wazuh#
root@44f96370db8a:/wazuh# /usr/share/wazuh-server/bin/wazuh-server start
2024/12/19 07:53:07 INFO: [Cluster] [Main] Starting server (pid: 35667)
2024/12/19 07:53:08 INFO: [Master] [Main] Configuration server is not available, retrying...
2024/12/19 07:53:08 INFO: [Master] [Config Server] Started server process [35667]
2024/12/19 07:53:08 INFO: [Master] [Config Server] Waiting for application startup.
2024/12/19 07:53:08 INFO: [Master] [Config Server] Application startup complete.
2024/12/19 07:53:08 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2024/12/19 07:53:09 INFO: [Local Server] [Main] Starting wazuh-engined
2024-12-19 07:53:09.504 35673:35673 info: Logging initialized.
2024/12/19 07:53:09 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 500
2024/12/19 07:53:09 ERROR: [Master] [Config Server] Exception in ASGI application
Traceback (most recent call last):
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 426, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
    return await self.app(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/routing.py", line 756, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/routing.py", line 776, in app
    await route.handle(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/routing.py", line 297, in handle
    await self.app(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/routing.py", line 77, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/starlette/routing.py", line 72, in app
    response = await func(request)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/wazuh/core/cluster/unix_server/config.py", line 36, in get_config
    config = CentralizedConfig.get_config_json(sections=validated_sections)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/wazuh/core/config/client.py", line 159, in get_config_json
    return cls._config.model_dump_json(include=[section.value for section in sections])
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/pydantic/main.py", line 477, in model_dump_json
    return self.__pydantic_serializer__.to_json(
pydantic_core._pydantic_core.PydanticSerializationError: Error serializing to JSON: PydanticSerializationError: Error calling function `convert_hosts_to_str`: AttributeError: 'NoneType' object has no attribute 'use_ssl'
2024-12-19 07:53:09.511 35673:35673 error: Error loading configuration: Error while loading configuration from API: 'HTTP response code said error' - '500'
2024/12/19 07:53:09 ERROR: [Cluster] [Main] Error starting wazuh-engined: return code 1
2024/12/19 07:53:09 INFO: [Cluster] [Main] Waiting for daemons shutdown.
root@44f96370db8a:/wazuh# ps auxf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   7604  4096 pts/0    SNs  07:41   0:00 bash
root       35674  0.0  0.0  10880  4352 pts/0    RN+  07:53   0:00 ps auxf
```

</p>
</details> 

<details><summary>wazuh-comms-apid start failure</summary>
<p>

```console
root@44f96370db8a:/wazuh# /usr/share/wazuh-server/bin/wazuh-server start
2024/12/19 07:55:45 INFO: [Cluster] [Main] Starting server (pid: 36179)
2024/12/19 07:55:46 INFO: [Master] [Main] Configuration server is not available, retrying...
2024/12/19 07:55:46 INFO: [Master] [Config Server] Started server process [36179]
2024/12/19 07:55:46 INFO: [Master] [Config Server] Waiting for application startup.
2024/12/19 07:55:46 INFO: [Master] [Config Server] Application startup complete.
2024/12/19 07:55:46 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2024/12/19 07:55:47 INFO: [Local Server] [Main] Starting wazuh-engined
2024-12-19 07:55:47.611 36185:36185 info: Logging initialized.
2024/12/19 07:55:47 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2024-12-19 07:55:47.615 36185:36185 info: Metrics manager configured successfully
2024-12-19 07:55:47.634 36185:36185 info: Metrics pipeline enabled successfully
2024-12-19 07:55:47.634 36185:36185 info: Metrics initialized.
2024-12-19 07:55:47.638 36185:36185 info: Store initialized.
2024-12-19 07:55:47.638 36185:36185 info: RBAC initialized.
2024-12-19 07:55:47.673 36185:36185 info: KVDB initialized.
2024-12-19 07:55:47.673 36185:36185 info: Geo initialized.
2024-12-19 07:55:47.688 36185:36185 info: Schema initialized.
2024-12-19 07:55:47.700 36185:36185 info: Loaded timezone database version: '2024a'
2024-12-19 07:55:47.704 36185:36185 info: HLP initialized.
2024-12-19 07:55:47.711 36185:36185 info: Indexer Connector initialized.
2024-12-19 07:55:47.711 36185:36185 info: Builder initialized.
2024-12-19 07:55:47.712 36185:36185 info: Catalog initialized.
2024-12-19 07:55:47.712 36185:36185 info: Policy manager initialized.
2024-12-19 07:55:47.712 36185:36185 info: No flooding file provided, the queue will not be flooded.
2024-12-19 07:55:47.722 36185:36185 info: No flooding file provided, the queue will not be flooded.
2024-12-19 07:55:47.722 36185:36185 warning: Router: router/tester/0 table is empty
2024-12-19 07:55:47.824 36185:36185 info: Router initialized.
2024-12-19 07:55:47.843 36185:36185 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2024-12-19 07:55:47.844 36185:36185 info: Starting the server...
2024/12/19 07:55:49 INFO: [Local Server] [Main] Started wazuh-engined (pid: 36185)
2024/12/19 07:55:49 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2024/12/19 07:55:50 INFO: [Communications API] Starting API
2024/12/19 07:55:50 INFO: [Communications API] Listening on localhost:27000
2024/12/19 07:55:50 ERROR: [Communications API] Error when trying to start the Wazuh Communications API. Error 2702 - Ensure the certificates have the correct permissions: [Errno 13] Permission denied: '/etc/wazuh-server/certs/api.key'
2024/12/19 07:55:50 INFO: [Communications API] Shutting down MuxDemuxRunner
2024/12/19 07:55:51 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 36620)
2024/12/19 07:55:51 INFO: [Local Server] [Main] Starting wazuh-apid
2024/12/19 07:55:52 INFO: [Management API] Starting API
2024/12/19 07:55:52 INFO: [Management API] Checking RBAC database integrity...
2024/12/19 07:55:52 INFO: [Management API] /var/lib/wazuh-server/rbac.db file was detected
2024/12/19 07:55:52 INFO: [Management API] RBAC database integrity check finished successfully
2024/12/19 07:55:53 INFO: [Local Server] [Main] Started wazuh-apid (pid: 36662)
2024/12/19 07:55:53 ERROR: [Master] [Main] Failed loading SSL context: [SSL] PEM lib (_ssl.c:3900). Using default one.
2024/12/19 07:55:53 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2024/12/19 07:55:53 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2024/12/19 07:55:53 INFO: [Master] [Local integrity] Starting.
2024/12/19 07:55:53 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 2 files.
2024/12/19 07:55:53 INFO: [Management API] Listening on ['localhost', '::1']:55000.
2024/12/19 07:55:53 INFO: [Management API] Getting installation UID...
2024/12/19 07:55:53 INFO: [Management API] Getting updates information...
2024/12/19 07:56:01 INFO: [Master] [Local integrity] Starting.
2024/12/19 07:56:01 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 2 files.
```

The exit process does not work when comms API fails because we have a signal problem. We'll review it in #27265.

</p>
</details> 

<details><summary>wazuh-apid start failure</summary>
<p>

```console
root@44f96370db8a:/wazuh# /usr/share/wazuh-server/bin/wazuh-server start
2024/12/19 07:54:21 INFO: [Cluster] [Main] Starting server (pid: 35683)
2024/12/19 07:54:21 INFO: [Master] [Main] Configuration server is not available, retrying...
2024/12/19 07:54:21 INFO: [Master] [Config Server] Started server process [35683]
2024/12/19 07:54:21 INFO: [Master] [Config Server] Waiting for application startup.
2024/12/19 07:54:21 INFO: [Master] [Config Server] Application startup complete.
2024/12/19 07:54:21 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2024/12/19 07:54:22 INFO: [Local Server] [Main] Starting wazuh-engined
2024-12-19 07:54:22.725 35689:35689 info: Logging initialized.
2024/12/19 07:54:22 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2024-12-19 07:54:22.730 35689:35689 info: Metrics manager configured successfully
2024-12-19 07:54:22.749 35689:35689 info: Metrics pipeline enabled successfully
2024-12-19 07:54:22.749 35689:35689 info: Metrics initialized.
2024-12-19 07:54:22.753 35689:35689 info: Store initialized.
2024-12-19 07:54:22.753 35689:35689 info: RBAC initialized.
2024-12-19 07:54:22.787 35689:35689 info: KVDB initialized.
2024-12-19 07:54:22.787 35689:35689 info: Geo initialized.
2024-12-19 07:54:22.801 35689:35689 info: Schema initialized.
2024-12-19 07:54:22.814 35689:35689 info: Loaded timezone database version: '2024a'
2024-12-19 07:54:22.817 35689:35689 info: HLP initialized.
2024-12-19 07:54:22.825 35689:35689 info: Indexer Connector initialized.
2024-12-19 07:54:22.826 35689:35689 info: Builder initialized.
2024-12-19 07:54:22.826 35689:35689 info: Catalog initialized.
2024-12-19 07:54:22.826 35689:35689 info: Policy manager initialized.
2024-12-19 07:54:22.827 35689:35689 info: No flooding file provided, the queue will not be flooded.
2024-12-19 07:54:22.836 35689:35689 info: No flooding file provided, the queue will not be flooded.
2024-12-19 07:54:22.836 35689:35689 warning: Router: router/tester/0 table is empty
2024-12-19 07:54:22.936 35689:35689 info: Router initialized.
2024-12-19 07:54:22.945 35689:35689 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2024-12-19 07:54:22.946 35689:35689 info: Starting the server...
2024/12/19 07:54:24 INFO: [Local Server] [Main] Started wazuh-engined (pid: 35689)
2024/12/19 07:54:24 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2024/12/19 07:54:25 INFO: [Communications API] Starting API
2024/12/19 07:54:25 INFO: [Communications API] Listening on localhost:27000
2024/12/19 07:54:25 INFO: [Communications API] Starting gunicorn 22.0.0
2024/12/19 07:54:25 INFO: [Communications API] Listening at: https://127.0.0.1:27000 (36124)
2024/12/19 07:54:25 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2024/12/19 07:54:25 INFO: [Communications API] Booting worker with pid: 36160
2024/12/19 07:54:25 INFO: [Communications API] Started server process [36124]
2024/12/19 07:54:25 INFO: [Communications API] Waiting for application startup.
2024/12/19 07:54:25 INFO: [Communications API] Application startup complete.
2024/12/19 07:54:25 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2024/12/19 07:54:26 INFO: [Communications API] Booting worker with pid: 36161
2024/12/19 07:54:26 INFO: [Communications API] Started server process [36161]
2024/12/19 07:54:26 INFO: [Communications API] Waiting for application startup.
2024/12/19 07:54:26 INFO: [Communications API] Application startup complete.
2024/12/19 07:54:26 INFO: [Communications API] Booting worker with pid: 36162
2024/12/19 07:54:26 INFO: [Communications API] Started server process [36162]
2024/12/19 07:54:26 INFO: [Communications API] Waiting for application startup.
2024/12/19 07:54:26 INFO: [Communications API] Application startup complete.
2024/12/19 07:54:26 INFO: [Communications API] Booting worker with pid: 36163
2024/12/19 07:54:26 INFO: [Communications API] Started server process [36163]
2024/12/19 07:54:26 INFO: [Communications API] Waiting for application startup.
2024/12/19 07:54:26 INFO: [Communications API] Application startup complete.
2024/12/19 07:54:26 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 36124)
2024/12/19 07:54:26 INFO: [Local Server] [Main] Starting wazuh-apid
2024/12/19 07:54:27 INFO: [Management API] HTTPS is enabled but cannot find the private key and/or certificate. Attempting to generate them
2024/12/19 07:54:27 ERROR: [Management API] 2003 - Error loading SSL/TLS certificates: Ensure the certificates have the correct permissions.
Traceback (most recent call last):
  File "/usr/share/wazuh-server/api/scripts/wazuh_apid.py", line 107, in configure_ssl
    private_key = generate_private_key(config.key)
  File "/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/api/configuration.py", line 121, in generate_private_key
    with open(private_key_path, 'wb') as f:
PermissionError: [Errno 13] Permission denied: '/etc/wazuh-server/certs/api.key'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/share/wazuh-server/api/scripts/wazuh_apid.py", line 331, in <module>
    configure_ssl(uvicorn_params, management_config.ssl)
  File "/usr/share/wazuh-server/api/scripts/wazuh_apid.py", line 162, in configure_ssl
    raise error from exc
api.api_exception.APIError: 2003 - Error loading SSL/TLS certificates: Ensure the certificates have the correct permissions.
2024/12/19 07:54:28 ERROR: [Cluster] [Main] Error starting wazuh-apid: return code 1
2024/12/19 07:54:28 INFO: [Cluster] [Main] Shutting down wazuh-engined (pid: 35689)
2024/12/19 07:54:28 INFO: [Cluster] [Main] Shutting down wazuh-comms-apid (pid: 36124)
2024/12/19 07:54:28 INFO: [Cluster] [Main] Waiting for daemons shutdown.
2024/12/19 07:54:28 INFO: [Communications API] Handling signal: term
2024/12/19 07:54:28 ERROR: [Communications API] Worker (pid:36160) was sent SIGTERM!
2024/12/19 07:54:28 INFO: [Communications API] Shutting down
2024/12/19 07:54:28 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2024/12/19 07:54:28 INFO: [Communications API] Shutting down
2024/12/19 07:54:28 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2024/12/19 07:54:28 INFO: [Communications API] Shutting down
2024/12/19 07:54:28 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2024/12/19 07:54:28 INFO: [Communications API] Waiting for application shutdown.
2024/12/19 07:54:28 INFO: [Communications API] Application shutdown complete.
2024/12/19 07:54:28 INFO: [Communications API] Finished server process [36163]
2024/12/19 07:54:28 INFO: [Communications API] Waiting for application shutdown.
2024/12/19 07:54:28 INFO: [Communications API] Application shutdown complete.
2024/12/19 07:54:28 INFO: [Communications API] Finished server process [36161]
2024/12/19 07:54:28 INFO: [Communications API] Worker exiting (pid: 36163)
2024/12/19 07:54:28 INFO: [Communications API] Worker exiting (pid: 36161)
2024/12/19 07:54:28 INFO: [Communications API] Waiting for application shutdown.
2024/12/19 07:54:28 INFO: [Communications API] Application shutdown complete.
2024/12/19 07:54:28 INFO: [Communications API] Finished server process [36162]
2024/12/19 07:54:28 INFO: [Communications API] Worker exiting (pid: 36162)
2024/12/19 07:54:28 INFO: [Communications API] Shutting down: Master
2024/12/19 07:54:28 INFO: [Communications API] Shutting down MuxDemuxRunner
root@44f96370db8a:/wazuh# ps auxf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   7604  4096 pts/0    SNs  07:41   0:00 bash
root       36171  0.0  0.0  10880  4480 pts/0    RN+  07:54   0:00 ps auxf
```

</p>
</details> 

## Tests

```console
(framework) ➜  wazuh git:(enhancement/27313-server-flow-execution) ✗ PYTHONPATH=$WAZUH_REPO/api:$WAZUH_REPO/framework:$WAZUH_REPO/apis/comms_api python -m pytest --disable-warnings framework/scripts/tests/test_wazuh_server.py -k test_start_daemons -v
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0 -- /home/nstefani/.pyenv/versions/framework/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-6.9.3-76060903-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'asyncio': '0.18.1', 'tavern': '1.23.5', 'trio': '0.8.0', 'anyio': '4.1.0', 'html': '2.1.1', 'metadata': '3.1.1', 'cov': '4.1.0'}}
rootdir: /home/nstefani/git/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, trio-0.8.0, anyio-4.1.0, html-2.1.1, metadata-3.1.1, cov-4.1.0
asyncio: mode=auto
collected 18 items / 15 deselected / 3 selected

framework/scripts/tests/test_wazuh_server.py::test_start_daemons[True] PASSED                                                                                                                                 [ 33%]
framework/scripts/tests/test_wazuh_server.py::test_start_daemons[False] PASSED                                                                                                                                [ 66%]
framework/scripts/tests/test_wazuh_server.py::test_start_daemons_ko PASSED                                                                                                                                    [100%]

========================================================================================= 3 passed, 15 deselected in 0.68s ==========================================================================================
```