### PR TITLE
Fix orders retrieval

### DIFF
--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -10,7 +10,7 @@ from .base import BaseIndex, IndexerKey, POST_METHOD
 from .utils import convert_enums
 from wazuh.core.exception import WazuhError
 from wazuh.core.indexer.models.commands import (
-    Action, Command, Source, Target, TargetType, CreateCommandResponse, ResponseResult
+    Action, Command, Source, Status, Target, TargetType, CreateCommandResponse, ResponseResult
 )
 
 COMMAND_USER_NAME = 'Management API'
@@ -62,12 +62,12 @@ class CommandsManager(BaseIndex):
             result=ResponseResult(response.get(IndexerKey.RESULT)),
         )
 
-    async def get_commands(self, status: str) -> List[Command]:
+    async def get_commands(self, status: Status) -> List[Command]:
         """Get commands that match with the given parameters.
 
         Parameters
         ----------
-        status : str
+        status : Status
             Status name.
 
         Returns
@@ -77,7 +77,7 @@ class CommandsManager(BaseIndex):
         """
         query = AsyncSearch(using=self._client, index=self.INDEX).filter({
             IndexerKey.TERM: {
-                f'{COMMAND_KEY}.{IndexerKey.STATUS}': status
+                f'{COMMAND_KEY}.{IndexerKey.STATUS}': status.value
             }
         })
         response = await query.execute()

--- a/framework/wazuh/core/indexer/models/commands.py
+++ b/framework/wazuh/core/indexer/models/commands.py
@@ -28,10 +28,10 @@ class Source(str, Enum):
 
 class Status(str, Enum):
     """Command status enum."""
-    PENDING = 'PENDING'
-    SENT = 'SENT'
-    SUCCESS = 'SUCCESS'
-    FAILED = 'FAILED'
+    PENDING = 'pending'
+    SENT = 'sent'
+    SUCCESS = 'success'
+    FAILED = 'failed'
 
 
 class TargetType(str, Enum):

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -82,14 +82,14 @@ class TestCommandsManager:
         client_mock.search.return_value = search_result
         expected_result = [Command(document_id=document_id)]
 
