### PR TITLE
Add vendor information to CISA vulnerability candidates and update database generation workflow

### DIFF
--- a/.github/actions/check_files/manager_base_deb.csv
+++ b/.github/actions/check_files/manager_base_deb.csv
@@ -543,7 +543,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/ruleset/sca/web_vulnerabilities.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/templates/vd_states_template.json,root,wazuh,440,file,-r--r-----,,
 /var/ossec/templates/vd_states_update_mappings.json,root,wazuh,440,file,-r--r-----,,
-/var/ossec/tmp/vd_1.0.0_vd_4.10.0.tar.xz,wazuh,wazuh,640,file,-rw-r-----,,
+/var/ossec/tmp/vd_1.0.0_vd_4.11.0.tar.xz,wazuh,wazuh,640,file,-rw-r-----,,
 /var/ossec/var/db/mitre.db,root,wazuh,660,file,-rw-rw----,,
 /var/ossec/var/selinux/wazuh.pp,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/wodles/__init__.py,root,wazuh,750,file,-rwxr-x---,,

--- a/.github/actions/check_files/manager_base_rpm.csv
+++ b/.github/actions/check_files/manager_base_rpm.csv
@@ -542,7 +542,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/ruleset/sca/web_vulnerabilities.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/templates/vd_states_template.json,root,wazuh,440,file,-r--r-----,,
 /var/ossec/templates/vd_states_update_mappings.json,root,wazuh,440,file,-r--r-----,,
-/var/ossec/tmp/vd_1.0.0_vd_4.10.0.tar.xz,wazuh,wazuh,750,file,-rwxr-x---,,
+/var/ossec/tmp/vd_1.0.0_vd_4.11.0.tar.xz,wazuh,wazuh,750,file,-rwxr-x---,,
 /var/ossec/var/db/mitre.db,root,wazuh,660,file,-rw-rw----,,
 /var/ossec/var/selinux/wazuh.pp,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/wodles/__init__.py,root,wazuh,750,file,-rwxr-x---,,

--- a/.github/workflows/vulnerability-scanner-generate-database.yml
+++ b/.github/workflows/vulnerability-scanner-generate-database.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
           # Identifiers of the generated content. The generated files will be named vd_1.0.0_vd_<content_version>.tar.xz
-          content_version: ["4.8.0", "4.10.0"]
+          content_version: ["4.8.0", "4.10.0", "4.11.0"]
 
     steps:
       # Checkout to the branch

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -327,7 +327,7 @@ if [ $1 = 2 ]; then
   fi
 fi
 
-%define _vdfilename vd_1.0.0_vd_4.10.0.tar.xz
+%define _vdfilename vd_1.0.0_vd_4.11.0.tar.xz
 
 # Fresh install code block
 if [ $1 = 1 ]; then

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1161,7 +1161,7 @@ TransferShared()
 
 checkDownloadContent()
 {
-    VD_FILENAME='vd_1.0.0_vd_4.10.0.tar.xz'
+    VD_FILENAME='vd_1.0.0_vd_4.11.0.tar.xz'
     VD_FULL_PATH=${INSTALLDIR}/tmp/${VD_FILENAME}
 
     if [ "X${DOWNLOAD_CONTENT}" = "Xy" ]; then

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -144,7 +144,8 @@ public:
                     defaultStatus,
                     affected->platforms() && affected->platforms()->size() ? &platformsVec : nullptr,
                     &versionFBArray,
-                    affected->vendor() && shortName == "nvd" ? affected->vendor()->c_str() : nullptr);
+                    affected->vendor() && (shortName == "nvd" || shortName == "cisa") ? affected->vendor()->c_str()
+                                                                                      : nullptr);
 
                 candidatesArraysMap.at(productName).first.push_back(candidate);
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -30,8 +30,8 @@ constexpr auto EVENTS_BULK_SIZE {1};
 constexpr auto EVENTS_QUEUE_PATH = "queue/vd/event";
 constexpr auto MICROSEC_FACTOR {1000000};
 
