### PR TITLE
Disable metrics module by default on Engine startup

### DIFF
--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -46,6 +46,7 @@ constexpr std::string_view API_SERVER_SOCKET = "/engine/api_server/socket";
 constexpr std::string_view TZDB_PATH = "/engine/tzdb/path";
 constexpr std::string_view TZDB_AUTO_UPDATE = "/engine/tzdb/auto_update";
 
+constexpr std::string_view METRICS_ENABLED = "/engine/metrics/enabled";
 constexpr std::string_view METRICS_EXPORT_INTERVAL = "/engine/metrics/export_interval";
 constexpr std::string_view METRICS_EXPORT_TIMEOUT = "/engine/metrics/export_timeout";
 

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -92,6 +92,7 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
     addUnit<bool>(key::TZDB_AUTO_UPDATE, "WAZUH_TZDB_AUTO_UPDATE", false);
 
     // Metrics module
+    addUnit<bool>(key::METRICS_ENABLED, "WAZUH_METRICS_ENABLED", false);
     addUnit<int64_t>(key::METRICS_EXPORT_INTERVAL, "WAZUH_METRICS_EXPORT_INTERVAL", 10000);
     addUnit<int64_t>(key::METRICS_EXPORT_TIMEOUT, "WAZUH_METRICS_EXPORT_TIMEOUT", 1000);
 };

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -201,8 +201,18 @@ int main(int argc, char* argv[])
 
             SingletonLocator::instance<metrics::IManager>().configure(config);
 
-            // TODO add enabled flag to the configuration when config refactor is done
-            SingletonLocator::instance<metrics::IManager>().enable();
+            LOG_INFO("Metrics initialized.");
+
+            if (confManager.get<bool>(conf::key::METRICS_ENABLED))
+            {
+                SingletonLocator::instance<metrics::IManager>().enable();
+                LOG_INFO("Metrics enabled.");
+            }
+            else
+            {
+                SingletonLocator::instance<metrics::IManager>().disable();
+                LOG_INFO("Metrics disabled.");
+            }
 
             exitHandler.add(
                 []()
@@ -210,8 +220,6 @@ int main(int argc, char* argv[])
                     SingletonLocator::instance<metrics::IManager>().disable();
                     SingletonLocator::clear();
                 });
-
-            LOG_INFO("Metrics initialized.");
         }
 
         // Store


### PR DESCRIPTION
|Related issue|
|---|
|27772|

This PR disable metrics module by default on Engine startup.