### PR TITLE
Backport to 4.11.0 - Change ms-graph page size to 50

### DIFF
--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -2244,7 +2244,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2411,7 +2411,7 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2504,7 +2504,7 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2597,7 +2597,7 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2690,7 +2690,7 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2793,7 +2793,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2898,7 +2898,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
 #endif
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=100'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=50'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2934,7 +2934,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error'");
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps/12345/managedDevices?$top=100&$select=id,deviceName'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps/12345/managedDevices?$top=50&$select=id,deviceName'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3041,7 +3041,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     os_strdup("test2", response2->header);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$top=100'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$top=50'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3215,7 +3215,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3273,7 +3273,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=100&$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=50&$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);

--- a/src/wazuh_modules/wm_ms_graph.h
+++ b/src/wazuh_modules/wm_ms_graph.h
@@ -38,7 +38,7 @@
 #define WM_MS_GRAPH_API_URL_FILTER_ACTIVITY_DATE WM_MS_GRAPH_API_URL "&$filter=activityDateTime+ge+%s+and+activityDateTime+lt+%s"
 #define WM_MS_GRAPH_ACCESS_TOKEN_URL "https://%s/%s/oauth2/v2.0/token"
 #define WM_MS_GRAPH_ACCESS_TOKEN_PAYLOAD "scope=https://%s/.default&grant_type=client_credentials&client_id=%s&client_secret=%s"
-#define WM_MS_GRAPH_ITEM_PER_PAGE 100
+#define WM_MS_GRAPH_ITEM_PER_PAGE 50
 
 // MDM Intune
 #define WM_MS_GRAPH_API_URL_DEVICES_EXPANDED "https://%s/%s/%s/%s/%s/%s?$top=%d"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28194|

## Description

Since some relationships in the MS-Graph integration require a maximum of 50 results per size, this PR changes the hard-coded value used to query results from 100 to 50.

> This is a back port to 4.11.0.

## Configuration options

N/A

## Logs/Alerts example

Error:

```
2025/02/07 19:01:56 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:83 at wm_ms_graph_main(): INFO: Scanning tenant '0fea4e03-8146-453b-b889-54b4bd11565b'
2025/02/07 19:01:56 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2025-02-07T19:01:26Z+and+createdDateTime+lt+2025-02-07T19:01:56Z'
2025/02/07 19:01:57 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-07T19:01:56Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'security' and relationship 'alerts_v2', waiting '30' seconds to run next scan.
2025/02/07 19:01:57 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/incidents?$top=100&$filter=createdDateTime+ge+2025-02-07T18:28:27Z+and+createdDateTime+lt+2025-02-07T19:01:57Z'
2025/02/07 19:01:58 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:308 at wm_ms_graph_scan_relationships(): WARNING: Received unsuccessful status code when attempting to get relationship 'incidents' logs: Status code was '400' & response was '{"error":{"code":"","message":"The query specified in the URI is not valid. The limit of '50' for Top query has been exceeded. The value from the incoming request is '100'.","details":[],"innerError":{"date":"2025-02-07T19:01:58","request-id":"fd2599bd-dd58-4a29-a886-b96aaeadd826","client-request-id":"fd2599bd-dd58-4a29-a886-b96aaeadd826"}}}'
2025/02/07 19:01:58 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/auditLogs/signIns?$top=100&$filter=createdDateTime+ge+2025-02-07T19:01:28Z+and+createdDateTime+lt+2025-02-07T19:01:58Z'
2025/02/07 19:02:01 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-07T19:01:58Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'auditLogs' and relationship 'signIns', waiting '30' seconds to run next scan.
2025/02/07 19:02:01 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=100&$filter=activityDateTime+ge+2025-02-07T19:01:30Z+and+activityDateTime+lt+2025-02-07T19:02:01Z'
2025/02/07 19:02:03 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-07T19:02:01Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'deviceManagement' and relationship 'auditEvents', waiting '30' seconds to run next scan.
2025/02/07 19:02:03 wazuh-modulesd:ms-graph[30588] wm_ms_graph.c:69 at wm_ms_graph_main(): DEBUG: Waiting until: 2025/02/07 19:02:26
```

Fix:

```
2025/02/07 19:10:53 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:83 at wm_ms_graph_main(): INFO: Scanning tenant '0fea4e03-8146-453b-b889-54b4bd11565b'
2025/02/07 19:10:53 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2025-02-07T19:10:23Z+and+createdDateTime+lt+2025-02-07T19:10:53Z'
2025/02/07 19:10:54 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-07T19:10:53Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'security' and relationship 'alerts_v2', waiting '30' seconds to run next scan.
2025/02/07 19:10:54 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/incidents?$top=50&$filter=createdDateTime+ge+2025-02-07T19:10:24Z+and+createdDateTime+lt+2025-02-07T19:10:54Z'
2025/02/07 19:10:55 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-07T19:10:54Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'security' and relationship 'incidents', waiting '30' seconds to run next scan.
2025/02/07 19:10:55 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/auditLogs/signIns?$top=50&$filter=createdDateTime+ge+2025-02-07T19:10:25Z+and+createdDateTime+lt+2025-02-07T19:10:55Z'
2025/02/07 19:10:56 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-07T19:10:55Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'auditLogs' and relationship 'signIns', waiting '30' seconds to run next scan.
2025/02/07 19:10:56 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=50&$filter=activityDateTime+ge+2025-02-07T19:10:26Z+and+activityDateTime+lt+2025-02-07T19:10:56Z'
2025/02/07 19:10:57 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-07T19:10:56Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'deviceManagement' and relationship 'auditEvents', waiting '30' seconds to run next scan.
2025/02/07 19:10:57 wazuh-modulesd:ms-graph[40130] wm_ms_graph.c:69 at wm_ms_graph_main(): DEBUG: Waiting until: 2025/02/07 19:11:23
```

> Note: notice the `top` parameter in the queries.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Source installation
- [x] Package installation
- [x] Source upgrade
- [x] Package upgrade