### PR TITLE
Improve single agent re-scan pipeline performance

### DIFF
--- a/.github/actions/legacy_unit_tests_build/action.yml
+++ b/.github/actions/legacy_unit_tests_build/action.yml
@@ -1,5 +1,5 @@
-name: "Legacy unit tests build for Wazuh agent"
-description: "This action builds legacy Unit Tests for Wazuh agent on Ubuntu Linux/Windows"
+name: "Legacy unit tests build for Wazuh"
+description: "This action builds legacy Unit Tests for Wazuh on Ubuntu Linux/Windows"
 inputs:
    target:
      required: true
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         chmod +x .github/actions/legacy_unit_tests.sh
-    - name: Build Wazuh Agent Unit Tests
+    - name: Build Wazuh Unit Tests
       shell: bash
       run: |
         source .github/actions/legacy_unit_tests.sh

--- a/.github/actions/legacy_unit_tests_run/action.yml
+++ b/.github/actions/legacy_unit_tests_run/action.yml
@@ -1,5 +1,5 @@
-name: "Legacy unit tests run for Wazuh agent"
-description: "This action runs Wazuh agent unit tests on Ubuntu Linux/Windows"
+name: "Legacy unit tests run for Wazuh"
+description: "This action runs Wazuh unit tests on Ubuntu Linux/Windows"
 inputs:
    target:
      required: true
@@ -22,7 +22,7 @@ runs:
         source .github/actions/legacy_unit_tests.sh
         format_display_test_results ${{ inputs.target }}
     - name: Format and Display Test Coverage
-      if: ${{ inputs.target == 'agent' }}
+      if: ${{ inputs.target != 'winagent' }}
       shell: bash
       run: |
         source .github/actions/legacy_unit_tests.sh

--- a/.github/workflows/legacy-unit-tests.yml
+++ b/.github/workflows/legacy-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Legacy unit tests for wazuh agent
+name: Legacy unit tests for wazuh
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ jobs:
     strategy:
           fail-fast: false
           matrix:
-              target: [agent, winagent]
+              target: [agent, winagent, server]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
@@ -26,15 +26,15 @@ jobs:
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
-      - name: "Build wazuh agent"
+      - name: "Build wazuh"
         uses: ./.github/actions/build_test_flags
         with:
           target: ${{ matrix.target }}
-      - name: "Build wazuh agent legacy unit tests"
+      - name: "Build wazuh legacy unit tests"
         uses: ./.github/actions/legacy_unit_tests_build
         with:
           target: ${{ matrix.target }}
-      - name: "Run wazuh agent legacy unit tests"
+      - name: "Run wazuh legacy unit tests"
         uses: ./.github/actions/legacy_unit_tests_run
         with:
           target: ${{ matrix.target }}

--- a/src/shared_modules/utils/benchmark/rocksdbqueue_test.cpp
+++ b/src/shared_modules/utils/benchmark/rocksdbqueue_test.cpp
@@ -1,9 +1,15 @@
 #include "rocksDBQueue.hpp"
+#include "rocksDBQueueCF.hpp"
 #include <benchmark/benchmark.h>
 #include <filesystem>
 #include <system_error>
 
 constexpr auto TEST_DB = "test.db";
+constexpr auto TEST_CF_DB = "test_cf.db";
+
+constexpr auto TEST_AGENT_NUMBER {1000};
+constexpr auto TEST_EVENTS_PER_AGENT {10000};
+constexpr auto TEST_THREADS {4};
 
 namespace Log
 {
@@ -59,3 +65,116 @@ static void frontBenchmark(benchmark::State& state)
 }
 
 BENCHMARK(frontBenchmark);
+
+class ThreadPoolBenchmarkFixture : public benchmark::Fixture
+{
+protected:
+    std::shared_ptr<RocksDBQueue<std::string>> queue;                   ///< RocksDB queue.
+    std::vector<std::shared_ptr<RocksDBQueueCF<std::string>>> queueCFs; ///< RocksDB queue with column family.
+
+public:
+    /**
+     * @brief Benchmark setup routine.
+     *
+     * @param state Benchmark state.
+     */
+    void SetUp(const ::benchmark::State& state) override
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(TEST_DB, ec);
+        queue = std::make_shared<RocksDBQueue<std::string>>(TEST_DB);
+
+        for (int i = 0; i < TEST_THREADS; ++i)
+        {
+            std::filesystem::remove_all(TEST_CF_DB + std::to_string(i), ec);
+            queueCFs.emplace_back(std::make_shared<RocksDBQueueCF<std::string>>(TEST_CF_DB + std::to_string(i)));
+        }
+    }
+
+    /**
+     * @brief Benchmark teardown routine.
+     *
+     * @param state Benchmark state.
+     */
+    void TearDown(const ::benchmark::State& state) override
+    {
+        queue.reset();
+
+        for (auto& queueCF : queueCFs)
+        {
+            queueCF.reset();
+        }
+    }
+};
+
+BENCHMARK_DEFINE_F(ThreadPoolBenchmarkFixture, ThreadPoolPerformance)(benchmark::State& state)
+{
+    std::atomic<bool> stop {false};
+    std::vector<std::thread> threads;
+
+    auto cfLambda = [&](int threadIndex)
+    {
+        while (!stop)
+        {
+            for (int i = 0; i < TEST_AGENT_NUMBER; ++i)
+            {
+                if (stop)
+                {
+                    break;
+                }
+                for (int j = 0; j < TEST_EVENTS_PER_AGENT; ++j)
+                {
+                    if (stop)
+                    {
+                        break;
+                    }
+                    queueCFs.at(threadIndex)->push(std::to_string(i), "test");
+                }
+            }
+
+            for (int i = 0; i < TEST_AGENT_NUMBER; ++i)
+            {
+                if (stop)
+                {
+                    break;
+                }
+                queueCFs.at(threadIndex)->clear(std::to_string(i));
+            }
+        }
+    };
+
+    for (int i = 0; i < TEST_THREADS; ++i)
+    {
+        threads.emplace_back(cfLambda, i);
+    }
+
+    for (auto _ : state)
+    {
+        for (int i = 0; i < TEST_AGENT_NUMBER; ++i)
+        {
+            for (int j = 0; j < TEST_EVENTS_PER_AGENT; ++j)
+            {
+                queue->push("test");
+            }
+        }
+
+        for (int i = 0; i < TEST_AGENT_NUMBER; ++i)
+        {
+            for (int j = 0; j < TEST_EVENTS_PER_AGENT; ++j)
+            {
+                queue->pop();
+            }
+        }
+    }
+
+    stop.store(true);
+    for (auto& thread : threads)
+    {
+        if (thread.joinable())
+        {
+            thread.join();
+        }
+    }
+}
+
+BENCHMARK_REGISTER_F(ThreadPoolBenchmarkFixture, ThreadPoolPerformance)->Iterations(1)->Threads(1);

