### PR TITLE
Delete unused directories

### DIFF
--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -30,16 +30,6 @@ InstallCommon()
   WAZUH_CONTROL_SRC='./init/wazuh-server.sh'
 
   ./init/adduser.sh ${WAZUH_USER} ${WAZUH_GROUP} ${INSTALLDIR}
-
-  # Folder for persistent databases (vulnerability scanner, ruleset, connector).
-  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine
-  # Folder for persistent databases (vulnerability scanner).
-  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/vd
-  # Folder for persistent databases (ruleset).
-  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/ruleset
-  # Folder for persistent queues for the indexer connector.
-  ${INSTALL} -d -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-engine/indexer-connector
-
 }
 
 InstallPython()


### PR DESCRIPTION
|Related issue|
|---|
|#27101|

## Description

During the installation from source of Wazuh-Server (which includes Wazuh-Engine), empty directories are being created under /var/lib/wazuh-engine/ that are not utilized by any process. Specifically, the following empty directories are being created:

```
/var/lib/wazuh-engine/indexer-connector:
/var/lib/wazuh-engine/ruleset:
/var/lib/wazuh-engine/vd:

```
However, Wazuh-Engine actually uses the directories located under /var/lib/wazuh-server/. The necessary directories under /var/lib/wazuh-server/ are already being correctly created during the installation process. Therefore, we need to adjust the installation scripts to prevent the creation of the unused directories under /var/lib/wazuh-engine/.