### PR TITLE
Check downloaded pre-compiled libs with -f operator

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1470,7 +1470,7 @@ external/$(CPYTHON).tar.gz: external-precompiled/$(CPYTHON).tar.gz
 
 external-precompiled/$(CPYTHON).tar.gz:
 	-$(CURL) external/$(patsubst external-precompiled/%,%,$@) $(RESOURCES_URL)/libraries/$(PRECOMPILED_RES)/$(patsubst external-precompiled/%,%,$@) || true
-	-cd external && test -e $(patsubst external-precompiled/%,%,$@) && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
+	-cd external && [ -f $(patsubst external-precompiled/%,%,$@) ] && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
 else
 external/$(CPYTHON).tar.gz:
 	$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@)
@@ -1506,9 +1506,9 @@ external/nlohmann.tar.gz: external-precompiled/nlohmann.tar.gz
 
 external-precompiled/nlohmann.tar.gz:
 	-$(CURL) external/$(patsubst external-precompiled/%,%,$@) $(RESOURCES_URL_NLOHMANN)/libraries/$(PRECOMPILED_RES)/$(patsubst external-precompiled/%,%,$@) || true
-	-cd external && test -e $(patsubst external-precompiled/%,%,$@) && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
-	-cd external && test -e $(patsubst external-precompiled/%.gz,%,$@) && $(TAR) $(patsubst external-precompiled/%.gz,%,$@) || true
-	-test -e external/$(patsubst external-precompiled/%.gz,%,$@) && rm external/$(patsubst external-precompiled/%.gz,%,$@) || true
+	-cd external && [ -f $(patsubst external-precompiled/%,%,$@) ] && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
+	-cd external && [ -f $(patsubst external-precompiled/%.gz,%,$@) ] && $(TAR) $(patsubst external-precompiled/%.gz,%,$@) || true
+	-[ -f external/$(patsubst external-precompiled/%.gz,%,$@) ] && rm external/$(patsubst external-precompiled/%.gz,%,$@) || true
 else
 external/nlohmann.tar.gz:
 	$(CURL) $@ $(RESOURCES_URL_NLOHMANN)/libraries/sources/$(patsubst external/%,%,$@)
@@ -1536,9 +1536,9 @@ endif
 ifneq (,$(PRECOMPILED_RES))
 external-precompiled/%.tar.gz:
 	-$(CURL) external/$(patsubst external-precompiled/%,%,$@) $(RESOURCES_URL)/libraries/$(PRECOMPILED_RES)/$(patsubst external-precompiled/%,%,$@) || true
-	-cd external && test -e $(patsubst external-precompiled/%,%,$@) && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
-	-cd external && test -e $(patsubst external-precompiled/%.gz,%,$@) && $(TAR) $(patsubst external-precompiled/%.gz,%,$@) || true
-	-test -e external/$(patsubst external-precompiled/%.gz,%,$@) && rm external/$(patsubst external-precompiled/%.gz,%,$@) || true
+	-cd external && [ -f $(patsubst external-precompiled/%,%,$@) ] && $(GUNZIP) $(patsubst external-precompiled/%,%,$@) || true
+	-cd external && [ -f $(patsubst external-precompiled/%.gz,%,$@) ] && $(TAR) $(patsubst external-precompiled/%.gz,%,$@) || true
+	-[ -f external/$(patsubst external-precompiled/%.gz,%,$@) ] && rm external/$(patsubst external-precompiled/%.gz,%,$@) || true
 endif
 
 # Shared tools


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/206|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

this PR changes the way pre-compiled libs are check to be properly downloaded. Using `test -e` was causing problems in `solaris 10` systems.

## Logs/Alerts example

Fetching deps in Solaris 10:

```
-bash-3.2$ gmake deps TARGET=agent 
grep: can't open /etc/os-release
Makefile:2677: warning: overriding recipe for target `win32/ui_resource.o'
Makefile:2617: warning: ignoring old recipe for target `win32/ui_resource.o'
Makefile:2680: warning: overriding recipe for target `win32/auth_resource.o'
Makefile:2620: warning: ignoring old recipe for target `win32/auth_resource.o'
curl -so external/cJSON.tar.gz https://packages.wazuh.com/deps/35/libraries/solaris/i386/cJSON.tar.gz || true
cd external && [ -f cJSON.tar.gz ] && gunzip cJSON.tar.gz || true
cd external && [ -f cJSON.tar ] && tar -xf cJSON.tar || true
[ -f external/cJSON.tar ] && rm external/cJSON.tar || true
test -d external/cJSON ||\
(curl -so external/cJSON.tar.gz https://packages.wazuh.com/deps/35/libraries/sources/cJSON.tar.gz &&\
cd external && gunzip cJSON.tar.gz && tar -xf cJSON.tar && rm cJSON.tar)
curl -so external/curl.tar.gz https://packages.wazuh.com/deps/35/libraries/solaris/i386/curl.tar.gz || true
```

Fetching deps in Ubuntu 22:

```
root@agent3-ubu22:/vagrant/wazuh/src# make deps TARGET=agent -j 2
Makefile:2677: warning: overriding recipe for target 'win32/ui_resource.o'
Makefile:2617: warning: ignoring old recipe for target 'win32/ui_resource.o'
Makefile:2680: warning: overriding recipe for target 'win32/auth_resource.o'
Makefile:2620: warning: ignoring old recipe for target 'win32/auth_resource.o'
curl -so external/cJSON.tar.gz https://packages.wazuh.com/deps/35/libraries/linux/amd64/cJSON.tar.gz || true
curl -so external/curl.tar.gz https://packages.wazuh.com/deps/35/libraries/linux/amd64/curl.tar.gz || true
cd external && [ -f cJSON.tar.gz ] && gunzip cJSON.tar.gz || true
cd external && [ -f cJSON.tar ] && tar -xf cJSON.tar || true
[ -f external/cJSON.tar ] && rm external/cJSON.tar || true
curl -so external/libdb.tar.gz https://packages.wazuh.com/deps/35/libraries/linux/amd64/libdb.tar.gz || true
```

After fetching deps, no recompilation of them is done.
<!--
Paste here related logs and alerts
-->

## Tests
  - [x] Compilation in Linux (Ubuntu 22)
  - [x] Compilation in Solaris 10: Tested WF: https://github.com/wazuh/wazuh-agent-packages/actions/runs/13264846466