--- a/src/shared_modules/utils/wazuhDBQueryBuilder.hpp
+++ b/src/shared_modules/utils/wazuhDBQueryBuilder.hpp
@@ -17,6 +17,7 @@
 #include <string>
 
 constexpr auto WAZUH_DB_ALLOWED_CHARS {"-_ "};
+constexpr auto WAZUH_DB_AGENT_ACTIVE_STATUS {"active"};
 
 class WazuhDBQueryBuilder final : public Utils::Builder<WazuhDBQueryBuilder>
 {

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -50,7 +50,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,wdb_global_insert_agent_group -Wl,--wrap,wdb_global_insert_agent_belong -Wl,--wrap,wdb_global_delete_group_belong \
                              -Wl,--wrap,wdb_global_delete_group -Wl,--wrap,wdb_global_select_groups \
                              -Wl,--wrap,wdb_global_sync_agent_info_get -Wl,--wrap,wdb_global_sync_agent_info_set \
-                             -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_reset_agents_connection \
+                             -Wl,--wrap,wdb_global_get_all_agents -Wl,--wrap,wdb_global_get_agent_info -Wl,--wrap,wdb_global_get_agent_info_by_connection_status_and_node -Wl,--wrap,wdb_global_reset_agents_connection \
                              -Wl,--wrap,wdb_global_get_agents_by_connection_status -Wl,--wrap,wdb_global_get_agents_to_disconnect \
                              -Wl,--wrap,sqlite3_step -Wl,--wrap,wdb_global_get_groups_integrity -Wl,--wrap,wdb_global_get_backups \
                              -Wl,--wrap,wdb_global_restore_backup -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
@@ -78,6 +78,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl
                              -Wl,--wrap,w_inc_global_agent_get_groups_integrity -Wl,--wrap,w_inc_global_agent_get_groups_integrity_time -Wl,--wrap,w_inc_global_agent_disconnect_agents \
                              -Wl,--wrap,w_inc_global_agent_disconnect_agents_time -Wl,--wrap,w_inc_global_agent_get_all_agents -Wl,--wrap,w_inc_global_agent_get_all_agents_time \
                              -Wl,--wrap,w_inc_global_agent_get_agent_info -Wl,--wrap,w_inc_global_agent_get_agent_info_time -Wl,--wrap,w_inc_global_agent_reset_agents_connection \
+                             -Wl,--wrap,w_inc_global_agent_get_agent_info_by_connection_status_and_node -Wl,--wrap,w_inc_global_agent_get_agent_info_by_connection_status_and_node_time \
                              -Wl,--wrap,w_inc_global_agent_reset_agents_connection_time -Wl,--wrap,w_inc_global_agent_get_agents_by_connection_status \
                              -Wl,--wrap,w_inc_global_agent_get_agents_by_connection_status_time -Wl,--wrap,w_inc_global_backup -Wl,--wrap,w_inc_global_backup_time \
                              -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state -Wl,--wrap,wdb_finalize_all_statements \

--- a/src/unit_tests/wazuh_db/test_wazuh_db_state.c
+++ b/src/unit_tests/wazuh_db/test_wazuh_db_state.c
@@ -193,6 +193,8 @@ static int test_setup(void ** state) {
     wdb_state.queries_breakdown.global_breakdown.agent.find_agent_time.tv_usec = 78120;
     wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_time.tv_sec = 0;
     wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_time.tv_usec = 152358;
+    wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_time.tv_sec = 0;
+    wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_time.tv_usec = 1000;
     wdb_state.queries_breakdown.global_breakdown.agent.get_all_agents_time.tv_sec = 0;
     wdb_state.queries_breakdown.global_breakdown.agent.get_all_agents_time.tv_usec = 25101;
     wdb_state.queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_time.tv_sec = 1;
@@ -507,7 +509,7 @@ void test_wazuhdb_create_state_json(void ** state) {
     cJSON* time = cJSON_GetObjectItem(metrics, "time");
 
     assert_non_null(cJSON_GetObjectItem(time, "execution"));
-    assert_int_equal(cJSON_GetObjectItem(time, "execution")->valueint, 26227);
+    assert_int_equal(cJSON_GetObjectItem(time, "execution")->valueint, 26228);
 
     cJSON* execution_breakdown = cJSON_GetObjectItem(time, "execution_breakdown");
 
@@ -605,7 +607,7 @@ void test_wazuhdb_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(agent_sync_time, "dbsync")->valueint, 2);
 
     assert_non_null(cJSON_GetObjectItem(execution_breakdown, "global"));
-    assert_int_equal(cJSON_GetObjectItem(execution_breakdown, "global")->valueint, 7091);
+    assert_int_equal(cJSON_GetObjectItem(execution_breakdown, "global")->valueint, 7092);
 
     cJSON* global_time_breakdown = cJSON_GetObjectItem(execution_breakdown, "global_breakdown");
 
@@ -646,6 +648,8 @@ void test_wazuhdb_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(global_agent_time_breakdown, "find-agent")->valueint, 78);
     assert_non_null(cJSON_GetObjectItem(global_agent_time_breakdown, "get-agent-info"));
     assert_int_equal(cJSON_GetObjectItem(global_agent_time_breakdown, "get-agent-info")->valueint, 152);
+    assert_non_null(cJSON_GetObjectItem(global_agent_time_breakdown, "get-agent-info-by-connection-status-and-node"));
+    assert_int_equal(cJSON_GetObjectItem(global_agent_time_breakdown, "get-agent-info-by-connection-status-and-node")->valueint, 1);
     assert_non_null(cJSON_GetObjectItem(global_agent_time_breakdown, "get-all-agents"));
     assert_int_equal(cJSON_GetObjectItem(global_agent_time_breakdown, "get-all-agents")->valueint, 25);
     assert_non_null(cJSON_GetObjectItem(global_agent_time_breakdown, "get-agents-by-connection-status"));

--- a/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_helpers.c
@@ -1191,6 +1191,36 @@ void test_wdb_get_agent_info_success(void **state) {
     assert_ptr_equal(1, root);
 }
 
+/* Tests wdb_get_agent_info_by_connection_status_and_node */
+
+void test_wdb_get_agent_info_by_connection_status_and_node_error_no_json_response(void **state) {
+    cJSON *root = NULL;
+    int id = 1;
+
+    // Calling Wazuh DB
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "Error querying Wazuh DB to get the agent's 1 filtered information.");
+
+    root = wdb_get_agent_info(id, NULL);
+
+    assert_null(root);
+}
+
+void test_wdb_get_agent_info_by_connection_status_and_node_success(void **state) {
+    cJSON *root = NULL;
+    int id = 1;
+
+    // Calling Wazuh DB
+    will_return(__wrap_wdbc_query_parse_json, 0);
+    will_return(__wrap_wdbc_query_parse_json, (cJSON *)1);
+
+    root = wdb_get_agent_info(id, NULL);
+
+    assert_ptr_equal(1, root);
+}
+
 /* Tests wdb_get_agent_labels */
 
 void test_wdb_get_agent_labels_error_no_json_response(void **state) {

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -4053,6 +4053,165 @@ void test_wdb_parse_global_get_agent_info_success(void **state)
     assert_int_equal(ret, OS_SUCCESS);
 }
 
