### PR TITLE
Update dev ruleset docker week 7

### DIFF
--- a/src/engine/tools/docker/Dockerfile
+++ b/src/engine/tools/docker/Dockerfile
@@ -15,7 +15,7 @@ ENV ENGINE_BUILD=$ENGINE_SRC/build
 # Force use the specific commit of main to avoid breaking changes like:
 # - Python packages
 # - Engine configuration and CLI
-ENV ENGINE_COMMIT_ID=3e82b9d7ec6fcd2e846008a6f5ada902f1a58ee2
+ENV ENGINE_COMMIT_ID=a40f0bd8704dd9ff4232e74ebd74df8dcefc13ef
 ENV ENGINE_PRESET=release
 ENV ENGINE_ON_BACKGROUND=1
 ENV MM_LICENCE_KEY=

--- a/src/engine/tools/docker/README.md
+++ b/src/engine/tools/docker/README.md
@@ -1,6 +1,6 @@
 # Description
 
-**Current version: 20250130-0**
+**Current version: 20250210-0**
 
 This is a container for the develop wazuh-engine. It is based on the `ubuntu:20.04` image and contains all the necessary dependencies to run the engine.
 To connect to the container, you can use the `ssh` service. The default user is `root` and the password is `Engine123`.
@@ -20,7 +20,7 @@ Once the container is created, you will not require to build the image again unt
 First step is to build the image. You can use the following command:
 
 ``` bash
-export VERSION=20250130-0
+export VERSION=20250210-0
 docker buildx build -t engine-container:$VERSION . --no-cache
 # Tag the image as latest to use it as the default image (recommended)
 docker tag engine-container:$VERSION engine-container:latest
@@ -34,10 +34,9 @@ To check the image, you can use the `docker images` command, you should see the 
 
 ```bash
 ╰─# docker images
-
-REPOSITORY         TAG          IMAGE ID       CREATED          SIZE
-engine-container   20250130-0   8kd72xgq1m9c   42 minutes ago   12.2GB
-engine-container   latest       8kd72xgq1m9c   42 minutes ago   12.2GB
+REPOSITORY         TAG          IMAGE ID       CREATED         SIZE
+engine-container   20250210-0   7bffbbf1e002   2 minutes ago   16.2GB
+engine-container   latest       7bffbbf1e002   2 minutes ago   16.2GB
 ```
 
 ## Create the container
@@ -50,7 +49,7 @@ docker create -p 4022:22 --name engine-container engine-container:latest
 
 Alternatively, you can use a specific version of the image
 ``` bash
-export VERSION=20250130-0
+export VERSION=20250210-0
 docker create -p 4022:22 --name engine-container engine-container:$VERSION
 ```
 This command will create a container named `engine-container` and will map the port `4022` of the host to the port `22` of the container. A container is created in a stopped state.
@@ -59,8 +58,8 @@ To check the status of the container, you can use the following command:
 
 ``` bash
 ╰─# docker ps -a
-CONTAINER ID   IMAGE                     COMMAND                  CREATED         STATUS    PORTS     NAMES
-8kd72xgq1m9c   engine-container:latest   "/usr/bin/EntryPoint…"   31 seconds ago   Created             engine-container
+CONTAINER ID   IMAGE                     COMMAND                  CREATED          STATUS    PORTS     NAMES
+972f6e656920   engine-container:latest   "/usr/bin/EntryPoint…"   44 seconds ago   Created             engine-container
 ```
 
 ## Start the container
@@ -81,8 +80,8 @@ You can check the status of the container using the following command:
 
 ``` bash
 ╰─# docker ps
