### PR TITLE
Add is_test_session helper function

### DIFF
--- a/src/engine/docs/README.md
+++ b/src/engine/docs/README.md
@@ -26,6 +26,7 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [is_object](#is_object)
 - [is_public_ip](#is_public_ip)
 - [is_string](#is_string)
+- [is_test_session](#is_test_session)
 - [kvdb_match](#kvdb_match)
 - [kvdb_not_match](#kvdb_not_match)
 - [match_value](#match_value)
@@ -834,6 +835,33 @@ field: is_string()
 
 Checks if the value stored in field is of type string.
 If they're not, the function evaluates to false. In case of error, the function will evaluate to false.
+This helper function is typically used in the check stage
+
+
+**Keywords**
+
+- `undefined` 
+
+---
+# is_test_session
+
+## Signature
+
+```
+
+field: is_test_session()
+```
+
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| [number, string, boolean, array, object] | - |
+
+
+## Description
+
+Check if the environment in use is testing or production.
 This helper function is typically used in the check stage
 
 

--- a/src/engine/docs/keyword_table.md
+++ b/src/engine/docs/keyword_table.md
@@ -24,6 +24,7 @@
 | [is_object](documentation.md#is_object) | undefined |
 | [is_public_ip](documentation.md#is_public_ip) | undefined |
 | [is_string](documentation.md#is_string) | undefined |
+| [is_test_session](documentation.md#is_test_session) | undefined |
 | [kvdb_match](documentation.md#kvdb_match) | kvdb |
 | [kvdb_not_match](documentation.md#kvdb_not_match) | kvdb |
 | [match_value](documentation.md#match_value) | undefined |

--- a/src/engine/source/api/src/graph/handlers.cpp
+++ b/src/engine/source/api/src/graph/handlers.cpp
@@ -74,10 +74,10 @@ api::HandlerSync resourceGet(const Config& config)
             return ::api::adapter::genericError<ResponseType>(std::string {"Invalid /policy name: "} + e.what());
         }
 
-        decltype(config.m_builder->buildPolicy({})) policy;
+        decltype(config.m_builder->buildPolicy({}, false, false)) policy;
         try
         {
-            policy = config.m_builder->buildPolicy({policyName});
+            policy = config.m_builder->buildPolicy({policyName}, false, false);
         }
         catch (const std::exception& e)
         {

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -121,6 +121,7 @@ add_executable(builder_utest
     ${UNIT_SRC_DIR}/builders/opfilter/arrayContains_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/types_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/match_test.cpp
+    ${UNIT_SRC_DIR}/builders/opfilter/is_test_session_test.cpp
 
     # Map Builders
     ${UNIT_SRC_DIR}/builders/opmap/map_test.cpp

--- a/src/engine/source/builder/include/builder/builder.hpp
+++ b/src/engine/source/builder/include/builder/builder.hpp
@@ -51,7 +51,8 @@ public:
             const std::shared_ptr<defs::IDefinitionsBuilder>& definitionsBuilder,
             const BuilderDeps& builderDeps);
 
-    std::shared_ptr<IPolicy> buildPolicy(const base::Name& name) const override;
+    std::shared_ptr<IPolicy>
+    buildPolicy(const base::Name& name, bool trace = false, bool sandbox = false) const override;
     base::Expression buildAsset(const base::Name& name) const override;
 
     base::OptError validateIntegration(const json::Json& json, const std::string& namespaceId) const override;

--- a/src/engine/source/builder/interface/builder/ibuilder.hpp
+++ b/src/engine/source/builder/interface/builder/ibuilder.hpp
@@ -24,9 +24,12 @@ public:
      * @brief Build a policy from the store.
      *
      * @param name Name of the policy.
+     * @param trace Indicates whether to enable or disable the trace
+     * @param sandbox If it is set to true, it indicates a test environment and if it is set to false, it indicates a
+     * production environment.
      * @return base::RespOrError<std::shared_ptr<IPolicy>> The policy or an error.
      */
-    virtual std::shared_ptr<IPolicy> buildPolicy(const base::Name& name) const = 0;
+    virtual std::shared_ptr<IPolicy> buildPolicy(const base::Name& name, bool trace, bool sandbox) const = 0;
 
     /**
      * @brief Build an asset expression from the store.

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
@@ -1573,4 +1573,32 @@ FilterOp opBuilderHelperIsIpv6(const Reference& targetField,
     };
 }
 
+// <field>: +is_test_session
+FilterOp opBuilderHelperIsTestSession(const Reference& targetField,
+                                      const std::vector<OpArg>& opArgs,
+                                      const std::shared_ptr<const IBuildCtx>& buildCtx)
+{
+    // Assert expected number of parameters
+    utils::assertSize(opArgs, 0);
+
+    const auto name = buildCtx->context().opName;
+    const auto runState = buildCtx->runState();
+
+    // Tracing
+    const std::string successTrace {fmt::format("[{}] -> Success", name)};
+
+    const std::string failureTrace {
+        fmt::format("[{}] -> Failure: The evaluated environment is a production environment", name)};
+
+    // Return op
+    return [failureTrace, successTrace, runState](base::ConstEvent event) -> FilterResult
+    {
+        if (runState->sandbox)
+        {
+            RETURN_SUCCESS(runState, true, successTrace);
+        }
+        RETURN_FAILURE(runState, false, failureTrace);
+    };
+}
+
 } // namespace builder::builders::opfilter

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
@@ -407,6 +407,20 @@ FilterOp opBuilderHelperIsIpv6(const Reference& targetField,
                                const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
+ * @brief Evaluate whether the current environment is test or production.
+ *
+ * @param targetField target field of the helper
+ * @param opArgs Vector of operation arguments containing numeric values to be converted.
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @return FilterOp
+ *
+ * @throws std::runtime_error if cannot create the filter.
+ */
+FilterOp opBuilderHelperIsTestSession(const Reference& targetField,
+                                      const std::vector<OpArg>& opArgs,
+                                      const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
  * @brief Create the helper function `array_not_contains_any` that filters events if the field
  * is an array and does not contain at least one of the specified values.
  *

--- a/src/engine/source/builder/src/policy/policy.cpp
+++ b/src/engine/source/builder/src/policy/policy.cpp
@@ -13,7 +13,9 @@ Policy::Policy(const store::Doc& doc,
                const std::shared_ptr<store::IStoreReader>& store,
                const std::shared_ptr<defs::IDefinitionsBuilder>& definitionsBuilder,
                const std::shared_ptr<builders::RegistryType>& registry,
-               const std::shared_ptr<schemf::IValidator>& schema)
+               const std::shared_ptr<schemf::IValidator>& schema,
+               const bool trace,
+               const bool sandbox)
 {
     // Read the policy data
     auto policyData = factory::readData(doc, store);
@@ -30,7 +32,8 @@ Policy::Policy(const store::Doc& doc,
     buildCtx->setRegistry(registry);
     buildCtx->setValidator(schema);
     buildCtx->context().policyName = m_name;
-    buildCtx->runState().trace = true;
+    buildCtx->runState().trace = trace;
+    buildCtx->runState().sandbox = sandbox;
 
     auto assetBuilder = std::make_shared<AssetBuilder>(buildCtx, definitionsBuilder);
     auto builtAssets = factory::buildAssets(policyData, store, assetBuilder);

--- a/src/engine/source/builder/src/policy/policy.hpp
+++ b/src/engine/source/builder/src/policy/policy.hpp
@@ -34,12 +34,17 @@ public:
      * @param definitionsBuilder Definitions builder
      * @param registry Registry instance
      * @param schema Schema validator instance
+     * @param trace Indicates whether to enable or disable the trace
+     * @param sandbox If it is set to true, it indicates a test environment and if it is set to false, it indicates a
+     * production environment.
      */
     Policy(const store::Doc& doc,
            const std::shared_ptr<store::IStoreReader>& store,
            const std::shared_ptr<defs::IDefinitionsBuilder>& definitionsBuilder,
            const std::shared_ptr<builders::RegistryType>& registry,
-           const std::shared_ptr<schemf::IValidator>& schema);
+           const std::shared_ptr<schemf::IValidator>& schema,
+           const bool trace = false,
+           const bool sandbox = false);
 
     /**
      * @copydoc IPolicy::name

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -53,6 +53,8 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
     registry->template add<builders::OpBuilderEntry>(
         "not_exists", {schemf::runtimeValidation(), builders::opfilter::notExistsBuilder});
     registry->template add<builders::OpBuilderEntry>(
+        "is_test_session", {schemf::runtimeValidation(), builders::opfilter::opBuilderHelperIsTestSession});
+    registry->template add<builders::OpBuilderEntry>(
         "array_contains", {schemf::isArrayToken(), builders::opfilter::opBuilderHelperContains});
     registry->template add<builders::OpBuilderEntry>(
         "array_contains_any", {schemf::isArrayToken(), builders::opfilter::opBuilderHelperContainsAny});

--- a/src/engine/source/builder/test/mocks/builder/mockBuilder.hpp
+++ b/src/engine/source/builder/test/mocks/builder/mockBuilder.hpp
@@ -10,7 +10,10 @@ namespace builder::mocks
 class MockBuilder : public IBuilder
 {
 public:
-    MOCK_METHOD(std::shared_ptr<IPolicy>, buildPolicy, (const base::Name& name), (const, override));
+    MOCK_METHOD(std::shared_ptr<IPolicy>,
+                buildPolicy,
+                (const base::Name& name, bool trace, bool sandbox),
+                (const, override));
     MOCK_METHOD(base::Expression, buildAsset, (const base::Name& name), (const, override));
 };
 } // namespace builder::mocks

--- a/src/engine/source/builder/test/src/unit/builders/baseBuilders_test.hpp
+++ b/src/engine/source/builder/test/src/unit/builders/baseBuilders_test.hpp
@@ -33,7 +33,7 @@ using BuilderWithDeps = std::function<Builder(void)>;
 struct BuildersMocks
 {
     std::shared_ptr<const MockBuildCtx> ctx;
-    std::shared_ptr<const RunState> runState;
+    std::shared_ptr<RunState> runState;
     std::shared_ptr<MockSchema> validator;
     std::shared_ptr<MockMetaRegistry<OpBuilderEntry, StageBuilder>> registry;
     std::shared_ptr<MockDefinitions> definitions;
@@ -49,7 +49,7 @@ protected:
     {
         mocks = std::make_shared<BuildersMocks>();
         mocks->ctx = std::make_shared<const MockBuildCtx>();
-        mocks->runState = std::make_shared<const RunState>();
+        mocks->runState = std::make_shared<RunState>();
         mocks->validator = std::make_shared<MockSchema>();
         mocks->registry = MockMetaRegistry<OpBuilderEntry, StageBuilder>::createMock();
         mocks->definitions = std::make_shared<MockDefinitions>();
@@ -62,7 +62,9 @@ protected:
     void expectBuildSuccess()
     {
         EXPECT_CALL(*mocks->ctx, context()).Times(testing::AtLeast(1));
-        EXPECT_CALL(*mocks->ctx, runState()).Times(testing::AtLeast(1));
+        EXPECT_CALL(*mocks->ctx, runState())
+            .Times(testing::AtLeast(1))
+            .WillRepeatedly(testing::Return(mocks->runState));
     }
 };
 

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/is_test_session_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/is_test_session_test.cpp
@@ -1,0 +1,51 @@
+#include "builders/baseBuilders_test.hpp"
+
+#include "builders/opfilter/opBuilderHelperFilter.hpp"
+
+namespace
+{
+
+auto runStateExpected(bool trace, bool sandbox)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        mocks.runState->sandbox = sandbox;
+        mocks.runState->trace = trace;
+        return None {};
+    };
+}
+
+} // namespace
+
+namespace filterbuildtest
+{
+INSTANTIATE_TEST_SUITE_P(BuilderIsSessionTest,
+                         FilterBuilderTest,
+                         testing::Values(
+                             // Wrong arguments number
+                             FilterT({makeValue()}, opfilter::opBuilderHelperIsTestSession, FAILURE()),
+                             FilterT({makeValue()}, opfilter::opBuilderHelperIsTestSession, FAILURE()),
+                             FilterT({makeRef()}, opfilter::opBuilderHelperIsTestSession, FAILURE()),
+                             FilterT({makeRef()}, opfilter::opBuilderHelperIsTestSession, FAILURE()),
+                             // Success case
+                             FilterT({}, opfilter::opBuilderHelperIsTestSession, SUCCESS())),
+                         testNameFormatter<FilterBuilderTest>("IsSessionTest"));
+} // namespace filterbuildtest
+
+namespace filteroperatestest
+{
+
+INSTANTIATE_TEST_SUITE_P(BuilderIsSessionTest,
+                         FilterOperationTest,
+                         testing::Values(FilterT(R"({"target": 1})",
+                                                 opfilter::opBuilderHelperIsTestSession,
+                                                 "target",
+                                                 {},
+                                                 FAILURE(runStateExpected(false, false))),
+                                         FilterT(R"({"target": 1})",
+                                                 opfilter::opBuilderHelperIsTestSession,
+                                                 "target",
+                                                 {},
+                                                 SUCCESS(runStateExpected(true, true)))),
+                         testNameFormatter<FilterOperationTest>("IsSessionTest"));
+} // namespace filteroperatestest

--- a/src/engine/source/router/src/environmentBuilder.hpp
+++ b/src/engine/source/router/src/environmentBuilder.hpp
@@ -73,12 +73,15 @@ public:
      * @brief Get the Controller object for a given policy.
      *
      * @param policyName The name of the policy.
-     * @param builder The builder used to construct the policy.
+     * @param trace Indicates whether to enable or disable the trace
+     * @param sandbox If it is set to true, it indicates a test environment and if it is set to false, it indicates a
+     * production environment.
      * @return std::shared_ptr<bk::IController> The constructed controller.
      * @throws std::runtime_error if the policy has no assets or if the backend cannot be built. // TODO Move to
      * base::Error
      */
-    auto makeController(const base::Name& policyName) -> std::pair<std::shared_ptr<bk::IController>, std::string>
+    auto makeController(const base::Name& policyName, const bool trace = true, const bool sandbox = true)
+        -> std::pair<std::shared_ptr<bk::IController>, std::string>
     {
         if (policyName.parts().size() == 0 || policyName.parts()[0] != "policy")
         {
@@ -91,7 +94,7 @@ public:
             throw std::runtime_error {"The builder is not available"};
         }
 
-        auto policy = builder->buildPolicy(policyName);
+        auto policy = builder->buildPolicy(policyName, trace, sandbox);
         if (policy->assets().empty())
         {
             throw std::runtime_error {fmt::format("Policy '{}' has no assets", policyName)};
@@ -121,7 +124,9 @@ public:
         try
         {
             std::string hash {};
-            std::tie(controller, hash) = makeController(policyName);
+            auto trace {false};
+            auto sandbox {false};
+            std::tie(controller, hash) = makeController(policyName, trace, sandbox);
             auto expression = getExpression(filterName);
             return std::make_unique<Environment>(std::move(expression), std::move(controller), std::move(hash));
         }

--- a/src/engine/source/router/test/src/component/router_test.cpp
+++ b/src/engine/source/router/test/src/component/router_test.cpp
@@ -111,7 +111,7 @@ void expectBuildPolicyOk(std::shared_ptr<builder::mocks::MockBuilder> mockbuilde
                          std::shared_ptr<builder::mocks::MockPolicy> mockPolicy)
 {
     // Build policy controller
-    EXPECT_CALL(*mockbuilder, buildPolicy(testing::_)).WillOnce(testing::Return(mockPolicy));
+    EXPECT_CALL(*mockbuilder, buildPolicy(testing::_, testing::_, testing::_)).WillOnce(testing::Return(mockPolicy));
     auto emptyNames = std::unordered_set<base::Name> {"asset/test/0"};
     EXPECT_CALL(*mockPolicy, assets()).WillRepeatedly(testing::ReturnRefOfCopy(emptyNames));
     auto emptyExpression = base::Expression {};

--- a/src/engine/source/router/test/src/component/tester_test.cpp
+++ b/src/engine/source/router/test/src/component/tester_test.cpp
@@ -111,7 +111,7 @@ void expectBuildPolicyOk(std::shared_ptr<builder::mocks::MockBuilder> mockbuilde
                          std::shared_ptr<builder::mocks::MockPolicy> mockPolicy)
 {
     // Build policy controller
-    EXPECT_CALL(*mockbuilder, buildPolicy(testing::_)).WillOnce(testing::Return(mockPolicy));
+    EXPECT_CALL(*mockbuilder, buildPolicy(testing::_, testing::_, testing::_)).WillOnce(testing::Return(mockPolicy));
     auto emptyNames = std::unordered_set<base::Name> {"asset/test/0"};
     EXPECT_CALL(*mockPolicy, assets()).WillRepeatedly(testing::ReturnRefOfCopy(emptyNames));
     auto emptyExpression = base::Expression {};

--- a/src/engine/source/router/test/src/unit/environmentBuilder_test.cpp
+++ b/src/engine/source/router/test/src/unit/environmentBuilder_test.cpp
@@ -27,7 +27,7 @@ TEST(EnvironmentBuilderTest, Create_ValidPolicyAndFilter)
     fakeAssets.insert(base::Name("asset/test/0"));
     fakeAssets.insert(base::Name("asset/test/1"));
     fakeAssets.insert(base::Name("asset/test/2"));
-    EXPECT_CALL(*builder, buildPolicy(policyName)).WillOnce(Return(resPolicy));
+    EXPECT_CALL(*builder, buildPolicy(policyName, testing::_, testing::_)).WillOnce(Return(resPolicy));
     EXPECT_CALL(*mockPolicy, assets()).Times(3).WillRepeatedly(ReturnRef(fakeAssets));
 
     auto mockController = std::make_shared<bk::mocks::MockController>();
@@ -58,7 +58,8 @@ TEST(EnvironmentBuilderTest, Create_inValidPolicy)
     auto policyName = base::Name("policy/test/0");
     auto filterName = base::Name("filter/test/0");
 
-    EXPECT_CALL(*builder, buildPolicy(policyName)).WillOnce(::testing::Throw(std::runtime_error("error")));
+    EXPECT_CALL(*builder, buildPolicy(policyName, testing::_, testing::_))
+        .WillOnce(::testing::Throw(std::runtime_error("error")));
 
     ASSERT_THROW(eBuilder.create(policyName, filterName), std::runtime_error);
 }
@@ -80,7 +81,7 @@ TEST(EnvironmentBuilderTest, Create_ValidPolicyAndInvalidFilter)
     fakeAssets.insert(base::Name("asset/test/0"));
     fakeAssets.insert(base::Name("asset/test/1"));
     fakeAssets.insert(base::Name("asset/test/2"));
-    EXPECT_CALL(*builder, buildPolicy(policyName)).WillOnce(Return(resPolicy));
+    EXPECT_CALL(*builder, buildPolicy(policyName, testing::_, testing::_)).WillOnce(Return(resPolicy));
     EXPECT_CALL(*mockPolicy, assets()).Times(3).WillRepeatedly(ReturnRef(fakeAssets));
 
     auto mockController = std::make_shared<bk::mocks::MockController>();

--- a/src/engine/source/router/test/src/unit/router_test.cpp
+++ b/src/engine/source/router/test/src/unit/router_test.cpp
@@ -41,14 +41,16 @@ public:
 
     void makeControllerBuildPolicyFailture(router::prod::EntryPost entryPost)
     {
-        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_)).WillOnce(::testing::Throw(std::runtime_error("error")));
+        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_, testing::_))
+            .WillOnce(::testing::Throw(std::runtime_error("error")));
         auto error = m_router->addEntry(entryPost);
         EXPECT_TRUE(error.has_value());
     }
 
     void makeControllerBuildPolicySuccess()
     {
-        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_)).WillOnce(::testing::Return(m_mockPolicy));
+        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_, testing::_))
+            .WillOnce(::testing::Return(m_mockPolicy));
     }
 
     void makeControllerPolicyAssetsFailture(router::prod::EntryPost entryPost)
@@ -132,7 +134,7 @@ public:
 
     void rebuildEntryBuildPolicyFailture(const std::string& name)
     {
-        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_))
+        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_, testing::_))
             .WillOnce(::testing::Throw(std::runtime_error("Policy was not building")));
         EXPECT_FALSE(rebuildEntry(name));
     }

--- a/src/engine/source/router/test/src/unit/tester_test.cpp
+++ b/src/engine/source/router/test/src/unit/tester_test.cpp
@@ -34,7 +34,8 @@ public:
 
     void addEntryCallers(const std::unordered_set<base::Name>& fakeAssets, const std::string& hash)
     {
-        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_)).WillOnce(::testing::Return(m_mockPolicy));
+        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_, testing::_))
+            .WillOnce(::testing::Return(m_mockPolicy));
         EXPECT_CALL(*m_mockPolicy, assets()).WillRepeatedly(::testing::ReturnRefOfCopy(fakeAssets));
         EXPECT_CALL(*m_mockControllerMaker, create(testing::_, testing::_, testing::_))
             .WillOnce(::testing::Return(m_mockController));
@@ -47,13 +48,14 @@ public:
 
     void rebuildEntryFailture()
     {
-        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_))
+        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_, testing::_))
             .WillOnce(::testing::Throw(std::runtime_error("Policy was not building")));
     }
 
     void rebuildEntryCallersSuccess(const std::unordered_set<base::Name>& fakeAssets, const std::string& hash)
     {
-        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_)).WillOnce(::testing::Return(m_mockPolicy));
+        EXPECT_CALL(*m_mockBuilder, buildPolicy(testing::_, testing::_, testing::_))
+            .WillOnce(::testing::Return(m_mockPolicy));
         EXPECT_CALL(*m_mockPolicy, assets()).WillRepeatedly(::testing::ReturnRefOfCopy(fakeAssets));
         EXPECT_CALL(*m_mockControllerMaker, create(testing::_, testing::_, testing::_))
             .WillOnce(::testing::Return(m_mockController));

--- a/src/engine/test/helper_tests/helpers_description/filter/is_test_session.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/is_test_session.yml
@@ -1,0 +1,29 @@
+# Name of the helper function
+name: is_test_session
+
+metadata:
+  description: |
+    Check if the environment in use is testing or production.
+    This helper function is typically used in the check stage
+
+  keywords:
+    - undefined
+
+helper_type: filter
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: false
+
+target_field:
+  type:
+    - number
+    - string
+    - boolean
+    - array
+    - object
+
+test:
+  - target_field:
+      key: value
+    should_pass: true
+    description: Is test session


### PR DESCRIPTION
|Related issue|
|---|
|#27928|

## Description
A new **`is_test_session()`** helper function is needed in Wazuh-Engine to distinguish between test and production env. This function will be of the "check" type—returning success if the current execution context is a test session, and failing if it is running in a production policy/route.

**Key Behavior**:
- If **`is_test_session()`** is called during a testing session (e.g., engine-test scenario), the function returns success.
- If **`is_test_session()`** is invoked in a production environment, the function should fail, indicating that the current execution context is not a test.

