### PR TITLE
Fix server status command

### DIFF
--- a/apis/server_management/scripts/wazuh_server_management_apid.py
+++ b/apis/server_management/scripts/wazuh_server_management_apid.py
@@ -52,10 +52,10 @@ SSL_DEPRECATED_MESSAGE = 'The `{ssl_protocol}` SSL protocol is deprecated.'
 CACHE_DELETED_MESSAGE = 'The `cache` API configuration option no longer takes effect since {release} and will ' \
                         'be completely removed in the next major release.'
 
-API_MAIN_PROCESS = 'wazuh-apid'
-API_LOCAL_REQUEST_PROCESS = 'wazuh-apid_exec'
-API_AUTHENTICATION_PROCESS = 'wazuh-apid_auth'
-API_SECURITY_EVENTS_PROCESS = 'wazuh-apid_events'
+API_MAIN_PROCESS = 'wazuh-server-management-apid'
+API_LOCAL_REQUEST_PROCESS = 'wazuh-server-management-apid_exec'
+API_AUTHENTICATION_PROCESS = 'wazuh-server-management-apid_auth'
+API_SECURITY_EVENTS_PROCESS = 'wazuh-server-management-apid_events'
 LOGGING_TAG = 'Management API'
 
 logger = None

--- a/apis/server_management/server_management_api/signals.py
+++ b/apis/server_management/server_management_api/signals.py
@@ -103,4 +103,4 @@ async def lifespan_handler(_: ConnexionMiddleware):
         task.cancel()
         await task
 
-    logger.info('Shutdown wazuh-apid server.')
+    logger.info('Shutdown wazuh-server-management-apid server.')

--- a/apis/server_management/server_management_api/spec/spec.yaml
+++ b/apis/server_management/server_management_api/spec/spec.yaml
@@ -1241,7 +1241,7 @@ components:
           $ref: '#/components/schemas/DaemonStatus'
         wazuh-syscheckd:
           $ref: '#/components/schemas/DaemonStatus'
-        wazuh-apid:
+        wazuh-server-management-apid:
           $ref: '#/components/schemas/DaemonStatus'
         wazuh-clusterd:
           $ref: '#/components/schemas/DaemonStatus'
@@ -3477,7 +3477,7 @@ paths:
                       wazuh-remoted: running
                       wazuh-reportd: stopped
                       wazuh-syscheckd: running
-                      wazuh-apid: running
+                      wazuh-server-management-apid: running
                       wazuh-clusterd: running
                       wazuh-db: running
                       wazuh-modulesd: running

--- a/apis/server_management/wrappers/generic_wrapper.sh
+++ b/apis/server_management/wrappers/generic_wrapper.sh
@@ -9,6 +9,6 @@ WAZUH_SHARE="/usr/share/wazuh-server"
 SCRIPT_PATH_NAME="$0"
 SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
 
-PYTHON_SCRIPT="${WAZUH_SHARE}/api/scripts/${SCRIPT_NAME}.py"
+PYTHON_SCRIPT="${WAZUH_SHARE}/apis/scripts/${SCRIPT_NAME}.py"
 
 ${PYTHON_SCRIPT} $@

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -77,7 +77,7 @@ def test_start_daemons(mock_popen, root):
     main_logger_mock.info.assert_has_calls([
         call('Starting wazuh-engined'),
         call('Starting wazuh-comms-apid'),
-        call('Starting wazuh-apid'),
+        call('Starting wazuh-server-management-apid'),
     ])
 
 
@@ -111,7 +111,7 @@ def test_start_daemons_ko(mock_popen):
             wait_mock.side_effect = (0, 1)
             wazuh_server.start_daemons(False)
 
-        with pytest.raises(wazuh_server.WazuhDaemonError, match='Error starting wazuh-apid: return code 1'):
+        with pytest.raises(wazuh_server.WazuhDaemonError, match='Error starting wazuh-server-management-apid: return code 1'):
             wait_mock.side_effect = (0, 0, 1)
             wazuh_server.start_daemons(False)
 
@@ -439,7 +439,7 @@ def test_start(print_mock, path_exists_mock, chown_mock, chmod_mock, setuid_mock
                 main_logger_info_mock.assert_has_calls([
                     call('Generating JWT signing key pair'),
                     call('Shutting down wazuh-engined (pid: 999)'),
-                    call('Shutting down wazuh-apid (pid: 999)'),
+                    call('Shutting down wazuh-server-management-apid (pid: 999)'),
                     call('Shutting down wazuh-comms-apid (pid: 999)'),
                 ])
                 start_daemons_mock.assert_called_once()

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -222,7 +222,7 @@ def get_manager_status(cache=False) -> typing.Dict:
     except (PermissionError, FileNotFoundError) as e:
         raise WazuhInternalError(1913, extra_message=str(e))
 
-    processes = ['wazuh-server', 'wazuh-engined', 'wazuh-apid', 'wazuh-comms-apid']
+    processes = ['wazuh-server', 'wazuh-engined', 'wazuh-server-management-apid', 'wazuh-comms-apid']
 
     data, pidfile_regex, run_dir = {}, re.compile(r'.+\-(\d+)\.pid$'), common.WAZUH_RUN
     for process in processes:

--- a/framework/wazuh/core/tests/test_pyDaemonModule.py
+++ b/framework/wazuh/core/tests/test_pyDaemonModule.py
@@ -34,10 +34,10 @@ def test_create_pid_ko(mock_chmod):
 @pytest.mark.parametrize('process_name, expected_pid', [
    ('foo', 123),
    ('bar', 456),
-   ('wazuh-apid', 789),
+   ('wazuh-server-management-apid', 789),
    ('wazuh-clusterd', None)
 ])
-@patch('os.listdir', return_value=['foo-123.pid', 'bar-456.pid', 'wazuh-apid-789.pid'])
+@patch('os.listdir', return_value=['foo-123.pid', 'bar-456.pid', 'wazuh-server-management-apid-789.pid'])
 def test_get_parent_pid(os_listdir_mock, expected_pid, process_name):
     """Validates that the get_parent_pid function works as expected."""
     actual_pid = get_parent_pid(process_name)
@@ -76,7 +76,7 @@ def test_get_wazuh_server_pid_ko(path_mock, next_mock):
 @patch('wazuh.core.pyDaemonModule.Path')
 def test_get_running_processes(path_mock):
     """Validate that `get_running_processes` works as expected."""
-    daemons = ['wazuh-server', 'wazuh-apid', 'wazuh-comms-apid', 'wazuh-engine']
+    daemons = ['wazuh-server', 'wazuh-server-management-apid', 'wazuh-comms-apid', 'wazuh-engine']
     path_mock.return_value.glob.return_value = (MagicMock(stem=f'{daemon}-{i}') for i, daemon in enumerate(daemons))
 
     assert get_running_processes() == daemons
@@ -85,15 +85,15 @@ def test_get_running_processes(path_mock):
 @pytest.mark.parametrize(
         'running_processes,expected',
         (
-            (['wazuh-apid', 'wazuh-comms-apid', 'wazuh-engine'], True),
-            (['wazuh-apid', 'wazuh-comms-apid'], True),
+            (['wazuh-server-management-apid', 'wazuh-comms-apid', 'wazuh-engine'], True),
+            (['wazuh-server-management-apid', 'wazuh-comms-apid'], True),
             ([], False),
         )
 )
 @patch('wazuh.core.pyDaemonModule.get_running_processes')
 def test_check_for_daemons_shutdown(get_running_processes_mock, running_processes, expected):
     """Validate that `check_for_daemons_shutdown` works as expected."""
-    daemons = ['wazuh-apid', 'wazuh-comms-apid', 'wazuh-engine']
+    daemons = ['wazuh-server-management-apid', 'wazuh-comms-apid', 'wazuh-engine']
     get_running_processes_mock.return_value = running_processes
 
     assert check_for_daemons_shutdown(daemons) == expected

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -56,7 +56,7 @@ manager_status = {'wazuh-agentlessd': 'running', 'wazuh-analysisd': 'running', '
  'wazuh-execd': 'running', 'wazuh-integratord': 'running', 'wazuh-logcollector': 'running',
  'wazuh-maild': 'running', 'wazuh-remoted': 'running', 'wazuh-reportd': 'running',
  'wazuh-syscheckd': 'running', 'wazuh-clusterd': 'running', 'wazuh-modulesd': 'running',
- 'wazuh-db': 'running', 'wazuh-apid': 'running', 'wazuh-comms-apid': 'running'}
+ 'wazuh-db': 'running', 'wazuh-server-management-apid': 'running', 'wazuh-comms-apid': 'running'}
 
 
 @patch('wazuh.core.manager.status', return_value=manager_status)


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27909 |

