### PR TITLE
Fix shared modules compiling warnings after upward merge

### DIFF
--- a/src/shared_modules/utils/jsonArrayParser.hpp
+++ b/src/shared_modules/utils/jsonArrayParser.hpp
@@ -430,8 +430,10 @@ namespace JsonArray
      * @param processBodyCallback Callback invoked at the end of the parsing with the body of the JSON object. The body
      * of the JSON object is the original JSON with the array items removed. If the \p processItemCallback stops the
      * parsing, the \p processBodyCallback will not be called.
+     *
+     * This function has [[maybe_unused]] attribute to avoid warnings when the function is not used.
      */
-    static void parse(
+    [[maybe_unused]] static void parse(
         const std::filesystem::path& filepath,
         std::function<bool(nlohmann::json&&, const size_t)> processItemCallback,
         const nlohmann::json::json_pointer& arrayPointer = nlohmann::json::json_pointer(),

--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -228,13 +228,13 @@ private:
         }
     }
 
+    // Keep this order to avoid warnings during compilation
     Functor m_functor;
+    const size_t m_maxQueueSize;
+    std::atomic<uint64_t> m_bulkSize;
     std::unique_ptr<TSafeQueueType> m_queue;
     std::thread m_thread;
     std::atomic_bool m_running = true;
-
-    const size_t m_maxQueueSize;
-    std::atomic<uint64_t> m_bulkSize;
 };
 
 template<typename Type, typename Functor>


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27823|


# Objective

This PR aims to restore the changes reverted on #27502 


## PoC

#### Before fix

```console
[ 74%] Building CXX object wazuh_modules/vulnerability_scanner/CMakeFiles/vulnerability_scanner.dir/src/vulnerabilityScannerFacade.cpp.o
In file included from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:21,
                 from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp:15,
                 from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp:15:
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/jsonArrayParser.hpp:434:17: warning: ‘void JsonArray::parse(const std::filesystem::__cxx11::path&, std::function<bool(nlohmann::json_abi_v3_11_2::basic_json<>&&, long unsigned int)>, const nlohmann::json_abi_v3_11_2::basic_json<>::json_pointer&, std::function<void(nlohmann::json_abi_v3_11_2::basic_json<>&&)>)’ defined but not used [-Wunused-function]
  434 |     static void parse(
      |                 ^~~~~
[ 74%] Building CXX object shared_modules/content_manager/tests/component/CMakeFiles/content_manager_component_tests.dir/pubSubPublisher_test.cpp.o
[ 74%] Building CXX object shared_modules/content_manager/tests/unit/CMakeFiles/content_manager_unit_tests.dir/updateOffline_test.cpp.o
In file included from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScannerDefs.hpp:18,
                 from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/include/vulnerabilityScanner.hpp:23,
                 from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/../policyManager/policyManager.hpp:20,
                 from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp:15,
                 from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp:15,
                 from /home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp:12:
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp: In instantiation of ‘TThreadEventDispatcher<T, U, Functor, TQueueType, TSafeQueueType>::TThreadEventDispatcher(Functor, const std::string&, uint64_t, size_t) [with T = std::__cxx11::basic_string<char>; U = std::__cxx11::basic_string<char>; Functor = std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>; TQueueType = RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >; TSafeQueueType = Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >; std::string = std::__cxx11::basic_string<char>; uint64_t = long unsigned int; size_t = long unsigned int]’:
/usr/include/c++/14/bits/stl_construct.h:119:7:   required from ‘void std::_Construct(_Tp*, _Args&& ...) [with _Tp = TThreadEventDispatcher<__cxx11::basic_string<char>, __cxx11::basic_string<char>, function<void(queue<__cxx11::basic_string<char> >&)>, RocksDBQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char> >, Utils::TSafeQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char>, RocksDBQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char> > > >; _Args = {VulnerabilityScannerFacade::initAlertReportDispatcher()::<lambda(queue<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, deque<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, allocator<__cxx11::basic_string<char, char_traits<char>, allocator<char> > > > >&)>, const char* const&, const int&}]’
  119 |       ::new((void*)__p) _Tp(std::forward<_Args>(__args)...);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/alloc_traits.h:694:19:   required from ‘static void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = TThreadEventDispatcher<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >; _Args = {VulnerabilityScannerFacade::initAlertReportDispatcher()::<lambda(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, const char* const&, const int&}; allocator_type = std::allocator<void>]’
  694 |         { std::_Construct(__p, std::forward<_Args>(__args)...); }
      |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:607:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {VulnerabilityScannerFacade::initAlertReportDispatcher()::<lambda(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, const char* const&, const int&}; _Tp = TThreadEventDispatcher<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  607 |           allocator_traits<_Alloc>::construct(__a, _M_ptr(),
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
  608 |               std::forward<_Args>(__args)...); // might throw
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:969:16:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = TThreadEventDispatcher<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >; _Alloc = std::allocator<void>; _Args = {VulnerabilityScannerFacade::initAlertReportDispatcher()::<lambda(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, const char* const&, const int&}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  969 |           auto __pi = ::new (__mem)
      |                       ^~~~~~~~~~~~~
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:1713:14:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {VulnerabilityScannerFacade::initAlertReportDispatcher()::<lambda(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, const char* const&, const int&}; _Tp = TThreadEventDispatcher<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr.h:463:59:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {VulnerabilityScannerFacade::initAlertReportDispatcher()::<lambda(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, const char* const&, const int&}; _Tp = TThreadEventDispatcher<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >]’
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |                                                                  ^
/usr/include/c++/14/bits/shared_ptr.h:1007:14:   required from ‘std::shared_ptr<typename std::enable_if<(! std::is_array<_Tp>::value), _Tp>::type> std::make_shared(_Args&& ...) [with _Tp = TThreadEventDispatcher<__cxx11::basic_string<char>, __cxx11::basic_string<char>, function<void(queue<__cxx11::basic_string<char> >&)>, RocksDBQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char> >, Utils::TSafeQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char>, RocksDBQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char> > > >; _Args = {VulnerabilityScannerFacade::initAlertReportDispatcher()::<lambda(queue<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, deque<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, allocator<__cxx11::basic_string<char, char_traits<char>, allocator<char> > > > >&)>, const char* const&, const int&}; typename enable_if<(! is_array<_Tp>::value), _Tp>::type = TThreadEventDispatcher<__cxx11::basic_string<char>, __cxx11::basic_string<char>, function<void(queue<__cxx11::basic_string<char> >&)>, RocksDBQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char> >, Utils::TSafeQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char>, RocksDBQueue<__cxx11::basic_string<char>, __cxx11::basic_string<char> > > >]’
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1008 |                              std::forward<_Args>(__args)...);
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp:123:60:   required from here
  123 |     m_reportDispatcher = std::make_shared<ReportDispatcher>(
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  124 |         [this, reportsWait](std::queue<std::string>& dataQueue)
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  125 |         {
      |         ~
  126 |             while (!dataQueue.empty())
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
  127 |             {
      |             ~
  128 |                 const auto& data = dataQueue.front();
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  129 |                 m_reportSocketClient->send(data.c_str(), data.size());
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  130 |                 // We wait to keep the maximum number of events per second
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  131 |                 if (reportsWait > 0)
      |                 ~~~~~~~~~~~~~~~~~~~~
  132 |                 {
      |                 ~
  133 |                     std::this_thread::sleep_for(std::chrono::microseconds(reportsWait));
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  134 |                 }
      |                 ~
  135 |                 logDebug2(WM_VULNSCAN_LOGTAG, "Report sent: %s", data.c_str());
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  136 |                 dataQueue.pop();
      |                 ~~~~~~~~~~~~~~~~
  137 |             }
      |             ~
  138 |         },
      |         ~~
  139 |         REPORTS_QUEUE_PATH,
      |         ~~~~~~~~~~~~~~~~~~~
  140 |         REPORTS_BULK_SIZE);
      |         ~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:237:27: warning: ‘TThreadEventDispatcher<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >::m_bulkSize’ will be initialized after [-Wreorder]
  237 |     std::atomic<uint64_t> m_bulkSize;
      |                           ^~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:232:37: warning:   ‘std::unique_ptr<Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >, std::default_delete<Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > > > TThreadEventDispatcher<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::function<void(std::queue<std::__cxx11::basic_string<char> >&)>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >, Utils::TSafeQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, RocksDBQueue<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >::m_queue’ [-Wreorder]
  232 |     std::unique_ptr<TSafeQueueType> m_queue;
      |                                     ^~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:33:14: warning:   when initialized here [-Wreorder]
   33 |     explicit TThreadEventDispatcher(Functor functor,
      |              ^~~~~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp: In instantiation of ‘TThreadEventDispatcher<T, U, Functor, TQueueType, TSafeQueueType>::TThreadEventDispatcher(const std::string&, uint64_t, size_t) [with T = rocksdb::Slice; U = rocksdb::PinnableSlice; Functor = std::function<void(std::queue<rocksdb::PinnableSlice>&)>; TQueueType = RocksDBQueue<rocksdb::Slice, rocksdb::PinnableSlice>; TSafeQueueType = Utils::TSafeQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueue<rocksdb::Slice, rocksdb::PinnableSlice> >; std::string = std::__cxx11::basic_string<char>; uint64_t = long unsigned int; size_t = long unsigned int]’:
/usr/include/c++/14/bits/stl_construct.h:119:7:   required from ‘void std::_Construct(_Tp*, _Args&& ...) [with _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, function<void(queue<rocksdb::PinnableSlice>&)> >; _Args = {const char* const&, const int&}]’
  119 |       ::new((void*)__p) _Tp(std::forward<_Args>(__args)...);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/alloc_traits.h:694:19:   required from ‘static void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(std::queue<rocksdb::PinnableSlice>&)> >; _Args = {const char* const&, const int&}; allocator_type = std::allocator<void>]’
  694 |         { std::_Construct(__p, std::forward<_Args>(__args)...); }
      |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:607:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {const char* const&, const int&}; _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(std::queue<rocksdb::PinnableSlice>&)> >; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  607 |           allocator_traits<_Alloc>::construct(__a, _M_ptr(),
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
  608 |               std::forward<_Args>(__args)...); // might throw
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:969:16:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(std::queue<rocksdb::PinnableSlice>&)> >; _Alloc = std::allocator<void>; _Args = {const char* const&, const int&}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  969 |           auto __pi = ::new (__mem)
      |                       ^~~~~~~~~~~~~
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:1713:14:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {const char* const&, const int&}; _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(std::queue<rocksdb::PinnableSlice>&)> >; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr.h:463:59:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {const char* const&, const int&}; _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(std::queue<rocksdb::PinnableSlice>&)> >]’
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |                                                                  ^
/usr/include/c++/14/bits/shared_ptr.h:1007:14:   required from ‘std::shared_ptr<typename std::enable_if<(! std::is_array<_Tp>::value), _Tp>::type> std::make_shared(_Args&& ...) [with _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, function<void(queue<rocksdb::PinnableSlice>&)> >; _Args = {const char* const&, const int&}; typename enable_if<(! is_array<_Tp>::value), _Tp>::type = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, function<void(queue<rocksdb::PinnableSlice>&)> >]’
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1008 |                              std::forward<_Args>(__args)...);
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp:447:62:   required from here
  447 |         m_eventDispatcher = std::make_shared<EventDispatcher>(EVENTS_QUEUE_PATH, EVENTS_BULK_SIZE);
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:237:27: warning: ‘TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(std::queue<rocksdb::PinnableSlice>&)> >::m_bulkSize’ will be initialized after [-Wreorder]
  237 |     std::atomic<uint64_t> m_bulkSize;
      |                           ^~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:232:37: warning:   ‘std::unique_ptr<Utils::TSafeQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueue<rocksdb::Slice, rocksdb::PinnableSlice> >, std::default_delete<Utils::TSafeQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueue<rocksdb::Slice, rocksdb::PinnableSlice> > > > TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(std::queue<rocksdb::PinnableSlice>&)> >::m_queue’ [-Wreorder]
  232 |     std::unique_ptr<TSafeQueueType> m_queue;
      |                                     ^~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:45:14: warning:   when initialized here [-Wreorder]
   45 |     explicit TThreadEventDispatcher(const std::string& dbPath,
      |              ^~~~~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp: In instantiation of ‘TThreadEventDispatcher<T, U, Functor, TQueueType, TSafeQueueType>::TThreadEventDispatcher(Functor, const std::string&, uint64_t, size_t) [with T = rocksdb::Slice; U = rocksdb::PinnableSlice; Functor = std::function<void(rocksdb::PinnableSlice&)>; TQueueType = RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>; TSafeQueueType = Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> >; std::string = std::__cxx11::basic_string<char>; uint64_t = long unsigned int; size_t = long unsigned int]’:
/usr/include/c++/14/bits/stl_construct.h:119:7:   required from ‘void std::_Construct(_Tp*, _Args&& ...) [with _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, function<void(rocksdb::PinnableSlice&)>, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>, Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > >; _Args = {TScanOrchestrator<>::initEventDelayedDispatcher()::<lambda(rocksdb::PinnableSlice&)>, const char* const&}]’
  119 |       ::new((void*)__p) _Tp(std::forward<_Args>(__args)...);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/alloc_traits.h:694:19:   required from ‘static void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(rocksdb::PinnableSlice&)>, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>, Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > >; _Args = {TScanOrchestrator<>::initEventDelayedDispatcher()::<lambda(rocksdb::PinnableSlice&)>, const char* const&}; allocator_type = std::allocator<void>]’
  694 |         { std::_Construct(__p, std::forward<_Args>(__args)...); }
      |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:607:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {TScanOrchestrator<>::initEventDelayedDispatcher()::<lambda(rocksdb::PinnableSlice&)>, const char* const&}; _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(rocksdb::PinnableSlice&)>, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>, Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > >; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  607 |           allocator_traits<_Alloc>::construct(__a, _M_ptr(),
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
  608 |               std::forward<_Args>(__args)...); // might throw
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:969:16:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(rocksdb::PinnableSlice&)>, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>, Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > >; _Alloc = std::allocator<void>; _Args = {TScanOrchestrator<>::initEventDelayedDispatcher()::<lambda(rocksdb::PinnableSlice&)>, const char* const&}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  969 |           auto __pi = ::new (__mem)
      |                       ^~~~~~~~~~~~~
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:1713:14:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {TScanOrchestrator<>::initEventDelayedDispatcher()::<lambda(rocksdb::PinnableSlice&)>, const char* const&}; _Tp = TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(rocksdb::PinnableSlice&)>, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>, Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > >; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr.h:463:59:   [ skipping 6 instantiation contexts, use -ftemplate-backtrace-limit=0 to disable ]
/usr/include/c++/14/bits/shared_ptr_base.h:607:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {std::shared_ptr<IndexerConnector>&, std::shared_ptr<TDatabaseFeedManager<PolicyManager, ContentRegister, Utils::TRocksDBWrapper<rocksdb::DB> > >&, std::shared_ptr<TThreadEventDispatcher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, Utils::TSafeQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >&, std::shared_mutex&}; _Tp = TScanOrchestrator<>; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  607 |           allocator_traits<_Alloc>::construct(__a, _M_ptr(),
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
  608 |               std::forward<_Args>(__args)...); // might throw
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:969:16:   required from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = TScanOrchestrator<>; _Alloc = std::allocator<void>; _Args = {std::shared_ptr<IndexerConnector>&, std::shared_ptr<TDatabaseFeedManager<PolicyManager, ContentRegister, Utils::TRocksDBWrapper<rocksdb::DB> > >&, std::shared_ptr<TThreadEventDispatcher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, Utils::TSafeQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >&, std::shared_mutex&}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
  969 |           auto __pi = ::new (__mem)
      |                       ^~~~~~~~~~~~~
  970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_base.h:1713:14:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::shared_ptr<IndexerConnector>&, std::shared_ptr<TDatabaseFeedManager<PolicyManager, ContentRegister, Utils::TRocksDBWrapper<rocksdb::DB> > >&, std::shared_ptr<TThreadEventDispatcher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, Utils::TSafeQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >&, std::shared_mutex&}; _Tp = TScanOrchestrator<>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’
 1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr.h:463:59:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::shared_ptr<IndexerConnector>&, std::shared_ptr<TDatabaseFeedManager<PolicyManager, ContentRegister, Utils::TRocksDBWrapper<rocksdb::DB> > >&, std::shared_ptr<TThreadEventDispatcher<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void(std::queue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::deque<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)>, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, Utils::TSafeQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RocksDBQueue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >&, std::shared_mutex&}; _Tp = TScanOrchestrator<>]’
  463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |                                                                  ^
/usr/include/c++/14/bits/shared_ptr.h:1007:14:   required from ‘std::shared_ptr<typename std::enable_if<(! std::is_array<_Tp>::value), _Tp>::type> std::make_shared(_Args&& ...) [with _Tp = TScanOrchestrator<>; _Args = {shared_ptr<IndexerConnector>&, shared_ptr<TDatabaseFeedManager<PolicyManager, ContentRegister, Utils::TRocksDBWrapper<rocksdb::DB> > >&, shared_ptr<TThreadEventDispatcher<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, __cxx11::basic_string<char, char_traits<char>, allocator<char> >, function<void(queue<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, deque<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, allocator<__cxx11::basic_string<char, char_traits<char>, allocator<char> > > > >&)>, RocksDBQueue<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, __cxx11::basic_string<char, char_traits<char>, allocator<char> > >, Utils::TSafeQueue<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, __cxx11::basic_string<char, char_traits<char>, allocator<char> >, RocksDBQueue<__cxx11::basic_string<char, char_traits<char>, allocator<char> >, __cxx11::basic_string<char, char_traits<char>, allocator<char> > > > > >&, shared_mutex&}; typename enable_if<(! is_array<_Tp>::value), _Tp>::type = TScanOrchestrator<>]’
 1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1008 |                              std::forward<_Args>(__args)...);
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp:150:63:   required from here
  150 |     auto scanOrchestrator = std::make_shared<ScanOrchestrator>(
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  151 |         m_indexerConnector, m_databaseFeedManager, m_reportDispatcher, m_internalMutex);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:237:27: warning: ‘TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(rocksdb::PinnableSlice&)>, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>, Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > >::m_bulkSize’ will be initialized after [-Wreorder]
  237 |     std::atomic<uint64_t> m_bulkSize;
      |                           ^~~~~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:232:37: warning:   ‘std::unique_ptr<Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> >, std::default_delete<Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > > > TThreadEventDispatcher<rocksdb::Slice, rocksdb::PinnableSlice, std::function<void(rocksdb::PinnableSlice&)>, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice>, Utils::TSafeMultiQueue<rocksdb::Slice, rocksdb::PinnableSlice, RocksDBQueueCF<rocksdb::Slice, rocksdb::PinnableSlice> > >::m_queue’ [-Wreorder]
  232 |     std::unique_ptr<TSafeQueueType> m_queue;
      |                                     ^~~~~~~
/home/virtualbox/Documents/Work/wazuh-back/src/shared_modules/utils/threadEventDispatcher.hpp:33:14: warning:   when initialized here [-Wreorder]
   33 |     explicit TThreadEventDispatcher(Functor functor,
      |              ^~~~~~~~~~~~~~~~~~~~~~
```


#### After fix

```console
make[2]: Leaving directory '/home/virtualbox/Documents/Work/wazuh-back/src/wazuh_modules/syscollector/build'
mkdir -p build && cd build && cmake .. -DTARGET=server -DCMAKE_SYMBOLS_IN_RELEASE=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TEST=ON  && make
make[1]: 'build_syscollector' is up to date.
==============================================
Wazuh version: v4.12.0
Wazuh revision: 41200
==============================================
Compiling schemas
-- Configuring done (0.0s)
-- Generating done (0.1s)
-- Build files have been written to: /home/virtualbox/Documents/Work/wazuh-back/src/build
make[2]: Entering directory '/home/virtualbox/Documents/Work/wazuh-back/src/build'
[  3%] Built target flatbuffer_tool
[  3%] Built target utils_benchmark_test
[  4%] Built target router
[  5%] Built target keystore
[  8%] Built target scan_orchestrator
[  9%] Built target urlrequest
[ 11%] Built target cve5_schema_target
[ 11%] Built target messageBuffer_schema_target
[ 12%] Built target vulnerabilityCandidate_schema_target
[ 13%] Building CXX object shared_modules/utils/tests/CMakeFiles/utils_unit_test.dir/threadEventDispatcher_test.cpp.o
[ 16%] Built target packageTranslation_schema_target
[ 16%] Built target vulnerabilityDescription_schema_target
[ 17%] Built target vulnerabilityRemediations_schema_target
[ 19%] Built target wazuh_db_query_testtool
[ 20%] Built target rocks_db_query_testtool
[ 21%] Building CXX object wazuh_modules/vulnerability_scanner/tests/benchmark/CMakeFiles/vulnerability_scanner_benchmark_tests.dir/versionMatcherBenchmark.cpp.o
[ 22%] Built target wazuh-keystore
[ 24%] Built target keystore_component_tests
[ 25%] Built target wazuh-keystore-testtool
[ 26%] Built target router_test_tool
[ 30%] Built target router_component_tests
[ 32%] Built target router_unit_tests
[ 34%] Built target content_manager
[ 35%] Building CXX object shared_modules/indexer_connector/CMakeFiles/indexer_connector.dir/src/indexerConnector.cpp.o
[ 47%] Built target content_manager_unit_tests
[ 47%] Built target compile_schemas
[ 48%] Built target content_manager_test_tool
[ 52%] Built target content_manager_component_tests
[ 53%] Building CXX object wazuh_modules/vulnerability_scanner/src/databaseFeedManager/CMakeFiles/database_feed.dir/databaseFeedManager.cpp.o
[ 53%] Linking CXX executable vulnerability_scanner_benchmark_tests
[ 53%] Built target vulnerability_scanner_benchmark_tests
[ 53%] Linking CXX executable utils_unit_test
[ 70%] Built target utils_unit_test
[ 70%] Linking CXX static library libdatabase_feed.a
[ 70%] Built target database_feed
[ 70%] Linking CXX shared library libindexer_connector.so
[ 70%] Built target indexer_connector
[ 70%] Building CXX object shared_modules/indexer_connector/testtool/CMakeFiles/indexer_connector_tool.dir/main.cpp.o
[ 70%] Linking CXX executable indexer_connector_unit_tests
[ 70%] Building CXX object wazuh_modules/vulnerability_scanner/CMakeFiles/vulnerability_scanner.dir/src/vulnerabilityScanner.cpp.o
[ 71%] Building CXX object shared_modules/indexer_connector/tests/component/CMakeFiles/indexer_connector_component_tests.dir/indexerConnector_test.cpp.o
[ 73%] Built target indexer_connector_unit_tests
[ 74%] Building CXX object wazuh_modules/vulnerability_scanner/CMakeFiles/vulnerability_scanner.dir/src/vulnerabilityScannerFacade.cpp.o
[ 75%] Linking CXX executable indexer_connector_tool
/usr/bin/ld: /lib/x86_64-linux-gnu/libasan.so.8: warning: the use of `tmpnam_r' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib/x86_64-linux-gnu/libasan.so.8: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib/x86_64-linux-gnu/libasan.so.8: warning: the use of `tempnam' is dangerous, better use `mkstemp'
[ 75%] Built target indexer_connector_tool
[ 76%] Building CXX object wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/CMakeFiles/database_feed_manager_testtool.dir/main.cpp.o
[ 76%] Linking CXX executable database_feed_manager_testtool
[ 76%] Built target database_feed_manager_testtool
[ 76%] Linking CXX shared library libvulnerability_scanner.so
[ 76%] Built target vulnerability_scanner
[ 77%] Building CXX object wazuh_modules/vulnerability_scanner/testtool/scanner/CMakeFiles/vd_scanner_testtool.dir/main.cpp.o
[ 78%] Building CXX object wazuh_modules/vulnerability_scanner/tests/component/CMakeFiles/vulnerability_scanner_component_tests.dir/databaseFeedManager_test.cpp.o
[ 79%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/alertClearBuilder_test.cpp.o
[ 79%] Linking CXX executable vd_scanner_testtool
/usr/bin/ld: /lib/x86_64-linux-gnu/libasan.so.8: warning: the use of `tmpnam_r' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib/x86_64-linux-gnu/libasan.so.8: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
/usr/bin/ld: /lib/x86_64-linux-gnu/libasan.so.8: warning: the use of `tempnam' is dangerous, better use `mkstemp'
[ 79%] Built target vd_scanner_testtool
[ 79%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/arrayResultIndexer_test.cpp.o
[ 80%] Linking CXX executable indexer_connector_component_tests
[ 80%] Built target indexer_connector_component_tests
[ 81%] Building CXX object wazuh_modules/vulnerability_scanner/tests/component/CMakeFiles/vulnerability_scanner_component_tests.dir/vulnerabilityScannerFacade_test.cpp.o
[ 82%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/buildAllAgentListContext_test.cpp.o
[ 82%] Linking CXX executable vulnerability_scanner_component_tests
[ 82%] Built target vulnerability_scanner_component_tests
[ 82%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/buildSingleAgentListContext_test.cpp.o
[ 83%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/cleanAgentInventory_test.cpp.o
[ 83%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/cleanInventory_test.cpp.o
[ 84%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/clearSendReport_test.cpp.o
[ 85%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/databaseFeedManager_test.cpp.o
[ 85%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/descriptionsHelper_test.cpp.o
[ 86%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/eventDecoder_test.cpp.o
[ 86%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/eventDeleteInventory_test.cpp.o
[ 87%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/eventDetailsBuilder_test.cpp.o
[ 87%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/eventInsertInventory_test.cpp.o
[ 88%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/eventPackageAlertDetailsBuilder_test.cpp.o
[ 88%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/eventSendReport_test.cpp.o
[ 89%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/factoryOrchestrator_test.cpp.o
[ 90%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/feedIndexer_test.cpp.o
[ 91%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/globalSyncInventory_test.cpp.o
[ 92%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/osDataCache_test.cpp.o
[ 92%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/osScanner_test.cpp.o
[ 93%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/packageScanner_test.cpp.o
[ 93%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/policyManager_test.cpp.o
[ 94%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/remediationDataCache_test.cpp.o
[ 94%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/resultIndexer_test.cpp.o
[ 95%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/scanAgentList_test.cpp.o
[ 95%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/scanContext_test.cpp.o
[ 96%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/scanOrchestrator_test.cpp.o
[ 96%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/scanOsAlertDetailsBuilder_test.cpp.o
[ 96%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/storeModel_test.cpp.o
[ 97%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/updateCVECandidates_test.cpp.o
[ 97%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/updateCVEDescription_test.cpp.o
[ 98%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/updateCVERemediations_test.cpp.o
[ 98%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/updateHotfixes_test.cpp.o
[ 99%] Building CXX object wazuh_modules/vulnerability_scanner/tests/unit/CMakeFiles/vulnerability_scanner_unit_tests.dir/versionMatcher_test.cpp.o
[ 99%] Linking CXX executable vulnerability_scanner_unit_tests
[100%] Built target vulnerability_scanner_unit_tests
make[2]: Leaving directory '/home/virtualbox/Documents/Work/wazuh-back/src/build'
make[1]: Leaving directory '/home/virtualbox/Documents/Work/wazuh-back/src'
```