### PR TITLE
Add ends_with helper function

### DIFF
--- a/src/engine/source/base/include/base/utils/stringUtils.hpp
+++ b/src/engine/source/base/include/base/utils/stringUtils.hpp
@@ -105,6 +105,24 @@ inline bool startsWith(std::string_view str, std::string_view prefix)
 }
 
 /**
+ * @brief Check if a string endss with a given prefix
+ *
+ * @param str String to be checked
+ * @param suffix suffix to check against
+ * @return true if the string ends with the prefix
+ * @return false otherwise
+ */
+inline bool endsWith(std::string_view str, std::string_view suffix)
+{
+    if (suffix.size() > str.size())
+    {
+        return false;
+    }
+
+    return str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+/**
  * @brief Unescapes a string by removing escape characters and replacing escaped characters with their original values.
  *
  * If the escapeChar is not escaped is added to the result.

--- a/src/engine/source/base/test/src/unit/stringUtils_test.cpp
+++ b/src/engine/source/base/test/src/unit/stringUtils_test.cpp
@@ -116,6 +116,29 @@ TEST(startsWith, Failure)
     ASSERT_FALSE(base::utils::string::startsWith(input, prefix));
 }
 
+TEST(endsWith, Success)
+{
+    std::string input = "this is a test";
+    std::string suffix = "test";
+    ASSERT_TRUE(base::utils::string::endsWith(input, suffix));
+
+    suffix = "this is a test";
+    ASSERT_TRUE(base::utils::string::endsWith(input, suffix));
+}
+
+TEST(endsWith, Failure)
+{
+    std::string input = "this is a test";
+    std::string suffix = "is a test1";
+    ASSERT_FALSE(base::utils::string::endsWith(input, suffix));
+
+    suffix = "test1";
+    ASSERT_FALSE(base::utils::string::endsWith(input, suffix));
+
+    suffix = "this is a test1";
+    ASSERT_FALSE(base::utils::string::endsWith(input, suffix));
+}
+
 TEST(join, defaut_separator)
 {
     const std::string expected = "test";

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(builder_utest
     ${UNIT_SRC_DIR}/builders/opfilter/filter_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/exists_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/startsWith_test.cpp
+    ${UNIT_SRC_DIR}/builders/opfilter/endsWith_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/intCmp_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/strCmp_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/regex_test.cpp

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
@@ -365,6 +365,20 @@ FilterOp opBuilderHelperNotContains(const Reference& targetField,
                                     const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
+ * @brief Checks if the string stored in the field ends with the value provided.
+ *
+ * @param targetField target field of the helper
+ * @param opArgs Vector of operation arguments containing numeric values to be converted.
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @return FilterOp
+ *
+ * @throws std::runtime_error if cannot create the filter.
+ */
+FilterOp opBuilderHelperEndsWith(const Reference& targetField,
+                                 const std::vector<OpArg>& opArgs,
+                                 const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
  * @brief Create the helper function `array_not_contains_any` that filters events if the field
  * is an array and does not contain at least one of the specified values.
  *

--- a/src/engine/source/builder/src/builders/opfilter/startsWith.cpp
+++ b/src/engine/source/builder/src/builders/opfilter/startsWith.cpp
@@ -19,6 +19,7 @@ startsWithValue(const Reference& targetField, const Value& value, const std::sha
 
     const auto targetNotFound =
         fmt::format("{} -> Target field '{}' not found", buildCtx->context().opName, targetField.dotPath());
+    const auto successTrace = fmt::format("{} -> Success", buildCtx->context().opName);
     const auto failure = fmt::format("{} -> Failure", buildCtx->context().opName);
     const auto targetNotString =
         fmt::format("{} -> Target field '{}' is not a string", buildCtx->context().opName, targetField.dotPath());
@@ -27,6 +28,7 @@ startsWithValue(const Reference& targetField, const Value& value, const std::sha
             runState = buildCtx->runState(),
             targetNotFound,
             failure,
+            successTrace,
             targetNotString](base::ConstEvent event) -> FilterResult
     {
         if (!event->exists(targetField))
@@ -48,7 +50,7 @@ startsWithValue(const Reference& targetField, const Value& value, const std::sha
             RETURN_FAILURE(runState, false, failure);
         }
 
-        RETURN_SUCCESS(runState, true, failure);
+        RETURN_SUCCESS(runState, true, successTrace);
     };
 }
 

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -141,6 +141,9 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
         "starts_with",
         {schemf::JTypeToken::create(json::Json::Type::String), builders::opfilter::opBuilderHelperStringStarts});
     registry->template add<builders::OpBuilderEntry>(
+        "ends_with",
+        {schemf::JTypeToken::create(json::Json::Type::String), builders::opfilter::opBuilderHelperEndsWith});
+    registry->template add<builders::OpBuilderEntry>(
         "contains",
         {schemf::JTypeToken::create(json::Json::Type::String), builders::opfilter::opBuilderHelperStringContains});
     registry->template add<builders::OpBuilderEntry>(

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/endsWith_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/endsWith_test.cpp
@@ -1,0 +1,244 @@
+#include "builders/baseBuilders_test.hpp"
+
+#include "builders/opfilter/opBuilderHelperFilter.hpp"
+
+namespace
+{
+auto customRef()
+{
+    return [](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, validator());
+        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillRepeatedly(testing::Return(false));
+        return None {};
+    };
+}
+} // namespace
+
+namespace filterbuildtest
+{
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    FilterBuilderTest,
+    testing::Values(
+        // Wrong arguments number
+        FilterT({}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        FilterT({makeValue(R"("string")"), makeValue(R"("string")")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        // Value
+        FilterT({makeValue(R"("string")")}, opfilter::opBuilderHelperEndsWith, SUCCESS()),
+        FilterT({makeValue(R"(2)")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        FilterT({makeValue(R"(1.2)")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        FilterT({makeValue(R"(true)")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        FilterT({makeValue(R"(false)")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        FilterT({makeValue(R"([1, 2, 3])")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        FilterT({makeValue(R"({"a": 1, "b": 2})")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        FilterT({makeValue(R"(null)")}, opfilter::opBuilderHelperEndsWith, FAILURE()),
+        // Reference
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperEndsWith,
+                SUCCESS(
+                    [](const BuildersMocks& mocks)
+                    {
+                        EXPECT_CALL(*mocks.ctx, validator());
+                        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillRepeatedly(testing::Return(false));
+                        return None {};
+                    })),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperEndsWith,
+                SUCCESS(
+                    [](const BuildersMocks& mocks)
+                    {
+                        EXPECT_CALL(*mocks.ctx, validator());
+                        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillRepeatedly(testing::Return(true));
+                        EXPECT_CALL(*mocks.validator, getType(DotPath("ref")))
+                            .WillRepeatedly(testing::Return(schemf::Type::KEYWORD));
+                        return None {};
+                    })),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperEndsWith,
+                SUCCESS(
+                    [](const BuildersMocks& mocks)
+                    {
+                        EXPECT_CALL(*mocks.ctx, validator());
+                        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillRepeatedly(testing::Return(true));
+                        EXPECT_CALL(*mocks.validator, getType(DotPath("ref")))
+                            .WillRepeatedly(testing::Return(schemf::Type::TEXT));
+                        return None {};
+                    })),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperEndsWith,
+                FAILURE(
+                    [](const BuildersMocks& mocks)
+                    {
+                        EXPECT_CALL(*mocks.ctx, validator());
+                        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillRepeatedly(testing::Return(true));
+                        EXPECT_CALL(*mocks.validator, getType(DotPath("ref")))
+                            .WillRepeatedly(testing::Return(schemf::Type::DOUBLE));
+                        return None {};
+                    }))),
+    testNameFormatter<FilterBuilderTest>("EndsWith"));
+} // namespace filterbuildtest
+
+namespace filteroperatestest
+{
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    FilterOperationTest,
+    testing::Values(
+        // Value cases
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("e")")}, SUCCESS()),
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("lue")")}, SUCCESS()),
+        FilterT(R"({"target": "value"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeValue(R"("value")")},
+                SUCCESS()),
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("v")")}, FAILURE()),
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("alu")")}, FAILURE()),
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("valu")")}, FAILURE()),
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("o")")}, FAILURE()),
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("van")")}, FAILURE()),
+        FilterT(R"({"target": "value"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeValue(R"("value2")")},
+                FAILURE()),
+        FilterT(
+            R"({"target": "value"})", opfilter::opBuilderHelperEndsWith, "notTarget", {makeValue(R"("v")")}, FAILURE()),
+        FilterT(R"({"target": 1})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("1")")}, FAILURE()),
+        FilterT(R"({"target": 1.2})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("1.2")")}, FAILURE()),
+        FilterT(
+            R"({"target": true})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("true")")}, FAILURE()),
+        FilterT(R"({"target": [1, 2, 3]})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeValue(R"("[1, 2, 3]")")},
+                FAILURE()),
+        FilterT(R"({"target": {"a": 1, "b": 2}})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeValue(R"("{\"a\": 1, \"b\": 2}")")},
+                FAILURE()),
+        // Reference cases
+        FilterT(R"({"target": "value", "ref": "e"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                SUCCESS(customRef())),
+        FilterT(R"({"target": "value", "ref": "lue"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                SUCCESS(customRef())),
+        FilterT(R"({"target": "value", "ref": "value"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                SUCCESS(customRef())),
+        FilterT(R"({"target": "value", "ref": "v"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": "alu"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": "valu"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": "o"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": "van"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": "value2"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": "v"})",
+                opfilter::opBuilderHelperEndsWith,
+                "notTarget",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": 1, "ref": "1"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": 1.2, "ref": "1.2"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": true, "ref": "true"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": [1, 2, 3], "ref": "[1, 2, 3]"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": {"a": 1, "b": 2}, "ref": "{\"a\": 1, \"b\": 2}"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": 1})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": 1.2})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": true})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": [1, 2, 3]})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "ref": {"a": 1, "b": 2}})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        FilterT(R"({"target": "value", "notRef": "v"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef())),
+        // Missing target field
+        FilterT(R"({"other": "value"})", opfilter::opBuilderHelperEndsWith, "target", {makeValue(R"("v")")}, FAILURE()),
+        FilterT(R"({"ref": "value"})",
+                opfilter::opBuilderHelperEndsWith,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRef()))),
+    testNameFormatter<FilterOperationTest>("EndsWith"));
+
+} // namespace filteroperatestest

--- a/src/engine/test/helper_tests/helpers_description/filter/ends_with.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/ends_with.yml
@@ -1,0 +1,47 @@
+# Name of the helper function
+name: ends_with
+
+metadata:
+  description: |
+    Checks if the string stored in the field ends with the value provided.
+    If they're not, the function evaluates to false. In case of error, the function will evaluate to false.
+
+  keywords:
+    - string
+
+helper_type: filter
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: false
+
+# Arguments expected by the helper function
+arguments:
+  conteined:
+    type: string  # Expected type is string
+    generate: string
+    source: both # includes values or references (their names start with $)
+
+# do not compare with target field to avoid failure
+skipped:
+  - success_cases
+
+target_field:
+  type: string
+  generate: string
+
+test:
+  - arguments:
+      conteined: wazuh!!
+    target_field: hello wazuh!!
+    should_pass: true
+    description: Success ends with
+  - arguments:
+      conteined: wazuh
+    target_field: hello wazuh!!!
+    should_pass: false
+    description: Failure ends with
+  - arguments:
+      conteined: hello
+    target_field: hello wazuh!
+    should_pass: false
+    description: Failure ends with


### PR DESCRIPTION
|Related issue|
|---|
|#27452|

## Description

We need to implement a new function helper called end_with() to optimize and replace current usages of contains() when checking if a string ends with a specific suffix. Currently, contains() is often used to verify substrings within larger strings, but this approach is inefficient and can produce false positives when checking if a string ends with a certain value.

The end_with() function will allow precise checking of whether a string ends with a given suffix, improving both performance and accuracy in these scenarios.

