### PR TITLE
Fix wazuh-apid script permission

### DIFF
--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -220,7 +220,7 @@ chmod 750 %{_localstatedir}usr/share/wazuh-server/framework/scripts/wazuh-server
 chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/framework/scripts/wazuh-server.py
 chmod 750 %{_localstatedir}usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
 chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
-chmod 750 %{_localstatedir}usr/share/wazuh-server/api/scripts/wazuh-comms-apid.py
+chmod 750 %{_localstatedir}usr/share/wazuh-server/api/scripts/wazuh-apid.py
 chown %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server/api/scripts/wazuh-apid.py
 
 # Fix Python permissions


### PR DESCRIPTION
|Related issue|
|---|
|#27738|

## Description

This PR closes #27738. Fix a mistype in the RPM spec to correctly set the permission for the `wazuh-apid`script.

## Logs/Alerts example

```console
[root@8e9267a05aa0 pkg]# ll /usr/share/wazuh-server/api/scripts/
total 16
-rwxr-x--- 1 wazuh-server wazuh-server 12837 Jan 20 16:09 wazuh-apid.py
```

```console
[root@8e9267a05aa0 pkg]# /usr/share/wazuh-server/bin/wazuh-server start
2025/01/20 16:42:45 INFO: [Cluster] [Main] Starting server (pid: 18117)
2025/01/20 16:42:46 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/20 16:42:46 INFO: [Master] [Config Server] Started server process [18117]
2025/01/20 16:42:46 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/20 16:42:46 INFO: [Master] [Config Server] Application startup complete.
2025/01/20 16:42:46 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/20 16:42:47 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-20 16:42:47.165 18123:18123 info: Logging initialized.
2025/01/20 16:42:47 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-20 16:42:47.169 18123:18123 info: Metrics manager configured successfully
2025-01-20 16:42:47.179 18123:18123 info: Metrics pipeline enabled successfully
2025-01-20 16:42:47.179 18123:18123 info: Metrics initialized.
2025-01-20 16:42:47.179 18123:18123 info: Store initialized.
2025-01-20 16:42:47.180 18123:18123 info: RBAC initialized.
2025-01-20 16:42:47.188 18123:18123 info: KVDB initialized.
2025-01-20 16:42:47.189 18123:18123 info: Geo initialized.
2025-01-20 16:42:47.206 18123:18123 info: Schema initialized.
2025-01-20 16:42:47.222 18123:18123 info: Loaded timezone database version: '2024a'
2025-01-20 16:42:47.226 18123:18123 info: HLP initialized.
2025-01-20 16:42:47.236 18123:18123 info: Indexer Connector initialized.
2025-01-20 16:42:47.236 18123:18123 info: Builder initialized.
2025-01-20 16:42:47.236 18123:18123 info: Catalog initialized.
2025-01-20 16:42:47.236 18123:18123 info: Policy manager initialized.
2025-01-20 16:42:47.237 18123:18123 info: No flooding file provided, the queue will not be flooded.
2025-01-20 16:42:47.246 18123:18123 info: No flooding file provided, the queue will not be flooded.
2025-01-20 16:42:47.246 18123:18123 warning: Router: router/router/0 table is empty
2025-01-20 16:42:47.246 18123:18123 warning: Router: router/tester/0 table is empty
2025-01-20 16:42:47.247 18123:18123 info: Router initialized.
2025-01-20 16:42:47.261 18123:18123 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-01-20 16:42:47.263 18123:18123 info: Starting the server...
2025/01/20 16:42:49 INFO: [Local Server] [Main] Started wazuh-engined (pid: 18123)
2025/01/20 16:42:49 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/20 16:42:50 INFO: [Communications API] Starting API
2025/01/20 16:42:50 INFO: [Communications API] Listening on localhost:27000
2025/01/20 16:42:50 INFO: [Communications API] Starting gunicorn 22.0.0
2025/01/20 16:42:50 INFO: [Communications API] Listening at: https://127.0.0.1:27000 (18228)
2025/01/20 16:42:50 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/01/20 16:42:50 INFO: [Communications API] Booting worker with pid: 18264
2025/01/20 16:42:50 INFO: [Communications API] Started server process [18228]
2025/01/20 16:42:50 INFO: [Communications API] Waiting for application startup.
2025/01/20 16:42:50 INFO: [Communications API] Application startup complete.
2025/01/20 16:42:50 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/01/20 16:42:50 INFO: [Communications API] Booting worker with pid: 18265
2025/01/20 16:42:50 INFO: [Communications API] Started server process [18265]
2025/01/20 16:42:50 INFO: [Communications API] Waiting for application startup.
2025/01/20 16:42:50 INFO: [Communications API] Application startup complete.
2025/01/20 16:42:50 INFO: [Communications API] Booting worker with pid: 18266
2025/01/20 16:42:50 INFO: [Communications API] Started server process [18266]
2025/01/20 16:42:50 INFO: [Communications API] Waiting for application startup.
2025/01/20 16:42:50 INFO: [Communications API] Application startup complete.
2025/01/20 16:42:50 INFO: [Communications API] Booting worker with pid: 18267
2025/01/20 16:42:50 INFO: [Communications API] Started server process [18267]
2025/01/20 16:42:50 INFO: [Communications API] Waiting for application startup.
2025/01/20 16:42:50 INFO: [Communications API] Application startup complete.
2025/01/20 16:42:51 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 18228)
2025/01/20 16:42:51 INFO: [Local Server] [Main] Starting wazuh-apid
2025/01/20 16:42:52 INFO: [Management API] Starting API
2025/01/20 16:42:52 INFO: [Management API] Checking RBAC database integrity...
2025/01/20 16:42:52 INFO: [Management API] /var/lib/wazuh-server/rbac.db file was detected
2025/01/20 16:42:52 INFO: [Management API] RBAC database integrity check finished successfully
2025/01/20 16:42:53 INFO: [Local Server] [Main] Started wazuh-apid (pid: 18268)
2025/01/20 16:42:53 ERROR: [Master] [Main] Failed loading SSL context: [SSL] PEM lib (_ssl.c:3900). Using default one.
2025/01/20 16:42:53 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/01/20 16:42:53 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2025/01/20 16:42:53 INFO: [Master] [Local integrity] Starting.
2025/01/20 16:42:53 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 2 files.
2025/01/20 16:42:53 INFO: [Management API] Listening on ['localhost', '::1']:55000.
2025/01/20 16:42:53 INFO: [Management API] Getting installation UID...
2025/01/20 16:42:53 INFO: [Management API] Getting updates information...
```