### PR TITLE
Add event handling to Batcher

### DIFF
--- a/framework/wazuh/core/batcher/client.py
+++ b/framework/wazuh/core/batcher/client.py
@@ -41,8 +41,4 @@ class BatcherClient:
         Optional[dict]
             Indexer response if available, None otherwise.
         """
-        while True:
-            if not self.queue.is_response_pending(packet_id):
-                return self.queue.receive_from_demux(packet_id)
-            
-            await asyncio.sleep(self.wait_frequency)
+        return await asyncio.to_thread(self.queue.receive_from_demux, packet_id)

--- a/framework/wazuh/core/batcher/tests/test_client.py
+++ b/framework/wazuh/core/batcher/tests/test_client.py
@@ -28,12 +28,10 @@ def test_send_event(queue_mock):
         ),
     ))
     header = Header(id='1234', module=Module.SCA, operation=Operation.CREATE)
-    data = {
-        'value': 1
-    }
+    data = 'data'
 
     packet = Packet()
-    packet.build_and_add_item(agent_metadata, header, data)
+    packet.build_and_add_item(agent_metadata, header, bytes(data, 'utf-8'))
     batcher.send_event(packet)
     queue_mock.send_to_mux.assert_called_once()
 
@@ -52,25 +50,4 @@ async def test_get_response(queue_mock):
 
     result = await batcher.get_response(expected_uid)
 
-    queue_mock.is_response_pending.assert_called_once_with(expected_uid)
-    assert result == event
-
-
-@pytest.mark.asyncio
-@patch("wazuh.core.batcher.mux_demux.MuxDemuxQueue")
-@patch("asyncio.sleep", new_callable=AsyncMock)
-async def test_get_response_wait(sleep_mock, queue_mock):
-    """Check that the `get_response` method works as expected with no response."""
-    batcher = BatcherClient(queue=queue_mock)
-
-    event = {"data": "test event"}
-    expected_uid = "ac5f7bed-363a-4095-bc19-5c1ebffd1be0"
-
-    queue_mock.is_response_pending.side_effect = [True, False]
-    queue_mock.receive_from_demux.return_value = event
-
-    result = await batcher.get_response(expected_uid)
-
-    queue_mock.is_response_pending.assert_has_calls([call(expected_uid), call(expected_uid)])
-    sleep_mock.assert_awaited()
     assert result == event


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/27405|


## Description

Adds signal handling to the Batcher to avoid using `wait` operations when retrieving events from the Indexer.