### PR TITLE
Fix reading of values from RocksDB during agent re-scan

### DIFF
--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -56,7 +56,7 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Clang-format errors - ${{ inputs.id }}

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -94,7 +94,7 @@ runs:
       # Upload the coverage report as an artifact
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Coverage Report - ${{ inputs.id }}
           path: ./${{ inputs.path }}/build/coverage_report

--- a/.github/actions/doxygen/action.yml
+++ b/.github/actions/doxygen/action.yml
@@ -56,7 +56,7 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Doxygen errors - ${{ inputs.id }}
@@ -64,7 +64,7 @@ runs:
           retention-days: 1
 
       # Upload the documentation as an artifact, when successful
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: Doxygen Documentation - ${{ inputs.id }}

--- a/.github/workflows/indexer-connector-tests.yml
+++ b/.github/workflows/indexer-connector-tests.yml
@@ -51,7 +51,7 @@ jobs:
       # Upload log files of the tests
       - name: Upload log files
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: QA log files
           path: ${{ github.workspace }}/qa_logs

--- a/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
@@ -43,7 +43,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -67,7 +67,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
@@ -44,7 +44,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -68,7 +68,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-execd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-win.yml
@@ -42,7 +42,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -66,7 +66,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-fim-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-0-1-win.yml
@@ -41,7 +41,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -65,7 +65,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-fim-tier-2-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-2-win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-github-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-github-tier-0-1-win.yml
@@ -42,7 +42,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -66,7 +66,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
@@ -41,7 +41,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -65,7 +65,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-office365-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-office365-tier-0-1-win.yml
@@ -42,7 +42,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -66,7 +66,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-sca-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-sca-tier-0-1-win.yml
@@ -43,7 +43,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -67,7 +67,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
@@ -41,7 +41,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -65,7 +65,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/rtr_syscheck.yml
+++ b/.github/workflows/rtr_syscheck.yml
@@ -39,7 +39,7 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/rtr_syscollector.yml
+++ b/.github/workflows/rtr_syscollector.yml
@@ -48,7 +48,7 @@ jobs:
           echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_report ${{ env.ARTIFACT_NAME }} ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -30,7 +30,7 @@ jobs:
           scan-build-14 --status-bugs --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=${{ matrix.target }} DEBUG=1 -j$(nproc)
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-${{ matrix.target }}-scan-build-report
           path: src/scan-build-report/
@@ -59,7 +59,7 @@ jobs:
           scan-build-14 --status-bugs --use-cc=/usr/bin/i686-w64-mingw32-gcc --use-c++=/usr/bin/i686-w64-mingw32-g++-posix --analyzer-target=i686-w64-mingw32 --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=winagent DEBUG=1 -j$(nproc)
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-agent-scan-build-report
           path: src/scan-build-report/
@@ -85,7 +85,7 @@ jobs:
           /opt/homebrew/opt/llvm@14/bin/scan-build --status-bugs --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=agent DEBUG=1 -j3
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-agent-scan-build-report
           path: src/scan-build-report/

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -338,7 +338,7 @@ jobs:
       # Upload log files of the tests
       - name: Upload log files
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: QA log files
           path: ${{ github.workspace }}/qa_logs

