### PR TITLE
Make page size configurable in MS-Graph integration

### DIFF
--- a/src/config/wmodules-ms-graph.c
+++ b/src/config/wmodules-ms-graph.c
@@ -18,6 +18,7 @@ static const char* XML_ONLY_FUTURE_EVENTS = "only_future_events";
 static const char* XML_CURL_MAX_SIZE = "curl_max_size";
 static const char* XML_RUN_ON_START = "run_on_start";
 static const char *XML_INTERVAL = "interval";
+static const char *XML_PAGE_SIZE = "page_size";
 
 static const char* XML_VERSION = "version";
 static const char* XML_API_AUTH = "api_auth";
@@ -45,6 +46,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 	ms_graph->enabled = WM_MS_GRAPH_DEFAULT_ENABLED;
 	ms_graph->only_future_events = WM_MS_GRAPH_DEFAULT_ONLY_FUTURE_EVENTS;
 	ms_graph->curl_max_size = WM_MS_GRAPH_DEFAULT_CURL_MAX_SIZE;
+	ms_graph->page_size = WM_MS_GRAPH_ITEM_PER_PAGE;
 	ms_graph->run_on_start = WM_MS_GRAPH_DEFAULT_RUN_ON_START;
 	os_strdup(WM_MS_GRAPH_DEFAULT_VERSION, ms_graph->version);
 
