### PR TITLE
Add PyServer CI internal documentation

### DIFF
--- a/apis/tools/ci/README.md
+++ b/apis/tools/ci/README.md
@@ -1,0 +1,52 @@
+## PyServer CI setup
+
+We use pre-commit along with ruff to lint and format our code.
+
+This combination gives us auto-formatting on save, lint warnings and prevents us from uploading non-compliant code when committing changes.
+
+The configurations can be found at the `.pre-commit-config.yaml` and `.ruff.toml` files at the root of the repository.
+
+To start using them, just install the tools following the steps below.
+
+### Ruff
+
+Install ruff:
+
+```console
+pip install ruff --break-system-packages
+```
+
+> [!Note]
+> You can now use `ruff check` and `ruff format` commands to look for or fix issues present in the code.
+
+### Pre-commit
+
+Install pre-commit:
+
+```console
+pip install pre-commit --break-system-packages
+```
+
+Install the pre-commit configuration:
+
+```
+pre-commit install
+```
+
+#### IDE
+
+Install and configure your IDE extension following the steps from the official guide: https://docs.astral.sh/ruff/editors/setup/
+
+##### VSCode configuration
+
+We can configure VSCode to format and fix lint issues on save, for that, include the following configuration in your `settings.json` file.
+
+```json
+"[python]": {
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "charliermarsh.ruff",
+  "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
+}
+```

--- a/apis/tools/ci/README.md
+++ b/apis/tools/ci/README.md
@@ -13,19 +13,24 @@ To start using them, just install the tools following the steps below.
 Install ruff:
 
 ```console
-pip install ruff --break-system-packages
+pip install ruff
 ```
 
 > [!Note]
-> You can now use `ruff check` and `ruff format` commands to look for or fix issues present in the code.
+> Python version +3.11 requires specifying the flag `--break-system-packages` to install a package outside of a virtual environment.
+
+You can now use `ruff check` and `ruff format` commands to look for or fix issues present in the code.
 
 ### Pre-commit
 
 Install pre-commit:
 
 ```console
-pip install pre-commit --break-system-packages
+pip install pre-commit
 ```
+
+> [!Note]
+> Python version +3.11 requires specifying the flag `--break-system-packages` to install a package outside of a virtual environment.
 
 Install the pre-commit configuration:
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/20759 |

## Description

Adds a README file explaining how to install and configure pre-commit and ruff for linting and formatting files.