### PR TITLE
Create indexer CA bundle

### DIFF
--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -245,7 +245,7 @@ MAXIMUM_DATABASE_LIMIT = 100000
 
 # ================================================ Wazuh path - Config =================================================
 WAZUH_SERVER_YML = WAZUH_ETC / 'wazuh-server.yml'
-
+WAZUH_INDEXER_CA_BUNDLE = WAZUH_ETC / 'certs' / 'root-ca-merged.pem'
 
 # ================================================= Wazuh path - Misc ==================================================
 DEFAULT_RBAC_RESOURCES = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'rbac', 'default')

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -2,7 +2,9 @@ from enum import Enum
 from typing import List
 
 from pydantic import Field, ValidationInfo, field_validator
+from wazuh.core.common import WAZUH_INDEXER_CA_BUNDLE
 from wazuh.core.config.models.base import ValidateFilePathMixin, WazuhConfigBaseModel
+from wazuh.core.exception import WazuhError
 
 
 class SSLProtocol(str, Enum):
@@ -76,14 +78,14 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
         List of paths to the CA certificate file. Default is a list containing one empty string.
     verify_certificates : bool
         Whether to verify the server TLS certificates or not. Default is True.
-
     """
 
     use_ssl: bool = False
     key: str = ''
     certificate: str = ''
-    certificate_authorities: List[str] = Field(default=[''], min_length=1)
+    certificate_authorities: List[str] = Field(default=[''], min_length=1, exclude=True)
     verify_certificates: bool = True
+    certificate_authorities_bundle: str = WAZUH_INDEXER_CA_BUNDLE
 
     @field_validator('key', 'certificate')
     @classmethod
@@ -113,8 +115,8 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
 
     @field_validator('certificate_authorities')
     @classmethod
-    def validate_cs_files(cls, paths: List[str], info: ValidationInfo) -> List[str]:
-        """Validate that the SSL certificate authorities files exist.
+    def validate_ca_files(cls, paths: List[str], info: ValidationInfo) -> List[str]:
+        """Validate that the SSL certificate authorities files exist and create a bundle file.
 
         Parameters
         ----------
@@ -137,7 +139,31 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
             for path in paths:
                 cls._validate_file_path(path, info.field_name)
 
+            cls.create_ca_bundle(paths)
+
         return paths
+
+    @classmethod
+    def create_ca_bundle(cls, file_paths: List[str]):
+        """Merge certificate authorities files into a single bundle file.
+
+        Parameters
+        ----------
+        file_paths : List[str]
+            CA files paths.
+
+        Raises
+        ------
+        WazuhError(1006)
+            File does not exist or permission error.
+        """
+        try:
+            with open(WAZUH_INDEXER_CA_BUNDLE, 'w') as bundle_file:
+                for file_path in file_paths:
+                    with open(file_path, 'r') as file:
+                        bundle_file.write(file.read())
+        except IOError as e:
+            raise WazuhError(1006, str(e))
 
 
 class APISSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -5,6 +5,7 @@ from pydantic import Field, ValidationInfo, field_validator
 from wazuh.core.common import WAZUH_INDEXER_CA_BUNDLE
 from wazuh.core.config.models.base import ValidateFilePathMixin, WazuhConfigBaseModel
 from wazuh.core.exception import WazuhError
+from wazuh.core.utils import assign_wazuh_ownership
 
 
 class SSLProtocol(str, Enum):
@@ -162,6 +163,8 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
                 for file_path in file_paths:
                     with open(file_path, 'r') as file:
                         bundle_file.write(file.read())
+
+            assign_wazuh_ownership(WAZUH_INDEXER_CA_BUNDLE)
         except IOError as e:
             raise WazuhError(1006, str(e))
 

--- a/framework/wazuh/core/config/models/tests/test_ssl_config.py
+++ b/framework/wazuh/core/config/models/tests/test_ssl_config.py
@@ -75,7 +75,8 @@ def test_ssl_config_fails_without_values(init_values):
 )
 @patch('os.path.isfile', return_value=True)
 @patch('builtins.open')
-def test_indexer_ssl_config_default_values(open_mock, file_exists_mock, init_values, expected):
+@patch('wazuh.core.config.models.ssl_config.assign_wazuh_ownership')
+def test_indexer_ssl_config_default_values(assign_ownership_mock, open_mock, file_exists_mock, init_values, expected):
     """Check the correct initialization of the `IndexerSSLConfig` class."""
     ssl_config = IndexerSSLConfig(**init_values)
 
@@ -88,7 +89,8 @@ def test_indexer_ssl_config_default_values(open_mock, file_exists_mock, init_val
 
 @patch('os.path.isfile', return_value=True)
 @patch('builtins.open')
-def test_indexer_ssl_config_create_bundle_file(open_mock, file_exists_mock):
+@patch('wazuh.core.config.models.ssl_config.assign_wazuh_ownership')
+def test_indexer_ssl_config_create_bundle_file(assign_ownership_mock, open_mock, file_exists_mock):
     """Validate that the CA bundle file is created during the indexer SSL configuration class construction."""
     ssl_config = IndexerSSLConfig(use_ssl=True, certificate_authorities=['root_ca.pem', 'intermediate.pem'])
 
@@ -100,6 +102,7 @@ def test_indexer_ssl_config_create_bundle_file(open_mock, file_exists_mock):
         ],
         any_order=True,
     )
+    assign_ownership_mock.assert_called_once_with(WAZUH_INDEXER_CA_BUNDLE)
     assert ssl_config.certificate_authorities_bundle == WAZUH_INDEXER_CA_BUNDLE
 
 

--- a/framework/wazuh/core/config/models/tests/test_ssl_config.py
+++ b/framework/wazuh/core/config/models/tests/test_ssl_config.py
@@ -72,11 +72,11 @@ def test_ssl_config_fails_without_values(init_values):
     ],
 )
 @patch('os.path.isfile', return_value=True)
-def test_indexer_ssl_config_default_values(file_exists_mock, init_values, expected):
+@patch('builtins.open')
+def test_indexer_ssl_config_default_values(open_mock, file_exists_mock, init_values, expected):
     """Check the correct initialization of the `IndexerSSLConfig` class."""
     ssl_config = IndexerSSLConfig(**init_values)
 
-    assert ssl_config.use_ssl == expected['use_ssl']
     assert ssl_config.use_ssl == expected['use_ssl']
     assert ssl_config.key == expected['key']
     assert ssl_config.certificate == expected['certificate']


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/27085 |

## Description

Takes the certificate authorities files from the configuration and creates a single bundle file that is then served in the configuration server to the engine and vulnerability detection components.

## Tests

### Single file

<details><summary>List server certificates</summary>

```console
root@wazuh-manager:/# ls -la /etc/wazuh-server/certs/
total 52
drwxr-x--- 1 wazuh-server wazuh-server 4096 Feb 17 15:54 .
drwxr-xr-x 1 wazuh-server wazuh-server 4096 Feb 17 15:54 ..
-r-------- 1 wazuh-server wazuh-server 1704 Feb 17 15:54 api-key.pem
-r-------- 1 wazuh-server wazuh-server 1233 Feb 17 15:54 api.pem
-rw------- 1 wazuh-server wazuh-server 1675 Feb 17 15:53 indexer-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1415 Feb 17 15:53 indexer.pem
-rw------- 1 wazuh-server wazuh-server  223 Feb 17 15:53 private-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server  174 Feb 17 15:53 public-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1338 Feb 17 15:55 root-ca-merged.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1338 Feb 17 15:53 root-ca.pem
-rw------- 1 wazuh-server wazuh-server 1704 Feb 17 15:53 server-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1415 Feb 17 15:53 server.pem
```

</details>

<details><summary>Compare CA file and bundle file</summary>

```console
root@wazuh-manager:/# sdiff -s /etc/wazuh-server/certs/root-ca.pem /etc/wazuh-server/certs/root-ca-merged.pem
root@wazuh-manager:/#
root@wazuh-manager:/# sdiff /etc/wazuh-server/certs/root-ca.pem /etc/wazuh-server/certs/root-ca-merged.pem
-----BEGIN CERTIFICATE-----         -----BEGIN CERTIFICATE-----
MIIDrjCCApagAwIBAgIUJwNXOTtSlRoHhU8ScFb7IJehbu4wDQYJKoZIhvcNA MIIDrjCCApagAwIBAgIUJwNXOTtSlRoHhU8ScFb7IJehbu4wDQYJKoZIhvcNA
BQAwXTELMAkGA1UEBhMCVVMxFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xDjAMB BQAwXTELMAkGA1UEBhMCVVMxFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xDjAMB
BAoTBVdhenVoMRYwFAYDVQQLEw1XYXp1aCBSb290IENBMQ4wDAYDVQQDEwVXY BAoTBVdhenVoMRYwFAYDVQQLEw1XYXp1aCBSb290IENBMQ4wDAYDVQQDEwVXY
aDAeFw0yNTAyMTcxNTQ5MDBaFw0zMDAyMTYxNTQ5MDBaMF0xCzAJBgNVBAYTA aDAeFw0yNTAyMTcxNTQ5MDBaFw0zMDAyMTYxNTQ5MDBaMF0xCzAJBgNVBAYTA
MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMQ4wDAYDVQQKEwVXYXp1aDEWMBQGA MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMQ4wDAYDVQQKEwVXYXp1aDEWMBQGA
CxMNV2F6dWggUm9vdCBDQTEOMAwGA1UEAxMFV2F6dWgwggEiMA0GCSqGSIb3D CxMNV2F6dWggUm9vdCBDQTEOMAwGA1UEAxMFV2F6dWgwggEiMA0GCSqGSIb3D
AQUAA4IBDwAwggEKAoIBAQCl8HvFox9AUssFUaXxhVFMW5Nmrve7RhKEeMwcV AQUAA4IBDwAwggEKAoIBAQCl8HvFox9AUssFUaXxhVFMW5Nmrve7RhKEeMwcV
PfqH1aW7epohar6aBLzvN7Ayq9iR7NgQ+t6UTHVvOhLfKT+cr8aHpPag9/RM7 PfqH1aW7epohar6aBLzvN7Ayq9iR7NgQ+t6UTHVvOhLfKT+cr8aHpPag9/RM7
GCjQEZllg90j3oBddRfpomHfpiBoMy645hBAOzysUTLT8b6h0xNUPO5t1/eoQ GCjQEZllg90j3oBddRfpomHfpiBoMy645hBAOzysUTLT8b6h0xNUPO5t1/eoQ
f4/ivTik9kG3BvIj+UrASX3Fn2/JO3BJ9zPYnF5A9lFJAFBrg1b4WPgnG2cxj f4/ivTik9kG3BvIj+UrASX3Fn2/JO3BJ9zPYnF5A9lFJAFBrg1b4WPgnG2cxj
M1wvXPKchawcafrnX383D4CkpfxsSEBmHbjnyWYj28Z8xYY64BKdp5tCjPL0B M1wvXPKchawcafrnX383D4CkpfxsSEBmHbjnyWYj28Z8xYY64BKdp5tCjPL0B
kon0yvFpCHiE/opwj3nW/CcWjcK6ThG3TV9FQRqY9Oz7AgMBAAGjZjBkMA4GA kon0yvFpCHiE/opwj3nW/CcWjcK6ThG3TV9FQRqY9Oz7AgMBAAGjZjBkMA4GA
DwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgECMB0GA1UdDgQWBBQmgexri DwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgECMB0GA1UdDgQWBBQmgexri
RURgrC/WSckLG45mSzAfBgNVHSMEGDAWgBQmgexri6IyRURgrC/WSckLG45mS RURgrC/WSckLG45mSzAfBgNVHSMEGDAWgBQmgexri6IyRURgrC/WSckLG45mS
BgkqhkiG9w0BAQsFAAOCAQEAUEurr5rVU1iaCblddAEcsyRA6yxinHh26evVG BgkqhkiG9w0BAQsFAAOCAQEAUEurr5rVU1iaCblddAEcsyRA6yxinHh26evVG
tlu8bi2quegLq0U4mjhx4EzBRYQmXwtBdmhBP9IiSs8nlIkCEioAiwAjOezwC tlu8bi2quegLq0U4mjhx4EzBRYQmXwtBdmhBP9IiSs8nlIkCEioAiwAjOezwC
jRugxhJBqJGKMLRli+gHDKweWV8BQ4T8MN6Jd5bs14vL5cmOk+v1uO0+alx0H jRugxhJBqJGKMLRli+gHDKweWV8BQ4T8MN6Jd5bs14vL5cmOk+v1uO0+alx0H
jRWKzexR5BUjRY+DB2umpBv1hVRLFa0stlncqmmKk2hhqyFy0fcg4SdIE9rdU jRWKzexR5BUjRY+DB2umpBv1hVRLFa0stlncqmmKk2hhqyFy0fcg4SdIE9rdU
0BjH+WUrqOhtZnCdaHVXsvVIC/eCgE7USso/iC4Y+e4MIKmhzJghC7BbkIh3A 0BjH+WUrqOhtZnCdaHVXsvVIC/eCgE7USso/iC4Y+e4MIKmhzJghC7BbkIh3A
FXyzLnrGyZ1Jm6bLTHdL8PPHVb07FQ34q/nN0deR5ILVTA==    FXyzLnrGyZ1Jm6bLTHdL8PPHVb07FQ34q/nN0deR5ILVTA==
-----END CERTIFICATE-----         -----END CERTIFICATE-----
```

</details>

### Multiple files

<details><summary>Server indexer configuration</summary>

```console
indexer:
  hosts:
    - host: wazuh-indexer
      port: 9200
  username: admin
  password: admin
  ssl:
    use_ssl: true
    key: /etc/wazuh-server/certs/indexer-key.pem
    certificate: /etc/wazuh-server/certs/indexer.pem
    certificate_authorities:
      - /etc/wazuh-server/certs/root-ca.pem
      - /etc/wazuh-server/certs/test-ca.pem
      - /etc/wazuh-server/certs/test2-ca.pem
```

</details>


<details><summary>List files</summary>

```console
root@wazuh-manager:/# ls -la /etc/wazuh-server/certs
total 60
drwxr-x--- 1 wazuh-server wazuh-server 4096 Feb 17 16:07 .
drwxr-xr-x 1 wazuh-server wazuh-server 4096 Feb 17 16:07 ..
-r-------- 1 wazuh-server wazuh-server 1704 Feb 17 16:07 api-key.pem
-r-------- 1 wazuh-server wazuh-server 1233 Feb 17 16:07 api.pem
-rw------- 1 wazuh-server wazuh-server 1675 Feb 17 15:53 indexer-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1415 Feb 17 15:53 indexer.pem
-rw------- 1 wazuh-server wazuh-server  223 Feb 17 15:53 private-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server  174 Feb 17 15:53 public-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1457 Feb 17 16:07 root-ca-merged.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1338 Feb 17 15:53 root-ca.pem
-rw------- 1 wazuh-server wazuh-server 1704 Feb 17 15:53 server-key.pem
-rw-r--r-- 1 wazuh-server wazuh-server 1415 Feb 17 15:53 server.pem
-rw-r--r-- 1 wazuh-server wazuh-server   59 Feb 17 16:05 test-ca.pem
-rw-r--r-- 1 wazuh-server wazuh-server   60 Feb 17 16:05 test2-ca.pem
```

</details>

<details><summary>Read CA files</summary>

```console
root@wazuh-manager:/# cat /etc/wazuh-server/certs/root-ca.pem
-----BEGIN CERTIFICATE-----
MIIDrjCCApagAwIBAgIUJwNXOTtSlRoHhU8ScFb7IJehbu4wDQYJKoZIhvcNAQEL
BQAwXTELMAkGA1UEBhMCVVMxFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xDjAMBgNV
BAoTBVdhenVoMRYwFAYDVQQLEw1XYXp1aCBSb290IENBMQ4wDAYDVQQDEwVXYXp1
aDAeFw0yNTAyMTcxNTQ5MDBaFw0zMDAyMTYxNTQ5MDBaMF0xCzAJBgNVBAYTAlVT
MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMQ4wDAYDVQQKEwVXYXp1aDEWMBQGA1UE
CxMNV2F6dWggUm9vdCBDQTEOMAwGA1UEAxMFV2F6dWgwggEiMA0GCSqGSIb3DQEB
AQUAA4IBDwAwggEKAoIBAQCl8HvFox9AUssFUaXxhVFMW5Nmrve7RhKEeMwcVpxc
PfqH1aW7epohar6aBLzvN7Ayq9iR7NgQ+t6UTHVvOhLfKT+cr8aHpPag9/RM7BHF
GCjQEZllg90j3oBddRfpomHfpiBoMy645hBAOzysUTLT8b6h0xNUPO5t1/eoQqsI
f4/ivTik9kG3BvIj+UrASX3Fn2/JO3BJ9zPYnF5A9lFJAFBrg1b4WPgnG2cxj2hK
M1wvXPKchawcafrnX383D4CkpfxsSEBmHbjnyWYj28Z8xYY64BKdp5tCjPL0BmsK
kon0yvFpCHiE/opwj3nW/CcWjcK6ThG3TV9FQRqY9Oz7AgMBAAGjZjBkMA4GA1Ud
DwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgECMB0GA1UdDgQWBBQmgexri6Iy
RURgrC/WSckLG45mSzAfBgNVHSMEGDAWgBQmgexri6IyRURgrC/WSckLG45mSzAN
BgkqhkiG9w0BAQsFAAOCAQEAUEurr5rVU1iaCblddAEcsyRA6yxinHh26evVGNc0
tlu8bi2quegLq0U4mjhx4EzBRYQmXwtBdmhBP9IiSs8nlIkCEioAiwAjOezwCJDb
jRugxhJBqJGKMLRli+gHDKweWV8BQ4T8MN6Jd5bs14vL5cmOk+v1uO0+alx0HUyg
jRWKzexR5BUjRY+DB2umpBv1hVRLFa0stlncqmmKk2hhqyFy0fcg4SdIE9rdUWRy
0BjH+WUrqOhtZnCdaHVXsvVIC/eCgE7USso/iC4Y+e4MIKmhzJghC7BbkIh3AuA5
FXyzLnrGyZ1Jm6bLTHdL8PPHVb07FQ34q/nN0deR5ILVTA==
-----END CERTIFICATE-----
root@wazuh-manager:/# cat /etc/wazuh-server/certs/test-ca.pem
-----BEGIN CERTIFICATE-----
test
-----END CERTIFICATE-----
root@wazuh-manager:/# cat /etc/wazuh-server/certs/test2-ca.pem
-----BEGIN CERTIFICATE-----
test2
-----END CERTIFICATE-----
```

</details>

<details><summary>Read CA bundle file</summary>

```console
root@wazuh-manager:/# cat /etc/wazuh-server/certs/root-ca-merged.pem
-----BEGIN CERTIFICATE-----
MIIDrjCCApagAwIBAgIUJwNXOTtSlRoHhU8ScFb7IJehbu4wDQYJKoZIhvcNAQEL
BQAwXTELMAkGA1UEBhMCVVMxFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xDjAMBgNV
BAoTBVdhenVoMRYwFAYDVQQLEw1XYXp1aCBSb290IENBMQ4wDAYDVQQDEwVXYXp1
aDAeFw0yNTAyMTcxNTQ5MDBaFw0zMDAyMTYxNTQ5MDBaMF0xCzAJBgNVBAYTAlVT
MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMQ4wDAYDVQQKEwVXYXp1aDEWMBQGA1UE
CxMNV2F6dWggUm9vdCBDQTEOMAwGA1UEAxMFV2F6dWgwggEiMA0GCSqGSIb3DQEB
AQUAA4IBDwAwggEKAoIBAQCl8HvFox9AUssFUaXxhVFMW5Nmrve7RhKEeMwcVpxc
PfqH1aW7epohar6aBLzvN7Ayq9iR7NgQ+t6UTHVvOhLfKT+cr8aHpPag9/RM7BHF
GCjQEZllg90j3oBddRfpomHfpiBoMy645hBAOzysUTLT8b6h0xNUPO5t1/eoQqsI
f4/ivTik9kG3BvIj+UrASX3Fn2/JO3BJ9zPYnF5A9lFJAFBrg1b4WPgnG2cxj2hK
M1wvXPKchawcafrnX383D4CkpfxsSEBmHbjnyWYj28Z8xYY64BKdp5tCjPL0BmsK
kon0yvFpCHiE/opwj3nW/CcWjcK6ThG3TV9FQRqY9Oz7AgMBAAGjZjBkMA4GA1Ud
DwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgECMB0GA1UdDgQWBBQmgexri6Iy
RURgrC/WSckLG45mSzAfBgNVHSMEGDAWgBQmgexri6IyRURgrC/WSckLG45mSzAN
BgkqhkiG9w0BAQsFAAOCAQEAUEurr5rVU1iaCblddAEcsyRA6yxinHh26evVGNc0
tlu8bi2quegLq0U4mjhx4EzBRYQmXwtBdmhBP9IiSs8nlIkCEioAiwAjOezwCJDb
jRugxhJBqJGKMLRli+gHDKweWV8BQ4T8MN6Jd5bs14vL5cmOk+v1uO0+alx0HUyg
jRWKzexR5BUjRY+DB2umpBv1hVRLFa0stlncqmmKk2hhqyFy0fcg4SdIE9rdUWRy
0BjH+WUrqOhtZnCdaHVXsvVIC/eCgE7USso/iC4Y+e4MIKmhzJghC7BbkIh3AuA5
FXyzLnrGyZ1Jm6bLTHdL8PPHVb07FQ34q/nN0deR5ILVTA==
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
test
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
test2
-----END CERTIFICATE-----
```

</details>

### Get indexer configuration section

<details><summary>Request</summary>

```console
root@wazuh-manager:/# curl --unix-socket /run/wazuh-server/config-server.sock -s http://localhost/api/v1/config?sections=indexer | jq
{
  "indexer": {
    "hosts": [
      "https://wazuh-indexer:9200"
    ],
    "username": "admin",
    "password": "admin",
    "ssl": {
      "use_ssl": true,
      "key": "/etc/wazuh-server/certs/indexer-key.pem",
      "certificate": "/etc/wazuh-server/certs/indexer.pem",
      "verify_certificates": true,
      "certificate_authorities_bundle": "/etc/wazuh-server/certs/root-ca-merged.pem"
    }
  }
}
```

</details>

### Unit tests

<details><summary>Logs</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/config/models/tests/test_ssl_config.py
========================================================================================== test session starts ==========================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 17 items                                                                                                                                                                                      

framework/wazuh/core/config/models/tests/test_ssl_config.py .................                                                                                                                     [100%]

========================================================================================== 17 passed in 0.11s ===========================================================================================
```

</details>