### PR TITLE
Add libsystemd-dev dependency

### DIFF
--- a/apis/tools/env/wazuh-agent/Dockerfile
+++ b/apis/tools/env/wazuh-agent/Dockerfile
@@ -2,12 +2,12 @@ FROM ubuntu:24.04 AS builder
 
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential cmake make gcc git zip curl tar ninja-build pkg-config wget \
-    gnupg lsb-release software-properties-common libbz2-dev iputils-ping
+    gnupg lsb-release software-properties-common libbz2-dev libsystemd-dev iputils-ping
 
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 18
 
 RUN apt-get update && apt-get install -y clang-tidy-18 autopoint libtool zlib1g-dev libgcrypt20-dev libmagic-dev \
-    libpopt-dev libmagic-dev libsqlite3-dev liblua5.4-dev gettext libarchive-dev libxml2
+    libpopt-dev libsqlite3-dev liblua5.4-dev gettext libarchive-dev libxml2
 
 # Clone repository and initialize submodules
 RUN git clone https://github.com/wazuh/wazuh-agent.git --single-branch --depth=1


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27767 |

## Description

Adds the `libsystemd-dev` package to the installed dependencies list before compiling the wazuh-agent binary.

## Tests

<details><summary>Docker build</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/wazuh-agent$ docker build -t dev-wazuh-agent .
[+] Building 1365.4s (19/19) FINISHED                                                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 1.16kB                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/ubuntu:24.04                                                                                                                                                                          1.2s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 35B                                                                                                                                                                                                         0.0s
 => [builder 1/9] FROM docker.io/library/ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab                                                                                                            0.0s
 => CACHED [builder 2/9] RUN apt-get update && apt-get install -y build-essential cmake make gcc git zip curl tar ninja-build pkg-config wget     gnupg lsb-release software-properties-common libbz2-dev libsystemd-dev iputils-ping    0.0s
 => CACHED [builder 3/9] RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 18                                                                                                                                       0.0s
 => CACHED [agent 2/5] RUN apt update && apt install -y iputils-ping curl                                                                                                                                                                0.0s
 => [builder 4/9] RUN apt-get update && apt-get install -y clang-tidy-18 autopoint libtool zlib1g-dev libgcrypt20-dev libmagic-dev     libpopt-dev libsqlite3-dev liblua5.4-dev gettext libarchive-dev libxml2                          14.1s
 => [builder 5/9] RUN git clone https://github.com/wazuh/wazuh-agent.git --single-branch --depth=1                                                                                                                                       2.6s 
 => [builder 6/9] WORKDIR /wazuh-agent                                                                                                                                                                                                   0.0s 
 => [builder 7/9] RUN git submodule update --init --recursive                                                                                                                                                                           13.2s 
 => [builder 8/9] RUN cmake /wazuh-agent/src -B /wazuh-agent/build                                                                                                                                                                     529.4s 
 => [builder 9/9] RUN cmake --build /wazuh-agent/build                                                                                                                                                                                 802.3s 
 => [agent 3/5] COPY --from=builder /wazuh-agent/build/wazuh-agent /usr/share/wazuh-agent/bin/wazuh-agent                                                                                                                                0.5s 
 => [agent 4/5] RUN mkdir -p /var/lib/wazuh-agent                                                                                                                                                                                        0.2s 
 => [agent 5/5] ADD entrypoint.sh /scripts/entrypoint.sh                                                                                                                                                                                 0.1s 
 => exporting to image                                                                                                                                                                                                                   0.3s 
 => => exporting layers                                                                                                                                                                                                                  0.3s 
 => => writing image sha256:167527e716b51304525037c7329073a8209ff70ad28cd1d9fd3d6133d6b361c0                                                                                                                                             0.0s 
 => => naming to docker.io/library/dev-wazuh-agent                                                                                                                                                                                       0.0s
```

</details>


<details><summary>Docker images</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env/wazuh-agent$ docker images
REPOSITORY          TAG       IMAGE ID       CREATED             SIZE
dev-wazuh-agent     latest    167527e716b5   2 minutes ago       275MB
dev-nginx-lb        latest    2aa7b6eec878   About an hour ago   192MB
dev-wazuh-server    latest    5aadb53bcaee   About an hour ago   1.09GB
dev-wazuh-indexer   latest    f745751f0c9e   2 hours ago         1.38GB
```

</details>