### PR TITLE
Prevent AWS and wodles unit tests from running on PR

### DIFF
--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -11,10 +11,6 @@ on:
         description: 'Base qa-integration-framework branch'
         required: true
         default: 'main'
-  pull_request:
-    paths:
-      - ".github/workflows/integration-tests-aws-tier-0-1.yml"
-      - "wodles/aws/**"
 
 jobs:
   build:

--- a/.github/workflows/integration-tests-aws-tier-0-1.yml
+++ b/.github/workflows/integration-tests-aws-tier-0-1.yml
@@ -1,0 +1,182 @@
+name: Integration tests for AWS - Tier 0 and 1
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch'
+        required: true
+        default: 'main'
+      base_qa_it_fw_branch:
+        description: 'Base qa-integration-framework branch'
+        required: true
+        default: 'main'
+  pull_request:
+    paths:
+      - ".github/workflows/integration-tests-aws-tier-0-1.yml"
+      - "wodles/aws/**"
+
+jobs:
+  build:
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
+      QA_IT_FW_BRANCH: ${{ github.base_ref || inputs.base_qa_it_fw_branch }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.IT_AWS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: 'us-east-1'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".github/workflows/.python-version-it"
+          architecture: x64
+      # Download and install integration tests framework.
+      - name: Download and install integration tests framework
+        run: |
+          if [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${BRANCH_BASE}`" != "X" ]; then
+              QA_BRANCH=${BRANCH_BASE}
+          elif [ "X`git ls-remote https://github.com/wazuh/qa-integration-framework.git ${QA_IT_FW_BRANCH}`" != "X" ]; then
+              QA_BRANCH=${QA_IT_FW_BRANCH}
+          else
+              QA_BRANCH="main"
+          fi
+          git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
+          sudo pip install qa-integration-framework/
+          sudo rm -rf qa-integration-framework/
+      - name: Set AWS credentials file
+        run: |
+          sudo aws configure set aws_access_key_id ${{ secrets.IT_AWS_KEY_ID }} --profile default
+          sudo aws configure set aws_secret_access_key ${{ secrets.IT_AWS_SECRET_ACCESS_KEY }} --profile default
+          sudo aws configure set default.region ${AWS_DEFAULT_REGION} --profile default
+      # Build wazuh server for linux.
+      - name: Build wazuh server for linux
+        run: |
+          make deps -C src TARGET=server -j2
+          make -C src TARGET=server -j2
+      # Install wazuh server for linux.
+      - name: Install wazuh server for linux
+        run: |
+          echo 'USER_LANGUAGE="en"' > ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_NO_STOP="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_INSTALL_TYPE="server"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo "USER_DIR=/var/ossec" >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_EMAIL="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSCHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_ROOTCHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSCOLLECTOR="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SCA="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_WHITE_LIST="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_SYSLOG="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_AUTHD="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_ENABLE_UPDATE_CHECK="n"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          echo 'USER_AUTO_START="y"' >> ./etc/preloaded-vars.conf
+          echo "" >> ./etc/preloaded-vars.conf
+          sudo sh install.sh
+          rm ./etc/preloaded-vars.conf
+      # Run AWS integration tests.
+      - name: Run Parser related tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_s3.py') ||
+            contains(steps.get_modified_files.outputs.files, 'wodles/aws/aws_tools.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 test_aws/test_parser.py
+      - name: Run every test due to base WazuhIntegration class change or manual dispatch
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/wazuh_integration.py') ||
+            ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 test_aws/
+      # Bucket tests
+      - name: Run Custom Buckets tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k kms test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k macie test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k trusted_advisor test_aws/
+      - name: Run Config tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/config.py') ||
+            contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k config test_aws/
+      - name: Run GuardDuty tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/guardduty.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k guardduty test_aws/
+      - name: Run CloudTrail tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/cloudtrail.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k cloudtrail test_aws/
+      - name: Run Load Balancers tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/load_balancers.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k alb test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k clb test_aws/
+          sudo python3 -m pytest --tier 0 --tier 1 -k nlb test_aws/
+      - name: Run Server Access tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/server_access.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k server_access test_aws/
+      - name: Run Umbrella tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/umbrella.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k cisco test_aws/
+      - name: Run VPC Flow tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/vpcflow.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k vpc test_aws/
+      - name: Run WAF tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/waf.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/buckets_s3/aws_bucket.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k waf test_aws/
+      # Services tests
+      - name: Run CloudWatch tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/cloudwatchlogs.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/aws_service.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k cloudwatch test_aws/
+      - name: Run Inspector tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/inspector.py') ||
+          contains(steps.get_modified_files.outputs.files, 'wodles/aws/services/aws_service.py')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 -k inspector test_aws/
+      # Custom Logs Buckets tests
+      - name: Run Inspector tests
+        if: contains(steps.get_modified_files.outputs.files, 'wodles/aws/subscribers/**')
+        run: |
+          cd tests/integration
+          sudo python3 -m pytest --tier 0 --tier 1 test_aws/test_custom_bucket.py

--- a/.github/workflows/wodles-unit-tests.yml
+++ b/.github/workflows/wodles-unit-tests.yml
@@ -1,0 +1,36 @@
+name: Wodles unit tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/wodles-unit-tests.yml'
+      - 'wodles/**'
+      - 'src/Makefile'
+
+jobs:
+  build: 
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+    env:
+      PYTHONPATH: /home/runner/work/wazuh/wazuh/api:/home/runner/work/wazuh/wazuh/framework
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'framework/requirements-dev.txt'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r framework/requirements-dev.txt --no-build-isolation
+
+      - name: Run Wodles tests
+        run: python -m pytest wodles --cov

--- a/.github/workflows/wodles-unit-tests.yml
+++ b/.github/workflows/wodles-unit-tests.yml
@@ -2,14 +2,9 @@ name: Wodles unit tests
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - '.github/workflows/wodles-unit-tests.yml'
-      - 'wodles/**'
-      - 'src/Makefile'
 
 jobs:
-  build: 
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27341|

This PR aims to restore back the AWS and wodles integration tests workflows removed by:
- #27342

In addition, we're prevent those workflows from triggering on new pull requests.