### PR TITLE
Avoid stateful events JSON encoding

### DIFF
--- a/apis/comms_api/core/events.py
+++ b/apis/comms_api/core/events.py
@@ -96,7 +96,7 @@ async def parse_stateful_events(request: Request) -> StatefulEvents:
                 if i == 0:
                     agent_metadata = AgentMetadata.model_validate_json(part)
                 elif i % 2 == 0:
-                    data.append(json.loads(part))
+                    data.append(part)
                 else:
                     header = Header.model_validate_json(part)
                     headers.append(header)

--- a/apis/comms_api/models/events.py
+++ b/apis/comms_api/models/events.py
@@ -8,7 +8,7 @@ from wazuh.core.indexer.models.events import AgentMetadata, Header, TaskResult
 class StatefulEvents(BaseModel):
     agent_metadata: AgentMetadata
     headers: List[Header]
-    data: List[dict]
+    data: List[bytes]
 
 
 class StatefulEventsResponse(BaseModel):

--- a/framework/wazuh/core/batcher/mux_demux.py
+++ b/framework/wazuh/core/batcher/mux_demux.py
@@ -149,7 +149,7 @@ class Packet:
         bytes
             Agent metadata and event joined.
         """
-        return b'{' + agent_metadata[1:-1] + b',' + data[1:-1] + b'}'
+        return b'{' + agent_metadata[1:-1] + b', ' + data[1:-1] + b'}'
 
 class MuxDemuxQueue:
     """Class for managing items between mux and demux components.

--- a/framework/wazuh/core/batcher/mux_demux.py
+++ b/framework/wazuh/core/batcher/mux_demux.py
@@ -134,7 +134,21 @@ class Packet:
 
         self.items.append(item)
     
-    def build_content(self, agent_metadata: bytes, data: bytes = None) -> bytes:        
+    def build_content(self, agent_metadata: bytes, data: bytes = None) -> bytes:
+        """Build event body.
+        
+        Parameters
+        ----------
+        agent_metadata : bytes
+            Agent metadata.
+        data : bytes
+            Event data.
+        
+        Returns
+        -------
+        bytes
+            Agent metadata and event joined.
+        """
         return b'{' + agent_metadata[1:-1] + b',' + data[1:-1] + b'}'
 
 class MuxDemuxQueue:

--- a/framework/wazuh/core/batcher/mux_demux.py
+++ b/framework/wazuh/core/batcher/mux_demux.py
@@ -21,12 +21,12 @@ class Item:
         Unique identifier for the item.
     operation : str
         Kind of operation to perform. Can be either 'create', 'delete' or 'update'.
-    content : dict
-        Item content as a dictionary. Can be either a stateful event, a response from OpenSearch or None.
+    content : bytes
+        Item content as bytes. Can be either a stateful event, a response from OpenSearch or None.
     index_name : str
         Name of the index the item should be created in. Should be set when inserting an item to the mux_queue only.
     """
-    def __init__(self, id: int, operation: str, content: dict = None, index_name: str = None):
+    def __init__(self, id: int, operation: str, content: bytes = None, index_name: str = None):
         self.id = id
         self.content = content
         self.operation = operation
@@ -75,7 +75,6 @@ class Packet:
         for item in self.items:
             if item.id == id:
                 return True
-
         return False
 
     def get_len(self) -> int:
@@ -110,7 +109,10 @@ class Packet:
         data : bytes, optional
             Optional additional data to include in the item's content. Defaults to None.
         """
