### PR TITLE
Updated duplicate location log message

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -231,7 +231,6 @@
 #define MISS_SOCK_LOC   "(1955): Missing field 'location' for socket."
 #define REM_ERROR       "(1956): Error removing '%s' file."
 #define NEW_GLOB_FILE   "(1957): New file that matches the '%s' pattern: '%s'."
-#define DUP_FILE        "(1958): Log file '%s' is duplicated."
 #define FORGET_FILE     "(1959): File '%s' no longer exists."
 #ifndef WIN32
 #define FILE_LIMIT      "(1960): File limit has been reached (%d). Please reduce the number of files or increase \"logcollector.max_files\"."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -158,6 +158,8 @@
 #define LOGCOLLECTOR_JOURNAL_CONFG_FILTER_EXP_FAIL    "(8021): Error compiling the PCRE2 expression '%s' for field '%s' in journal filter."
 #define LOGCOLLECTOR_JOURNAL_CONFG_DISABLE_FILTER    "(8022): The filters of the journald log will be disabled in the merge, because one of the configuration does not have filters."
 
+#define LOGCOLLECTOR_DUP_LOG_LOC                     "(8023): Duplicate localfile location '%s'. Check both ossec.conf and agent.conf. Last one will override the previous ones."
+
 /* Remoted */
 #define REMOTED_NET_PROTOCOL_ERROR              "(9000): Error getting protocol. Default value (%s) will be used."
 #define REMOTED_INV_VALUE_IGNORE                "(9001): Ignored invalid value '%s' for '%s'."

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -1634,7 +1634,7 @@ static IT_control remove_duplicates(logreader *current, int i, int j) {
             }
 
             if (current != dup && dup->file && !strcmp(current->file, dup->file)) {
-                mwarn(DUP_FILE, current->file);
+                mwarn(LOGCOLLECTOR_DUP_LOG_LOC, current->file);
                 int result;
 
                 if (j < 0) {


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/27507 |

## Description

The issue is trivial. The current warning message was not giving enough context.

https://github.com/wazuh/wazuh/blob/bb79682718344e81d5978a5e810eb997d70e32cb/src/error_messages/error_messages.h#L234

Since it is not an error message but a warning anymore, I also moved it to warning_messages.h, causing a change of the message ID as well.

https://github.com/wazuh/wazuh/blob/bb79682718344e81d5978a5e810eb997d70e32cb/src/logcollector/logcollector.c#L1637

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

**Before**

```syslog
2025/01/07 12:07:49 wazuh-agent: WARNING: (1958): Log file 'Security' is duplicated.
```

**After**
```syslog
2025/01/07 12:07:49 wazuh-agent: WARNING: (8023): Duplicate localfile location 'Security'. Check both ossec.conf and agent.conf. Last one will override the previous ones.
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [x] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors