### PR TITLE
Add new scanner.condition field to vulnerability scanner index template

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -7,6 +7,11 @@
     "settings": {
       "index": {
         "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": 1000
+          }
+        },
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
@@ -20,7 +25,7 @@
           "vulnerability.severity",
           "wazuh.cluster.name"
         ],
-        "refresh_interval": "5s"
+        "refresh_interval": "2s"
       }
     },
     "mappings": {

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -7,16 +7,10 @@
     "settings": {
       "index": {
         "codec": "best_compression",
-        "mapping": {
-          "total_fields": {
-            "limit": 1000
-          }
-        },
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
           "agent.id",
-          "host.os.family",
           "host.os.full",
           "host.os.version",
           "package.name",
@@ -26,7 +20,7 @@
           "vulnerability.severity",
           "wazuh.cluster.name"
         ],
-        "refresh_interval": "2s"
+        "refresh_interval": "5s"
       }
     },
     "mappings": {
@@ -189,11 +183,15 @@
             },
             "scanner": {
               "properties": {
-                "vendor": {
+                "condition": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "source": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "vendor": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }


### PR DESCRIPTION
Add new field 'scanner.condition'

|Related issue|
|---|
| #27519 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Update the Vulnerability Scanner index pattern adding the new field `scanner.condition`

Closes: #27519

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors