### PR TITLE
Catch errors in asset validation and loading in the policy

### DIFF
--- a/src/engine/test/health_test/engine-health-test/src/health_test/assets_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/assets_validate.py
@@ -144,7 +144,7 @@ def validator(args, ruleset_path: Path, resource_handler: rs.ResourceHandler, ap
     if len(specified_args) > 1:
         sys.exit("Error: Only one of 'integration', 'rule_folder', or 'decoder' can be specified at a time.")
 
-    executor = exec.Executor()
+    executor = exec.Executor(debug=False)
 
     if integration:
         integration_path = ruleset_path / 'integrations' / integration
@@ -198,7 +198,11 @@ def validator(args, ruleset_path: Path, resource_handler: rs.ResourceHandler, ap
     executor.list_tasks()
     print('\nExecuting tasks...')
     executor.execute()
-    print('\nDone')
+
+    if not executor.has_error:
+        print('\nDone')
+    else:
+        sys.exit(executor.has_error)
 
 def run(args):
     env_path = Path(args['environment']).resolve()

--- a/src/engine/test/health_test/engine-health-test/src/health_test/load_decoders.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/load_decoders.py
@@ -1,8 +1,7 @@
-import subprocess
 import sys
 from pathlib import Path
 from google.protobuf.json_format import ParseDict
-import json
+
 from engine_handler.handler import EngineHandler
 from api_communication.client import APIClient
 from api_communication.proto import catalog_pb2 as api_catalog
@@ -25,12 +24,12 @@ def load_filters(ruleset_path: Path, engine_handler: EngineHandler) -> None:
         print(f"Loading filter...\n{request}")
         error, response = engine_handler.api_client.send_recv(request)
         if error:
-            raise Exception(error)
+            sys.exit(error)
 
         parsed_response = ParseDict(
             response, api_engine.GenericStatus_Response())
         if parsed_response.status == api_engine.ERROR:
-            raise Exception(parsed_response.error)
+            sys.exit(parsed_response.error)
         print(f"Filter loaded.")
 
 
@@ -41,7 +40,7 @@ def load_integrations(ruleset_path: Path, engine_handler: EngineHandler) -> None
         # Load integration
         print(f"Loading integration...\n")
         rs = ResourceHandler.ResourceHandler()
-        engine_integration_add(engine_handler.api_socket_path, ns, integration_dir.resolve().as_posix(), False, rs)
+        engine_integration_add(engine_handler.api_socket_path, ns, integration_dir.resolve().as_posix(), False, rs, False)
         print(f"Integration loaded.")
 
 
@@ -52,10 +51,10 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
     print(f"Creating policy...\n{request}")
     error, response = engine_handler.api_client.send_recv(request)
     if error:
-        raise Exception(error)
+        sys.exit(error)
     parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
     if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
+        sys.exit(parsed_response.error)
     print("Policy created.")
 
     # Set default parents for wazuh and user namespaces
@@ -66,13 +65,13 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
     print(f"Setting default parent...\n{request}")
     error, response = engine_handler.api_client.send_recv(request)
     if error:
-        raise Exception(error)
+        sys.exit(error)
     parsed_response = ParseDict(
         response, api_policy.DefaultParentPost_Response())
     if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
+        sys.exit(parsed_response.error)
     if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
+        sys.exit(parsed_response.warning)
     print("Default parent set.")
 
     request = api_policy.DefaultParentPost_Request()
@@ -82,13 +81,13 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
     print(f"Setting default parent...\n{request}")
     error, response = engine_handler.api_client.send_recv(request)
     if error:
-        raise Exception(error)
+        sys.exit(error)
     parsed_response = ParseDict(
         response, api_policy.DefaultParentPost_Response())
     if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
+        sys.exit(parsed_response.error)
     if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
+        sys.exit(parsed_response.warning)
     print("Default parent set.")
 
     # Add wazuh-core
@@ -99,12 +98,12 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
     print(f"Adding wazuh-core...\n{request}")
     error, response = engine_handler.api_client.send_recv(request)
     if error:
-        raise Exception(error)
+        sys.exit(error)
     parsed_response = ParseDict(response, api_policy.AssetPost_Response())
     if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
+        sys.exit(parsed_response.error)
     if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
+        sys.exit(parsed_response.warning)
     print("wazuh-core added.")
 
     # Add rest of integrations
@@ -120,13 +119,13 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
         print(f"Adding {integration_name}...\n{request}")
         error, response = engine_handler.api_client.send_recv(request)
         if error:
-            raise Exception(error)
+            sys.exit(error)
         parsed_response = ParseDict(
             response, api_policy.AssetPost_Response())
         if parsed_response.status == api_engine.ERROR:
-            raise Exception(parsed_response.error)
+            sys.exit(parsed_response.error)
         if len(parsed_response.warning) > 0 and stop_on_warn:
-            raise Exception(parsed_response.warning)
+            sys.exit(parsed_response.warning)
         print(f"{integration_name} added.")
 
     # Load environment
@@ -139,10 +138,10 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
     print(f"Loading environment...\n{request}")
     error, response = engine_handler.api_client.send_recv(request)
     if error:
-        raise Exception(error)
+        sys.exit(error)
     parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
     if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
+        sys.exit(parsed_response.error)
     print("Environment loaded.")
 
 

--- a/src/engine/test/health_test/engine-health-test/src/health_test/load_rules.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/load_rules.py
@@ -13,7 +13,7 @@ def load_rules(ruleset_path: Path, engine_handler: EngineHandler) -> None:
     rules_directory = ruleset_path / 'rules'
 
     if not rules_directory.exists() or not rules_directory.is_dir():
-        raise Exception(f"The directory {rules_directory} was not found.")
+        sys.exit(f"The directory {rules_directory} was not found.")
 
     for subdirectory in rules_directory.iterdir():
         if subdirectory.is_dir():
@@ -31,11 +31,11 @@ def load_rules(ruleset_path: Path, engine_handler: EngineHandler) -> None:
                 error, response = engine_handler.api_client.send_recv(request)
 
                 if error:
-                    raise Exception(error)
+                    sys.exit(error)
 
                 parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
                 if parsed_response.status == api_engine.ERROR:
-                    raise Exception(parsed_response.error)
+                    sys.exit(parsed_response.error)
 
                 print(f"Rules loaded.")
 
@@ -48,13 +48,13 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
     print(f"Setting default parent...\n{request}")
     error, response = engine_handler.api_client.send_recv(request)
     if error:
-        raise Exception(error)
+        sys.exit(error)
     parsed_response = ParseDict(
         response, api_policy.DefaultParentPost_Response())
     if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
+        sys.exit(parsed_response.error)
     if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
+        sys.exit(parsed_response.warning)
     print("Default parent set.")
 
     # Add enrichment rule
@@ -65,12 +65,12 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
     print(f"Adding enrichment rule...\n{request}")
     error, response = engine_handler.api_client.send_recv(request)
     if error:
-        raise Exception(error)
+        sys.exit(error)
     parsed_response = ParseDict(response, api_policy.AssetPost_Response())
     if parsed_response.status == api_engine.ERROR:
-        raise Exception(parsed_response.error)
+        sys.exit(parsed_response.error)
     if len(parsed_response.warning) > 0 and stop_on_warn:
-        raise Exception(parsed_response.warning)
+        sys.exit(parsed_response.warning)
     print("enrichment rule added.")
 
     # Add rest of rules
@@ -90,13 +90,13 @@ def load_policy(ruleset_path: Path, engine_handler: EngineHandler, stop_on_warn:
             print(f"Adding {rule_name}...\n{request}")
             error, response = engine_handler.api_client.send_recv(request)
             if error:
-                raise Exception(error)
+                sys.exit(error)
             parsed_response = ParseDict(
                 response, api_policy.AssetPost_Response())
             if parsed_response.status == api_engine.ERROR:
-                raise Exception(parsed_response.error)
+                sys.exit(parsed_response.error)
             if len(parsed_response.warning) > 0 and stop_on_warn:
-                raise Exception(parsed_response.warning)
+                sys.exit(parsed_response.warning)
             print(f"{rule_name} added.")
 
 

--- a/src/engine/tools/engine-suite/src/engine_integration/cmds/add.py
+++ b/src/engine/tools/engine-suite/src/engine_integration/cmds/add.py
@@ -65,7 +65,7 @@ def add_asset_task(executor: exec.Executor, client: APIClient, asset_name: str, 
     executor.add(exec.RecoverableTask(do, undo, f'Add asset [{namespace}]: {asset_name}'))
 
 
-def add_integration(api_socket, namespace, integration_path, dry_run, resource_handler):
+def add_integration(api_socket, namespace, integration_path, dry_run, resource_handler, debug=True):
     # Configuration
     integration_path = Path(integration_path).resolve()
     if not integration_path.exists() or not integration_path.is_dir():
@@ -113,7 +113,7 @@ def add_integration(api_socket, namespace, integration_path, dry_run, resource_h
             return -1
 
     # Create tasks to add decoders, rules, outputs, filters and kvdbs
-    executor = exec.Executor()
+    executor = exec.Executor(debug=debug)
 
     for asset_type in [type for type in manifest.keys() if type in ['decoders', 'rules', 'outputs', 'filters']]:
         assets_path = ruleset_path / asset_type

--- a/src/engine/tools/engine-suite/src/shared/executor.py
+++ b/src/engine/tools/engine-suite/src/shared/executor.py
@@ -6,7 +6,7 @@ class RecoverableTask:
         self.do = do
         self.undo = undo
         self.task_info = task_info
-    
+
     def execute(self) -> Optional[str]:
         error = None
         try:
@@ -15,7 +15,7 @@ class RecoverableTask:
             return str(err)
         else:
             return error
-    
+
     def undo(self) -> Optional[str]:
         error = None
         try:
@@ -26,40 +26,47 @@ class RecoverableTask:
             return error
 
 class Executor:
-    def __init__(self):
+    def __init__(self, debug: bool = True):
         self.tasks = []
-    
+        self.has_error = False
+        self.debug = debug
+
     def add(self, task: RecoverableTask):
         self.tasks.append(task)
-    
+
+    def print_debug(self, message: str):
+        if self.debug:
+            print(message)
+
     def execute(self, dry_run: bool = False):
         index = 0
         for task in self.tasks:
             if dry_run:
                 print(f'Will execute {index}: {task.task_info}...')
             else:
-                print(f'Executing {index}: {task.task_info}...')
+                self.print_debug(f'Executing {index}: {task.task_info}...')
                 error = task.execute()
                 if error:
-                    print(f'Error: {error}')
+                    print(f'Error: {task.task_info} --> {error}')
+                    self.has_error = True
                     if index > 0:
-                        print('\nUndoing previous tasks...')
+                        self.print_debug('\nUndoing previous tasks...')
                         self.undo(index)
-                    else :
-                        print('Nothing to undo')
+                    else:
+                        self.print_debug('Nothing to undo')
                     break
-                
+
             index += 1
-            
+
     def undo(self, fromidx: int):
         index = fromidx-1
         for task in reversed(self.tasks[:fromidx]):
-            print(f'Undoing {index}: {task.task_info}...')
+            self.print_debug(f'Undoing {index}: {task.task_info}...')
             error = task.undo()
             if error:
                 print(f'Error: {error}')
                 print('Engine might be left in an inconsistent state')
-            
+
             index -= 1
 
     def list_tasks(self):
@@ -67,4 +74,3 @@ class Executor:
         for task in self.tasks:
             print(f'{index}: {task.task_info}')
             index += 1
-        


### PR DESCRIPTION
|Related issue|
|---|
|#28258|

## Description
When running dynamic tests with the Python suite `engine-health-test dynamic`, specifically during the asset validation stage, the tool does not exit with a non-zero status code upon encountering validation errors. This behavior causes the testing workflow to incorrectly pass during the `assets_validate` stage, even when there are failures. This issue needs to be addressed to ensure that the workflow accurately reflects the success or failure of the tests.

## Steps to Reproduce
1. Run the command:
   ```bash
   engine-health-test dynamic -e /tmp/ht-env assets_validate
   ```
2. Introduce a validation error intentionally in the assets being tested.
3. Observe that the tool completes the run without exiting with a non-zero status code despite the validation error.

## Expected Behavior
The `engine-health-test` tool should exit with a non-zero status code when a validation error occurs, indicating a failure in the testing process. This change will ensure that the CI/CD pipeline correctly identifies and reacts to errors during the validation stage.

## Example Output
Below is an example output of the current behavior, where the tool does not exit with a non-zero status code despite encountering validation errors:
```
Run engine-health-test dynamic -e /tmp/ht-env assets_validate
engine-health-test dynamic -e /tmp/ht-env assets_validate
shell: /usr/bin/bash -e {0}
...
Error: Stage 'check' failed to build expression 'exists($tmp_json.ts) AND exists($tmp_json.tags) AND match_value($tmp_json.method, http_method)': Failed to build operation 'tmp_json.method: match_value("http_method")': Expected 'array' type for parameter 1, got 'string'
...
Engine stopped.
```