-        result = await index_instance.get_commands(Status.PENDING.value)
+        result = await index_instance.get_commands(Status.PENDING)
 
         query = {
             IndexerKey.QUERY: {
                 IndexerKey.BOOL: {
                     IndexerKey.FILTER: [
                         {
-                            IndexerKey.TERM: {'command.status': Status.PENDING.value}
+                            IndexerKey.TERM: {'command.status': Status.PENDING}
                         }
                     ]
                 }

--- a/framework/wazuh/core/task/order.py
+++ b/framework/wazuh/core/task/order.py
@@ -25,7 +25,7 @@ async def get_orders(logger: WazuhLogger):
         logger.info('Getting orders from indexer')
 
         async with get_indexer_client() as indexer_client:
-            pending_commands = await indexer_client.commands_manager.get_commands(Status.PENDING.value)
+            pending_commands = await indexer_client.commands_manager.get_commands(Status.PENDING)
             logger.debug(f'Commands index response: {pending_commands}')
             pending_commands = {
                 COMMANDS_KEY: [asdict(command, dict_factory=convert_enums) for command in pending_commands]
@@ -60,7 +60,6 @@ async def get_orders(logger: WazuhLogger):
                         order_ids=processed_commands_ids,
                         status=Status.SENT.value
                     )
-
 
             except (httpx.ConnectError, httpx.TimeoutException) as e:
                 logger.error(f'An error occurs sending the orders to the Communications API :', str(e))


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27826 |

## Description

Modifies the commands status values to make them lowercase, fixing an issue that was causing the orders not to be retrieved correctly and therefore not distributed to the agents.

## Tests

<details><summary>Create group and assign agent to it</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ TOKEN=$(curl -u wazuh:wazuh -s -k -X POST https://0.0.0.0:55000/security/user/authenticate | jq -r '.data.token') && echo $TOKEN                                                                             
eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzM3NzMzMTU2LCJleHAiOjE3Mzc3MzQwNTYsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.nXOpsso-z6CoVlu0
6cCHF3YCWs8_8qJr-pS2BQEofDrkLE8mLyX83PowdcOOt-Th5_xjWZliTfVpUGBYUBGDfw
```

```console                        
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ks https://0.0.0.0:55000/groups -d '{"group_id": "group1"}' | jq                                                         
{                                                                                                                                                                                                                                             
  "message": "Group 'group1' created.",                                                                                                                                                                                                       
  "error": 0                                                                                                                                                                                                                                  
}
```

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55000/agents | jq                                                                                                                                 
{           
  "data": {                          
    "affected_items": [                   
      {         
        "id": "ea5eeeb0-b9a8-4d29-98b8-fb19702a6406",                          
        "name": "22b39eb4e9fc",
        "key": "Y529oAktSIz7fasGsLksRqu8+6Ecn8FjtMeSuVBsqQqcG9mXNXIZn9AXnnwmtvLV",   
        "type": "Endpoint",
        "version": "5.0.0",       
        "last_login": "2025-01-24T15:39:14.688434+00:00",       
        "status": "active",
        "host": {       
          "hostname": "22b39eb4e9fc",                   
          "os": {       
            "name": "Ubuntu",          
            "type": "Linux",                          
            "version": "24.04.1 LTS (Noble Numbat)"                                                                                                                                                                                           
          },                   
          "ip": [            
            "172.18.0.7"                          
          ],  
          "architecture": "x86_64"                          
        }                          
      }                          
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []  
  },      
  "message": "All selected agents information was returned",                                                                                                                                                                                  
  "error": 0                        
}
```

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X PUT -ks "https://0.0.0.0:55000/agents/group?agents_list=ea5eeeb0-b9a8-4d29-98b8-fb19702a6406&group_id=group1" | jq             
{              
  "data": { 
    "affected_items": [
      "ea5eeeb0-b9a8-4d29-98b8-fb19702a6406"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were assigned to group1",                                                                                                                                          
  "error": 0
}
```

</details>

<details><summary>Manager logs</summary>

```console
2025/01/24 15:39:47 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/24 15:39:47 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/24 15:39:47 DEBUG: [Cluster] [Main] Commands index response: [Command(document_id=None, request_id='sDD4mJQB4iXGSPnWCACm', order_id='sTD4mJQB4iXGSPnWCACm', source='Users/Services', user='Management API', target=Target(id='ea5eeeb0-b9a8-4d29-98b8-fb19702a6406', type='agent'), action=Action(name='set-group', version='5.0.0', args={'groups': ['group1']}), timeout=100, status='pending', result=None)]
2025/01/24 15:39:47 DEBUG: [Cluster] [Main] Post orders response: 200 - {'commands': []}
2025/01/24 15:39:47 DEBUG: [Cluster] [Main] Closing the indexer client session.
```

</details>

<details><summary>Agent logs</summary>

```console
[2025-01-24 15:40:16.735] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:232] [Co_PerformHttpRequest] Request /api/v1/commands: Status 200                        
[2025-01-24 15:40:16.735] [wazuh-agent] [trace] [TRACE] [http_client.cpp:233] [Co_PerformHttpRequest] Request endpoint: /api/v1/commands
Response: HTTP/1.1 200 OK
date: Fri, 24 Jan 2025 15:40:16 GMT
server: uvicorn
server: Wazuh                          
content-length: 316
content-type: application/json
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
                                                                                                                                                                                                                                              
{"commands":[{"request_id":"sDD4mJQB4iXGSPnWCACm","order_id":"sTD4mJQB4iXGSPnWCACm","source":"Users/Services","user":"Management API","target":{"id":"ea5eeeb0-b9a8-4d29-98b8-fb19702a6406","type":"agent"},"action":{"name":"set-group","version":"5.0.0","args":{"groups":["group1"]}},"timeout":100,"status":"pending"}]}
[2025-01-24 15:40:17.734] [wazuh-agent] [info] [INFO] [command_handler_utils.cpp:77] [DispatchCommand] Dispatching command set-group(CentralizedConfiguration)
[2025-01-24 15:40:17.741] [wazuh-agent] [info] [INFO] [agent.cpp:91] [ReloadModules] Reloading Modules
[2025-01-24 15:40:17.741] [wazuh-agent] [info] [INFO] [configuration_parser.cpp:181] [ReloadConfiguration] Reload configuration.
[2025-01-24 15:40:17.741] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:54] [LoadLocalConfig] Loading local config file: /etc/wazuh-agent/wazuh-agent.yml.
[2025-01-24 15:40:17.742] [wazuh-agent] [debug] [DEBUG] [configuration_parser.cpp:134] [LoadSharedConfig] Loading shared configuration.
[2025-01-24 15:40:17.742] [wazuh-agent] [info] [INFO] [configuration_parser.cpp:192] [ReloadConfiguration] Reload configuration done.
```

</details>

<details><summary>Indexed orders</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -X POST -H "Content-Type: application/json" -ku admin:admin https://localhost:9200/wazuh-commands/_search?pretty -d'                                                                                 
{
   "query": {
      "match_all": {}
   }
}'           
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "wazuh-commands",
        "_id" : "sjD4mJQB4iXGSPnWCACn",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "@timestamp" : "2025-01-24T15:39:39Z",
          "delivery_timestamp" : "2025-01-24T15:41:19Z",
          "command" : {
            "action" : {
              "args" : {
                "groups" : [
                  "group1"
                ]
              },
              "name" : "set-group",
              "version" : "5.0.0"
            },
            "source" : "Users/Services",
            "user" : "Management API",
            "order_id" : "sTD4mJQB4iXGSPnWCACm",
            "request_id" : "sDD4mJQB4iXGSPnWCACm",
            "timeout" : 100,
            "target" : {
              "id" : "ea5eeeb0-b9a8-4d29-98b8-fb19702a6406",
              "type" : "agent"
            },
            "status" : [
              "sent"
            ]
          }
        }
      }
    ]
  }
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/task/tests/test_order.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 10 items                                                                                                                                                                                                                           

framework/wazuh/core/task/tests/test_order.py ..........                                                                                                                                                                               [100%]

============================================================================================================= 10 passed in 0.39s =============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 8 items                                                                                                                                                                                                                            

framework/wazuh/core/indexer/tests/test_commands.py ........                                                                                                                                                                           [100%]

============================================================================================================= 8 passed in 0.26s ==============================================================================================================
```

</details>