### PR TITLE
Path deletion and references in the code

### DIFF
--- a/apis/tools/env/wazuh-server/Dockerfile
+++ b/apis/tools/env/wazuh-server/Dockerfile
@@ -62,8 +62,6 @@ RUN groupmod -n "$GROUP" ubuntu && usermod -l "$USER" ubuntu
 # Copy directories from builder
 COPY --from=builder --chown=${USER}:${GROUP} /etc/wazuh-server /etc/wazuh-server
 
-COPY --from=builder --chown=${USER}:${GROUP} /var/log/wazuh-server /var/log/wazuh-server
-
 COPY --from=builder --chown=${USER}:${GROUP} /var/lib/wazuh-server /var/lib/wazuh-server
 
 COPY --from=builder --chown=${USER}:${GROUP} /usr/share/wazuh-server /usr/share/wazuh-server

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -26,7 +26,7 @@ class WazuhException(Exception):
         # Wazuh: 0999 - 1099
         999: 'Incompatible version of Python',
         1000: {'message': 'Wazuh Internal Error',
-       '       remediation': 'Please, check the Wazuh Server logs for more information about the error'},
+       '       remediation': 'Please, check the server logs for more information about the error'},
         1001: 'Error importing module',
         1002: 'Error executing command',
         1005: {'message': 'Error reading file',
@@ -43,8 +43,6 @@ class WazuhException(Exception):
                'remediation': 'Please, restart Wazuh to restore sockets'},
         1017: 'Some Wazuh daemons are not ready yet in node "{node_name}" ({not_ready_daemons})',
         1018: 'Body request is not a valid JSON',
-        1020: {'message': 'Could not find any Wazuh log file',
-               'remediation': 'Please check `WAZUH_HOME/logs`'},
 
         # Configuration: 1100 - 1199
         1101: {'message': 'Requested component does not exist',
@@ -288,7 +286,7 @@ class WazuhException(Exception):
         3022: {'message': 'Unknown node ID',
                'remediation': 'Check the name of the node'},
         3023: {'message': 'Worker node is not connected to master',
-               'remediation': 'Check the Wazuh Server logs to identify potential connection errors.'},
+               'remediation': 'Check the server logs to identify potential connection errors.'},
         3024: "Length of command exceeds limit defined in wazuh.cluster.common.Handler.cmd_len.",
         3026: "Error sending request: Memory error. Request chunk size divided by 2.",
         3027: "Unknown received task name",
@@ -431,7 +429,7 @@ class WazuhException(Exception):
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
         dapi_errors : dict
             Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': 'Refer to the Wazuh Server logs for more details.'}}
+            'logfile': 'Refer to the server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str
@@ -570,7 +568,7 @@ class WazuhInternalError(WazuhException):
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
         dapi_errors : dict
             Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': 'Refer to the Wazuh Server logs for more details.'}}
+            'logfile': 'Refer to the server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str
@@ -661,7 +659,7 @@ class WazuhError(WazuhException):
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
         dapi_errors : dict
             Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': 'Refer to the Wazuh Server logs for more details.'}}
+            'logfile': 'Refer to the server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -26,8 +26,7 @@ class WazuhException(Exception):
         # Wazuh: 0999 - 1099
         999: 'Incompatible version of Python',
         1000: {'message': 'Wazuh Internal Error',
-               'remediation': 'Please, check `/var/log/wazuh-server/cluster.log` and '
-                              '`/var/log/wazuh-server/logs/api.log` to get more information about the error'},
+       '       remediation': 'Please, check the Wazuh Server logs for more information about the error'},
         1001: 'Error importing module',
         1002: 'Error executing command',
         1005: {'message': 'Error reading file',
@@ -289,8 +288,7 @@ class WazuhException(Exception):
         3022: {'message': 'Unknown node ID',
                'remediation': 'Check the name of the node'},
         3023: {'message': 'Worker node is not connected to master',
-               'remediation': 'Check the cluster.log located at WAZUH_HOME/logs/cluster.log file to see if there are '
-                              'connection errors. Restart the `wazuh-manager` service.'},
+               'remediation': 'Check the Wazuh Server logs to identify potential connection errors.'},
         3024: "Length of command exceeds limit defined in wazuh.cluster.common.Handler.cmd_len.",
         3026: "Error sending request: Memory error. Request chunk size divided by 2.",
         3027: "Unknown received task name",
