### PR TITLE
Fix local RPM package creation.

### DIFF
--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -252,7 +252,7 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/store
 %{_localstatedir}var/lib/wazuh-server/engine/store/*
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
-%config(missingok) %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
+%ghost %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
 %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -252,7 +252,7 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/store
 %{_localstatedir}var/lib/wazuh-server/engine/store/*
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
-%{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
+%config(missingok) %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
 %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -98,10 +98,12 @@ installFallbackStore()
 {
     # Creating fallback store directories
     local STORE_PATH=${INSTALLDIR}var/lib/wazuh-server/engine/store
+    local KVDB_PATH=${INSTALLDIR}var/lib/wazuh-server/engine/kvdb
     local SCHEMA_PATH=${STORE_PATH}/schema
     local ENGINE_SCHEMA_PATH=${SCHEMA_PATH}/engine-schema/
     local ENGINE_LOGPAR_TYPE_PATH=${SCHEMA_PATH}/wazuh-logpar-types
 
+    mkdir -p "${KVDB_PATH}"
     mkdir -p "${ENGINE_SCHEMA_PATH}"
     mkdir -p "${ENGINE_LOGPAR_TYPE_PATH}"
 
@@ -116,7 +118,9 @@ installFallbackStore()
     fi
 
     chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${STORE_PATH}
+    chown -R ${WAZUH_USER}:${WAZUH_GROUP} ${KVDB_PATH}
     find ${STORE_PATH} -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
+    find ${KVDB_PATH} -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 }
 
 installEngineStore()


### PR DESCRIPTION
|Related issue|
|---|
| #27954  |

This PR closes https://github.com/wazuh/wazuh/issues/27954, fixing the local RPM package creation.

## Description

<details>

<summary>Package creation with the changes</summary>

```console
wazuh@javier:~/Git/wazuh/packages$ ./generate_package.sh --system rpm -j 16 -r test -a amd64 -b bug/27954-add-directory-kvdb
...
Checking for unpackaged file(s): /usr/local/lib/rpm/check-files /build_wazuh/rpmbuild/BUILDROOT/wazuh-server-5.0.0-test.x86_64
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-server-5.0.0-test.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm
Executing(%clean): /bin/sh -e /usr/local/var/tmp/rpm-tmp.0UGDAG
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-server-5.0.0
+ rm -fr /build_wazuh/rpmbuild/BUILDROOT/wazuh-server-5.0.0-test.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
+ return 0
+ get_package_and_checksum 5.0.0 440e3c95c1 no
+ src=no
++ ls -R /build_wazuh/rpmbuild/RPMS
++ grep wazuh-server
++ grep -v debuginfo
+ RPM_NAME=wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm
++ ls -R /build_wazuh/rpmbuild/SRPMS
++ grep '\.src\.rpm$'
+ SRC_NAME=wazuh-server-5.0.0-test.src.rpm
++ ls -R /build_wazuh/rpmbuild/RPMS
+ SYMBOLS_NAME='/build_wazuh/rpmbuild/RPMS:
wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm
wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm'
++ echo '/build_wazuh/rpmbuild/RPMS:
wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm
wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm'
++ grep wazuh-server-debuginfo
+ SYMBOLS_NAME=wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm
+ echo 'RPM_NAME: wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm'
RPM_NAME: wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm
+ echo SYMBOLS_NAME:wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm
SYMBOLS_NAME:wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ mv /build_wazuh/rpmbuild/RPMS/wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm /var/local/wazuh
+ '[' -n wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm ']'
+ mv /build_wazuh/rpmbuild/RPMS/wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm /var/local/wazuh
++ ls -Art /home/wazuh/Git/wazuh/packages/output/
++ tail -n 1
+ echo 'Package wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm added to /home/wazuh/Git/wazuh/packages/output/.'
Package wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm added to /home/wazuh/Git/wazuh/packages/output/.
+ return 0
+ return 0
+ clean 0
+ exit_code=0
+ find /home/wazuh/Git/wazuh/packages/rpms/amd64 '(' -name '*.sh' -o -name '*.tar.gz' -o -name 'wazuh-*' ')' '!' -name docker_builder.sh -exec rm -rf '{}' +
+ exit 0
```

```console
wazuh@javier:~/Git/wazuh/packages$ find ~/Git/wazuh/packages -type f -name "*.rpm"
/home/wazuh/Git/wazuh/packages/output/wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm
/home/wazuh/Git/wazuh/packages/output/wazuh-server-debuginfo_5.0.0-test_x86_64_440e3c95c1.rpm
```

</details>

<details>

<summary>Package testing</summary>

```console
[root@490b36d9dcc1 ~]# ls
wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm
[root@490b36d9dcc1 ~]# rpm -ivh wazuh-server_5.0.0-test_x86_64_440e3c95c1.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-server-5.0.0-test          ################################# [100%]
```

```console
[root@490b36d9dcc1 ~]# rpm -q wazuh-server
wazuh-server-5.0.0-test.x86_64
```


```console
[root@490b36d9dcc1 ~]# find / -iname wazuh-server
/usr/share/wazuh-server
/usr/share/wazuh-server/bin/wazuh-server
/etc/rc.d/init.d/wazuh-server
/etc/wazuh-server
/var/lib/wazuh-server
```

```console
[root@490b36d9dcc1 ~]# rpm -ql wazuh-server | grep "^/var/lib/wazuh-server/engine/"
/var/lib/wazuh-server/engine/kvdb
/var/lib/wazuh-server/engine/kvdb/*
/var/lib/wazuh-server/engine/store
/var/lib/wazuh-server/engine/store/schema
/var/lib/wazuh-server/engine/store/schema/engine-schema
/var/lib/wazuh-server/engine/store/schema/engine-schema/0
/var/lib/wazuh-server/engine/store/schema/wazuh-logpar-types
/var/lib/wazuh-server/engine/store/schema/wazuh-logpar-types/0
/var/lib/wazuh-server/engine/tzdb
/var/lib/wazuh-server/engine/tzdb/CONTRIBUTING
/var/lib/wazuh-server/engine/tzdb/LICENSE
/var/lib/wazuh-server/engine/tzdb/Makefile
/var/lib/wazuh-server/engine/tzdb/NEWS
/var/lib/wazuh-server/engine/tzdb/README
/var/lib/wazuh-server/engine/tzdb/SECURITY
/var/lib/wazuh-server/engine/tzdb/africa
/var/lib/wazuh-server/engine/tzdb/antarctica
/var/lib/wazuh-server/engine/tzdb/asctime.c
/var/lib/wazuh-server/engine/tzdb/asia
/var/lib/wazuh-server/engine/tzdb/australasia
/var/lib/wazuh-server/engine/tzdb/backward
/var/lib/wazuh-server/engine/tzdb/backzone
/var/lib/wazuh-server/engine/tzdb/calendars
/var/lib/wazuh-server/engine/tzdb/checklinks.awk
/var/lib/wazuh-server/engine/tzdb/checknow.awk
/var/lib/wazuh-server/engine/tzdb/checktab.awk
/var/lib/wazuh-server/engine/tzdb/date.1
/var/lib/wazuh-server/engine/tzdb/date.1.txt
/var/lib/wazuh-server/engine/tzdb/date.c
/var/lib/wazuh-server/engine/tzdb/difftime.c
/var/lib/wazuh-server/engine/tzdb/etcetera
/var/lib/wazuh-server/engine/tzdb/europe
/var/lib/wazuh-server/engine/tzdb/factory
/var/lib/wazuh-server/engine/tzdb/iso3166.tab
/var/lib/wazuh-server/engine/tzdb/leap-seconds.list
/var/lib/wazuh-server/engine/tzdb/leapseconds
/var/lib/wazuh-server/engine/tzdb/leapseconds.awk
/var/lib/wazuh-server/engine/tzdb/localtime.c
/var/lib/wazuh-server/engine/tzdb/newctime.3
/var/lib/wazuh-server/engine/tzdb/newctime.3.txt
/var/lib/wazuh-server/engine/tzdb/newstrftime.3
/var/lib/wazuh-server/engine/tzdb/newstrftime.3.txt
/var/lib/wazuh-server/engine/tzdb/newtzset.3
/var/lib/wazuh-server/engine/tzdb/newtzset.3.txt
/var/lib/wazuh-server/engine/tzdb/northamerica
/var/lib/wazuh-server/engine/tzdb/private.h
/var/lib/wazuh-server/engine/tzdb/southamerica
/var/lib/wazuh-server/engine/tzdb/strftime.c
/var/lib/wazuh-server/engine/tzdb/theory.html
/var/lib/wazuh-server/engine/tzdb/time2posix.3
/var/lib/wazuh-server/engine/tzdb/time2posix.3.txt
/var/lib/wazuh-server/engine/tzdb/to2050.tzs
/var/lib/wazuh-server/engine/tzdb/tz-art.html
/var/lib/wazuh-server/engine/tzdb/tz-how-to.html
/var/lib/wazuh-server/engine/tzdb/tz-link.html
/var/lib/wazuh-server/engine/tzdb/tzdata.zi
/var/lib/wazuh-server/engine/tzdb/tzfile.5
/var/lib/wazuh-server/engine/tzdb/tzfile.5.txt
/var/lib/wazuh-server/engine/tzdb/tzfile.h
/var/lib/wazuh-server/engine/tzdb/tzselect.8
/var/lib/wazuh-server/engine/tzdb/tzselect.8.txt
/var/lib/wazuh-server/engine/tzdb/tzselect.ksh
/var/lib/wazuh-server/engine/tzdb/version
/var/lib/wazuh-server/engine/tzdb/workman.sh
/var/lib/wazuh-server/engine/tzdb/zdump.8
/var/lib/wazuh-server/engine/tzdb/zdump.8.txt
/var/lib/wazuh-server/engine/tzdb/zdump.c
/var/lib/wazuh-server/engine/tzdb/zic.8
/var/lib/wazuh-server/engine/tzdb/zic.8.txt
/var/lib/wazuh-server/engine/tzdb/zic.c
/var/lib/wazuh-server/engine/tzdb/ziguard.awk
/var/lib/wazuh-server/engine/tzdb/zishrink.awk
/var/lib/wazuh-server/engine/tzdb/zone.tab
/var/lib/wazuh-server/engine/tzdb/zone1970.tab
/var/lib/wazuh-server/engine/tzdb/zonenow.tab
```
</details>

