### PR TITLE
Remove `WARNING` about events in cloudwatchlogs

### DIFF
--- a/wodles/aws/services/cloudwatchlogs.py
+++ b/wodles/aws/services/cloudwatchlogs.py
@@ -321,8 +321,8 @@ class AWSCloudWatchLogs(aws_service.AWSService):
                                 2)
                             continue
                         else:
-                            print(f'WARNING: The "{self.discard_regex.pattern}" regex did not find a match. '
-                                  f'The event will be processed.')
+                            aws_tools.debug(f'+++ The "{self.discard_regex.pattern}" regex did not find a match. '
+                                  f'The event will be processed.', 3)
                     aws_tools.debug('The message is "{}"'.format(event_msg), 2)
                     aws_tools.debug('The message\'s timestamp is {}'.format(event["timestamp"]), 3)
                     self.send_msg(event_msg, dump_json=False)


### PR DESCRIPTION
|Related issue|
|---|
| #26348  |



## Description

```console
root@wazuh-master:/# /var/ossec/wodles/aws/aws-s3 -sr cloudwatchlogs -g framework-test -s 2024-JAN-01 -p default -r us-east-1 -d 3
DEBUG: +++ Debug mode on - Level: 3
DEBUG: +++ Getting alerts from "us-east-1" region.
DEBUG: No retries configuration found in profile config. Generating default configuration for retries: mode: standard - max_attempts: 10
DEBUG: Created Config object using profile: 'default' configuration
DEBUG: only logs: 1704067200000
DEBUG: +++ Table does not exist; create
DEBUG: Getting log streams for "framework-test" log group
DEBUG: Found "test_log_stream" log stream in framework-test
DEBUG: Getting data from DB for log stream "test_log_stream" in log group "framework-test"
DEBUG: Token: "None", start_time: "None", end_time: "None"
DEBUG: Getting CloudWatch logs from log stream "test_log_stream" in log group "framework-test" using token "None", start_time "1704067200000" and end_time "None"
DEBUG: +++ Sending events to Analysisd...
DEBUG: +++ Retrieved log event is not a JSON object.
DEBUG: +++ The "None" regex did not find a match. The event will be processed.
DEBUG: The message is "test-message"
DEBUG: The message's timestamp is 1704303945634
DEBUG: "test-message"
DEBUG: +++ The "None" regex did not find a match in the "None" field. The event will be processed.
DEBUG: The message is "{     "networkInterfaces": [         {             "networkInterfaceId": "eni-networkInterfaceId",             "subnetId": "subnet-subnetId",             "vpcId": "vpc-vpcId",             "privateDnsName": "ip-0-0-0-0.ec2.internal",             "privateIpAddress": "0.0.0.0",             "privateIpAddresses": [                 {                     "privateDnsName": "ip-0-0-0-0.ec2.internal",                     "privateIpAddress": "0.0.0.0"                 }             ],             "publicDnsName": "ec2-0-0-0-0.compute-1.amazonaws.com",             "publicIp": "0.0.0.0",             "ipv6Addresses": [],             "securityGroups": [                 {                     "groupName": "groupName0",                     "groupId": "sg-groupId0"                 },                 {                     "groupName": "groupName1",                     "groupId": "sg-groupID1"                 }             ]         }     ] }"
DEBUG: The message's timestamp is 1719912585759
DEBUG: "{     \"networkInterfaces\": [         {             \"networkInterfaceId\": \"eni-networkInterfaceId\",             \"subnetId\": \"subnet-subnetId\",             \"vpcId\": \"vpc-vpcId\",             \"privateDnsName\": \"ip-0-0-0-0.ec2.internal\",             \"privateIpAddress\": \"0.0.0.0\",             \"privateIpAddresses\": [                 {                     \"privateDnsName\": \"ip-0-0-0-0.ec2.internal\",                     \"privateIpAddress\": \"0.0.0.0\"                 }             ],             \"publicDnsName\": \"ec2-0-0-0-0.compute-1.amazonaws.com\",             \"publicIp\": \"0.0.0.0\",             \"ipv6Addresses\": [],             \"securityGroups\": [                 {                     \"groupName\": \"groupName0\",                     \"groupId\": \"sg-groupId0\"                 },                 {                     \"groupName\": \"groupName1\",                     \"groupId\": \"sg-groupID1\"                 }             ]         }     ] }"
DEBUG: +++ Sent 2 events to Analysisd
DEBUG: Getting CloudWatch logs from log stream "test_log_stream" in log group "framework-test" using token "f/38355332338757407856783507781858568662400217203959070720/s", start_time "1704067200000" and end_time "None"
DEBUG: +++ There are no new events in the "framework-test" group
DEBUG: Saving data for log group "framework-test" and log stream "test_log_stream".
DEBUG: The saved values are "{'token': 'f/38355332656353470xxxxxxxxx9697807204351/s', 'start_time': 1704067200000, 'end_time': 1719912585759}"
DEBUG: Purging the BD
DEBUG: Getting log streams for "framework-test" log group
DEBUG: Found "test_log_stream" log stream in framework-test
DEBUG: committing changes and closing the DB
```
```console
DEBUG: +++ The "None" regex did not find a match. The event will be processed.
```
## Tests

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/test_cloudwatchlogs.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 53 items                                                                                                                                                                                                

wodles/aws/tests/test_cloudwatchlogs.py .....................................................                                                                                                               [100%]

=============================================================================================== 53 passed in 0.58s ================================================================================================
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 685 items                                                                                                                                                                                               

wodles/aws/tests/test_aws_bucket.py ....................................................................................................................................................................... [ 24%]
..........................................................................                                                                                                                                  [ 35%]
wodles/aws/tests/test_aws_s3.py ......................                                                                                                                                                      [ 38%]
wodles/aws/tests/test_aws_service.py ....                                                                                                                                                                   [ 38%]
wodles/aws/tests/test_cloudtrail.py ..                                                                                                                                                                      [ 39%]
wodles/aws/tests/test_cloudwatchlogs.py .....................................................                                                                                                               [ 47%]
wodles/aws/tests/test_config.py .................................................................................                                                                                           [ 58%]
wodles/aws/tests/test_guardduty.py .................                                                                                                                                                        [ 61%]
wodles/aws/tests/test_inspector.py ......                                                                                                                                                                   [ 62%]
wodles/aws/tests/test_load_balancers.py ............                                                                                                                                                        [ 63%]
wodles/aws/tests/test_s3_log_handler.py .......................                                                                                                                                             [ 67%]
wodles/aws/tests/test_server_access.py .................................                                                                                                                                    [ 72%]
wodles/aws/tests/test_sqs_message_processor.py ........                                                                                                                                                     [ 73%]
wodles/aws/tests/test_sqs_queue.py .......                                                                                                                                                                  [ 74%]
wodles/aws/tests/test_tools.py ..................................                                                                                                                                           [ 79%]
wodles/aws/tests/test_umbrella.py ......                                                                                                                                                                    [ 80%]
wodles/aws/tests/test_vpcflow.py ...........................                                                                                                                                                [ 84%]
wodles/aws/tests/test_waf.py .......                                                                                                                                                                        [ 85%]
wodles/aws/tests/test_wazuh_integration.py ......................................................................................................                                                           [100%]

=============================================================================================== 685 passed in 3.44s ===============================================================================================
```