@@ -433,7 +431,7 @@ class WazuhException(Exception):
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
         dapi_errors : dict
             Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': WAZUH_HOME/logs/api.log}}
+            'logfile': 'Refer to the Wazuh Server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str
@@ -572,7 +570,7 @@ class WazuhInternalError(WazuhException):
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
         dapi_errors : dict
             Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': WAZUH_HOME/logs/api.log}}
+            'logfile': 'Refer to the Wazuh Server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str
@@ -663,7 +661,7 @@ class WazuhError(WazuhException):
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
         dapi_errors : dict
             Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': WAZUH_HOME/logs/api.log}}
+            'logfile': 'Refer to the Wazuh Server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str

--- a/framework/wazuh/core/manager.py
+++ b/framework/wazuh/core/manager.py
@@ -132,7 +132,7 @@ def get_ossec_logs(limit: int = 2000) -> list:
     elif log_format == LoggingFormat.json and exists(common.WAZUH_LOG_JSON):
         wazuh_log_content = tail(common.WAZUH_LOG_JSON, limit)
     else:
-        raise WazuhInternalError(1020)
+        raise WazuhInternalError(1000)
 
     for line in wazuh_log_content:
         log_fields = get_ossec_log_fields(line, log_format=log_format)

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -122,7 +122,7 @@ def test_get_ossec_logs(log_format):
     logs = get_logs(json_log=log_format == LoggingFormat.json).splitlines()
 
     with patch("wazuh.core.manager.get_wazuh_active_logging_format", return_value=log_format):
-        with pytest.raises(WazuhInternalError, match=".*1020.*"):
+        with pytest.raises(WazuhInternalError, match=".*1000.*"):
             get_ossec_logs()
 
         with patch('wazuh.core.manager.exists', return_value=True):

--- a/packages/debs/SPECS/debian/postrm
+++ b/packages/debs/SPECS/debian/postrm
@@ -34,10 +34,6 @@ case "$1" in
         if [ -d "/etc/wazuh-server" ]; then
             rm -rf /etc/wazuh-server || true
         fi
-
-        if [ -d "/var/log/wazuh-server" ]; then
-            rm -rf /var/log/wazuh-server || true
-        fi
     ;;
 
     upgrade)

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -74,7 +74,6 @@ override_dh_install:
 	cp -p $(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-keystore $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/
 
 	cp -pr $(INSTALLATION_DIR)var/lib/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/
-	cp -pr $(INSTALLATION_DIR)var/log/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/log/
 	cp -pr $(INSTALLATION_DIR)usr/share/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/
 	cp -pr $(INSTALLATION_DIR)etc/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)etc/
 
@@ -97,8 +96,6 @@ override_dh_fixperms:
 	find $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server
-	find $(TARGET_DIR)$(INSTALLATION_DIR)var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 	# Binaries
 	chown $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-keystore

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -91,7 +91,6 @@ cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-server ${RPM_BUILD_ROOT}
 cp -p %{_localstatedir}usr/share/wazuh-server/bin/wazuh-keystore ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/wazuh-server/bin/
 
 cp -pr %{_localstatedir}var/lib/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}var/lib/
-cp -pr %{_localstatedir}var/log/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}var/log/
 cp -pr %{_localstatedir}usr/share/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}usr/share/
 cp -pr %{_localstatedir}etc/wazuh-server ${RPM_BUILD_ROOT}%{_localstatedir}etc/
 
@@ -174,7 +173,6 @@ if [ $1 = 0 ];then
   # Remove lingering folders and files
   rm -rf %{_localstatedir}run/wazuh-server
   rm -rf %{_localstatedir}var/lib/wazuh-server
-  rm -rf %{_localstatedir}var/log/wazuh-server
   rm -rf %{_localstatedir}usr/share/wazuh-server
   rm -rf %{_localstatedir}etc/wazuh-server
 fi
@@ -198,8 +196,6 @@ fi
 
 chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}var/lib/wazuh-server
 find %{_localstatedir}var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}var/log/wazuh-server
-find %{_localstatedir}var/log/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server
 find %{_localstatedir}usr/share/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}etc/wazuh-server
