### PR TITLE
Add API certificates paths validation

### DIFF
--- a/apis/communications/scripts/wazuh_comms_apid.py
+++ b/apis/communications/scripts/wazuh_comms_apid.py
@@ -174,7 +174,7 @@ def get_gunicorn_options(pid: int, log_config_dict: dict, config: CommsAPIConfig
         'preload_app': True,
         'keyfile': config.ssl.key,
         'certfile': config.ssl.cert,
-        'ca_certs': config.ssl.ca,
+        'ca_certs': config.ssl.ca if config.ssl.use_ca else None,
         'ssl_context': ssl_context,
         'ciphers': config.ssl.ssl_ciphers,
         'logconfig_dict': log_config_dict,

--- a/framework/wazuh/core/config/models/base.py
+++ b/framework/wazuh/core/config/models/base.py
@@ -10,7 +10,7 @@ class WazuhConfigBaseModel(BaseModel):
 
 class ValidateFilePathMixin:
     @classmethod
-    def _validate_file_path(cls, path: str, field_name: str, file_type: str):
+    def _validate_file_path(cls, path: str, field_name: str):
         """Validate that a single file path is non-empty and points to an existing file.
 
         Parameters
@@ -26,7 +26,7 @@ class ValidateFilePathMixin:
             If the file path is empty or the file does not exist.
         """
         if path == '':
-            raise ValueError(f'{field_name}: missing {file_type} file')
+            raise ValueError(f'{field_name}: no file path specified')
 
         if not os.path.isfile(path):
             raise ValueError(f"{field_name}: the file '{path}' does not exist")

--- a/framework/wazuh/core/config/models/server.py
+++ b/framework/wazuh/core/config/models/server.py
@@ -297,7 +297,7 @@ class JWTConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
         str
             JWT key path.
         """
-        cls._validate_file_path(path, info.field_name, 'key')
+        cls._validate_file_path(path, info.field_name)
         return path
 
 

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -1,4 +1,3 @@
-import os
 from enum import Enum
 from typing import List
 from pydantic import Field
@@ -140,7 +139,7 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
         return paths
 
 
-class APISSLConfig(WazuhConfigBaseModel):
+class APISSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
     """Configuration for API SSL settings.
 
     Parameters
@@ -161,6 +160,33 @@ class APISSLConfig(WazuhConfigBaseModel):
     key: str
     cert: str
     use_ca: bool = False
-    ca: str = ""
+    ca: str = ''
     ssl_protocol: SSLProtocol = SSLProtocol.auto
-    ssl_ciphers: str = ""
+    ssl_ciphers: str = ''
+
+    @field_validator('ca')
+    @classmethod
+    def validate_ca_file(cls, path: str, info: ValidationInfo) -> str:
+        """Validate that the certificate authority file exists.
+
+        Parameters
+        ----------
+        path : str
+            Path to the SSL certificate authority file.
+        info : ValidationInfo
+            Validation context information.
+
+        Raises
+        ------
+        ValueError
+            Invalid SSL file path.
+
+        Returns
+        ------
+        str
+            SSL certificate authority file path.
+        """
+        if info.data['use_ca']:
+            cls._validate_file_path(path, info.field_name)
+
+        return path

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -7,8 +7,6 @@ from pydantic import field_validator, ValidationInfo
 
 from wazuh.core.config.models.base import ValidateFilePathMixin, WazuhConfigBaseModel
 
-CERTIFICATE_TYPE = 'certificate'
-
 
 class SSLProtocol(str, Enum):
     """Enum representing supported SSL/TLS protocols."""
@@ -60,7 +58,7 @@ class SSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
         str
             SSL certificate/key path.
         """
-        cls._validate_file_path(path, info.field_name, CERTIFICATE_TYPE)
+        cls._validate_file_path(path, info.field_name)
         return path
 
 
@@ -110,7 +108,7 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
             SSL certificate/key path.
         """
         if info.data['use_ssl']:
-            cls._validate_file_path(path, info.field_name, CERTIFICATE_TYPE)
+            cls._validate_file_path(path, info.field_name)
         return path
 
     @field_validator('certificate_authorities')
@@ -137,7 +135,7 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
         """
         if info.data['use_ssl']:
             for path in paths:
-                cls._validate_file_path(path, info.field_name, CERTIFICATE_TYPE)
+                cls._validate_file_path(path, info.field_name)
 
         return paths
 

--- a/framework/wazuh/core/config/models/tests/test_ssl_config.py
+++ b/framework/wazuh/core/config/models/tests/test_ssl_config.py
@@ -80,7 +80,8 @@ def test_indexer_ssl_config_default_values(file_exists_mock, init_values, expect
         {'use_ca': True, 'ca': 'ca_example', 'ssl_protocol': SSLProtocol.tls, 'ssl_ciphers': 'cipher_example'}
     )
 ])
-def test_api_ssl_config_default_values(init_values, expected):
+@patch('os.path.isfile', return_value=True)
+def test_api_ssl_config_default_values(isfile_mock, init_values, expected):
     """Check the correct initialization of the `APISSLConfig` class."""
     ssl_config = APISSLConfig(**init_values)
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27822 |

## Description

Adds API CA certificates validations and fixes a bug in which CA files where used in the Comms API even if `ssl.use_ca` was `False`.

## Tests

<details><summary>Configuration</summary>

```yml
communications_api:
  host: '0.0.0.0'
  ssl:
    key: /etc/wazuh-server/certs/api-key.pem
    cert: /etc/wazuh-server/certs/api.pem
    use_ca: true
    ca: '/tmp/root-ca.pem'
```

</details>

<details><summary>Server execution</summary>

```console
2025/01/27 15:34:39 ERROR: [Cluster] [Main] 1 validation error for Config
communications_api.ssl.ca
  Value error, ca: the file '/tmp/root-ca.pem' does not exist [type=value_error, input_value='/tmp/root-ca.pem', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/value_error
```

</details>

<details><summary>Server execution with use_ca=False</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ docker logs -f wazuh-manager                                                                                                        
2025/01/27 15:39:48 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.                                                                                           
2025/01/27 15:39:48 DEBUG: [Cluster] [Main] Nothing to remove in '/run/wazuh-server/cluster/'.                                                                               
2025/01/27 15:39:48 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.                                                                   
2025/01/27 15:39:48 INFO: [Cluster] [Main] Starting server (pid: 12)                                                                                                         
2025/01/27 15:39:48 INFO: [Master] [Main] Configuration server is not available, retrying...                                                                                 
2025/01/27 15:39:48 INFO: [Master] [Config Server] Started server process [12]                                                                                               
2025/01/27 15:39:48 INFO: [Master] [Config Server] Waiting for application startup.                                                                                          
2025/01/27 15:39:48 INFO: [Master] [Config Server] Application startup complete.                                                                                             
2025/01/27 15:39:48 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)                                
2025/01/27 15:39:49 INFO: [Local Server] [Main] Starting wazuh-comms-apid                                                                                                    
2025/01/27 15:39:50 INFO: [Communications API] Starting API                                                                                                                  
2025/01/27 15:39:50 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/01/27 15:39:50 INFO: [Communications API] Generated private key file in /etc/wazuh-server/certs/api-key.pem
2025/01/27 15:39:50 INFO: [Communications API] Generated certificate file in /etc/wazuh-server/certs/api.pem
2025/01/27 15:39:51 INFO: [Communications API] Starting gunicorn 22.0.0
2025/01/27 15:39:51 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (18)
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/config/models/tests/test_ssl_config.py --disable-warnings
============================================================================ test session starts ============================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 15 items                                                                                                                                                          

framework/wazuh/core/config/models/tests/test_ssl_config.py ...............                                                                                           [100%]

============================================================================ 15 passed in 0.11s =============================================================================
```

</details>