### PR TITLE
Update agent commands structure

### DIFF
--- a/apis/tools/env/wazuh-agent/entrypoint.sh
+++ b/apis/tools/env/wazuh-agent/entrypoint.sh
@@ -25,7 +25,7 @@ echo "Waiting for the nodes to sync..."
 sleep 10
 
 # Register agent
-SPDLOG_LEVEL=TRACE /usr/share/wazuh-agent/bin/wazuh-agent --register --url $NGINX_URL --user $USER --password $PASSWORD
+SPDLOG_LEVEL=TRACE /usr/share/wazuh-agent/bin/wazuh-agent --register --url $NGINX_URL --user $USER --password $PASSWORD --verification-mode none
 
 # Run agent
 SPDLOG_LEVEL=TRACE /usr/share/wazuh-agent/bin/wazuh-agent

--- a/apis/tools/env/wazuh-agent/wazuh-agent.yml
+++ b/apis/tools/env/wazuh-agent/wazuh-agent.yml
@@ -2,6 +2,7 @@ agent:
   thread_count: 4
   server_url: https://nginx-lb:27000
   retry_interval: 30s
+  verification_mode: none
 inventory:
   enabled: true
   interval: 1h

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -19,7 +19,7 @@ from wazuh.core.indexer import get_indexer_client
 from wazuh.core.indexer.base import IndexerKey
 from wazuh.core.indexer.models.agent import Host as IndexerAgentHost
 from wazuh.core.indexer.models.commands import ResponseResult
-from wazuh.core.indexer.commands import create_restart_command, create_set_group_command, create_update_group_command
+from wazuh.core.indexer.commands import create_restart_command, create_set_group_command, create_fetch_config_command
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.utils import (
@@ -535,7 +535,7 @@ async def delete_groups(group_list: list = None) -> AffectedItemsWazuhResult:
                 if len(agents) > 0:
                     commands = []
                     for agent in agents:
-                        command = create_update_group_command(agent_id=agent.id)
+                        command = create_fetch_config_command(agent_id=agent.id)
                         commands.append(command)
 
                     response = await indexer_client.commands_manager.create(commands)
@@ -691,7 +691,7 @@ async def remove_agents_from_group(agent_list: list = None, group_list: list = N
 
             commands = []
             for agent_id in agent_list:
-                command = create_update_group_command(agent_id=agent_id)
+                command = create_fetch_config_command(agent_id=agent_id)
                 commands.append(command)
 
             response = await indexer_client.commands_manager.create(commands)

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -191,6 +191,7 @@ def create_update_group_command(agent_id: str) -> Command:
         ),
         action=Action(
             name='update-group',
+            args={},
             version='5.0.0'
         ),
         user=COMMAND_USER_NAME,

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -160,7 +160,9 @@ def create_set_group_command(agent_id: str, groups: List[str]) -> Command:
         ),
         action=Action(
             name='set-group',
-            args=groups,
+            args={
+                'groups': groups
+            },
             version='5.0.0'
         ),
         user=COMMAND_USER_NAME,

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -170,8 +170,8 @@ def create_set_group_command(agent_id: str, groups: List[str]) -> Command:
     )
 
 
-def create_update_group_command(agent_id: str) -> Command:
-    """Create a update group command for an agent with the ID specified.
+def create_fetch_config_command(agent_id: str) -> Command:
+    """Create a fetch config command for an agent with the ID specified.
 
     Parameters
     ----------
@@ -181,7 +181,7 @@ def create_update_group_command(agent_id: str) -> Command:
     Returns
     -------
     Command