--- a/.github/workflows/windows-dll-hijack.yml
+++ b/.github/workflows/windows-dll-hijack.yml
@@ -29,7 +29,7 @@ jobs:
           rm -f src/win32/setup-*.exe
           cp src/win32/*.exe src/exe_files/
       - name: Upload Artifact executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: executables
           path: src/exe_files
@@ -42,7 +42,7 @@ jobs:
           sed -i 's+windows.debug=0+windows.debug=2+g' etc/internal_options.conf
           cp src/win32/internal_options.conf src/configuration_files/
       - name: Upload Artifact configuration files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: configuration
           path: src/configuration_files
@@ -61,12 +61,12 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Download Artifact executables
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: executables
           path: C:\executables\
       - name: Download Artifact configuration files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: configuration
           path: C:\configuration_files\
@@ -87,7 +87,7 @@ jobs:
           python -m pytest -vv ./test_dll_hijack.py
       - name: Upload .csv files
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: csv_files ${{ matrix.os }}
           path: C:\executables\*.csv

--- a/.github/workflows/windows-file-details.yml
+++ b/.github/workflows/windows-file-details.yml
@@ -31,7 +31,7 @@ jobs:
           rm -f src/win32/libstdc++-6.dll
           find src/ -name "*.dll" -not -path "src/external/*" -not -path "src/win32/SimpleSC/*" -not -path "src/win32/nsProcess/*" -exec cp {} src/bin_files/ \;
       - name: Upload Artifact binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: src/bin_files
@@ -47,7 +47,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Download Artifact binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: binaries
           path: C:\binaries\

--- a/.github/workflows/windows-msi-upgrade-check.yml
+++ b/.github/workflows/windows-msi-upgrade-check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Compress folder
         run: 7z a win-agent-base.zip ./*
       - name: Upload base branch folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: win-agent-base.zip
           path: win-agent-base.zip
@@ -56,7 +56,7 @@ jobs:
           mkdir C:\win-agent-released
           python -m wget https://packages.wazuh.com/4.x/windows/wazuh-agent-${{ matrix.wazuh_version }}.msi -o C:\win-agent-released
       - name: Download base folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: win-agent-base.zip
           path: C:\win-agent-base
@@ -74,13 +74,13 @@ jobs:
           python -m pytest -vv ./test_win_upgrade.py
       - name: Upload release installation log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release_log
           path: C:\win-agent-released\win-agent-released.log
       - name: Upload base installation log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: base_log
           path: C:\win-agent-base\win-agent-base.log

--- a/.github/workflows/windows-syscollector-tests.yml
+++ b/.github/workflows/windows-syscollector-tests.yml
@@ -34,31 +34,31 @@ jobs:
           cp src/win32/libwinpthread-1.dll src/shared_libraries/
       # Upload build artifacts for the shared libraries.
       - name: Upload Artifact shared_libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: shared_libraries
           path: src/shared_libraries
       # Upload build artifacts for the data provider.
       - name: Upload Artifact data_provider
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: data_provider
           path: src/data_provider/build/bin
       # Upload build artifacts for dbsync.
       - name: Upload Artifact dbsync
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dbsync
           path: src/shared_modules/dbsync/build/bin
       # Upload build artifacts for rsync.
       - name: Upload Artifact rsync
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rsync
           path: src/shared_modules/rsync/build/bin
       # Upload build artifacts for syscollector.
       - name: Upload Artifact syscollector
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: syscollector
           path: src/wazuh_modules/syscollector/build/bin
@@ -74,27 +74,27 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Download Artifact data_provider
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: data_provider
           path: C:\data_provider\
       - name: Download Artifact dbsync
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dbsync
           path: C:\dbsync\
       - name: Download Artifact rsync
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rsync
           path: C:\rsync\
       - name: Download Artifact syscollector
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: syscollector
           path: C:\syscollector\
       - name: Download Artifact shared_libraries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: shared_libraries
           path: C:\shared_libraries\

--- a/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
+++ b/src/wazuh_modules/vulnerability_scanner/doc/rtr.md
@@ -61,9 +61,9 @@ act -W .github/workflows/vulnerability-scanner-tests.yml --artifact-server-path 
 [Vulnerability Scanner/style-and-documentation]   ❌  Failure - Main Check Coding style
 [Vulnerability Scanner/style-and-documentation] exitcode '1': failure
 [Vulnerability Scanner/style-and-documentation]   ☁  git clone 'https://github.com/actions/upload-artifact' # ref=v3
-[Vulnerability Scanner/style-and-documentation] ⭐ Run Main actions/upload-artifact@v3
-[Vulnerability Scanner/style-and-documentation]   🐳  docker cp src=/home/damangold/.cache/act/actions-upload-artifact@v3/ dst=/var/run/act/actions/actions-upload-artifact@v3/
-[Vulnerability Scanner/style-and-documentation]   🐳  docker exec cmd=[node /var/run/act/actions/actions-upload-artifact@v3/dist/index.js] user= workdir=
+[Vulnerability Scanner/style-and-documentation] ⭐ Run Main actions/upload-artifact@v4
+[Vulnerability Scanner/style-and-documentation]   🐳  docker cp src=/home/damangold/.cache/act/actions-upload-artifact@v4/ dst=/var/run/act/actions/actions-upload-artifact@v4/
+[Vulnerability Scanner/style-and-documentation]   🐳  docker exec cmd=[node /var/run/act/actions/actions-upload-artifact@v4/dist/index.js] user= workdir=
 [Vulnerability Scanner/style-and-documentation]   💬  ::debug::followSymbolicLinks 'true'
 [Vulnerability Scanner/style-and-documentation]   💬  ::debug::implicitDescendants 'true'
 [Vulnerability Scanner/style-and-documentation]   💬  ::debug::omitBrokenSymbolicLinks 'true'
@@ -98,7 +98,7 @@ act -W .github/workflows/vulnerability-scanner-tests.yml --artifact-server-path 
 | Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads 
 | 
 | Artifact Clang-format errors - content_manager has been successfully uploaded!
-[Vulnerability Scanner/style-and-documentation]   ✅  Success - Main actions/upload-artifact@v3
+[Vulnerability Scanner/style-and-documentation]   ✅  Success - Main actions/upload-artifact@v4
 [Vulnerability Scanner/style-and-documentation]   ❌  Failure - Main Content manager - Coding style
 [Vulnerability Scanner/style-and-documentation] exitcode '1': failure
 [Vulnerability Scanner/style-and-documentation] ⭐ Run Post Content manager - Coding style

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -130,7 +130,7 @@ private:
                 if (!schema)
                 {
                     // Resources in JSON format.
-                    auto jsonData = nlohmann::json::parse(slice.data());
+                    auto jsonData = nlohmann::json::parse(slice.data(), slice.data() + slice.size());
                     jsonData.patch_inplace(data->resource.at("operations"));
                     data->feedDatabase->put(data->resource.at("resource"), jsonData.dump(), column);
                 }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -223,8 +223,19 @@ public:
         }
         else if (message->type() == BufferType::BufferType_JSON)
         {
-            auto jsonData =
-                nlohmann::json::parse(message->data()->data(), message->data()->data() + message->data()->size());
+            nlohmann::json jsonData;
+            try
+            {
+                jsonData =
+                    nlohmann::json::parse(message->data()->data(), message->data()->data() + message->data()->size());
+            }
+            catch (const nlohmann::json::parse_error& e)
+            {
+                std::string jsonMessage {message->data()->data(), message->data()->data() + message->data()->size()};
+                logDebug2(WM_VULNSCAN_LOGTAG, "Error parsing JSON: %s", jsonMessage.c_str());
+                throw;
+            }
+
             std::variant<const SyscollectorDeltas::Delta*,
                          const SyscollectorSynchronization::SyncMsg*,
                          const nlohmann::json*>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -223,7 +223,8 @@ public:
         }
         else if (message->type() == BufferType::BufferType_JSON)
         {
-            auto jsonData = nlohmann::json::parse(message->data()->data());
+            auto jsonData =
+                nlohmann::json::parse(message->data()->data(), message->data()->data() + message->data()->size());
             std::variant<const SyscollectorDeltas::Delta*,
                          const SyscollectorSynchronization::SyncMsg*,
                          const nlohmann::json*>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -168,10 +168,7 @@ public:
                 }
                 catch (const std::exception& e)
                 {
-                    logError(WM_VULNSCAN_LOGTAG,
-                             "Error processing delayed event: %s. Event message: %s",
-                             e.what(),
-                             parseEventMessage(element).c_str());
+                    logError(WM_VULNSCAN_LOGTAG, "Error processing delayed event: %s.", e.what());
                 }
             },
             DELAYED_QUEUE_PATH);

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -128,6 +128,16 @@ public:
             // coverity[copy_constructor_call]
             [this](rocksdb::PinnableSlice& element)
             {
+                const auto parseEventMessage = [](const rocksdb::PinnableSlice& elementToParse) -> std::string
+                {
+                    if (const auto eventMessageBuffer = GetMessageBuffer(elementToParse.data()); eventMessageBuffer)
+                    {
+                        return std::string(eventMessageBuffer->data()->begin(), eventMessageBuffer->data()->end());
+                    }
+
+                    return "unable to parse";
+                };
+
                 try
                 {
                     processEvent(element, true);
@@ -148,9 +158,20 @@ public:
                                                            std::chrono::seconds(DELAYED_POSTPONE_SECONDS));
                     }
                 }
+                catch (const nlohmann::json::exception& e)
+                {
+                    logError(WM_VULNSCAN_LOGTAG,
+                             "ScanOrchestrator::initEventDelayedDispatcher: json exception (%d) - Event "
+                             "message: %s",
+                             e.id,
+                             parseEventMessage(element).c_str());
+                }
                 catch (const std::exception& e)
                 {
-                    logError(WM_VULNSCAN_LOGTAG, "Error processing delayed event: %s.", e.what());
+                    logError(WM_VULNSCAN_LOGTAG,
+                             "Error processing delayed event: %s. Event message: %s",
+                             e.what(),
+                             parseEventMessage(element).c_str());
                 }
             },
             DELAYED_QUEUE_PATH);
@@ -223,19 +244,8 @@ public:
         }
         else if (message->type() == BufferType::BufferType_JSON)
         {
-            nlohmann::json jsonData;
-            try
-            {
-                jsonData =
-                    nlohmann::json::parse(message->data()->data(), message->data()->data() + message->data()->size());
-            }
-            catch (const nlohmann::json::parse_error& e)
-            {
-                std::string jsonMessage {message->data()->data(), message->data()->data() + message->data()->size()};
-                logDebug2(WM_VULNSCAN_LOGTAG, "Error parsing JSON: %s", jsonMessage.c_str());
-                throw;
-            }
-
+            auto jsonData =
+                nlohmann::json::parse(message->data()->data(), message->data()->data() + message->data()->size());
             std::variant<const SyscollectorDeltas::Delta*,
                          const SyscollectorSynchronization::SyncMsg*,
                          const nlohmann::json*>

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -195,10 +195,7 @@ void VulnerabilityScannerFacade::initEventDispatcher()
             }
             catch (const std::exception& e)
             {
-                logError(WM_VULNSCAN_LOGTAG,
-                         "VulnerabilityScannerFacade::initEventDispatcher: %s - Event message: %s",
-                         e.what(),
-                         parseEventMessage(element).c_str());
+                logError(WM_VULNSCAN_LOGTAG, "VulnerabilityScannerFacade::initEventDispatcher: %s.", e.what());
             }
         });
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -1138,3 +1138,123 @@ TEST_F(ScanOrchestratorTest, TestInvalidMessageDeltaOsDataMissing)
     ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
     ASSERT_FALSE(parser.Parse(DELTA_OSINFO_DATA_MISSING_MSG.c_str()));
 }
+
+TEST_F(ScanOrchestratorTest, TestRunScannerTypeJSON)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "osdata_codeName",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
+
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spPackageInsertOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spPackageDeleteOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spIntegrityClearOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
+
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
+    auto spGlobalInventorySyncOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spGlobalInventorySyncOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spHotfixInsertOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(1);
+
+    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
+    EXPECT_CALL(*spFactoryOrchestratorMock, create())
+        .WillOnce(testing::Return(spOsOrchestrationMock))
+        .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
+        .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
+        .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock))
+        .WillOnce(testing::Return(spGlobalInventorySyncOrchestrationMock))
+        .WillOnce(testing::Return(spHotfixInsertOrchestrationMock));
+
+    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>(
+        [](const std::queue<std::string>&)
+        {
+            // Not used
+        },
+        TEST_REPORTS_QUEUE_PATH,
+        TEST_REPORTS_BULK_SIZE);
+    std::shared_mutex mutexScanOrchestrator;
+
+    nlohmann::json jsonData = R"({"action":"deleteAgent","agent_info":{"agent_id":"097"}})"_json;
+
+    spScanContext =
+        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(&jsonData);
+
+    TScanOrchestrator<TrampolineTScanContext,
+                      TrampolineFactoryOrchestrator,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
+                      MockIndexerConnector,
+                      MockDatabaseFeedManager,
+                      OSPrimitives,
+                      TrampolineSocketDBWrapper>
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
+
+    std::string jsonString = jsonData.dump();
+    std::vector<char> bufferVector(jsonString.begin(), jsonString.end());
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto object = CreateMessageBufferDirect(
+        builder, reinterpret_cast<const std::vector<int8_t>*>(&bufferVector), BufferType::BufferType_JSON, 0);
+
+    builder.Finish(object);
+    auto bufferData = reinterpret_cast<const char*>(builder.GetBufferPointer());
+    size_t bufferSize = builder.GetSize();
+    const rocksdb::Slice messageSlice(bufferData, bufferSize);
+
+    rocksdb::PinnableSlice pinnableSlice;
+    pinnableSlice.PinSlice(messageSlice, nullptr);
+
+    EXPECT_NO_THROW(scanOrchestrator.processEvent(pinnableSlice));
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -1258,3 +1258,125 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeJSON)
 
     EXPECT_NO_THROW(scanOrchestrator.processEvent(pinnableSlice));
 }
+
+TEST_F(ScanOrchestratorTest, TestRunScannerTypeJSONWithError)
+{
+    Os osData {.hostName = "osdata_hostname",
+               .architecture = "osdata_architecture",
+               .name = "osdata_name",
+               .codeName = "osdata_codeName",
+               .majorVersion = "osdata_majorVersion",
+               .minorVersion = "osdata_minorVersion",
+               .patch = "osdata_patch",
+               .build = "osdata_build",
+               .platform = "osdata_platform",
+               .version = "osdata_version",
+               .release = "osdata_release",
+               .displayVersion = "osdata_displayVersion",
+               .sysName = "osdata_sysName",
+               .kernelVersion = "osdata_kernelVersion",
+               .kernelRelease = "osdata_kernelRelease"};
+
+    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
+
+    auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spOsOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spPackageInsertOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spPackageDeleteOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spPackageDeleteOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spIntegrityClearOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spIntegrityClearOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spFetchAllGlobalDb = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spFetchAllGlobalDb, handleRequest(_)).Times(0);
+
+    auto spCleanUpAllOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spCleanUpAllOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spQueryAllPkgsOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spQueryAllPkgsOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spDeleteAgentScanOrchestration =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
+    auto spGlobalInventorySyncOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spGlobalInventorySyncOrchestrationMock, handleRequest(_)).Times(0);
+
+    auto spHotfixInsertOrchestrationMock =
+        std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+    EXPECT_CALL(*spDeleteAgentScanOrchestration, handleRequest(_)).Times(0);
+
+    spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
+    EXPECT_CALL(*spFactoryOrchestratorMock, create())
+        .WillOnce(testing::Return(spOsOrchestrationMock))
+        .WillOnce(testing::Return(spPackageInsertOrchestrationMock))
+        .WillOnce(testing::Return(spPackageDeleteOrchestrationMock))
+        .WillOnce(testing::Return(spIntegrityClearOrchestrationMock))
+        .WillOnce(testing::Return(spFetchAllGlobalDb))
+        .WillOnce(testing::Return(spCleanUpAllOrchestrationMock))
+        .WillOnce(testing::Return(spDeleteAgentScanOrchestration))
+        .WillOnce(testing::Return(spQueryAllPkgsOrchestrationMock))
+        .WillOnce(testing::Return(spGlobalInventorySyncOrchestrationMock))
+        .WillOnce(testing::Return(spHotfixInsertOrchestrationMock));
+
+    auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
+
+    auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+    auto spReportDispatcher = std::make_shared<ReportDispatcher>(
+        [](const std::queue<std::string>&)
+        {
+            // Not used
+        },
+        TEST_REPORTS_QUEUE_PATH,
+        TEST_REPORTS_BULK_SIZE);
+    std::shared_mutex mutexScanOrchestrator;
+
+    nlohmann::json jsonData = R"({"action":"deleteAgent","agent_info":{"agent_id":"097"}})"_json;
+
+    spScanContext =
+        std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(&jsonData);
+
+    TScanOrchestrator<TrampolineTScanContext,
+                      TrampolineFactoryOrchestrator,
+                      MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
+                      MockIndexerConnector,
+                      MockDatabaseFeedManager,
+                      OSPrimitives,
+                      TrampolineSocketDBWrapper>
+        scanOrchestrator(spIndexerConnectorMock, spDatabaseFeedManagerMock, spReportDispatcher, mutexScanOrchestrator);
+
+    std::string jsonString = jsonData.dump();
+    std::vector<char> bufferVector(jsonString.begin(), jsonString.end());
+    // Truncate the buffer to generate an error
+    bufferVector.pop_back();
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto object = CreateMessageBufferDirect(
+        builder, reinterpret_cast<const std::vector<int8_t>*>(&bufferVector), BufferType::BufferType_JSON, 0);
+
+    builder.Finish(object);
+    auto bufferData = reinterpret_cast<const char*>(builder.GetBufferPointer());
+    size_t bufferSize = builder.GetSize();
+    const rocksdb::Slice messageSlice(bufferData, bufferSize);
+
+    rocksdb::PinnableSlice pinnableSlice;
+    pinnableSlice.PinSlice(messageSlice, nullptr);
+
+    EXPECT_THROW(scanOrchestrator.processEvent(pinnableSlice), nlohmann::json::exception);
+}

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/argsParser.hpp
@@ -36,6 +36,9 @@ public:
         , m_columnFamily {paramValueOf(argc, argv, "-c", std::make_pair(false, ""))}
         , m_seekKey {paramValueOf(argc, argv, "-s", std::make_pair(false, ""))}
         , m_value {paramValueOf(argc, argv, "-v", std::make_pair(false, ""))}
+        , m_valueIsMessageBuffer {paramValueOf(argc, argv, "-m", std::make_pair(false, ""))}
+        , m_fbsDeltaPath {paramValueOf(argc, argv, "-fd", std::make_pair(false, ""))}
+        , m_fbsSyncPath {paramValueOf(argc, argv, "-fs", std::make_pair(false, ""))}
     {
     }
 
@@ -47,6 +50,26 @@ public:
     std::string getDBPath()
     {
         return m_dbPath;
+    }
+
+    /**
+     * @brief Get the .fbs Delta schema path.
+     *
+     * @return std::string Schema path.
+     */
+    std::string getFbsDeltaPath()
+    {
+        return m_fbsDeltaPath;
+    }
+
+    /**
+     * @brief Get the .fbs Sync schema path.
+     *
+     * @return std::string Schema path.
+     */
+    std::string getFbsSyncPath()
+    {
+        return m_fbsSyncPath;
     }
 
     /**
@@ -100,6 +123,16 @@ public:
     }
 
     /**
+     * @brief Get the requested value is a message buffer.
+     *
+     * @return std::string Value is a message buffer.
+     */
+    std::string getValueIsMessageBuffer()
+    {
+        return m_valueIsMessageBuffer;
+    }
+
+    /**
      * @brief Shows the help to the user.
      */
     static void showHelp()
