### PR TITLE
Remove error logs when the response is 409 (Version conflicts)

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -339,8 +339,8 @@ void IndexerConnector::sendBulkReactive(const std::vector<std::pair<std::string,
             }
             else if (statusCode == HTTP_VERSION_CONFLICT)
             {
-                logDebug2(IC_NAME, "Document version conflict, sync omitted");
-                throw std::runtime_error("Version conflict, retrying in 1 second.");
+                logDebug2(IC_NAME, "Document version conflict, sync omitted.");
+                throw std::runtime_error("Document version conflict, sync omitted.");
             }
             else
             {
@@ -698,7 +698,7 @@ IndexerConnector::IndexerConnector(
                     else if (statusCode == HTTP_VERSION_CONFLICT)
                     {
                         logDebug2(IC_NAME, "Document version conflict, retrying in 1 second.");
-                        throw std::runtime_error("Version conflict, retrying in 1 second.");
+                        throw std::runtime_error("Document version conflict, retrying in 1 second.");
                     }
                     else
                     {

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -32,6 +32,7 @@ constexpr auto MINIMAL_ELEMENTS_PER_BULK {5};
 
 constexpr auto HTTP_BAD_REQUEST {400};
 constexpr auto HTTP_CONTENT_LENGTH {413};
+constexpr auto HTTP_VERSION_CONFLICT {409};
 
 constexpr auto RECURSIVE_MAX_DEPTH {20};
 
@@ -335,6 +336,11 @@ void IndexerConnector::sendBulkReactive(const std::vector<std::pair<std::string,
 
                 sendBulkReactive(left, url, secureCommunication, depth + 1);
                 sendBulkReactive(right, url, secureCommunication, depth + 1);
+            }
+            else if (statusCode == HTTP_VERSION_CONFLICT)
+            {
+                logDebug2(IC_NAME, "Version conflict, retrying in 1 second.");
+                throw std::runtime_error("Version conflict, retrying in 1 second.");
             }
             else
             {
@@ -689,9 +695,17 @@ IndexerConnector::IndexerConnector(
                                                      "indexer.");
                         }
                     }
+                    else if (statusCode == HTTP_VERSION_CONFLICT)
+                    {
+                        logDebug2(IC_NAME, "Version conflict, retrying in 1 second.");
+                        throw std::runtime_error("Version conflict, retrying in 1 second.");
+                    }
+                    else
+                    {
 
-                    logError(IC_NAME, "%s, status code: %ld.", error.c_str(), statusCode);
-                    throw std::runtime_error(error);
+                        logError(IC_NAME, "%s, status code: %ld.", error.c_str(), statusCode);
+                        throw std::runtime_error(error);
+                    }
                 };
 
                 HTTPRequest::instance().post(

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -339,7 +339,7 @@ void IndexerConnector::sendBulkReactive(const std::vector<std::pair<std::string,
             }
             else if (statusCode == HTTP_VERSION_CONFLICT)
             {
-                logDebug2(IC_NAME, "Version conflict, retrying in 1 second.");
+                logDebug2(IC_NAME, "Document version conflict, sync omitted");
                 throw std::runtime_error("Version conflict, retrying in 1 second.");
             }
             else
@@ -697,7 +697,7 @@ IndexerConnector::IndexerConnector(
                     }
                     else if (statusCode == HTTP_VERSION_CONFLICT)
                     {
-                        logDebug2(IC_NAME, "Version conflict, retrying in 1 second.");
+                        logDebug2(IC_NAME, "Document version conflict, retrying in 1 second.");
                         throw std::runtime_error("Version conflict, retrying in 1 second.");
                     }
                     else


### PR DESCRIPTION
|Related issue|
|---|
| #28025 |

## Description
This pr aims not to log an error when the response is 409 in certain calls to opensearch.