### PR TITLE
Bug/27891 enable and fix legacy server tests

### DIFF
--- a/.github/actions/legacy_unit_tests_build/action.yml
+++ b/.github/actions/legacy_unit_tests_build/action.yml
@@ -1,5 +1,5 @@
-name: "Legacy unit tests build for Wazuh agent"
-description: "This action builds legacy Unit Tests for Wazuh agent on Ubuntu Linux/Windows"
+name: "Legacy unit tests build for Wazuh"
+description: "This action builds legacy Unit Tests for Wazuh on Ubuntu Linux/Windows"
 inputs:
    target:
      required: true
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         chmod +x .github/actions/legacy_unit_tests.sh
-    - name: Build Wazuh Agent Unit Tests
+    - name: Build Wazuh Unit Tests
       shell: bash
       run: |
         source .github/actions/legacy_unit_tests.sh

--- a/.github/actions/legacy_unit_tests_run/action.yml
+++ b/.github/actions/legacy_unit_tests_run/action.yml
@@ -1,5 +1,5 @@
-name: "Legacy unit tests run for Wazuh agent"
-description: "This action runs Wazuh agent unit tests on Ubuntu Linux/Windows"
+name: "Legacy unit tests run for Wazuh"
+description: "This action runs Wazuh unit tests on Ubuntu Linux/Windows"
 inputs:
    target:
      required: true
@@ -22,7 +22,7 @@ runs:
         source .github/actions/legacy_unit_tests.sh
         format_display_test_results ${{ inputs.target }}
     - name: Format and Display Test Coverage
-      if: ${{ inputs.target == 'agent' }}
+      if: ${{ inputs.target != 'winagent' }}
       shell: bash
       run: |
         source .github/actions/legacy_unit_tests.sh

--- a/.github/workflows/legacy-unit-tests.yml
+++ b/.github/workflows/legacy-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Legacy unit tests for wazuh agent
+name: Legacy unit tests for wazuh
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ jobs:
     strategy:
           fail-fast: false
           matrix:
-              target: [agent, winagent]
+              target: [agent, winagent, server]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
@@ -26,15 +26,15 @@ jobs:
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
-      - name: "Build wazuh agent"
+      - name: "Build wazuh"
         uses: ./.github/actions/build_test_flags
         with:
           target: ${{ matrix.target }}
-      - name: "Build wazuh agent legacy unit tests"
+      - name: "Build wazuh legacy unit tests"
         uses: ./.github/actions/legacy_unit_tests_build
         with:
           target: ${{ matrix.target }}
-      - name: "Run wazuh agent legacy unit tests"
+      - name: "Run wazuh legacy unit tests"
         uses: ./.github/actions/legacy_unit_tests_run
         with:
           target: ${{ matrix.target }}