-CONTAINER ID   IMAGE                     COMMAND                  CREATED          STATUS          PORTS                                   NAMES
-8kd72xgq1m9c   engine-container:latest   "/usr/bin/EntryPoint…"   49 seconds ago   Up 10q seconds   0.0.0.0:4022->22/tcp, :::4022->22/tcp   engine-container
+CONTAINER ID   IMAGE                     COMMAND                  CREATED              STATUS         PORTS                                     NAMES
+972f6e656920   engine-container:latest   "/usr/bin/EntryPoint…"   About a minute ago   Up 8 seconds   0.0.0.0:4022->22/tcp, [::]:4022->22/tcp   engine-container
 ```
 
 


### PR DESCRIPTION
Closes #28146 

This PR update the dev ruleset docker for wazuh-engine


## Testing

### Build
```
╭─root@fcda3b064380 /workspaces/engine-ubuntu-22/wazuh/src/engine/tools/docker ‹change/28146-update-docker-for-ruleset●› 
╰─# export VERSION=20250210-0                                                                                                                                                                                                                               1 ↵
docker buildx build -t engine-container:$VERSION . --no-cache
[+] Building 1037.6s (34/34) FINISHED                                                                                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 3.81kB                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                                                                                            2.1s
 => [internal] load .dockerignore                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                            0.0s
 => CACHED [ 1/29] FROM docker.io/library/ubuntu:20.04@sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                                                                          0.3s
 => => transferring context: 69.81MB                                                                                                                                                                                                                       0.3s
 => [ 2/29] RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/*  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8                                                                              11.6s
 => [ 3/29] RUN ln -snf /usr/share/zoneinfo/America/New_York /etc/localtime && echo America/New_York > /etc/timezone                                                                                                                                       0.2s 
 => [ 4/29] RUN apt-get update && apt-get install -y     build-essential     pkg-config     clang-format     cmake     git     openssh-server     software-properties-common     python3-apt     curl     zip     lzip     unzip     tar                 101.5s 
 => [ 5/29] RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y                                                                                                                                                                                          6.6s 
 => [ 6/29] RUN apt-get update && apt-get install -y gcc-11 g++-11                                                                                                                                                                                       157.4s 
 => [ 7/29] RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 1                                                                                                                                                                           0.2s 
 => [ 8/29] RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 1                                                                                                                                                                           0.2s 
 => [ 9/29] RUN add-apt-repository ppa:deadsnakes/ppa -y                                                                                                                                                                                                   6.9s 
 => [10/29] RUN apt-get update && apt-get install -y python3.12                                                                                                                                                                                           23.7s 
 => [11/29] RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12                                                                                                                                                                                 2.3s
 => [12/29] RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1                                                                                                                                                               0.2s
 => [13/29] RUN git clone "https://github.com/microsoft/vcpkg.git" /root/vcpkg     && cd /root/vcpkg     && ./bootstrap-vcpkg.sh     && echo "export VCPKG_ROOT=/root/vcpkg" >> ~/.bashrc     && echo "export PATH=$PATH:$VCPKG_ROOT" >> ~/.bashrc        11.7s
 => [14/29] COPY scripts/reinstall-cmake.sh /tmp/reinstall-cmake.sh                                                                                                                                                                                        0.0s
 => [15/29] RUN chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh 3.30.5                                                                                                                                                                         7.5s
 => [16/29] COPY mmdbs/GeoLite2-City.mmdb /tmp/GeoLite2-City.mmdb                                                                                                                                                                                          0.0s
 => [17/29] COPY mmdbs/GeoLite2-ASN.mmdb /tmp/GeoLite2-ASN.mmdb                                                                                                                                                                                            0.0s
 => [18/29] COPY scripts/build-and-install-engine.sh /tmp/build-and-install-engine.sh                                                                                                                                                                      0.0s
 => [19/29] RUN chmod +x /tmp/build-and-install-engine.sh && /tmp/build-and-install-engine.sh                                                                                                                                                            655.8s
 => [20/29] RUN mkdir /var/run/sshd                                                                                                                                                                                                                        0.2s
 => [21/29] RUN echo 'root:Engine123' | chpasswd                                                                                                                                                                                                           0.2s
 => [22/29] RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config                                                                                                                                                     0.2s
 => [23/29] RUN sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config                                                                                                                                                                  0.2s
 => [24/29] RUN sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config                                                                                                                                                      0.2s
 => [25/29] RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config                                                                                                                                                    0.2s
 => [26/29] RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd                                                                                                                                         0.2s
 => [27/29] RUN mkdir -p -m 755 /etc/apt/keyrings     && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null     && chmod go+r /etc/apt/keyrings/githubcli-archive-  6.6s
 => [28/29] COPY scripts/EntryPoint.sh /usr/bin/EntryPoint.sh                                                                                                                                                                                              0.0s
 => [29/29] RUN chmod +x /usr/bin/EntryPoint.sh                                                                                                                                                                                                            0.1s
 => exporting to image                                                                                                                                                                                                                                    41.6s
 => => exporting layers                                                                                                                                                                                                                                   41.6s
 => => writing image sha256:7bffbbf1e002be50ea5d9c97eea345711cd531530f02e74d3dba3665e9465751                                                                                                                                                               0.0s
 => => naming to docker.io/library/engine-container:20250210-0                                                                                                                                                                                             0.0s

 1 warning found (use docker --debug to expand):
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "MM_LICENCE_KEY") (line 21)
```

### Run and load route
```
root@972f6e656920:~/intelligence-data# cd engine/integrations/
root@972f6e656920:~/intelligence-data/engine/integrations# engine-integration add -n system wazuh-core && \
> engine-integration add -n wazuh apache-http && \
> engine-integration add -n wazuh suricata    && \
> engine-integration add -n wazuh syslog      && \
> engine-integration add -n wazuh system      && \
> engine-integration add -n wazuh wazuh-dashboard && \
> engine-integration add -n wazuh modsecurity && \
> engine-integration add -n wazuh pfsense && \
> engine-integration add -n wazuh snort && \
> engine-integration add -n wazuh windows
Adding integration from: /root/intelligence-data/engine/integrations/wazuh-core
Loading manifest.yml...
Adding integration/wazuh-core/0 to the catalog

Tasks:
0: [system] Add decoder/core-wazuh-message/0 to catalog
1: [system] Add decoder/integrations/0 to catalog
2: [system] Add output/file-output-integrations/0 to catalog
3: [system] Add integration/wazuh-core/0 to catalog

Executing tasks...
Executing 0: [system] Add decoder/core-wazuh-message/0 to catalog...
Executing 1: [system] Add decoder/integrations/0 to catalog...
Executing 2: [system] Add output/file-output-integrations/0 to catalog...
Executing 3: [system] Add integration/wazuh-core/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/apache-http
Loading manifest.yml...
Adding integration/apache-http/0 to the catalog

Tasks:
0: [wazuh] Add decoder/apache-error/0 to catalog
1: [wazuh] Add decoder/apache-access/0 to catalog
2: [wazuh] Add integration/apache-http/0 to catalog

Executing tasks...
Executing 0: [wazuh] Add decoder/apache-error/0 to catalog...
Executing 1: [wazuh] Add decoder/apache-access/0 to catalog...
Executing 2: [wazuh] Add integration/apache-http/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/suricata
Loading manifest.yml...
Adding integration/suricata/0 to the catalog

Tasks:
0: Add KVDB suricata_event_id_to_info
1: [wazuh] Add decoder/suricata/0 to catalog
2: [wazuh] Add integration/suricata/0 to catalog

Executing tasks...
Executing 0: Add KVDB suricata_event_id_to_info...
Executing 1: [wazuh] Add decoder/suricata/0 to catalog...
Executing 2: [wazuh] Add integration/suricata/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/syslog
Loading manifest.yml...
Adding integration/syslog/0 to the catalog

Tasks:
0: [wazuh] Add decoder/syslog/0 to catalog
1: [wazuh] Add integration/syslog/0 to catalog

Executing tasks...
Executing 0: [wazuh] Add decoder/syslog/0 to catalog...
Executing 1: [wazuh] Add integration/syslog/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/system
Loading manifest.yml...
Adding integration/system/0 to the catalog

Tasks:
0: [wazuh] Add decoder/system-auth/0 to catalog
1: [wazuh] Add decoder/sysmon-linux/0 to catalog
2: [wazuh] Add integration/system/0 to catalog

Executing tasks...
Executing 0: [wazuh] Add decoder/system-auth/0 to catalog...
Executing 1: [wazuh] Add decoder/sysmon-linux/0 to catalog...
Executing 2: [wazuh] Add integration/system/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/wazuh-dashboard
Loading manifest.yml...
Adding integration/wazuh-dashboard/0 to the catalog

Tasks:
0: [wazuh] Add decoder/wazuh-dashboard/0 to catalog
1: [wazuh] Add integration/wazuh-dashboard/0 to catalog

Executing tasks...
Executing 0: [wazuh] Add decoder/wazuh-dashboard/0 to catalog...
Executing 1: [wazuh] Add integration/wazuh-dashboard/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/modsecurity
Loading manifest.yml...
Adding integration/modsecurity/0 to the catalog

Tasks:
0: [wazuh] Add decoder/modsecurity-nginx/0 to catalog
1: [wazuh] Add decoder/modsecurity-apache/0 to catalog
2: [wazuh] Add integration/modsecurity/0 to catalog

Executing tasks...
Executing 0: [wazuh] Add decoder/modsecurity-nginx/0 to catalog...
Executing 1: [wazuh] Add decoder/modsecurity-apache/0 to catalog...
Executing 2: [wazuh] Add integration/modsecurity/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/pfsense
Loading manifest.yml...
Adding integration/pfsense/0 to the catalog

Tasks:
0: [wazuh] Add decoder/pfsense-unbound/0 to catalog
1: [wazuh] Add decoder/pfsense-firewall/0 to catalog
2: [wazuh] Add decoder/pfsense-php-fpm/0 to catalog
3: [wazuh] Add decoder/pfsense-dhcp/0 to catalog
4: [wazuh] Add integration/pfsense/0 to catalog

Executing tasks...
Executing 0: [wazuh] Add decoder/pfsense-unbound/0 to catalog...
Executing 1: [wazuh] Add decoder/pfsense-firewall/0 to catalog...
Executing 2: [wazuh] Add decoder/pfsense-php-fpm/0 to catalog...
Executing 3: [wazuh] Add decoder/pfsense-dhcp/0 to catalog...
Executing 4: [wazuh] Add integration/pfsense/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/snort
Loading manifest.yml...
Adding integration/snort/0 to the catalog

Tasks:
0: [wazuh] Add decoder/snort-json/0 to catalog
1: [wazuh] Add decoder/snort-plaintext/0 to catalog
2: [wazuh] Add decoder/snort-plaintext-csv/0 to catalog
3: [wazuh] Add decoder/snort-plaintext-syslog/0 to catalog
4: [wazuh] Add integration/snort/0 to catalog

Executing tasks...
Executing 0: [wazuh] Add decoder/snort-json/0 to catalog...
Executing 1: [wazuh] Add decoder/snort-plaintext/0 to catalog...
Executing 2: [wazuh] Add decoder/snort-plaintext-csv/0 to catalog...
Executing 3: [wazuh] Add decoder/snort-plaintext-syslog/0 to catalog...
Executing 4: [wazuh] Add integration/snort/0 to catalog...

Done
Adding integration from: /root/intelligence-data/engine/integrations/windows
Loading manifest.yml...
Adding integration/windows/0 to the catalog

Tasks:
0: Add KVDB windows_event_type_to_eventid_list
1: Add KVDB windows_sec_iana_number_name
2: Add KVDB windows_sec_id_to_message
3: Add KVDB windows_trust_attribute_value_to_attribute
4: Add KVDB windows_logon_type_to_title
5: Add KVDB windows_audit_access_id_to_description
6: Add KVDB windows_logon_failure_status_to_description
7: Add KVDB windows_audit_SubcategoryGUID_to_categories
8: Add KVDB windows_trust_direction_value_to_attribute
9: Add KVDB windows_powershell_bitmask_tables
10: Add KVDB windows_sec_bitmask_tables
11: Add KVDB windows_sidlist_tables
12: Add KVDB windows_powershell_operational_winmeta_opcodes
13: Add KVDB windows_security_eventid_to_category_type_action
14: Add KVDB windows_kerberos_encryption_type_to_description
15: Add KVDB windows_powershell_id_to_message
16: Add KVDB windows_powershell_op_id_to_message
17: Add KVDB windows_service_value_to_service_type
18: Add KVDB windows_trust_type_value_to_attribute
19: Add KVDB windows_kerberos_status_code_to_code_name
20: [wazuh] Add decoder/windows-sysmon/0 to catalog
21: [wazuh] Add decoder/windows-event/0 to catalog
22: [wazuh] Add decoder/windows-powershell/0 to catalog
23: [wazuh] Add decoder/windows-powershell-operational/0 to catalog
24: [wazuh] Add decoder/windows-security/0 to catalog
25: [wazuh] Add integration/windows/0 to catalog

Executing tasks...
Executing 0: Add KVDB windows_event_type_to_eventid_list...
Executing 1: Add KVDB windows_sec_iana_number_name...
Executing 2: Add KVDB windows_sec_id_to_message...
Executing 3: Add KVDB windows_trust_attribute_value_to_attribute...
Executing 4: Add KVDB windows_logon_type_to_title...
Executing 5: Add KVDB windows_audit_access_id_to_description...
Executing 6: Add KVDB windows_logon_failure_status_to_description...
Executing 7: Add KVDB windows_audit_SubcategoryGUID_to_categories...
Executing 8: Add KVDB windows_trust_direction_value_to_attribute...
Executing 9: Add KVDB windows_powershell_bitmask_tables...
Executing 10: Add KVDB windows_sec_bitmask_tables...
Executing 11: Add KVDB windows_sidlist_tables...
Executing 12: Add KVDB windows_powershell_operational_winmeta_opcodes...
Executing 13: Add KVDB windows_security_eventid_to_category_type_action...
Executing 14: Add KVDB windows_kerberos_encryption_type_to_description...
Executing 15: Add KVDB windows_powershell_id_to_message...
Executing 16: Add KVDB windows_powershell_op_id_to_message...
Executing 17: Add KVDB windows_service_value_to_service_type...
Executing 18: Add KVDB windows_trust_type_value_to_attribute...
Executing 19: Add KVDB windows_kerberos_status_code_to_code_name...
Executing 20: [wazuh] Add decoder/windows-sysmon/0 to catalog...
Executing 21: [wazuh] Add decoder/windows-event/0 to catalog...
Executing 22: [wazuh] Add decoder/windows-powershell/0 to catalog...
Executing 23: [wazuh] Add decoder/windows-powershell-operational/0 to catalog...
Executing 24: [wazuh] Add decoder/windows-security/0 to catalog...
Executing 25: [wazuh] Add integration/windows/0 to catalog...

Done
root@972f6e656920:~/intelligence-data/engine/integrations# cd ..
root@972f6e656920:~/intelligence-data/engine# engine-catalog -n system create filter < filters/allow-all.yml
root@972f6e656920:~/intelligence-data/engine# engine-policy create -p policy/wazuh/0
cy parent-set decoder/integrations/0
engine-policy parent-set -n wazuh decoder/integrations/0
engine-policy asset-add -n system integration/wazuh-core/0
engine-policy asset-add -n wazuh integration/syslog/0
engine-policy asset-add -n wazuh integration/system/0
engine-policy asset-add -n wazuh integration/windows/0
engine-policy asset-add -n wazuh integration/apache-http/0
engine-policy asset-add -n wazuh integration/suricata/0
engine-policy asset-add -n wazuh integration/modsecurity/0
engine-policy asset-add -n wazuh integration/pfsense/0
engine-policy asset-add -n wazuh integration/snort/0root@972f6e656920:~/intelligence-data/engine# engine-policy parent-set decoder/integrations/0
root@972f6e656920:~/intelligence-data/engine# engine-policy parent-set -n wazuh decoder/integrations/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n system integration/wazuh-core/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/syslog/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/system/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/windows/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/apache-http/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/suricata/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/modsecurity/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/pfsense/0
root@972f6e656920:~/intelligence-data/engine# engine-policy asset-add -n wazuh integration/snort/0
root@972f6e656920:~/intelligence-data/engine# engine-router add default filter/allow-all/0 100 policy/wazuh/0
root@972f6e656920:~/intelligence-data/engine# engine-router list
- entry_status: ENABLED
  filter: filter/allow-all/0
  name: default
  policy: policy/wazuh/0
  policy_sync: UPDATED
  priority: 100
  uptime: 17
```


### Integration test
```
root@972f6e656920:~/intelligence-data/engine# engine-test -c ./integrations/apache-http/test/engine-test.conf run apache-http-error

Enter any events [ENTER to send event, CTRL+C to finish]:

[Fri Sep 09 10:42:29.902022 2011] [core:error] [pid 35708:tid 4328636416] [client 89.160.20.156] File does not exist: /usr/local/apache2/htdocs/favicon.ico


---
'@timestamp': '2025-02-10T16:11:34Z'
agent:
  groups:
  - group1
  - group2
  host:
    architecture: x86_64
    hostname: wazuh-endpoint-linux
    ip:
    - 192.168.1.2
    os:
      name: Amazon Linux 2
      platform: Linux
  id: 2887e1cf-9bf2-431a-b066-a46860080f56
  name: wazuh-agent-name
  type: endpoint
  version: 5.0.0
event:
  category:
  - web
  collector: file
  created: '2024-10-22T02:00:00Z'
  dataset: apache-error
  kind: event
  module: logcollector
  original: '[Fri Sep 09 10:42:29.902022 2011] [core:error] [pid 35708:tid 4328636416]
    [client 89.160.20.156] File does not exist: /usr/local/apache2/htdocs/favicon.ico'
  start: '2011-09-09T10:42:29.902Z'
  type:
  - error
file:
  path: /usr/local/apache2/htdocs/favicon.ico
log:
  file:
    path: /var/log/apache2/error.log
  level: error
  logger: core
message: 'File does not exist: /usr/local/apache2/htdocs/favicon.ico'
process:
  pid: 35708
  thread:
    id: 4328636416
service:
  type: apache
source:
  address: 89.160.20.156
  ip: 89.160.20.156
tags:
- production-server
wazuh:
  decoders:
  - apache-error



Enter any events [ENTER to send event, CTRL+C to finish]:
```
