### PR TITLE
Fix error at packages-retag-images workflow due to empty variable

### DIFF
--- a/.github/workflows/packages-retag-images.yml
+++ b/.github/workflows/packages-retag-images.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     name: Package - Retag Docker images
 
@@ -64,10 +64,10 @@ jobs:
       - name: Run retag script
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            new_version=$(sed 's|[/\]|--|g' <<< ${{ inputs.new_version }})
-            old_version=$(sed 's|[/\]|--|g' <<< ${{ inputs.old_version }})
+            new_version=$(sed 's|[/\]|--|g' <<< "${{ inputs.new_version }}")
+            old_version=$(sed 's|[/\]|--|g' <<< "${{ inputs.old_version }}")
           else
-            new_version=${{ env.NEW_VERSION }}
-            old_version=${{ env.OLD_VERSION }}
+            new_version="${{ env.NEW_VERSION }}"
+            old_version="${{ env.OLD_VERSION }}"
           fi
-          bash $GITHUB_WORKSPACE/.github/actions/ghcr-pull-and-push/retag_image.sh ${{ secrets.CI_WAZUH_AGENT_PACKAGES_CLASSIC }} ${{ github.actor}} $old_version $new_version ${{ inputs.single_docker_image }}
+          bash $GITHUB_WORKSPACE/.github/actions/ghcr-pull-and-push/retag_image.sh "${{ secrets.CI_WAZUH_AGENT_PACKAGES_CLASSIC }}" "${{ github.actor}}" "$old_version" "$new_version" "${{ inputs.single_docker_image }}"


### PR DESCRIPTION
## Description

This PR aims to fix an issue in the **packages-retag-images** workflow that failed due to an empty variable reference.

## Proposed fix

- Enclose variable references in quotes.
- Anchor runner version to Ubuntu 22.04.

## Evidences

- Workflow 4.10.0 → 4.11.0: [#40](https://github.com/wazuh/wazuh/actions/runs/12929037996)
- Workflow 4.11.0 → 4.12.0: [#41](https://github.com/wazuh/wazuh/actions/runs/12929768102)
- [common_wpk_builder package](https://github.com/wazuh/wazuh/pkgs/container/common_wpk_builder)

![image](https://github.com/user-attachments/assets/749ea567-8853-452e-99db-5440629ce832)

