### PR TITLE
Adds Engine index selection when publishing messages to indexer

### DIFF
--- a/src/engine/source/builder/src/builders/stage/indexerOutput.cpp
+++ b/src/engine/source/builder/src/builders/stage/indexerOutput.cpp
@@ -1,6 +1,7 @@
 #include "indexerOutput.hpp"
 
 #include <memory>
+#include <regex>
 #include <stdexcept>
 
 #include "builders/utils.hpp"
@@ -45,6 +46,13 @@ base::Expression indexerOutputBuilder(const json::Json& definition,
     }
 
     auto indexName = value.getString().value();
+    // Verify index name starts with wazuh- and contains only lowecase alphanumeric characters, hyphens and dots
+    if (!std::regex_match(indexName, std::regex("wazuh-[a-z0-9.-]+")))
+    {
+        throw std::runtime_error(fmt::format("Invalid index name '{}'. Index name must start with 'wazuh-' and contain "
+                                             "only lowercase alphanumeric characters, hyphens and dots",
+                                             indexName));
+    }
 
     auto name = fmt::format("write.output({}/{})", syntax::asset::INDEXER_OUTPUT_KEY, indexName);
     const auto successTrace = fmt::format("{} -> Success", name);

--- a/src/engine/source/builder/src/builders/stage/indexerOutput.cpp
+++ b/src/engine/source/builder/src/builders/stage/indexerOutput.cpp
@@ -46,32 +46,26 @@ base::Expression indexerOutputBuilder(const json::Json& definition,
 
     auto indexName = value.getString().value();
 
-    if (indexName != "alerts")
-    {
-        throw std::runtime_error(fmt::format("In stage '{}' the index name must be 'alerts' but got '{}'",
-                                             syntax::asset::INDEXER_OUTPUT_KEY,
-                                             indexName));
-    }
-
     auto name = fmt::format("write.output({}/{})", syntax::asset::INDEXER_OUTPUT_KEY, indexName);
     const auto successTrace = fmt::format("{} -> Success", name);
     const auto failureTrace = fmt::format("{} -> The indexer connector is disabled", name);
 
-    return base::Term<base::EngineOp>::create(name,
-                                              [iConnector, successTrace, failureTrace, runState = buildCtx->runState()](
-                                                  base::Event event) -> base::result::Result<base::Event>
-                                              {
-                                                  if (!iConnector)
-                                                  {
-                                                      RETURN_FAILURE(runState, event, failureTrace);
-                                                  }
+    return base::Term<base::EngineOp>::create(
+        name,
+        [indexName, iConnector, successTrace, failureTrace, runState = buildCtx->runState()](
+            base::Event event) -> base::result::Result<base::Event>
+        {
+            if (!iConnector)
+            {
+                RETURN_FAILURE(runState, event, failureTrace);
+            }
 
-                                                  const auto pushEvent = fmt::format(
-                                                      R"({{"operation": "ADD", "data": {} }})", event->str());
-                                                  iConnector->publish(pushEvent);
+            const auto pushEvent =
+                fmt::format(R"({{"operation": "ADD", "index": "{}", "data": {} }})", indexName, event->str());
+            iConnector->publish(pushEvent);
 
-                                                  RETURN_SUCCESS(runState, event, successTrace);
-                                              });
+            RETURN_SUCCESS(runState, event, successTrace);
+        });
 }
 
 StageBuilder getIndexerOutputBuilder(const std::shared_ptr<IIndexerConnector>& indexerPtr)

--- a/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
@@ -106,7 +106,7 @@ protected:
         // Reset the mock
         ::testing::Mock::VerifyAndClearExpectations(&mockConnector);
         // Set success definition for builder creation
-        definition = json::Json(R"({"index": "alerts"})");
+        definition = json::Json(R"({"index": "wazuh-alerts"})");
     }
 
     void TearDown() override
@@ -134,14 +134,14 @@ TEST_F(IndexerOutputOperationTest, output_success)
     // Check the expression
     ASSERT_TRUE(expression->isTerm());
     auto term = expression->getPtr<base::Term<base::EngineOp>>();
-    ASSERT_EQ(term->getName(), "write.output(wazuh-indexer/alerts)");
+    ASSERT_EQ(term->getName(), "write.output(wazuh-indexer/wazuh-alerts)");
 
     // Check the operation
     auto operation = term->getFn();
     ASSERT_TRUE(operation);
 
     // Configure the behavior
-    EXPECT_CALL(*iConnector, publish(StartsWith(R"({"operation": "ADD", "index": "alerts", "data": {)")));
+    EXPECT_CALL(*iConnector, publish(StartsWith(R"({"operation": "ADD", "index": "wazuh-alerts", "data": {)")));
 
     // Run the operation
     auto result = operation(event);
@@ -161,7 +161,7 @@ TEST_F(IndexerOutputOperationTest, output_fail)
     // Check the expression
     ASSERT_TRUE(expression->isTerm());
     auto term = expression->getPtr<base::Term<base::EngineOp>>();
-    ASSERT_EQ(term->getName(), "write.output(wazuh-indexer/alerts)");
+    ASSERT_EQ(term->getName(), "write.output(wazuh-indexer/wazuh-alerts)");
 
     // Check the operation
     auto operation = term->getFn();

--- a/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
@@ -31,15 +31,13 @@ INSTANTIATE_TEST_SUITE_P(
         StageT(R"(true)", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
         StageT(R"({})", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
         StageT(R"({"key": "val", "key2": "val2"})", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
-        // -- Index name is not 'alerts' string
+        // -- Index name is not string
         StageT(R"({"index": 1})", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
         StageT(R"({"index": true})", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
         StageT(R"({"index": null})", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
         StageT(R"({"index": [{"index": "non-alerts"}]})",
                getIndexerOutputBuilder(getNullIndexerConnector()),
                FAILURE()),
-        StageT(R"({"index": "non-alerts"})", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
-        // -- Index name is 'alerts'
         StageT(R"({"index": "alerts"})",
                getIndexerOutputBuilder(getNullIndexerConnector()),
                SUCCESS(
@@ -56,15 +54,13 @@ INSTANTIATE_TEST_SUITE_P(
         StageT(R"(true)", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
         StageT(R"({})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
         StageT(R"({"key": "val", "key2": "val2"})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
-        // -- Index name is not 'alerts' string
+        // -- Index name is not string
         StageT(R"({"index": 1})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
         StageT(R"({"index": true})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
         StageT(R"({"index": null})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
         StageT(R"({"index": [{"index": "non-alerts"}]})",
                getIndexerOutputBuilder(getMockIndexerConnector()),
                FAILURE()),
-        StageT(R"({"index": "non-alerts"})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
-        // -- Index name is 'alerts'
         StageT(R"({"index": "alerts"})",
                getIndexerOutputBuilder(getMockIndexerConnector()),
                SUCCESS(
@@ -147,7 +143,7 @@ TEST_F(IndexerOutputOperationTest, output_success)
     ASSERT_TRUE(operation);
 
     // Configure the behavior
-    EXPECT_CALL(*iConnector, publish(StartsWith(R"({"operation": "ADD", "data": {)")));
+    EXPECT_CALL(*iConnector, publish(StartsWith(R"({"operation": "ADD", "index": "alerts", "data": {)")));
 
     // Run the operation
     auto result = operation(event);

--- a/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
@@ -38,14 +38,7 @@ INSTANTIATE_TEST_SUITE_P(
         StageT(R"({"index": [{"index": "non-alerts"}]})",
                getIndexerOutputBuilder(getNullIndexerConnector()),
                FAILURE()),
-        StageT(R"({"index": "alerts"})",
-               getIndexerOutputBuilder(getNullIndexerConnector()),
-               SUCCESS(
-                   [](const BuildersMocks& mocks)
-                   {
-                       EXPECT_CALL(*mocks.ctx, runState());
-                       return base::Term<base::EngineOp>::create("write.output(wazuh-indexer/alerts)", {});
-                   })),
+        StageT(R"({"index": "alerts"})", getIndexerOutputBuilder(getNullIndexerConnector()), FAILURE()),
         // non-null Indexer connector
         StageT(R"([])", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
         StageT(R"("notObject")", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
@@ -61,13 +54,18 @@ INSTANTIATE_TEST_SUITE_P(
         StageT(R"({"index": [{"index": "non-alerts"}]})",
                getIndexerOutputBuilder(getMockIndexerConnector()),
                FAILURE()),
-        StageT(R"({"index": "alerts"})",
+        // Invalid string
+        StageT(R"({"index": "alerts"})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
+        StageT(R"({"index": "wazuh-Alerts"})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
+        StageT(R"({"index": "wazuh-alerts-#"})", getIndexerOutputBuilder(getMockIndexerConnector()), FAILURE()),
+        // Valid string
+        StageT(R"({"index": "wazuh-alerts-5.x"})",
                getIndexerOutputBuilder(getMockIndexerConnector()),
                SUCCESS(
                    [](const BuildersMocks& mocks)
                    {
                        EXPECT_CALL(*mocks.ctx, runState());
-                       return base::Term<base::EngineOp>::create("write.output(wazuh-indexer/alerts)", {});
+                       return base::Term<base::EngineOp>::create("write.output(wazuh-indexer/wazuh-alerts-5.x)", {});
                    }))
         // End
         ),

--- a/src/engine/source/indexerconnector/interface/indexerConnector/iindexerconnector.hpp
+++ b/src/engine/source/indexerconnector/interface/indexerConnector/iindexerconnector.hpp
@@ -13,7 +13,12 @@ public:
      * @brief Publishes a message (in JSON string format) to a persistent queue.
      * This method returns immediately without waiting for the message to be processed.
      *
-     * @param message The message to be published (must be in JSON string format).
+     * @param message The message to be published (must be in JSON string format). The message is a JSON string that
+     * includes the following fields:
+     * - operation: The operation to be performed. Currently, the only supported operations are ADD and DELETE.
+     * - index: The name of the index to which the data will be sent. Only applicable for the ADD operation.
+     * - data: The data to be sent to the index. Only applicable for the ADD operation.
+     * - id: The unique identifier of the element.
      */
     virtual void publish(const std::string& message) = 0;
 };

--- a/src/engine/source/indexerconnector/src/indexerConnector.cpp
+++ b/src/engine/source/indexerconnector/src/indexerConnector.cpp
@@ -191,6 +191,13 @@ IndexerConnector::IndexerConnector(const IndexerConnectorOptions& indexerConnect
                         continue;
                     }
 
+                    if (parsedData.contains("index"))
+                    {
+                        indexNameCurrentDate = parsedData.at("index").get<std::string>();
+                        base::utils::string::replaceAll(
+                            indexNameCurrentDate, "$(date)", base::utils::time::getCurrentDate("."));
+                    }
+
                     const auto dataString = parsedData.at("data").dump();
                     builderBulkIndex(bulkData, id, indexNameCurrentDate, dataString);
                 }

--- a/src/engine/test/health_test/engine-health-test/src/health_test/validate_custom_field_indexing.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/validate_custom_field_indexing.py
@@ -524,7 +524,7 @@ def load_indexer_output(engine_handler: EngineHandler) -> None:
         "outputs": [
             {
                 "wazuh-indexer": {
-                    "index": "alerts"
+                    "index": Constants.INDEX_PATTERN
                 }
             }
         ]

--- a/src/engine/test/health_test/engine-health-test/src/health_test/validate_event_indexing.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/validate_event_indexing.py
@@ -378,7 +378,7 @@ def load_indexer_output(engine_handler: EngineHandler) -> None:
         "outputs": [
             {
                 "wazuh-indexer": {
-                    "index": "alerts"
+                    "index": Constants.INDEX_PATTERN
                 }
             }
         ]


### PR DESCRIPTION
|Related issue|
|---|
|#28055|

Adds the key "index" on the json data sent to publish function, if the key does not exists the index selected when building the IndexerConnection object is used.