@@ -241,8 +237,6 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/tmp
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/log/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/cluster

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -175,8 +175,6 @@ InstallEngine()
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/vd
   ${INSTALL} -d -m 0750 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine
-  ${INSTALL} -d -m 0755 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server
-  ${INSTALL} -d -m 0755 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ${INSTALLDIR}var/log/wazuh-server/engine
 
   cp -rp engine/build/tzdb ${INSTALLDIR}var/lib/wazuh-server/engine/
   chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}var/lib/wazuh-server/engine/tzdb


### PR DESCRIPTION
|Related issue|
|---|
| #27809  |


## Description

This PR closes https://github.com/wazuh/wazuh/issues/27809, thus removing the references, files, and paths related to:

- `/var/log/wazuh-server`
- `var/log/wazuh-server/engine`
- `cluster.log`
- `api.log`

<details>

<summary>Manager-start</summary>

```console
wazuh@javier:~/Git/wazuh/apis/tools/env$ docker logs 0c9bfed29b6c
2025/01/30 12:31:27 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2025/01/30 12:31:27 DEBUG: [Cluster] [Main] Nothing to remove in '/run/wazuh-server/cluster/'.
2025/01/30 12:31:27 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
2025/01/30 12:31:27 INFO: [Cluster] [Main] Starting server (pid: 12)
2025/01/30 12:31:27 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/30 12:31:27 INFO: [Master] [Config Server] Started server process [12]
2025/01/30 12:31:27 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/30 12:31:27 INFO: [Master] [Config Server] Application startup complete.
2025/01/30 12:31:27 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/30 12:31:28 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-30 12:31:28.646 18:18 info: Logging initialized.
2025/01/30 12:31:28 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-30 12:31:28.650 18:18 info: Metrics manager configured successfully
2025-01-30 12:31:28.650 18:18 info: Metrics initialized.
2025-01-30 12:31:28.650 18:18 info: Metrics disabled.
2025-01-30 12:31:28.650 18:18 info: Store initialized.
2025-01-30 12:31:28.650 18:18 warning: Could not load RBAC model, using default model: File '/var/lib/wazuh-server/engine/store/internal/rbac/model/0' does not exist
2025-01-30 12:31:28.651 18:18 info: RBAC initialized.
2025-01-30 12:31:28.663 18:18 info: KVDB initialized.
2025-01-30 12:31:28.663 18:18 info: Geo initialized.
2025-01-30 12:31:28.678 18:18 info: Schema initialized.
2025-01-30 12:31:28.691 18:18 info: Loaded timezone database version: '2024a'
2025-01-30 12:31:28.695 18:18 info: HLP initialized.
2025-01-30 12:31:28.705 18:18 info: Indexer Connector initialized.
2025-01-30 12:31:28.705 18:18 info: Builder initialized.
2025-01-30 12:31:28.705 18:18 info: Catalog initialized.
2025-01-30 12:31:28.705 18:18 info: Policy manager initialized.
2025-01-30 12:31:28.706 18:18 info: No flooding file provided, the queue will not be flooded.
2025-01-30 12:31:28.713 18:18 info: No flooding file provided, the queue will not be flooded.
2025-01-30 12:31:28.714 18:18 info: Router: router/router/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/router/0' does not exist
2025-01-30 12:31:28.714 18:18 info: Router: router/tester/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/tester/0' does not exist
2025-01-30 12:31:28.714 18:18 warning: Router: EPS settings could not be loaded from the store due to 'File '/var/lib/wazuh-server/engine/store/router/eps/0' does not exist'. Using default settings
2025-01-30 12:31:28.714 18:18 info: Router: EPS settings dumped to the store
2025-01-30 12:31:28.714 18:18 info: Router initialized.
2025-01-30 12:31:28.714 18:18 info: Starting database file decompression.
2025/01/30 12:31:30 INFO: [Local Server] [Main] Started wazuh-engined (pid: 18)
2025/01/30 12:31:30 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/30 12:31:32 INFO: [Communications API] Starting API
2025/01/30 12:31:32 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/01/30 12:31:32 INFO: [Communications API] Generated private key file in /etc/wazuh-server/certs/api-key.pem
2025/01/30 12:31:32 INFO: [Communications API] Generated certificate file in /etc/wazuh-server/certs/api.pem
2025/01/30 12:31:32 INFO: [Communications API] Starting gunicorn 22.0.0
2025/01/30 12:31:32 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (74)
2025/01/30 12:31:32 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/01/30 12:31:32 INFO: [Communications API] Booting worker with pid: 123
2025/01/30 12:31:32 INFO: [Communications API] Started server process [74]
2025/01/30 12:31:32 INFO: [Communications API] Waiting for application startup.
2025/01/30 12:31:32 INFO: [Communications API] Application startup complete.
2025/01/30 12:31:32 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/01/30 12:31:32 INFO: [Communications API] Booting worker with pid: 124
2025/01/30 12:31:32 INFO: [Communications API] Started server process [124]
2025/01/30 12:31:32 INFO: [Communications API] Waiting for application startup.
2025/01/30 12:31:32 INFO: [Communications API] Application startup complete.
2025/01/30 12:31:32 INFO: [Communications API] Booting worker with pid: 125
2025/01/30 12:31:32 INFO: [Communications API] Started server process [125]
2025/01/30 12:31:32 INFO: [Communications API] Waiting for application startup.
2025/01/30 12:31:32 INFO: [Communications API] Application startup complete.
2025/01/30 12:31:32 INFO: [Communications API] Booting worker with pid: 126
2025/01/30 12:31:32 INFO: [Communications API] Started server process [126]
2025/01/30 12:31:32 INFO: [Communications API] Waiting for application startup.
2025/01/30 12:31:32 INFO: [Communications API] Application startup complete.
2025/01/30 12:31:32 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 74)
2025/01/30 12:31:32 INFO: [Local Server] [Main] Starting wazuh-server-management-apid
2025/01/30 12:31:33 INFO: [Management API] Starting API
2025/01/30 12:31:33 INFO: [Management API] Checking RBAC database integrity...
2025/01/30 12:31:33 INFO: [Management API] RBAC database not found. Initializing
2025/01/30 12:31:34 INFO: [Local Server] [Main] Started wazuh-server-management-apid (pid: 127)
2025/01/30 12:31:34 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/01/30 12:31:34 DEBUG: [Local Server] [Keep alive] Calculating.
2025/01/30 12:31:34 DEBUG: [Local Server] [Keep alive] Calculated.
2025/01/30 12:31:34 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2025/01/30 12:31:34 DEBUG: [Master] [Keep alive] Calculating.
2025/01/30 12:31:34 DEBUG: [Master] [Keep alive] Calculated.
2025/01/30 12:31:34 INFO: [Master] [Local integrity] Starting.
2025/01/30 12:31:34 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/01/30 12:31:34 INFO: [Worker] [Main] Connection from ('172.18.0.4', 50438)
2025/01/30 12:31:34 DEBUG: [Worker] [Main] Command received: b'hello'
2025/01/30 12:31:35 INFO: [Management API] /var/lib/wazuh-server/rbac.db database created successfully
2025/01/30 12:31:35 INFO: [Management API] RBAC database integrity check finished successfully
2025/01/30 12:31:36 INFO: [Management API] Listening on ['0.0.0.0', '::']:55000.
2025/01/30 12:31:36 INFO: [Management API] Populating installation UID...
2025/01/30 12:31:36 INFO: [Management API] Getting updates information...
2025/01/30 12:31:37 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/30 12:31:37 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/30 12:31:37 WARNING: [Cluster] [Main] Cannot initialize the indexer client.
2025/01/30 12:31:37 INFO: [Cluster] [Main] Sleeping 1.1521289890660524s until next try.
2025/01/30 12:31:38 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/30 12:31:38 WARNING: [Cluster] [Main] Cannot initialize the indexer client.
2025/01/30 12:31:38 INFO: [Cluster] [Main] Sleeping 2.4079769370683506s until next try.
2025/01/30 12:31:40 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/30 12:31:40 WARNING: [Cluster] [Main] Cannot initialize the indexer client.
2025/01/30 12:31:40 INFO: [Cluster] [Main] Sleeping 4.9175746922816375s until next try.
2025/01/30 12:31:42 INFO: [Master] [Local integrity] Starting.
2025/01/30 12:31:42 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
2025/01/30 12:31:43 DEBUG: [Worker worker1] [Main] Command received: b'syn_i_w_m_p'
2025/01/30 12:31:43 DEBUG: [Worker worker1] [Main] Command received: b'syn_i_w_m'
2025/01/30 12:31:43 INFO: [Worker worker1] [Integrity check] Starting.
2025/01/30 12:31:43 DEBUG: [Worker worker1] [Main] Command received: b'new_file'
2025/01/30 12:31:43 DEBUG: [Worker worker1] [Main] Command received: b'file_upd'
2025/01/30 12:31:43 DEBUG: [Worker worker1] [Main] Command received: b'file_end'
2025/01/30 12:31:43 DEBUG: [Worker worker1] [Main] Command received: b'syn_i_w_m_e'
```
</details>

<details>

<summary>Manager testing</summary>

```console
root@wazuh-manager:/# ls -l /var/log/
total 264
-rw-r--r-- 1 root root   9285 Jan 30 11:47 alternatives.log
drwxr-xr-x 1 root root   4096 Jan 30 11:47 apt
-rw-r--r-- 1 root root  61229 Nov 19 09:46 bootstrap.log
-rw-rw---- 1 root utmp      0 Nov 19 09:46 btmp
-rw-r--r-- 1 root root 187301 Jan 30 11:47 dpkg.log
-rw-r--r-- 1 root root      0 Nov 19 09:46 faillog
-rw-rw-r-- 1 root utmp      0 Nov 19 09:46 lastlog
-rw-rw-r-- 1 root utmp      0 Nov 19 09:46 wtmp
```

```console
root@wazuh-manager:/# ls -l /var/log/wazuh-server
ls: cannot access '/var/log/wazuh-server': No such file or directory
```

```console
root@wazuh-manager:/# find / -iname wazuh-server
/run/wazuh-server
/usr/share/wazuh-server
/usr/share/wazuh-server/bin/wazuh-server
/etc/wazuh-server
/var/lib/wazuh-server
```

```console
root@wazuh-manager:/# find / -iname engine
/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/wazuh/core/engine
/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/sqlalchemy/engine
/var/lib/wazuh-server/engine
```

</details>


<details>

<summary>RPM package testing</summary>

```console
[root@bae46e61abaa /]# cat /etc/os-release
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"
```

```console
[root@bae46e61abaa /]# ls -lh /root/
total 289M
-rw-r--r-- 1 1000 1000 289M Jan 30 14:08 wazuh-server_5.0.0-27809_x86_64_fdce330.rpm
```

```console
[root@bae46e61abaa /]# rpm -qa | grep wazuh-server
wazuh-server-5.0.0-27809.x86_64
```


```console
[root@bae46e61abaa /]# ls -l /var/log/
total 48
-rw------- 1 root utmp      0 Nov 13  2020 btmp
-rw-r--r-- 1 root root    193 Nov 13  2020 grubby_prune_debug
-rw-r--r-- 1 root root 292000 Jan 31 09:47 lastlog
-rw------- 1 root root  64000 Jan 31 09:47 tallylog
-rw-rw-r-- 1 root utmp      0 Nov 13  2020 wtmp
-rw------- 1 root root   1430 Nov 13  2020 yum.log
```

```console
[root@bae46e61abaa /]# ls -l /var/log/wazuh-server
ls: cannot access /var/log/wazuh-server: No such file or directory
```

```console
[root@bae46e61abaa /]# find / -iname wazuh-server
/usr/share/wazuh-server
/usr/share/wazuh-server/bin/wazuh-server
/etc/rc.d/init.d/wazuh-server
/etc/wazuh-server
/var/lib/wazuh-server
```

```console
[root@bae46e61abaa /]# find / -iname engine      
/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/wazuh/core/engine
/usr/share/wazuh-server/framework/python/lib/python3.10/site-packages/sqlalchemy/engine
/var/lib/wazuh-server/engine
```

</details>


### Unit test

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/wazuh/core/tests/test_exception.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: cov-4.1.0, anyio-4.8.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 10 items                                                                                                                                                                                                

framework/wazuh/core/tests/test_exception.py ..........                                                                                                                                                     [100%]

=============================================================================================== 10 passed in 0.06s ================================================================================================
```