### PR TITLE
Get JWT keypair from configuration

### DIFF
--- a/apis/tools/env/certs/gen_certs.sh
+++ b/apis/tools/env/certs/gen_certs.sh
@@ -69,7 +69,13 @@ EOF
 openssl pkcs8 -topk8 -inform pem -in $name-key.pem -outform pem -nocrypt -out $name.key
 }
 
+gen_jwt_keys() {
+  openssl ecparam -name secp256k1 -genkey -noout -out private-key.pem
+  openssl ec -in private-key.pem -pubout -out public-key.pem
+}
+
 hosts=(wazuh-indexer wazuh-manager wazuh-worker1 wazuh-worker2)
 for i in "${hosts[@]}"; do
     gencert $i www
 done
+gen_jwt_keys

--- a/apis/tools/env/docker-compose.yml
+++ b/apis/tools/env/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - ./certs/root-ca.pem:/etc/wazuh-server/certs/root-ca.pem
       - ./certs/wazuh-manager.pem:/etc/wazuh-server/certs/server.pem
       - ./certs/wazuh-manager.key:/etc/wazuh-server/certs/server.key
+      - ./certs/private-key.pem:/etc/wazuh-server/certs/private-key.pem
+      - ./certs/public-key.pem:/etc/wazuh-server/certs/public-key.pem
       # Indexer certificates
       - ./certs/wazuh-indexer.pem:/etc/wazuh-server/certs/indexer.pem
       - ./certs/wazuh-indexer-key.pem:/etc/wazuh-server/certs/indexer-key.pem
@@ -50,6 +52,8 @@ services:
       - ./certs/root-ca.pem:/etc/wazuh-server/certs/root-ca.pem
       - ./certs/wazuh-worker1.pem:/etc/wazuh-server/certs/server.pem
       - ./certs/wazuh-worker1.key:/etc/wazuh-server/certs/server.key
+      - ./certs/private-key.pem:/etc/wazuh-server/certs/private-key.pem
+      - ./certs/public-key.pem:/etc/wazuh-server/certs/public-key.pem
       # Indexer certificates
       - ./certs/wazuh-indexer.pem:/etc/wazuh-server/certs/indexer.pem
       - ./certs/wazuh-indexer-key.pem:/etc/wazuh-server/certs/indexer-key.pem
@@ -88,6 +92,8 @@ services:
       - ./certs/root-ca.pem:/etc/wazuh-server/certs/root-ca.pem
       - ./certs/wazuh-worker2.pem:/etc/wazuh-server/certs/server.pem
       - ./certs/wazuh-worker2.key:/etc/wazuh-server/certs/server.key
+      - ./certs/private-key.pem:/etc/wazuh-server/certs/private-key.pem
+      - ./certs/public-key.pem:/etc/wazuh-server/certs/public-key.pem
       # Indexer certificates
       - ./certs/wazuh-indexer.pem:/etc/wazuh-server/certs/indexer.pem
       - ./certs/wazuh-indexer-key.pem:/etc/wazuh-server/certs/indexer-key.pem

--- a/apis/tools/env/wazuh-server/wazuh-server.yml
+++ b/apis/tools/env/wazuh-server/wazuh-server.yml
@@ -11,8 +11,11 @@ server:
       ca: /etc/wazuh-server/certs/root-ca.pem
   logging:
     level: debug2
+  jwt:
+    private_key: /etc/wazuh-server/certs/private-key.pem
+    public_key: /etc/wazuh-server/certs/public-key.pem
 indexer:
-  hosts: 
+  hosts:
     - host: wazuh-indexer
       port: 9200
   username: admin
@@ -27,6 +30,6 @@ indexer:
 communications_api:
   host: '0.0.0.0'
 management_api:
-  host: 
+  host:
     - '0.0.0.0'
     - '::'

--- a/etc/wazuh-server.yml
+++ b/etc/wazuh-server.yml
@@ -8,6 +8,9 @@ server:
       key: /etc/wazuh-server/certs/server.key
       cert: /etc/wazuh-server/certs/server.crt
       ca: /etc/wazuh-server/certs/server.ca
+  jwt:
+      private_key: /etc/wazuh-server/certs/private-key.pem
+      public_key: /etc/wazuh-server/certs/public-key.pem
 indexer:
   hosts:
     - host: localhost
@@ -29,7 +32,7 @@ communications_api:
     use_ca: false
     ca: <CA_FILE_PATH>
 management_api:
-  host: 
+  host:
     - localhost
     - ::1
   port: 55000

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -413,8 +413,6 @@ def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock
             wazuh_server.args = args
             with patch('wazuh.core.cluster.cluster.clean_up') as clean_up_mock, \
                 patch('scripts.wazuh_server.clean_pid_files') as clean_pid_files_mock, \
-                patch('wazuh.core.authentication.keypair_exists', return_value=False), \
-                patch('wazuh.core.authentication.generate_keypair') as generate_keypair_mock, \
                 patch('scripts.wazuh_server.start_daemons') as start_daemons_mock, \
                 patch.object(wazuh_server.pyDaemonModule, 'get_parent_pid', return_value=999), \
                 patch('os.kill') as os_kill_mock, \
@@ -444,7 +442,6 @@ def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock
                     call('Shutting down wazuh-apid (pid: 999)'),
                     call('Shutting down wazuh-comms-apid (pid: 999)'),
                 ])
-                generate_keypair_mock.assert_called_once()
                 start_daemons_mock.assert_called_once()
 
                 args.foreground = True

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -17,7 +17,6 @@ from functools import partial
 from typing import Any, List
 
 from wazuh.core import pyDaemonModule
-from wazuh.core.authentication import generate_keypair, keypair_exists
 from wazuh.core.common import WAZUH_SHARE, wazuh_gid, wazuh_uid, CONFIG_SERVER_SOCKET_PATH, WAZUH_RUN
 from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.config.models.server import NodeType
@@ -374,11 +373,6 @@ def start():
 
     if server_config.node.type == NodeType.MASTER:
         main_function = master_main
-
-        # Generate JWT signing key pair if it doesn't exist
-        if not keypair_exists():
-            main_logger.info('Generating JWT signing key pair')
-            generate_keypair()
     else:
         main_function = worker_main
 

--- a/framework/wazuh/core/authentication.py
+++ b/framework/wazuh/core/authentication.py
@@ -4,11 +4,8 @@ from typing import Tuple
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from wazuh import WazuhInternalError
-from wazuh.core.common import wazuh_uid, wazuh_gid, WAZUH_ETC
-
-_private_key_path = WAZUH_ETC / 'private_key.pem'
-_public_key_path = WAZUH_ETC / 'public_key.pem'
+from wazuh.core.common import wazuh_uid, wazuh_gid
+from wazuh.core.config.client import CentralizedConfig
 
 JWT_ALGORITHM = 'ES256'
 JWT_ISSUER = 'wazuh'
@@ -23,18 +20,12 @@ def get_keypair() -> Tuple[str, str]:
         Private key.
     public_key : str
         Public key.
-
-    Raises
-    ------
-    WazuhInternalError(6003)
-        If there was an error trying to load the JWT secret.
     """
-    if not keypair_exists():
-        raise WazuhInternalError(6003, extra_message='key pair files not found')
+    config = CentralizedConfig.get_server_config()
 
-    with open(_private_key_path, mode='r') as key_file:
+    with open(config.jwt.private_key, mode='r') as key_file:
         private_key = key_file.read()
-    with open(_public_key_path, mode='r') as key_file:
+    with open(config.jwt.public_key, mode='r') as key_file:
         public_key = key_file.read()
 
     return private_key, public_key

--- a/framework/wazuh/core/authentication.py
+++ b/framework/wazuh/core/authentication.py
@@ -1,10 +1,5 @@
-import os
 from typing import Tuple
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
-
-from wazuh.core.common import wazuh_uid, wazuh_gid
 from wazuh.core.config.client import CentralizedConfig
 
 JWT_ALGORITHM = 'ES256'
@@ -29,52 +24,3 @@ def get_keypair() -> Tuple[str, str]:
         public_key = key_file.read()
 
     return private_key, public_key
-
-
-def generate_keypair() -> Tuple[str, str]:
-    """Generate JWT signing key pair and store them in files.
-
-    Returns
-    -------
-    private_key : str
-        Private key.
-    public_key : str
-        Public key.
-    """
-    key_obj = ec.generate_private_key(ec.SECP256K1())
-    private_key = key_obj.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption()
-    ).decode('utf-8')
-    public_key = key_obj.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo
-    ).decode('utf-8')
-
-    with open(_private_key_path, mode='w') as key_file:
-        key_file.write(private_key)
-    with open(_public_key_path, mode='w') as key_file:
-        key_file.write(public_key)
-
-    try:
-        os.chown(_private_key_path, wazuh_uid(), wazuh_gid())
-        os.chown(_public_key_path, wazuh_uid(), wazuh_gid())
-    except PermissionError:
-        pass
-
-    os.chmod(_private_key_path, 0o640)
-    os.chmod(_public_key_path, 0o640)
-
-    return private_key, public_key
-
-
-def keypair_exists() -> bool:
-    """Return whether the key pair exists or not.
-
-    Returns
-    -------
-    bool
-        Whether the private and public key files exist or not.
-    """
-    return os.path.exists(_private_key_path) and os.path.exists(_public_key_path)

--- a/framework/wazuh/core/config/models/base.py
+++ b/framework/wazuh/core/config/models/base.py
@@ -1,6 +1,32 @@
+import os
+
 from pydantic import BaseModel, ConfigDict
 
 
 class WazuhConfigBaseModel(BaseModel):
     """Main model for the configuration sections."""
     model_config = ConfigDict(use_enum_values=True)
+
+
+class ValidateFilePathMixin:
+    @classmethod
+    def _validate_file_path(cls, path: str, field_name: str, file_type: str):
+        """Validate that a single file path is non-empty and points to an existing file.
+
+        Parameters
+        ----------
+        path : str
+            File path to validate.
+        field_name : str
+            Name of the field being validated.
+
+        Raises
+        ------
+        ValueError
+            If the file path is empty or the file does not exist.
+        """
+        if path == '':
+            raise ValueError(f'{field_name}: missing {file_type} file')
+
+        if not os.path.isfile(path):
+            raise ValueError(f"{field_name}: the file '{path}' does not exist")

--- a/framework/wazuh/core/config/models/server.py
+++ b/framework/wazuh/core/config/models/server.py
@@ -263,17 +263,6 @@ class CTIConfig(WazuhConfigBaseModel):
 DEFAULT_SERVER_INTERNAL_CONFIG = ServerSyncConfig(
     files=[
         SharedFiles(
-            dir=WAZUH_ETC.as_posix(),
-            description='JWT signing key pair',
-            permissions=416,
-            source='master',
-            names=['private_key.pem', 'public_key.pem'],
-            recursive=False,
-            restart=False,
-            remove_subdirs_if_empty=False,
-            extra_valid=False,
-        ),
-        SharedFiles(
             dir=WAZUH_GROUPS.as_posix(),
             description='group files',
             permissions=432,

--- a/framework/wazuh/core/config/models/server.py
+++ b/framework/wazuh/core/config/models/server.py
@@ -1,9 +1,10 @@
-from pydantic import PositiveInt, conint, confloat, PrivateAttr, Field
 from typing import List, Optional
 from enum import Enum
 
-from wazuh.core.common import WAZUH_ETC, WAZUH_GROUPS
-from wazuh.core.config.models.base import WazuhConfigBaseModel
+from pydantic import PositiveInt, conint, confloat, PrivateAttr, Field, field_validator, ValidationInfo
+
+from wazuh.core.common import WAZUH_GROUPS
+from wazuh.core.config.models.base import ValidateFilePathMixin, WazuhConfigBaseModel
 from wazuh.core.config.models.ssl_config import SSLConfig
 from wazuh.core.config.models.logging import LoggingConfig, LoggingLevel
 
@@ -260,6 +261,46 @@ class CTIConfig(WazuhConfigBaseModel):
     url: str = DEFAULT_CTI_URL
 
 
+class JWTConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
+    """Configuration for JWT key pair.
+
+    Parameters
+    ----------
+    private_key : str
+        The path to the private JTW key file.
+    public_key : str
+        The path to the public JTW key file.
+    """
+    private_key: str
+    public_key: str
+
+
+    @field_validator('private_key', 'public_key')
+    @classmethod
+    def validate_key_files(cls, path: str, info: ValidationInfo) -> str:
+        """Validate that the JWT keys exist.
+
+        Parameters
+        ----------
+        path : str
+            Path to the JTW key.
+        info : ValidationInfo
+            Validation context information.
+
+        Raises
+        ------
+        ValueError
+            Invalid JWT file path.
+
+        Returns
+        ------
+        str
+            JWT key path.
+        """
+        cls._validate_file_path(path, info.field_name, 'key')
+        return path
+
+
 DEFAULT_SERVER_INTERNAL_CONFIG = ServerSyncConfig(
     files=[
         SharedFiles(
@@ -321,6 +362,7 @@ class ServerConfig(WazuhConfigBaseModel):
     communications: CommunicationsConfig = CommunicationsConfig()
     logging: LoggingConfig = LoggingConfig(level=LoggingLevel.info)
     cti: CTIConfig = CTIConfig()
+    jwt: JWTConfig
     _internal: ServerSyncConfig = PrivateAttr(DEFAULT_SERVER_INTERNAL_CONFIG)
 
     def get_internal_config(self) -> ServerSyncConfig:

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -5,7 +5,9 @@ from pydantic import Field
 
 from pydantic import field_validator, ValidationInfo
 
-from wazuh.core.config.models.base import WazuhConfigBaseModel
+from wazuh.core.config.models.base import ValidateFilePathMixin, WazuhConfigBaseModel
+
+CERTIFICATE_TYPE = 'certificate'
 
 
 class SSLProtocol(str, Enum):
@@ -15,30 +17,6 @@ class SSLProtocol(str, Enum):
     tls_v1_1 = "TLSv1.1"
     tls_v1_2 = "TLSv1.2"
     auto = "auto"
-
-
-class ValidateFilePathMixin:
-    @classmethod
-    def _validate_file_path(cls, path: str, field_name: str):
-        """Validate that a single file path is non-empty and points to an existing file.
-
-        Parameters
-        ----------
-        path : str
-            File path to validate.
-        field_name : str
-            Name of the field being validated.
-
-        Raises
-        ------
-        ValueError
-            If the file path is empty or the file does not exist.
-        """
-        if path == '':
-            raise ValueError(f'{field_name}: missing certificate file')
-
-        if not os.path.isfile(path):
-            raise ValueError(f"{field_name}: the file '{path}' does not exist")
 
 
 class SSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
@@ -82,7 +60,7 @@ class SSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
         str
             SSL certificate/key path.
         """
