### PR TITLE
Update Github actions version

### DIFF
--- a/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
@@ -23,6 +23,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-agentd-tier-0-1-win.yml
@@ -43,7 +43,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -67,7 +67,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
@@ -24,6 +24,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-enrollment-tier-0-1-win.yml
@@ -44,7 +44,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -68,7 +68,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-execd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-win.yml
@@ -19,6 +19,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-execd-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-execd-tier-0-1-win.yml
@@ -39,7 +39,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -60,7 +60,7 @@ jobs:
           architecture: x64
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-fim-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-0-1-win.yml
@@ -41,7 +41,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -65,7 +65,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-fim-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-0-1-win.yml
@@ -21,6 +21,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-fim-tier-2-win.yml
+++ b/.github/workflows/integration-tests-fim-tier-2-win.yml
@@ -32,7 +32,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -56,7 +56,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-github-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-github-tier-0-1-win.yml
@@ -40,7 +40,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -61,7 +61,7 @@ jobs:
           architecture: x64
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-github-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-github-tier-0-1-win.yml
@@ -20,6 +20,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
@@ -41,7 +41,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -65,7 +65,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-logcollector-tier-0-1-win.yml
@@ -21,6 +21,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-office365-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-office365-tier-0-1-win.yml
@@ -40,7 +40,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -61,7 +61,7 @@ jobs:
           architecture: x64
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-office365-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-office365-tier-0-1-win.yml
@@ -20,6 +20,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-sca-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-sca-tier-0-1-win.yml
@@ -23,6 +23,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.

--- a/.github/workflows/integration-tests-sca-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-sca-tier-0-1-win.yml
@@ -43,7 +43,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -67,7 +67,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
@@ -41,7 +41,7 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: winagent
           path: src/winagent
@@ -65,7 +65,7 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
+++ b/.github/workflows/integration-tests-syscollector-tier-0-1-win.yml
@@ -21,6 +21,7 @@ jobs:
   # Build the winagent on linux.
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main')
     steps:
       - uses: actions/checkout@v3
       # Install wingw required to build the winagent.


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27957 |


## Description

This PR updates the version of deprecated actions.
Also, skips the 4.x workflows if they were triggered from a PR to main.