+/* Tests wdb_parse_global_get_agent_info_by_connection_status_and_node */
+
+void test_wdb_parse_global_get_agent_info_by_connection_status_and_node_syntax_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info-by-connection-status-and-node";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info-by-connection-status-and-node");
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid DB query syntax for get-agent-info-by-connection-status-and-node.");
+    expect_string(__wrap__mdebug2, formatted_msg, "Global DB query error near: get-agent-info-by-connection-status-and-node");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_open_time);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+    expect_function_call(__wrap_wdb_pool_leave);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid DB query syntax, near 'get-agent-info-by-connection-status-and-node'");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_info_by_connection_status_and_node_syntax_error2(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info-by-connection-status-and-node 1";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info-by-connection-status-and-node 1");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments 'connection_status' not found.");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_open_time);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+    expect_function_call(__wrap_wdb_pool_leave);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid arguments 'connection_status' not found");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_info_by_connection_status_and_node_syntax_error3(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info-by-connection-status-and-node 1 active";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info-by-connection-status-and-node 1 active");
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid arguments 'node_name' not found.");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_open_time);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+    expect_function_call(__wrap_wdb_pool_leave);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Invalid arguments 'node_name' not found");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_info_by_connection_status_and_node_query_error(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info-by-connection-status-and-node 1 active worker1";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info-by-connection-status-and-node 1 active worker1");
+    expect_value(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, id, 1);
+    expect_string(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, status, "active");
+    expect_string(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, node, "worker1");
+    will_return(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, NULL);
+    expect_string(__wrap__mdebug1, formatted_msg, "Error getting agent filtered information from global.db.");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_open_time);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node_time);
+
+    expect_string(__wrap_w_is_file, file, "queue/db/global.db");
+    will_return(__wrap_w_is_file, 1);
+    expect_function_call(__wrap_wdb_pool_leave);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "err Error getting agent filtered information from global.db.");
+    assert_int_equal(ret, OS_INVALID);
+}
+
+void test_wdb_parse_global_get_agent_info_by_connection_status_and_node_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global get-agent-info-by-connection-status-and-node 1 active worker1";
+    cJSON *j_object = NULL;
+
+    j_object = cJSON_CreateObject();
+    cJSON_AddStringToObject(j_object, "name", "test_name");
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: get-agent-info-by-connection-status-and-node 1 active worker1");
+    expect_value(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, id, 1);
+    expect_string(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, status, "active");
+    expect_string(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, node, "worker1");
+    will_return(__wrap_wdb_global_get_agent_info_by_connection_status_and_node, j_object);
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_open_time);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok {\"name\":\"test_name\"}");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
 /* Tests wdb_parse_reset_agents_connection */
 
 void test_wdb_parse_reset_agents_connection_syntax_error(void **state)
