### PR TITLE
Fix server RPM package generation

### DIFF
--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -233,7 +233,6 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/tmp
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/keystore
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server


### PR DESCRIPTION
|Related issue|
|---|
| #27377 |

## Description
This PR fixes the RPM package generation pipeline, there was an unexpected file

## Testing
Installed [generated package](https://github.com/wazuh/wazuh/actions/runs/12415252518):
```
ls -l
total 31464
-rwxr-x---. 1 wazuh-server wazuh-server      479 Dec 19 15:15 rbac_control
-rwxr-x---. 1 wazuh-server wazuh-server      476 Dec 19 15:15 wazuh-apid
-rwxr-x---. 1 wazuh-server wazuh-server      477 Dec 19 15:15 wazuh-comms-apid
-rwxr-x---. 1 wazuh-server wazuh-server 26066360 Dec 19 15:15 wazuh-engine
-rwxr-x---. 1 wazuh-server wazuh-server  6133312 Dec 19 15:15 wazuh-keystore
-rwxr-x---. 1 wazuh-server wazuh-server      479 Dec 19 15:15 wazuh-server

./wazuh-keystore -k testing -v testing
Key store file updated successfully.
```