### PR TITLE
Update SCA Policy for CentOS Linux 8 to Support CentOS Stream 10

### DIFF
--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -24,6 +24,7 @@ requirements:
   condition: any
   rules:
     - "f:/etc/redhat-release -> r:^Centos && r:release 8"
+    - "f:/etc/redhat-release -> r:^Centos && r:release 10"
 
 variables:
   $sshd_file: /etc/ssh/sshd_config


### PR DESCRIPTION
| Component | Action type           | Main Issue 
| --- | --- | ---
| SCA       | Modify |  #24495

## Description

To update the requirements rules of the existing CentOS 8 SCA to support CentOS stream 10.
### Unit testing

- [x] a) Output from the SCA scan.
<details><summary>Output</summary>
<p>

```
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6690; Result: 'failed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6691; Result: 'failed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6692; Result: 'failed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6693; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6694; Result: 'failed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6695; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6696; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6697; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6698; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6699; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6700; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6701; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6702; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6703; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6704; Result: 'passed'
2025/01/14 15:16:40 sca[4587] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6705; Result: 'passed'
2025/01/14 15:16:43 sca[4587] wm_sca.c:2598 at wm_sca_send_summary(): DEBUG: Sending summary event for file: 'cis_centos8_linux.yml'
2025/01/14 15:16:43 sca[4587] wm_sca.c:271 at wm_sca_send_alert(): DEBUG: Sending event: {"type":"summary","scan_id":1186965011,"name":"CIS CentOS Linux 8 Benchmark v2.0.0","policy_id":"cis_centos8_linux","file":"cis_centos8_linux.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for CentOS Linux 8 systems running on x86 and x64 platforms. This document was tested against CentOS Linux 8.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":99,"failed":86,"invalid":20,"total_checks":205,"score":53.513515472412109,"start_time":1736867796,"end_time":1736867800,"hash":"67d8617cc22719ee19ba22c20891bb083a962e693a3a263c28355af5c233f0eb","hash_file":"ea0e6a769729be9ba8ba297f047493339d2fe8e0d762bfdad7033e5c0f174dfa","first_scan":1}

```

</p>
</details>
