### PR TITLE
Add custom field documentation validate test

### DIFF
--- a/src/engine/test/health_test/README.md
+++ b/src/engine/test/health_test/README.md
@@ -129,6 +129,34 @@ To evaluate the mapping in all decoders and rules
 engine-health-test static -r ruleset_dir mapping_validate
 ```
 
+### Custom field documentation validate
+This tool validates that the fields defined in the custom_fields.yml file of each integration are correctly documented. It verifies that it is not empty, that it is not too short, that it does not have repeated words or letters and words usually used to fill fields.
+
+```bash
+usage: engine-health-test custom_field_documentation_validate [-h] -r RULESET [--integration INTEGRATION] [--rule_folder rule_folder]
+
+options:
+  -h, --help            show this help message and exit
+  --integration INTEGRATION
+                        Specify integration name
+  --rule_folder rule_folder
+                        Specify rule folder name
+```
+
+#### Use
+To evaluate a particular integration
+```bash
+engine-health-test static -r ruleset_dir custom_field_documentation_validate --integration windows
+```
+To evaluate  particular rule folder
+```bash
+engine-health-test static -r ruleset_dir custom_field_documentation_validate --rule_folder windows
+```
+To evaluate all decoders and rules
+```bash
+engine-health-test static -r ruleset_dir custom_field_documentation_validate
+```
+
 ### Event processing
 This tool validates that each asset in the ruleset has processed at least one event
 

--- a/src/engine/test/health_test/engine-health-test/src/health_test/__main__.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/__main__.py
@@ -17,6 +17,7 @@ from health_test.decoder_mapping_validate import run as decoder_mapping_validate
 from health_test.rule_mapping_validate import run as rule_mapping_validate_run
 from health_test.validate_successful_assets import run as validate_successful_assets_run
 from health_test.validate_non_modifiables_fields import run as validate_non_modifiables_fields_run
+from health_test.validate_custom_field_documentation import run as validate_custom_field_documentation_run
 
 
 def parse_args() -> Namespace:
@@ -75,6 +76,13 @@ def parse_args() -> Namespace:
     non_modifiable_fields_validate.add_argument('--integration', help='Specify integration name', required=False)
     non_modifiable_fields_validate.add_argument('--rule_folder', help='Specify rule folder name', required=False)
     non_modifiable_fields_validate.set_defaults(func=validate_non_modifiables_fields_run)
+
+    # custom field documentation subcommand
+    custom_field_documentation_validate_parser = static_subparsers.add_parser(
+        'custom_field_documentation_validate', help='Validates that each field defined as custom has been properly documented')
+    custom_field_documentation_validate_parser.add_argument('--integration', help='Specify integration name', required=False)
+    custom_field_documentation_validate_parser.add_argument('--rule_folder', help='Specify rule folder name', required=False)
+    custom_field_documentation_validate_parser.set_defaults(func=validate_custom_field_documentation_run)
 
     # Dynamic subcommand group
     dynamic_parser = subparsers.add_parser(

--- a/src/engine/test/health_test/engine-health-test/src/health_test/decoder_mapping_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/decoder_mapping_validate.py
@@ -23,14 +23,18 @@ class UnitResult(UnitResultInterface):
 
     def setup(self, actual_output: dict):
         traces = actual_output.get('traces', [])
-        any = False
+        any_asset = False
         for trace in traces:
             if self.is_decoder_asset(trace.get('asset')) and trace.get('success'):
-                any = True
+                any_asset = True
                 self.check_trace(trace)
 
-        if not any:
-            sys.exit("The decoders were not added to the policy. You must run the decoders load")
+        if not any_asset:
+            self.diff.setdefault(self.index, {}).setdefault("events_not_consumed", {}).update({
+                "status": "events not consumed by any decoder",
+                "event": actual_output['output']['event']['original']
+            })
+            self.success = False
 
     def is_decoder_asset(self, asset: str) -> bool:
         parts = asset.split('/')

--- a/src/engine/test/health_test/engine-health-test/src/health_test/validate_custom_field_documentation.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/validate_custom_field_documentation.py
@@ -1,0 +1,157 @@
+import sys
+import json
+import re
+from pathlib import Path
+import shared.resource_handler as rs
+from health_test.error_managment import ErrorReporter
+
+def evaluate_description(description):
+    feedback = []
+
+    if description == None or description == "":
+        return ["Invalid input: The description must be a string."]
+
+    if len(description.split()) < 5:
+        feedback.append("The description is too short to be meaningful.")
+
+    if not description[0].isupper():
+        feedback.append("The description does not start with an uppercase letter.")
+
+    if not description.strip().endswith(('.', '?', '!')):
+        feedback.append("The description does not end with proper punctuation.")
+
+    if re.search(r"(.)\1{3,}", description):
+        feedback.append("The description contains repetitive text.")
+
+    if re.match(r"^(bla|lorem|xyz)+", description.lower()):
+        feedback.append("The description appears to contain placeholder text ('blablabla', etc.).")
+
+    if re.search(r'\b(\w+)\b(?:\s+\b\1\b)+', description, re.IGNORECASE):
+        feedback.append("The description contains consecutive repeated words.")
+
+    return feedback
+
+def load_custom_fields(integration, custom_fields_path, allowed_types, reporter):
+    """
+    Load custom fields from 'custom_fields.yml' into a map of field -> (type, validation_function).
+    """
+    try:
+        custom_fields_data = rs.ResourceHandler().load_file(custom_fields_path.as_posix())
+        for item in custom_fields_data:
+            if item['field']:
+                if item['type'] not in allowed_types:
+                    message = f"\nIntegration: {integration.name}\n"
+                    message += f"Invalid type '{item['type']}' for field '{item['field']}'. Allowed types: {allowed_types}\n"
+                    reporter.add_error("Decoders Validator", str(integration), "Error: 'integrations' directory does not exist.")
+                    continue
+
+        return custom_fields_data
+    except Exception as e:
+        sys.exit(f"Error loading custom fields from {custom_fields_path}: {e}")
+
+def verify_custom_field_documentation(custom_field_file, integration, reporter):
+    for custom_file in custom_field_file:
+        if custom_file["field"] != "":
+            failures = evaluate_description(custom_file["description"])
+            if failures:
+                reporter.add_error(integration.name, str(integration), f"The custom field {custom_file['field']} have errors: {failures}")
+
+
+def verify(integration: Path, allowed_types, reporter):
+    if integration.name != 'wazuh-core':
+        test_folder = integration / 'test'
+        if not test_folder.exists() or not test_folder.is_dir():
+            sys.exit(f"No 'test' folder found in '{integration}'.")
+
+        custom_field_path = test_folder / 'custom_fields.yml'
+        custom_field = load_custom_fields(integration, custom_field_path, allowed_types, reporter)
+
+        verify_custom_field_documentation(custom_field, integration, reporter)
+
+def integration_validator(ruleset_path: Path, integration: str, reporter):
+    """
+    Validate the custom field documentation for all integrations or a specific one.
+    Accumulate and report errors at the end of the validation.
+    """
+    integration_path = ruleset_path / 'integrations'
+    schema = ruleset_path / "schemas/engine-schema.json"
+    try:
+        with open(schema, 'r') as schema_file:
+            schema_data = json.load(schema_file)
+    except Exception as e:
+        sys.exit(f"Error reading the JSON schema file: {e}")
+
+    allowed_types = {field_info["type"] for field_info in schema_data["fields"].values()}
+    if not integration_path.exists() or not integration_path.is_dir():
+        sys.exit(f"Error: '{integration_path}' directory does not exist or not found.")
+
+    if integration:
+        folder = integration_path / integration
+        if not folder.exists():
+            sys.exit(f"Integration {integration} does not exist.")
+        verify(integration_path / integration, allowed_types, reporter)
+    else:
+        for integration in integration_path.iterdir():
+            if integration.is_dir():
+                verify(integration, allowed_types, reporter)
+
+def rules_validator(ruleset_path: Path, rule_folder: str, reporter):
+    rules_path = ruleset_path / 'rules'
+    if not rules_path.exists() or not rules_path.is_dir():
+        reporter.add_error("Rules Validator", str(rules_path), "Error: 'rules' directory does not exist.")
+        return
+
+    schema = ruleset_path / "schemas/engine-schema.json"
+    try:
+        with open(schema, 'r') as schema_file:
+            schema_data = json.load(schema_file)
+    except Exception as e:
+        sys.exit(f"Error reading the JSON schema file: {e}")
+
+    allowed_types = {field_info["type"] for field_info in schema_data["fields"].values()}
+
+    if rule_folder:
+        rule = rules_path / rule_folder
+        if not rule.exists():
+            sys.exit(f"Rule folder {rule} does not exist.")
+        verify(rules_path / rule_folder, allowed_types, reporter)
+    else:
+        for rule_folder in rules_path.iterdir():
+            if rule_folder.is_dir():
+                verify(rule_folder, allowed_types, reporter)
+
+def run(args):
+    ruleset_path = Path(args['ruleset']).resolve()
+    integration = args['integration']
+    rule_folder = args['rule_folder']
+
+    if not ruleset_path.is_dir():
+        sys.exit(f"Engine ruleset not found: {ruleset_path}")
+
+    reporter = ErrorReporter("Validation")
+
+    if rule_folder and integration:
+        sys.exit("Error: Only one of 'integration' or 'rule_folder' can be specified at a time.")
+
+    try:
+        print("Running custom field documentation tests.")
+
+        if integration:
+            print("Validating integration only.")
+            integration_validator(ruleset_path, integration, reporter)
+
+        elif rule_folder:
+            print("Validating rules only.")
+            rules_validator(ruleset_path, rule_folder, reporter)
+
+        else:
+            print("Validating both integration and rules.")
+            integration_validator(ruleset_path, integration, reporter)
+            rules_validator(ruleset_path, rule_folder, reporter)
+
+        # After both validators have run, check if there are errors and exit if necessary
+        reporter.exit_with_errors("There are fields that should be mapped and are not present in the expected event", ruleset_path)
+
+        print("Success execution")
+    except Exception as e:
+        sys.exit(f"Error running test: {e}")

--- a/src/engine/test/health_test/engine-health-test/src/health_test/validate_custom_field_indexing.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/validate_custom_field_indexing.py
@@ -154,23 +154,6 @@ def is_valid_ip(value):
         return False
 
 
-def is_valid_date(value):
-    try:
-        datetime.fromisoformat(value)
-        return True
-    except ValueError:
-        return False
-
-
-def is_valid_ip(value):
-    """ Check if the value is a valid IP address. """
-    try:
-        ipaddress.ip_address(value)
-        return True
-    except ValueError:
-        return False
-
-
 def get_validation_function(field_type):
     if field_type == 'object':
         return lambda value: isinstance(value, dict) and bool(value)
@@ -222,7 +205,6 @@ def load_custom_fields(integration, custom_fields_path, allowed_types):
         return custom_fields_map, failure_load_custom_fields
     except Exception as e:
         sys.exit(f"Error loading custom fields from {custom_fields_path}: {e}")
-        return {}, failure_load_custom_fields
 
 
 def get_value_from_hierarchy(data, field):
@@ -309,16 +291,16 @@ class OpensearchManagement:
     def check_custom_fields(self, custom_fields: dict, all_custom_fields: set, hits: list):
         filtered_invalid_fields = set(all_custom_fields)
         for hit in hits:
-            for field, (type, validate_function) in custom_fields.items():
+            for field, (type_, validate_function) in custom_fields.items():
                 expected_value = get_value_from_hierarchy(hit['_source'], field)
                 if expected_value == None:
                     continue
                 if validate_function(expected_value):
-                    if type == 'object':
+                    if type_ == 'object':
                         for invalid_field in filtered_invalid_fields:
                             if invalid_field.startswith(field + '.'):
                                 all_custom_fields.discard(invalid_field)
-                    elif type == 'nested':
+                    elif type_ == 'nested':
                         for invalid_field in filtered_invalid_fields:
                             all_custom_fields.discard(invalid_field)
                     else:


### PR DESCRIPTION
### Description

Currently, the ruleset tests do not enforce documentation for individual custom fields within each decoder. To improve consistency and usability, we need to enhance our test suite to check that all custom fields are documented explicitly. This update should also include a review of existing decoders to ensure they meet this new requirement.

### Tasks

1. **Update Ruleset Tests**: 
   - Modify the existing test suite to validate that each custom field in a decoder is documented.
   - Ensure that the test fails if any custom field lacks documentation, not just the object itself.

2. **Update Decoders**:
   - Review and update all existing decoders to comply with the new test requirement.
   - Add documentation for any undocumented custom fields to avoid test failures after implementation.