@@ -91,6 +93,12 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 			ms_graph->curl_max_size = w_parse_size(nodes[i]->content);
 			if (ms_graph->curl_max_size < 1024L) {
 				merror("Invalid content for tag '%s' at module '%s'. The minimum value allowed is 1KB.", XML_CURL_MAX_SIZE, WM_MS_GRAPH_CONTEXT.name);
+				return OS_CFGERR;
+			}
+		} else if (!strcmp(nodes[i]->element, XML_PAGE_SIZE)) {
+			ms_graph->page_size = atol(nodes[i]->content);
+			if (ms_graph->page_size < 1) {
+				merror("Invalid content for tag '%s' at module '%s'. The minimum value allowed is 1.", XML_PAGE_SIZE, WM_MS_GRAPH_CONTEXT.name);
 				return OS_CFGERR;
 			}
 		} else if (!strcmp(nodes[i]->element, XML_RUN_ON_START)) {

--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -1219,6 +1219,7 @@ void test_setup_complete(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_string", module_data->auth_config[0]->client_id);
@@ -1264,6 +1265,7 @@ void test_main_token(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -1340,6 +1342,7 @@ void test_main_relationships(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -1459,6 +1462,7 @@ void test_dump(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1478,6 +1482,7 @@ void test_dump(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_string", module_data->auth_config[0]->client_id);
@@ -1495,7 +1500,7 @@ void test_dump(void **state) {
     cJSON* dump = wm_ms_graph_dump(module_data);
     char* dump_text = cJSON_PrintUnformatted(dump);
 
-    assert_string_equal(dump_text, "{\"ms_graph\":{\"enabled\":\"yes\",\"only_future_events\":\"no\",\"curl_max_size\":1024,\"run_on_start\":\"yes\",\"version\":\"v1.0\",\"wday\":\"sunday\",\"api_auth\":{\"client_id\":\"example_string\",\"tenant_id\":\"example_string\",\"secret_value\":\"example_string\",\"api_type\":\"global\",\"name\":\"security\"},\"resources\":[{\"relationship\":\"alerts_v2\"}]}}");
+    assert_string_equal(dump_text, "{\"ms_graph\":{\"enabled\":\"yes\",\"only_future_events\":\"no\",\"curl_max_size\":1024,\"page_size\":100,\"run_on_start\":\"yes\",\"version\":\"v1.0\",\"wday\":\"sunday\",\"api_auth\":{\"client_id\":\"example_string\",\"tenant_id\":\"example_string\",\"secret_value\":\"example_string\",\"api_type\":\"global\",\"name\":\"security\"},\"resources\":[{\"relationship\":\"alerts_v2\"}]}}");
 
     cJSON_Delete(dump);
     os_free(dump_text);
@@ -1506,6 +1511,7 @@ void test_dump_gcc_configuration(void **state) {
     <enabled>no</enabled>
     <only_future_events>yes</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>no</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1523,6 +1529,7 @@ void test_dump_gcc_configuration(void **state) {
     module_data->enabled = false;
     module_data->only_future_events = true;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = false;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_string", module_data->auth_config[0]->client_id);
@@ -1537,7 +1544,7 @@ void test_dump_gcc_configuration(void **state) {
     cJSON* dump = wm_ms_graph_dump(module_data);
     char* dump_text = cJSON_PrintUnformatted(dump);
 
-    assert_string_equal(dump_text, "{\"ms_graph\":{\"enabled\":\"no\",\"only_future_events\":\"yes\",\"curl_max_size\":1024,\"run_on_start\":\"no\",\"version\":\"v1.0\",\"wday\":\"sunday\",\"api_auth\":{\"client_id\":\"example_string\",\"tenant_id\":\"example_string\",\"secret_value\":\"example_string\",\"api_type\":\"gcc-high\"}}}");
+    assert_string_equal(dump_text, "{\"ms_graph\":{\"enabled\":\"no\",\"only_future_events\":\"yes\",\"curl_max_size\":1024,\"page_size\":100,\"run_on_start\":\"no\",\"version\":\"v1.0\",\"wday\":\"sunday\",\"api_auth\":{\"client_id\":\"example_string\",\"tenant_id\":\"example_string\",\"secret_value\":\"example_string\",\"api_type\":\"gcc-high\"}}}");
 
     cJSON_Delete(dump);
     os_free(dump_text);
@@ -1551,6 +1558,7 @@ void test_dump_dod_configuration(void **state) {
     <enabled>no</enabled>
     <only_future_events>yes</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>no</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1568,6 +1576,7 @@ void test_dump_dod_configuration(void **state) {
     module_data->enabled = false;
     module_data->only_future_events = true;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = false;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_string", module_data->auth_config[0]->client_id);
@@ -1579,7 +1588,7 @@ void test_dump_dod_configuration(void **state) {
     cJSON* dump = wm_ms_graph_dump(module_data);
     char* dump_text = cJSON_PrintUnformatted(dump);
 
-    assert_string_equal(dump_text, "{\"ms_graph\":{\"enabled\":\"no\",\"only_future_events\":\"yes\",\"curl_max_size\":1024,\"run_on_start\":\"no\",\"version\":\"v1.0\",\"wday\":\"sunday\",\"api_auth\":{\"client_id\":\"example_string\",\"tenant_id\":\"example_string\",\"secret_value\":\"example_string\",\"api_type\":\"dod\"}}}");
+    assert_string_equal(dump_text, "{\"ms_graph\":{\"enabled\":\"no\",\"only_future_events\":\"yes\",\"curl_max_size\":1024,\"page_size\":100,\"run_on_start\":\"no\",\"version\":\"v1.0\",\"wday\":\"sunday\",\"api_auth\":{\"client_id\":\"example_string\",\"tenant_id\":\"example_string\",\"secret_value\":\"example_string\",\"api_type\":\"dod\"}}}");
 
     cJSON_Delete(dump);
     os_free(dump_text);
@@ -1590,6 +1599,7 @@ void test_wm_ms_graph_get_access_token_no_response(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1609,6 +1619,7 @@ void test_wm_ms_graph_get_access_token_no_response(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -1649,6 +1660,7 @@ void test_wm_ms_graph_get_access_token_unsuccessful_status_code(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1668,6 +1680,7 @@ void test_wm_ms_graph_get_access_token_unsuccessful_status_code(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -1714,6 +1727,7 @@ void test_wm_ms_graph_get_access_token_curl_max_size(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1733,6 +1747,7 @@ void test_wm_ms_graph_get_access_token_curl_max_size(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -1779,6 +1794,7 @@ void test_wm_ms_graph_get_access_token_parse_json_fail(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1798,6 +1814,7 @@ void test_wm_ms_graph_get_access_token_parse_json_fail(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -1844,6 +1861,7 @@ void test_wm_ms_graph_get_access_token_success(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1863,6 +1881,7 @@ void test_wm_ms_graph_get_access_token_success(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -1913,6 +1932,7 @@ void test_wm_ms_graph_get_access_token_no_access_token(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1932,6 +1952,7 @@ void test_wm_ms_graph_get_access_token_no_access_token(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -1977,6 +1998,7 @@ void test_wm_ms_graph_get_access_token_no_expire_time(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -1996,6 +2018,7 @@ void test_wm_ms_graph_get_access_token_no_expire_time(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     os_strdup("v1.0", module_data->version);
     os_strdup("example_client", module_data->auth_config[0]->client_id);
@@ -2041,6 +2064,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2060,6 +2084,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2114,6 +2139,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void
     <enabled>yes</enabled>
     <only_future_events>yes</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>100</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2133,6 +2159,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_yes_fail_write(void
     module_data->enabled = true;
     module_data->only_future_events = true;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 100;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2179,6 +2206,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>50</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2200,6 +2228,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 50;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2244,7 +2273,7 @@ void test_wm_ms_graph_scan_relationships_single_initial_only_no_next_time_no_res
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2266,6 +2295,7 @@ void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **s
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>50</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2287,6 +2317,7 @@ void test_wm_ms_graph_scan_relationships_single_no_initial_no_timestamp(void **s
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 50;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2341,6 +2372,7 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>50</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2362,6 +2394,7 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 50;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2411,7 +2444,7 @@ void test_wm_ms_graph_scan_relationships_single_unsuccessful_status_code(void **
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2433,6 +2466,7 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>50</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2454,6 +2488,7 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 50;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2504,7 +2539,7 @@ void test_wm_ms_graph_scan_relationships_single_reached_curl_size(void **state) 
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2526,6 +2561,7 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>25</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2547,6 +2583,7 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 25;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2597,7 +2634,7 @@ void test_wm_ms_graph_scan_relationships_single_failed_parse(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=25&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2619,6 +2656,7 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>25</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2640,6 +2678,7 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 25;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2690,7 +2729,7 @@ void test_wm_ms_graph_scan_relationships_single_no_logs(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=25&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2721,6 +2760,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>10</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2742,6 +2782,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 10;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2793,7 +2834,7 @@ void test_wm_ms_graph_scan_relationships_single_success_one_log(void **state) {
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=10&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2833,6 +2874,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>10</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -2852,6 +2894,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 10;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -2898,7 +2941,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
 #endif
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=100'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps?$top=10'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2934,7 +2977,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_logs(void **state) {
     expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Error'");
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps/12345/managedDevices?$top=100&$select=id,deviceName'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/detectedApps/12345/managedDevices?$top=10&$select=id,deviceName'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -2983,6 +3026,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>200</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -3002,6 +3046,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 200;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -3041,7 +3086,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_pages(void **state) 
     os_strdup("test2", response2->header);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$top=100'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices?$top=200'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3133,6 +3178,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     <enabled>yes</enabled>
     <only_future_events>no</only_future_events>
     <curl_max_size>1M</curl_max_size>
+    <page_size>200</page_size>
     <run_on_start>yes</run_on_start>
     <version>v1.0</version>
     <api_auth>
@@ -3160,6 +3206,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     module_data->enabled = true;
     module_data->only_future_events = false;
     module_data->curl_max_size = 1024L;
+    module_data->page_size = 200;
     module_data->run_on_start = true;
     module_data->scan_config.interval = 60;
     os_strdup("v1.0", module_data->version);
@@ -3215,7 +3262,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=100&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=200&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3273,7 +3320,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=100&$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/deviceManagement/auditEvents?$top=200&$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);

--- a/src/wazuh_modules/wm_ms_graph.c
+++ b/src/wazuh_modules/wm_ms_graph.c
@@ -272,7 +272,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
                     ms_graph->version,
                     WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
                     WM_MS_GRAPH_RELATIONSHIP_AUDIT_EVENTS,
-                    WM_MS_GRAPH_ITEM_PER_PAGE,
+                    ms_graph->page_size,
                     start_time_str,
                     end_time_str);
                 } else {
@@ -281,7 +281,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
                     ms_graph->version,
                     WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
                     ms_graph->resources[resource_num].relationships[relationship_num],
-                    WM_MS_GRAPH_ITEM_PER_PAGE);
+                    ms_graph->page_size);
                 }
             } else {
                 snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_CREATED_DATE,
@@ -289,7 +289,7 @@ void wm_ms_graph_scan_relationships(wm_ms_graph* ms_graph, wm_ms_graph_auth* aut
                 ms_graph->version,
                 ms_graph->resources[resource_num].name,
                 ms_graph->resources[resource_num].relationships[relationship_num],
-                WM_MS_GRAPH_ITEM_PER_PAGE,
+                ms_graph->page_size,
                 start_time_str,
                 end_time_str);
             }
@@ -403,7 +403,7 @@ cJSON* wm_ms_graph_scan_apps_devices(const wm_ms_graph* ms_graph, const cJSON* a
 
     if (cJSON_IsString(app_id)) {
         snprintf(url, OS_SIZE_8192 - 1, WM_MS_GRAPH_API_URL_FILTER_DEVICE_FIELDS, query_fqdn, ms_graph->version, WM_MS_GRAPH_RESOURCE_DEVICE_MANAGEMENT,
-            WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS, app_id->valuestring, WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES, WM_MS_GRAPH_ITEM_PER_PAGE);
+            WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS, app_id->valuestring, WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES, ms_graph->page_size);
 
         next_page = true;
         while (next_page) {
@@ -499,6 +499,9 @@ cJSON* wm_ms_graph_dump(const wm_ms_graph* ms_graph) {
     }
     if (ms_graph->curl_max_size) {
         cJSON_AddNumberToObject(ms_graph_info, "curl_max_size", ms_graph->curl_max_size);
+    }
+    if (ms_graph->page_size) {
+        cJSON_AddNumberToObject(ms_graph_info, "page_size", ms_graph->page_size);
     }
     if (ms_graph->run_on_start) {
         cJSON_AddStringToObject(ms_graph_info, "run_on_start", "yes");

--- a/src/wazuh_modules/wm_ms_graph.h
+++ b/src/wazuh_modules/wm_ms_graph.h
@@ -72,6 +72,7 @@ typedef struct wm_ms_graph {
 	bool enabled;
 	bool only_future_events;
 	ssize_t curl_max_size;
+	unsigned int page_size;
 	bool run_on_start;
 	char* version;
 	sched_scan_config scan_config;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/27579|

## Description

This PR introduces a new configuration option for the MS-Graph integration to be able to configure the page size of each request made to the API.

## Configuration options

Example:

```
  <ms-graph>
    <enabled>yes</enabled>
    <only_future_events>yes</only_future_events>
    <curl_max_size>10M</curl_max_size>
    <page_size>50</page_size>
    <run_on_start>yes</run_on_start>
    <interval>30s</interval>
    <version>v1.0</version>
    <api_auth>
      <client_id>xxxxx</client_id>
      <tenant_id>yyyyy</tenant_id>
      <secret_value>zzzzz</secret_value>
      <api_type>global</api_type>
    </api_auth>
    <resource>
      <name>security</name>
      <relationship>alerts_v2</relationship>
      <relationship>incidents</relationship>
    </resource>
  </ms-graph>
```

## Logs/Alerts example

Example:

```
2025/02/17 20:26:55 wazuh-modulesd:ms-graph[36274] wm_ms_graph.c:83 at wm_ms_graph_main(): INFO: Scanning tenant '0fea4e03-8146-453b-b889-54b4bd11565b'
2025/02/17 20:26:55 wazuh-modulesd:ms-graph[36274] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=50&$filter=createdDateTime+ge+2025-02-17T20:26:25Z+and+createdDateTime+lt+2025-02-17T20:26:55Z'
2025/02/17 20:26:56 wazuh-modulesd:ms-graph[36274] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-17T20:26:55Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'security' and relationship 'alerts_v2', waiting '30' seconds to run next scan.
2025/02/17 20:26:56 wazuh-modulesd:ms-graph[36274] wm_ms_graph.c:299 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/incidents?$top=50&$filter=createdDateTime+ge+2025-02-17T20:26:26Z+and+createdDateTime+lt+2025-02-17T20:26:56Z'
2025/02/17 20:26:57 wazuh-modulesd:ms-graph[36274] wm_ms_graph.c:388 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-17T20:26:56Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'security' and relationship 'incidents', waiting '30' seconds to run next scan.
2025/02/17 20:27:01 wazuh-modulesd:ms-graph[36274] wm_ms_graph.c:69 at wm_ms_graph_main(): DEBUG: Waiting until: 2025/02/17 20:27:25
```

## Tests

- [ ]  Code changes reviewed
- [x]  Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues