### PR TITLE
Remove groups field and command creation

### DIFF
--- a/api/api/models/agent_registration_model.py
+++ b/api/api/models/agent_registration_model.py
@@ -201,7 +201,6 @@ class AgentRegistrationModel(Body):
         key: str = None,
         type: str = None,
         version: str = None,
-        groups: List[str] = None,
         host: Host = None,
     ):
         self.swagger_types = {
@@ -210,7 +209,6 @@ class AgentRegistrationModel(Body):
             'key': str,
             'type': str,
             'version': str,
-            'groups': List[str],
             'host': Host,
         }
 
@@ -220,7 +218,6 @@ class AgentRegistrationModel(Body):
             'key': 'key',
             'type': 'type',
             'version': 'version',
-            'groups': 'groups',
             'host': 'host',
         }
 
@@ -229,7 +226,6 @@ class AgentRegistrationModel(Body):
         self._key = key
         self._type = type
         self._version = version
-        self._groups = groups
         self._host = host
 
     @property
@@ -274,14 +270,6 @@ class AgentRegistrationModel(Body):
     def version(self, version: str):
         self._version = version
     
-    @property
-    def groups(self) -> List[str]:
-        return self._groups
-
-    @groups.setter
-    def groups(self, groups: List[str]):
-        self._groups = groups
-
     @property
     def host(self) -> Host:
         return self._host

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -755,11 +755,6 @@ components:
         version:
           description: "Agent version"
           type: string
-        groups:
-          description: "Agent groups"
-          type: array
-          items:
-            type: string
         host:
           description: "Agent host"
           type: object
@@ -2577,8 +2572,6 @@ paths:
               id: 019008da-1575-7375-b54f-ef43e393517ef
               name: NewHost_2
               key: 7b8276c3bf96aff5709346d368f04fed
-              groups:
-                - group1
               type: endpoint
               version: 5.0.0
               host:

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -326,7 +326,6 @@ async def add_agent(
     key: str,
     type: str,
     version: str,
-    groups: List[str] = None,
     host: Host = None,
 ) -> WazuhResult:
     """Add a new Wazuh agent.
@@ -343,8 +342,6 @@ async def add_agent(
         Agent type.
     version : str
         Agent version.
-    groups : List[str]
-        Agent groups.
     host : Host
         Agent host information.
 
@@ -352,10 +349,6 @@ async def add_agent(
     ------
     WazuhError(1738)
         Name length is greater than 128 characters.
-    WazuhError(1710)
-        Group doesn't exist.
-    WazuhError(1762)
-        Failed while creating the update-group order.
     
     Returns
     -------
@@ -366,11 +359,6 @@ async def add_agent(
     if len(name) > common.AGENT_NAME_LEN_LIMIT:
         raise WazuhError(1738)
 
-    if groups is not None:
-        for group in groups:
-            if not Agent.group_exists(group):
-                raise WazuhError(1710, extra_message=group)
-
     async with get_indexer_client() as indexer_client:
         new_agent = await indexer_client.agents.create(
             id=id,
@@ -378,7 +366,6 @@ async def add_agent(
             key=key,
             type=type,
             version=version,
-            groups=groups,
             host=IndexerAgentHost(
                 architecture=host['architecture'],
                 ip=host['ip'],

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -387,11 +387,6 @@ async def add_agent(
             ) if host else None
         )
 
-        command = create_update_group_command(agent_id=id)
-        response = await indexer_client.commands_manager.create([command])
-        if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
-            raise WazuhError(1762, extra_message=response.result.value)
-
     return WazuhResult({'data': new_agent})
 
 

--- a/framework/wazuh/core/indexer/agent.py
+++ b/framework/wazuh/core/indexer/agent.py
@@ -34,7 +34,6 @@ class AgentsIndex(BaseIndex):
         key: str,
         type: str,
         version: str,
-        groups: List[str] = None,
         host: Host = None,
     ) -> Agent:
         """Create a new agent.
@@ -51,8 +50,6 @@ class AgentsIndex(BaseIndex):
             Agent type.
         version : str
             Agent version.
-        groups : str
-            Agent groups.
         host : Host
             Agent host information.
 