-constexpr auto COMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.10.0.tar.xz"};
-constexpr auto DECOMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.10.0.tar"};
+constexpr auto COMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.11.0.tar.xz"};
+constexpr auto DECOMPRESSED_DB_PATH {"tmp/vd_1.0.0_vd_4.11.0.tar"};
 constexpr auto VD_STATE_QUEUE_PATH = "queue/vd/state_track";
 constexpr auto VD_KEYSTORE_PATH = "queue/keystore";
 constexpr auto VD_DATABASE_PATH {"queue/vd"};


### PR DESCRIPTION
|Related issue|
|---|
|#27985|

## Description 

This PR adds the required changes to: 

- Add the vendor information for package in CISA vendor 
- Update the database generation workflow to generate a 4.11 database version 
- Update code in charge to manage the decompression of database to accept the new 4.11 version
- Add UTs to verify new behavior

## Logs/Alerts example

- Using a Windows 2019 server for testing 

### Baseline detection
- Using provided content snapshot_all_vendors_and_cisa.zip

66 vulnerabilities have been found

### Dev detection 
- Using provided content snapshot_all_vendors_and_cisa.zip plus adp array and adp descriptions for cisa 

```json
  "adp_default_array": [
    "cisa",
    "nvd"
  ],
  ...
  "cisa": {
    "adp": "CISA",
    "cvss": "cisa",
    "description": "cisa"
  },
```

With CISA information we detect 4 more vulnerabilities for Wireshark 

<details><summary>Expand</summary>

```json
{
  "category": "Packages",
  "classification": "CVSS",
  "description": "A Buffer Overflow in Wireshark before 4.2.0 allows a remote attacker to cause a denial of service via the wsutil/to_str.c, and format_fractional_part_nsecs components. NOTE: this is disputed by the vendor because neither release 4.2.0 nor any other release was affected.",
  "enumeration": "CVE",
  "id": "CVE-2024-24479",
  "published_at": "2024-02-21T19:15:09Z",
  "reference": "https://gist.github.com/1047524396/c50ad17e9a1a18990043a7cd27814c78, https://github.com/wireshark/wireshark/commit/c3720cff158c265dec2a0c6104b1d65954ae6bfd, https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZT2BX7UARZVVWKITSZMHW7BHXGIKRSR2/",
  "scanner": {
    "source": "CISA",
    "vendor": "Wazuh"
  },
  "score": {
    "base": 7.5,
    "version": "3.1"
  },
  "severity": "High",
  "under_evaluation": false
}
{
  "category": "Packages",
  "classification": "CVSS",
  "description": "A buffer overflow in Wireshark before 4.2.0 allows a remote attacker to cause a denial of service via the pan/addr_resolv.c, and ws_manuf_lookup_str(), size components. NOTE: this is disputed by the vendor because neither release 4.2.0 nor any other release was affected.",
  "enumeration": "CVE",
  "id": "CVE-2024-24476",
  "published_at": "2024-02-21T19:15:09Z",
  "reference": "https://gist.github.com/1047524396/369ba0ccffe255cf8142208b6142be2b, https://github.com/wireshark/wireshark/commit/108217f4bb1afb8b25fc705c2722b3e328b1ad78, https://gitlab.com/wireshark/wireshark/-/issues/19344, https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZT2BX7UARZVVWKITSZMHW7BHXGIKRSR2/",
  "scanner": {
    "source": "CISA",
    "vendor": "Wazuh"
  },
  "score": {
    "base": 7.5,
    "version": "3.1"
  },
  "severity": "High",
  "under_evaluation": false
}
{
  "category": "Packages",
  "classification": "CVSS",
  "description": "An issue in Wireshark before 4.2.0 allows a remote attacker to cause a denial of service via the packet-bgp.c, dissect_bgp_open(tvbuff_t*tvb, proto_tree*tree, packet_info*pinfo), optlen components. NOTE: this is disputed by the vendor because neither release 4.2.0 nor any other release was affected.",
  "enumeration": "CVE",
  "id": "CVE-2024-24478",
  "published_at": "2024-02-21T17:15:09Z",
  "reference": "https://gist.github.com/1047524396/e82c55147cd3cb62ef20cbdb0ec83694, https://github.com/wireshark/wireshark/commit/80a4dc55f4d2fa33c2b36a99406500726d3faaef, https://gitlab.com/wireshark/wireshark/-/issues/19347",
  "scanner": {
    "source": "CISA",
    "vendor": "Wazuh"
  },
  "score": {
    "base": 7.5,
    "version": "3.1"
  },
  "severity": "High",
  "under_evaluation": false
}
{
  "category": "Packages",
  "classification": "CVSS",
  "description": "If a garbage collection was triggered at the right time, a use-after-free could have occurred during object transplant. This vulnerability affects Firefox < 127, Firefox ESR < 115.12, and Thunderbird < 115.12.",
  "enumeration": "CVE",
  "id": "CVE-2024-5688",
  "published_at": "2024-06-11T13:15:50Z",
  "reference": "https://bugzilla.mozilla.org/show_bug.cgi?id=1895086, https://lists.debian.org/debian-lts-announce/2024/06/msg00000.html, https://lists.debian.org/debian-lts-announce/2024/06/msg00010.html, https://www.mozilla.org/security/advisories/mfsa2024-25/, https://www.mozilla.org/security/advisories/mfsa2024-26/, https://www.mozilla.org/security/advisories/mfsa2024-28/",
  "scanner": {
    "source": "CISA",
    "vendor": "Wazuh"
  },
  "score": {
    "base": 8.1,
    "version": "3.1"
  },
  "severity": "High",
  "under_evaluation": false
}
```

</details>

- Before = baseline, after = dev 
[vulnerabilities.tar.gz](https://github.com/user-attachments/files/18663898/vulnerabilities.tar.gz)

> [!NOTE]
> We don't have information for those 4 CVEs in NVD 

![image](https://github.com/user-attachments/assets/ca216478-ca20-4956-842b-a18ce44d452c)

### Check priority 

CISA CVEs for wireshark

<details><summary>Expand</summary>

```json
{"wireshark_CVE-2023-6175":{"candidates":[{"cveId":"CVE-2023-6175","versions":[{"version":"3.6.0","lessThan":"3.6.19","versionType":"semver"},{"version":"4.0.0","lessThan":"4.0.11","versionType":"semver"}]}]}}
{"wireshark_CVE-2024-11595":{"candidates":[{"cveId":"CVE-2024-11595","defaultStatus":"unaffected","versions":[{"version":"4.2.0","lessThan":"4.2.9","versionType":"semver"},{"version":"4.4.0","lessThan":"4.4.2","versionType":"semver"}]}]}}
{"wireshark_CVE-2024-11596":{"candidates":[{"cveId":"CVE-2024-11596","defaultStatus":"unaffected","versions":[{"version":"4.2.0","lessThan":"4.2.9","versionType":"semver"},{"version":"4.4.0","lessThan":"4.4.2","versionType":"semver"}]}]}}
{"wireshark_CVE-2024-24476":{"candidates":[{"cveId":"CVE-2024-24476","versions":[{"version":"0","lessThan":"4.2.0","versionType":"custom"}]}]}}
{"wireshark_CVE-2024-24478":{"candidates":[{"cveId":"CVE-2024-24478","versions":[{"version":"0","lessThan":"4.2.0","versionType":"custom"}]}]}}
{"wireshark_CVE-2024-24479":{"candidates":[{"cveId":"CVE-2024-24479","versions":[{"version":"0","lessThan":"4.2.0","versionType":"custom"}]}]}}
{"wireshark_CVE-2024-2955":{"candidates":[{"cveId":"CVE-2024-2955","versions":[{"version":"4.0.0","lessThan":"4.0.14","versionType":"custom"},{"version":"4.2.0","lessThan":"4.2.4","versionType":"semver"}]}]}}
{"wireshark_CVE-2024-8250":{"candidates":[{"cveId":"CVE-2024-8250","defaultStatus":"unaffected","versions":[{"version":"4.0.0","lessThan":"4.0.17","versionType":"custom"},{"version":"4.2.0","lessThan":"4.2.7","versionType":"semver"}]}]}}
{"wireshark_CVE-2024-8645":{"candidates":[{"cveId":"CVE-2024-8645","defaultStatus":"unaffected","versions":[{"version":"4.0.0","lessThan":"4.0.16","versionType":"custom"},{"version":"4.2.0","lessThan":"4.2.6","versionType":"custom"}]}]}}
{"wireshark_CVE-2024-9780":{"candidates":[{"cveId":"CVE-2024-9780","defaultStatus":"unaffected","versions":[{"version":"4.4.0","lessThan":"4.4.1","versionType":"semver"}]}]}}
{"wireshark_CVE-2024-9781":{"candidates":[{"cveId":"CVE-2024-9781","defaultStatus":"unaffected","versions":[{"version":"4.2.0","lessThan":"4.2.8","versionType":"semver"},{"version":"4.4.0","lessThan":"4.4.1","versionType":"semver"}]}]}}
```

</details>

All detected CVEs for NVD 

<details><summary>Expand</summary>

```console
CVE-2024-49112
CVE-2024-6197
CVE-2024-30092
CVE-2023-2906
CVE-2019-9214
CVE-2019-9209
CVE-2019-5721
CVE-2019-5719
CVE-2018-19624
CVE-2018-16056
CVE-2018-9270
CVE-2019-12295
CVE-2018-14370
CVE-2018-14438
CVE-2018-9264
CVE-2018-19622
CVE-2018-14343
CVE-2018-18227
CVE-2018-14368
CVE-2018-16057
CVE-2018-16058
CVE-2018-11358
CVE-2018-19623
CVE-2019-10895
CVE-2019-10899
CVE-2018-11357
CVE-2018-11360
CVE-2018-9266
CVE-2018-14342
CVE-2018-11362
CVE-2018-19627
CVE-2018-9257
CVE-2018-19626
CVE-2018-14339
CVE-2018-14341
CVE-2018-9271
CVE-2018-9256
CVE-2018-9273
CVE-2018-9258
CVE-2018-9259
CVE-2018-9260
CVE-2018-9268
CVE-2019-5717
CVE-2019-9208
CVE-2018-9261
CVE-2018-14344
CVE-2018-9262
CVE-2020-26575
CVE-2018-14367
CVE-2018-9263
CVE-2018-11359
CVE-2018-14340
CVE-2018-9265
CVE-2018-19625
CVE-2019-5718
CVE-2018-9269
CVE-2018-9272
CVE-2018-9267
CVE-2018-9274
CVE-2019-10894
CVE-2019-10896
CVE-2019-10901
CVE-2018-14369
CVE-2018-11356
CVE-2019-10903
CVE-2019-13619
```

</details>

All the detected CVEs for NVD do not have counterpart in CISA 
![image](https://github.com/user-attachments/assets/eb4b6bf6-52bd-4bd5-a6fc-0471b984af7c)

CISA information used first. 
```console
2025/02/04 17:47:22 wazuh-modulesd:vulnerability-scanner[66105] osScanner.hpp:306 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array for OS.
2025/02/04 17:47:22 wazuh-modulesd:vulnerability-scanner[66105] osScanner.hpp:306 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array for OS.
2025/02/04 17:47:22 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:22 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:22 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:22 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'cisa' from CNA array.
2025/02/04 17:47:23 wazuh-modulesd:vulnerability-scanner[66105] packageScanner.hpp:770 at handleRequest(): DEBUG: Using CNA 'nvd' from CNA array.
```

### Logs 
No errors found 
![image](https://github.com/user-attachments/assets/4f8969d9-b54b-43b2-8827-12339b93e5bf)

[ossec.log.tar.gz](https://github.com/user-attachments/files/18672613/ossec.log.tar.gz)
