### PR TITLE
Fix malformed lane in deb wazuh manager and agent changelog

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -2,7 +2,7 @@ wazuh-agent (4.11.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
 
-   -- Wazuh, Inc <info@wazuh.com>  Tue, 28 Jan 2025 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 28 Jan 2025 00:00:00 +0000
 
 wazuh-agent (4.10.1-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -2,7 +2,7 @@ wazuh-manager (4.11.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html
 
-   -- Wazuh, Inc <info@wazuh.com>  Tue, 28 Jan 2025 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Tue, 28 Jan 2025 00:00:00 +0000
 
 wazuh-manager (4.10.1-RELEASE) stable; urgency=low
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/186|

Hi team, this PR fixes the malformed changelog for the `4.11.0` agent letting the agent be built for deb systems for the mentioned version.

Tested runs:
Agent:
* https://github.com/wazuh/wazuh-agent-packages/actions/runs/12870568274

Manager:
* https://github.com/wazuh/wazuh/actions/runs/12871080381/job/35883580094