### PR TITLE
Use PowerShell to check problematic findings

### DIFF
--- a/ruleset/sca/windows/cis_win2022.yml
+++ b/ruleset/sca/windows/cis_win2022.yml
@@ -5322,10 +5322,9 @@ checks:
     compliance:
       - cis: ["18.10.12.1"]
     condition: all
-    rules:
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CloudContent'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CloudContent -> DisableConsumerAccountStateContent'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CloudContent -> DisableConsumerAccountStateContent -> 1'
+      - 'c:powershell \"(Test-Path -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent\\\")\" -> r:1'
+      - 'c:powershell \"(Get-ItemProperty -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent\\\") | Select-Object -ExpandProperty DisableConsumerAccountStateContent -ErrorAction SilentlyContinue\" -> r:1'
+      - 'c:powershell \"(Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent\\\" -Name DisableConsumerAccountStateContent) -eq 1\" -> r:1'
 
   # 18.10.12.2 (L2) Ensure 'Turn off cloud optimized content' is set to 'Enabled'. (Automated)
   - id: 27263 

--- a/ruleset/sca/windows/cis_win2022.yml
+++ b/ruleset/sca/windows/cis_win2022.yml
@@ -6676,9 +6676,9 @@ checks:
       - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search -> AllowCloudSearch'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search -> AllowCloudSearch -> 0'
+      - 'c:powershell \"(Test-Path -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Search\\\")\" -> r:1'
+      - 'c:powershell \"(Get-ItemProperty -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Search\\\") | Select-Object -ExpandProperty AllowCloudSearch -ErrorAction SilentlyContinue\" -> r:1'
+      - 'c:powershell \"(Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Search\\\" -Name AllowCloudSearch) -eq 0\" -> r:1'
 
   # 18.10.59.3 (L1) Ensure 'Allow indexing of encrypted files' is set to 'Disabled'. (Automated)
   - id: 27331 

--- a/ruleset/sca/windows/cis_win2022.yml
+++ b/ruleset/sca/windows/cis_win2022.yml
@@ -3691,11 +3691,11 @@ checks:
       - cis: ["18.6.14.1"]
     condition: all
     rules:
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths -> \\*\NETLOGON'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths -> \\*\SYSVOL'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths -> \\*\NETLOGON -> r:RequireMutualAuthentication=1, RequireIntegrity=1'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths -> \\*\SYSVOL -> r:RequireMutualAuthentication=1, RequireIntegrity=1'
+      - 'c:powershell \"(Get-ItemProperty -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\")\" -> r:1'
+      - 'c:powershell \"(Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\" -Name \\\"\\\\\\\\*\\\\NETLOGON\\\") -ne $null\" -> r:1'
+      - 'c:powershell \"(Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\" -Name \\\"\\\\\\\\*\\\\SYSVOL\\\") -ne $null\" -> r:1'
+      - 'c:powershell \"(Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\" -Name \\\"\\\\\\\\*\\\\NETLOGON\\\") -match \\\"RequireMutualAuthentication=1\\\" -and (Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\" -Name \\\"\\\\\\\\*\\\\NETLOGON\\\") -match \\\"RequireIntegrity=1\\\"\" -> r:1'
+      - 'c:powershell \"(Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\" -Name \\\"\\\\\\\\*\\\\SYSVOL\\\") -match \\\"RequireMutualAuthentication=1\\\" -and (Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\" -Name \\\"\\\\\\\\*\\\\SYSVOL\\\") -match \\\"RequireIntegrity=1\\\"\" -> r:1'
 
   # 18.6.19.2.1 (L2) Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set to '0xff (255)'). (Automated)
   - id: 27181 

--- a/ruleset/sca/windows/cis_win2022.yml
+++ b/ruleset/sca/windows/cis_win2022.yml
@@ -685,9 +685,9 @@ checks:
       - cis: ["2.3.7.4"]
     condition: all
     rules:
-      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system'
-      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext'
-      - 'r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -> legalnoticetext-> r:\w+'
+      - 'c:powershell \"(Test-Path -Path \\\"HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\system\\\")\" -> r:1'
+      - 'c:powershell \"(Get-ItemProperty -Path \\\"HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\system\\\") | Select-Object -ExpandProperty legalnoticetext -ErrorAction SilentlyContinue\" -> r:1'
+      - 'c:powershell \"(Get-ItemPropertyValue -Path \\\"HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\\" -Name LegalNoticeText) -ne \\\"\\\"\" -> r:1'
 
   # 2.3.7.5 (L1) Configure 'Interactive logon: Message title for users attempting to log on'. (Automated)
   - id: 27032 


### PR DESCRIPTION
|Related issue|
|---|
|#27438, #27439, #27440, #27441|

## Description
Trying to address problem I encounter in Windows Server 2022 with checks:

- 27031
- 27330
- 27262
- 27180

As I mentioned in my issues, some registry values are not checked correctly within Registry  `r:` rule. That is why, I decided to rewrite them to Command `c:` rulers.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors