### PR TITLE
Add commands `document_id` field parsing

### DIFF
--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -84,7 +84,10 @@ class CommandsManager(BaseIndex):
 
         commands = []
         for hit in response:
-            commands.append(Command(**hit.to_dict()[COMMAND_KEY]))
+            commands.append(Command(
+                document_id=hit.meta[IndexerKey.ID],
+                **hit.to_dict()[COMMAND_KEY]
+            ))
 
         return commands
 

--- a/framework/wazuh/core/indexer/tests/test_commands.py
+++ b/framework/wazuh/core/indexer/tests/test_commands.py
@@ -78,9 +78,18 @@ class TestCommandsManager:
     async def test_get_commands(self, index_instance: CommandsManager, client_mock: mock.AsyncMock):
         """Check the correct functionality of the `get_commands` method."""
         document_id = '0191c248-095c-75e6-89ec-612fa5727c2e'
-        search_result = {'_hits': [Hit({IndexerKey._SOURCE: {COMMAND_KEY: {'document_id': document_id}}})]}
+        search_result = {'_hits': [
+            Hit({
+                IndexerKey._ID: document_id,
+                IndexerKey._SOURCE: {
+                    COMMAND_KEY: {
+                        'source': Source.SERVICES
+                    }
+                }
+            })
+        ]}
         client_mock.search.return_value = search_result
-        expected_result = [Command(document_id=document_id)]
+        expected_result = [Command(document_id=document_id, source=Source.SERVICES)]
 
         result = await index_instance.get_commands(Status.PENDING)
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27885 |

## Description

Fixes the commands `document_id` field parsing.

## Tests

<details><summary>Agent group assignment</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X PUT -ks "https://0.0.0.0:55000/agents/group?agents_list=0a96a0ab-5bef-415c-bb3c-ea3e294215a0&group_id=group1" | jq
{
  "data": {
    "affected_items": [
      "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents were assigned to group1",
  "error": 0
}
```

</details>

<details><summary>Indexed commands</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -X POST -H "Content-Type: application/json" -ku admin:admin https://localhost:9200/wazuh-commands/_search?pretty 
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "wazuh-commands",
        "_id" : "OQ1crZQBZMgnVZd3NKxQ",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "command" : {
            "source" : "Users/Services",
            "user" : "Management API",
            "target" : {
              "type" : "agent",
              "id" : "0a96a0ab-5bef-415c-bb3c-ea3e294215a0"
            },
            "action" : {
              "name" : "set-group",
              "args" : {
                "groups" : [
                  "group1"
                ]
              },
              "version" : "5.0.0"
            },
            "timeout" : 100,
            "status" : "pending",
            "order_id" : "OA1crZQBZMgnVZd3NKxQ",
            "request_id" : "Nw1crZQBZMgnVZd3NKxQ"
          },
          "@timestamp" : "2025-01-28T14:41:28Z",
          "delivery_timestamp" : "2025-01-28T14:43:08Z"
        }
      }
    ]
  }
}
```

</details>


<details><summary>Get agent commands</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:27000/api/v1/commands | jq
{
  "commands": [
    {
      "document_id": "OQ1crZQBZMgnVZd3NKxQ",
      "request_id": "Nw1crZQBZMgnVZd3NKxQ",
      "order_id": "OA1crZQBZMgnVZd3NKxQ",
      "source": "Users/Services",
      "user": "Management API",
      "target": {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "type": "agent"
      },
      "action": {
        "name": "set-group",
        "version": "5.0.0",
        "args": {
          "groups": [
            "group1"
          ]
        }
      },
      "timeout": 100,
      "status": "pending"
    }
  ]
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
===================================================================== test session starts =====================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 8 items                                                                                                                                             

framework/wazuh/core/indexer/tests/test_commands.py ........                                                                                            [100%]

====================================================================== 8 passed in 0.24s ======================================================================
```

</details>
