### PR TITLE
Enhance merge_key_in and kvdb_get_merge hf

### DIFF
--- a/src/engine/docs/helpers/README.md
+++ b/src/engine/docs/helpers/README.md
@@ -5,6 +5,7 @@ This documentation provides an overview of the auxiliary functions available. Au
 ## Filter
 - [binary_and](#binary_and)
 - [contains](#contains)
+- [ends_with](#ends_with)
 - [exists](#exists)
 - [exists_key_in](#exists_key_in)
 - [int_equal](#int_equal)
@@ -41,7 +42,9 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [date_from_epoch](#date_from_epoch)
 - [decode_base16](#decode_base16)
 - [downcase](#downcase)
+- [float_calculate](#float_calculate)
 - [geoip](#geoip)
+- [get_date](#get_date)
 - [hex_to_number](#hex_to_number)
 - [int_calculate](#int_calculate)
 - [ip_version](#ip_version)
@@ -67,8 +70,11 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [kvdb_get](#kvdb_get)
 - [kvdb_get_array](#kvdb_get_array)
 - [kvdb_get_merge](#kvdb_get_merge)
+- [kvdb_get_merge_recursive](#kvdb_get_merge_recursive)
 - [kvdb_set](#kvdb_set)
 - [merge](#merge)
+- [merge_key_in](#merge_key_in)
+- [merge_recursive_key_in](#merge_recursive_key_in)
 - [parse_alphanumeric](#parse_alphanumeric)
 - [parse_between](#parse_between)
 - [parse_binary](#parse_binary)
@@ -159,6 +165,40 @@ In case of error, the function will evaluate to false.
 **Keywords**
 
 - `undefined` 
+
+---
+# ends_with
+
+## Signature
+
+```
+
+field: ends_with(conteined)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| conteined | string | value or reference | Any string |
+
+
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| string | Any string |
+
+
+## Description
+
+Checks if the string stored in the field ends with the value provided.
+If they're not, the function evaluates to false. In case of error, the function will evaluate to false.
+
+
+**Keywords**
+
+- `string` 
 
 ---
 # exists
@@ -1269,8 +1309,7 @@ field: date_from_epoch(epoch)
 ## Description
 
 Date from epoch will convert the input value, can be a reference or a value representing the epoch time to a human readable date time.
-Remember epoch, understood as UNIX epoch, is the seconds passed since january first of 1970, so it will fail on negative values.
-Floating points numbers will be converted to integers.
+Transforms UNIX epoch time to a human readable date time in the format of 'YYYY-MM-DDTHH:MM:SSZ'.
 
 
 **Keywords**
@@ -1347,6 +1386,51 @@ If the field field already exists, then it will be replaced. In case of errors â
 - `string` 
 
 ---
+# float_calculate
+
+## Signature
+
+```
+
+field: float_calculate(operator, operand_left, operand_right, [...])
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| operator | string | value | mul, div, sub, sum |
+| operand_left | number | value or reference |
+| operand_right | number | value or reference |
+
+
+## Outputs
+
+| Type | Possible values |
+| ---- | --------------- |
+| number |
+
+
+## Description
+
+The function `float_calculate` performs basic arithmetic operations on floats and integers.
+The function receives an operator and two or more operands.
+The function applies the operator to the first two operands and then applies the result to the next operand.
+The result of the operation is stored in the field `field`.
+The function supports the following operators: `sum` (addition), `sub` (subtraction), `mul` (multiplication), and `div` (division).
+
+
+**Keywords**
+
+- `math` 
+
+## Notes
+
+- Division by zero is not allowed (the function will fail).
+
+- The limit for a float is 3.402823466e+38
+
+---
 # geoip
 
 ## Signature
@@ -1391,6 +1475,32 @@ In case of success it will return an object with the following fields:
 **Keywords**
 
 - `max_min_db` 
+
+---
+# get_date
+
+## Signature
+
+```
+
+field: get_date()
+```
+
+## Outputs
+
+| Type | Possible values |
+| ---- | --------------- |
+| string | Any string |
+
+
+## Description
+
+Get the current date in the format "%Y-%m-%dT%H:%M:%SZ". The date is generated in UTC time zone.
+
+
+**Keywords**
+
+- `time` 
 
 ---
 # hex_to_number
@@ -2264,6 +2374,45 @@ value type hold by field. This helper function is typically used in the map stag
 - `kvdb` 
 
 ---
+# kvdb_get_merge_recursive
+
+## Signature
+
+```
+
+field: kvdb_get_merge_recursive(db-name, key)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| db-name | string | value | Any string |
+| key | string | value or reference | Any string |
+
+
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| [object, array] | - |
+
+
+## Description
+
+Gets the value of a given key in the DB named db-name and, if successful, merges this value with what the field had before.
+The merge process is recursive, meaning that for object or array types, the new value is deeply integrated with the existing value in the field.
+Key value type can be string, number, object, array, or null, and it must match the previous value type held by the field.
+This helper function is typically used in the map stage.
+
+
+**Keywords**
+
+- `kvdb` 
+
+- `recursive` 
+
+---
 # kvdb_set
 
 ## Signature
@@ -2334,6 +2483,80 @@ When merging objects, if a collision is produced the target key will be overridd
 When merging arrays, if a collision is produced the target key will be preserved in its original order
 and will be not duplicated.
 This helper function is typically used in the map stage
+
+
+**Keywords**
+
+- `undefined` 
+
+---
+# merge_key_in
+
+## Signature
+
+```
+
+field: merge_key_in(any_object, key)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| any_object | object | value or reference | Any object |
+| key | string | reference | Any string |
+
+
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| object | Any object |
+
+
+## Description
+
+Merge in target field value with the content of some key in the specified object, where the key is specified with a reference to another field.
+The object parameter must be a definition object or a reference to a field containing the object.
+This helper function is typically used in the map stage.
+
+
+**Keywords**
+
+- `undefined` 
+
+---
+# merge_recursive_key_in
+
+## Signature
+
+```
+
+field: merge_recursive_key_in(any_object, key)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| any_object | object | value or reference | Any object |
+| key | string | reference | Any string |
+
+
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| object | Any object |
+
+
+## Description
+
+Recursively merge the target field value with the content of a specified key in the given object.
+The key is identified through a reference to another field.
+If the key's value contains nested objects, the merge operation is applied recursively, combining all levels of the structure.
+The object parameter must be a definition object or a reference to a field containing the object.
+This helper function is typically used in the map stage to ensure deep merging of complex objects.
 
 
 **Keywords**

--- a/src/engine/docs/helpers/keyword_table.md
+++ b/src/engine/docs/helpers/keyword_table.md
@@ -3,6 +3,7 @@
 | ------ | -------- |
 | [binary_and](documentation.md#binary_and) | undefined |
 | [contains](documentation.md#contains) | undefined |
+| [ends_with](documentation.md#ends_with) | string |
 | [exists](documentation.md#exists) | undefined |
 | [exists_key_in](documentation.md#exists_key_in) | undefined |
 | [int_equal](documentation.md#int_equal) | comparison, integer |
@@ -38,7 +39,9 @@
 | [date_from_epoch](documentation.md#date_from_epoch) | undefined |
 | [decode_base16](documentation.md#decode_base16) | undefined |
 | [downcase](documentation.md#downcase) | string |
+| [float_calculate](documentation.md#float_calculate) | math |
 | [geoip](documentation.md#geoip) | max_min_db |
+| [get_date](documentation.md#get_date) | time |
 | [hex_to_number](documentation.md#hex_to_number) | undefined |
 | [int_calculate](documentation.md#int_calculate) | math |
 | [ip_version](documentation.md#ip_version) | ip |
@@ -63,8 +66,11 @@
 | [kvdb_get](documentation.md#kvdb_get) | kvdb |
 | [kvdb_get_array](documentation.md#kvdb_get_array) | kvdb |
 | [kvdb_get_merge](documentation.md#kvdb_get_merge) | kvdb |
+| [kvdb_get_merge_recursive](documentation.md#kvdb_get_merge_recursive) | kvdb, recursive |
 | [kvdb_set](documentation.md#kvdb_set) | kvdb |
 | [merge](documentation.md#merge) | undefined |
+| [merge_key_in](documentation.md#merge_key_in) | undefined |
+| [merge_recursive_key_in](documentation.md#merge_recursive_key_in) | undefined |
 | [parse_alphanumeric](documentation.md#parse_alphanumeric) | parser |
 | [parse_between](documentation.md#parse_between) | parser |
 | [parse_binary](documentation.md#parse_binary) | parser |

--- a/src/engine/source/base/test/src/unit/json_test.cpp
+++ b/src/engine/source/base/test/src/unit/json_test.cpp
@@ -1828,37 +1828,102 @@ TEST_F(JsonSettersTest, Erase)
     ASSERT_THROW(jObj.erase("object/key"), std::runtime_error);
 }
 
-TEST_F(JsonSettersTest, MergeObjRoot)
+TEST_F(JsonSettersTest, MergeObjRootRecursive)
 {
     Json jObjSrc {R"({
-        "key1": "newValue1",
-        "key3": "newValue3",
-        "key4": {
-            "key5": "newValue5"
+        "event": {
+            "category": ["network", "other_type"],
+            "kind": "alert"
         }
     })"};
 
     Json jObjDst {R"({
-        "key1": "value1",
-        "key2": "value2",
-        "key6": {
-            "key7": "value7"
+        "event": {
+            "category": ["networkOne"],
+            "end": "yesteday",
+            "kind": "event",
+            "module": "suricata",
+            "severity": "low",
+            "start": "yesteday"
         }
     })"};
 
     Json jObjExpected {R"({
-        "key1": "newValue1",
-        "key2": "value2",
-        "key3": "newValue3",
-        "key4": {
-            "key5": "newValue5"
-        },
-        "key6": {
-            "key7": "value7"
+        "event": {
+            "category": ["networkOne", "network", "other_type"],
+            "end": "yesteday",
+            "kind": "alert",
+            "module": "suricata",
+            "severity": "low",
+            "start": "yesteday"
+        }
+    })"};
+
+    ASSERT_NO_THROW(jObjDst.merge(json::RECURSIVE, jObjSrc));
+    ASSERT_EQ(jObjDst, jObjExpected);
+}
+
+TEST_F(JsonSettersTest, MergeObjRootWithoutRecursive)
+{
+    Json jObjSrc {R"({
+        "event": {
+            "category": ["network", "other_type"],
+            "kind": "alert"
+        }
+    })"};
+
+    Json jObjDst {R"({
+        "event": {
+            "category": ["networkOne"],
+            "end": "yesteday",
+            "kind": "event",
+            "module": "suricata",
+            "severity": "low",
+            "start": "yesteday"
+        }
+    })"};
+
+    Json jObjExpected {R"({
+        "event": {
+            "category": ["network", "other_type"],
+            "kind": "alert"
         }
     })"};
 
     ASSERT_NO_THROW(jObjDst.merge(json::NOT_RECURSIVE, jObjSrc));
+    ASSERT_EQ(jObjDst, jObjExpected);
+}
+
+TEST_F(JsonSettersTest, MergeObjEventRef)
+{
+    Json jObjSrc {R"({
+        "category": ["network", "other_type"],
+        "kind": "alert"
+    })"};
+
+    Json jObjDst {R"({
+        "event": {
+            "category": ["networkOne"],
+            "end": "yesteday",
+            "kind": "event",
+            "module": "suricata",
+            "severity": "low",
+            "start": "yesteday"
+        }
+    })"};
+
+    Json jObjExpected {R"({
+        "event": {
+            "category": ["network", "other_type"],
+            "end": "yesteday",
+            "kind": "alert",
+            "module": "suricata",
+            "severity": "low",
+            "start": "yesteday"
+        }
+    })"};
+
+    ASSERT_NO_THROW(jObjDst.merge(json::NOT_RECURSIVE, jObjSrc, "/event"));
     ASSERT_EQ(jObjDst, jObjExpected);
 }
 

--- a/src/engine/source/builder/src/builders/opmap/kvdb.cpp
+++ b/src/engine/source/builder/src/builders/opmap/kvdb.cpp
@@ -20,7 +20,8 @@ TransformOp KVDBGet(std::shared_ptr<IKVDBManager> kvdbManager,
                     const Reference& targetField,
                     const std::vector<OpArg>& opArgs,
                     const std::shared_ptr<const IBuildCtx>& buildCtx,
-                    const bool doMerge)
+                    const bool doMerge,
+                    const bool isRecursive)
 {
     // Assert expected number of parameters
     utils::assertSize(opArgs, 2);
@@ -177,7 +178,7 @@ TransformOp KVDBGet(std::shared_ptr<IKVDBManager> kvdbManager,
                 {
                     RETURN_FAILURE(runState, event, failureTrace5)
                 }
-                event->merge(json::NOT_RECURSIVE, value, targetField);
+                event->merge(isRecursive ? json::RECURSIVE : json::NOT_RECURSIVE, value, targetField);
             }
             else
             {
@@ -212,6 +213,18 @@ TransformBuilder getOpBuilderKVDBGetMerge(std::shared_ptr<IKVDBManager> kvdbMana
                                         const std::shared_ptr<const IBuildCtx>& buildCtx)
     {
         return KVDBGet(kvdbManager, kvdbScopeName, targetField, opArgs, buildCtx, true);
+    };
+}
+
+// <field>: +kvdb_get_merge_recursive/<DB>/<ref_key>
+TransformBuilder getOpBuilderKVDBGetMergeRecursive(std::shared_ptr<IKVDBManager> kvdbManager,
+                                                   const std::string& kvdbScopeName)
+{
+    return [kvdbManager, kvdbScopeName](const Reference& targetField,
+                                        const std::vector<OpArg>& opArgs,
+                                        const std::shared_ptr<const IBuildCtx>& buildCtx)
+    {
+        return KVDBGet(kvdbManager, kvdbScopeName, targetField, opArgs, buildCtx, true, true);
     };
 }
 

--- a/src/engine/source/builder/src/builders/opmap/kvdb.hpp
+++ b/src/engine/source/builder/src/builders/opmap/kvdb.hpp
@@ -27,7 +27,8 @@ TransformOp KVDBGet(std::shared_ptr<IKVDBManager> kvdbManager,
 
                     const std::vector<OpArg>& opArgs,
                     const std::shared_ptr<const IBuildCtx>& buildCtx,
-                    bool merge);
+                    bool merge,
+                    bool isRecursive = false);
 
 /**
  * @brief Builder for KVDB set operation
@@ -76,6 +77,15 @@ TransformBuilder getOpBuilderKVDBGet(std::shared_ptr<IKVDBManager> kvdbManager, 
  * @return Builder
  */
 TransformBuilder getOpBuilderKVDBGetMerge(std::shared_ptr<IKVDBManager> kvdbManager, const std::string& kvdbScopeName);
+
+/**
+ * @brief Builds KVDB extract and merge recursive function helper
+ *
+ * @param kvdbScope KVDB Scope
+ * @return Builder
+ */
+TransformBuilder getOpBuilderKVDBGetMergeRecursive(std::shared_ptr<IKVDBManager> kvdbManager,
+                                                   const std::string& kvdbScopeName);
 
 /**
  * @brief get the KVDB match function helper builder

--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.cpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.cpp
@@ -1877,7 +1877,8 @@ MapOp opBuilderHelperHashSHA1(const std::vector<OpArg>& opArgs, const std::share
 TransformOp opBuilderHelperGetValueGeneric(const Reference& targetField,
                                            const std::vector<OpArg>& opArgs,
                                            const std::shared_ptr<const IBuildCtx>& buildCtx,
-                                           bool isMerge)
+                                           bool isMerge,
+                                           bool isRecursive)
 {
     // TODO: add runtime validation
     // Assert expected number of parameters
@@ -2033,7 +2034,7 @@ TransformOp opBuilderHelperGetValueGeneric(const Reference& targetField,
         {
             try
             {
-                event->merge(json::NOT_RECURSIVE, resolvedValue.value(), targetField);
+                event->merge(isRecursive ? json::RECURSIVE : json::NOT_RECURSIVE, resolvedValue.value(), targetField);
             }
             catch (std::runtime_error& e)
             {
@@ -2059,6 +2060,14 @@ TransformOp opBuilderHelperMergeValue(const Reference& targetField,
                                       const std::shared_ptr<const IBuildCtx>& buildCtx)
 {
     return opBuilderHelperGetValueGeneric(targetField, opArgs, buildCtx, true);
+}
+
+// <field>: +merge_recursive_key_in/$<definition_object>|$<object_reference>/$<key>
+TransformOp opBuilderHelperMergeRecursiveValue(const Reference& targetField,
+                                               const std::vector<OpArg>& opArgs,
+                                               const std::shared_ptr<const IBuildCtx>& buildCtx)
+{
+    return opBuilderHelperGetValueGeneric(targetField, opArgs, buildCtx, true, true);
 }
 
 } // namespace builder::builders

--- a/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
+++ b/src/engine/source/builder/src/builders/opmap/opBuilderHelperMap.hpp
@@ -344,7 +344,8 @@ MapOp opBuilderHelperHashSHA1(const std::vector<OpArg>& opArgs, const std::share
 TransformOp opBuilderHelperGetValueGeneric(const Reference& targetField,
                                            const std::vector<OpArg>& opArgs,
                                            const std::shared_ptr<const IBuildCtx>& buildCtx,
-                                           bool isMerge = false);
+                                           bool isMerge = false,
+                                           bool isRecurive = false);
 
 /**
  * @brief Get the 'get_key_in' function helper builder
@@ -371,6 +372,18 @@ TransformOp opBuilderHelperMergeValue(const Reference& targetField,
                                       const std::vector<OpArg>& opArgs,
                                       const std::shared_ptr<const IBuildCtx>& buildCtx);
 
+/**
+ * @brief Get the 'merge_recursive_key_in' function helper builder
+ *
+ * <field>: +merge_key_in/$<definition_object>|$<object_reference>/$<key>
+ * @param targetField target field of the helper
+ * @param opArgs Vector of operation arguments containing numeric values to be converted.
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @return builder
+ */
+TransformOp opBuilderHelperMergeRecursiveValue(const Reference& targetField,
+                                               const std::vector<OpArg>& opArgs,
+                                               const std::shared_ptr<const IBuildCtx>& buildCtx);
 } // namespace builder::builders
 
 #endif // _OP_BUILDER_HELPER_MAP_H

--- a/src/engine/source/builder/src/builders/utils.hpp
+++ b/src/engine/source/builder/src/builders/utils.hpp
@@ -52,7 +52,7 @@ inline void assertRef(const std::vector<OpArg>& args, Idx... idx)
         {
             if (!args[i]->isReference())
             {
-                throw std::runtime_error(fmt::format("Expected argument {} to be a reference", i));
+                throw std::runtime_error(fmt::format("Expected argument {} to be a reference", i + 1));
             }
         }
     }
@@ -63,7 +63,7 @@ inline void assertRef(const std::vector<OpArg>& args, Idx... idx)
             {
                 if (!args[i]->isReference())
                 {
-                    throw std::runtime_error(fmt::format("Expected argument {} to be a reference", i));
+                    throw std::runtime_error(fmt::format("Expected argument {} to be a reference", i + 1));
                 }
             }(args, idx),
             ...);
@@ -79,7 +79,7 @@ inline void assertValue(const std::vector<OpArg>& args, Idx... idx)
         {
             if (!args[i]->isValue())
             {
-                throw std::runtime_error(fmt::format("Expected argument {} to be a value", i));
+                throw std::runtime_error(fmt::format("Expected argument {} to be a value", i + 1));
             }
         }
     }
@@ -90,7 +90,7 @@ inline void assertValue(const std::vector<OpArg>& args, Idx... idx)
             {
                 if (!args[i]->isValue())
                 {
-                    throw std::runtime_error(fmt::format("Expected argument {} to be a value", i));
+                    throw std::runtime_error(fmt::format("Expected argument {} to be a value", i + 1));
                 }
             }(args, idx),
             ...);

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -231,6 +231,9 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
         "get_key_in", {schemf::runtimeValidation(), builders::opBuilderHelperGetValue}); // TODO: add validation
     registry->template add<builders::OpBuilderEntry>(
         "merge_key_in", {schemf::STypeToken::create(schemf::Type::OBJECT), builders::opBuilderHelperMergeValue});
+    registry->template add<builders::OpBuilderEntry>(
+        "merge_recursive_key_in",
+        {schemf::STypeToken::create(schemf::Type::OBJECT), builders::opBuilderHelperMergeRecursiveValue});
     // Transform helpers: MMDB functions
     registry->template add<builders::OpBuilderEntry>(
         "geoip",
@@ -293,7 +296,12 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
         "kvdb_get", {schemf::runtimeValidation(), builders::getOpBuilderKVDBGet(deps.kvdbManager, deps.kvdbScopeName)});
     registry->template add<builders::OpBuilderEntry>(
         "kvdb_get_merge",
-        {schemf::runtimeValidation(), builders::getOpBuilderKVDBGetMerge(deps.kvdbManager, deps.kvdbScopeName)});
+        {schemf::STypeToken::create(schemf::Type::OBJECT),
+         builders::getOpBuilderKVDBGetMerge(deps.kvdbManager, deps.kvdbScopeName)});
+    registry->template add<builders::OpBuilderEntry>(
+        "kvdb_get_merge_recursive",
+        {schemf::STypeToken::create(schemf::Type::OBJECT),
+         builders::getOpBuilderKVDBGetMergeRecursive(deps.kvdbManager, deps.kvdbScopeName)});
     registry->template add<builders::OpBuilderEntry>(
         "kvdb_match",
         {schemf::runtimeValidation(), builders::getOpBuilderKVDBMatch(deps.kvdbManager, deps.kvdbScopeName)});

--- a/src/engine/source/builder/test/src/unit/builders/opmap/kvdb_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opmap/kvdb_test.cpp
@@ -400,6 +400,40 @@ INSTANTIATE_TEST_SUITE_P(
         TransformDepsT({makeValue(R"("dbname")"), makeValue(R"("key")")},
                        getTrBuilderExpectHandlerError(getOpBuilderKVDBGetMerge, "dbname"),
                        FAILURE()),
+        /*** GET MERGE RECURSIVE***/
+        TransformDepsT({}, getTrBuilder(getOpBuilderKVDBGetMergeRecursive), FAILURE()),
+        TransformDepsT({makeValue(R"("dbname")")}, getTrBuilder(getOpBuilderKVDBGetMergeRecursive), FAILURE()),
+        TransformDepsT({makeValue(R"("dbname")"), makeValue(R"("key")")},
+                       getTrBuilderExpectHandler(getOpBuilderKVDBGetMergeRecursive, "dbname"),
+                       SUCCESS()),
+        TransformDepsT({makeRef("ref"), makeValue(R"("key")")},
+                       getTrBuilder(getOpBuilderKVDBGetMergeRecursive),
+                       FAILURE()),
+        TransformDepsT({makeValue(R"("dbname")"), makeRef("ref")},
+                       getTrBuilderExpectHandler(getOpBuilderKVDBGetMergeRecursive, "dbname"),
+                       SUCCESS(customRefExpected("ref", "targetField"))),
+        TransformDepsT({makeValue(R"("dbname")"), makeValue(R"("key")"), makeValue(R"("other")")},
+                       getTrBuilder(getOpBuilderKVDBGetMergeRecursive),
+                       FAILURE()),
+        TransformDepsT({makeValue(R"("dbname")"), makeValue(R"(1)")},
+                       getTrBuilder(getOpBuilderKVDBGetMergeRecursive),
+                       FAILURE()),
+        TransformDepsT({makeValue(R"("dbname")"), makeRef("ref")},
+                       getTrBuilderExpectHandler(getOpBuilderKVDBGetMergeRecursive, "dbname"),
+                       SUCCESS(
+                           [](const auto& mocks)
+                           {
+                               jTypeRefExpected("ref", json::Json::Type::String)(mocks);
+                               EXPECT_CALL(*mocks.validator, hasField(DotPath("targetField")))
+                                   .WillOnce(testing::Return(false));
+                               return None {};
+                           })),
+        TransformDepsT({makeValue(R"("dbname")"), makeRef("ref")},
+                       getTrBuilder(getOpBuilderKVDBGetMergeRecursive),
+                       FAILURE(jTypeRefExpected("ref", json::Json::Type::Number))),
+        TransformDepsT({makeValue(R"("dbname")"), makeValue(R"("key")")},
+                       getTrBuilderExpectHandlerError(getOpBuilderKVDBGetMergeRecursive, "dbname"),
+                       FAILURE()),
         /*** SET ***/
         TransformDepsT({}, getTrBuilder(getOpBuilderKVDBSet), FAILURE()),
         TransformDepsT({makeValue(R"("dbname")")}, getTrBuilder(getOpBuilderKVDBSet), FAILURE()),

--- a/src/engine/test/helper_tests/helpers_description/transformation/kvdb_get_merge_recursive.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/kvdb_get_merge_recursive.yml
@@ -1,0 +1,47 @@
+# Name of the helper function
+name: kvdb_get_merge_recursive
+
+metadata:
+  description: |
+    Gets the value of a given key in the DB named db-name and, if successful, merges this value with what the field had before.
+    The merge process is recursive, meaning that for object or array types, the new value is deeply integrated with the existing value in the field.
+    Key value type can be string, number, object, array, or null, and it must match the previous value type held by the field.
+    This helper function is typically used in the map stage.
+
+  keywords:
+    - kvdb
+    - recursive
+
+helper_type: transformation
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: false
+
+# Arguments expected by the helper function
+arguments:
+  db-name:
+    type: string  # Accept only object
+    generate: string
+    source: value # Includes only values
+  key:
+    type: string  # Accept only string
+    generate: string
+    source: both # Includes values or references (their names start with $)
+
+# Database not exists
+skipped:
+  - success_cases # key indicate by target_field not found
+
+target_field:
+  type:
+    - object
+    - array
+
+test:
+  - arguments:
+      db-name: testing
+      key: key
+    target_field: Type mismatch between target field and value when merging
+    should_pass: false
+    expected: false
+    description: Failure kvdb get merge

--- a/src/engine/test/helper_tests/helpers_description/transformation/merge_key_in.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/merge_key_in.yml
@@ -1,0 +1,97 @@
+# Name of the helper function
+name: merge_key_in
+
+metadata:
+  description: |
+    Merge in target field value with the content of some key in the specified object, where the key is specified with a reference to another field.
+    The object parameter must be a definition object or a reference to a field containing the object.
+    This helper function is typically used in the map stage.
+
+  keywords:
+    - undefined
+
+helper_type: transformation
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: false
+
+# Arguments expected by the helper function
+arguments:
+  any_object:
+    type: object  # Accept only object
+    generate: object
+    source: both # Includes values or references (their names start with $)
+  key:
+    type: string  # Accept only string
+    generate: string
+    source: reference # includes only references (their names start with $)
+
+# Key not found
+skipped:
+  - success_cases
+
+target_field:
+  type: object
+  generate: object
+
+test:
+  - arguments:
+      any_object:
+        input_key_1:
+          v1: k1
+        input_key_2:
+          v2: k2
+      key: input_key_1
+    target_field:
+      v0: k0
+    should_pass: true
+    expected:
+      v0: k0
+      v1: k1
+    description: The merge was success
+  - arguments:
+      any_object:
+        input_key_1:
+          v1: k1
+        input_key_2:
+          v2: k2
+      key: input_key_not_found
+    target_field:
+      v0: k0
+    should_pass: false
+    description: The input key was not found
+  - arguments:
+      any_object:
+        input_key_1:
+          v1: k1
+          nested:
+            n1: value1
+        input_key_2:
+          v2: k2
+      key: input_key_1
+    target_field:
+      v0: k0
+      nested:
+        n2: value2
+    should_pass: true
+    expected:
+      v0: k0
+      v1: k1
+      nested:
+        n1: value1
+    description: The value from the specified key `input_key_1` is not merged into `target_field`, due to the need for recursion.
+  - arguments:
+      any_object:
+        input_key_1:
+          b: a-value
+          c: a-value
+      key: input_key_1
+    target_field:
+      a: b-value
+      c: b-value
+    should_pass: true
+    expected:
+      a: b-value
+      b: a-value
+      c: a-value
+    description: Success merge in object with same keys

--- a/src/engine/test/helper_tests/helpers_description/transformation/merge_recursive_key_in.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/merge_recursive_key_in.yml
@@ -1,0 +1,117 @@
+# Name of the helper function
+name: merge_recursive_key_in
+
+metadata:
+  description: |
+    Recursively merge the target field value with the content of a specified key in the given object.
+    The key is identified through a reference to another field.
+    If the key's value contains nested objects, the merge operation is applied recursively, combining all levels of the structure.
+    The object parameter must be a definition object or a reference to a field containing the object.
+    This helper function is typically used in the map stage to ensure deep merging of complex objects.
+
+  keywords:
+    - undefined
+
+helper_type: transformation
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: false
+
+# Arguments expected by the helper function
+arguments:
+  any_object:
+    type: object  # Accept only object
+    generate: object
+    source: both # Includes values or references (their names start with $)
+  key:
+    type: string  # Accept only string
+    generate: string
+    source: reference # includes only references (their names start with $)
+
+# Key not found
+skipped:
+  - success_cases
+
+target_field:
+  type: object
+  generate: object
+
+test:
+  - arguments:
+      any_object:
+        input_key_1:
+          v1: k1
+          nested:
+            n1: value1
+        input_key_2:
+          v2: k2
+      key: input_key_1
+    target_field:
+      v0: k0
+      nested:
+        n2: value2
+    should_pass: true
+    expected:
+      v0: k0
+      v1: k1
+      nested:
+        n1: value1
+        n2: value2
+    description: The value from the specified key `input_key_1` is merged into `target_field`, including nested structures.
+  - arguments:
+      any_object:
+        input_key_1:
+          v1: k1
+          other_nested:
+            n1: value1
+        input_key_2:
+          v2: k2
+      key: input_key_1
+    target_field:
+      v0: k0
+      nested:
+        n2: value2
+    should_pass: true
+    expected:
+      v0: k0
+      v1: k1
+      other_nested:
+        n1: value1
+      nested:
+        n2: value2
+    description: The value from the specified key `input_key_1`, including a different nested structure (`other_nested`), is merged into `target_field`.
+  - arguments:
+      any_object:
+        input_key_1:
+          v1: k1
+          nested:
+            n1: value1
+        input_key_2:
+          v2: k2
+      key: input_key_1
+    target_field:
+      v1: k1
+      nested:
+        n2: value2
+    should_pass: true
+    expected:
+      v1: k1
+      nested:
+        n1: value1
+        n2: value2
+    description: The `nested` content from the specified key `input_key_1` is merged into `target_field`, preserving existing fields.
+  - arguments:
+      any_object:
+        input_key_1:
+          v1: k1
+          nested:
+            n1: value1
+        input_key_2:
+          v2: k2
+      key: input_key_not_exists
+    target_field:
+      v0: k0
+      nested:
+        n2: value2
+    should_pass: false
+    description: The specified key `input_key_not_exists` does not exist in `any_object`, so no merge is performed, and the test fails as expected.


### PR DESCRIPTION
|Related issue|
|---|
|#27878|

## Description
The helper functions `kvdb_get_merge` and `get_key_in` within the Wazuh-Engine ruleset need enhancements to increase their functionality and flexibility. It is proposed to add optional parameters to these functions to control their behavior more finely.

## Objective
- **Enhance Functionality**: Introduce optional parameters to the `kvdb_get_merge` and `get_key_in` functions to specify their operational behaviors.
- **Default Behavior Preservation**: Ensure that the default behaviors of these functions remain unchanged unless explicitly specified by the new parameters.