## Description

Renames the management API daemon name to `wazuh-server-management-apid` which is what the server is looking for in the `status` command.

## Tests

<details><summary>wazuh-server start</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ docker logs -f wazuh-manager
2025/01/29 14:37:40 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2025/01/29 14:37:40 DEBUG: [Cluster] [Main] Nothing to remove in '/run/wazuh-server/cluster/'.
2025/01/29 14:37:40 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
2025/01/29 14:37:40 INFO: [Cluster] [Main] Starting server (pid: 12)
2025/01/29 14:37:41 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/29 14:37:41 INFO: [Master] [Config Server] Started server process [12]
2025/01/29 14:37:41 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/29 14:37:41 INFO: [Master] [Config Server] Application startup complete.
2025/01/29 14:37:41 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/29 14:37:42 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-29 14:37:42.160 18:18 info: Logging initialized.
2025/01/29 14:37:42 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-29 14:37:42.165 18:18 info: Metrics manager configured successfully
2025-01-29 14:37:42.165 18:18 info: Metrics initialized.
2025-01-29 14:37:42.165 18:18 info: Metrics disabled.
2025-01-29 14:37:42.165 18:18 info: Store initialized.
2025-01-29 14:37:42.165 18:18 warning: Could not load RBAC model, using default model: File '/var/lib/wazuh-server/engine/store/internal/rbac/model/0' does not exist
2025-01-29 14:37:42.165 18:18 info: RBAC initialized.
2025-01-29 14:37:42.201 18:18 info: KVDB initialized.
2025-01-29 14:37:42.201 18:18 info: Geo initialized.
2025-01-29 14:37:42.213 18:18 info: Schema initialized.
2025-01-29 14:37:42.222 18:18 info: Loaded timezone database version: '2024a'
2025-01-29 14:37:42.226 18:18 info: HLP initialized.
2025-01-29 14:37:42.256 18:18 info: Indexer Connector initialized.
2025-01-29 14:37:42.256 18:18 info: Builder initialized.
2025-01-29 14:37:42.256 18:18 info: Catalog initialized.
2025-01-29 14:37:42.256 18:18 info: Policy manager initialized.
2025-01-29 14:37:42.256 18:18 info: No flooding file provided, the queue will not be flooded.
2025-01-29 14:37:42.260 18:18 info: No flooding file provided, the queue will not be flooded.
2025-01-29 14:37:42.260 18:18 info: Router: router/router/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/router/0' does not exist
2025-01-29 14:37:42.260 18:18 info: Router: router/tester/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/tester/0' does not exist
2025-01-29 14:37:42.261 18:18 warning: Router: EPS settings could not be loaded from the store due to 'File '/var/lib/wazuh-server/engine/store/router/eps/0' does not exist'. Using default settings
2025-01-29 14:37:42.261 18:18 info: Router: EPS settings dumped to the store
2025-01-29 14:37:42.261 18:18 info: Router initialized.
2025-01-29 14:37:42.261 18:18 info: Starting database file decompression.
2025/01/29 14:37:44 INFO: [Local Server] [Main] Started wazuh-engined (pid: 18)
2025/01/29 14:37:44 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/29 14:37:45 INFO: [Communications API] Starting API
2025/01/29 14:37:45 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/01/29 14:37:45 INFO: [Communications API] Generated private key file in /etc/wazuh-server/certs/api-key.pem
2025/01/29 14:37:45 INFO: [Communications API] Generated certificate file in /etc/wazuh-server/certs/api.pem
2025/01/29 14:37:45 INFO: [Communications API] Starting gunicorn 22.0.0
2025/01/29 14:37:45 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (74)
2025/01/29 14:37:45 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/01/29 14:37:45 INFO: [Communications API] Booting worker with pid: 122
2025/01/29 14:37:45 INFO: [Communications API] Started server process [74]
2025/01/29 14:37:45 INFO: [Communications API] Waiting for application startup.
2025/01/29 14:37:45 INFO: [Communications API] Application startup complete.
2025/01/29 14:37:45 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/01/29 14:37:45 INFO: [Communications API] Booting worker with pid: 123
2025/01/29 14:37:45 INFO: [Communications API] Started server process [123]
2025/01/29 14:37:45 INFO: [Communications API] Waiting for application startup.
2025/01/29 14:37:45 INFO: [Communications API] Application startup complete.
2025/01/29 14:37:45 INFO: [Communications API] Booting worker with pid: 124
2025/01/29 14:37:45 INFO: [Communications API] Started server process [124]
2025/01/29 14:37:45 INFO: [Communications API] Waiting for application startup.
2025/01/29 14:37:45 INFO: [Communications API] Application startup complete.
2025/01/29 14:37:45 INFO: [Communications API] Booting worker with pid: 125
2025/01/29 14:37:45 INFO: [Communications API] Started server process [125]
2025/01/29 14:37:45 INFO: [Communications API] Waiting for application startup.
2025/01/29 14:37:45 INFO: [Communications API] Application startup complete.
2025/01/29 14:37:46 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 74)
2025/01/29 14:37:46 INFO: [Local Server] [Main] Starting wazuh-server-management-apid
2025/01/29 14:37:46 INFO: [Management API] Starting API
2025/01/29 14:37:46 INFO: [Management API] Checking RBAC database integrity...
2025/01/29 14:37:46 INFO: [Management API] RBAC database not found. Initializing
2025/01/29 14:37:48 INFO: [Local Server] [Main] Started wazuh-server-management-apid (pid: 126)
2025/01/29 14:37:48 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/01/29 14:37:48 DEBUG: [Local Server] [Keep alive] Calculating.
2025/01/29 14:37:48 DEBUG: [Local Server] [Keep alive] Calculated.
2025/01/29 14:37:48 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2025/01/29 14:37:48 DEBUG: [Master] [Keep alive] Calculating.
2025/01/29 14:37:48 DEBUG: [Master] [Keep alive] Calculated.
2025/01/29 14:37:48 INFO: [Master] [Local integrity] Starting.
2025/01/29 14:37:48 INFO: [Master] [Local integrity] Finished in 0.006s. Calculated metadata of 0 files.
2025/01/29 14:37:48 INFO: [Worker] [Main] Connection from ('172.18.0.4', 56660)
2025/01/29 14:37:48 DEBUG: [Worker] [Main] Command received: b'hello'
2025/01/29 14:37:48 INFO: [Worker] [Main] Connection from ('172.18.0.5', 48830)
2025/01/29 14:37:48 DEBUG: [Worker] [Main] Command received: b'hello'
2025/01/29 14:37:50 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/29 14:37:50 DEBUG: [Cluster] [Main] Connecting to the indexer client.
```

</details>

<details><summary>ps auxf</summary>

```console
root@wazuh-manager:/# ps auxf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root          14  0.2  0.0   4588  3992 pts/0    Ss   14:47   0:00 bash
root         137  0.0  0.0   7888  3984 pts/0    R+   14:47   0:00  \_ ps auxf
root           1  0.0  0.0   4324  3528 ?        Ss   14:47   0:00 bash /scripts/entrypoint.sh wazuh-manager manager-node manager
root          10  0.0  0.0   2800  1052 ?        S    14:47   0:00 /bin/sh /usr/share/wazuh-server/bin/wazuh-server start
wazuh-s+      12 14.3  0.7 404084 117860 ?       Sl   14:47   0:01  \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/framework/scripts/wazuh-server.py start
wazuh-s+      22  0.0  0.5 256620 94268 ?        S    14:47   0:00      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/framework/scripts/wazuh-server.py start
wazuh-s+      23  0.0  0.5 256620 94004 ?        S    14:47   0:00      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/framework/scripts/wazuh-server.py start
wazuh-s+      26 28.9  0.3 1861212 60428 ?       Dl   14:47   0:02      \_ /usr/share/wazuh-server/bin/wazuh-engine server -l trace start
wazuh-s+      82 22.3  0.5 234560 96516 ?        Sl   14:47   0:01      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+      98  3.5  0.4 526188 77232 ?        Sl   14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+     115  0.0  0.4 157548 73260 ?        S    14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+     117  1.8  0.4 157680 74228 ?        S    14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+     120  0.0  0.4 305012 76460 ?        Sl   14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+     133  0.0  0.5 234876 83336 ?        S    14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+     134  0.0  0.5 234876 83336 ?        S    14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+     135  0.0  0.5 234876 83344 ?        S    14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+     136  0.0  0.5 234876 83340 ?        S    14:47   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
wazuh-s+      97 25.2  0.6 169236 100848 ?       D    14:47   0:00      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py
```

</details>

<details><summary>API scripts path</summary>

```console
root@wazuh-manager:/# ls -la /usr/share/wazuh-server/
total 36
drwxr-xr-x 1 wazuh-server wazuh-server 4096 Jan 28 12:04 .
drwxr-xr-x 1 root         root         4096 Jan 28 12:05 ..
drwxr-xr-x 3 wazuh-server wazuh-server 4096 Jan 28 12:04 apis
drwxr-x--- 2 wazuh-server wazuh-server 4096 Jan 28 12:04 bin
drwxr-x--- 1 wazuh-server wazuh-server 4096 Jan 28 12:04 framework
drwxr-xr-x 2 wazuh-server wazuh-server 4096 Jan 28 12:03 lib
root@wazuh-manager:/# ls -la /usr/share/wazuh-server/apis/
total 16
drwxr-xr-x 3 wazuh-server wazuh-server 4096 Jan 28 12:04 .
drwxr-xr-x 1 wazuh-server wazuh-server 4096 Jan 28 12:04 ..
drwxr-x--- 2 wazuh-server wazuh-server 4096 Jan 28 12:04 scripts
root@wazuh-manager:/# ls -la /usr/share/wazuh-server/apis/scripts/
total 36
drwxr-x--- 2 wazuh-server wazuh-server  4096 Jan 28 12:04 .
drwxr-xr-x 3 wazuh-server wazuh-server  4096 Jan 28 12:04 ..
-rwxr-xr-x 1 wazuh-server wazuh-server 10963 Jan 28 13:43 wazuh-comms-apid.py
-rwxr-xr-x 1 wazuh-server wazuh-server 13053 Jan 29 14:24 wazuh-server-management-apid.py
```

</details>

<details><summary>wazuh-server status</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ docker exec -it wazuh-manager bash
root@wazuh-manager:/# /usr/share/wazuh-server/framework/scripts/wazuh-server.py status
wazuh-server is running...
wazuh-comms-apid is running...
wazuh-server-management-apid is running...
wazuh-engined is running...
```

