### PR TITLE
Added condition field in indexed vulnerabilities

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -267,6 +267,34 @@ public:
                                 .at("adp");
                         ecsData["vulnerability"]["under_evaluation"] = isUnderEvaluation();
 
+                        if (const auto it = context->m_matchConditions.find(cve);
+                            it != context->m_matchConditions.end())
+                        {
+                            if (it->second.condition == MatchRuleCondition::LessThanOrEqual)
+                            {
+                                ecsData["vulnerability"]["scanner"]["condition"] =
+                                    "Package less than or equal to " + it->second.version;
+                            }
+                            else if (it->second.condition == MatchRuleCondition::LessThan)
+                            {
+                                ecsData["vulnerability"]["scanner"]["condition"] =
+                                    "Package less than " + it->second.version;
+                            }
+                            else if (it->second.condition == MatchRuleCondition::DefaultStatus)
+                            {
+                                ecsData["vulnerability"]["scanner"]["condition"] = "Package default status";
+                            }
+                            else if (it->second.condition == MatchRuleCondition::Equal)
+                            {
+                                ecsData["vulnerability"]["scanner"]["condition"] =
+                                    "Package equal to " + it->second.version;
+                            }
+                            else
+                            {
+                                logDebug2(WM_VULNSCAN_LOGTAG, "Unknown match condition");
+                            }
+                        }
+
                         // ECS wazuh fields.
                         auto vulnerabilityDetection = PolicyManager::instance().getVulnerabilityDetection();
                         ecsData["wazuh"]["cluster"]["name"] = context->clusterName();

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/eventDetailsBuilder.hpp
@@ -291,6 +291,7 @@ public:
                             }
                             else
                             {
+                                ecsData["vulnerability"]["scanner"]["condition"] = "Unknown";
                                 logDebug2(WM_VULNSCAN_LOGTAG, "Unknown match condition");
                             }
                         }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -362,6 +362,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
         R"({"operation":"INSERTED", "id":"001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2024-1234"})"_json;
     // Mock vulnerability information source
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
+    // Mock a vulnerability condition
+    scanContext->m_matchConditions = {{"CVE-2024-1234", {"<vulnerable_version>", MatchRuleCondition::Equal}}};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -470,6 +472,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
                 Utils::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("vulnerability").at("scanner").at("condition").get_ref<const std::string&>().c_str(),
+                 "Package equal to <vulnerable_version>");
 }
 
 TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
@@ -562,6 +566,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     scanContext->m_alerts[CVEID] = nlohmann::json::object(); // Mock one alert
     // Mock vulnerability information source
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
+    // Mock a vulnerability condition
+    scanContext->m_matchConditions = {{"CVE-2024-1234", {"<vulnerable_version>", MatchRuleCondition::LessThanOrEqual}}};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -673,6 +679,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
                 Utils::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("vulnerability").at("scanner").at("condition").get_ref<const std::string&>().c_str(),
+                 "Package less than or equal to <vulnerable_version>");
 }
 
 TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
@@ -763,6 +771,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
     scanContext->m_elements[CVEID] = R"({"operation":"INSERTED"})"_json;
     // Mock vulnerability information source
     scanContext->m_vulnerabilitySource = {"suse", "suse"};
+    // Mock a vulnerability condition
+    scanContext->m_matchConditions = {{"CVE-2024-1234", {"<vulnerable_version>", MatchRuleCondition::LessThan}}};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -868,6 +878,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
         R"({"operation":"INSERTED", "id":"002_Microsoft Windows 10 Pro_CVE-2024-1234"})"_json;
     // Mock vulnerability information source
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
+    // Mock a vulnerability condition
+    scanContext->m_matchConditions = {{"CVE-2024-1234", {"<vulnerable_version>", MatchRuleCondition::DefaultStatus}}};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -961,6 +973,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
                 Utils::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("vulnerability").at("scanner").at("condition").get_ref<const std::string&>().c_str(),
+                 "Package default status");
 }
 
 TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
@@ -1053,6 +1067,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
         R"({"operation":"INSERTED", "id":"001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2024-1234"})"_json;
     // Mock vulnerability information source
     scanContext->m_vulnerabilitySource = {"suse", "suse"};
+    // Mock a vulnerability condition
+    scanContext->m_matchConditions = {{"CVE-2024-1234", {"<vulnerable_version>", MatchRuleCondition::Unknown}}};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -1162,6 +1178,8 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
                 Utils::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("vulnerability").at("scanner").at("condition").get_ref<const std::string&>().c_str(),
+                 "Unknown");
 }
 
 TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
@@ -1254,6 +1272,8 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
         R"({"operation":"INSERTED", "id":"001_ec465b7eb5fa011a336e95614072e4c7f1a65a53_CVE-2024-1234"})"_json;
     // Mock vulnerability information source
     scanContext->m_vulnerabilitySource = {"nvd", "nvd"};
+    // Mock a vulnerability condition
+    scanContext->m_matchConditions = {{"CVE-2024-1234", {"<vulnerable_version>", MatchRuleCondition::NotEqual}}};
 
     spGlobalDataMock = std::make_shared<MockGlobalData>();
     EXPECT_CALL(*spGlobalDataMock, vendorMaps()).WillRepeatedly(testing::ReturnRef(ADP_DESCRIPTIONS));
@@ -1362,6 +1382,8 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
                  GetVulnerabilityDescription(fbBuilder.GetBufferPointer())->datePublished()->c_str());
     EXPECT_TRUE(elementData.at("vulnerability").at("detected_at").get_ref<const std::string&>() <=
                 Utils::getCurrentISO8601());
+    EXPECT_STREQ(elementData.at("vulnerability").at("scanner").at("condition").get_ref<const std::string&>().c_str(),
+                 "Unknown");
 }
 
 void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)


### PR DESCRIPTION
|Related issue|
|---|
|#27520|

## Description

- Vulnerability condition was added to indexed vulnerabilities report considering the same approach as in alerts. 
- Some UTs were modified to test the changes with mocked conditions 
- A default value was proposed to avoid having null condition. 

## Logs/Alerts example

![image](https://github.com/user-attachments/assets/37060085-ea45-49c8-ac4f-c29182dc2093)

- Indexed vulnerabilities.

[vulnerabilities.tar.gz](https://github.com/user-attachments/files/18416042/vulnerabilities.tar.gz)
