### PR TITLE
Link openssl to geo module

### DIFF
--- a/src/engine/source/geo/CMakeLists.txt
+++ b/src/engine/source/geo/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SRCS
     ${SRC_DIR}/locator.cpp
 )
 set(PRIVATE_LINKS
-    CURL::libcurl
+    urlrequest
     maxminddb::maxminddb
 )
 set(PUBLIC_LINKS
@@ -23,7 +23,7 @@ set(PUBLIC_LINKS
 )
 
 # Patch the maxminddb target
-set_target_properties(maxminddb::maxminddb 
+set_target_properties(maxminddb::maxminddb
   PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ""
 )

--- a/src/engine/source/geo/src/manager.cpp
+++ b/src/engine/source/geo/src/manager.cpp
@@ -238,7 +238,11 @@ Manager::remoteUpsertDb(const std::string& path, Type type, const std::string& d
     // If the type has a different database, fail
     if (m_dbTypes.find(type) != m_dbTypes.end() && m_dbTypes.at(type) != name)
     {
-        return base::Error {fmt::format("Type '{}' already has the database '{}'", typeName(type), m_dbTypes.at(type))};
+        return base::Error {fmt::format(
+            "The name '{}' does not correspond to any database for type '{}'. "
+            "If you want it to correspond, please delete the existing database and recreate it with this name.",
+            name,
+            typeName(type))};
     }
 
     // Download the database hash


### PR DESCRIPTION
|Related issue|
|---|
|#27103|

## Description

Currently, Wazuh-Engine depends on the system-installed OpenSSL library, which can lead to inconsistencies due to varying versions across different environments. To ensure version control and consistency, we need to integrate OpenSSL into the Wazuh-Engine project using vcpkg. This approach will allow us to specify and manage the OpenSSL version explicitly, enhancing build reliability and eliminating the need to install OpenSSL via system package managers during Docker builds.