### PR TITLE
Improve coverage calculate

### DIFF
--- a/src/engine/test/health_test/engine-health-test/src/health_test/schema_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/schema_validate.py
@@ -145,7 +145,7 @@ def verify_schema_types(schema, expected_json_files, custom_fields_map, integrat
 
                     for field, (type, validate_function) in custom_fields_map.items():
                         expected_value = get_value_from_hierarchy(expected, field)
-                        if expected == None:
+                        if expected_value == None:
                             continue
                         if validate_function(expected_value):
                             if type == 'object':


### PR DESCRIPTION
|Related issue|
|---|
|#28082|

## Description:
As part of the continuous improvement of Health Tests for assets, an issue has been identified in the coverage calculation during the trace collection for each stage. Specifically, the problem lies in detecting when a trace initially failed but later succeeded for a different event. In these cases, the successful trace should be retained, and the failed one should be discarded.

## Observations:
The current coverage report does not produce the expected results. For example:

- **Coverage Report**:

microsoft.dnsserver_audit_policy: map($windows.EventData.Policy) -> Reference 'windows.EventData.Policy' not found
microsoft.dnsserver_audit_processing_order: map($windows.EventData.ProcessingOrder) -> Reference 'windows.EventData.ProcessingOrder' not found
