### PR TITLE
Refresh affected shards on agent creation

### DIFF
--- a/framework/wazuh/core/indexer/agent.py
+++ b/framework/wazuh/core/indexer/agent.py
@@ -77,7 +77,7 @@ class AgentsIndex(BaseIndex):
                 id=id,
                 body={AGENT_KEY: agent.to_dict()},
                 op_type='create',
-                refresh='wait_for'
+                refresh='true'
             )
         except exceptions.ConflictError:
             raise WazuhError(1708, extra_message=id)

--- a/framework/wazuh/core/indexer/tests/test_agent.py
+++ b/framework/wazuh/core/indexer/tests/test_agent.py
@@ -38,7 +38,7 @@ class TestAgentIndex:
             id=self.create_id,
             body={AGENT_KEY: new_agent.to_dict()},
             op_type='create',
-            refresh='wait_for'
+            refresh='true'
         )
 
     async def test_create_ko(self, index_instance: AgentsIndex, client_mock: mock.AsyncMock):


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27947 |

## Description

Sets the `wait_for` parameter to `true` on the request used to index new agents

## Tests

<details><summary>Set wazuh-agents index debug logs</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -X PUT -H "Content-Type: application/json" -ku admin:admin https://localhost:9200/wazuh-agents/_settings -d '{
  "index.indexing.slowlog.threshold.index.debug" : "0s",
  "index.search.slowlog.threshold.fetch.debug" : "0s",
  "index.search.slowlog.threshold.query.debug" : "0s"
}'
{"acknowledged":true}
```

</details>


<details><summary>Create agent</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Thu, 30 Jan 2025 14:17:02 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

</details>

<details><summary>Indexer logs</summary>

```console
[2025-01-30T14:17:02,650][DEBUG][i.i.s.index              ] [wazuh-indexer] [wazuh-agents/owMb8g5iQv2Om91Y7X3Deg] took[971.6micros], took_millis[0], id[0a96a0ab-5bef-415c-bb3c-ea3e294215a0], routing[], source[{"agent":{"id":"0a96a0ab-5bef-415c-bb3c-ea3e294215a0","name":"test","key":"4R13IaOBYJhy8D3eNeedBtV3Ws/PNPiZ6pkj0GqxYzv2ejIqjhs4+cYZy7Yz/fUI","type":"endpoint","version":"5.0.0","status":"never_connected"}}]
```

</details>

<details><summary>Indexed agent</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Content-Type: application/json" -ksu admin:admin https://localhost:9200/wazuh-agents/_doc/0a96a0ab-5bef-415c-bb3c-ea3e294215a0 | jq
{
  "_index": "wazuh-agents",
  "_id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "_version": 1,
  "_seq_no": 2,
  "_primary_term": 1,
  "found": true,
  "_source": {
    "agent": {
      "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
      "name": "test",
      "key": "4R13IaOBYJhy8D3eNeedBtV3Ws/PNPiZ6pkj0GqxYzv2ejIqjhs4+cYZy7Yz/fUI",
      "type": "endpoint",
      "version": "5.0.0",
      "status": "never_connected"
    }
  }
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_agent.py --disable-warnings
====================================== test session starts ======================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 13 items                                                                              

framework/wazuh/core/indexer/tests/test_agent.py .............                            [100%]

====================================== 13 passed in 0.31s =======================================
```

</details>