### PR TITLE
Fixed tsan warnings in monitoring class unit test.

### DIFF
--- a/src/engine/source/indexerconnector/src/monitoring.hpp
+++ b/src/engine/source/indexerconnector/src/monitoring.hpp
@@ -182,9 +182,9 @@ public:
                     if (!m_stop)
                     {
                         // Check the health of the servers.
+                        std::lock_guard lock(m_mutex);
                         for (const auto& [serverAddress, _] : m_servers)
                         {
-                            std::lock_guard lock(m_mutex);
                             healthCheck(serverAddress, authentication);
                         }
                     }
@@ -201,7 +201,7 @@ public:
      */
     bool isAvailable(const std::string& serverAddress)
     {
-        std::lock_guard lock(m_mutex);
+        std::scoped_lock lock(m_mutex);
         return m_servers.at(serverAddress);
     }
 };


### PR DESCRIPTION
|Related issue|
|---|
|#28071|

## Description

This PR fixes an issue with threads in monitoring class. Mixing scoped_lock and unique_lock with same mutex causes a double lock and race conditions. 

## DoD

- After fix 
![image](https://github.com/user-attachments/assets/03f43124-41a9-4643-ae6c-6c7047e52a3d)

- It was verified that the m_stop stops the thread successfully even with huge m_interval value 
![image](https://github.com/user-attachments/assets/5b04d5d7-494b-4737-9b7a-b75a656dbc80)

```diff
diff --git a/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp b/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp
index db8ff360e6..dd86250c03 100644
--- a/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp
+++ b/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp
@@ -105,9 +105,9 @@ TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
     const std::string unregisteredServer {"http://localhost:9500"};

     // Instantiate the Monitoring object
-    auto monitoring = std::make_shared<TMonitoring<TrampolineHTTPRequest>>(m_servers, MONITORING_HEALTH_CHECK_INTERVAL);
+    auto monitoring = std::make_shared<TMonitoring<TrampolineHTTPRequest>>(m_servers, 10000);

-    std::this_thread::sleep_for(std::chrono::milliseconds(MONITORING_HEALTH_CHECK_INTERVAL * 2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2u * 2));

     // Ensure no exceptions during instantiation
     EXPECT_NO_THROW(monitoring);
@@ -118,7 +118,7 @@ TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
     EXPECT_FALSE(monitoring->isAvailable(RED_SERVER));

     // Check server health status after interval
-    std::this_thread::sleep_for(std::chrono::milliseconds(MONITORING_HEALTH_CHECK_INTERVAL * 2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2u * 2));

     EXPECT_TRUE(monitoring->isAvailable(GREEN_SERVER));
     EXPECT_TRUE(monitoring->isAvailable(YELLOW_SERVER));
```

- The same test before without using conditional variable to break the waiting when m_stop is true 
This does not work, because it waits the m_interval and it shouldn't. 
![image](https://github.com/user-attachments/assets/ef223060-16d5-4d17-8728-841f78f862b0)

```diff
diff --git a/src/engine/source/indexerconnector/src/monitoring.hpp b/src/engine/source/indexerconnector/src/monitoring.hpp
index 9d937168b6..87a275a0b8 100644
--- a/src/engine/source/indexerconnector/src/monitoring.hpp
+++ b/src/engine/source/indexerconnector/src/monitoring.hpp
@@ -174,10 +174,7 @@ public:
                 while (!m_stop)
                 {
                     // Wait for the interval.
-                    std::unique_lock lock(m_mutex_wait);
-                    m_condition.wait_for(
-                        lock, std::chrono::milliseconds(m_interval), [this]() { return m_stop.load(); });
-
+                    std::this_thread::sleep_for(std::chrono::milliseconds(m_interval));
                     // If the thread is not stopped, check the health of the servers.
                     if (!m_stop)
                     {
diff --git a/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp b/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp
index db8ff360e6..dd86250c03 100644
--- a/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp
+++ b/src/engine/source/indexerconnector/test/unit/monitoring_test.cpp
@@ -105,9 +105,9 @@ TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
     const std::string unregisteredServer {"http://localhost:9500"};

     // Instantiate the Monitoring object
-    auto monitoring = std::make_shared<TMonitoring<TrampolineHTTPRequest>>(m_servers, MONITORING_HEALTH_CHECK_INTERVAL);
+    auto monitoring = std::make_shared<TMonitoring<TrampolineHTTPRequest>>(m_servers, 10000);

-    std::this_thread::sleep_for(std::chrono::milliseconds(MONITORING_HEALTH_CHECK_INTERVAL * 2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2u * 2));

     // Ensure no exceptions during instantiation
     EXPECT_NO_THROW(monitoring);
@@ -118,7 +118,7 @@ TEST_F(MonitoringTest, TestCheckIfAnUnregisteredServerIsAvailable)
     EXPECT_FALSE(monitoring->isAvailable(RED_SERVER));

     // Check server health status after interval
-    std::this_thread::sleep_for(std::chrono::milliseconds(MONITORING_HEALTH_CHECK_INTERVAL * 2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2u * 2));

     EXPECT_TRUE(monitoring->isAvailable(GREEN_SERVER));
     EXPECT_TRUE(monitoring->isAvailable(YELLOW_SERVER));
```