### PR TITLE
Improve signal handling

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -28,7 +28,7 @@ install:
     # Copy files and create folders
 	# SHARE
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/api/scripts
-	$(INSTALL_FILE) scripts/wazuh_apid.py ${SHARE_INSTALLDIR}/api/scripts
+	$(INSTALL_EXEC) scripts/wazuh_apid.py ${SHARE_INSTALLDIR}/api/scripts
 
     # Install scripts/%.py on $(INSTALLDIR)/bin/%
 	$(foreach script,$(wildcard scripts/*.py),$(INSTALL_EXEC) api/wrappers/generic_wrapper.sh $(patsubst scripts/%.py,${BIN_INSTALLDIR}/%,$(script));)

--- a/api/Makefile
+++ b/api/Makefile
@@ -28,7 +28,7 @@ install:
     # Copy files and create folders
 	# SHARE
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/api/scripts
-	$(INSTALL_EXEC) scripts/wazuh_apid.py ${SHARE_INSTALLDIR}/api/scripts
+	$(INSTALL_EXEC) scripts/wazuh_apid.py ${SHARE_INSTALLDIR}/api/scripts/wazuh-apid.py
 
     # Install scripts/%.py on $(INSTALLDIR)/bin/%
 	$(foreach script,$(wildcard scripts/*.py),$(INSTALL_EXEC) api/wrappers/generic_wrapper.sh $(patsubst scripts/%.py,${BIN_INSTALLDIR}/%,$(script));)

--- a/api/api/wrappers/generic_wrapper.sh
+++ b/api/api/wrappers/generic_wrapper.sh
@@ -9,6 +9,6 @@ WAZUH_SHARE="/usr/share/wazuh-server"
 SCRIPT_PATH_NAME="$0"
 SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
 
-PYTHON_SCRIPT="${WAZUH_SHARE}/api/scripts/$(echo ${SCRIPT_NAME} | sed 's/\-/_/g').py"
+PYTHON_SCRIPT="${WAZUH_SHARE}/api/scripts/${SCRIPT_NAME}.py"
 
 ${PYTHON_SCRIPT} $@

--- a/api/api/wrappers/generic_wrapper.sh
+++ b/api/api/wrappers/generic_wrapper.sh
@@ -11,4 +11,4 @@ SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
 
 PYTHON_SCRIPT="${WAZUH_SHARE}/api/scripts/$(echo ${SCRIPT_NAME} | sed 's/\-/_/g').py"
 
-${WAZUH_SHARE}/${WPYTHON_BIN} ${PYTHON_SCRIPT} $@
+${PYTHON_SCRIPT} $@

--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -1,4 +1,4 @@
-#!/var/ossec/framework/python/bin/python3
+#!/usr/share/wazuh-server/framework/python/bin/python3
 
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.

--- a/apis/comms_api/Makefile
+++ b/apis/comms_api/Makefile
@@ -24,7 +24,7 @@ all: install
 install:
 
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/apis/scripts
-	$(INSTALL_FILE) scripts/wazuh_comms_apid.py ${SHARE_INSTALLDIR}/apis/scripts
+	$(INSTALL_EXEC) scripts/wazuh_comms_apid.py ${SHARE_INSTALLDIR}/apis/scripts
 
     # Install scripts/%.py on $(INSTALLDIR)/bin/%
 	$(foreach script,$(wildcard scripts/*.py),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,${BIN_INSTALLDIR}/%,$(script));)

--- a/apis/comms_api/Makefile
+++ b/apis/comms_api/Makefile
@@ -24,7 +24,7 @@ all: install
 install:
 
 	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/apis/scripts
-	$(INSTALL_EXEC) scripts/wazuh_comms_apid.py ${SHARE_INSTALLDIR}/apis/scripts
+	$(INSTALL_EXEC) scripts/wazuh_comms_apid.py ${SHARE_INSTALLDIR}/apis/scripts/wazuh-comms-apid.py
 
     # Install scripts/%.py on $(INSTALLDIR)/bin/%
 	$(foreach script,$(wildcard scripts/*.py),$(INSTALL_EXEC) wrappers/generic_wrapper.sh $(patsubst scripts/%.py,${BIN_INSTALLDIR}/%,$(script));)

--- a/apis/comms_api/scripts/wazuh_comms_apid.py
+++ b/apis/comms_api/scripts/wazuh_comms_apid.py
@@ -1,4 +1,4 @@
-#!/var/ossec/framework/python/bin/python3
+#!/usr/share/wazuh-server/framework/python/bin/python3
 
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.

--- a/apis/comms_api/wrappers/generic_wrapper.sh
+++ b/apis/comms_api/wrappers/generic_wrapper.sh
@@ -11,4 +11,4 @@ SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
 
 PYTHON_SCRIPT="${WAZUH_SHARE}/apis/scripts/$(echo ${SCRIPT_NAME} | sed 's/\-/_/g').py"
 
-${WAZUH_SHARE}/${WPYTHON_BIN} ${PYTHON_SCRIPT} $@
+${PYTHON_SCRIPT} $@

--- a/apis/comms_api/wrappers/generic_wrapper.sh
+++ b/apis/comms_api/wrappers/generic_wrapper.sh
@@ -9,6 +9,6 @@ WAZUH_SHARE="/usr/share/wazuh-server"
 SCRIPT_PATH_NAME="$0"
 SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
 
-PYTHON_SCRIPT="${WAZUH_SHARE}/apis/scripts/$(echo ${SCRIPT_NAME} | sed 's/\-/_/g').py"
+PYTHON_SCRIPT="${WAZUH_SHARE}/apis/scripts/${SCRIPT_NAME}.py"
 
 ${PYTHON_SCRIPT} $@

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -55,7 +55,7 @@ install:
 	$(INSTALL_DIR) $(ETC_INSTALLDIR)/groups
 
 	# SHARE
-	$(INSTALL_EXEC) scripts/*.py ${SHARE_INSTALLDIR}/framework/scripts
+	$(INSTALL_EXEC) scripts/wazuh_server.py ${SHARE_INSTALLDIR}/framework/scripts/wazuh-server.py
 	$(INSTALL_FILE) wazuh/*.py ${SHARE_INSTALLDIR}/framework/wazuh
 	$(INSTALL_FILE) wazuh/core/cluster/*.py ${SHARE_INSTALLDIR}/framework/wazuh/core/cluster
 	$(INSTALL_FILE) wazuh/core/cluster/dapi/*.py ${SHARE_INSTALLDIR}/framework/wazuh/core/cluster/dapi

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -55,7 +55,7 @@ install:
 	$(INSTALL_DIR) $(ETC_INSTALLDIR)/groups
 
 	# SHARE
-	$(INSTALL_FILE) scripts/*.py ${SHARE_INSTALLDIR}/framework/scripts
+	$(INSTALL_EXEC) scripts/*.py ${SHARE_INSTALLDIR}/framework/scripts
 	$(INSTALL_FILE) wazuh/*.py ${SHARE_INSTALLDIR}/framework/wazuh
 	$(INSTALL_FILE) wazuh/core/cluster/*.py ${SHARE_INSTALLDIR}/framework/wazuh/core/cluster
 	$(INSTALL_FILE) wazuh/core/cluster/dapi/*.py ${SHARE_INSTALLDIR}/framework/wazuh/core/cluster/dapi

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -68,9 +68,9 @@ def test_start_daemons(mock_popen, root):
 
     mock_popen.assert_has_calls([
         call([wazuh_server.ENGINE_BINARY_PATH, 'server', '-l', 'info','start']),
-        call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.MANAGEMENT_API_SCRIPT_PATH] + \
+        call([wazuh_server.MANAGEMENT_API_SCRIPT_PATH] + \
               (['-r'] if root else [])),
-        call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.COMMS_API_SCRIPT_PATH] + \
+        call([wazuh_server.COMMS_API_SCRIPT_PATH] + \
               (['-r'] if root else [])),
     ], any_order=True)
 
@@ -117,8 +117,8 @@ def test_start_daemons_ko(mock_popen):
 
     mock_popen.assert_has_calls([
         call([wazuh_server.ENGINE_BINARY_PATH, 'server', '-l', 'info', 'start']),
-        call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.MANAGEMENT_API_SCRIPT_PATH]),
-        call([wazuh_server.EMBEDDED_PYTHON_PATH, wazuh_server.COMMS_API_SCRIPT_PATH]),
+        call([wazuh_server.MANAGEMENT_API_SCRIPT_PATH]),
+        call([wazuh_server.COMMS_API_SCRIPT_PATH]),
     ], any_order=True)
 
 

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -11,8 +11,9 @@ import os
 import signal
 import subprocess
 import sys
-from typing import List
 import time
+from functools import partial
+from typing import Any, List
 
 from wazuh.core import pyDaemonModule
 from wazuh.core.authentication import generate_keypair, keypair_exists
@@ -364,7 +365,10 @@ def start():
         os.setuid(wazuh_uid())
 
     server_pid = os.getpid()
+
     pyDaemonModule.create_pid(SERVER_DAEMON_NAME, server_pid)
+    signal.signal(signal.SIGTERM, partial(sigterm_handler, server_pid=server_pid))
+
     main_logger.info(f'Starting server (pid: {server_pid})')
 
     if server_config.node.type == NodeType.MASTER:
@@ -378,17 +382,47 @@ def start():
         main_function = worker_main
 
     try:
-        asyncio.run(main_function(args, server_config, main_logger))
+        loop = asyncio.new_event_loop()
+        loop.add_signal_handler(signal.SIGTERM, partial(stop_loop, loop))
+        loop.run_until_complete(main_function(args, server_config, main_logger))
     except KeyboardInterrupt:
         main_logger.info('SIGINT received. Shutting down...')
     except MemoryError:
         main_logger.error("Directory '/tmp' needs read, write & execution " "permission for 'wazuh' user")
     except WazuhDaemonError as e:
         main_logger.error(e)
+    except RuntimeError:
+        main_logger.info('Main loop stopped.')
     except Exception as e:
         main_logger.error(f'Unhandled exception: {e}')
     finally:
         shutdown_server(server_pid)
+
+
+def stop_loop(loop: asyncio.BaseEventLoop):
+    """Stop the given asyncio loop.
+
+    Parameters
+    ----------
+    loop : asyncio.BaseEventLoop
+        The loop to stop.
+    """
+    loop.stop()
+
+
+def sigterm_handler(signum: int, frame: Any, server_pid: int) -> None:
+    """Handle SIGTERM signal shutting down the server.
+
+    Parameters
+    ----------
+    signum : int
+        The signal number received.
+    frame : Any
+        The current stack frame (unused).
+    server_pid : int
+        The server process ID used to terminate.
+    """
+    shutdown_server(server_pid)
 
 
 def stop():
@@ -399,7 +433,6 @@ def stop():
         main_logger.warning('Wazuh server is not running.')
         sys.exit(0)
 
-    shutdown_server(server_pid)
     os.kill(server_pid, signal.SIGTERM)
 
 

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -8,6 +8,7 @@ import argparse
 import asyncio
 import logging
 import os
+import psutil
 import signal
 import subprocess
 import sys
@@ -337,7 +338,7 @@ def start():
     """Start function of the wazuh-server script in charge of starting the server process."""
     try:
         server_pid = pyDaemonModule.get_wazuh_server_pid(SERVER_DAEMON_NAME)
-        if server_pid:
+        if server_pid and psutil.pid_exists(server_pid):
             print(f'The server is already running on process {server_pid}')
             sys.exit(1)
     except StopIteration:
@@ -383,6 +384,7 @@ def start():
     try:
         loop = asyncio.new_event_loop()
         loop.add_signal_handler(signal.SIGTERM, partial(stop_loop, loop))
+        loop.create_task(monitor_server_daemons(loop, server_pid))
         loop.run_until_complete(main_function(args, server_config, main_logger))
     except KeyboardInterrupt:
         main_logger.info('SIGINT received. Shutting down...')
@@ -396,6 +398,64 @@ def start():
         main_logger.error(f'Unhandled exception: {e}')
     finally:
         shutdown_server(server_pid)
+
+
+class ChildDaemonError(Exception):
+    pass
+
+
+def check_daemon(proc_list: list, proc_name: str, children_number: int):
+    """Check the daemon is in the list of children process and have the correct number of children.
+
+    Parameters
+    ----------
+    proc_list : list
+        List of children process to search within.
+    proc_name : str
+        Name of the process to check.
+    children_number : int
+        Expected number of children to check.
+
+    Raises
+    ------
+    ChildDaemonError
+        When the process does not have the correct number of children process.
+    """
+    child: psutil.Process = [i for i in proc_list if proc_name.replace('-', '_')[:-1] in i.name()][0]
+    if child.status() == psutil.STATUS_ZOMBIE:
+        main_logger.error(f"Daemon `{proc_name}` is not running, killing the whole server.")
+        clean_pid_files(proc_name)
+    if len(child.children()) != children_number:
+        raise ChildDaemonError(f'Daemon {child.name()} does not have the correct number of children process.')
+
+
+async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_pid: int):
+    """Monitor the status of the server daemons.
+
+    Parameters
+    ----------
+    loop : asyncio.BaseEventLoop
+        The loop to stop in case any of the daemons does not meet the expected status.
+    server_pid : int
+        PID of the server to get the children.
+    """
+    proc_tree = {
+        MANAGEMENT_API_DAEMON_NAME: {"children": 3},
+        COMMS_API_DAEMON_NAME: {"children": 8},
+        ENGINE_DAEMON_NAME: {"children": 1}
+    }
+
+    while True:
+        await asyncio.sleep(10)
+        server_proc = psutil.Process(server_pid)
+        child_proceses = server_proc.children()
+
+        try:
+            for key, value in proc_tree.items():
+                check_daemon(child_proceses, key, value['children'])
+        except ChildDaemonError as e:
+            main_logger.error(f'{e} Stopping the whole server.')
+            stop_loop(loop)
 
 
 def stop_loop(loop: asyncio.BaseEventLoop):

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -31,12 +31,12 @@ from wazuh.core.config.models.server import ServerConfig
 
 
 SERVER_DAEMON_NAME = 'wazuh-server'
-COMMS_API_SCRIPT_PATH = WAZUH_SHARE / 'apis' / 'scripts' / 'wazuh_comms_apid.py'
 COMMS_API_DAEMON_NAME = 'wazuh-comms-apid'
+COMMS_API_SCRIPT_PATH = WAZUH_SHARE / 'apis' / 'scripts' / f'{COMMS_API_DAEMON_NAME}.py'
 ENGINE_BINARY_PATH = WAZUH_SHARE / 'bin' / 'wazuh-engine'
 ENGINE_DAEMON_NAME = 'wazuh-engined'
-MANAGEMENT_API_SCRIPT_PATH = WAZUH_SHARE / 'api' / 'scripts' / 'wazuh_apid.py'
 MANAGEMENT_API_DAEMON_NAME = 'wazuh-apid'
+MANAGEMENT_API_SCRIPT_PATH = WAZUH_SHARE / 'api' / 'scripts' / f'{MANAGEMENT_API_DAEMON_NAME}.py'
 
 
 #
@@ -400,10 +400,6 @@ def start():
         shutdown_server(server_pid)
 
 
-class ChildDaemonError(Exception):
-    pass
-
-
 def check_daemon(proc_list: list, proc_name: str, children_number: int):
     """Check the daemon is in the list of children process and have the correct number of children.
 
@@ -418,15 +414,15 @@ def check_daemon(proc_list: list, proc_name: str, children_number: int):
 
     Raises
     ------
-    ChildDaemonError
+    WazuhDaemonError
         When the process does not have the correct number of children process.
     """
-    child: psutil.Process = [i for i in proc_list if proc_name.replace('-', '_')[:-1] in i.name()][0]
+    child: psutil.Process = [i for i in proc_list if proc_name[:-1] in i.name()][0]
     if child.status() == psutil.STATUS_ZOMBIE:
-        main_logger.error(f"Daemon `{proc_name}` is not running, killing the whole server.")
+        main_logger.error(f"Daemon `{proc_name}` is not running, stopping the whole server.")
         clean_pid_files(proc_name)
     if len(child.children()) != children_number:
-        raise ChildDaemonError(f'Daemon {child.name()} does not have the correct number of children process.')
+        raise WazuhDaemonError(f'Daemon `{proc_name}` does not have the correct number of children process.')
 
 
 async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_pid: int):
@@ -439,10 +435,11 @@ async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_pid: int):
     server_pid : int
         PID of the server to get the children.
     """
+    comms_api_config = CentralizedConfig.get_comms_api_config()
     proc_tree = {
         MANAGEMENT_API_DAEMON_NAME: {"children": 3},
-        COMMS_API_DAEMON_NAME: {"children": 8},
-        ENGINE_DAEMON_NAME: {"children": 1}
+        COMMS_API_DAEMON_NAME: {"children": comms_api_config.workers + 4},
+        ENGINE_DAEMON_NAME: {"children": 0}
     }
 
     while True:
@@ -453,8 +450,8 @@ async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_pid: int):
         try:
             for key, value in proc_tree.items():
                 check_daemon(child_proceses, key, value['children'])
-        except ChildDaemonError as e:
-            main_logger.error(f'{e} Stopping the whole server.')
+        except WazuhDaemonError as error:
+            main_logger.error(f'{error.code} Stopping the whole server.')
             stop_loop(loop)
 
 

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/share/wazuh-server/framework/python/bin/python3
 
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
@@ -32,7 +32,6 @@ from wazuh.core.config.models.server import ServerConfig
 SERVER_DAEMON_NAME = 'wazuh-server'
 COMMS_API_SCRIPT_PATH = WAZUH_SHARE / 'apis' / 'scripts' / 'wazuh_comms_apid.py'
 COMMS_API_DAEMON_NAME = 'wazuh-comms-apid'
-EMBEDDED_PYTHON_PATH = WAZUH_SHARE / 'framework' / 'python' / 'bin' / 'python3'
 ENGINE_BINARY_PATH = WAZUH_SHARE / 'bin' / 'wazuh-engine'
 ENGINE_DAEMON_NAME = 'wazuh-engined'
 MANAGEMENT_API_SCRIPT_PATH = WAZUH_SHARE / 'api' / 'scripts' / 'wazuh_apid.py'
@@ -106,9 +105,9 @@ def start_daemons(root: bool):
 
     daemons = {
         ENGINE_DAEMON_NAME: [ENGINE_BINARY_PATH, 'server', '-l', engine_log_level[debug_mode_], 'start'],
-        COMMS_API_DAEMON_NAME: [EMBEDDED_PYTHON_PATH, COMMS_API_SCRIPT_PATH]
+        COMMS_API_DAEMON_NAME: [COMMS_API_SCRIPT_PATH]
             + (['-r'] if root else []),
-        MANAGEMENT_API_DAEMON_NAME: [EMBEDDED_PYTHON_PATH, MANAGEMENT_API_SCRIPT_PATH]
+        MANAGEMENT_API_DAEMON_NAME: [MANAGEMENT_API_SCRIPT_PATH]
             + (['-r'] if root else []),
     }
 

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -384,7 +384,7 @@ def start():
     try:
         loop = asyncio.new_event_loop()
         loop.add_signal_handler(signal.SIGTERM, partial(stop_loop, loop))
-        loop.create_task(monitor_server_daemons(loop, server_pid))
+        loop.create_task(monitor_server_daemons(loop, psutil.Process(server_pid)))
         loop.run_until_complete(main_function(args, server_config, main_logger))
     except KeyboardInterrupt:
         main_logger.info('SIGINT received. Shutting down...')
@@ -401,7 +401,7 @@ def start():
 
 
 def check_daemon(proc_list: list, proc_name: str, children_number: int):
-    """Check the daemon is in the list of children process and have the correct number of children.
+    """Check the daemon is in the list of process and have the correct number of children.
 
     Parameters
     ----------
@@ -421,11 +421,12 @@ def check_daemon(proc_list: list, proc_name: str, children_number: int):
     if child.status() == psutil.STATUS_ZOMBIE:
         main_logger.error(f"Daemon `{proc_name}` is not running, stopping the whole server.")
         clean_pid_files(proc_name)
+        return
     if len(child.children()) != children_number:
         raise WazuhDaemonError(f'Daemon `{proc_name}` does not have the correct number of children process.')
 
 
-async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_pid: int):
+async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_process: psutil.Process):
     """Monitor the status of the server daemons.
 
     Parameters
@@ -444,8 +445,7 @@ async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_pid: int):
 
     while True:
         await asyncio.sleep(10)
-        server_proc = psutil.Process(server_pid)
-        child_proceses = server_proc.children()
+        child_proceses = server_process.children()
 
         try:
             for key, value in proc_tree.items():

--- a/framework/wazuh/core/batcher/batcher.py
+++ b/framework/wazuh/core/batcher/batcher.py
@@ -140,7 +140,6 @@ class Batcher:
         self._shutdown_event = asyncio.Event()
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGTERM, self._handle_signal, signal.SIGTERM)
-        loop.add_signal_handler(signal.SIGINT, signal.SIG_IGN)
 
         try:
             while not self._shutdown_event.is_set():
@@ -219,7 +218,7 @@ def create_bulk_list(items: List[Item]) -> List[BulkDoc]:
     docs: List[BulkDoc] = []
     for item in items:
         if item.operation == Operation.CREATE.value:
-            docs.append(BulkDoc.create(index=item.index_name, doc_id=item.id, doc=item.content))    
+            docs.append(BulkDoc.create(index=item.index_name, doc_id=item.id, doc=item.content))
         elif item.operation == Operation.DELETE.value:
             docs.append(BulkDoc.delete(index=item.index_name, doc_id=item.id))
         elif item.operation == Operation.UPDATE.value:

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -81,7 +81,8 @@ def clean_pid_files(daemon: str) -> None:
             try:
                 pid = int(match.group(1))
                 process = psutil.Process(pid)
-                command = process.cmdline()[-1]
+                command = process.cmdline()[-1] if process.status() != psutil.STATUS_ZOMBIE \
+                    else daemon.replace('-', '_')
 
                 if daemon.replace('-', '_') in command:
                     pgid = os.getpgid(pid)

--- a/framework/wrappers/generic_wrapper.sh
+++ b/framework/wrappers/generic_wrapper.sh
@@ -9,6 +9,6 @@ WAZUH_PATH="/usr/share/wazuh-server"
 SCRIPT_PATH_NAME="$0"
 SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
 
-PYTHON_SCRIPT="${WAZUH_PATH}/framework/scripts/$(echo ${SCRIPT_NAME} | sed 's/\-/_/g').py"
+PYTHON_SCRIPT="${WAZUH_PATH}/framework/scripts/${SCRIPT_NAME}.py"
 
 ${PYTHON_SCRIPT} "$@"

--- a/framework/wrappers/generic_wrapper.sh
+++ b/framework/wrappers/generic_wrapper.sh
@@ -11,4 +11,4 @@ SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
 
 PYTHON_SCRIPT="${WAZUH_PATH}/framework/scripts/$(echo ${SCRIPT_NAME} | sed 's/\-/_/g').py"
 
-${WAZUH_PATH}/${WPYTHON_BIN} ${PYTHON_SCRIPT} "$@"
+${PYTHON_SCRIPT} "$@"

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -112,6 +112,10 @@ override_dh_fixperms:
 	chown $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
 	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-server
 
+	# Scripts
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/framework/scripts/wazuh-server.py
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
+	chmod 750 $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/api/scripts/wazuh-apid.py
 
 	# Services
 	chown root:root $(TARGET_DIR)/etc/init.d/wazuh-server

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -215,6 +215,14 @@ chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/bin
 chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
 chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server
 
+# Scripts
+chmod 750 %{_localstatedir}usr/share/wazuh-server/framework/scripts/wazuh-server.py
+chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/framework/scripts/wazuh-server.py
+chmod 750 %{_localstatedir}usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
+chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
+chmod 750 %{_localstatedir}usr/share/wazuh-server/api/scripts/wazuh-comms-apid.py
+chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/api/scripts/wazuh-apid.py
+
 # Fix Python permissions
 chmod -R 0750 %{_localstatedir}usr/share/wazuh-server/framework/python/bin
 


### PR DESCRIPTION
|Related issue|
|---|
|#27265|

## Description

This PR closes #27265. Add mechanisms to handle the exit signals correctly.


## Logs/Alerts example

<details><summary>Clean exit on Ctrl + C</summary>
<p>

```console
2025/01/02 19:52:25 INFO: [Cluster] [Main] Starting server (pid: 1180)
2025/01/02 19:52:25 INFO: [Cluster] [Main] Generating JWT signing key pair
2025/01/02 19:52:25 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/02 19:52:25 INFO: [Master] [Config Server] Started server process [1180]
2025/01/02 19:52:25 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/02 19:52:25 INFO: [Master] [Config Server] Application startup complete.
2025/01/02 19:52:25 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/02 19:52:26 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-02 19:52:26.746 1186:1186 info: Logging initialized.
2025/01/02 19:52:26 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-02 19:52:26.750 1186:1186 info: Metrics manager configured successfully
2025-01-02 19:52:26.762 1186:1186 info: Metrics pipeline enabled successfully
2025-01-02 19:52:26.762 1186:1186 info: Metrics initialized.
2025-01-02 19:52:26.762 1186:1186 info: Store initialized.
2025-01-02 19:52:26.762 1186:1186 warning: Could not load RBAC model, using default model: File '/var/lib/wazuh-server/engine/store/internal/rbac/model/0' does not exist
2025-01-02 19:52:26.763 1186:1186 info: RBAC initialized.
2025-01-02 19:52:26.775 1186:1186 info: KVDB initialized.
2025-01-02 19:52:26.775 1186:1186 info: Geo initialized.
2025-01-02 19:52:26.787 1186:1186 info: Schema initialized.
2025-01-02 19:52:26.800 1186:1186 info: Loaded timezone database version: '2024a'
2025-01-02 19:52:26.803 1186:1186 info: HLP initialized.
2025-01-02 19:52:26.814 1186:1186 info: Indexer Connector initialized.
2025-01-02 19:52:26.815 1186:1186 info: Builder initialized.
2025-01-02 19:52:26.815 1186:1186 info: Catalog initialized.
2025-01-02 19:52:26.815 1186:1186 info: Policy manager initialized.
...
^C2025/01/02 19:52:41 INFO: [Cluster] [Main] SIGINT received. Shutting down...
2025-01-02 19:52:41.658 1186:1186 info: Stopping the server
2025-01-02 19:52:41.658 1186:1186 info: Server closed
2025-01-02 19:52:41.658 1186:1186 info: bind::<lambda>handleCloseEvent
2025-01-02 19:52:41.658 1186:1186 info: Server stopped
2025/01/02 19:52:41 INFO: [Cluster] [Main] Shutting down wazuh-engined (pid: 1186)
2025-01-02 19:52:41.658 1186:1186 info: API terminated.
2025/01/02 19:52:41 INFO: [Communications API] Handling signal: int
2025/01/02 19:52:41 INFO: [Cluster] [Main] Shutting down wazuh-apid (pid: 1331)
2025/01/02 19:52:41 INFO: [Cluster] [Main] Shutting down wazuh-comms-apid (pid: 1291)
2025/01/02 19:52:41 INFO: [Cluster] [Main] Waiting for daemons shutdown.
2025/01/02 19:52:41 ERROR: [Communications API] Worker (pid:1327) was sent SIGINT!
2025/01/02 19:52:41 INFO: [Communications API] Shutting down
2025/01/02 19:52:41 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 19:52:41 INFO: [Communications API] Shutting down
2025/01/02 19:52:41 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 19:52:41 INFO: [Communications API] Shutting down
2025/01/02 19:52:41 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 19:52:41 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 19:52:41 INFO: [Communications API] Application shutdown complete.
2025/01/02 19:52:41 INFO: [Communications API] Finished server process [1330]
2025/01/02 19:52:41 INFO: [Communications API] Worker exiting (pid: 1330)
2025/01/02 19:52:41 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 19:52:41 INFO: [Communications API] Application shutdown complete.
2025/01/02 19:52:41 INFO: [Communications API] Finished server process [1328]
2025/01/02 19:52:41 INFO: [Communications API] Worker exiting (pid: 1328)
2025/01/02 19:52:41 INFO: [Management API] Shutdown wazuh-apid server.
2025/01/02 19:52:41 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 19:52:41 INFO: [Communications API] Application shutdown complete.
2025/01/02 19:52:41 INFO: [Communications API] Finished server process [1329]
2025/01/02 19:52:41 INFO: [Communications API] Worker exiting (pid: 1329)
2025/01/02 19:52:42 INFO: [Communications API] Shutting down: Master
2025/01/02 19:52:42 INFO: [Communications API] Shutting down
2025/01/02 19:52:42 INFO: [Communications API] MuxDemuxRunner (pid: 1309) - Received signal SIGTERM, shutting down
2025/01/02 19:52:42 INFO: [Communications API] Shutting down MuxDemuxRunner
2025/01/02 19:52:42 INFO: [Communications API] Batcher (pid: 1311) - Received signal SIGTERM, shutting down
```

</p>
</details> 

<details><summary>The whole server is stopped when one of his daemons is killed</summary>
<p>

```console
2025/01/02 19:54:50 INFO: [Cluster] [Main] Starting server (pid: 1351)
2025/01/02 19:54:51 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/02 19:54:51 INFO: [Master] [Config Server] Started server process [1351]
2025/01/02 19:54:51 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/02 19:54:51 INFO: [Master] [Config Server] Application startup complete.
2025/01/02 19:54:51 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/02 19:54:52 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-02 19:54:52.119 1357:1357 info: Logging initialized.
2025/01/02 19:54:52 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-02 19:54:52.123 1357:1357 info: Metrics manager configured successfully
2025-01-02 19:54:52.146 1357:1357 info: Metrics pipeline enabled successfully
2025-01-02 19:54:52.146 1357:1357 info: Metrics initialized.
2025-01-02 19:54:52.146 1357:1357 info: Store initialized.
2025-01-02 19:54:52.146 1357:1357 info: RBAC initialized.
2025-01-02 19:54:52.155 1357:1357 info: KVDB initialized.
2025-01-02 19:54:52.156 1357:1357 info: Geo initialized.
2025-01-02 19:54:52.168 1357:1357 info: Schema initialized.
2025-01-02 19:54:52.180 1357:1357 info: Loaded timezone database version: '2024a'
2025-01-02 19:54:52.184 1357:1357 info: HLP initialized.
2025-01-02 19:54:52.191 1357:1357 info: Indexer Connector initialized.
2025-01-02 19:54:52.191 1357:1357 info: Builder initialized.
2025-01-02 19:54:52.191 1357:1357 info: Catalog initialized.
2025-01-02 19:54:52.191 1357:1357 info: Policy manager initialized.
2025-01-02 19:54:52.192 1357:1357 info: No flooding file provided, the queue will not be flooded.
2025-01-02 19:54:52.200 1357:1357 info: No flooding file provided, the queue will not be flooded.
2025-01-02 19:54:52.200 1357:1357 warning: Router: router/router/0 table is empty
2025-01-02 19:54:52.200 1357:1357 warning: Router: router/tester/0 table is empty
2025-01-02 19:54:52.200 1357:1357 info: Router initialized.
2025-01-02 19:54:52.207 1357:1357 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-01-02 19:54:52.209 1357:1357 info: Starting the server...
2025/01/02 19:54:54 INFO: [Local Server] [Main] Started wazuh-engined (pid: 1357)
2025/01/02 19:54:54 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/02 19:54:55 INFO: [Communications API] Starting API
...
25/01/02 19:54:58 ERROR: [Master] [Main] Failed loading SSL context: [SSL] PEM lib (_ssl.c:3900). Using default one.
2025/01/02 19:54:58 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/01/02 19:54:58 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2025/01/02 19:54:58 INFO: [Master] [Local integrity] Starting.
2025/01/02 19:54:58 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 2 files.
2025/01/02 19:54:58 INFO: [Management API] Listening on ['localhost', '::1']:55000.
2025/01/02 19:54:58 INFO: [Management API] Getting installation UID...
2025/01/02 19:54:58 INFO: [Management API] Getting updates information...
2025/01/02 19:55:06 INFO: [Master] [Local integrity] Starting.
2025/01/02 19:55:06 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 2 files.
2025/01/02 19:55:10 ERROR: [Cluster] [Main] Daemon `wazuh-apid` is not running, stopping the whole server.
```

</p>
</details> 

<details><summary>The whole server is stopped when one of the daemon children is killed</summary>
<p>

```console
2025/01/02 19:59:14 INFO: [Cluster] [Main] Starting server (pid: 1181)
2025/01/02 19:59:14 INFO: [Cluster] [Main] Generating JWT signing key pair
2025/01/02 19:59:15 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/02 19:59:15 INFO: [Master] [Config Server] Started server process [1181]
2025/01/02 19:59:15 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/02 19:59:15 INFO: [Master] [Config Server] Application startup complete.
2025/01/02 19:59:15 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/02 19:59:16 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-02 19:59:16.108 1187:1187 info: Logging initialized.
2025/01/02 19:59:16 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-02 19:59:16.112 1187:1187 info: Metrics manager configured successfully
2025-01-02 19:59:16.127 1187:1187 info: Metrics pipeline enabled successfully
2025-01-02 19:59:16.127 1187:1187 info: Metrics initialized.
2025-01-02 19:59:16.127 1187:1187 info: Store initialized.
2025-01-02 19:59:16.127 1187:1187 warning: Could not load RBAC model, using default model: File '/var/lib/wazuh-server/engine/store/internal/rbac/model/0' does not exist
2025-01-02 19:59:16.128 1187:1187 info: RBAC initialized.
2025-01-02 19:59:16.138 1187:1187 info: KVDB initialized.
2025-01-02 19:59:16.138 1187:1187 info: Geo initialized.
2025-01-02 19:59:16.151 1187:1187 info: Schema initialized.
2025-01-02 19:59:16.163 1187:1187 info: Loaded timezone database version: '2024a'
2025-01-02 19:59:16.167 1187:1187 info: HLP initialized.
2025-01-02 19:59:16.179 1187:1187 info: Indexer Connector initialized.
2025-01-02 19:59:16.179 1187:1187 info: Builder initialized.
2025-01-02 19:59:16.179 1187:1187 info: Catalog initialized.
2025-01-02 19:59:16.179 1187:1187 info: Policy manager initialized.
2025-01-02 19:59:16.180 1187:1187 info: No flooding file provided, the queue will not be flooded.
2025-01-02 19:59:16.188 1187:1187 info: No flooding file provided, the queue will not be flooded.
2025-01-02 19:59:16.188 1187:1187 info: Router: router/router/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/router/0' does not exist
2025-01-02 19:59:16.188 1187:1187 info: Router: router/tester/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/tester/0' does not exist
2025-01-02 19:59:16.189 1187:1187 warning: Router: EPS settings could not be loaded from the store due to 'File '/var/lib/wazuh-server/engine/store/router/eps/0' does not exist'. Using default settings
2025-01-02 19:59:16.189 1187:1187 info: Router: EPS settings dumped to the store
2025-01-02 19:59:16.189 1187:1187 info: Router initialized.
2025-01-02 19:59:16.199 1187:1187 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-01-02 19:59:16.201 1187:1187 info: Starting the server...
2025/01/02 19:59:18 INFO: [Local Server] [Main] Started wazuh-engined (pid: 1187)
2025/01/02 19:59:18 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/02 19:59:19 INFO: [Communications API] Starting API
...
2025/01/02 19:59:34 ERROR: [Cluster] [Main] Daemon `wazuh-apid` does not have the correct number of children process. Stopping the whole server.
2025/01/02 19:59:34 INFO: [Cluster] [Main] Main loop stopped.
2025/01/02 19:59:34 INFO: [Cluster] [Main] Shutting down wazuh-engined (pid: 1187)
2025/01/02 19:59:34 INFO: [Cluster] [Main] Shutting down wazuh-apid (pid: 1332)
2025/01/02 19:59:34 INFO: [Cluster] [Main] Shutting down wazuh-comms-apid (pid: 1292)
2025/01/02 19:59:34 INFO: [Cluster] [Main] Waiting for daemons shutdown.
2025/01/02 19:59:34 INFO: [Communications API] Handling signal: term
2025/01/02 19:59:34 ERROR: [Communications API] Worker (pid:1328) was sent SIGTERM!
2025/01/02 19:59:34 INFO: [Communications API] Shutting down
2025/01/02 19:59:34 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 19:59:34 INFO: [Communications API] Shutting down
2025/01/02 19:59:34 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 19:59:34 INFO: [Communications API] Shutting down
2025/01/02 19:59:34 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 19:59:34 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 19:59:34 INFO: [Communications API] Application shutdown complete.
2025/01/02 19:59:34 INFO: [Communications API] Finished server process [1331]
2025/01/02 19:59:34 INFO: [Communications API] Worker exiting (pid: 1331)
2025/01/02 19:59:34 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 19:59:34 INFO: [Communications API] Application shutdown complete.
2025/01/02 19:59:34 INFO: [Communications API] Finished server process [1330]
2025/01/02 19:59:34 INFO: [Communications API] Worker exiting (pid: 1330)
2025/01/02 19:59:34 INFO: [Management API] Shutdown wazuh-apid server.
2025/01/02 19:59:34 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 19:59:34 INFO: [Communications API] Application shutdown complete.
2025/01/02 19:59:34 INFO: [Communications API] Finished server process [1329]
2025/01/02 19:59:34 INFO: [Communications API] Worker exiting (pid: 1329)
2025/01/02 19:59:35 INFO: [Communications API] Shutting down: Master
2025/01/02 19:59:35 INFO: [Communications API] Shutting down
2025/01/02 19:59:35 INFO: [Communications API] MuxDemuxRunner (pid: 1310) - Received signal SIGTERM, shutting down
2025/01/02 19:59:35 INFO: [Communications API] Shutting down MuxDemuxRunner
2025/01/02 19:59:35 INFO: [Communications API] Batcher (pid: 1312) - Received signal SIGTERM, shutting down
```

</p>
</details> 

<details><summary>The whole server is stopped when receives SIGTERM</summary>
<p>

```console
2025/01/02 20:02:35 INFO: [Cluster] [Main] Starting server (pid: 1353)
2025/01/02 20:02:36 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/02 20:02:36 INFO: [Master] [Config Server] Started server process [1353]
2025/01/02 20:02:36 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/02 20:02:36 INFO: [Master] [Config Server] Application startup complete.
2025/01/02 20:02:36 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/02 20:02:37 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-02 20:02:37.322 1359:1359 info: Logging initialized.
2025/01/02 20:02:37 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-02 20:02:37.327 1359:1359 info: Metrics manager configured successfully
2025-01-02 20:02:37.381 1359:1359 info: Metrics pipeline enabled successfully
2025-01-02 20:02:37.381 1359:1359 info: Metrics initialized.
2025-01-02 20:02:37.381 1359:1359 info: Store initialized.
2025-01-02 20:02:37.381 1359:1359 info: RBAC initialized.
2025-01-02 20:02:37.391 1359:1359 info: KVDB initialized.
2025-01-02 20:02:37.391 1359:1359 info: Geo initialized.
2025-01-02 20:02:37.406 1359:1359 info: Schema initialized.
2025-01-02 20:02:37.419 1359:1359 info: Loaded timezone database version: '2024a'
2025-01-02 20:02:37.422 1359:1359 info: HLP initialized.
2025-01-02 20:02:37.430 1359:1359 info: Indexer Connector initialized.
2025-01-02 20:02:37.430 1359:1359 info: Builder initialized.
2025-01-02 20:02:37.430 1359:1359 info: Catalog initialized.
2025-01-02 20:02:37.430 1359:1359 info: Policy manager initialized.
2025-01-02 20:02:37.431 1359:1359 info: No flooding file provided, the queue will not be flooded.
2025-01-02 20:02:37.439 1359:1359 info: No flooding file provided, the queue will not be flooded.
2025-01-02 20:02:37.439 1359:1359 warning: Router: router/router/0 table is empty
2025-01-02 20:02:37.439 1359:1359 warning: Router: router/tester/0 table is empty
2025-01-02 20:02:37.439 1359:1359 info: Router initialized.
2025-01-02 20:02:37.446 1359:1359 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-01-02 20:02:37.448 1359:1359 info: Starting the server...
2025/01/02 20:02:39 INFO: [Local Server] [Main] Started wazuh-engined (pid: 1359)
2025/01/02 20:02:39 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/02 20:02:40 INFO: [Communications API] Starting API
2025/01/02 20:02:40 INFO: [Communications API] Listening on localhost:27000
....
025/01/02 20:02:51 INFO: [Master] [Local integrity] Starting.
2025/01/02 20:02:51 INFO: [Master] [Local integrity] Finished in 0.003s. Calculated metadata of 2 files.
2025/01/02 20:02:57 INFO: [Cluster] [Main] Main loop stopped.
2025/01/02 20:02:57 INFO: [Cluster] [Main] Shutting down wazuh-engined (pid: 1359)
2025/01/02 20:02:57 INFO: [Cluster] [Main] Shutting down wazuh-apid (pid: 1504)
2025/01/02 20:02:57 INFO: [Cluster] [Main] Shutting down wazuh-comms-apid (pid: 1464)
2025/01/02 20:02:57 INFO: [Cluster] [Main] Waiting for daemons shutdown.
2025/01/02 20:02:57 INFO: [Communications API] Handling signal: term
2025/01/02 20:02:57 ERROR: [Communications API] Worker (pid:1500) was sent SIGTERM!
2025/01/02 20:02:57 INFO: [Communications API] Shutting down
2025/01/02 20:02:57 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 20:02:57 INFO: [Communications API] Shutting down
2025/01/02 20:02:57 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 20:02:57 INFO: [Communications API] Shutting down
2025/01/02 20:02:57 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/02 20:02:57 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 20:02:57 INFO: [Communications API] Application shutdown complete.
2025/01/02 20:02:57 INFO: [Communications API] Finished server process [1503]
2025/01/02 20:02:57 INFO: [Management API] Shutdown wazuh-apid server.
2025/01/02 20:02:57 INFO: [Communications API] Worker exiting (pid: 1503)
2025/01/02 20:02:57 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 20:02:57 INFO: [Communications API] Application shutdown complete.
2025/01/02 20:02:57 INFO: [Communications API] Finished server process [1501]
2025/01/02 20:02:57 INFO: [Communications API] Worker exiting (pid: 1501)
2025/01/02 20:02:57 INFO: [Communications API] Waiting for application shutdown.
2025/01/02 20:02:57 INFO: [Communications API] Application shutdown complete.
2025/01/02 20:02:57 INFO: [Communications API] Finished server process [1502]
2025/01/02 20:02:57 INFO: [Communications API] Worker exiting (pid: 1502)
2025/01/02 20:02:57 INFO: [Communications API] Shutting down: Master
2025/01/02 20:02:57 INFO: [Communications API] Shutting down
2025/01/02 20:02:57 INFO: [Communications API] MuxDemuxRunner (pid: 1482) - Received signal SIGTERM, shutting down
2025/01/02 20:02:57 INFO: [Communications API] Shutting down MuxDemuxRunner
2025/01/02 20:02:57 INFO: [Communications API] Batcher (pid: 1483) - Received signal SIGTERM, shutting down
```

</p>
</details> 