### PR TITLE
Rename agents and commands indices

### DIFF
--- a/framework/wazuh/core/indexer/agent.py
+++ b/framework/wazuh/core/indexer/agent.py
@@ -17,7 +17,7 @@ AGENT_KEY = 'agent'
 class AgentsIndex(BaseIndex):
     """Set of methods to interact with the `agents` index."""
 
-    INDEX = '.agents'
+    INDEX = 'wazuh-agents'
     SECONDARY_INDEXES = []
     REMOVE_GROUP_SCRIPT = """
     for (int i=ctx._source.agent.groups.length-1; i>=0; i--) {

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -20,7 +20,7 @@ COMMAND_KEY = 'command'
 class CommandsManager(BaseIndex):
     """Set of methods to interact with the commands manager."""
 
-    INDEX = '.commands'
+    INDEX = 'wazuh-commands'
     PLUGIN_URL = '/_plugins/_command_manager'
 
     UPDATE_STATUS_SCRIPT = 'ctx._source.command.status = new String[] {params.status};'

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -44,6 +44,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.agent import Agent
         from wazuh.core.exception import WazuhResourceNotFound
         from wazuh.core.indexer.base import IndexerKey
+        from wazuh.core.indexer.commands import CommandsManager
         from wazuh.core.indexer.models.agent import Agent as IndexerAgent
         from wazuh.core.indexer.models.commands import CreateCommandResponse, ResponseResult
         from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
@@ -141,7 +142,7 @@ async def test_agent_restart_agents(create_indexer_mock, agent_list, expected_it
     create_indexer_mock.return_value.agents.search = agents_search_mock
 
     create_response = CreateCommandResponse(
-        index='.commands',
+        index=CommandsManager.INDEX,
         document_ids=['pBjePGfvgm'],
         result=ResponseResult.INTERNAL_ERROR if fail else ResponseResult.CREATED,
     )
@@ -548,7 +549,11 @@ async def test_agent_remove_agents_from_group(mock_get_groups, create_indexer_mo
     search_mock = AsyncMock(return_value=[IndexerAgent(id='0191c7fa-26d5-705f-bc3c-f54810d30d79')])
     create_indexer_mock.return_value.agents.search = search_mock
 
-    create_response = CreateCommandResponse(index='.commands', document_ids=['pwrD5Ddf'], result=ResponseResult.CREATED)
+    create_response = CreateCommandResponse(
+        index=CommandsManager.INDEX,
+        document_ids=['pwrD5Ddf'],
+        result=ResponseResult.CREATED
+    )
     commands_create_mock = AsyncMock(return_value=create_response)
     create_indexer_mock.return_value.commands_manager.create = commands_create_mock
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27784 |

## Description

Changes the agents index name to `wazuh-agents` and the commands index name to `wazuh-commands.

## Tests

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_agent.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 13 items                                                                                                                                                                                                                           

framework/wazuh/core/indexer/tests/test_agent.py .............                                                                                                                                                                         [100%]

============================================================================================================= 13 passed in 0.32s =============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 8 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py ........                                                                                                                                                                           [100%]

============================================================================================================= 8 passed in 0.23s ==============================================================================================================
```

</details>

> [!Note]
> Manual tests against an indexer instance using the new names can be found in https://github.com/wazuh/wazuh/pull/27825.