-        Update group command.
+        Fetch config command.
     """
     return Command(
         source=Source.SERVICES,
@@ -190,7 +190,7 @@ def create_update_group_command(agent_id: str) -> Command:
             id=agent_id,
         ),
         action=Action(
-            name='update-group',
+            name='fetch-config',
             args={},
             version='5.0.0'
         ),

--- a/framework/wazuh/core/indexer/models/agent.py
+++ b/framework/wazuh/core/indexer/models/agent.py
@@ -74,7 +74,7 @@ class Agent:
     key: str = None
     type: str = None
     version: str = None
-    groups: List[str] = None
+    groups: List[str] | None = None
     last_login: datetime = None
     status: Status = None
     host: Host = None

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -8,7 +8,7 @@ class Action:
     """Command action data model."""
     name: str
     version: str
-    args: List[str] = None
+    args: dict = None
 
 
 @dataclass

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -186,8 +186,9 @@ def test_create_update_group_command():
             id=agent_id,
         ),
         action=Action(
-            name='update-group',
-            version='5.0.0'
+            name='fetch-config',
+            version='5.0.0',
+            args={}
         ),
         user=COMMAND_USER_NAME,
         timeout=100

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -12,7 +12,7 @@ from wazuh.core.indexer.commands import (
     COMMAND_KEY,
     COMMAND_USER_NAME,
     create_set_group_command,
-    create_update_group_command
+    create_fetch_config_command
 )
 from wazuh.core.indexer.base import POST_METHOD, IndexerKey
 from wazuh.core.indexer.utils import convert_enums
@@ -176,8 +176,8 @@ def test_create_set_group_command():
     assert command.document_id is None
 
 
-def test_create_update_group_command():
-    """Check the correct functionality of the `create_update_group_command` function."""
+def test_create_fetch_config_command():
+    """Check the correct functionality of the `create_fetch_config_command` function."""
     agent_id = '0191dd54-bd16-7025-80e6-ae49bc101c7a'
     expected_command = Command(
         source=Source.SERVICES,
@@ -194,7 +194,7 @@ def test_create_update_group_command():
         timeout=100
     )
 
-    command = create_update_group_command(agent_id=agent_id)
+    command = create_fetch_config_command(agent_id=agent_id)
 
     assert command == expected_command
     assert command.document_id is None

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -161,7 +161,9 @@ def test_create_set_group_command():
         ),
         action=Action(
             name='set-group',
-            args=groups,
+            args={
+                'groups': groups
+            },
             version='5.0.0'
         ),
         user=COMMAND_USER_NAME,


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27765 |

## Description

Updates the groups commands sent to the agents to use objects as action arguments. It also changes the name of the command `update-group` to `fetch-config` and replaces all `fetch-config` commands with `set-group`.

## Tests

> [!Note]
> Indexer packages used to perform the tests: https://github.com/wazuh/wazuh-indexer/actions/runs/12951170049

<details><summary>Create agent</summary>

```console
gasti@gasti:~$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Fri, 24 Jan 2025 14:31:26 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

</details>

<details><summary>Create group</summary>

```console
gasti@gasti:~$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55000/groups -d '{"group_id": "group1"}' | jq
{
  "message": "Group 'group1' created.",
  "error": 0
}
```

</details>

<details><summary>Assign agent to group</summary>

```console
gasti@gasti:~$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X PUT -ks "https://0.0.0.0:55000/agents/group?agents_list=0a96a0ab-5bef-415c-bb3c-ea3e294215a0&group_id=group1" | jq
{
  "data": {
    "affected_items": [
      "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were assigned to group1",
  "error": 0
}
```

</details>

<details><summary>Get agents</summary>

```console
gasti@gasti:~$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "fY9Vh4t3oDunsN0c/jWKiAMMEiq1hMkDnHsSKK4lFzX80oVdfA6jvU0LFiAkVp4w",
        "type": "endpoint",
        "version": "5.0.0",
        "groups": [
          "group1"
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>


<details><summary>Remove agent from group</summary>

```console
gasti@gasti:~$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X DELETE -ks "https://0.0.0.0:55000/agents/group?agents_list=0a96a0ab-5bef-415c-bb3c-ea3e294215a0&group_id=group1" | jq
{
  "data": {
    "affected_items": [
      "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were removed from group group1",
  "error": 0
}
```

</details>

<details><summary>Get agents</summary>

```console
gasti@gasti:~$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "fY9Vh4t3oDunsN0c/jWKiAMMEiq1hMkDnHsSKK4lFzX80oVdfA6jvU0LFiAkVp4w",
        "type": "endpoint",
        "version": "5.0.0",
        "groups": []
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

<details><summary>Delete group</summary>

```console
gasti@gasti:~$ curl -H "Authorization: Bearer $TOKEN" -X DELETE -ks https://0.0.0.0:55000/groups?groups_list=group1 | jq
{
  "data": {
    "affected_items": [
      "group1"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected groups were deleted",
  "error": 0
}
```

</details>

<details><summary>List indexer groups commands</summary>

```console
gasti@gasti:~$ curl -X POST -H "Content-Type: application/json" -ku admin:admin https://localhost:9200/wazuh-commands/_search?pretty -d'
{              
   "query": {         
      "match_all": {}
   }                 
}'                          
{                         
  "took" : 1,                           
  "timed_out" : false,                
  "_shards" : {       
    "total" : 1,                
    "successful" : 1,               
    "skipped" : 0,          
    "failed" : 0             
  },             
  "hits" : {                         
    "total" : {                   
      "value" : 2,                  
      "relation" : "eq"               
    },        
    "max_score" : 1.0,                         
    "hits" : [         
      { # Remove agent from group command
        "_index" : "wazuh-commands",                           
        "_id" : "ApDUmJQBPS_z69c55AcC",
        "_score" : 1.0,
        "_source" : {            
          "agent" : {                
            "groups" : [                  
              "groups000"                 
            ]              
          },                        
          "@timestamp" : "2025-01-24T15:01:16Z",                         
          "delivery_timestamp" : "2025-01-24T15:02:56Z",
          "command" : {
            "action" : {                
              "args" : {                 
                "groups" : [ ]                
              },           
              "name" : "set-group",
              "version" : "5.0.0"
            },
            "source" : "Users/Services",
            "user" : "Management API",
            "order_id" : "AZDUmJQBPS_z69c55AcC",
            "request_id" : "AJDUmJQBPS_z69c55AcC",
            "timeout" : 100,
            "target" : {
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
              "type" : "agent"
            },
            "status" : "failure"
          }
        }
      },
      { # Assign agent to group command
        "_index" : "wazuh-commands",
        "_id" : "_5DTmJQBPS_z69c5gQZ1",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "@timestamp" : "2025-01-24T14:59:45Z",
          "delivery_timestamp" : "2025-01-24T15:01:25Z",
          "command" : {
            "action" : {
              "args" : {
                "groups" : [
                  "group1"
                ]
              },
              "name" : "set-group",
              "version" : "5.0.0"
            },
            "source" : "Users/Services",
            "user" : "Management API",
            "order_id" : "_pDTmJQBPS_z69c5gQZ0",
            "request_id" : "_ZDTmJQBPS_z69c5gQZ0",
            "timeout" : 100,
            "target" : {
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
              "type" : "agent"
            },
            "status" : "failure"
          }
        }
      }
    ]
  }
}
```

</details>

<details><summary>Unit tests</summary>

> Some unit tests fail because of https://github.com/wazuh/wazuh/issues/26725.

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_agent.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 13 items

framework/wazuh/core/indexer/tests/test_agent.py .............                                                                                                                                                                         [100%]

============================================================================================================= 13 passed in 0.32s =============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 8 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py ........                                                                                                                                                                           [100%]

============================================================================================================= 8 passed in 0.25s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/tests/test_agent.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 0 items / 1 error                                                                                                                                                                                                                  

=================================================================================================================== ERRORS ===================================================================================================================
_________________________________________________________________________________________________ ERROR collecting wazuh/tests/test_agent.py _________________________________________________________________________________________________
framework/wazuh/tests/test_agent.py:20: in <module>
    with patch('wazuh.core.utils.load_wazuh_xml'):
/usr/local/lib/python3.10/unittest/mock.py:1447: in __enter__
    original, local = self.get_original()
/usr/local/lib/python3.10/unittest/mock.py:1420: in get_original
    raise AttributeError(
E   AttributeError: <module 'wazuh.core.utils' from '/home/gasti/work/wazuh/framework/wazuh/core/utils.py'> does not have the attribute 'load_wazuh_xml'
========================================================================================================== short test summary info ===========================================================================================================
ERROR framework/wazuh/tests/test_agent.py - AttributeError: <module 'wazuh.core.utils' from '/home/gasti/work/wazuh/framework/wazuh/core/utils.py'> does not have the attribute 'load_wazuh_xml'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================================================== 1 error in 0.18s ==============================================================================================================
```

</details>
