### PR TITLE
Update default certificate paths

### DIFF
--- a/etc/wazuh-server.yml
+++ b/etc/wazuh-server.yml
@@ -9,8 +9,8 @@ server:
       cert: /etc/wazuh-server/certs/server.pem
       ca: /etc/wazuh-server/certs/root-ca.pem
   jwt:
-      private_key: /etc/wazuh-server/certs/private-key.pem
-      public_key: /etc/wazuh-server/certs/public-key.pem
+    private_key: /etc/wazuh-server/certs/private-key.pem
+    public_key: /etc/wazuh-server/certs/public-key.pem
 indexer:
   hosts:
     - host: localhost
@@ -19,16 +19,16 @@ indexer:
   password: admin
   ssl:
     use_ssl: true
-    key: /etc/wazuh-server/certs/indexer-key.pem
-    certificate: /etc/wazuh-server/certs/indexer.pem
+    key: /etc/wazuh-server/certs/server-key.pem
+    certificate: /etc/wazuh-server/certs/server.pem
     certificate_authorities:
       - /etc/wazuh-server/certs/root-ca.pem
 communications_api:
   host: localhost
   port: 27000
   ssl:
-    key: /etc/wazuh-server/certs/api-key.pem
-    cert: /etc/wazuh-server/certs/api.pem
+    key: /etc/wazuh-server/certs/server-key.pem
+    cert: /etc/wazuh-server/certs/server.pem
     use_ca: false
     ca: /etc/wazuh-server/certs/root-ca.pem
 management_api:
@@ -37,7 +37,7 @@ management_api:
     - ::1
   port: 55000
   ssl:
-    key: /etc/wazuh-server/certs/api-key.pem
-    cert: /etc/wazuh-server/certs/api.pem
+    key: /etc/wazuh-server/certs/server-key.pem
+    cert: /etc/wazuh-server/certs/server.pem
     use_ca: false
     ca: /etc/wazuh-server/certs/root-ca.pem


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27905 |

## Description

Updates the default configuration certificates paths to facilitate development and testing deployments.

> [!Note]
> This shouldn't be the production default configuration when `5.0.0` gets released, reusing the same certificate has many security downsides.

## Tests

<details><summary>Validate default configuration content</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ docker run -it dev-wazuh-server bash
root@ab2465c65543:/# cat /etc/wazuh-server/wazuh-server.yml
server:
  nodes:
    - master
  node:
    name: server_01
    type: master
    ssl:
      key: /etc/wazuh-server/certs/server-key.pem
      cert: /etc/wazuh-server/certs/server.pem
      ca: /etc/wazuh-server/certs/root-ca.pem
  jwt:
      private_key: /etc/wazuh-server/certs/private-key.pem
      public_key: /etc/wazuh-server/certs/public-key.pem
indexer:
  hosts:
    - host: localhost
      port: 9200
  username: admin
  password: admin
  ssl:
    use_ssl: true
    key: /etc/wazuh-server/certs/server-key.pem
    certificate: /etc/wazuh-server/certs/server.pem
    certificate_authorities:
      - /etc/wazuh-server/certs/root-ca.pem
communications_api:
  host: localhost
  port: 27000
  ssl:
    key: /etc/wazuh-server/certs/server-key.pem
    cert: /etc/wazuh-server/certs/server.pem
    use_ca: false
    ca: /etc/wazuh-server/certs/root-ca.pem
management_api:
  host:
    - localhost
    - ::1
  port: 55000
  ssl:
    key: /etc/wazuh-server/certs/server-key.pem
    cert: /etc/wazuh-server/certs/server.pem
    use_ca: false
    ca: /etc/wazuh-server/certs/root-ca.pem

