### PR TITLE
Update Vulnerability Scanner package.size ECS field to unsigned_long

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -138,7 +138,7 @@
               "type": "keyword"
             },
             "size": {
-              "type": "long"
+              "type": "unsigned_long"
             },
             "type": {
               "ignore_above": 1024,

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/update-mappings.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/update-mappings.json
@@ -1,28 +1,30 @@
 {
     "properties": {
-        "vulnerability": {
+      "vulnerability": {
+        "properties": {
+          "under_evaluation": {
+            "type": "boolean"
+          },
+          "scanner": {
             "properties": {
-                "under_evaluation": {
-                    "type": "boolean"
-                },
-                "scanner": {
-                    "properties": {
-                        "source": {
-                            "type": "keyword",
-                            "ignore_above": 1024
-                        },
-                        "condition": {
-                            "ignore_above": 1024,
-                            "type": "keyword"
-                        }
-                    }
-                }
+              "source": {
+                "type": "keyword",
+                "ignore_above": 1024
+              },
+              "condition": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
             }
-        },
-        "package": {
-            "size": {
-                "type": "unsigned_long"
-            }
+          }
         }
+      },
+      "package": {
+        "properties": {
+          "size": {
+            "type": "unsigned_long"
+          }
+      }
     }
+  }
 }

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/update-mappings.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/update-mappings.json
@@ -1,23 +1,28 @@
 {
     "properties": {
-      "vulnerability": {
-        "properties": {
-          "under_evaluation": {
-            "type": "boolean"
-          },
-          "scanner": {
+        "vulnerability": {
             "properties": {
-              "source": {
-                "type": "keyword",
-                "ignore_above": 1024
-              },
-              "condition": {
-                "ignore_above": 1024,
-                "type": "keyword"
-              }
+                "under_evaluation": {
+                    "type": "boolean"
+                },
+                "scanner": {
+                    "properties": {
+                        "source": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        },
+                        "condition": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                }
             }
-          }
+        },
+        "package": {
+            "size": {
+                "type": "unsigned_long"
+            }
         }
-      }
     }
-  }
+}


### PR DESCRIPTION
|Related issue|
|---|
| #27979  |

## Description
Change vulnerability scanner's `package.size` from `long` to `unsigned_long`.


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors