### PR TITLE
Add Python lint GitHub action

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v2

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,17 @@
+name: Python lint
+on: 
+  pull_request:
+    paths:
+      - '.github/workflows/python-lint.yml'
+      - 'api/**'
+      - 'apis/**'
+      - 'framework/**'
+      - 'integrations/**'
+      - 'wodles/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v2

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -14,4 +14,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/ruff-action@v2
+        # Trick to avoid running the linter and failing in this stage
+        with:
+          args: check --show-settings
+      - run: ruff check $(git diff --name-only ${{ github.event.pull_request.base.sha }} -- '*.py')


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/21034 |

## Description

Adds a Python lint workflow to prevent uncompliant code to be uploaded to PyServer-owned directories.

> [!Note]
> The workflow is expected to fail for this pull request, as the amount of changes required is enormous.
> 
> We should decide whether to fix all the errors in a specific PR or loose the rules to avoid being too strict.

### Tests

Some tests were performed in this pull request: https://github.com/wazuh/wazuh/pull/27447