@@ -119,6 +152,7 @@ public:
                   << "\n\t./rocksDBQuery -d rocksDBPath/ [-f schema.fbs] -s CVE_ \n"
                   << "\n\t./rocksDBQuery -d rocksDBPath/ [-f schema.fbs] -c columnFamily1 \n"
                   << "\n\t./rocksDBQuery -d rocksDBPath/ -k key1 -v val1 -c column\n"
+                  << "\n\t./rocksDBQuery -d rocksDBPath/ -m true -fd schemaDelta.fbs -fs schemaSync.fbs\n"
                   << std::endl;
     }
 
@@ -153,6 +187,9 @@ private:
     const std::string m_columnFamily;
     const std::string m_seekKey;
     const std::string m_value;
+    const std::string m_valueIsMessageBuffer;
+    const std::string m_fbsDeltaPath;
+    const std::string m_fbsSyncPath;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery/main.cpp
@@ -12,6 +12,9 @@
 #include "argsParser.hpp"
 #include "flatbuffers/flatbuffers.h"
 #include "flatbuffers/idl.h"
+#include "flatbuffers/include/syscollector_deltas_generated.h"
+#include "flatbuffers/include/syscollector_synchronization_generated.h"
+#include "messageBuffer_generated.h"
 #include "rocksDBWrapper.hpp"
 #include <iostream>
 
