### PR TITLE
Update index-template.json

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -2505,6 +2505,9 @@
               },
               "cve_version": {
                 "type": "keyword"
+              },
+              "scanner.reference": {
+                "type": "keyword"
               }
             }
           },

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -7,11 +7,6 @@
     "settings": {
       "index": {
         "codec": "best_compression",
-        "mapping": {
-          "total_fields": {
-            "limit": 1000
-          }
-        },
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
@@ -25,7 +20,7 @@
           "vulnerability.severity",
           "wazuh.cluster.name"
         ],
-        "refresh_interval": "2s"
+        "refresh_interval": "5s"
       }
     },
     "mappings": {
@@ -189,6 +184,10 @@
             "scanner": {
               "properties": {
                 "condition": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/index-template.json
@@ -7,6 +7,11 @@
     "settings": {
       "index": {
         "codec": "best_compression",
+        "mapping": {
+          "total_fields": {
+            "limit": 1000
+          }
+        },
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
@@ -20,7 +25,7 @@
           "vulnerability.severity",
           "wazuh.cluster.name"
         ],
-        "refresh_interval": "5s"
+        "refresh_interval": "2s"
       }
     },
     "mappings": {

--- a/src/wazuh_modules/vulnerability_scanner/indexer/template/update-mappings.json
+++ b/src/wazuh_modules/vulnerability_scanner/indexer/template/update-mappings.json
@@ -7,11 +7,15 @@
           },
           "scanner": {
             "properties": {
-              "source": {
-                "type": "keyword",
-                "ignore_above": 1024
-              },
               "condition": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "reference": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "source": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }


### PR DESCRIPTION
|Related issue|
|---|
| #28220 |

## Description

Add new `vulnerability.scanner.reference` field to VD index template.

![image](https://github.com/user-attachments/assets/b28bc952-a2a5-4bfd-bc91-24ad72859a42)


## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors