### PR TITLE
Add is_ipv6 helper function

### DIFF
--- a/src/engine/docs/README.md
+++ b/src/engine/docs/README.md
@@ -17,6 +17,7 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [is_array](#is_array)
 - [is_boolean](#is_boolean)
 - [is_ipv4](#is_ipv4)
+- [is_ipv6](#is_ipv6)
 - [is_not_array](#is_not_array)
 - [is_not_boolean](#is_not_boolean)
 - [is_not_object](#is_not_object)
@@ -549,6 +550,7 @@ This helper function is typically used in the check stage
 
 ---
 # is_ipv4
+# is_ipv6
 
 ## Signature
 
@@ -557,16 +559,28 @@ This helper function is typically used in the check stage
 field: is_ipv4()
 ```
 
+field: is_ipv6(ip)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| ip | string | reference | Any IP |
+
+
 ## Target Field
 
 | Type | Possible values |
 | ---- | --------------- |
 | string | Any IP |
+| [number, string, object, boolean, array] | - |
 
 
 ## Description
 
 Checks if the IP address stored in the field is an IPv4.
+Checks if the IP address stored in the field is an IPv6.
 IPv4:
   - 10.0.0.0
   - 172.16.0.0

--- a/src/engine/docs/README.md
+++ b/src/engine/docs/README.md
@@ -37,7 +37,6 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [string_less_or_equal](#string_less_or_equal)
 - [string_not_equal](#string_not_equal)
 ## Map
-- [active_response_send](#active_response_send)
 - [as](#as)
 - [concat](#concat)
 - [concat_any](#concat_any)
@@ -52,14 +51,11 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [ip_version](#ip_version)
 - [join](#join)
 - [regex_extract](#regex_extract)
-- [send_upgrade_confirmation](#send_upgrade_confirmation)
 - [sha1](#sha1)
 - [system_epoch](#system_epoch)
 - [to_int](#to_int)
 - [to_string](#to_string)
 - [upcase](#upcase)
-- [wdb_query](#wdb_query)
-- [wdb_update](#wdb_update)
 ## Transformation
 - [array_append](#array_append)
 - [array_append_any](#array_append_any)
@@ -550,7 +546,6 @@ This helper function is typically used in the check stage
 
 ---
 # is_ipv4
-# is_ipv6
 
 ## Signature
 
@@ -559,27 +554,47 @@ This helper function is typically used in the check stage
 field: is_ipv4()
 ```
 
-field: is_ipv6(ip)
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| string | Any IP |
+
+
+## Description
+
+Checks if the IP address stored in the field is an IPv4.
+IPv4:
+  - 10.0.0.0
+  - 172.16.0.0
+  - 192.168.0.0
+  - 127.0.0.0
+This helper function is typically used in the check stage
+
+
+**Keywords**
+
+- `undefined` 
+
+---
+# is_ipv6
+
+## Signature
+
 ```
 
-## Arguments
-
-| parameter | Type | Source | Accepted values |
-| --------- | ---- | ------ | --------------- |
-| ip | string | reference | Any IP |
-
+field: is_ipv6()
+```
 
 ## Target Field
 
 | Type | Possible values |
 | ---- | --------------- |
 | string | Any IP |
-| [number, string, object, boolean, array] | - |
 
 
 ## Description
 
-Checks if the IP address stored in the field is an IPv4.
 Checks if the IP address stored in the field is an IPv6.
 IPv4:
   - 10.0.0.0
@@ -1186,42 +1201,6 @@ This helper function is typically used in the check stage
 - `comparison` 
 
 ---
-# active_response_send
-
-## Signature
-
-```
-
-field: active_response_send(ar-message)
-```
-
-## Arguments
-
-| parameter | Type | Source | Accepted values |
-| --------- | ---- | ------ | --------------- |
-| ar-message | string | value or reference | Any string |
-
-
-## Outputs
-
-| Type | Possible values |
-| ---- | --------------- |
-| string | Any string |
-
-
-## Description
-
-Sends a message through the active response queue and updates the field with the result of the execution
-if the message could be sent without any problem it will be set to true, if not to false.
-Thre result value doesn`t mean that it checks the correct execution of the Active response.
-This helper function is typically used in the map stage.
-
-
-**Keywords**
-
-- `undefined` 
-
----
 # as
 
 ## Signature
@@ -1744,41 +1723,6 @@ This helper function is used in the map stage
 - `undefined` 
 
 ---
-# send_upgrade_confirmation
-
-## Signature
-
-```
-
-field: send_upgrade_confirmation(json)
-```
-
-## Arguments
-
-| parameter | Type | Source | Accepted values |
-| --------- | ---- | ------ | --------------- |
-| json | object | reference | Any object |
-
-
-## Outputs
-
-| Type | Possible values |
-| ---- | --------------- |
-| boolean | Any boolean |
-
-
-## Description
-
-Receives a JSON object that must contain the agent id, error field and message among other mandatory fields and
-send it throug the UPGRADE socket. The result of the communication will be return as a boolean value
-being true when sent ok and false otherwise. This helper function is typically used in the map stage.
-
-
-**Keywords**
-
-- `undefined` 
-
----
 # sha1
 
 ## Signature
@@ -1950,78 +1894,6 @@ If the “field” already exists, then it will be replaced. In case of errors �
 **Keywords**
 
 - `string` 
-
----
-# wdb_query
-
-## Signature
-
-```
-
-field: wdb_query(query)
-```
-
-## Arguments
-
-| parameter | Type | Source | Accepted values |
-| --------- | ---- | ------ | --------------- |
-| query | string | value or reference | Any string |
-
-
-## Outputs
-
-| Type | Possible values |
-| ---- | --------------- |
-| string | Any string |
-
-
-## Description
-
-Perform a query to wazuh-db. If it was able to connect to wazuh-db and run a valid query (no errors)
-then map the payload response of wazuh-db into field. If the field field already exists, then it will be replaced.
-In case of errors target field will not be modified.
-This helper function is typically used in the map stage
-
-
-**Keywords**
-
-- `wdb` 
-
----
-# wdb_update
-
-## Signature
-
-```
-
-field: wdb_update(query)
-```
-
-## Arguments
-
-| parameter | Type | Source | Accepted values |
-| --------- | ---- | ------ | --------------- |
-| query | string | value or reference | Any string |
-
-
-## Outputs
-
-| Type | Possible values |
-| ---- | --------------- |
-| boolean | Any boolean |
-
-
-## Description
-
-Perform a query to wazuh-db. If it was able to connect to wazuh-db and run a valid query (no errors)
-then map `true` into field if not, then map `false` into field.
-If the field field already exists, then it will be replaced. In case of errors target field will not be modified.
-This helper function is typically used in the map stage
-
-
-**Keywords**
-
-- `wdb` 
 
 ---
 # array_append

--- a/src/engine/docs/keyword_table.md
+++ b/src/engine/docs/keyword_table.md
@@ -15,6 +15,7 @@
 | [is_array](documentation.md#is_array) | undefined |
 | [is_boolean](documentation.md#is_boolean) | undefined |
 | [is_ipv4](documentation.md#is_ipv4) | undefined |
+| [is_ipv6](documentation.md#is_ipv6) | undefined |
 | [is_not_array](documentation.md#is_not_array) | undefined |
 | [is_not_boolean](documentation.md#is_not_boolean) | undefined |
 | [is_not_object](documentation.md#is_not_object) | undefined |

--- a/src/engine/docs/keyword_table.md
+++ b/src/engine/docs/keyword_table.md
@@ -34,7 +34,6 @@
 | [string_less](documentation.md#string_less) | comparison, string |
 | [string_less_or_equal](documentation.md#string_less_or_equal) | comparison, string |
 | [string_not_equal](documentation.md#string_not_equal) | comparison, string |
-| [active_response_send](documentation.md#active_response_send) | undefined |
 | [as](documentation.md#as) | max_min_db |
 | [concat](documentation.md#concat) | different_types |
 | [concat_any](documentation.md#concat_any) | different_types |
@@ -49,14 +48,11 @@
 | [ip_version](documentation.md#ip_version) | ip |
 | [join](documentation.md#join) | undefined |
 | [regex_extract](documentation.md#regex_extract) | undefined |
-| [send_upgrade_confirmation](documentation.md#send_upgrade_confirmation) | undefined |
 | [sha1](documentation.md#sha1) | undefined |
 | [system_epoch](documentation.md#system_epoch) | time |
 | [to_int](documentation.md#to_int) | double, float, integer |
 | [to_string](documentation.md#to_string) | undefined |
 | [upcase](documentation.md#upcase) | string |
-| [wdb_query](documentation.md#wdb_query) | wdb |
-| [wdb_update](documentation.md#wdb_update) | wdb |
 | [array_append](documentation.md#array_append) | array |
 | [array_append_any](documentation.md#array_append_any) | array |
 | [array_append_unique](documentation.md#array_append_unique) | array |

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -116,6 +116,7 @@ add_executable(builder_utest
     ${UNIT_SRC_DIR}/builders/opfilter/strCmp_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/regex_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/is_ipv4_test.cpp
+    ${UNIT_SRC_DIR}/builders/opfilter/is_ipv6_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/ip_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/arrayContains_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/types_test.cpp

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.cpp
@@ -1497,7 +1497,7 @@ FilterOp opBuilderHelperEndsWith(const Reference& targetField,
     };
 }
 
-// <field>: +is_ipv4/$<reference>
+// <field>: +is_ipv4/
 FilterOp opBuilderHelperIsIpv4(const Reference& targetField,
                                const std::vector<OpArg>& opArgs,
                                const std::shared_ptr<const IBuildCtx>& buildCtx)
@@ -1527,6 +1527,44 @@ FilterOp opBuilderHelperIsIpv4(const Reference& targetField,
         }
 
         if (!::utils::ip::checkStrIsIPv4(targetString.value()))
+        {
+            RETURN_FAILURE(runState, false, failureTrace2);
+        }
+
+        RETURN_SUCCESS(runState, true, successTrace);
+    };
+}
+
+// <field>: +is_ipv6/
+FilterOp opBuilderHelperIsIpv6(const Reference& targetField,
+                               const std::vector<OpArg>& opArgs,
+                               const std::shared_ptr<const IBuildCtx>& buildCtx)
+{
+    // Assert expected number of parameters
+    utils::assertSize(opArgs, 0);
+
+    const auto name = buildCtx->context().opName;
+
+    // Tracing
+    const std::string successTrace {fmt::format("[{}] -> Success", name)};
+    const std::string failureTrace1 {
+        fmt::format("[{}] -> Failure: Target field '{}' not found or is not a string", name, targetField.dotPath())};
+    const std::string failureTrace2 {fmt::format("{} -> Failure: IP address is not IPv6", name)};
+
+    // Return op
+    return [failureTrace1,
+            failureTrace2,
+            successTrace,
+            runState = buildCtx->runState(),
+            targetField = targetField.jsonPath()](base::ConstEvent event) -> FilterResult
+    {
+        const auto targetString = event->getString(targetField);
+        if (!targetString.has_value())
+        {
+            RETURN_FAILURE(runState, false, failureTrace1);
+        }
+
+        if (!::utils::ip::checkStrIsIPv6(targetString.value()))
         {
             RETURN_FAILURE(runState, false, failureTrace2);
         }

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
@@ -393,6 +393,20 @@ FilterOp opBuilderHelperIsIpv4(const Reference& targetField,
                                const std::shared_ptr<const IBuildCtx>& buildCtx);
 
 /**
+ * @brief Check if the reference parameter contains a valid IPv6 address.
+ *
+ * @param targetField target field of the helper
+ * @param opArgs Vector of operation arguments containing numeric values to be converted.
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @return FilterOp
+ *
+ * @throws std::runtime_error if cannot create the filter.
+ */
+FilterOp opBuilderHelperIsIpv6(const Reference& targetField,
+                               const std::vector<OpArg>& opArgs,
+                               const std::shared_ptr<const IBuildCtx>& buildCtx);
+
+/**
  * @brief Create the helper function `array_not_contains_any` that filters events if the field
  * is an array and does not contain at least one of the specified values.
  *

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -85,6 +85,8 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
     registry->template add<builders::OpBuilderEntry>(
         "is_ipv4", {schemf::STypeToken::create(schemf::Type::IP), builders::opfilter::opBuilderHelperIsIpv4});
     registry->template add<builders::OpBuilderEntry>(
+        "is_ipv6", {schemf::STypeToken::create(schemf::Type::IP), builders::opfilter::opBuilderHelperIsIpv6});
+    registry->template add<builders::OpBuilderEntry>(
         "is_array", {schemf::runtimeValidation(), builders::opfilter::opBuilderHelperIsArray});
     registry->template add<builders::OpBuilderEntry>(
         "is_boolean", {schemf::runtimeValidation(), builders::opfilter::opBuilderHelperIsBool});

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/is_ipv6_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/is_ipv6_test.cpp
@@ -8,83 +8,41 @@ namespace filterbuildtest
 INSTANTIATE_TEST_SUITE_P(
     BuilderIsIPv6,
     FilterBuilderTest,
-    testing::Values(FilterT({}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
-                    FilterT({makeValue(R"("192.168.255.255")")}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
-                    FilterT({makeRef("ref1"), makeRef("ref2")}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
-                    FilterT({makeRef("ref")}, opfilter::opBuilderHelperIsIpv6, SUCCESS())),
+    testing::Values(
+        FilterT({}, opfilter::opBuilderHelperIsIpv6, SUCCESS()),
+        FilterT({makeValue(R"("192.168.255.255")")}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
+        FilterT({makeRef("ref"), makeValue(R"("192.168.255.255")")}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
+        FilterT({makeRef("ref")}, opfilter::opBuilderHelperIsIpv6, FAILURE())),
     testNameFormatter<FilterBuilderTest>("BuilderIsIPv6"));
 } // namespace filterbuildtest
 
 namespace filteroperatestest
 {
-INSTANTIATE_TEST_SUITE_P(BuilderIsIPv6,
-                         FilterOperationTest,
-                         testing::Values(
-                             // Invalid input
-                             FilterT(R"({"target": 123, "ref": 123})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     FAILURE()),
-                             FilterT(R"({"target": 123, "ref": "1.23"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     FAILURE()),
-                             FilterT(R"({"target": 123, "ref": [1,2,3]})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     FAILURE()),
-                             FilterT(R"({"target": 123, "ref": "False"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     FAILURE()),
-                             // IPv4
-                             FilterT(R"({"target": "::1", "ref": "127.0.0.1"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     FAILURE()),
-                             FilterT(R"({"target": "::1", "ref": "8.8.8.8"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     FAILURE()),
-                             FilterT(R"({"target": "::1", "ref": "192.168.1.1"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     FAILURE()),
-                             // Special IPs
-                             FilterT(R"({"target": "::1", "ref": "::1"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     SUCCESS()),
-                             FilterT(R"({"target": "::1", "ref": "fd12:3456:789a::1"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     SUCCESS()),
-                             FilterT(R"({"target": "::1", "ref": "fd00:abcd::1234"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     SUCCESS()),
-                             // Public IP
-                             FilterT(R"({"target": "::1", "ref": "2001:0db8::1"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     SUCCESS()),
-                             FilterT(R"({"target": "::1", "ref": "2a03:2880:f10c:83:face:b00c::25de"})",
-                                     opfilter::opBuilderHelperIsIpv6,
-                                     "target",
-                                     {makeRef("ref")},
-                                     SUCCESS())
-                             // End of test cases
-                             ),
-                         testNameFormatter<FilterOperationTest>("BuilderIsIPv6"));
+INSTANTIATE_TEST_SUITE_P(
+    BuilderIsIPv6,
+    FilterOperationTest,
+    testing::Values(
+        // Invalid input
+        FilterT(R"({"target": 123})", opfilter::opBuilderHelperIsIpv6, "target", {}, FAILURE()),
+        FilterT(R"({"target": 12.3})", opfilter::opBuilderHelperIsIpv6, "target", {}, FAILURE()),
+        FilterT(R"({"target": [1,2,3]})", opfilter::opBuilderHelperIsIpv6, "target", {}, FAILURE()),
+        FilterT(R"({"target": "False"})", opfilter::opBuilderHelperIsIpv6, "target", {}, FAILURE()),
+        // IPv4
+        FilterT(R"({"target": "127.0.0.1"})", opfilter::opBuilderHelperIsIpv6, "target", {}, FAILURE()),
+        FilterT(R"({"target": "8.8.8.8"})", opfilter::opBuilderHelperIsIpv6, "target", {}, FAILURE()),
+        FilterT(R"({"target": "192.168.1.1"})", opfilter::opBuilderHelperIsIpv6, "target", {}, FAILURE()),
+        // Special IPs
+        FilterT(R"({"target": "::1"})", opfilter::opBuilderHelperIsIpv6, "target", {}, SUCCESS()),
+        FilterT(R"({"target": "fd12:3456:789a::1"})", opfilter::opBuilderHelperIsIpv6, "target", {}, SUCCESS()),
+        FilterT(R"({"target": "fd00:abcd::1234"})", opfilter::opBuilderHelperIsIpv6, "target", {}, SUCCESS()),
+        // Public IP
+        FilterT(R"({"target": "2001:0db8::1"})", opfilter::opBuilderHelperIsIpv6, "target", {}, SUCCESS()),
+        FilterT(R"({"target": "2a03:2880:f10c:83:face:b00c::25de"})",
+                opfilter::opBuilderHelperIsIpv6,
+                "target",
+                {},
+                SUCCESS())
+        // End of test cases
+        ),
+    testNameFormatter<FilterOperationTest>("BuilderIsIPv6"));
 } // namespace filteroperatestest

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/is_ipv6_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/is_ipv6_test.cpp
@@ -1,0 +1,90 @@
+#include "builders/baseBuilders_test.hpp"
+
+#include "builders/opfilter/opBuilderHelperFilter.hpp"
+
+namespace filterbuildtest
+{
+
+INSTANTIATE_TEST_SUITE_P(
+    BuilderIsIPv6,
+    FilterBuilderTest,
+    testing::Values(FilterT({}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
+                    FilterT({makeValue(R"("192.168.255.255")")}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
+                    FilterT({makeRef("ref1"), makeRef("ref2")}, opfilter::opBuilderHelperIsIpv6, FAILURE()),
+                    FilterT({makeRef("ref")}, opfilter::opBuilderHelperIsIpv6, SUCCESS())),
+    testNameFormatter<FilterBuilderTest>("BuilderIsIPv6"));
+} // namespace filterbuildtest
+
+namespace filteroperatestest
+{
+INSTANTIATE_TEST_SUITE_P(BuilderIsIPv6,
+                         FilterOperationTest,
+                         testing::Values(
+                             // Invalid input
+                             FilterT(R"({"target": 123, "ref": 123})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     FAILURE()),
+                             FilterT(R"({"target": 123, "ref": "1.23"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     FAILURE()),
+                             FilterT(R"({"target": 123, "ref": [1,2,3]})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     FAILURE()),
+                             FilterT(R"({"target": 123, "ref": "False"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     FAILURE()),
+                             // IPv4
+                             FilterT(R"({"target": "::1", "ref": "127.0.0.1"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     FAILURE()),
+                             FilterT(R"({"target": "::1", "ref": "8.8.8.8"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     FAILURE()),
+                             FilterT(R"({"target": "::1", "ref": "192.168.1.1"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     FAILURE()),
+                             // Special IPs
+                             FilterT(R"({"target": "::1", "ref": "::1"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     SUCCESS()),
+                             FilterT(R"({"target": "::1", "ref": "fd12:3456:789a::1"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     SUCCESS()),
+                             FilterT(R"({"target": "::1", "ref": "fd00:abcd::1234"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     SUCCESS()),
+                             // Public IP
+                             FilterT(R"({"target": "::1", "ref": "2001:0db8::1"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     SUCCESS()),
+                             FilterT(R"({"target": "::1", "ref": "2a03:2880:f10c:83:face:b00c::25de"})",
+                                     opfilter::opBuilderHelperIsIpv6,
+                                     "target",
+                                     {makeRef("ref")},
+                                     SUCCESS())
+                             // End of test cases
+                             ),
+                         testNameFormatter<FilterOperationTest>("BuilderIsIPv6"));
+} // namespace filteroperatestest

--- a/src/engine/test/helper_tests/helpers_description/filter/is_ipv6.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/is_ipv6.yml
@@ -1,0 +1,57 @@
+# Name of the helper function
+name: is_ipv6
+
+metadata:
+  description: |
+    Checks if the IP address stored in the field is an IPv6.
+    IPv4:
+      - 10.0.0.0
+      - 172.16.0.0
+      - 192.168.0.0
+      - 127.0.0.0
+    This helper function is typically used in the check stage
+
+  keywords:
+    - undefined
+
+helper_type: filter
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: false
+
+arguments:
+  ip:
+    type: string
+    generate: ip
+    source: reference
+
+
+target_field:
+  type:
+    - number
+    - string
+    - object
+    - boolean
+    - array
+
+test:
+  - arguments:
+      ip: 127.0.0.1
+    target_field: any_value
+    should_pass: false
+    description: Invalid IPv6. It's an IPv4
+  - arguments:
+      ip: ::1
+    target_field: any_value
+    should_pass: true
+    description: Valid special IPv6
+  - arguments:
+      ip: fd00:abcd::1234
+    target_field: any_value
+    should_pass: true
+    description: Valid special IPv6
+  - arguments:
+      ip: 2a03:2880:f10c:83:face:b00c::25de
+    target_field: any_value
+    should_pass: true
+    description: Valid public IPv6

--- a/src/engine/test/helper_tests/helpers_description/filter/is_ipv6.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/is_ipv6.yml
@@ -19,39 +19,20 @@ helper_type: filter
 # Indicates whether the helper function supports a variable number of arguments
 is_variadic: false
 
-arguments:
-  ip:
-    type: string
-    generate: ip
-    source: reference
-
-
 target_field:
-  type:
-    - number
-    - string
-    - object
-    - boolean
-    - array
+  type: string
+  generate: ip
 
 test:
-  - arguments:
-      ip: 127.0.0.1
-    target_field: any_value
+  - target_field: 127.0.0.1
     should_pass: false
     description: Invalid IPv6. It's an IPv4
-  - arguments:
-      ip: ::1
-    target_field: any_value
+  - target_field: ::1
     should_pass: true
     description: Valid special IPv6
-  - arguments:
-      ip: fd00:abcd::1234
-    target_field: any_value
+  - target_field:  fd00:abcd::1234
     should_pass: true
     description: Valid special IPv6
-  - arguments:
-      ip: 2a03:2880:f10c:83:face:b00c::25de
-    target_field: any_value
+  - target_field: a03:2880:f10c:83:face:b00c::25de
     should_pass: true
     description: Valid public IPv6


### PR DESCRIPTION
|Related issue|
|---|
|#27997|

## Description
To enhance the capabilities of rule assets in Wazuh-engine, there is a need to introduce a new helper function of type filter named `is_ipv6`. This function will evaluate whether a given reference points to an IPv6 address, improving the specificity and accuracy of rule conditions.

## Objective
- **Enhance Rule Conditions**: Provide a robust mechanism to determine if a reference within an event's data is an IPv6 address, thereby allowing more precise conditions in rule assets.

## Function Signature
```plaintext
is_ipv6($ref)
```