### PR TITLE
Fix typo in agents restart commands creation

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -20,7 +20,7 @@ from wazuh.core.indexer.base import IndexerKey
 from wazuh.core.indexer.agent import DEFAULT_GROUP
 from wazuh.core.indexer.models.agent import Host as IndexerAgentHost
 from wazuh.core.indexer.models.commands import ResponseResult
-from wazuh.core.indexer.commands import create_restart_command, create_set_group_command, create_fetch_config_command
+from wazuh.core.indexer.commands import create_restart_command, create_set_group_command
 from wazuh.core.InputValidator import InputValidator
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.utils import (

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -154,7 +154,7 @@ async def restart_agents(agent_list: list) -> AffectedItemsWazuhResult:
                 commands.append(command)
 
             response = await indexer_client.commands_manager.create(commands)
-            if response.result not in (ResponseResult.OK, ResponseResult.CREATED):
+            if response.result in (ResponseResult.OK, ResponseResult.CREATED):
                 result.affected_items.extend(agent_list)
             else:
                 for agent_id in agent_list:


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27888 |

## Description

Fixes a typo in the condition that checked the success of the `restart` commands creation.

## Tests

<details><summary>Restart agents</summary>

```console
gasti@gasti:~$ curl -X PUT https://127.0.0.1:55000/agents/restart -k -H "Authorization: Bearer $TOKEN"
{"data": {"affected_items": ["fce92761-e3aa-417d-b20b-d3229bcffd09"], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "Restart command was sent to all agents", "error": 0}
```

</details>

<details><summary>Indexed command</summary>

```console
gasti@gasti:~$ curl -X POST -H "Content-Type: application/json" -ku admin:admin https://localhost:9200/wazuh-commands/_search?pretty -d'
{
   "query": {
      "match_all": {}
   }
}'
{
  "took" : 1,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "wazuh-commands",
        "_id" : "YJJ3rZQBy01sG9R088Dt",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "groups" : [
              "groups000"
            ]
          },
          "@timestamp" : "2025-01-28T15:11:47Z",
          "delivery_timestamp" : "2025-01-28T15:13:27Z",
          "command" : {
            "action" : {
              "args" : { },
              "name" : "restart",
              "version" : "5.0.0"
            },
            "source" : "Users/Services",
            "user" : "Management API",
            "order_id" : "X5J3rZQBy01sG9R088Dt",
            "request_id" : "XpJ3rZQBy01sG9R088Dt",
            "timeout" : 100,
            "target" : {
              "id" : "fce92761-e3aa-417d-b20b-d3229bcffd09",
              "type" : "agent"
            },
            "status" : [
              "sent"
            ]
          }
        }
      }
    ]
  }
}
```

</details>

<details><summary>Agent logs</summary>

This error is expected, since the agent currently only supports commands `set-group` and `fetch-config` -> https://github.com/wazuh/wazuh-agent/blob/0201834a4e244224f84996d9d1ca3dde77cdec16/src/agent/command_handler/src/command_handler.cpp#L13-L21

Support will be added in https://github.com/wazuh/wazuh-agent/issues/54 

```console
[2025-01-28 15:12:01.850] [wazuh-agent] [debug] [DEBUG] [http_client.cpp:232] [Co_PerformHttpRequest] Request /api/v1/commands: Status 200
[2025-01-28 15:12:01.850] [wazuh-agent] [trace] [TRACE] [http_client.cpp:233] [Co_PerformHttpRequest] Request endpoint: /api/v1/commands
Response: HTTP/1.1 200 OK
date: Tue, 28 Jan 2025 15:12:01 GMT
server: uvicorn
server: Wazuh
content-length: 295
content-type: application/json
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store

{"commands":[{"request_id":"XpJ3rZQBy01sG9R088Dt","order_id":"X5J3rZQBy01sG9R088Dt","source":"Users/Services","user":"Management API","target":{"id":"fce92761-e3aa-417d-b20b-d3229bcffd09","type":"agent"},"action":{"name":"restart","version":"5.0.0","args":{}},"timeout":100,"status":"pending"}]}
[2025-01-28 15:12:02.843] [wazuh-agent] [debug] [DEBUG] [command_handler.cpp:72] [CommandsProcessingTask] Processing command: restart({})
[2025-01-28 15:12:02.843] [wazuh-agent] [error] [ERROR] [command_handler.cpp:176] [CheckCommand] The command restart is not valid.
[2025-01-28 15:12:02.843] [wazuh-agent] [error] [ERROR] [command_handler.cpp:78] [CommandsProcessingTask] Error checking module and args for command:  restart. Error: Command is not valid
```

</details>

<details><summary>Unit tests</summary>

Unit tests are still broken. We should fix them as soon as possible, this bug could have been detected by a unit test failing.

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/tests/test_agent.py::test_agent_restart_agents --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 0 items / 1 error                                                                                                                                                                                                                  

=================================================================================================================== ERRORS ===================================================================================================================
_________________________________________________________________________________________________ ERROR collecting wazuh/tests/test_agent.py _________________________________________________________________________________________________
framework/wazuh/tests/test_agent.py:20: in <module>
    with patch('wazuh.core.utils.load_wazuh_xml'):
/usr/local/lib/python3.10/unittest/mock.py:1447: in __enter__
    original, local = self.get_original()
/usr/local/lib/python3.10/unittest/mock.py:1420: in get_original
    raise AttributeError(
E   AttributeError: <module 'wazuh.core.utils' from '/home/gasti/work/wazuh/framework/wazuh/core/utils.py'> does not have the attribute 'load_wazuh_xml'
========================================================================================================== short test summary info ===========================================================================================================
ERROR framework/wazuh/tests/test_agent.py - AttributeError: <module 'wazuh.core.utils' from '/home/gasti/work/wazuh/framework/wazuh/core/utils.py'> does not have the attribute 'load_wazuh_xml'
============================================================================================================== 1 error in 0.20s ==============================================================================================================
ERROR: not found: /home/gasti/work/wazuh/framework/wazuh/tests/test_agent.py::test_agent_restart_agents
(no name '/home/gasti/work/wazuh/framework/wazuh/tests/test_agent.py::test_agent_restart_agents' in any of [<Module wazuh/tests/test_agent.py>])
```

</details>
