### PR TITLE
 Remove "ca.com" domain filter from Rootcheck malware ruleset

### DIFF
--- a/ruleset/rootcheck/db/win_malware_rcl.txt
+++ b/ruleset/rootcheck/db/win_malware_rcl.txt
@@ -156,8 +156,8 @@ f:%WINDIR%\Sysnative\Files32.vxd;
 [Anti-virus site on the hosts file] [any] []
 f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:avp.ch|avp.ru|nai.com;
 f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:avp.ch|avp.ru|nai.com;
-f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;
-f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;
+f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:awaps.net|mcafee.com;
+f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:awaps.net|mcafee.com;
 f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:microsoft.com|f-secure.com;
 f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:microsoft.com|f-secure.com;
 f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:sophos.com|symantec.com;


### PR DESCRIPTION
## Description

This pull request proposes the removal of the rule in the Rootcheck malware ruleset for Windows that flags domains ending with "ca.com" as suspicious. This rule has been identified as the source of false positives, incorrectly flagging legitimate domains such as "ca.com" (owned by Broadcom Inc.) and its subdomains like "support.ca.com" and "community.ca.com."

Closes #28037

## Proposed Changes

- Removed the condition in the Rootcheck Windows malware ruleset that flags domains ending with "ca.com."

## Results and Evidence

### Before this fix

#### Windows malware file

```shell
# grep "ca.com" /var/ossec/etc/rootcheck/win_malware_rcl.txt
f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;
f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;

# grep "ca.com" /var/ossec/etc/shared/default/win_malware_rcl.txt
f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;
f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;
```

#### Alert

```
** Alert 1738832350.67119: - ossec,rootcheck,pci_dss_10.6.1,gpg13_4.2,gdpr_IV_35.7.d,
2025 Feb 06 09:59:10 (Rocket) any->rootcheck
Rule: 513 (level 9) -> 'Windows malware detected.'
Windows Malware: Anti-virus site on the hosts file. File: C:\WINDOWS\System32\Drivers\etc\HOSTS.
title: Windows Malware: Anti-virus site on the hosts file.
file: C:\WINDOWS\System32\Drivers\etc\HOSTS
```

### Package upgrade

```
dpkg -i wazuh-manager_4.11.0-0_amd64_cdc90fb.deb
```

#### Windows malware file

```shell
# grep "ca.com" /var/ossec/etc/rootcheck/win_malware_rcl.txt

# grep "ca.com" /var/ossec/etc/shared/default/win_malware_rcl.txt
f:%WINDIR%\System32\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;
f:%WINDIR%\Sysnative\Drivers\etc\HOSTS -> r:awaps.net|ca.com|mcafee.com;
```

> [!IMPORTANT]
> After this upgrade, we need to manually update the _win_malware_rcl.txt_ file in the shared configuration.

```shell
cp /var/ossec/etc/rootcheck/win_malware_rcl.txt /var/ossec/etc/shared/default/win_malware_rcl.txt
```

#### Alert

The agent gets restarted to apply the shared configuration. No Rootcheck alerts appear:

```
** Alert 1738832567.71107: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2025 Feb 06 10:02:47 (Rocket) any->wazuh-remoted
Rule: 506 (level 3) -> 'Wazuh agent stopped.'
ossec: Agent stopped: 'Rocket->any'.

** Alert 1738832567.71430: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2025 Feb 06 10:02:47 (Rocket) any->wazuh-agent
Rule: 503 (level 3) -> 'Wazuh agent started.'
ossec: Agent started: 'Rocket->any'.
```

### Sources upgrade

```
USER_LANGUAGE="en" USER_NO_STOP="y" USER_INSTALL_TYPE="server" USER_DIR="/var/ossec" USER_UPDATE="y" USER_AUTO_START="n" ./install.sh
```

#### Windows malware file

> [!NOTE]
> Unlike package upgrade, this kind of upgrade will also update the _win_malware_rcl.txt_ file in the shared configuration.

```shell
# grep "ca.com" /var/ossec/etc/rootcheck/win_malware_rcl.txt
  <empty>
# grep "ca.com" /var/ossec/etc/shared/default/win_malware_rcl.txt
  <empty>
```

#### Alerts

No Rootcheck alerts appear:

```
** Alert 1738833848.72778: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2025 Feb 06 10:24:08 (Rocket) any->wazuh-remoted
Rule: 506 (level 3) -> 'Wazuh agent stopped.'
ossec: Agent stopped: 'Rocket->any'.

** Alert 1738833849.73101: - ossec,pci_dss_10.6.1,pci_dss_10.2.6,gpg13_10.1,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,nist_800_53_AU.14,nist_800_53_AU.5,tsc_CC7.2,tsc_CC7.3,tsc_CC6.8,
2025 Feb 06 10:24:09 (Rocket) any->wazuh-agent
Rule: 503 (level 3) -> 'Wazuh agent started.'
ossec: Agent started: 'Rocket->any'.
```

## Artifacts Affected

- Rootcheck malware files ruleset for Windows
- Manager package

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Upgrade behavior evidence provided
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