@@ -34,35 +37,86 @@ int main(const int argc, const char** argv)
         auto seekKey = cmdLineArgs.getSeekKey();
         auto columnFamily = cmdLineArgs.getColumnFamily();
         auto requestedValue = cmdLineArgs.getValue();
+        auto isMessageBuffer = cmdLineArgs.getValueIsMessageBuffer();
+        auto fbsDelta = cmdLineArgs.getFbsDeltaPath();
+        auto fbsSync = cmdLineArgs.getFbsSyncPath();
 
         flatbuffers::IDLOptions options;
         options.strict_json = true;
-        flatbuffers::Parser parser(options);
-        std::string schemaStr;
+        flatbuffers::Parser fbParser(options);
+        flatbuffers::Parser deltaParser(options);
+        flatbuffers::Parser syncParser(options);
 
-        if (!fbs.empty())
+        auto parseSchema = [&](const std::string& fbsPath, flatbuffers::Parser& parser)
         {
-            if (!flatbuffers::LoadFile(fbs.c_str(), false, &schemaStr))
+            std::string schemaStr;
+            if (!fbsPath.empty())
             {
-                throw std::runtime_error("Unable to load schema file.");
+                if (!flatbuffers::LoadFile(fbsPath.c_str(), false, &schemaStr))
+                {
+                    throw std::runtime_error("Unable to load schema file: " + fbsPath);
+                }
+                if (!parser.Parse(schemaStr.c_str()))
+                {
+                    throw std::runtime_error("Unable to parse schema file: " + fbsPath);
+                }
             }
-            if (!parser.Parse(schemaStr.c_str()))
-            {
-                throw std::runtime_error("Unable to parse schema file.");
-            }
-        }
+        };
+
+        parseSchema(fbs, fbParser);
+        parseSchema(fbsDelta, deltaParser);
+        parseSchema(fbsSync, syncParser);
 
         auto printValue = [&](const std::string& key, const auto& slice)
         {
-            if (!fbs.empty())
+            if (isMessageBuffer.empty())
             {
-                std::string strData;
-                flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &strData);
-                std::cout << key << " ==> " << strData << std::endl;
+                if (!fbs.empty())
+                {
+                    std::string strData;
+                    flatbuffers::GenText(fbParser, reinterpret_cast<const uint8_t*>(slice.data()), &strData);
+                    std::cout << key << " ==> " << strData << std::endl;
+                }
+                else
+                {
+                    std::cout << key << " ==> " << slice.ToString() << std::endl;
+                }
             }
             else
             {
-                std::cout << key << " ==> " << slice.ToString() << std::endl;
+                auto message = GetMessageBuffer(slice.data());
+
+                if (message->type() == BufferType::BufferType_RSync)
+                {
+                    std::string strData;
+                    flatbuffers::GenText(syncParser, reinterpret_cast<const uint8_t*>(message->data()), &strData);
+                    std::cout << key << " ==> " << strData << std::endl;
+                }
+                else if (message->type() == BufferType::BufferType_DBSync)
+                {
+                    std::string strData;
+                    flatbuffers::GenText(deltaParser, reinterpret_cast<const uint8_t*>(message->data()), &strData);
+                    std::cout << key << " ==> " << strData << std::endl;
+                }
+                else if (message->type() == BufferType::BufferType_JSON)
+                {
+                    try
+                    {
+                        auto jsonData = nlohmann::json::parse(message->data()->data(),
+                                                              message->data()->data() + message->data()->size());
+
+                        std::cout << key << " ==> " << jsonData.dump() << std::endl;
+                    }
+                    catch (const std::exception& e)
+                    {
+                        std::cout << "ERROR. Unable to parse key: '" << key << "'. JSON: '" << message->data()->data()
+                                  << "'. Reason: " << e.what() << std::endl;
+                    }
+                }
+                else
+                {
+                    throw std::runtime_error("Unknown event type");
+                }
             }
         };
 