-        cls._validate_file_path(path, info.field_name)
+        cls._validate_file_path(path, info.field_name, CERTIFICATE_TYPE)
         return path
 
 
@@ -132,7 +110,7 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
             SSL certificate/key path.
         """
         if info.data['use_ssl']:
-            cls._validate_file_path(path, info.field_name)
+            cls._validate_file_path(path, info.field_name, CERTIFICATE_TYPE)
         return path
 
     @field_validator('certificate_authorities')
@@ -159,7 +137,7 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
         """
         if info.data['use_ssl']:
             for path in paths:
-                cls._validate_file_path(path, info.field_name)
+                cls._validate_file_path(path, info.field_name, CERTIFICATE_TYPE)
 
         return paths
 

--- a/framework/wazuh/core/security.py
+++ b/framework/wazuh/core/security.py
@@ -8,7 +8,6 @@ from functools import lru_cache
 import yaml
 
 from api import __path__ as api_path
-from wazuh.core.authentication import generate_keypair
 from wazuh.rbac.orm import RolesManager, TokenManager, check_database_integrity, DB_FILE
 
 REQUIRED_FIELDS = ['id']
@@ -82,7 +81,6 @@ def revoke_tokens() -> dict:
     dict
         Confirmation message.
     """
-    generate_keypair()
     with TokenManager() as tm:
         tm.delete_all_rules()
 

--- a/framework/wazuh/core/tests/test_authentication.py
+++ b/framework/wazuh/core/tests/test_authentication.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch, call, MagicMock
 
-import pytest
-
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         from wazuh.core import authentication
@@ -17,33 +15,3 @@ def test_get_keypair(mock_open, get_server_config_mock):
     authentication.get_keypair()
     calls = [call(private_key, mode='r'), call(public_key, mode='r')]
     mock_open.assert_has_calls(calls, any_order=True)
-
-
-@patch('os.chmod')
-@patch('os.chown')
-@patch('builtins.open')
-def test_generate_keypair(mock_open, mock_chown, mock_chmod):
-    """Verify correct params when calling open method inside generate_keypair."""
-    result = authentication.generate_keypair()
-    assert isinstance(result[0], str)
-    assert isinstance(result[1], str)
-
-    mock_open.assert_has_calls([
-        call(authentication._private_key_path, mode='w'),
-        call(authentication._public_key_path, mode='w')
-    ], any_order=True)
-    mock_chown.assert_has_calls([
-        call(authentication._private_key_path, authentication.wazuh_uid(), authentication.wazuh_gid()),
-        call(authentication._public_key_path, authentication.wazuh_uid(), authentication.wazuh_gid())
-    ])
-    mock_chmod.assert_has_calls([
-        call(authentication._private_key_path, 0o640),
-        call(authentication._public_key_path, 0o640)
-    ])
-
-
-@pytest.mark.parametrize("exists", [True, False])
-def test_keypair_exists(exists):
-    """Verify that `keypair_exists` works as expected."""
-    with patch('os.path.exists', return_value=exists):
-        assert authentication.keypair_exists() == exists

--- a/framework/wazuh/core/tests/test_security.py
+++ b/framework/wazuh/core/tests/test_security.py
@@ -38,12 +38,11 @@ def test_revoke_tokens(db_setup):
     db_setup: callable
         This function creates the rbac.db file.
     """
