### PR TITLE
Adapt generate_stage_packages script for master packages

### DIFF
--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -131,6 +131,14 @@ main() {
         "-h"|"--help")
             help 0
             ;;
+        "-t"|"--target")
+            if [ -n "$2" ]; then
+                TARGET="$2"
+                shift 2
+            else
+                help 1
+            fi
+            ;;
         "-a"|"--architecture")
             if [ -n "$2" ]; then
                 ARCHITECTURE="$2"


### PR DESCRIPTION
| Related issue |
| --- |
| [Adapt generate_stage_packages script for 5.0.0 packages](https://github.com/wazuh/wazuh-qa-automation/issues/472) |

## Description

While working on issue https://github.com/wazuh/wazuh-qa-automation/issues/472, a problem was detected when generating the package for the `master` branch. After analyzing it, it seems that the `-t` parameter that is injected into the workflow and is present in other branches is missing.

The purpose of this PR is to add the parameter, as can be found in other [branches](https://github.com/wazuh/wazuh/blob/4.10.0/packages/generate_package.sh#L155-L162) to be able to generate packages in the `master` branch.

## Tests

Since it is a problem that has been detected in the workflow, the tests will be carried out by executing the script from the PR [Adapt generate_stage_packages script](https://github.com/wazuh/wazuh-qa-automation/pull/513)