### PR TITLE
Fix daemons monitor

### DIFF
--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -649,8 +649,8 @@ def test_check_daemon_ko_children_number(clean_pid_files_mock):
 
 
 @patch('scripts.wazuh_server.asyncio.sleep', side_effect=(None, StopAsyncIteration))
-async def test_check_for_server_state(sleep_mock):
-    """Check and set the behavior of wazuh_server `check_for_server_state` function."""
+async def test_check_for_server_readiness(sleep_mock):
+    """Check and set the behavior of wazuh_server `check_for_server_readiness` function."""
     wazuh_server.main_logger = Mock()
 
     proc_name = "test_daemon"
@@ -666,7 +666,7 @@ async def test_check_for_server_state(sleep_mock):
     )
     main_proc_mock = Mock(**{"children.return_value": [child_proc_mock]})
 
-    await wazuh_server.check_for_server_state(main_proc_mock, expected_state)
+    await wazuh_server.check_for_server_readiness(main_proc_mock, expected_state)
 
     sleep_mock.assert_not_called()
     wazuh_server.main_logger.warning_assert_not_called()
@@ -679,8 +679,8 @@ async def test_check_for_server_state(sleep_mock):
     ]
 )
 @patch('scripts.wazuh_server.asyncio.sleep', side_effect=(None, StopAsyncIteration))
-async def test_check_for_server_state_ko(sleep_mock, daemon_exists, children_number):
-    """Validate that `check_for_server_state` works as expected when server doesn't have the expected requirements."""
+async def test_check_for_server_readiness_ko(sleep_mock, daemon_exists, children_number):
+    """Validate that `check_for_server_readiness` works as expected when server doesn't have the expected requirements."""
     wazuh_server.main_logger = Mock()
 
     proc_name = "test_daemon"
