### PR TITLE
Delete `/run/wazuh-server` dir on apt remove

### DIFF
--- a/packages/debs/SPECS/debian/postrm
+++ b/packages/debs/SPECS/debian/postrm
@@ -8,6 +8,9 @@ WAZUH_GROUP="wazuh-server"
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)
+        if [ -d "/run/wazuh-server" ]; then
+            rm -rf /run/wazuh-server || true
+        fi
 
     ;;
 


### PR DESCRIPTION
|Related issue|
|---|
|#27785|

## Description

This PR closes #27785. Fix the behavior on `apt remove` to delete the `/run/wazuh-server` directory.


## Logs/Alerts example

Directories after the remove

```console
root@f5159d9fe301:/pkg# find / -iname wazuh-server
/etc/init.d/wazuh-server
/etc/wazuh-server
/var/log/wazuh-server
/var/lib/wazuh-server
/usr/share/doc/wazuh-server
/usr/share/wazuh-server
/usr/share/wazuh-server/bin/wazuh-server
/run/wazuh-server
```

After execute the `remove` we have 

```console
root@f5159d9fe301:/pkg# apt remove wazuh-server
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  wazuh-server
0 upgraded, 0 newly installed, 1 to remove and 18 not upgraded.
After this operation, 564 MB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 26164 files and directories currently installed.)
Removing wazuh-server (5.0.0-test) ...
Processing triggers for libc-bin (2.39-0ubuntu8.3) ..
```

```console
root@f5159d9fe301:/pkg# find / -iname wazuh-server
/etc/init.d/wazuh-server
/etc/wazuh-server
/var/lib/wazuh-server
```

