### PR TITLE
Modify check 3.5.3.1.2 to ensure nftables and iptables don't co-exist in Ubuntu SCAs

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu18-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu18-04.yml
@@ -2007,8 +2007,8 @@ checks:
       - pci_dss_v3.2.1: ["1.4"]
     condition: all
     rules:
-      - "c:dpkg -s iptables -> r:Status: install ok installed"
-      - "c:dpkg -s nftables -> r:package 'nftables' is not installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:install ok installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:unknown ok not-installed|no packages found matching"
 
   # 3.5.3.1.3 Ensure ufw is uninstalled or disabled with iptables (Automated)
   - id: 18601

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -2324,7 +2324,8 @@ checks:
       - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables -> r:unknown ok not-installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:install ok installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:unknown ok not-installed|no packages found matching"
 
   # 3.4.3.1.3 Ensure ufw is uninstalled or disabled with iptables. (Automated)
   - id: 19095

--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -2097,8 +2097,8 @@ checks:
       - soc_2: ["CC6.6"]
     condition: all
     rules:
-      - "not c:dpkg-query -s nftables -> r:install ok installed"
-      - "c:dpkg-query -s iptables -> r:install ok installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:install ok installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:unknown ok not-installed|no packages found matching"
 
   # 3.5.3.1.3 Ensure ufw is uninstalled or disabled with iptables. (Automated)
   - id: 28585

--- a/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
@@ -3282,8 +3282,8 @@ checks:
        - soc_2: ["CC6.6"]
      condition: all
      rules:
-      - "not c:dpkg-query -s nftables -> r:install ok installed"
-      - "c:dpkg-query -s iptables -> r:install ok installed"
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:install ok installed""
+      - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:unknown ok not-installed|no packages found matching"
 
   # 4.4.1.3 Ensure ufw is not in use with iptables. (Automated)
    - id: 35635


### PR DESCRIPTION
## Description
User reported that their host fail the check even though it had only nftables without iptables.

## Change to be made

```
- condition: all  # iptables or nftables installed AND iptables or nftables not installed
        rules:
          - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:install ok installed" 
          - "c:dpkg-query -W -f='${binary:Package}\\t${Status}\\t${db:Status-Status}\\n' nftables iptables -> r:unknown ok not-installed|no packages found matching"
```