### PR TITLE
Add cleanup logic for content folder

### DIFF
--- a/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
+++ b/src/shared_modules/content_manager/src/components/cleanUpContent.hpp
@@ -34,21 +34,44 @@ private:
      */
     void cleanUp(const UpdaterContext& context) const
     {
-        // Get the path to the folder.
-        const auto& path = context.spUpdaterBaseContext->downloadsFolder;
+
+        logDebug1(WM_CONTENTUPDATER,
+                  "Cleaning up the folder: %s.",
+                  context.spUpdaterBaseContext->downloadsFolder.string().c_str());
 
         // Check if the path exists.
-        if (!std::filesystem::exists(path))
+        if (!std::filesystem::exists(context.spUpdaterBaseContext->downloadsFolder))
         {
-            logWarn(WM_CONTENTUPDATER, "The path does not exist: %s.", path.string().c_str());
+            logWarn(WM_CONTENTUPDATER,
+                    "The path does not exist: %s.",
+                    context.spUpdaterBaseContext->downloadsFolder.string().c_str());
             return;
         }
 
         // Delete the folder.
-        std::filesystem::remove_all(path);
+        std::filesystem::remove_all(context.spUpdaterBaseContext->downloadsFolder);
 
         // Create the folder again.
-        std::filesystem::create_directory(path);
+        std::filesystem::create_directory(context.spUpdaterBaseContext->downloadsFolder);
+
+        logDebug1(WM_CONTENTUPDATER,
+                  "Cleaning up the folder: %s.",
+                  context.spUpdaterBaseContext->contentsFolder.string().c_str());
+
+        // Check if the path exists.
+        if (!std::filesystem::exists(context.spUpdaterBaseContext->contentsFolder))
+        {
+            logWarn(WM_CONTENTUPDATER,
+                    "The path does not exist: %s.",
+                    context.spUpdaterBaseContext->contentsFolder.string().c_str());
+            return;
+        }
+
+        // Delete the folder.
+        std::filesystem::remove_all(context.spUpdaterBaseContext->contentsFolder);
+
+        // Create the folder again.
+        std::filesystem::create_directory(context.spUpdaterBaseContext->contentsFolder);
     }
 
 public:

--- a/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/actionOrchestrator_test.cpp
@@ -267,7 +267,9 @@ TEST_F(ActionOrchestratorTest, TestInstantiationAndExecutionWhitXZCompressionTyp
     EXPECT_FALSE(std::filesystem::exists(downloadPath));
 
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + Utils::rightTrim(fileName, ".xz")};
-    EXPECT_TRUE(std::filesystem::exists(contentPath));
+
+    // This file shouldn't exist because we clean up the content folder too
+    EXPECT_FALSE(std::filesystem::exists(contentPath));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 }

--- a/src/shared_modules/content_manager/tests/component/action_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/action_test.cpp
@@ -140,7 +140,9 @@ TEST_F(ActionTest, TestInstantiationAndStartActionSchedulerForRawDataWithDeleteD
     EXPECT_FALSE(std::filesystem::exists(downloadPath));
 
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + Utils::rightTrim(fileName, ".xz")};
-    EXPECT_TRUE(std::filesystem::exists(contentPath));
+
+    // This file shouldn't exist because we clean up the content folder too
+    EXPECT_FALSE(std::filesystem::exists(contentPath));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 }

--- a/src/shared_modules/content_manager/tests/component/contentModuleFacade_test.cpp
+++ b/src/shared_modules/content_manager/tests/component/contentModuleFacade_test.cpp
@@ -411,7 +411,9 @@ TEST_F(ContentModuleFacadeTest,
     EXPECT_FALSE(std::filesystem::exists(downloadPath));
 
     const auto contentPath {outputFolder + "/" + CONTENTS_FOLDER + "/3-" + Utils::rightTrim(fileName, ".xz")};
-    EXPECT_TRUE(std::filesystem::exists(contentPath));
+
+    // This file shouldn't exist because we clean up the content folder too
+    EXPECT_FALSE(std::filesystem::exists(contentPath));
 
     EXPECT_TRUE(std::filesystem::exists(outputFolder));
 }

--- a/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/cleanUpContent_test.cpp
@@ -40,5 +40,5 @@ TEST_F(CleanUpContentTest, OutputPathSet)
 
     // Check the folder content
     EXPECT_TRUE(std::filesystem::is_empty(DOWNLOAD_DIR));
-    EXPECT_FALSE(std::filesystem::is_empty(CONTENTS_DIR));
+    EXPECT_TRUE(std::filesystem::is_empty(CONTENTS_DIR));
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27691 |


# Objective

This PR aims to add the removing logic for both, the download and content folder inside of the `vd_updater/tmp` directory.


# PoC

![2025-01-20_17-05](https://github.com/user-attachments/assets/0a85b852-1c22-4ffd-8051-08513b16e35a)


![gif_issue](https://github.com/user-attachments/assets/63793e56-2fc4-47b4-bffe-64788fc85bda)