--- a/src/unit_tests/analysisd/test_dbsync.c
+++ b/src/unit_tests/analysisd/test_dbsync.c
@@ -194,19 +194,8 @@ static int setup_DispatchDBSync2(void **state) {
     if(data->lf = calloc(1, sizeof(Eventinfo)), !data->lf)
         return -1;
 
-    data->lf->log = strdup(
-        "{"
-            "\"component\": \"invalid\","
-            "\"type\": \"integrity_check_test\","
-            "\"data\": {"
-                "\"tail\": \"tail\","
-                "\"checksum\": \"checksum\","
-                "\"begin\": \"/a/path\","
-                "\"end\": \"/z/path\""
-            "}"
-        "}");
-
-    if(data->lf->log == NULL) return -1;
+    if (data->lf->log = calloc(OS_SIZE_512, sizeof(char)), !data->lf->log)
+        return -1;
 
     data->lf->agent_id = calloc(OS_SIZE_16, sizeof(char));
 
@@ -1022,8 +1011,76 @@ static void test_DispatchDBSync_null_lf(void **state) {
     expect_assert_failure(DispatchDBSync(data->ctx, NULL));
 }
 
-static void test_DispatchDBSync_invalid_component(void **state) {
+static void test_DispatchDBSync_invalid_blasqlblabla_component(void **state) {
     test_dbsync_t *data = *state;
+
+    snprintf(data->lf->log, OS_SIZE_512, "{"
+        "\"component\": \"blasqlblabla\","
+        "\"type\": \"integrity_check_test\","
+        "\"data\": {"
+            "\"tail\": \"tail\","
+            "\"checksum\": \"checksum\","
+            "\"begin\": \"/a/path\","
+            "\"end\": \"/z/path\""
+        "}"
+    "}");
+
+    expect_string(__wrap__merror, formatted_msg, "dbsync: Invalid component specified.");
+
+    DispatchDBSync(data->ctx, data->lf);
+}
+
+static void test_DispatchDBSync_invalid_command_component_component(void **state) {
+    test_dbsync_t *data = *state;
+
+    snprintf(data->lf->log, OS_SIZE_512, "{"
+        "\"component\": \"command_component\","
+        "\"type\": \"integrity_check_test\","
+        "\"data\": {"
+            "\"tail\": \"tail\","
+            "\"checksum\": \"checksum\","
+            "\"begin\": \"/a/path\","
+            "\"end\": \"/z/path\""
+        "}"
+    "}");
+
+    expect_string(__wrap__merror, formatted_msg, "dbsync: Invalid component specified.");
+
+    DispatchDBSync(data->ctx, data->lf);
+}
+
+static void test_DispatchDBSync_invalid_command_component_dash_component(void **state) {
+    test_dbsync_t *data = *state;
+
+    snprintf(data->lf->log, OS_SIZE_512, "{"
+        "\"component\": \"command_component-\","
+        "\"type\": \"integrity_check_test\","
+        "\"data\": {"
+            "\"tail\": \"tail\","
+            "\"checksum\": \"checksum\","
+            "\"begin\": \"/a/path\","
+            "\"end\": \"/z/path\""
+        "}"
+    "}");
+
+    expect_string(__wrap__merror, formatted_msg, "dbsync: Invalid component specified.");
+
+    DispatchDBSync(data->ctx, data->lf);
+}
+
+static void test_DispatchDBSync_invalid_xxxxx_component(void **state) {
+    test_dbsync_t *data = *state;
+
+    snprintf(data->lf->log, OS_SIZE_512, "{"
+        "\"component\": \"xxxxx\","
+        "\"type\": \"integrity_check_test\","
+        "\"data\": {"
+            "\"tail\": \"tail\","
+            "\"checksum\": \"checksum\","
+            "\"begin\": \"/a/path\","
+            "\"end\": \"/z/path\""
+        "}"
+    "}");
 
     expect_string(__wrap__merror, formatted_msg, "dbsync: Invalid component specified.");
 
@@ -1085,7 +1142,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_DispatchDBSync_invalid_message_type, setup_DispatchDBSync, teardown_DispatchDBSync),
         cmocka_unit_test_setup_teardown(test_DispatchDBSync_null_ctx, setup_DispatchDBSync, teardown_DispatchDBSync),
         cmocka_unit_test_setup_teardown(test_DispatchDBSync_null_lf, setup_DispatchDBSync, teardown_DispatchDBSync),
-        cmocka_unit_test_setup_teardown(test_DispatchDBSync_invalid_component, setup_DispatchDBSync2, teardown_DispatchDBSync),
+        cmocka_unit_test_setup_teardown(test_DispatchDBSync_invalid_blasqlblabla_component, setup_DispatchDBSync2, teardown_DispatchDBSync),
+        cmocka_unit_test_setup_teardown(test_DispatchDBSync_invalid_command_component_component, setup_DispatchDBSync2, teardown_DispatchDBSync),
+        cmocka_unit_test_setup_teardown(test_DispatchDBSync_invalid_command_component_dash_component, setup_DispatchDBSync2, teardown_DispatchDBSync),
+        cmocka_unit_test_setup_teardown(test_DispatchDBSync_invalid_xxxxx_component, setup_DispatchDBSync2, teardown_DispatchDBSync)
     };
 
     return cmocka_run_group_tests(tests, setup_dbsync_context, teardown_dbsync_context);

--- a/src/unit_tests/analysisd/test_dbsync.c
+++ b/src/unit_tests/analysisd/test_dbsync.c
@@ -1066,7 +1066,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_dispatch_answer_local_success, setup_dispatch_answer, teardown_dispatch_answer),
         cmocka_unit_test_setup_teardown(test_dispatch_answer_remote_success, setup_dispatch_answer, teardown_dispatch_answer),
         cmocka_unit_test_setup_teardown(test_dispatch_answer_query_too_long, setup_dispatch_answer, teardown_dispatch_answer),
-        cmonka_unit_test_setup_teardown(test_dispatch_answer_query_invalid, setup_dispatch_answer, teardown_dispatch_answer),
+        cmocka_unit_test_setup_teardown(test_dispatch_answer_query_invalid, setup_dispatch_answer, teardown_dispatch_answer),
 
         /* dispatch_check */
         cmocka_unit_test_setup_teardown(test_dispatch_check_success, setup_dispatch_check, teardown_dispatch_check),


### PR DESCRIPTION
|Related issue|
|---|
|#27891|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds the required change to enable the legacy cmocka tests for server and fix the failing ones. 