@@ -66,17 +63,13 @@ class AgentsIndex(BaseIndex):
         Agent : dict
             The created agent instance.
         """
-        group_list = [DEFAULT_GROUP]
-        if groups is not None:
-            group_list.extend(groups)
-
         agent = Agent(
             id=id,
             name=name,
             raw_key=key,
             type=type,
             version=version,
-            groups=group_list,
+            groups=[DEFAULT_GROUP],
             host=host if host else None
         )
         try:

--- a/framework/wazuh/core/indexer/agent.py
+++ b/framework/wazuh/core/indexer/agent.py
@@ -69,7 +69,6 @@ class AgentsIndex(BaseIndex):
             raw_key=key,
             type=type,
             version=version,
-            groups=[DEFAULT_GROUP],
             host=host if host else None
         )
         try:

--- a/framework/wazuh/core/indexer/tests/test_agent.py
+++ b/framework/wazuh/core/indexer/tests/test_agent.py
@@ -16,7 +16,6 @@ class TestAgentIndex:
     create_params = {
         'name': 'test',
         'key': '015fb915771223a3fdd7c0c0a5adcab8',
-        'groups': 'group1',
         'type': 'endpoint',
         'version': '5.0.0',
     }

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -300,8 +300,8 @@ async def test_agent_delete_agents(
 async def test_agent_add_agent(
     mock_group_exists,
     create_indexer_mock,
-    name,
     id,
+    name,
     key,
     groups,
     type,
@@ -318,9 +318,6 @@ async def test_agent_add_agent(
     )
     agents_create_mock = AsyncMock(return_value=new_agent)
     create_indexer_mock.return_value.agents.create = agents_create_mock
-    create_response = CreateCommandResponse(index='.commands', document_ids=['pwrD5Ddf'], result=ResponseResult.CREATED)
-    commands_create_mock = AsyncMock(return_value=create_response)
-    create_indexer_mock.return_value.commands_manager.create = commands_create_mock
 
     result = await add_agent(
         name=name,

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -285,12 +285,11 @@ async def test_agent_delete_agents(
         assert list(result.failed_items.values())[0] == set(agent_list[1:])
 
 
-@pytest.mark.parametrize('id,name,key,groups,type,version', [
+@pytest.mark.parametrize('id,name,key,type,version', [
     (
         '019008da-1575-7375-b54f-ef43e393517ef',
         'test',
         '95fffd306c752289d426e66013881538',
-        ['group1'],
         'endpoint',
         '5.0.0'
     ),
@@ -303,7 +302,6 @@ async def test_agent_add_agent(
     id,
     name,
     key,
-    groups,
     type,
     version,
 ):
@@ -314,7 +312,6 @@ async def test_agent_add_agent(
         raw_key=key,
         type=type,
         version=version,
-        groups=groups,
     )
     agents_create_mock = AsyncMock(return_value=new_agent)
     create_indexer_mock.return_value.agents.create = agents_create_mock
@@ -325,7 +322,6 @@ async def test_agent_add_agent(
         key=key,
         type=type,
         version=version,
-        groups=groups,
 
     )
 
@@ -334,7 +330,6 @@ async def test_agent_add_agent(
     assert result.dikt['data'].key == new_agent.key
     assert result.dikt['data'].type == new_agent.type
     assert result.dikt['data'].version == new_agent.version
-    assert result.dikt['data'].groups == new_agent.groups
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27737 |

## Description

Removes the `groups` field from the `POST /agents` endpoint and deletes the `update-group` command creation when registering an agent.

## Tests


<details><summary>Creating an agent</summary>

```console
(venv) gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '                     
{                                                                                                                                           
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",                                                                                             
  "name": "test",                                                                                                                           
  "key": "7b8276c3bf96aff5709346d368f04fed",                                                                                                
  "type": "endpoint",                                                                                                                       
  "version": "5.0.0"                                                                                                        
}                                                                                                                                           
'
HTTP/1.1 201 Created
date: Mon, 20 Jan 2025 15:03:41 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store

```

</details>

<details><summary>Trying to create an agent with groups</summary>

```console
(venv) gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '                     
{                                                                                                                                           
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",                                                                                             
  "name": "test",                                                                                                                           
  "key": "7b8276c3bf96aff5709346d368f04fed",                                                                                                
  "type": "endpoint",                                                                                                                       
  "version": "5.0.0",
  "groups": ["group1"]                                                                                                                     
}                                                                                                                                           
'
HTTP/1.1 400 Bad Request
date: Mon, 20 Jan 2025 15:04:20 GMT
content-type: application/problem+json; charset=utf-8
content-length: 68

{"title": "Bad Request", "detail": "Invalid field found {'groups'}"}
```

</details>

<details><summary>List agents</summary>

```console
(venv) gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "DeiaI3zPLsZZKzefuajv6uhEUogQJc8gHpnBNim510TkIhQBHNUieznfd7ovoaFd",
        "type": "endpoint",
        "version": "5.0.0"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

<details><summary>Unit tests</summary>

> Some unit tests fail because of https://github.com/wazuh/wazuh/issues/26725

```console

(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_agent.py --disable-warnings
=========================================================== test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 13 items                                                                                                                         

framework/wazuh/core/indexer/tests/test_agent.py .............                                                                       [100%]

============================================================ 13 passed in 0.33s ============================================================
(venv) gasti@gasti:~/work/wazuh$ pytest api/api/controllers/test/test_agent_controller.py --disable-warnings
=========================================================== test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/api/api
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 0 items / 1 error                                                                                                                

================================================================== ERRORS ==================================================================
________________________________________ ERROR collecting controllers/test/test_agent_controller.py ________________________________________
api/api/controllers/test/test_agent_controller.py:17: in <module>
    from wazuh import agent, stats
framework/wazuh/agent.py:33: in <module>
    node_id = get_node().get('node')
framework/wazuh/core/cluster/cluster.py:167: in get_node
    server_config = CentralizedConfig.get_server_config()
framework/wazuh/core/config/client.py:118: in get_server_config
    cls.load()
framework/wazuh/core/config/client.py:37: in load
    raise FileNotFoundError(f"Configuration file not found: {WAZUH_SERVER_YML}")
E   FileNotFoundError: Configuration file not found: /etc/wazuh-server/wazuh-server.yml
========================================================= short test summary info ==========================================================
ERROR api/api/controllers/test/test_agent_controller.py - FileNotFoundError: Configuration file not found: /etc/wazuh-server/wazuh-server.yml
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================= 7 warnings, 1 error in 0.32s =======================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/tests/test_agent.py::test_agent_add_agent --disable-warnings                        
=========================================================== test session starts ============================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0                                                                                
rootdir: /home/gasti/work/wazuh/framework                                                                                                   
configfile: pytest.ini                                                                                                                      
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4                       
asyncio: mode=auto                                                                                                                          
collected 0 items / 1 error                                                                                                                 
                                                                                                                                            
================================================================== ERRORS ==================================================================
________________________________________________ ERROR collecting wazuh/tests/test_agent.py ________________________________________________
framework/wazuh/tests/test_agent.py:20: in <module>                                                                                         
    with patch('wazuh.core.utils.load_wazuh_xml'):                                                                                          
/usr/local/lib/python3.10/unittest/mock.py:1447: in __enter__                                                                               
    original, local = self.get_original()                                                                                                   
/usr/local/lib/python3.10/unittest/mock.py:1420: in get_original                                                                            
    raise AttributeError(                                                                                                                   
E   AttributeError: <module 'wazuh.core.utils' from '/home/gasti/work/wazuh/framework/wazuh/core/utils.py'> does not have the attribute 'loa
d_wazuh_xml'                                                                                                                                
========================================================= short test summary info ==========================================================
ERROR framework/wazuh/tests/test_agent.py - AttributeError: <module 'wazuh.core.utils' from '/home/gasti/work/wazuh/framework/wazuh/core/uti
ls.py'> does not have the attribute 'lo...                                                                                                  
============================================================= 1 error in 0.14s =============================================================
ERROR: not found: /home/gasti/work/wazuh/framework/wazuh/tests/test_agent.py::test_agent_add_agent                                          
(no name '/home/gasti/work/wazuh/framework/wazuh/tests/test_agent.py::test_agent_add_agent' in any of [<Module wazuh/tests/test_agent.py>])
```

</details>