### PR TITLE
Remove cache-apt-pkgs-action dependency on engine workflow

### DIFF
--- a/.github/workflows/engine_style_documentation.yml
+++ b/.github/workflows/engine_style_documentation.yml
@@ -148,11 +148,10 @@ jobs:
 
       # Dependencies for testing:
       # - clang-format 
-      - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-            packages: clang-format 
-            version: 1.0
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
 
       - name: Check Coding style
         shell: bash


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27798|

This PR removes the `awalsh128/cache-apt-pkgs-action@latest` for caching apt packages. This action indirectly depends on the deprecated `actions/upload-artifact@v3`, leading to consistent workflow failures.