</details>

<details><summary>wazuh-server stop</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ docker exec -it wazuh-manager bash
root@wazuh-manager:/# /usr/share/wazuh-server/framework/scripts/wazuh-server.py stop
root@wazuh-manager:/# gasti@gasti:~/work/wazuh/apis/tools/env$
```

```console
2025/01/29 14:38:37 INFO: [Cluster] [Main] Main loop stopped.
2025/01/29 14:38:37 INFO: [Cluster] [Main] Shutting down wazuh-engined (pid: 18)
2025/01/29 14:38:37 INFO: [Cluster] [Main] Shutting down wazuh-server-management-apid (pid: 126)
2025/01/29 14:38:37 INFO: [Cluster] [Main] Shutting down wazuh-comms-apid (pid: 74)
2025/01/29 14:38:37 INFO: [Cluster] [Main] Waiting for daemons shutdown.
2025/01/29 14:38:37 INFO: [Communications API] Handling signal: term
2025/01/29 14:38:37 ERROR: [Communications API] Worker (pid:122) was sent SIGTERM!
2025/01/29 14:38:37 INFO: [Communications API] Shutting down
2025/01/29 14:38:37 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/29 14:38:37 INFO: [Communications API] Shutting down
2025/01/29 14:38:37 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/29 14:38:37 INFO: [Communications API] Shutting down
2025/01/29 14:38:37 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/29 14:38:37 INFO: [Communications API] Waiting for application shutdown.
2025/01/29 14:38:37 INFO: [Communications API] Application shutdown complete.
2025/01/29 14:38:37 INFO: [Communications API] Finished server process [124]
2025/01/29 14:38:37 INFO: [Communications API] Worker exiting (pid: 124)
2025/01/29 14:38:37 INFO: [Communications API] Waiting for application shutdown.
2025/01/29 14:38:37 INFO: [Communications API] Application shutdown complete.
2025/01/29 14:38:37 INFO: [Communications API] Finished server process [123]
2025/01/29 14:38:37 INFO: [Communications API] Worker exiting (pid: 123)
2025/01/29 14:38:37 INFO: [Communications API] Waiting for application shutdown.
2025/01/29 14:38:37 INFO: [Communications API] Application shutdown complete.
2025/01/29 14:38:37 INFO: [Communications API] Finished server process [125]
2025/01/29 14:38:37 INFO: [Communications API] Worker exiting (pid: 125)
2025/01/29 14:38:38 INFO: [Communications API] Shutting down: Master
2025/01/29 14:38:38 INFO: [Communications API] Shutting down
2025/01/29 14:38:38 INFO: [Communications API] MuxDemuxRunner (pid: 104) - Received signal SIGTERM, shutting down
2025/01/29 14:38:38 INFO: [Communications API] Shutting down MuxDemuxRunner
2025/01/29 14:38:38 INFO: [Communications API] Batcher (pid: 105) - Received signal SIGTERM, shutting down
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/scripts/tests/test_wazuh_server.py::test_start_daemons --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 2 items                                                                                                                                                                                                                            

framework/scripts/tests/test_wazuh_server.py ..                                                                                                                                                                                        [100%]

============================================================================================================= 2 passed in 0.81s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/tests/test_pyDaemonModule.py::test_get_parent_pid --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 4 items                                                                                                                                                                                                                            

framework/wazuh/core/tests/test_pyDaemonModule.py ....                                                                                                                                                                                 [100%]

============================================================================================================= 4 passed in 0.06s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/tests/test_pyDaemonModule.py::test_get_running_processes --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/tests/test_pyDaemonModule.py .                                                                                                                                                                                    [100%]

============================================================================================================= 1 passed in 0.05s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/tests/test_pyDaemonModule.py::test_check_for_daemons_shutdown --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 3 items                                                                                                                                                                                                                            

framework/wazuh/core/tests/test_pyDaemonModule.py ...                                                                                                                                                                                  [100%]

============================================================================================================= 3 passed in 0.05s ==============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/cluster/tests/test_utils.py::test_get_manager_status --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 1 item                                                                                                                                                                                                                             

framework/wazuh/core/cluster/tests/test_utils.py .                                                                                                                                                                                     [100%]

============================================================================================================= 1 passed in 0.17s ==============================================================================================================
```

</details>