### PR TITLE
Set never_connect status during agent register

### DIFF
--- a/framework/wazuh/core/indexer/agent.py
+++ b/framework/wazuh/core/indexer/agent.py
@@ -6,7 +6,7 @@ from opensearchpy._async.helpers.update_by_query import AsyncUpdateByQuery
 from opensearchpy._async.helpers.search import AsyncSearch
 
 from wazuh.core.indexer.base import BaseIndex, IndexerKey
-from wazuh.core.indexer.models.agent import Agent, Host
+from wazuh.core.indexer.models.agent import Agent, Host, Status
 from wazuh.core.indexer.utils import get_source_items
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 
@@ -67,6 +67,7 @@ class AgentsIndex(BaseIndex):
             id=id,
             name=name,
             raw_key=key,
+            status=Status.NEVER_CONNECTED,
             type=type,
             version=version,
             host=host if host else None

--- a/framework/wazuh/core/indexer/models/agent.py
+++ b/framework/wazuh/core/indexer/models/agent.py
@@ -46,6 +46,7 @@ class Status(str, Enum):
     """Agent connection status enum."""
     ACTIVE = 'active'
     DISCONNECTED = 'disconnected'
+    NEVER_CONNECTED = 'never_connected'
 
 
 @dataclass

--- a/framework/wazuh/core/indexer/tests/test_agent.py
+++ b/framework/wazuh/core/indexer/tests/test_agent.py
@@ -7,7 +7,7 @@ from opensearchpy.helpers.response import Hit
 from wazuh.core.exception import WazuhError
 from wazuh.core.indexer.agent import AgentsIndex, AGENT_KEY
 from wazuh.core.indexer.base import IndexerKey
-from wazuh.core.indexer.models.agent import Agent
+from wazuh.core.indexer.models.agent import Agent, Status
 
 
 class TestAgentIndex:
@@ -31,8 +31,9 @@ class TestAgentIndex:
     async def test_create(self, index_instance: AgentsIndex, client_mock: mock.AsyncMock):
         """Check the correct function of `create` method."""
         new_agent = await index_instance.create(id=self.create_id, **self.create_params)
-
         assert isinstance(new_agent, Agent)
+        new_agent.status = Status.NEVER_CONNECTED
+
         client_mock.index.assert_called_once_with(
             index=index_instance.INDEX,
             id=self.create_id,


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27949 |

## Description

Modifies the agent registration request to set the status to `never_connected`.

## Tests

<details><summary>Set wazuh-agents index debug logs</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -X PUT -H "Content-Type: application/json" -ku admin:admin https://localhost:9200/wazuh-agents/_settings -d '{
  "index.indexing.slowlog.threshold.index.debug" : "0s",
  "index.search.slowlog.threshold.fetch.debug" : "0s",
  "index.search.slowlog.threshold.query.debug" : "0s"
}'
{"acknowledged":true}
```

</details>

<details><summary>Create agent</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Thu, 30 Jan 2025 14:17:02 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

</details>

<details><summary>Indexer logs</summary>

```console
[2025-01-30T14:17:02,650][DEBUG][i.i.s.index              ] [wazuh-indexer] [wazuh-agents/owMb8g5iQv2Om91Y7X3Deg] took[971.6micros], took_millis[0], id[0a96a0ab-5bef-415c-bb3c-ea3e294215a0], routing[], source[{"agent":{"id":"0a96a0ab-5bef-415c-bb3c-ea3e294215a0","name":"test","key":"4R13IaOBYJhy8D3eNeedBtV3Ws/PNPiZ6pkj0GqxYzv2ejIqjhs4+cYZy7Yz/fUI","type":"endpoint","version":"5.0.0","status":"never_connected"}}]
```

</details>

<details><summary>Indexed agent</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Content-Type: application/json" -ksu admin:admin https://localhost:9200/wazuh-agents/_doc/0a96a0ab-5bef-415c-bb3c-ea3e294215a0 | jq
{
  "_index": "wazuh-agents",
  "_id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "_version": 1,
  "_seq_no": 2,
  "_primary_term": 1,
  "found": true,
  "_source": {
    "agent": {
      "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
      "name": "test",
      "key": "4R13IaOBYJhy8D3eNeedBtV3Ws/PNPiZ6pkj0GqxYzv2ejIqjhs4+cYZy7Yz/fUI",
      "type": "endpoint",
      "version": "5.0.0",
      "status": "never_connected"
    }
  }
}
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_agent.py --disable-warnings
====================================== test session starts ======================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.1.0, trio-0.8.0, aiohttp-1.0.4
asyncio: mode=auto
collected 13 items                                                                              

framework/wazuh/core/indexer/tests/test_agent.py .............                            [100%]

====================================== 13 passed in 0.31s =======================================
```

</details>