-    with patch('wazuh.core.security.generate_keypair', side_effect=None):
-        security, WazuhResult, _ = db_setup
-        mock_current_user = ContextVar('current_user', default='wazuh')
-        with patch("wazuh.core.common.current_user", new=mock_current_user):
-            result = security.revoke_current_user_tokens()
-            assert isinstance(result, WazuhResult)
+    security, WazuhResult, _ = db_setup
+    mock_current_user = ContextVar('current_user', default='wazuh')
+    with patch("wazuh.core.common.current_user", new=mock_current_user):
+        result = security.revoke_current_user_tokens()
+        assert isinstance(result, WazuhResult)
 
 
 @pytest.mark.parametrize('role_list, expected_roles', [


### PR DESCRIPTION
|Related issue|
|---|
|#27461|

## Description

This PR closes #27461. Removes the functionalities to generate and share the JWT key pairs in favor of getting these from configuration.

The proposed configuration with the JWT addition will be

```yaml
server:
  bind_addr: '0.0.0.0'
  nodes:
    - wazuh-manager
  node:
    name: server_01
    type: master
    ssl:
      key: /etc/wazuh-server/certs/server.key
      cert: /etc/wazuh-server/certs/server.pem
      ca: /etc/wazuh-server/certs/root-ca.pem
  logging:
    level: debug2
  jwt:
    private_key: /etc/wazuh-server/certs/private-key.pem
    public_key: /etc/wazuh-server/certs/public-key.pem
indexer:
  hosts:
    - host: wazuh-indexer
      port: 9200
  username: admin
  password: admin
  ssl:
    use_ssl: true
    key: /etc/wazuh-server/certs/indexer-key.pem
    certificate: /etc/wazuh-server/certs/indexer.pem
    certificate_authorities:
      - /etc/wazuh-server/certs/root-ca.pem
    verify_certificates: true
communications_api:
  host: '0.0.0.0'
management_api:
  host:
    - '0.0.0.0'
    - '::'
```

## Logs/Alerts example

> [!NOTE]  
> The key pair was generated with
>```
> openssl ecparam -name secp256k1 -genkey -noout -out private-key.pem
> openssl ec -in private-key.pem -pubout -out public-key.pem
>```

As we can see it is possible to obtain the JWT from one server and use it in another

<details><summary>MAPI</summary>
<p>

```console
(framework) ➜  wazuh-for-tools git:(enhancement/27461-refactor-jwt-machanisms) TOKEN=$(curl --silent -u wazuh:wazuh -k -X POST "https://0.0.0.0:55000/security/user/authenticate?raw=true")
```

```console
(framework) ➜  wazuh-for-tools git:(enhancement/27461-refactor-jwt-machanisms) curl -s -H "Authorization: Bearer $TOKEN" -k "https://0.0.0.0:55001/agents" | jq
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "No agent information was returned",
  "error": 0
}
```

```console
(framework) ➜  wazuh-for-tools git:(enhancement/27461-refactor-jwt-machanisms) curl -s -H "Authorization: Bearer $TOKEN" -k "https://0.0.0.0:55002/agents" | jq
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "No agent information was returned",
  "error": 0
}

```
</p>
</details> 

<details><summary>CAPI</summary>
<p>

```console
(framework) ➜  wazuh-for-tools git:(enhancement/27461-refactor-jwt-machanisms) CTOKEN=$(curl -ks -XPOST "https://0.0.0.0:27001/api/v1/authentication" --header "Content-Type: application/json" --data '{"uuid": "0a96a0ab-5bef-415c-bb3c-ea3e294215a1", "key": "7b8276c3bf96aff5709346d368f04fed"}' | jq -r .token)
```

```console
(framework) ➜  wazuh-for-tools git:(enhancement/27461-refactor-jwt-machanisms) curl -H "Authorization: Bearer $CTOKEN" -X GET -ks https://0.0.0.0:27001/api/v1/commands | jq
{
  "commands": [
    {
      "request_id": "Nts_cJQBTwHevOWPn313",
      "order_id": "N9s_cJQBTwHevOWPn313",
      "source": "Users/Services",
      "user": "Management API",
      "target": {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a1",
        "type": "agent"
      },
      "action": {
        "name": "update-group",
        "version": "5.0.0",
        "args": []
      },
      "timeout": 100,
      "status": "PENDING"
    }
  ]
}
```

```console
(framework) ➜  wazuh-for-tools git:(enhancement/27461-refactor-jwt-machanisms) curl -H "Authorization: Bearer $CTOKEN" -X GET -ks https://0.0.0.0:27002/api/v1/commands | jq
{
  "message": "Request exceeded the processing time limit",
  "code": 408
}
```
</p>
</details> 