### PR TITLE
Add CA merged path to configurations

### DIFF
--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -21,6 +21,7 @@ constexpr std::string_view INDEXER_SSL_CERTIFICATE = "/indexer/ssl/certificate";
 constexpr std::string_view INDEXER_SSL_KEY = "/indexer/ssl/key";
 constexpr std::string_view INDEXER_SSL_USE_SSL = "/indexer/ssl/use_ssl";
 constexpr std::string_view INDEXER_SSL_VERIFY_CERTS = "/indexer/ssl/verify_certificates";
+constexpr std::string_view INDEXER_SSL_CA_MERGED = "/indexer/ssl/certificate_authorities/tmp/root-ca-merged.pem";
 
 constexpr std::string_view INDEXER_TIMEOUT = "/indexer/timeout";
 constexpr std::string_view INDEXER_THREADS = "/indexer/threads";

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -51,6 +51,8 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
     addUnit<std::string>(key::INDEXER_INDEX, "WAZUH_INDEXER_INDEX", "wazuh-alerts-5.x-0001");
     addUnit<std::vector<std::string>>(key::INDEXER_HOST, "WAZUH_INDEXER_HOST", {"http://127.0.0.1:9200"});
     addUnit<std::string>(key::INDEXER_USER, "WAZUH_INDEXER_USER", "admin");
+    addUnit<std::string>(
+        key::INDEXER_SSL_CA_MERGED, "INDEXER_SSL_CA_MERGED", "/var/lib/wazuh-server/tmp/root-ca-merged.pem");
     addUnit<std::string>(key::INDEXER_PASSWORD, "WAZUH_INDEXER_PASSWORD", "WazuhEngine5+");
     addUnit<std::vector<std::string>>(key::INDEXER_SSL_CA_LIST, "WAZUH_INDEXER_SSL_CA_LIST", {});
     addUnit<std::string>(key::INDEXER_SSL_CERTIFICATE, "WAZUH_INDEXER_SSL_CERTIFICATE", "");

--- a/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
+++ b/src/engine/source/indexerconnector/include/indexerConnector/indexerConnector.hpp
@@ -38,6 +38,7 @@ struct IndexerConnectorOptions
     std::vector<std::string> hosts; ///< The list of hosts to connect to. i.e. ["https://localhost:9200"]
     std::string username;           ///< The username to authenticate with OpenSearch.
     std::string password;           ///< The password to authenticate with OpenSearch.
+    std::string mergedCaPath;       ///< The path to the merged CA certificate.
 
     struct
     {

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -173,6 +173,7 @@ int main(int argc, char* argv[])
             icConfig.hosts = confManager.get<std::vector<std::string>>(conf::key::INDEXER_HOST);
             icConfig.username = confManager.get<std::string>(conf::key::INDEXER_USER);
             icConfig.password = confManager.get<std::string>(conf::key::INDEXER_PASSWORD);
+            icConfig.mergedCaPath = confManager.get<std::string>(conf::key::INDEXER_SSL_CA_MERGED);
             if (confManager.get<bool>(conf::key::INDEXER_SSL_USE_SSL))
             {
                 icConfig.sslOptions.cacert = confManager.get<std::vector<std::string>>(conf::key::INDEXER_SSL_CA_LIST);


### PR DESCRIPTION
|Related issue|
|---|
| Closes #27804 |

# Objective

This PR aims to avoid hard codded path for the merged certificate authority. This approach follows the previous paths using the `IndexerConnectorOptions` object  