```

</details>

<details><summary>Server logs using default configuration</summary>

> The only values different from the default ones are the API hosts which were changed to `0.0.0.0`. 

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ docker logs -f wazuh-manager
2025/01/29 12:31:06 INFO: [Cluster] [Main] Starting server (pid: 12)
2025/01/29 12:31:06 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/29 12:31:06 INFO: [Master] [Config Server] Started server process [12]
2025/01/29 12:31:06 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/29 12:31:06 INFO: [Master] [Config Server] Application startup complete.
2025/01/29 12:31:06 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/29 12:31:07 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/29 12:31:08 INFO: [Communications API] Starting API
2025/01/29 12:31:08 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/01/29 12:31:08 INFO: [Communications API] Starting gunicorn 22.0.0
2025/01/29 12:31:08 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (18)
2025/01/29 12:31:08 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/01/29 12:31:08 INFO: [Communications API] Booting worker with pid: 54
2025/01/29 12:31:08 INFO: [Communications API] Started server process [18]
2025/01/29 12:31:08 INFO: [Communications API] Waiting for application startup.
2025/01/29 12:31:08 INFO: [Communications API] Application startup complete.
2025/01/29 12:31:08 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/01/29 12:31:08 INFO: [Communications API] Booting worker with pid: 55
2025/01/29 12:31:08 INFO: [Communications API] Started server process [55]
2025/01/29 12:31:08 INFO: [Communications API] Waiting for application startup.
2025/01/29 12:31:08 INFO: [Communications API] Application startup complete.
2025/01/29 12:31:08 INFO: [Communications API] Booting worker with pid: 56
2025/01/29 12:31:08 INFO: [Communications API] Started server process [56]
2025/01/29 12:31:08 INFO: [Communications API] Waiting for application startup.
2025/01/29 12:31:08 INFO: [Communications API] Application startup complete.
2025/01/29 12:31:09 INFO: [Communications API] Booting worker with pid: 57
2025/01/29 12:31:09 INFO: [Communications API] Started server process [57]
2025/01/29 12:31:09 INFO: [Communications API] Waiting for application startup.
2025/01/29 12:31:09 INFO: [Communications API] Application startup complete.
2025/01/29 12:31:09 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 18)
2025/01/29 12:31:09 INFO: [Local Server] [Main] Starting wazuh-server-management-apid
2025/01/29 12:31:10 INFO: [Management API] Starting API
2025/01/29 12:31:10 INFO: [Management API] Checking RBAC database integrity...
2025/01/29 12:31:10 INFO: [Management API] RBAC database not found. Initializing
2025/01/29 12:31:11 INFO: [Local Server] [Main] Started wazuh-server-management-apid (pid: 58)
2025/01/29 12:31:11 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/01/29 12:31:11 INFO: [Master] [Main] Serving on ('::1', 1516, 0, 0)
2025/01/29 12:31:11 INFO: [Master] [Local integrity] Starting.
2025/01/29 12:31:11 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/01/29 12:31:15 INFO: [Management API] /var/lib/wazuh-server/rbac.db database created successfully
2025/01/29 12:31:15 INFO: [Management API] RBAC database integrity check finished successfully
2025/01/29 12:31:16 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/29 12:31:16 WARNING: [Cluster] [Main] Cannot initialize the indexer client.
2025/01/29 12:31:16 INFO: [Cluster] [Main] Sleeping 1.4331274234741311s until next try.
2025/01/29 12:31:16 INFO: [Management API] Listening on ['0.0.0.0', '::']:55000.
2025/01/29 12:31:16 INFO: [Management API] Populating installation UID...
2025/01/29 12:31:16 INFO: [Management API] Getting updates information...
2025/01/29 12:31:17 INFO: [Management API] None 172.18.0.7 "HEAD /" with parameters {} and body {} done in 0.001s: 401
2025/01/29 12:31:19 INFO: [Master] [Local integrity] Starting.
2025/01/29 12:31:19 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
```

</details>

<details><summary>Management API authentication</summary>

> Requires generating a certificate with `0.0.0.0` as one of the hostnames

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -s -u wazuh:wazuh -X POST https://0.0.0.0:55000/security/user/authenticate --cacert certs/root-ca.pem | jq
{
  "data": {
    "token": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzM4MTU0MzY1LCJleHAiOjE3MzgxNTUyNjUsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.whph4dh9NrifyzrAQllbFV1kuVgdwqtoTEc3uKWcfpsi30uGRyoZkrMy-k2fjTIrOHHnjUQ41D92L0ZSa5WC9g"
  },
  "error": 0
}
```

</details>

<details><summary>Communications API authentication</summary>

> Requires generating a certificate with `0.0.0.0` as one of the hostnames

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -s -X POST -H "Content-Type: application/json" -d '{"uuid": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0", "key": "7b8276c3bf96aff5709346d368f04fed"}' https://0.0.0.0:27000/api/v1/authentication --cacert certs/root-ca.pem | jq
{
  "token": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIENvbW11bmljYXRpb25zIEFQSSIsImlhdCI6MTczODE1NDM4OSwiZXhwIjoxNzM4MTU1Mjg5LCJ1dWlkIjoiMGE5NmEwYWItNWJlZi00MTVjLWJiM2MtZWEzZTI5NDIxNWEwIn0.p_d5bF8J2ulA-g3Ktbv-jycM-iVCL23YLRuoaS4Sk-v9eZV-QS31ibBVSaHk8nRmdo4dtuI8h_nawvZgWLWbcw"
}
```

</details>