-        content = agent_metadata.model_dump() | data if data else None
+        content = None
+        if data is not None:
+            content = self.build_content(agent_metadata.model_dump_json().encode(), data)
+
         item = Item(
             id=header.id,
             operation=header.operation,
@@ -131,7 +133,9 @@ class Packet:
             self.id = item.id
 
         self.items.append(item)
-
+    
+    def build_content(self, agent_metadata: bytes, data: bytes = None) -> bytes:        
+        return b'{' + agent_metadata[1:-1] + b',' + data[1:-1] + b'}'
 
 class MuxDemuxQueue:
     """Class for managing items between mux and demux components.

--- a/framework/wazuh/core/batcher/mux_demux.py
+++ b/framework/wazuh/core/batcher/mux_demux.py
@@ -236,8 +236,8 @@ class MuxDemuxQueue:
 
         Returns
         -------
-        Item
-            Item retrieved from the demux queue.
+        Packet
+            Packet retrieved from the demux queue.
         """
         return self.demux_queue.get()
 

--- a/framework/wazuh/core/batcher/tests/test_mux_demux.py
+++ b/framework/wazuh/core/batcher/tests/test_mux_demux.py
@@ -94,6 +94,18 @@ def test_packet_add_item():
     assert packet.id == item.id
 
 
+def test_packet_build_content():
+    """Check that the `build_content` method works as expected."""
+    agent_metadata = b'{"key": "value"}'
+    data = b'{"foo": "bar"}'
+    expected = b'{"key": "value", "foo": "bar"}'
+
+    packet = Packet()
+    actual = packet.build_content(agent_metadata, data)
+
+    assert actual == expected
+
+
 def test_send_to_mux():
     """Check that the `send_to_mux` method works as expected."""
     mux_queue = Queue()

--- a/framework/wazuh/core/indexer/bulk.py
+++ b/framework/wazuh/core/indexer/bulk.py
@@ -54,7 +54,7 @@ class BulkMetadata:
         Returns
         -------
         bytes
-            Metadata in a dictionary format.
+            Metadata in bytes.
         """
         return f'{{"{self.operation}": {{"_index": "{self.index}", "_id": "{self.doc_id}"}}}}'.encode()
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27172 |

## Description

Introduces changes to manage the stateful events bodies as bytes instead of parsing them to dictionaries.

## Tests

<details><summary>Logs</summary>

```console
2024/12/19 18:37:40 INFO: [Communications API] Stateful events batch. Packets: 2. Items: 256
2024/12/19 18:37:40 INFO: [Communications API] (9977ca5a-36e6-41f3-9f2f-91d0af13b1c6) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.160s: 200
2024/12/19 18:37:40 INFO: [Communications API] (987cee73-611b-4589-8adb-8930fc3fa495) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.263s: 200
2024/12/19 18:37:40 INFO: [Communications API] Stateful events batch. Packets: 15. Items: 1920
2024/12/19 18:37:40 INFO: [Communications API] Stateful events batch. Packets: 3. Items: 384
2024/12/19 18:37:41 INFO: [Communications API] (c9c4e1b9-4666-47a7-996b-ed47d952c66e) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.477s: 200
2024/12/19 18:37:41 INFO: [Communications API] (003a67fb-3e19-4bb0-9fc6-4101534ed820) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.473s: 200
2024/12/19 18:37:41 INFO: [Communications API] (e32bce5c-5fee-4d27-a443-48ea55660e83) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.474s: 200
2024/12/19 18:37:41 INFO: [Communications API] (edfa4a9d-cab3-4775-9077-0d18347bda83) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.776s: 200
2024/12/19 18:37:41 INFO: [Communications API] (0fab5acf-b3d3-4e22-be66-3c7af9ba65dd) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.795s: 200
2024/12/19 18:37:41 INFO: [Communications API] (fa776051-e256-4de6-8268-33ddfaba0d4f) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.780s: 200
2024/12/19 18:37:41 INFO: [Communications API] (4f0624c2-ebea-40dc-8b5c-5cfc43303f66) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.770s: 200
2024/12/19 18:37:41 INFO: [Communications API] (150d0ef4-c530-451e-a0ea-56be2ac8a99e) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.780s: 200
2024/12/19 18:37:41 INFO: [Communications API] (607a089b-204f-48a4-8161-b1e77f60e68c) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.728s: 200
2024/12/19 18:37:41 INFO: [Communications API] (5f93fd3a-e605-4c6e-9641-b65e238d69da) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.729s: 200
2024/12/19 18:37:41 INFO: [Communications API] (175bc102-dc24-41c4-88d1-43847e58b13f) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.765s: 200
2024/12/19 18:37:41 INFO: [Communications API] (6f53946c-6315-42e9-a581-f03a9b988ea9) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.820s: 200
2024/12/19 18:37:41 INFO: [Communications API] (6a09a421-7cfe-4d64-af29-656ebe8fe421) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.816s: 200
2024/12/19 18:37:41 INFO: [Communications API] (51f42d8b-e892-4892-9362-5579f0171083) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.755s: 200
2024/12/19 18:37:41 INFO: [Communications API] (33d3e54a-dfd0-4dbd-9a39-4cd209a037fe) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.806s: 200
2024/12/19 18:37:41 INFO: [Communications API] (f72d7fc6-d470-4fa0-b748-4e95098a6e76) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.746s: 200
2024/12/19 18:37:41 INFO: [Communications API] (8800324c-d86f-4556-a674-a11eeeb44a6f) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.799s: 200
2024/12/19 18:37:41 INFO: [Communications API] (d1352479-5c4b-4d81-82a5-01e07be93482) "POST /api/v1/events/stateful" with parameters {} and body {} done in 0.789s: 200
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_bulk.py::test_bulk_metadata_decode --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/indexer/tests/test_bulk.py .                                                                                                                                                                                      [100%]

============================================================================================================= 1 passed in 0.25s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_bulk.py::test_bulk_doc_decode --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 3 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_bulk.py ...                                                                                                                                                                                    [100%]

============================================================================================================= 3 passed in 0.23s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_bulk.py::test_mixin_bulk --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/indexer/tests/test_bulk.py .                                                                                                                                                                                      [100%]

============================================================================================================= 1 passed in 0.25s ==============================================================================================================
```

</details>