### PR TITLE
Fix 4.12.0 release date

### DIFF
--- a/packages/aix/SPECS/wazuh-agent-aix.spec
+++ b/packages/aix/SPECS/wazuh-agent-aix.spec
@@ -284,7 +284,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/*
 
 %changelog
-* Tue Jan 28 2025 support <info@wazuh.com> - 4.12.0
+* Wed Mar 26 2025 support <info@wazuh.com> - 4.12.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-12-0.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html

--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -2,7 +2,7 @@ wazuh-agent (4.12.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-12-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Tue, 28 Jan 2025 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 26 Mar 2025 00:00:00 +0000
 
 wazuh-agent (4.11.0-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-agent/debian/copyright
+++ b/packages/debs/SPECS/wazuh-agent/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Wed, 19 Feb 2025 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 26 Mar 2025 00:00:00 +0000
 
 It was downloaded from:
 

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -2,7 +2,7 @@ wazuh-manager (4.12.0-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-12-0.html
 
- -- Wazuh, Inc <info@wazuh.com>  Tue, 28 Jan 2025 00:00:00 +0000
+ -- Wazuh, Inc <info@wazuh.com>  Wed, 26 Mar 2025 00:00:00 +0000
 
 wazuh-manager (4.11.0-RELEASE) stable; urgency=low
 

--- a/packages/debs/SPECS/wazuh-manager/debian/copyright
+++ b/packages/debs/SPECS/wazuh-manager/debian/copyright
@@ -1,6 +1,6 @@
 This work was packaged for Debian by:
 
-    Wazuh, Inc <info@wazuh.com> on Wed, 19 Feb 2025 00:00:00 +0000
+    Wazuh, Inc <info@wazuh.com> on Wed, 26 Mar 2025 00:00:00 +0000
 
 It was downloaded from:
 

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -765,7 +765,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Tue Jan 28 2025 support <info@wazuh.com> - 4.12.0
+* Wed Mar 26 2025 support <info@wazuh.com> - 4.12.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-12-0.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -904,7 +904,7 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %changelog
-* Tue Jan 28 2025 support <info@wazuh.com> - 4.12.0
+* Wed Mar 26 2025 support <info@wazuh.com> - 4.12.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-12-0.html
 * Wed Feb 19 2025 support <info@wazuh.com> - 4.11.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-11-0.html

--- a/packages/solaris/solaris10/pkginfo
+++ b/packages/solaris/solaris10/pkginfo
@@ -1,11 +1,11 @@
 NAME=Wazuh - Wazuh unifies historically separate functions into a single agent and platform architecture. Providing protection for public clouds, private clouds, and on-premise data centers.
 PKG="wazuh-agent"
-VERSION="4.11.0"
+VERSION="4.12.0"
 ARCH="i386"
 CLASSES="none"
 CATEGORY="system"
 VENDOR="Wazuh, Inc <info@wazuh.com>"
-PSTAMP="19Feb2025"
+PSTAMP="26Mar2025"
 EMAIL="info@wazuh.com"
 ISTATES="S s 1 2 3"
 RSTATES="S s 1 2 3"


### PR DESCRIPTION
|Related issue|
|---|
| #28043|

## Description
This PR fixes the release date in the spec and changelog files for the 4.12.0 version

>[!NOTE]
> New date based on alpha1 code release date (26/03/2025)