@@ -697,7 +697,7 @@ async def test_check_for_server_state_ko(sleep_mock, daemon_exists, children_num
     main_proc_mock = Mock(**{"children.return_value": [child_proc_mock] if daemon_exists else []})
 
     with pytest.raises(StopAsyncIteration):
-        await wazuh_server.check_for_server_state(main_proc_mock, expected_state)
+        await wazuh_server.check_for_server_readiness(main_proc_mock, expected_state)
 
     sleep_mock.assert_any_call(10)
     wazuh_server.main_logger.warning.assert_any_call(

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -398,6 +398,43 @@ def start():
         shutdown_server(server_pid)
 
 
+def _get_child_process(processes: List[psutil.Process], proc_name: str) -> psutil.Process:
+    """Search for proc_name whithin the list of processes.
+
+    Parameters
+    ----------
+    processes : List[psutil.Process]
+        List of processes to search within.
+    proc_name : str
+        Name of the process to search.
+
+    Returns
+    -------
+    psutil.Process
+        The found process.
+    """
+    return [i for i in processes if proc_name[:-1] in i.name()][0]
+
+
+def _check_children_number(process: psutil.Process, expected_children_number: int) -> bool:
+    """Check the process had the expected number of children number.
+
+    Parameters
+    ----------
+    process : psutil.Process
+        Process to get the current number of childre.
+    expected_children_number : int
+        Expected value to check.
+
+    Returns
+    -------
+    bool
+        True if the process had the expected number of children else False.
+    """
+
+    return len(process.children()) == expected_children_number
+
+
 def check_daemon(processes: list, proc_name: str, children_number: int):
     """Check if the daemon is in the list of processes and has the correct number of children.
 
@@ -415,21 +452,24 @@ def check_daemon(processes: list, proc_name: str, children_number: int):
     WazuhDaemonError
         When the process does not have the correct number of children process.
     """
-    child: psutil.Process = [i for i in processes if proc_name[:-1] in i.name()][0]
+    child: psutil.Process = _get_child_process(processes, proc_name)
     if child.status() == psutil.STATUS_ZOMBIE:
         main_logger.error(f"Daemon `{proc_name}` is not running, stopping the whole server.")
         clean_pid_files(proc_name)
         return
-    if len(child.children()) != children_number:
+    if not _check_children_number(child, children_number):
         raise WazuhDaemonError(f'Daemon `{proc_name}` does not have the correct number of children process.')
 
 
-async def check_for_server_state(server_process: psutil.Process, expected_state: dict):
-    """Check the server meets the expected daemons requirements.
+async def check_for_server_readiness(server_process: psutil.Process, expected_state: dict):
+    """Check the server meets the expected daemons requirements at the startup.
 
-    Args:
-        server_process (psutil.Process): Main server process to get current daemons status.
-        expected_state (dict): Expected daemons names and children number.
+    Parameters
+    ----------
+    server_process : psutil.Process
+        Main server process to get current daemons status.
+    expected_state : dict
+        Expected daemons names and children number.
     """
     while True:
         states = {}
@@ -437,12 +477,12 @@ async def check_for_server_state(server_process: psutil.Process, expected_state:
 
         for proc_name, children in expected_state.items():
             try:
-                child: psutil.Process = [i for i in processes if proc_name[:-1] in i.name()][0]
+                child: psutil.Process = _get_child_process(processes, proc_name)
             except IndexError:
                 states.update({proc_name: False})
                 continue
 
-            if len(child.children()) == children:
+            if _check_children_number(child, children):
                 states.update({proc_name: True})
             else:
                 states.update({proc_name: False})
@@ -472,7 +512,8 @@ async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_process: ps
         COMMS_API_DAEMON_NAME:  comms_api_config.workers + 4,
         ENGINE_DAEMON_NAME:  0
     }
-    await check_for_server_state(server_process, process_children)
+
+    await check_for_server_readiness(server_process, process_children)
 
     while True:
         await asyncio.sleep(10)

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -425,11 +425,11 @@ def check_daemon(processes: list, proc_name: str, children_number: int):
 
 
 async def check_for_server_state(server_process: psutil.Process, expected_state: dict):
-    """Check the server meets the expected processes requirements.
+    """Check the server meets the expected daemons requirements.
 
     Args:
         server_process (psutil.Process): Main server process to get current daemons status.
-        expected_state (dict): Expected processes names and children number.
+        expected_state (dict): Expected daemons names and children number.
     """
     while True:
         states = {}
@@ -450,8 +450,10 @@ async def check_for_server_state(server_process: psutil.Process, expected_state:
         if all(states.values()):
             return
         else:
-            main_logger.debug(f'Server daemons state: {states}. Sleeping until next checking...')
-        await asyncio.sleep(5)
+            main_logger.warning(
+                f"The Server doesn't meet the expected daemons state: {states}. Sleeping until next checking..."
+            )
+        await asyncio.sleep(10)
 
 
 async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_process: psutil.Process):


### PR DESCRIPTION
|Related issue|
|---|
|#27886|

## Description

This PR closes #27886. It adds a process of waiting until all the daemons are working before starting the daemon monitor.

## Logs/Alerts example

```console
root@wazuh-manager:/# /usr/share/wazuh-server/bin/wazuh-server start
2025/01/29 19:34:27 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2025/01/29 19:34:27 DEBUG: [Cluster] [Main] Nothing to remove in '/run/wazuh-server/cluster/'.
2025/01/29 19:34:27 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
2025/01/29 19:34:27 INFO: [Cluster] [Main] Starting server (pid: 315)
2025/01/29 19:34:27 WARNING: [Cluster] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': False, 'wazuh-engined': False}. Sleeping until next checking...
2025/01/29 19:34:27 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/01/29 19:34:27 INFO: [Master] [Config Server] Started server process [315]
2025/01/29 19:34:27 INFO: [Master] [Config Server] Waiting for application startup.
2025/01/29 19:34:27 INFO: [Master] [Config Server] Application startup complete.
2025/01/29 19:34:27 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/01/29 19:34:28 INFO: [Local Server] [Main] Starting wazuh-engined
2025-01-29 19:34:28.745 334:334 info: Logging initialized.
2025/01/29 19:34:28 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-01-29 19:34:28.749 334:334 info: Metrics manager configured successfully
2025-01-29 19:34:28.749 334:334 info: Metrics initialized.
2025-01-29 19:34:28.749 334:334 info: Metrics disabled.
2025-01-29 19:34:28.749 334:334 info: Store initialized.
2025-01-29 19:34:28.750 334:334 info: RBAC initialized.
2025-01-29 19:34:28.792 334:334 info: KVDB initialized.
2025-01-29 19:34:28.792 334:334 info: Geo initialized.
2025-01-29 19:34:28.809 334:334 info: Schema initialized.
2025-01-29 19:34:28.824 334:334 info: Loaded timezone database version: '2024a'
2025-01-29 19:34:28.829 334:334 info: HLP initialized.
2025-01-29 19:34:28.895 334:334 info: Indexer Connector initialized.
2025-01-29 19:34:28.895 334:334 info: Builder initialized.
2025-01-29 19:34:28.895 334:334 info: Catalog initialized.
2025-01-29 19:34:28.895 334:334 info: Policy manager initialized.
2025-01-29 19:34:28.896 334:334 info: No flooding file provided, the queue will not be flooded.
2025-01-29 19:34:28.904 334:334 info: No flooding file provided, the queue will not be flooded.
2025-01-29 19:34:28.905 334:334 warning: Router: router/router/0 table is empty
2025-01-29 19:34:28.905 334:334 warning: Router: router/tester/0 table is empty
2025-01-29 19:34:28.905 334:334 info: Router initialized.
2025-01-29 19:34:29.054 334:334 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-01-29 19:34:29.056 334:334 info: Starting the server...
2025/01/29 19:34:30 INFO: [Local Server] [Main] Started wazuh-engined (pid: 334)
2025/01/29 19:34:30 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/01/29 19:34:31 INFO: [Communications API] Starting API
2025/01/29 19:34:31 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/01/29 19:34:31 INFO: [Communications API] Starting gunicorn 22.0.0
2025/01/29 19:34:31 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (421)
2025/01/29 19:34:31 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/01/29 19:34:31 INFO: [Communications API] Booting worker with pid: 457
2025/01/29 19:34:31 INFO: [Communications API] Booting worker with pid: 458
2025/01/29 19:34:31 INFO: [Communications API] Started server process [421]
2025/01/29 19:34:31 INFO: [Communications API] Waiting for application startup.
2025/01/29 19:34:31 INFO: [Communications API] Application startup complete.
2025/01/29 19:34:31 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/01/29 19:34:31 INFO: [Communications API] Booting worker with pid: 459
2025/01/29 19:34:31 INFO: [Communications API] Started server process [459]
2025/01/29 19:34:31 INFO: [Communications API] Waiting for application startup.
2025/01/29 19:34:31 INFO: [Communications API] Application startup complete.
2025/01/29 19:34:32 INFO: [Communications API] Booting worker with pid: 460
2025/01/29 19:34:32 INFO: [Communications API] Started server process [460]
2025/01/29 19:34:32 INFO: [Communications API] Waiting for application startup.
2025/01/29 19:34:32 INFO: [Communications API] Application startup complete.
2025/01/29 19:34:32 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 421)
2025/01/29 19:34:32 INFO: [Local Server] [Main] Starting wazuh-server-management-apid
2025/01/29 19:34:33 INFO: [Management API] Starting API
2025/01/29 19:34:33 INFO: [Management API] Checking RBAC database integrity...
2025/01/29 19:34:33 INFO: [Management API] /var/lib/wazuh-server/rbac.db file was detected
2025/01/29 19:34:33 INFO: [Management API] RBAC database integrity check finished successfully
2025/01/29 19:34:34 INFO: [Management API] Listening on ['0.0.0.0', '::']:55000.
2025/01/29 19:34:34 INFO: [Management API] Getting installation UID...
2025/01/29 19:34:34 INFO: [Management API] Getting updates information...
025/01/29 19:34:34 INFO: [Local Server] [Main] Started wazuh-server-management-apid (pid: 461)
2025/01/29 19:34:34 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/01/29 19:34:34 DEBUG: [Local Server] [Keep alive] Calculating.
2025/01/29 19:34:34 DEBUG: [Local Server] [Keep alive] Calculated.
2025/01/29 19:34:34 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2025/01/29 19:34:34 DEBUG: [Master] [Keep alive] Calculating.
2025/01/29 19:34:34 DEBUG: [Master] [Keep alive] Calculated.
2025/01/29 19:34:34 INFO: [Master] [Local integrity] Starting.
2025/01/29 19:34:34 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
2025/01/29 19:34:37 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/29 19:34:37 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/29 19:34:37 DEBUG: [Cluster] [Main] Commands index response: []
2025/01/29 19:34:37 DEBUG: [Cluster] [Main] Closing the indexer client session.
2025/01/29 19:34:42 INFO: [Master] [Local integrity] Starting.
2025/01/29 19:34:42 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/01/29 19:34:47 DEBUG: [Cluster] [Main] Checking server daemons status...
2025/01/29 19:34:47 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/29 19:34:47 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/29 19:34:47 DEBUG: [Cluster] [Main] Commands index response: []
2025/01/29 19:34:47 DEBUG: [Cluster] [Main] Closing the indexer client session.
2025/01/29 19:34:50 INFO: [Master] [Local integrity] Starting.
2025/01/29 19:34:50 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/01/29 19:34:57 DEBUG: [Cluster] [Main] Checking server daemons status...
2025/01/29 19:34:57 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/29 19:34:57 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/29 19:34:57 DEBUG: [Cluster] [Main] Commands index response: []
2025/01/29 19:34:57 DEBUG: [Cluster] [Main] Closing the indexer client session.
2025/01/29 19:34:58 INFO: [Master] [Local integrity] Starting.
2025/01/29 19:34:58 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/01/29 19:35:06 INFO: [Master] [Local integrity] Starting.
2025/01/29 19:35:06 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/01/29 19:35:07 DEBUG: [Cluster] [Main] Checking server daemons status...
2025/01/29 19:35:07 INFO: [Cluster] [Main] Getting orders from indexer
2025/01/29 19:35:07 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/01/29 19:35:07 DEBUG: [Cluster] [Main] Commands index response: []
2025/01/29 19:35:07 DEBUG: [Cluster] [Main] Closing the indexer client session.
^C2025/01/29 19:35:08 INFO: [Cluster] [Main] SIGINT received. Shutting down...
2025/01/29 19:35:08 INFO: [Communications API] Handling signal: int
2025-01-29 19:35:08.407 334:334 info: Stopping the server
2025-01-29 19:35:08.407 334:334 info: Server closed
2025-01-29 19:35:08.407 334:334 info: bind::<lambda>handleCloseEvent
2025-01-29 19:35:08.407 334:334 info: Server stopped
2025-01-29 19:35:08.407 334:334 info: API terminated.
2025/01/29 19:35:08 INFO: [Cluster] [Main] Shutting down wazuh-engined (pid: 334)
2025/01/29 19:35:08 INFO: [Cluster] [Main] Shutting down wazuh-comms-apid (pid: 421)
2025/01/29 19:35:08 INFO: [Cluster] [Main] Waiting for daemons shutdown.
2025/01/29 19:35:08 ERROR: [Communications API] Worker (pid:458) was sent SIGINT!
2025/01/29 19:35:08 ERROR: [Communications API] Worker (pid:457) was sent SIGINT!
2025/01/29 19:35:08 INFO: [Communications API] Shutting down
2025/01/29 19:35:08 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/29 19:35:08 INFO: [Communications API] Shutting down
2025/01/29 19:35:08 INFO: [Communications API] Error while closing socket [Errno 9] Bad file descriptor
2025/01/29 19:35:08 INFO: [Communications API] Waiting for application shutdown.
2025/01/29 19:35:08 INFO: [Communications API] Application shutdown complete.
2025/01/29 19:35:08 INFO: [Communications API] Finished server process [460]
2025/01/29 19:35:08 INFO: [Communications API] Worker exiting (pid: 460)
2025/01/29 19:35:08 INFO: [Communications API] Waiting for application shutdown.
2025/01/29 19:35:08 INFO: [Communications API] Application shutdown complete.
2025/01/29 19:35:08 INFO: [Communications API] Finished server process [459]
2025/01/29 19:35:08 INFO: [Communications API] Worker exiting (pid: 459)
2025/01/29 19:35:08 INFO: [Management API] Shutdown wazuh-apid server.
2025/01/29 19:35:08 INFO: [Communications API] Shutting down: Master
2025/01/29 19:35:08 INFO: [Communications API] Shutting down
2025/01/29 19:35:08 INFO: [Communications API] MuxDemuxRunner (pid: 439) - Received signal SIGTERM, shutting down
2025/01/29 19:35:08 INFO: [Communications API] Shutting down MuxDemuxRunner
2025/01/29 19:35:08 INFO: [Communications API] Batcher (pid: 441) - Received signal SIGTERM, shutting down
```