@@ -82,12 +136,12 @@ int main(const int argc, const char** argv)
 
             if (!fbs.empty())
             {
-                if (!parser.Parse(requestedValue.c_str()))
+                if (!fbParser.Parse(requestedValue.c_str()))
                 {
                     throw std::runtime_error("Unable to parse value.");
                 }
-                rocksdb::Slice flatbufferResource(reinterpret_cast<const char*>(parser.builder_.GetBufferPointer()),
-                                                  parser.builder_.GetSize());
+                rocksdb::Slice flatbufferResource(reinterpret_cast<const char*>(fbParser.builder_.GetBufferPointer()),
+                                                  fbParser.builder_.GetSize());
                 rocksDB.put(requestedKey, flatbufferResource, columnFamily);
             }
             else


### PR DESCRIPTION
|Related issue|
|---|
|Closes #24546|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR fixes the JSON parse of the values read from the DBs adding the corresponding size.
I've also added the capability of reading message buffer flatbuffers to the internal `rocks_db_test_tool` to make the future debugging easier.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

Here I have the ASAN errors for the added test without the fix

<details><summary>Details</summary>
<p>

```

==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ScanOrchestratorTest
[ RUN      ] ScanOrchestratorTest.TestRunScannerTypeJSON
=================================================================
==384983==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x519000044180 at pc 0x7f4a1e23f96f bp 0x7ffe932203a0 sp 0x7ffe9321fb48
READ of size 57 at 0x519000044180 thread T0
    #0 0x7f4a1e23f96e in strlen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
    #1 0x562f5d91a6cf in nlohmann::json_abi_v3_11_2::detail::iterator_input_adapter<char const*> nlohmann::json_abi_v3_11_2::detail::input_adapter<signed char const*, 0>(signed char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/nlohmann/json.hpp:6520
    #2 0x562f5d907786 in nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > >::parse<signed char const*>(signed char const*&&, std::function<bool (int, nlohmann::json_abi_v3_11_2::detail::parse_event_t, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > >&)>, bool, bool) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/nlohmann/json.hpp:23192
    #3 0x562f5d8eef3e in TScanOrchestrator<TrampolineTScanContext, TrampolineFactoryOrchestrator, MockAbstractHandler<std::shared_ptr<TrampolineTScanContext> >, MockIndexerConnector, MockDatabaseFeedManager, OSPrimitives, TrampolineSocketDBWrapper, 60>::processEvent(rocksdb::PinnableSlice const&, bool) const /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/../scanOrchestrator/scanOrchestrator.hpp:226
    #4 0x562f5d8a7679 in ScanOrchestratorTest_TestRunScannerTypeJSON_Test::TestBody() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp:1259
    #5 0x562f5de08efc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2607
    #6 0x562f5de015da in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2643
    #7 0x562f5ddd45e9 in testing::Test::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2682
    #8 0x562f5ddd5109 in testing::TestInfo::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2861
    #9 0x562f5ddd5a74 in testing::TestSuite::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:3015
    #10 0x562f5dde6533 in testing::internal::UnitTestImpl::RunAllTests() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:5855
    #11 0x562f5de09f44 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2607
    #12 0x562f5de028d2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2643
    #13 0x562f5dde4ac4 in testing::UnitTest::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:5438
    #14 0x562f5d23102b in RUN_ALL_TESTS() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/include/gtest/gtest.h:2490
    #15 0x562f5d230de6 in main /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/wazuh_modules/vulnerability_scanner/tests/unit/main.cpp:17
    #16 0x7f4a19e021c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #17 0x7f4a19e0228a in __libc_start_main_impl ../csu/libc-start.c:360
    #18 0x562f5be80624 in _start (/workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/build/wazuh_modules/vulnerability_scanner/tests/unit/vulnerability_scanner_unit_tests+0xc41d624) (BuildId: ce6071d19b630d984be6111a1e5e622a9a7c9585)

0x519000044180 is located 0 bytes after 1024-byte region [0x519000043d80,0x519000044180)
allocated by thread T0 here:
    #0 0x7f4a1e2c06c8 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x562f5becfc57 in flatbuffers::DefaultAllocator::allocate(unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/default_allocator.h:29
    #2 0x562f5c7eaecf in flatbuffers::Allocate(flatbuffers::Allocator*, unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/default_allocator.h:43
    #3 0x562f5c933569 in flatbuffers::vector_downward<unsigned int>::reallocate(unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/vector_downward.h:280
    #4 0x562f5c8e5380 in flatbuffers::vector_downward<unsigned int>::ensure_space(unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/vector_downward.h:145
    #5 0x562f5c8e4b06 in flatbuffers::vector_downward<unsigned int>::make_space(unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/vector_downward.h:152
    #6 0x562f5c933f2c in flatbuffers::vector_downward<unsigned int>::push(unsigned char const*, unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/vector_downward.h:196
    #7 0x562f5c8e71c0 in flatbuffers::FlatBufferBuilderImpl<false>::PushBytes(unsigned char const*, unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/flatbuffer_builder.h:303
    #8 0x562f5d8f8967 in flatbuffers::Offset<flatbuffers::Vector<signed char> > flatbuffers::FlatBufferBuilderImpl<false>::CreateVector<signed char, flatbuffers::Offset, flatbuffers::Vector>(signed char const*, unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/flatbuffer_builder.h:738
    #9 0x562f5d8df9fc in flatbuffers::Offset<flatbuffers::Vector<signed char, unsigned int> > flatbuffers::FlatBufferBuilderImpl<false>::CreateVector<signed char, std::allocator<signed char> >(std::vector<signed char, std::allocator<signed char> > const&) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/flatbuffers/include/flatbuffers/flatbuffer_builder.h:789
    #10 0x562f5d8d962c in CreateMessageBufferDirect(flatbuffers::FlatBufferBuilderImpl<false>&, std::vector<signed char, std::allocator<signed char> > const*, BufferType, unsigned long) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/wazuh_modules/vulnerability_scanner/include/messageBuffer_generated.h:122
    #11 0x562f5d8a724a in ScanOrchestratorTest_TestRunScannerTypeJSON_Test::TestBody() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp:1248
    #12 0x562f5de08efc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2607
    #13 0x562f5de015da in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2643
    #14 0x562f5ddd45e9 in testing::Test::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2682
    #15 0x562f5ddd5109 in testing::TestInfo::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2861
    #16 0x562f5ddd5a74 in testing::TestSuite::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:3015
    #17 0x562f5dde6533 in testing::internal::UnitTestImpl::RunAllTests() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:5855
    #18 0x562f5de09f44 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2607
    #19 0x562f5de028d2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:2643
    #20 0x562f5dde4ac4 in testing::UnitTest::Run() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/src/gtest.cc:5438
    #21 0x562f5d23102b in RUN_ALL_TESTS() /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/external/googletest/googletest/include/gtest/gtest.h:2490
    #22 0x562f5d230de6 in main /workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/wazuh_modules/vulnerability_scanner/tests/unit/main.cpp:17
    #23 0x7f4a19e021c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #24 0x7f4a19e0228a in __libc_start_main_impl ../csu/libc-start.c:360
    #25 0x562f5be80624 in _start (/workspaces/wazuh.worktrees/bug/24546-vd-error-processing-delayed-event/src/build/wazuh_modules/vulnerability_scanner/tests/unit/vulnerability_scanner_unit_tests+0xc41d624) (BuildId: ce6071d19b630d984be6111a1e5e622a9a7c9585)

SUMMARY: AddressSanitizer: heap-buffer-overflow ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391 in strlen
Shadow bytes around the buggy address:
  0x519000043f00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x519000043f80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x519000044000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x519000044080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x519000044100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x519000044180:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x519000044200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x519000044280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x519000044300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x519000044380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x519000044400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==384983==ABORTING

```

</p>
</details> 

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation


- [x] Added unit tests (for new features)

