### PR TITLE
Package data provider is storing negative size values

### DIFF
--- a/src/data_provider/src/packages/appxWindowsWrapper.h
+++ b/src/data_provider/src/packages/appxWindowsWrapper.h
@@ -95,7 +95,7 @@ class AppxWindowsWrapper final : public IPackageWrapper
             return UNKNOWN_VALUE;
         }
 
-        int size() const override
+        int64_t size() const override
         {
             return 0;
         }

--- a/src/data_provider/src/packages/brewWrapper.h
+++ b/src/data_provider/src/packages/brewWrapper.h
@@ -111,7 +111,7 @@ class BrewWrapper final : public IPackageWrapper
             return m_priority;
         }
 
-        int size() const override
+        int64_t size() const override
         {
             return m_size;
         }
@@ -136,7 +136,7 @@ class BrewWrapper final : public IPackageWrapper
         const std::string m_source;
         const std::string m_location;
         std::string m_priority;
-        int m_size;
+        int64_t m_size;
         std::string m_vendor;
         std::string m_installTime;
         std::string m_multiarch;

--- a/src/data_provider/src/packages/ipackageWrapper.h
+++ b/src/data_provider/src/packages/ipackageWrapper.h
@@ -29,7 +29,7 @@ class IPackageWrapper
         virtual std::string source() const = 0;
         virtual std::string location() const = 0;
         virtual std::string priority() const = 0;
-        virtual int size() const = 0;
+        virtual int64_t size() const = 0;
         virtual std::string vendor() const = 0;
         virtual std::string install_time() const = 0;
         virtual std::string multiarch() const = 0;

--- a/src/data_provider/src/packages/macportsWrapper.h
+++ b/src/data_provider/src/packages/macportsWrapper.h
@@ -95,7 +95,7 @@ class MacportsWrapper final : public IPackageWrapper
             return m_priority;
         }
 
-        int size() const override
+        int64_t size() const override
         {
             return m_size;
         }
@@ -178,7 +178,7 @@ class MacportsWrapper final : public IPackageWrapper
         std::string m_location;
         std::string m_multiarch;
         std::string m_priority;
-        int m_size;
+        int64_t m_size;
         std::string m_vendor;
         std::string m_installTime;
 };

--- a/src/data_provider/src/packages/packageLinuxApkParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxApkParserHelper.h
@@ -26,7 +26,7 @@ namespace PackageLinuxHelper
         {'P', {typeid(std::string), "name"}},
         {'V', {typeid(std::string), "version"}},
         {'A', {typeid(std::string), "architecture"}},
-        {'I', {typeid(int32_t), "size"}},
+        {'I', {typeid(int64_t), "size"}},
         {'T', {typeid(std::string), "description"}},
     };
 
@@ -55,11 +55,11 @@ namespace PackageLinuxHelper
                 {
                     packageInfo[key.second] = value;
                 }
-                else if (key.first == typeid(int32_t))
+                else if (key.first == typeid(int64_t))
                 {
                     try
                     {
-                        packageInfo[key.second] = std::stol(value);
+                        packageInfo[key.second] = std::stoll(value);
                     }
                     catch (const std::exception&)
                     {

--- a/src/data_provider/src/packages/packageLinuxParserHelper.h
+++ b/src/data_provider/src/packages/packageLinuxParserHelper.h
@@ -71,7 +71,7 @@ namespace PackageLinuxHelper
             std::string version {UNKNOWN_VALUE};
             std::string vendor {UNKNOWN_VALUE};
             std::string description {UNKNOWN_VALUE};
-            int size                 { 0 };
+            int64_t size { 0 };
 
             auto it{info.find("Priority")};
 
@@ -91,7 +91,7 @@ namespace PackageLinuxHelper
 
             if (it != info.end())
             {
-                size = stol(it->second) * 1024;
+                size = stoll(it->second) * 1024;
             }
 
             it = info.find("Multi-Arch");
@@ -163,7 +163,7 @@ namespace PackageLinuxHelper
         std::string vendor       { UNKNOWN_VALUE };
         std::string install_time { UNKNOWN_VALUE };
         std::string description  { UNKNOWN_VALUE };
-        int         size         { 0 };
+        int64_t     size         { 0 };
         bool        hasName      { false };
         bool        hasVersion   { false };
 
@@ -224,7 +224,7 @@ namespace PackageLinuxHelper
 
             if (data.is_number())
             {
-                size = data.get<int>();
+                size = data.get<int64_t>();
             }
             else if (data.is_string())
             {
@@ -234,7 +234,7 @@ namespace PackageLinuxHelper
                 {
                     try
                     {
-                        size = std::stoi( stringData );
+                        size = std::stoll( stringData );
                     }
                     catch (const std::exception& e)
                     {

--- a/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
+++ b/src/data_provider/src/packages/packageLinuxRpmParserHelperLegacy.h
@@ -57,7 +57,7 @@ namespace PackageLinuxHelper
                 }
 
                 ret["name"]         = name;
-                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoi(size);
+                ret["size"]         = size.empty() || size.compare(DEFAULT_VALUE) == 0 ? 0 : stoll(size);
                 ret["install_time"] = install_time.empty() || install_time.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : install_time;
                 ret["location"]     = UNKNOWN_VALUE;
                 ret["groups"]       = groups.empty() || groups.compare(DEFAULT_VALUE) == 0 ? UNKNOWN_VALUE : groups;

--- a/src/data_provider/src/packages/pkgWrapper.h
+++ b/src/data_provider/src/packages/pkgWrapper.h
@@ -100,7 +100,7 @@ class PKGWrapper final : public IPackageWrapper
             return m_priority;
         }
 
-        int size() const override
+        int64_t size() const override
         {
             return m_size;
         }
@@ -373,7 +373,7 @@ class PKGWrapper final : public IPackageWrapper
         std::string m_location;
         std::string m_multiarch;
         std::string m_priority;
-        int m_size;
+        int64_t m_size;
         std::string m_vendor;
         std::string m_installTime;
 };

--- a/src/data_provider/src/packages/solarisWrapper.h
+++ b/src/data_provider/src/packages/solarisWrapper.h
@@ -169,7 +169,7 @@ class SolarisWrapper final : public IPackageWrapper
             return UNKNOWN_VALUE;
         }
 
-        int size() const override
+        int64_t size() const override
         {
             return 0;
         }

--- a/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesLinuxHelper/sysInfoPackagesLinuxHelper_test.cpp
@@ -31,13 +31,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformation)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t3\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5-24.el5", jsPackageInfo["version"]);
@@ -51,7 +51,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationLibRpm)
 {
     RpmPackageManager::Package input;
     input.name = "mktemp";
-    input.size = 15432;
+    input.size = 4111222333;
     input.installTime = "1425472738";
     input.group = "System Environment/Base";
     input.version = "1.5";
@@ -63,7 +63,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationLibRpm)
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5-24.el5", jsPackageInfo["version"]);
@@ -118,13 +118,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpoch)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5-24.el5", jsPackageInfo["version"]);
@@ -138,7 +138,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochNoReleaseLibRpm)
 {
     RpmPackageManager::Package input;
     input.name = "mktemp";
-    input.size = 15432;
+    input.size = 4111222333;
     input.installTime = "1425472738";
     input.group = "System Environment/Base";
     input.version = "4.16";
@@ -148,7 +148,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochNoReleaseLibRpm)
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("4.16", jsPackageInfo["version"]);
@@ -162,7 +162,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochLibRpm)
 {
     RpmPackageManager::Package input;
     input.name = "mktemp";
-    input.size = 15432;
+    input.size = 4111222333;
     input.installTime = "1425472738";
     input.group = "System Environment/Base";
     input.version = "4.16";
@@ -173,7 +173,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmNoEpochLibRpm)
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(input) };
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1:4.16", jsPackageInfo["version"]);
@@ -187,13 +187,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonRelease)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5", jsPackageInfo["version"]);
@@ -207,13 +207,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonRelease)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t3\t\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5", jsPackageInfo["version"]);
@@ -227,13 +227,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochWithNone)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t(none)\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t(none)\t24.el5\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5-24.el5", jsPackageInfo["version"]);
@@ -247,13 +247,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonReleaseWithNone)
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t3\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t3\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("3:1.5", jsPackageInfo["version"]);
@@ -267,13 +267,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseRpmInformationNonEpochNonReleaseWith
 {
     constexpr auto RPM_PACKAGE_CENTOS
     {
-        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t15432\t(none)\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
+        "mktemp\tx86_64\tA small utility for safely making /tmp files.\t4111222333\t(none)\t(none)\t1.5\tCentOS\t1425472738\tSystem Environment/Base\t"
     };
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseRpm(RPM_PACKAGE_CENTOS) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("mktemp", jsPackageInfo["name"]);
-    EXPECT_EQ(15432, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1425472738", jsPackageInfo["install_time"]);
     EXPECT_EQ("System Environment/Base", jsPackageInfo["groups"]);
     EXPECT_EQ("1.5", jsPackageInfo["version"]);
@@ -289,7 +289,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseDpkgInformation)
     constexpr auto STATUS_INFO      {"Status: install ok installed"};
     constexpr auto PRIORITY_INFO    {"Priority: optional"};
     constexpr auto SECTION_INFO     {"Section: libdevel"};
-    constexpr auto SIZE_INFO        {"Installed-Size: 591"};
+    constexpr auto SIZE_INFO        {"Installed-Size: 4014865"};
     constexpr auto VENDOR_INFO      {"Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>"};
     constexpr auto ARCH_INFO        {"Architecture: amd64"};
     constexpr auto MULTIARCH_INFO   {"Multi-Arch: same"};
@@ -318,7 +318,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseDpkgInformation)
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("zlib1g-dev", jsPackageInfo["name"]);
     EXPECT_EQ("optional", jsPackageInfo["priority"]);
-    EXPECT_EQ(605184, jsPackageInfo["size"]);
+    EXPECT_EQ(4111221760, jsPackageInfo["size"]);
     EXPECT_EQ("libdevel", jsPackageInfo["groups"]);
     EXPECT_EQ("same", jsPackageInfo["multiarch"]);
     EXPECT_EQ("1:1.2.11.dfsg-2ubuntu1.2", jsPackageInfo["version"]);
@@ -344,7 +344,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parsePacmanInformation)
 
     data.handle        = &dataHandle;
     data.groups        = &dataGroups;
-    data.isize         = 1;
+    data.isize         = 4111222333;
     data.installdate   = 0;
     data.groups->next  = nullptr;
     data.name          = const_cast<char*>(PKG_NAME);
@@ -358,7 +358,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parsePacmanInformation)
     const auto& jsPackageInfo { PackageLinuxHelper::parsePacman(&mock) };
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ(PKG_NAME, jsPackageInfo["name"]);
-    EXPECT_EQ(1, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("1970/01/01 00:00:00", jsPackageInfo["install_time"]);
     EXPECT_EQ(PKG_GROUP, jsPackageInfo["groups"]);
     EXPECT_EQ(PKG_VERSION, jsPackageInfo["version"]);
@@ -465,14 +465,14 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseApkArchitectureKeyNotFound)
     std::vector<std::pair<char, std::string>> input;
     input.push_back(std::pair<char, std::string>('P', "musl"));
     input.push_back(std::pair<char, std::string>('V', "1.2.3-r4"));
-    input.push_back(std::pair<char, std::string>('I', "634880"));
+    input.push_back(std::pair<char, std::string>('I', "4111222333"));
     input.push_back(std::pair<char, std::string>('T', "the musl c library (libc) implementation"));
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseApk(input) };
     EXPECT_EQ("musl", jsPackageInfo.at("name"));
     EXPECT_EQ("1.2.3-r4", jsPackageInfo.at("version"));
     EXPECT_EQ(UNKNOWN_VALUE, jsPackageInfo.at("architecture"));
-    EXPECT_EQ(634880, jsPackageInfo.at("size"));
+    EXPECT_EQ(4111222333, jsPackageInfo.at("size"));
     EXPECT_EQ("the musl c library (libc) implementation", jsPackageInfo.at("description"));
     EXPECT_EQ("apk", jsPackageInfo.at("format"));
     EXPECT_EQ("Alpine Linux", jsPackageInfo.at("vendor"));
@@ -529,13 +529,13 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseApkSuccess)
     input.push_back(std::pair<char, std::string>('P', "musl"));
     input.push_back(std::pair<char, std::string>('V', "1.2.3-r4"));
     input.push_back(std::pair<char, std::string>('A', "x86_64"));
-    input.push_back(std::pair<char, std::string>('I', "634880"));
+    input.push_back(std::pair<char, std::string>('I', "4111222333"));
     input.push_back(std::pair<char, std::string>('T', "the musl c library (libc) implementation"));
 
     const auto& jsPackageInfo { PackageLinuxHelper::parseApk(input) };
     EXPECT_EQ("musl", jsPackageInfo.at("name"));
     EXPECT_EQ("1.2.3-r4", jsPackageInfo.at("version"));
-    EXPECT_EQ(634880, jsPackageInfo.at("size"));
+    EXPECT_EQ(4111222333, jsPackageInfo.at("size"));
     EXPECT_EQ("the musl c library (libc) implementation", jsPackageInfo.at("description"));
     EXPECT_EQ("apk", jsPackageInfo.at("format"));
     EXPECT_EQ("Alpine Linux", jsPackageInfo.at("vendor"));
@@ -550,7 +550,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapCorrectMapping)
             "summary": "Shared GNOME 3.38 Ubuntu stack",
             "description": "This snap includes a GNOME 3.38 stack (the base libraries and desktop \nintegration components) and shares it through the content interface. \n",
             "icon": "/v2/icons/gnome-3-38-2004/icon",
-            "installed-size": 363151360,
+            "installed-size": 4111222333,
             "name": "gnome-3-38-2004",
             "publisher": {
                 "id": "canonical",
@@ -585,7 +585,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapCorrectMapping)
 
     EXPECT_FALSE(jsPackageInfo.empty());
     EXPECT_EQ("gnome-3-38-2004", jsPackageInfo["name"]);
-    EXPECT_EQ(363151360, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
     EXPECT_EQ("2022/11/23 20:33:59", jsPackageInfo["install_time"]);
     EXPECT_EQ(" ", jsPackageInfo["groups"]);
     EXPECT_EQ("0+git.6f39565", jsPackageInfo["version"]);
@@ -692,7 +692,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapValidSizeAsString)
             "summary": "Shared GNOME 3.38 Ubuntu stack",
             "description": "This snap includes a GNOME 3.38 stack (the base libraries and desktop \nintegration components) and shares it through the content interface. \n",
             "icon": "/v2/icons/gnome-3-38-2004/icon",
-            "installed-size": "363151360",
+            "installed-size": "4111222333",
             "name": "gnome-3-38-2004",
             "publisher": {
                 "id": "canonical",
@@ -726,7 +726,7 @@ TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapValidSizeAsString)
         )"_json) };
 
     EXPECT_FALSE(jsPackageInfo.empty());
-    EXPECT_EQ(363151360, jsPackageInfo["size"]);
+    EXPECT_EQ(4111222333, jsPackageInfo["size"]);
 }
 
 TEST_F(SysInfoPackagesLinuxHelperTest, parseSnapEmptyJSON)

--- a/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesMAC/sysInfoMacPackages_test.cpp
@@ -39,7 +39,7 @@ class SysInfoMacPackagesWrapperMock: public IPackageWrapper
         MOCK_METHOD(std::string, source, (), (const override));
         MOCK_METHOD(std::string, location, (), (const override));
         MOCK_METHOD(std::string, priority, (), (const override));
-        MOCK_METHOD(int, size, (), (const override));
+        MOCK_METHOD(int64_t, size, (), (const override));
         MOCK_METHOD(std::string, vendor, (), (const override));
         MOCK_METHOD(std::string, install_time, (), (const override));
         MOCK_METHOD(std::string, multiarch, (), (const override));

--- a/src/data_provider/tests/sysInfoPackagesSolaris/sysInfoSolarisPackages_test.cpp
+++ b/src/data_provider/tests/sysInfoPackagesSolaris/sysInfoSolarisPackages_test.cpp
@@ -35,7 +35,7 @@ class SysInfoSolarisPackagesWrapperMock: public IPackageWrapper
         MOCK_METHOD(std::string, source, (), (const override));
         MOCK_METHOD(std::string, location, (), (const override));
         MOCK_METHOD(std::string, priority, (), (const override));
-        MOCK_METHOD(int, size, (), (const override));
+        MOCK_METHOD(int64_t, size, (), (const override));
         MOCK_METHOD(std::string, vendor, (), (const override));
         MOCK_METHOD(std::string, install_time, (), (const override));
         MOCK_METHOD(std::string, multiarch, (), (const override));

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -324,7 +324,7 @@ constexpr auto PACKAGES_SQL_STATEMENT
     architecture TEXT,
     groups TEXT,
     description TEXT,
-    size INTEGER,
+    size BIGINT,
     priority TEXT,
     multiarch TEXT,
     source TEXT,

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -79,7 +79,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
 
@@ -151,7 +151,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -339,7 +339,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
 
@@ -407,7 +407,7 @@ TEST_F(SyscollectorImpTest, noHardware)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -512,7 +512,7 @@ TEST_F(SyscollectorImpTest, noOs)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
 
@@ -580,7 +580,7 @@ TEST_F(SyscollectorImpTest, noOs)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult11
     {
@@ -684,7 +684,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
 
@@ -740,7 +740,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1007,7 +1007,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
 
@@ -1075,7 +1075,7 @@ TEST_F(SyscollectorImpTest, noPorts)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1180,7 +1180,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
 
@@ -1252,7 +1252,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1363,7 +1363,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":"KB12345678"}])"_json));
 
@@ -1428,7 +1428,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -1534,7 +1534,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     EXPECT_CALL(*spInfoWrapper, packages(_))
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::InvokeArgument<0>
-              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+              (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
 
     EXPECT_CALL(*spInfoWrapper, hotfixes()).Times(0);
 
@@ -1606,7 +1606,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
     };
     const auto expectedResult9
     {
-        R"({"data":{"architecture":"amd64","checksum":"c084f78ed87ed19974b1fd90bbf727c2d1416f7d","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
     const auto expectedResult10
     {
@@ -2280,9 +2280,9 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
     .Times(::testing::AtLeast(1))
     .WillOnce(::testing::DoAll(
                   ::testing::InvokeArgument<0>
-                  (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json),
+                  (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json),
                   ::testing::InvokeArgument<0>
-                  (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json)));
+                  (R"({"architecture":"amd64","scan_time":"2020/12/28 21:49:50", "group":"x11","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json)));
 
 
 
