### PR TITLE
Ignore unexpected fields in CVE 5.0 schema

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -160,6 +160,7 @@ private:
                     }
                     flatbuffers::IDLOptions options;
                     options.output_default_scalars_in_json = true;
+                    options.skip_unexpected_fields_in_json = true;
                     options.strict_json = true;
                     flatbuffers::Parser parser(options);
                     parser.Parse(schema);

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -207,6 +207,43 @@ auto constexpr UPDATED_RESOURCE {R"(
     }
 )"};
 
+auto constexpr UPDATED_RESOURCE_UNEXPECTED_FIELDS {R"(
+    {
+        "offset": 2,
+        "type": "update",
+        "version": 1,
+        "context": "vulnerabilities",
+        "resource": "CVE-2010-0002",
+        "operations":
+            [
+                {
+                    "op": "replace",
+                    "path": "/containers/adp/0/affected/0/defaultStatus",
+                    "value": "unknown"
+                },
+                {
+                    "op": "add",
+                    "path": "/containers/adp/0/affected/1/platforms/-",
+                    "value": "buster"
+                },
+                {
+                    "op": "remove",
+                    "path": "/containers/cna/problemTypes"
+                },
+                {
+                    "op": "replace",
+                    "path": "/containers/adp/0/metrics/0/cvssV3_1/baseScore",
+                    "value": 7.8
+                },
+                {
+                    "op": "add",
+                    "path": "/containers/adp/0/x_newfield",
+                    "value": "test"
+                }
+            ]
+    }
+)"};
+
 auto constexpr UPDATED_DATA {R"(
     {
         "containers": {
@@ -718,6 +755,50 @@ TEST_F(EventDecoderTest, TestUpdatedResource)
 
     // Apply update
     auto updatedJsonResource = nlohmann::json::parse(UPDATED_RESOURCE);
+    auto updatedEventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = updatedJsonResource, .feedDatabase = m_feedDb});
+    EXPECT_NO_THROW(eventDecoder->handleRequest(updatedEventContext));
+
+    // Verify flatbuffer.
+    rocksdb::PinnableSlice slice;
+    EXPECT_TRUE(m_feedDb->get(CVE_ID, slice, COLUMNS.at(ResourceType::CVE)));
+
+    flatbuffers::Verifier verifierCVE5(reinterpret_cast<const uint8_t*>(slice.data()), slice.size());
+    EXPECT_TRUE(cve_v5::VerifyEntryBuffer(verifierCVE5));
+
+    // Verify data
+    flatbuffers::IDLOptions options;
+    options.output_default_scalars_in_json = true;
+    options.strict_json = true;
+
+    flatbuffers::Parser parser(options);
+    EXPECT_TRUE(parser.Parse(cve5_SCHEMA));
+
+    std::string jsongen;
+    flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &jsongen);
+    EXPECT_EQ(nlohmann::json::parse(jsongen), nlohmann::json::parse(UPDATED_DATA));
+}
+
+/*
+ * @brief Test an update for a resource with unexpected fields.
+ */
+TEST_F(EventDecoderTest, TestUpdatedResourceUnexpectedFields)
+{
+    std::string message;
+    auto jsonResource = nlohmann::json::parse(CREATED_RESOURCE);
+    auto eventContext = std::make_shared<EventContext>(
+        EventContext {.message = message, .resource = jsonResource, .feedDatabase = m_feedDb});
+
+    std::shared_ptr<EventDecoder> eventDecoder;
+
+    // Instantiation of the EventDecoder class.
+    EXPECT_NO_THROW(eventDecoder = std::make_shared<EventDecoder>());
+
+    // HandleRequest
+    EXPECT_NO_THROW(eventDecoder->handleRequest(eventContext));
+
+    // Apply update
+    auto updatedJsonResource = nlohmann::json::parse(UPDATED_RESOURCE_UNEXPECTED_FIELDS);
     auto updatedEventContext = std::make_shared<EventContext>(
         EventContext {.message = message, .resource = updatedJsonResource, .feedDatabase = m_feedDb});
     EXPECT_NO_THROW(eventDecoder->handleRequest(updatedEventContext));


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27976|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds the `skip_unexpected_fields_in_json` flatbuffer option to the CVE 5.0 JSON parsing to avoid error messages in cas `x_` fields are received. 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
 
- [x] Added unit tests (for new features)
