### PR TITLE
Update CURL 8.11.1 for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Here you can find all the automation tools maintained by the Wazuh team.
 |[bzip2](https://github.com/libarchive/bzip2)|1.0.8|Julian Seward|BSD License|
 |[cJSON](https://github.com/DaveGamble/cJSON)|1.7.12|Dave Gamble|MIT License|
 |[cPython](https://github.com/python/cpython)|3.10.13|Guido van Rossum|Python Software Foundation License version 2|
-|[cURL](https://github.com/curl/curl)|8.5.0|Daniel Stenberg|MIT License|
+|[cURL](https://github.com/curl/curl)|8.11.1|Daniel Stenberg|MIT License|
 |[Flatbuffers](https://github.com/google/flatbuffers/)|23.5.26|Google Inc.|Apache 2.0 License|
 |[GoogleTest](https://github.com/google/googletest)|1.11.0|Google Inc.|3-Clause "New" BSD License|
 |[jemalloc](https://github.com/jemalloc/jemalloc)|5.2.1|Jason Evans|2-Clause "Simplified" BSD License|

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -233,7 +233,6 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/tmp
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/keystore
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server

--- a/src/engine/vcpkg.json
+++ b/src/engine/vcpkg.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "curl",
-      "version": "8.9.1#0"
+      "version": "8.11.1#0"
     },
     {
       "name": "date",


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27257|

# Objective

This PR aims to update the CURL despency for master branch

### Output 

```log
[cmake] -- Running vcpkg install
[cmake] Detecting compiler hash for triplet x64-linux...
[cmake] Compiler found: /usr/bin/c++
[cmake] The following packages will be rebuilt:
[cmake]     curl[core,non-http,openssl,ssl]:x64-linux@8.11.1 -- /root/.cache/vcpkg/registries/git-trees/aae0f4f9dd2f724e673c0d458fc4531626864393
[cmake]     opentelemetry-cpp:x64-linux@1.8.3#6 -- /root/.cache/vcpkg/registries/git-trees/dfd999f93f24e916631d57bf73c0bf02f8c2da0a
[cmake] Restored 0 package(s) from /root/.cache/vcpkg/archives in 344 us. Use --debug to see more details.
[cmake] Removing 1/4 opentelemetry-cpp:x64-linux
[cmake] Elapsed time to handle opentelemetry-cpp:x64-linux: 14 ms
[cmake] Removing 2/4 curl:x64-linux
[cmake] Elapsed time to handle curl:x64-linux: 1.97 ms
[cmake] Installing 3/4 curl[core,non-http,openssl,ssl]:x64-linux@8.11.1...
[cmake] Building curl[core,non-http,openssl,ssl]:x64-linux@8.11.1...
[cmake] /root/.cache/vcpkg/registries/git-trees/aae0f4f9dd2f724e673c0d458fc4531626864393: info: installing overlay port from here
[cmake] Downloading curl-curl-curl-8_11_1.tar.gz
[cmake] Successfully downloaded curl-curl-curl-8_11_1.tar.gz.
[cmake] -- Extracting source /usr/local/vcpkg-downloads/curl-curl-curl-8_11_1.tar.gz
[cmake] -- Applying patch 0005_remove_imp_suffix.patch
[cmake] -- Applying patch 0020-fix-pc-file.patch
[cmake] -- Applying patch 0022-deduplicate-libs.patch
[cmake] -- Applying patch export-components.patch
[cmake] -- Applying patch dependencies.patch
[cmake] -- Applying patch cmake-config.patch
[cmake] -- Using source at /usr/local/vcpkg/buildtrees/curl/src/url-8_11_1-50c8f64114.clean
[cmake] -- Found external ninja('1.11.1').
[cmake] -- Configuring x64-linux
[cmake] -- Building x64-linux-dbg
[cmake] -- Building x64-linux-rel
[cmake] -- Fixing pkgconfig file: /usr/local/vcpkg/packages/curl_x64-linux/lib/pkgconfig/libcurl.pc
[cmake] -- Fixing pkgconfig file: /usr/local/vcpkg/packages/curl_x64-linux/debug/lib/pkgconfig/libcurl.pc
[cmake] -- Installing: /usr/local/vcpkg/packages/curl_x64-linux/share/curl/vcpkg-cmake-wrapper.cmake
[cmake] -- Installing: /usr/local/vcpkg/packages/curl_x64-linux/share/curl/usage
[cmake] -- Performing post-build validation
[cmake] Stored binaries in 1 destinations in 589 ms.
[cmake] Elapsed time to handle curl:x64-linux: 20 s
[cmake] curl:x64-linux package ABI: e5f2ead5457a25cf6a13b1d62c8865a0c6e613e8e2936db7d24e359ae7aa8f35
[cmake] Installing 4/4 opentelemetry-cpp:x64-linux@1.8.3#6...
[cmake] Building opentelemetry-cpp:x64-linux@1.8.3#6...
[cmake] /root/.cache/vcpkg/registries/git-trees/dfd999f93f24e916631d57bf73c0bf02f8c2da0a: info: installing overlay port from here
[cmake] -- Using cached open-telemetry-opentelemetry-cpp-v1.8.3.tar.gz.
[cmake] -- Cleaning sources at /usr/local/vcpkg/buildtrees/opentelemetry-cpp/src/v1.8.3-b38e6ca96f.clean. Use --editable to skip cleaning for the packages you specify.
[cmake] -- Extracting source /usr/local/vcpkg-downloads/open-telemetry-opentelemetry-cpp-v1.8.3.tar.gz
[cmake] -- Applying patch use-default-cxx-version.patch
[cmake] -- Applying patch add-missing-dependencies.patch
[cmake] -- Applying patch add-missing-find-dependency.patch
[cmake] -- Using source at /usr/local/vcpkg/buildtrees/opentelemetry-cpp/src/v1.8.3-b38e6ca96f.clean
[cmake] -- Found external ninja('1.11.1').
[cmake] -- Configuring x64-linux
[cmake] -- Building x64-linux-dbg

---------------------------



100% tests passed, 0 tests failed out of 6939

Total Test time (real) = 515.81 sec
````