@@ -2300,7 +2300,7 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
 
     const auto expectedResult1
     {
-        R"({"data":{"architecture":"amd64","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":411,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+        R"({"data":{"architecture":"amd64","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
     };
 
     EXPECT_CALL(wrapper, callbackMock(expectedResult1)).Times(1);


### PR DESCRIPTION
|Related issue|
|---|
| #27865 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes an overflow that occurs in the field _size_ of _packages_, when the size of the package installed in the agent exceeds the limit for an `int` variable (32bits). This causes the field to have a wrong negative value.

## Logs/Alerts example

As can be seen, prior to the changes introduced in this PR, the size of the _kf6-core22_ package is stored in _local.db_ with a negative value:

```console
sqlite> select name, version, description, size from dbsync_packages where name="kf6-core22";
name        version                    description       size       
----------  -------------------------  ----------------  -----------
kf6-core22  6.6.0                      KDE Frameworks 6  -2103541760
```

Being its size 2191425536 bytes:

```console
nbertoldo@nbertoldo:~/workspace/wazuh/src/data_provider/build/bin$ curl --unix-socket /run/snapd.socket http://localhost/v2/snaps | jq '.result[] | select(.name == "kf6-core22")'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 67040    0 67040    0     0  3526k      0 --:--:-- --:--:-- --:--:-- 3637k
{
  "id": "DlAIkaMJ1XMsnQRKcn0EjE2nc1S37X4r",
  "title": "kf6-core22",
  "summary": "KDE Frameworks 6",
  "description": "KDE Frameworks are addons and useful extensions to Qt",
  "installed-size": 2191425536,
  "install-date": "2024-12-26T08:56:30.243457999-03:00",
  "name": "kf6-core22",
  "publisher": {
    "id": "2rsYZu6kqYVFsSejExu4YENdXQEO40Xb",
    "username": "kde",
    "display-name": "KDE",
    "validation": "verified"
  },
  "developer": "kde",
  "status": "active",
  "type": "app",
  "base": "core22",
  "version": "6.6.0",
  "channel": "latest/stable",
  "tracking-channel": "latest/stable",
  "ignore-validation": false,
  "revision": "40",
  "confinement": "strict",
  "private": false,
  "devmode": false,
  "jailmode": false,
  "mounted-from": "/var/lib/snapd/snaps/kf6-core22_40.snap",
  "links": null,
  "contact": ""
}
```

After increasing the variable size to 64 bits:

```console
sqlite> select name, version, description, size from dbsync_packages where size>2147483648;
name        version                    description       size      
----------  -------------------------  ----------------  ----------
kf6-core22  6.6.0                      KDE Frameworks 6  2191425536
```

Rsync event:

```console
2025/02/05 12:42:48 wazuh-modulesd:syscollector[81971] logging_helper.c:40 at taggedLogFunction(): DEBUG: Sync sent: {"component":"syscollector_packages","data":{"attributes":{"architecture":" ","checksum":"5b5b2fa9f65bbd684875624ca9d7816c5f1954e0","description":"KDE Frameworks 6","format":"snap","groups":" ","install_time":"2024/12/26 08:56:30","item_id":"f5f70eea11d3f050b89cbfff66d4a60103c0f369","location":"/snap/kf6-core22","multiarch":" ","name":"kf6-core22","priority":" ","scan_time":"2025/02/05 15:42:48","size":2191425536,"source":"snapcraft","vendor":"KDE","version":"6.6.0"},"index":"f5f70eea11d3f050b89cbfff66d4a60103c0f369","timestamp":""},"type":"state"}
```

Dbsync 'DELETE' event:

```console
2025/02/05 12:48:13 wazuh-modulesd:syscollector[81971] logging_helper.c:40 at taggedLogFunction(): DEBUG: Delta sent: {"data":{"architecture":" ","checksum":"5b5b2fa9f65bbd684875624ca9d7816c5f1954e0","description":"KDE Frameworks 6","format":"snap","groups":" ","install_time":"2024/12/26 08:56:30","item_id":"f5f70eea11d3f050b89cbfff66d4a60103c0f369","location":"/snap/kf6-core22","multiarch":" ","name":"kf6-core22","priority":" ","scan_time":"2025/02/05 15:48:13","size":2191425536,"source":"snapcraft","vendor":"KDE","version":"6.6.0"},"operation":"DELETED","type":"dbsync_packages"}
```

Dbsync 'INSERT' event:
```console
2025/02/05 13:08:16 wazuh-modulesd:syscollector[81971] logging_helper.c:40 at taggedLogFunction(): DEBUG: Delta sent: {"data":{"architecture":" ","checksum":"69db4e7955dd82565e9071727588feb183465f94","description":"KDE Frameworks 6","format":"snap","groups":" ","install_time":"2025/02/05 12:59:48","item_id":"f5f70eea11d3f050b89cbfff66d4a60103c0f369","location":"/snap/kf6-core22","multiarch":" ","name":"kf6-core22","priority":" ","scan_time":"2025/02/05 16:08:16","size":2191425536,"source":"snapcraft","vendor":"KDE","version":"6.6.0"},"operation":"INSERTED","type":"dbsync_packages"}
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

- Unit tests

<details><summary>Data-provider</summary>

```console
nbertoldo@nbertoldo:~/workspace/wazuh/src/data_provider/build$ ctest
Test project /home/nbertoldo/workspace/wazuh/src/data_provider/build
      Start  1: sysInfoPackagesLinuxHelper_unit_test
 1/10 Test  #1: sysInfoPackagesLinuxHelper_unit_test .....   Passed    0.01 sec
      Start  2: sysInfoPackagesBerkeleyDB_unit_test
 2/10 Test  #2: sysInfoPackagesBerkeleyDB_unit_test ......   Passed    0.00 sec
      Start  3: sysInfoNetworkLinux_unit_test
 3/10 Test  #3: sysInfoNetworkLinux_unit_test ............   Passed    0.00 sec
      Start  4: sysInfoNetworkSolaris_unit_test
 4/10 Test  #4: sysInfoNetworkSolaris_unit_test ..........   Passed    0.00 sec
      Start  5: Rpm_unit_test
 5/10 Test  #5: Rpm_unit_test ............................   Passed    0.00 sec
      Start  6: sysInfoPackageLinuxParserRPM_unit_test
 6/10 Test  #6: sysInfoPackageLinuxParserRPM_unit_test ...   Passed    0.01 sec
      Start  7: sysInfoSolarisPackage_unit_test
 7/10 Test  #7: sysInfoSolarisPackage_unit_test ..........   Passed    0.00 sec
      Start  8: sysInfoPackages_unit_test
 8/10 Test  #8: sysInfoPackages_unit_test ................   Passed    0.01 sec
      Start  9: sysinfo_unit_test
 9/10 Test  #9: sysinfo_unit_test ........................   Passed    0.04 sec
      Start 10: sysInfoPort_unit_test
10/10 Test #10: sysInfoPort_unit_test ....................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) =   0.09 sec
```

</details> 
 
<details><summary>Syscollector</summary>

```console
nbertoldo@nbertoldo:~/workspace/wazuh/src/wazuh_modules/syscollector/build$ ctest
Test project /home/nbertoldo/workspace/wazuh/src/wazuh_modules/syscollector/build
    Start 1: syscollectorimp_unit_test
1/2 Test #1: syscollectorimp_unit_test ........   Passed   39.03 sec
    Start 2: sys_normalizer_unit_test
2/2 Test #2: sys_normalizer_unit_test .........   Passed    0.05 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  39.08 sec
```

</details> 