@@ -5311,6 +5470,12 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_success, test_setup, test_teardown),
+        /* Tests wdb_parse_global_get_agent_info_by_connection_status_and_node */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_by_connection_status_and_node_syntax_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_by_connection_status_and_node_syntax_error2, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_by_connection_status_and_node_syntax_error3, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_by_connection_status_and_node_query_error, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_agent_info_by_connection_status_and_node_success, test_setup, test_teardown),
         /* Tests wdb_parse_reset_agents_connection */
         cmocka_unit_test_setup_teardown(test_wdb_parse_reset_agents_connection_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_reset_agents_connection_query_error, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -265,6 +265,16 @@ cJSON* __wrap_wdb_global_get_agent_info(__attribute__((unused)) wdb_t *wdb,
     return mock_ptr_type(cJSON*);
 }
 
+cJSON* __wrap_wdb_global_get_agent_info_by_connection_status_and_node(__attribute__((unused)) wdb_t *wdb,
+                                        int id,
+                                        char* status,
+                                        char* node) {
+    check_expected(id);
+    check_expected(status);
+    check_expected(node);
+    return mock_ptr_type(cJSON*);
+}
+
 int __wrap_wdb_global_reset_agents_connection(__attribute__((unused)) wdb_t *wdb, const char *sync_status) {
     check_expected(sync_status);
     return mock();

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -86,6 +86,8 @@ int __wrap_wdb_global_get_all_agents_context(wdb_t *wdb);
 
 cJSON* __wrap_wdb_global_get_agent_info(wdb_t *wdb, int id);
 
+cJSON* __wrap_wdb_global_get_agent_info_by_connection_status_and_node(__attribute__((unused)) wdb_t *wdb, int id, char* status, char* node);
+
 int __wrap_wdb_global_reset_agents_connection(wdb_t *wdb, const char *sync_status);
 
 cJSON* __wrap_wdb_global_get_agents_by_connection_status (wdb_t *wdb, int last_agent_id, const char* connection_status, const char* node_name, int limit, wdbc_result* status);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.c
@@ -160,7 +160,15 @@ void __wrap_w_inc_global_agent_get_agent_info() {
     function_called();
 }
 
+void __wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node() {
+    function_called();
+}
+
 void __wrap_w_inc_global_agent_get_agent_info_time(__attribute__((unused))struct timeval diff) {
+    function_called();
+}
+
+void __wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node_time(__attribute__((unused))struct timeval diff) {
     function_called();
 }
 

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_state_wrappers.h
@@ -90,7 +90,11 @@ void __wrap_w_inc_global_agent_find_agent_time(__attribute__((unused))struct tim
 
 void __wrap_w_inc_global_agent_get_agent_info();
 
+void __wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node();
+
 void __wrap_w_inc_global_agent_get_agent_info_time(__attribute__((unused))struct timeval diff);
+
+void __wrap_w_inc_global_agent_get_agent_info_by_connection_status_and_node_time(__attribute__((unused))struct timeval diff);
 
 void __wrap_w_inc_global_agent_get_all_agents();
 

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -28,6 +28,7 @@ static const char *global_db_commands[] = {
     [WDB_GET_ALL_AGENTS] = "global get-all-agents last_id %d",
     [WDB_FIND_AGENT] = "global find-agent %s",
     [WDB_GET_AGENT_INFO] = "global get-agent-info %d",
+    [WDB_GET_AGENT_INFO_BY_CONNECTION_STATUS_AND_NODE] = "global get-agent-info-by-connection-status-and-node %d %s %s",
     [WDB_GET_AGENT_LABELS] = "global get-labels %d",
     [WDB_SELECT_AGENT_NAME] = "global select-agent-name %d",
     [WDB_SELECT_AGENT_GROUP] = "global select-agent-group %d",
@@ -584,6 +585,27 @@ cJSON* wdb_get_agent_info(int id, int *sock) {
 
     if (!root) {
         merror("Error querying Wazuh DB to get the agent's %d information.", id);
+        return NULL;
+    }
+
+    return root;
+}
+
+cJSON* wdb_get_agent_info_by_connection_status_and_node(int id, char* status, char* node, int *sock) {
+    cJSON *root = NULL;
+    char wdbquery[WDBQUERY_SIZE] = "";
+    char wdboutput[WDBOUTPUT_SIZE] = "";
+    int aux_sock = -1;
+
+    sqlite3_snprintf(sizeof(wdbquery), wdbquery, global_db_commands[WDB_GET_AGENT_INFO_BY_CONNECTION_STATUS_AND_NODE], id, status, node);
+    root = wdbc_query_parse_json(sock?sock:&aux_sock, wdbquery, wdboutput, sizeof(wdboutput));
+
+    if (!sock) {
+        wdbc_close(&aux_sock);
+    }
+
+    if (!root) {
+        merror("Error querying Wazuh DB to get the agent's %d filtered information.", id);
         return NULL;
     }
 

--- a/src/wazuh_db/helpers/wdb_global_helpers.h
+++ b/src/wazuh_db/helpers/wdb_global_helpers.h
@@ -25,6 +25,7 @@ typedef enum global_db_access {
     WDB_GET_ALL_AGENTS,
     WDB_FIND_AGENT,
     WDB_GET_AGENT_INFO,
+    WDB_GET_AGENT_INFO_BY_CONNECTION_STATUS_AND_NODE,
     WDB_GET_AGENT_LABELS,
     WDB_SELECT_AGENT_NAME,
     WDB_SELECT_AGENT_GROUP,
@@ -169,6 +170,17 @@ int wdb_find_agent(const char *name, const char *ip, int *sock);
  * @return JSON* with the information on success or NULL on failure.
  */
 cJSON* wdb_get_agent_info(int id, int *sock);
+
+/**
+ * @brief Returns a JSON with all the agent's information filtered by connection status and node.
+ *
+ * @param[in] id Id of the agent for whom the information is requested.
+ * @param[in] status The connection status to filter.
+ * @param[in] node The node name to filter.
+ * @param[in] sock The Wazuh DB socket connection. If NULL, a new connection will be created and closed locally.
+ * @return JSON* with the information on success or NULL on failure.
+ */
+cJSON* wdb_get_agent_info_by_connection_status_and_node(int id, char* status, char* node, int *sock);
 
 /**
  * @brief Returns a JSON with all the agent's labels.

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -203,6 +203,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? AND node_name = ? ORDER BY id LIMIT ?;",
     [WDB_STMT_GLOBAL_GET_AGENT_INFO] = "SELECT * FROM agent WHERE id = ?;",
+    [WDB_STMT_GLOBAL_GET_AGENT_INFO_BY_CONNECTION_STATUS_AND_NODE] = "SELECT * FROM agent WHERE id = ? AND connection_status = ? AND node_name = ?;",
     [WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS] = "UPDATE agent SET connection_status = 'disconnected', status_code = ?, sync_status = ?, disconnection_time = STRFTIME('%s', 'NOW') where connection_status != 'disconnected' AND connection_status != 'never_connected' AND id != 0;",
     [WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT] = "SELECT id FROM agent WHERE id > ? AND (connection_status = 'active' OR connection_status = 'pending') AND last_keepalive < ?;",
     [WDB_STMT_GLOBAL_AGENT_EXISTS] = "SELECT EXISTS(SELECT 1 FROM agent WHERE id=?);",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -261,6 +261,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE,
     WDB_STMT_GLOBAL_GET_AGENT_INFO,
+    WDB_STMT_GLOBAL_GET_AGENT_INFO_BY_CONNECTION_STATUS_AND_NODE,
     WDB_STMT_GLOBAL_GET_AGENTS_TO_DISCONNECT,
     WDB_STMT_GLOBAL_RESET_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_AGENT_EXISTS,
@@ -1172,6 +1173,17 @@ int wdb_parse_global_recalculate_agent_group_hashes(wdb_t* wdb, char* output);
  * @retval -1 On error: invalid DB query syntax.
  */
 int wdb_parse_global_get_agent_info(wdb_t * wdb, char * input, char * output);
+
+/**
+ * @brief Function to get all the agent information filtered by connection status and node name.
+ *
+ * @param wdb The global struct database.
+ * @param input String with 'agent_id', 'connection_status' and 'node_name'.
+ * @param output Response of the query in JSON format.
+ * @retval 0 Success: response contains the value.
+ * @retval -1 On error: invalid DB query syntax.
+ */
+int wdb_parse_global_get_agent_info_by_connection_status_and_node(wdb_t* wdb, char* input, char* output);
 
 /**
  * @brief Function to parse string with agent's labels and set them in labels table in global database.
@@ -2235,6 +2247,18 @@ wdbc_result wdb_global_set_agent_groups(wdb_t *wdb, wdb_groups_set_mode_t mode, 
  * @retval NULL on error.
  */
 cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
+
+/**
+ * @brief Function to get the information of a particular agent stored in Wazuh DB filtered by connection status and node name.
+ *
+ * @param wdb The Global struct database.
+ * @param id Agent id.
+ * @param connection_status Connection status of the agent requested.
+ * @param node_name Cluster node name.
+ * @retval JSON with agent information on success.
+ * @retval NULL on error.
+ */
+cJSON* wdb_global_get_agent_info_by_connection_status_and_node(wdb_t *wdb, int id, char* connection_status, char* node_name);
 
 /**
  * @brief Gets every agent ID.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1709,6 +1709,46 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id) {
     return result;
 }
 
+cJSON* wdb_global_get_agent_info_by_connection_status_and_node(wdb_t *wdb, int id, char* connection_status, char* node_name) {
+    sqlite3_stmt *stmt = NULL;
+    cJSON * result = NULL;
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("Cannot begin transaction");
+        return NULL;
+    }
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENT_INFO_BY_CONNECTION_STATUS_AND_NODE) < 0) {
+        mdebug1("Cannot cache statement");
+        return NULL;
+    }
+
+    stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENT_INFO_BY_CONNECTION_STATUS_AND_NODE];
+
+    if (sqlite3_bind_int(stmt, 1, id) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return NULL;
+    }
+
+    if (sqlite3_bind_text(stmt, 2, connection_status, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return NULL;
+    }
+
+    if (sqlite3_bind_text(stmt, 3, node_name, -1, NULL) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return NULL;
+    }
+
+    result = wdb_exec_stmt(stmt);
+
+    if (!result) {
+        mdebug1("wdb_exec_stmt(): %s", sqlite3_errmsg(wdb->db));
+    }
+
+    return result;
+}
+
 cJSON* wdb_global_get_agents_to_disconnect(wdb_t *wdb, int last_agent_id, int keep_alive, const char *sync_status, wdbc_result* status) {
     sqlite3_stmt* stmt = NULL;
 

--- a/src/wazuh_db/wdb_state.c
+++ b/src/wazuh_db/wdb_state.c
@@ -652,9 +652,21 @@ void w_inc_global_agent_get_agent_info() {
     w_mutex_unlock(&db_state_t_mutex);
 }
 
+void w_inc_global_agent_get_agent_info_by_connection_status_and_node() {
+    w_mutex_lock(&db_state_t_mutex);
+    wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_queries++;
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
 void w_inc_global_agent_get_agent_info_time(struct timeval time) {
     w_mutex_lock(&db_state_t_mutex);
     timeradd(&wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_time, &time, &wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_time);
+    w_mutex_unlock(&db_state_t_mutex);
+}
+
+void w_inc_global_agent_get_agent_info_by_connection_status_and_node_time(struct timeval time) {
+    w_mutex_lock(&db_state_t_mutex);
+    timeradd(&wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_time, &time, &wdb_state.queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_time);
     w_mutex_unlock(&db_state_t_mutex);
 }
 
@@ -1156,6 +1168,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_global_tables_agent, "disconnect-agents", wdb_state_cpy.queries_breakdown.global_breakdown.agent.disconnect_agents_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "find-agent", wdb_state_cpy.queries_breakdown.global_breakdown.agent.find_agent_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "get-agent-info", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agent_info_queries);
+    cJSON_AddNumberToObject(_global_tables_agent, "get-agent-info-by-connection-status-and-node", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "get-agents-by-connection-status", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "get-all-agents", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_all_agents_queries);
     cJSON_AddNumberToObject(_global_tables_agent, "get-distinct-groups", wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_distinct_groups_queries);
@@ -1348,6 +1361,7 @@ cJSON* wdb_create_state_json() {
     cJSON_AddNumberToObject(_global_tables_agent_t, "disconnect-agents", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.disconnect_agents_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "find-agent", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.find_agent_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-agent-info", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agent_info_time));
+    cJSON_AddNumberToObject(_global_tables_agent_t, "get-agent-info-by-connection-status-and-node", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-agents-by-connection-status", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-all-agents", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_all_agents_time));
     cJSON_AddNumberToObject(_global_tables_agent_t, "get-distinct-groups", timeval_to_milis(wdb_state_cpy.queries_breakdown.global_breakdown.agent.get_distinct_groups_time));
@@ -1496,6 +1510,7 @@ STATIC uint64_t get_global_time(wdb_state_t *state){
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.select_agent_group_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.find_agent_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_agent_info_time, &task_time);
+    timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_agent_info_by_connection_status_and_node_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_all_agents_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_distinct_groups_time, &task_time);
     timeradd(&task_time, &state->queries_breakdown.global_breakdown.agent.get_agents_by_connection_status_time, &task_time);

--- a/src/wazuh_db/wdb_state.h
+++ b/src/wazuh_db/wdb_state.h
@@ -124,6 +124,7 @@ typedef struct _global_agent_t {
     uint64_t disconnect_agents_queries;
     uint64_t find_agent_queries;
     uint64_t get_agent_info_queries;
+    uint64_t get_agent_info_by_connection_status_and_node_queries;
     uint64_t get_agents_by_connection_status_queries;
     uint64_t get_all_agents_queries;
     uint64_t get_distinct_groups_queries;
@@ -146,6 +147,7 @@ typedef struct _global_agent_t {
     struct timeval disconnect_agents_time;
     struct timeval find_agent_time;
     struct timeval get_agent_info_time;
+    struct timeval get_agent_info_by_connection_status_and_node_time;
     struct timeval get_agents_by_connection_status_time;
     struct timeval get_all_agents_time;
     struct timeval get_distinct_groups_time;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -31,6 +31,105 @@ template<typename TScanContext = ScanContext, typename TSocketDBWrapper = Socket
 class TBuildSingleAgentListInfoContext final : public AbstractHandler<std::shared_ptr<TScanContext>>
 {
 
+private:
+    void handleNoCluster(std::shared_ptr<TScanContext> data)
+    {
+        const auto agentId = data->agentId();
+
+        nlohmann::json response;
+
+        try
+        {
+            // Execute query
+            TSocketDBWrapper::instance().query(
+                WazuhDBQueryBuilder::builder().globalGetCommand(std::string("agent-info ") + agentId.data()).build(),
+                response);
+        }
+        catch (const SocketDbWrapperException& e)
+        {
+            throw WdbDataException(e.what(), agentId.data());
+        }
+        catch (std::exception& e)
+        {
+            throw std::runtime_error(std::string("Unable to retrieve agent-info (agent ") + agentId.data() +
+                                     "). Reason: " + e.what() + ".");
+        }
+
+        if (response.size() == 1)
+        {
+            try
+            {
+                const auto& agent = response.front();
+
+                const auto& wdbAgentVersion = agent.at("version").get_ref<const std::string&>();
+                const auto& wdbAgentName = agent.at("name").get_ref<const std::string&>();
+                const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
+
+                data->m_agents.push_back(
+                    {agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp});
+                logDebug2(WM_VULNSCAN_LOGTAG, "Agent %s added to the list of agents to be re-scanned", agentId.data());
+            }
+            catch (const std::exception& e)
+            {
+                throw std::runtime_error("Invalid agent-info response format");
+            }
+        }
+    }
+
+    void handleCluster(std::shared_ptr<TScanContext> data)
+    {
+        const auto clusterNodeName = data->clusterNodeName();
+        const auto agentId = data->agentId();
+
+        nlohmann::json response;
+
+        try
+        {
+            // Execute query
+            TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder()
+                                                   .global()
+                                                   .selectAll()
+                                                   .fromTable("agent")
+                                                   .whereColumn("id")
+                                                   .equalsTo(agentId.data())
+                                                   .andColumn("connection_status")
+                                                   .equalsTo("active")
+                                                   .andColumn("node_name")
+                                                   .equalsTo(clusterNodeName.data())
+                                                   .build(),
+                                               response);
+        }
+        catch (const SocketDbWrapperException& e)
+        {
+            throw WdbDataException(e.what(), data->agentId().data());
+        }
+        catch (std::exception& e)
+        {
+            throw std::runtime_error(std::string("Unable to retrieve agent-info (agent ") + data->agentId().data() +
+                                     "). Reason: " + e.what() + ".");
+        }
+
+        if (response.size() == 1)
+        {
+            try
+            {
+                const auto& agent = response.front();
+
+                const auto& wdbAgentVersion = agent.at("version").get_ref<const std::string&>();
+                const auto& wdbAgentName = agent.at("name").get_ref<const std::string&>();
+                const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
+
+                data->m_agents.push_back(
+                    {agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp});
+                logDebug2(WM_VULNSCAN_LOGTAG, "Agent %s added to the list of agents to be re-scanned", agentId.data());
+            }
+            catch (const std::exception& e)
+            {
+                throw std::runtime_error("Invalid agent-info response format");
+            }
+        }
+    }
+
 public:
     /**
      * @brief Construct a new global fetch object
@@ -46,70 +145,15 @@ public:
      */
     std::shared_ptr<TScanContext> handleRequest(std::shared_ptr<TScanContext> data) override
     {
-        nlohmann::json response;
-
-        try
+        if (data->clusterStatus())
         {
-            // Execute query
-            TSocketDBWrapper::instance().query(
-                WazuhDBQueryBuilder::builder()
-                    .globalGetCommand(std::string("agent-info ") + data->agentId().data())
-                    .build(),
-                response);
+            handleCluster(data);
         }
-        catch (const SocketDbWrapperException& e)
+        else
         {
-            throw WdbDataException(e.what(), data->agentId().data());
-        }
-        catch (std::exception& e)
-        {
-            throw std::runtime_error(std::string("Unable to retrieve agent-info (agent ") + data->agentId().data() +
-                                     "). Reason: " + e.what() + ".");
+            handleNoCluster(data);
         }
 
-        // Return elements should be one agent.
-        if (response.size() == 1)
-        {
-            const auto clusterStatus = data->clusterStatus();
-            const auto clusterNodeName = data->clusterNodeName();
-            const auto agentId = data->agentId();
-
-            try
-            {
-                const auto& agent = response.front();
-                const auto& wdbAgentNodeName = agent.at("node_name").get_ref<const std::string&>();
-                const auto& wdbAgentConnectionStatus = agent.at("connection_status").get_ref<const std::string&>();
-                const auto& wdbAgentVersion = agent.at("version").get_ref<const std::string&>();
-                const auto& wdbAgentName = agent.at("name").get_ref<const std::string&>();
-                const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
-
-                // Add the agent to the scan list if one of the conditions is met:
-                //   - It's not in a cluster
-                //   - It's in the cluster and matches the server node name and the connection status is active.
-                if (!clusterStatus || (clusterNodeName == wdbAgentNodeName && "active" == wdbAgentConnectionStatus))
-                {
-                    data->m_agents.push_back(
-                        {agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp});
-                    logDebug2(
-                        WM_VULNSCAN_LOGTAG, "Agent %s added to the list of agents to be re-scanned", agentId.data());
-                }
-                else
-                {
-                    logDebug2(WM_VULNSCAN_LOGTAG,
-                              "Agent %s not added to the list of agents to be re-scanned (cluster status: %s) (cluster "
-                              "node_name: %s) (connection_status: %s) (agent node_name: %s)",
-                              agentId.data(),
-                              clusterStatus ? "true" : "false",
-                              clusterNodeName.data(),
-                              wdbAgentConnectionStatus.c_str(),
-                              wdbAgentNodeName.c_str());
-                }
-            }
-            catch (const std::exception& e)
-            {
-                throw std::runtime_error("Invalid agent-info response format");
-            }
-        }
         return AbstractHandler<std::shared_ptr<TScanContext>>::handleRequest(std::move(data));
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildSingleAgentListContext.hpp
@@ -34,7 +34,7 @@ class TBuildSingleAgentListInfoContext final : public AbstractHandler<std::share
 private:
     void handleNoCluster(std::shared_ptr<TScanContext> data)
     {
-        const auto agentId = data->agentId();
+        const auto& agentId = data->agentId();
 
         nlohmann::json response;
 
@@ -65,8 +65,9 @@ private:
                 const auto& wdbAgentName = agent.at("name").get_ref<const std::string&>();
                 const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
 
-                data->m_agents.push_back(
-                    {agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp});
+                data->m_agents.emplace_back(
+                    agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp);
+
                 logDebug2(WM_VULNSCAN_LOGTAG, "Agent %s added to the list of agents to be re-scanned", agentId.data());
             }
             catch (const std::exception& e)
@@ -78,26 +79,20 @@ private:
 
     void handleCluster(std::shared_ptr<TScanContext> data)
     {
-        const auto clusterNodeName = data->clusterNodeName();
-        const auto agentId = data->agentId();
+        const auto& clusterNodeName = data->clusterNodeName();
+        const auto& agentId = data->agentId();
 
         nlohmann::json response;
 
         try
         {
             // Execute query
-            TSocketDBWrapper::instance().query(WazuhDBQueryBuilder::builder()
-                                                   .global()
-                                                   .selectAll()
-                                                   .fromTable("agent")
-                                                   .whereColumn("id")
-                                                   .equalsTo(agentId.data())
-                                                   .andColumn("connection_status")
-                                                   .equalsTo("active")
-                                                   .andColumn("node_name")
-                                                   .equalsTo(clusterNodeName.data())
-                                                   .build(),
-                                               response);
+            TSocketDBWrapper::instance().query(
+                WazuhDBQueryBuilder::builder()
+                    .globalGetCommand(std::string("agent-info-by-connection-status-and-node ") + agentId.data() + " " +
+                                      WAZUH_DB_AGENT_ACTIVE_STATUS + " " + clusterNodeName.data())
+                    .build(),
+                response);
         }
         catch (const SocketDbWrapperException& e)
         {
@@ -119,8 +114,9 @@ private:
                 const auto& wdbAgentName = agent.at("name").get_ref<const std::string&>();
                 const auto& wdbAgentIp = agent.at("ip").get_ref<const std::string&>();
 
-                data->m_agents.push_back(
-                    {agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp});
+                data->m_agents.emplace_back(
+                    agentId.data(), wdbAgentName, Utils::leftTrim(wdbAgentVersion, "Wazuh "), wdbAgentIp);
+
                 logDebug2(WM_VULNSCAN_LOGTAG, "Agent %s added to the list of agents to be re-scanned", agentId.data());
             }
             catch (const std::exception& e)

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -110,6 +110,22 @@ struct AgentData
     std::string name;    ///< Agent name.
     std::string version; ///< Agent version.
     std::string ip;      ///< Agent IP.
+
+    /**
+     * @brief Construct a new Agent Data object.
+     *
+     * @param _id Id of the agent.
+     * @param _name Name of the agent.
+     * @param _version Version of the agent.
+     * @param _ip IP of the agent.
+     */
+    AgentData(std::string _id, std::string _name, std::string _version, std::string _ip)
+        : id(_id)
+        , name(_name)
+        , version(_version)
+        , ip(_ip)
+    {
+    }
 };
 
 /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
 include_directories(${SRC_FOLDER}/wazuh_modules/vulnerability_scanner/src/)
 include_directories(${SRC_FOLDER}/wazuh_modules/vulnerability_scanner/include/)
 include_directories(${SRC_FOLDER}/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/)
+include_directories(${SRC_FOLDER}/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/)
 
 link_directories(${SRC_FOLDER}/external/googletest/lib/)
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/benchmark/buildSingleAgentListContextBenchmark.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/benchmark/buildSingleAgentListContextBenchmark.cpp
@@ -1,0 +1,123 @@
+/*
+ * Wazuh Vulnerability scanner - Benchmark tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 31, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "buildSingleAgentListContext.hpp"
+#include <benchmark/benchmark.h>
+
+class MockSocketDBWrapper : public Singleton<MockSocketDBWrapper>
+{
+public:
+    /**
+     * @brief Returns a mocked JSON response.
+     *
+     * @param query Query. Ignored.
+     * @param response The JSON response.
+     */
+    void query(const std::string& query, nlohmann::json& response)
+    {
+        response = nlohmann::json::parse(R"([{"name": "test_name", "version": "v4.10.0", "ip": "192.168.0.1"}])");
+    }
+};
+
+class MockScanContext
+{
+private:
+    std::string m_clusterNodeName; ///< Cluster node name.
+    std::string m_agentId;         ///< Agent ID.
+
+public:
+    MockScanContext() = default;
+
+    /**
+     * @brief Construct a new Mock Scan Context object with parameters.
+     *
+     * @param clusterNodeName The cluster node name.
+     * @param agentId The agent ID.
+     */
+    MockScanContext(std::string clusterNodeName, std::string agentId)
+        : m_clusterNodeName(clusterNodeName)
+        , m_agentId(agentId)
+    {
+    }
+
+    /**
+     * @brief Returns the cluster status. Fixed to true.
+     *
+     * @return true Always returns.
+     * @return false Unused.
+     */
+    bool clusterStatus() const
+    {
+        return true;
+    }
+
+    /**
+     * @brief Returns the cluster node name.
+     *
+     * @return std::string_view The cluster node name.
+     */
+    std::string_view clusterNodeName() const
+    {
+        return m_clusterNodeName;
+    }
+
+    /**
+     * @brief Returns the agent ID.
+     *
+     * @return std::string_view The agent ID.
+     */
+    std::string_view agentId() const
+    {
+        return m_agentId;
+    }
+
+    std::vector<AgentData> m_agents; ///< Agent data list.
+};
+
+/**
+ * @brief This class is used to test the performance of the build single agent list context.
+ *
+ */
+class BuildSingleAgentListContextFixture : public benchmark::Fixture
+{
+protected:
+    std::shared_ptr<MockScanContext> scanContext; ///< Mock scan context.
+    TBuildSingleAgentListInfoContext<MockScanContext, MockSocketDBWrapper>
+        buildSingleAgentListInfoContext {}; ///< Build single agent list context.
+
+public:
+    /**
+     * @brief Benchmark setup routine.
+     *
+     * @param state Benchmark state.
+     */
+    void SetUp(const ::benchmark::State& state) override
+    {
+        scanContext = std::make_shared<MockScanContext>("node01", "test_agent");
+    }
+
+    /**
+     * @brief Benchmark teardown routine.
+     *
+     * @param state Benchmark state.
+     */
+    void TearDown(const ::benchmark::State& state) override {}
+};
+
+BENCHMARK_DEFINE_F(BuildSingleAgentListContextFixture, BuildContextPerformance)(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        buildSingleAgentListInfoContext.handleRequest(scanContext);
+    }
+}
+
+BENCHMARK_REGISTER_F(BuildSingleAgentListContextFixture, BuildContextPerformance)->Iterations(100000)->Threads(1);

--- a/src/wazuh_modules/vulnerability_scanner/tests/benchmark/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/benchmark/main.cpp
@@ -1,0 +1,14 @@
+/*
+ * Wazuh Vulnerability scanner - Benchmark tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * December 31, 2024.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN();

--- a/src/wazuh_modules/vulnerability_scanner/tests/benchmark/versionMatcherBenchmark.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/benchmark/versionMatcherBenchmark.cpp
@@ -418,5 +418,3 @@ BENCHMARK_REGISTER_F(ComparisonMajorMinorPerformanceFixture, ComparisonMajorMino
     ->Iterations(100000)
     ->Threads(1);
 BENCHMARK_REGISTER_F(ComparisonSemVerPerformanceFixture, ComparisonSemVerPerformance)->Iterations(100000)->Threads(1);
-
-BENCHMARK_MAIN();

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildSingleAgentListContext_test.cpp
@@ -29,6 +29,8 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextEmpty)
 
     auto scanContext = std::make_shared<MockScanContext>();
     EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillOnce(testing::Return("node_1"));
+    EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(true));
 
     EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
 
@@ -88,6 +90,7 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextMultiple)
 
     auto scanContext = std::make_shared<MockScanContext>();
     EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+    EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(false));
 
     EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
 
@@ -107,6 +110,7 @@ TEST_F(BuildSingleAgentListContextTest, ExceptionOnDB)
 
     auto scanContext = std::make_shared<MockScanContext>();
     EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+    EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(false));
 
     // Context is not used
     EXPECT_THROW(singleAgentContext->handleRequest(scanContext), WdbDataException);
@@ -127,6 +131,7 @@ TEST_F(BuildSingleAgentListContextTest, ExceptionOnDBRuntimeError)
 
     auto scanContext = std::make_shared<MockScanContext>();
     EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
+    EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(false));
 
     // Context is not used
     EXPECT_THROW(singleAgentContext->handleRequest(scanContext), std::runtime_error);
@@ -156,7 +161,6 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsC
     auto scanContext = std::make_shared<MockScanContext>();
 
     EXPECT_CALL(*scanContext, clusterStatus()).WillOnce(testing::Return(false));
-    EXPECT_CALL(*scanContext, clusterNodeName()).WillOnce(testing::Return("node_1"));
     EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(testing::Return("001"));
 
     EXPECT_NO_THROW(singleAgentContext->handleRequest(scanContext));
@@ -176,14 +180,7 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsC
 TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterOnDifferentNodeName)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
-    nlohmann::json queryResult = R"([{
-        "id": 1,
-        "name": "name",
-        "version": "Wazuh v4.4.4",
-        "ip": "192.168.0.1",
-        "node_name": "node_1",
-        "connection_status": "active"
-    }])"_json;
+    nlohmann::json queryResult = R"([])"_json;
 
     EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
         .Times(1)
@@ -208,14 +205,7 @@ TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsC
 TEST_F(BuildSingleAgentListContextTest, BuildSingleAgentListContextWithElementsClusterDisconnected)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
-    nlohmann::json queryResult = R"([{
-        "id": 1,
-        "name": "name",
-        "version": "Wazuh v4.4.4",
-        "ip": "192.168.0.1",
-        "node_name": "node_1",
-        "connection_status": "disconnected"
-    }])"_json;
+    nlohmann::json queryResult = R"([])"_json;
 
     EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
         .Times(1)


### PR DESCRIPTION
|Related issue|
|---|
| #27260 |

## Description
Improved buildSingleAgentListContext performance by making wazuhDB query more restrictive

## Testing

### RC1
![image](https://github.com/user-attachments/assets/a60d41a8-5f5a-4960-87b5-4cfa76d7473b)

### RC1 vs Changes
![image](https://github.com/user-attachments/assets/28990ba9-27b0-49dd-8202-81bc6b0bdf43)
