### PR TITLE
Agent enrollment naming

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -21,6 +21,7 @@ select = [
 ignore = [
     "F405", # Star imports
     "D100", # Module comment
+    "D105", # Magic method comment
     "D107", # Init docstring
     "D203", # Blank line before docstring
     "D204", # Blank line after docstring

--- a/apis/server_management/server_management_api/controllers/agent_controller.py
+++ b/apis/server_management/server_management_api/controllers/agent_controller.py
@@ -12,8 +12,8 @@ from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.common import DATABASE_LIMIT
 
 from server_management_api.controllers.util import JSON_CONTENT_TYPE, json_response
+from server_management_api.models.agent_enrollment_model import AgentEnrollmentModel
 from server_management_api.models.agent_group_added_model import GroupAddedModel
-from server_management_api.models.agent_registration_model import AgentRegistrationModel
 from server_management_api.models.base_model_ import Body
 from server_management_api.util import parse_api_param, raise_if_exc, remove_nones_to_dict
 
@@ -51,7 +51,7 @@ async def delete_agents(
         Filter by version.
     older_than : str
         Filter out disconnected agents for longer than specified. Time in seconds, '[n_days]d',
-        '[n_hours]h', '[n_minutes]m' or '[n_seconds]s'. For never_connected agents, use the register date.
+        '[n_hours]h', '[n_minutes]m' or '[n_seconds]s'. For never_connected agents, use the enrollment date.
     is_connected : bool
         Filter by connection status.
 
@@ -127,7 +127,7 @@ async def get_agents(
         Filter by agents version.
     older_than : str
         Filter out disconnected agents for longer than specified. Time in seconds, '[n_days]d',
-        '[n_hours]h', '[n_minutes]m' or '[n_seconds]s'. For never_connected agents, use the register date.
+        '[n_hours]h', '[n_minutes]m' or '[n_seconds]s'. For never_connected agents, use the enrollment date.
     offset : int
         First element to return in the collection.
     limit : int
@@ -197,7 +197,7 @@ async def add_agent(pretty: bool = False, wait_for_complete: bool = False) -> Co
     """
     # Get body parameters
     Body.validate_content_type(request, expected_content_type=JSON_CONTENT_TYPE)
-    f_kwargs = await AgentRegistrationModel.get_kwargs(request)
+    f_kwargs = await AgentEnrollmentModel.get_kwargs(request)
 
     dapi = DistributedAPI(
         f=agent.add_agent,

--- a/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
@@ -147,7 +147,7 @@ async def test_add_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp,
     """Verify 'add_agent' endpoint is working as expected."""
     with patch('server_management_api.controllers.agent_controller.Body.validate_content_type'):
         with patch(
-            'server_management_api.controllers.agent_controller.AgentRegistrationModel.get_kwargs',
+            'server_management_api.controllers.agent_controller.AgentEnrollmentModel.get_kwargs',
             return_value=AsyncMock(),
         ) as mock_getkwargs:
             result = await add_agent()

--- a/apis/server_management/server_management_api/models/agent_enrollment_model.py
+++ b/apis/server_management/server_management_api/models/agent_enrollment_model.py
@@ -16,32 +16,6 @@ from server_management_api.models.base_model_ import Body, Model
 KEY_LENGTH = 32
 
 
-class DisconnectedTime(Model):
-    def __init__(self, enabled=True, value='1h'):
-        self.swagger_types = {'enabled': bool, 'value': str}
-
-        self.attribute_map = {'enabled': 'enabled', 'value': 'value'}
-
-        self._enabled = enabled
-        self._value = value
-
-    @property
-    def enabled(self):
-        return self._enabled
-
-    @enabled.setter
-    def enabled(self, enabled):
-        self._enabled = enabled
-
-    @property
-    def value(self):
-        return self._value
-
-    @value.setter
-    def value(self, value):
-        self._value = value
-
-
 class OS(Model):
     """Agent OS model."""
 
@@ -56,6 +30,13 @@ class OS(Model):
 
     @property
     def name(self) -> str:
+        """Get OS name.
+
+        Returns
+        -------
+        str
+            OS name.
+        """
         return self._name
 
     @name.setter
@@ -64,6 +45,13 @@ class OS(Model):
 
     @property
     def type(self) -> str:
+        """Get OS type.
+
+        Returns
+        -------
+        str
+            OS type.
+        """
         return self._type
 
     @type.setter
@@ -72,6 +60,13 @@ class OS(Model):
 
     @property
     def version(self) -> str:
+        """Get OS version.
+
+        Returns
+        -------
+        str
+            OS version.
+        """
         return self._version
 
     @version.setter
@@ -104,6 +99,13 @@ class Host(Model):
 
     @property
     def architecture(self) -> str:
+        """Get host architecture.
+
+        Returns
+        -------
+        str
+            Host architecture.
+        """
         return self._architecture
 
     @architecture.setter
@@ -112,6 +114,13 @@ class Host(Model):
 
     @property
     def hostname(self) -> str:
+        """Get host name.
+
+        Returns
+        -------
+        str
+            Host name.
+        """
         return self._hostname
 
     @hostname.setter
@@ -120,6 +129,13 @@ class Host(Model):
 
     @property
     def ip(self) -> List[str]:
+        """Get host IP addresses.
+
+        Returns
+        -------
+        List[str]
+            Host IPs.
+        """
         return self._ip
 
     @ip.setter
@@ -128,6 +144,13 @@ class Host(Model):
 
     @property
     def os(self) -> OS:
+        """Get host operating system.
+
+        Returns
+        -------
+        OS
+            Host OS.
+        """
         return self._os
 
     @os.setter
@@ -174,6 +197,13 @@ class AgentEnrollmentModel(Body):
 
     @property
     def id(self) -> str:
+        """Get agent ID.
+
+        Returns
+        -------
+        str
+            Agent ID.
+        """
         return self._id
 
     @id.setter
@@ -182,6 +212,13 @@ class AgentEnrollmentModel(Body):
 
     @property
     def name(self) -> str:
+        """Get agent name.
+
+        Returns
+        -------
+        str
+            Agent name.
+        """
         return self._name
 
     @name.setter
@@ -190,6 +227,13 @@ class AgentEnrollmentModel(Body):
 
     @property
     def key(self) -> str:
+        """Get agent key.
+
+        Returns
+        -------
+        str
+            Agent key.
+        """
         return self._key
 
     @key.setter
@@ -200,6 +244,13 @@ class AgentEnrollmentModel(Body):
 
     @property
     def type(self) -> str:
+        """Get agent type.
+
+        Returns
+        -------
+        str
+            Agent type.
+        """
         return self._type
 
     @type.setter
@@ -208,6 +259,13 @@ class AgentEnrollmentModel(Body):
 
     @property
     def version(self) -> str:
+        """Get agent version.
+
+        Returns
+        -------
+        str
+            Agent version.
+        """
         return self._version
 
     @version.setter
@@ -216,6 +274,13 @@ class AgentEnrollmentModel(Body):
 
     @property
     def host(self) -> Host:
+        """Get agent host.
+
+        Returns
+        -------
+        Host
+            Agent host.
+        """
         return self._host
 
     @host.setter

--- a/apis/server_management/server_management_api/models/agent_enrollment_model.py
+++ b/apis/server_management/server_management_api/models/agent_enrollment_model.py
@@ -42,45 +42,6 @@ class DisconnectedTime(Model):
         self._value = value
 
 
-class AgentForce(Model):
-    def __init__(self, enabled=True, disconnected_time=None, after_registration_time='1h'):
-        self.swagger_types = {'enabled': bool, 'disconnected_time': DisconnectedTime, 'after_registration_time': str}
-
-        self.attribute_map = {
-            'enabled': 'enabled',
-            'disconnected_time': 'disconnected_time',
-            'after_registration_time': 'after_registration_time',
-        }
-
-        self._enabled = enabled
-        self._disconnected_time = DisconnectedTime(**disconnected_time or {}).to_dict()
-        self._after_registration_time = after_registration_time
-
-    @property
-    def enabled(self):
-        return self._enabled
-
-    @enabled.setter
-    def enabled(self, enabled):
-        self._enabled = enabled
-
-    @property
-    def disconnected_time(self):
-        return self._disconnected_time
-
-    @disconnected_time.setter
-    def disconnected_time(self, disconnected_time):
-        self._disconnected_time = disconnected_time
-
-    @property
-    def after_registration_time(self):
-        return self._after_registration_time
-
-    @after_registration_time.setter
-    def after_registration_time(self, after_registration_time):
-        self._after_registration_time = after_registration_time
-
-
 class OS(Model):
     """Agent OS model."""
 
@@ -174,8 +135,8 @@ class Host(Model):
         self._os = os
 
 
-class AgentRegistrationModel(Body):
-    """Agent registration model."""
+class AgentEnrollmentModel(Body):
+    """Agent enrollment model."""
 
     def __init__(
         self,

--- a/apis/server_management/server_management_api/models/test/test_model.py
+++ b/apis/server_management/server_management_api/models/test/test_model.py
@@ -54,14 +54,24 @@ class RequestMock:
 
     @property
     def mimetype(self):
+        """Get request mock content type."""
         return self._content_type
 
 
 class ToDictObject:
+    """Mock object to test the `to_dict` models method."""
+
     def __init__(self, value):
         self.value = value
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
+        """Convert object into a dictionary.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the value.
+        """
         return {'value': self.value}
 
     def __repr__(self):
@@ -123,6 +133,7 @@ def test_model_operator_overloading():
 
 
 def test_allof():
+    """Validate that the `AllOf` model method works as expected."""
     model1 = TestModel('a', 1)
     model2 = TestModel('a', 2)
 

--- a/apis/server_management/server_management_api/models/test/test_model.py
+++ b/apis/server_management/server_management_api/models/test/test_model.py
@@ -13,12 +13,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from connexion import ProblemException
 from server_management_api.controllers.util import JSON_CONTENT_TYPE
-from server_management_api.models import agent_registration_model
+from server_management_api.models import agent_enrollment_model
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
         sys.modules['server_management_api.authentication'] = MagicMock()
-        from server_management_api.models import agent_registration_model
+        from server_management_api.models import agent_enrollment_model
         from server_management_api.models import base_model_ as bm
         from server_management_api.util import deserialize_model
         from wazuh import WazuhError
@@ -283,7 +283,7 @@ def test_all_models(deserialize_mock, module_name):
                 for p in [p for p in module_class.__dict__ if not p.startswith('__')]:
                     # Assert that all its attributes have defined properties (getter and setter)
                     value = ''
-                    if module_class.__name__ == 'AgentRegistrationModel' and p == 'key':
+                    if module_class.__name__ == 'AgentEnrollmentModel' and p == 'key':
                         value = '7b8276c3bf96aff5709346d368f04aed'
                     else:
                         value = 'test'
@@ -297,7 +297,8 @@ def test_all_models(deserialize_mock, module_name):
 
 
 @pytest.mark.parametrize('key', ('7b8276c3bf96aff5709346d368f04aed', 'test', '7b8276c3bf96aff5709346d368f04aedA'))
-async def test_agent_registration_model_validation(key):
+async def test_agent_enrollment_model_validation(key):
+    """Validate that the agent enrollment model validations work as expected."""
     request = {
         'id': '01929571-49b5-75e8-a3f6-1d2b84f4f71a',
         'name': 'testing',
@@ -306,11 +307,11 @@ async def test_agent_registration_model_validation(key):
         'version': '5.0.0',
     }
 
-    if len(key) != agent_registration_model.KEY_LENGTH:
+    if len(key) != agent_enrollment_model.KEY_LENGTH:
         with pytest.raises(ProblemException) as exc:
-            await agent_registration_model.AgentRegistrationModel.get_kwargs(request)
+            await agent_enrollment_model.AgentEnrollmentModel.get_kwargs(request)
 
         assert exc.value.title == 'Invalid key length'
         assert exc.value.detail == 'The key must be 32 characters long'
     else:
-        await agent_registration_model.AgentRegistrationModel.get_kwargs(request)
+        await agent_enrollment_model.AgentEnrollmentModel.get_kwargs(request)

--- a/apis/server_management/server_management_api/spec/spec.yaml
+++ b/apis/server_management/server_management_api/spec/spec.yaml
@@ -670,7 +670,7 @@ components:
           $ref: '#/components/schemas/AgentID'
         name:
           type: string
-          description: "Agent name used at the registration process"
+          description: "Agent name used at the enrollment process"
         status:
           $ref: '#/components/schemas/AgentStatus'
         configSum:
@@ -690,7 +690,7 @@ components:
           will be the same as registerIP field"
         registerIP:
           type: string
-          description: "IP used at agent the registration process"
+          description: "IP used at agent the enrollment process"
         manager:
           type: string
           description: "Hostname of the manager the agent is reporting to"
@@ -1270,7 +1270,7 @@ components:
         max_agents:
           type: string
           minimum: 0
-          description: "Maximum number of agents that can be registered."
+          description: "Maximum number of agents that can be enrolled."
         openssl_support:
           type: string
         tz_offset:
@@ -1845,7 +1845,8 @@ components:
       name: older_than
       description: "Filter out agents whose time lapse from last keep alive signal is longer than specified. Time in
       seconds, ‘[n_days]d’, ‘[n_hours]h’, ‘[n_minutes]m’ or ‘[n_seconds]s’. For never_connected agents, uses the
-      register date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, seconds are used"
+      enrollment date. For example, `7d`, `10s` and `10` are valid values. If no time unit is specified, 
+      seconds are used"
       schema:
         type: string
         format: timeframe
@@ -2283,7 +2284,7 @@ components:
       in: query
       name: older_than
       description: "Consider only agents whose last keep alive is older than the specified time frame. For
-      never_connected agents, register date is considered instead of last keep alive. For example, `7d`, `10s` and `10`
+      never_connected agents, enrollment date is considered instead of last keep alive. For example, `7d`, `10s` and `10`
       are valid values. When no time unit is specified, seconds are assumed. Use 0s to select all agents"
       schema:
         type: string
@@ -2300,7 +2301,7 @@ components:
     registerIP:
       in: query
       name: registerIP
-      description: "Filter by the IP used when registering the agent"
+      description: "Filter by the IP used when enrolling the agent"
       schema:
         type: string
         format: alphanumeric
@@ -2585,7 +2586,7 @@ paths:
                   version: 12 "Bookworm"
       responses:
         '201':
-          description: "Empty response indicating the agent was registered successfully"
+          description: "Empty response indicating the agent was enrolled successfully"
         '400':
           $ref: '#/components/responses/ResponseError'
         '401':

--- a/apis/server_management/server_management_api/spec/spec.yaml
+++ b/apis/server_management/server_management_api/spec/spec.yaml
@@ -663,76 +663,48 @@ components:
     Agent:
       type: object
       properties:
-        version:
-          type: string
-          description: "Wazuh version the agent has installed"
         id:
           $ref: '#/components/schemas/AgentID'
         name:
           type: string
           description: "Agent name used at the enrollment process"
-        status:
-          $ref: '#/components/schemas/AgentStatus'
-        configSum:
-          type: string
-          description: "MD5 checksum of the group configuration file (agent.conf)"
-        group:
+        groups:
           type: array
           description: "List of groups the agent belongs to"
           items:
             type: string
-        mergedSum:
+        type:
           type: string
-          description: "MD5 checksum of all group shared files merged in a single one (merged.mg)"
-        ip:
+          description: "Type of agent"
+        version:
           type: string
-          description: "IP where the agent communicates with the manager. If the manager can't get this information, it
-          will be the same as registerIP field"
-        registerIP:
+          description: "Wazuh version the agent has installed"
+        last_login:
           type: string
-          description: "IP used at agent the enrollment process"
-        manager:
-          type: string
-          description: "Hostname of the manager the agent is reporting to"
-        node_name:
-          type: string
-          description: "ID of the node the agent is reporting to"
-        dateAdd:
-          type: string
-          description: "Date when the agent was registered"
-        lastKeepAlive:
-          type: string
-          description: "Date when the last keepalive was received from the agent"
-        os:
+          description: "The last time the agent has authenticated with the server"
+        is_connected:
+          type: boolean
+          description: "Whether the agent is currently connected or not"
+        host:
           type: object
           properties:
-            major:
+            architecture:
               type: string
-            name:
+            hostname:
               type: string
-            uname:
-              type: string
-            platform:
-              type: string
-            version:
-              type: string
-            codename:
-              type: string
-            arch:
-              type: string
-            minor:
-              type: string
-          description: "Agent OS information"
-        status_code:
-          description: "Agent connection status code"
-          type: integer
-          format: int32
-          default: 0
-          minimum: 0
-          maximum: 5
-        group_config_status:
-          type: string
-          description: "Agent groups configuration sync status"
+            ip:
+              type: array
+              items:
+                type: string
+            os:
+              type: object
+              properties:
+                name:
+                  type: string
+                type:
+                  type: string
+                version:
+                  type: string
 
     AgentAddBody:
       type: object

--- a/apis/tools/env/wazuh-agent/entrypoint.sh
+++ b/apis/tools/env/wazuh-agent/entrypoint.sh
@@ -24,7 +24,7 @@ done
 echo "Waiting for the nodes to sync..."
 sleep 10
 
-# Register agent
+# Enrol agent
 SPDLOG_LEVEL=TRACE /usr/share/wazuh-agent/bin/wazuh-agent --register --url $NGINX_URL --user $USER --password $PASSWORD --verification-mode none
 
 # Run agent

--- a/apis/tools/env/wazuh-agent/entrypoint.sh
+++ b/apis/tools/env/wazuh-agent/entrypoint.sh
@@ -24,7 +24,7 @@ done
 echo "Waiting for the nodes to sync..."
 sleep 10
 
-# Enrol agent
+# Enroll agent
 SPDLOG_LEVEL=TRACE /usr/share/wazuh-agent/bin/wazuh-agent --register --url $NGINX_URL --user $USER --password $PASSWORD --verification-mode none
 
 # Run agent

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -73,7 +73,7 @@ def reconnect_agents(agent_list: Union[list, str] = None) -> AffectedItemsWazuhR
 
     Parameters
     ----------
-    list or str
+    agent_list : list or str
         List of agent IDs. All possible values from 001 onwards. Default `*`
 
     Returns
@@ -171,7 +171,7 @@ async def get_agents(
     sort: dict = None,
     select: dict = None,
 ) -> AffectedItemsWazuhResult:
-    """Gets a list of available agents with basic attributes.
+    """Get a list of available agents with basic attributes.
 
     Parameters
     ----------
@@ -223,7 +223,7 @@ async def get_agents_in_group(
     select: str = None,
     distinct: bool = False,
 ) -> AffectedItemsWazuhResult:
-    """Gets the list of agents that belong to a specific group.
+    """Get the list of agents that belong to a specific group.
 
     Parameters
     ----------
@@ -418,7 +418,7 @@ async def get_agent_groups(
     select: str = None,
     distinct: bool = False,
 ) -> AffectedItemsWazuhResult:
-    """Gets the existing groups.
+    """Get the existing groups.
 
     Parameters
     ----------
@@ -494,7 +494,7 @@ async def get_agent_groups(
 
 @expose_resources(actions=['group:create'], resources=['*:*:*'], post_proc_func=None)
 async def create_group(group_id: str) -> WazuhResult:
-    """Creates a group.
+    """Create a group.
 
     Parameters
     ----------

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -5,7 +5,7 @@
 from os import chmod, chown, path
 from typing import Optional, Union
 
-from server_management_api.models.agent_registration_model import Host
+from server_management_api.models.agent_enrollment_model import Host
 from wazuh.core import common, configuration
 from wazuh.core.agent import (
     Agent,

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from copy import deepcopy
-from typing import Union
+from typing import Any, Union
 
 from wazuh.core.cluster import __version__
 from wazuh.core.common import AGENT_NAME_LEN_LIMIT, MAX_SOCKET_BUFFER_SIZE, WAZUH_SERVER_YML
@@ -426,8 +426,7 @@ class WazuhException(Exception):
         },
         5007: {
             'message': 'Insecure user password provided',
-            'remediation': 'The password must contain at least one upper and lower case letter, a number and a '
-            'symbol.',
+            'remediation': 'The password must contain at least one upper and lower case letter, a number and a symbol.',
         },
         5008: {
             'message': 'The current user cannot be deleted',
@@ -459,8 +458,7 @@ class WazuhException(Exception):
         6002: {'message': 'The body type is not the one specified in the content-type'},
         6003: {
             'message': 'Error trying to load the JWT secret',
-            'remediation': 'Make sure you have the right permissions: WAZUH_PATH/api/configuration/security/'
-            'jwt_secret',
+            'remediation': 'Make sure you have the right permissions: WAZUH_PATH/api/configuration/security/jwt_secret',
         },
         6004: {
             'message': 'The current user does not have authentication enabled through authorization context',
@@ -581,6 +579,13 @@ class WazuhException(Exception):
         return obj
 
     def to_dict(self) -> dict:
+        """Convert object into a dictionary.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the values.
+        """
         return {
             'type': self._type,
             'title': self._title,
@@ -592,23 +597,58 @@ class WazuhException(Exception):
         }
 
     @property
-    def type(self):
+    def type(self) -> str:
+        """Get type.
+
+        Returns
+        -------
+        str
+            Error type.
+        """
         return self._type
 
     @property
-    def title(self):
+    def title(self) -> str:
+        """Get title.
+
+        Returns
+        -------
+        str
+            Error title.
+        """
         return self._title
 
     @property
-    def message(self):
+    def message(self) -> Any | str:
+        """Get message.
+
+        Returns
+        -------
+        Any | str
+            Error message.
+        """
         return self._message
 
     @property
-    def remediation(self):
+    def remediation(self) -> str | None:
+        """Get remediation message.
+
+        Returns
+        -------
+        str | None
+            Remediation message or None.
+        """
         return self._remediation
 
     @property
-    def dapi_errors(self):
+    def dapi_errors(self) -> dict | Any:
+        """Get distributed API errors.
+
+        Returns
+        -------
+        dict | Any
+            DAPI errors.
+        """
         return self._dapi_errors
 
     @dapi_errors.setter
@@ -616,18 +656,30 @@ class WazuhException(Exception):
         self._dapi_errors = value
 
     @property
-    def code(self):
+    def code(self) -> int:
+        """Get code.
+
+        Returns
+        -------
+        int
+            Error code.
+        """
         return self._code
 
     @classmethod
-    def from_dict(cls, dct):
+    def from_dict(cls, dct: dict):
+        """Convert a dictionary into a WazuhException object.
+
+        Parameters
+        ----------
+        dct : dict
+            Dictionary holding the values.
+        """
         return cls(**dct)
 
 
 class WazuhInternalError(WazuhException):
-    """This type of exception is raised when an unexpected error in framework code occurs,
-    which means an internal error could not be handled.
-    """
+    """Class representing an error in the code that could not be handled."""
 
     _default_type = 'about:blank'
     _default_title = 'Wazuh Internal Error'
@@ -678,51 +730,49 @@ class WazuhInternalError(WazuhException):
 
 
 class WazuhClusterError(WazuhInternalError):
-    """This type of exception is raised inside the cluster."""
+    """Cluster exception."""
 
     _default_type = 'about:blank'
     _default_title = 'Wazuh Cluster Error'
 
 
 class WazuhHAPHelperError(WazuhClusterError):
-    """This type of exception is raised inside the HAProxy Helper."""
+    """HAProxy Helper exception."""
 
     _default_type = 'about:blank'
     _default_title = 'HAProxy Helper Error'
 
 
 class WazuhCommsAPIError(WazuhInternalError):
-    """This type of exception is raised inside the Communications API."""
+    """Communications API exception."""
 
     _default_type = 'about:blank'
     _default_title = 'Communications API Error'
 
 
 class WazuhEngineError(WazuhInternalError):
-    """This type of exception is raised inside the engine."""
+    """Engine client exception."""
 
     _default_type = 'about:blank'
     _default_title = 'Wazuh Engine Error'
 
 
 class WazuhIndexerError(WazuhInternalError):
-    """This type of exception is raised inside the indexer."""
+    """Indexer client exception."""
 
     _default_type = 'about:blank'
     _default_title = 'Wazuh Indexer Error'
 
 
 class WazuhDaemonError(WazuhInternalError):
-    """This type of exception is raised inside the server daemons."""
+    """Server daemons exception."""
 
     _default_type = 'about:blank'
     _default_title = 'Wazuh Daemon Error'
 
 
 class WazuhError(WazuhException):
-    """This type of exception is raised as a controlled response to a bad request from user
-    that cannot be performed properly.
-    """
+    """Class representing a controlled response to a bad request from user that cannot be performed properly."""
 
     _default_type = 'about:blank'
     _default_title = 'Bad Request'
@@ -772,7 +822,14 @@ class WazuhError(WazuhException):
         self._ids = set() if ids is None else set(ids)
 
     @property
-    def ids(self):
+    def ids(self) -> set:
+        """Get IDs.
+
+        Returns
+        -------
+        set
+            IDs ordered list.
+        """
         return self._ids
 
     def __or__(self, other):
@@ -783,6 +840,13 @@ class WazuhError(WazuhException):
         return result
 
     def to_dict(self) -> dict:
+        """Convert object into a dictionary.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the value.
+        """
         result = super().to_dict()
         result['ids'] = list(self.ids)
 
@@ -790,28 +854,28 @@ class WazuhError(WazuhException):
 
 
 class WazuhPermissionError(WazuhError):
-    """This type of exception is raised as a controlled response to a permission denied accessing a resource."""
+    """Class representing a controlled response to a permission denied accessing a resource."""
 
     _default_type = 'about:blank'
     _default_title = 'Permission Denied'
 
 
 class WazuhResourceNotFound(WazuhError):
-    """This type of exception is raised as a controlled response to a not found resource."""
+    """Class representing a controlled response to a not found resource."""
 
     _default_type = 'about:blank'
     _default_title = 'Resource Not Found'
 
 
 class WazuhTooManyRequests(WazuhError):
-    """This type of exception is raised as a controlled response to too many requests."""
+    """Class representing a controlled response to too many requests."""
 
     _default_type = 'about:blank'
     _default_title = 'Too Many Requests'
 
 
 class WazuhNotAcceptable(WazuhError):
-    """This type of exception is raised as a controlled response to a not acceptable request."""
+    """Class representing a controlled response to a not acceptable request."""
 
     _default_type = 'about:blank'
     _default_title = 'Not Acceptable'

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -150,7 +150,7 @@ class WazuhException(Exception):
             'remediation': 'Please, check non-active agents connection and try again. Visit '
             f'https://documentation.wazuh.com/{DOCU_VERSION}/user-manual/registering/index.html and '
             f'https://documentation.wazuh.com/{DOCU_VERSION}/user-manual/agents/agent-connection.'
-            f'html to obtain more information on registering and connecting agents',
+            f'html to obtain more information on enrolling and connecting agents',
         },
         1708: {'message': 'There is an agent with the same ID', 'remediation': 'Please choose another ID'},
         1709: {
@@ -178,7 +178,7 @@ class WazuhException(Exception):
         },
         1723: 'Hash algorithm not available',
         1724: {'message': 'Not a valid select field', 'remediation': 'Please, use only allowed select fields'},
-        1725: {'message': 'Error registering a new agent', 'remediation': 'Please check all data fields and try again'},
+        1725: {'message': 'Error enrolling a new agent', 'remediation': 'Please check all data fields and try again'},
         1726: {
             'message': 'Wazuh authd is not running',
             'remediation': 'Please enable authd or check if there is any error',

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -60,7 +60,7 @@ default_policies:
         effect: allow
 
   agents_create:
-    description: Allow registering new agents.
+    description: Allow enrolling new agents.
     policies:
       resourceless:
         actions:

--- a/framework/wazuh/rbac/default/relationships.yaml
+++ b/framework/wazuh/rbac/default/relationships.yaml
@@ -12,7 +12,7 @@ relationships:
 
     agent-init:
       role_ids:
-        - agent_register
+        - agent_enrol
 
   roles:
     administrator:
@@ -56,7 +56,7 @@ relationships:
         - cluster_all
       rule_ids: []
 
-    agent_register:
+    agent_enrol:
       policy_ids:
         - agents_create
       rule_ids: []

--- a/framework/wazuh/rbac/default/relationships.yaml
+++ b/framework/wazuh/rbac/default/relationships.yaml
@@ -12,7 +12,7 @@ relationships:
 
     agent-init:
       role_ids:
-        - agent_enrol
+        - agent_enroll
 
   roles:
     administrator:
@@ -56,7 +56,7 @@ relationships:
         - cluster_all
       rule_ids: []
 
-    agent_enrol:
+    agent_enroll:
       policy_ids:
         - agents_create
       rule_ids: []

--- a/framework/wazuh/rbac/default/roles.yaml
+++ b/framework/wazuh/rbac/default/roles.yaml
@@ -22,5 +22,5 @@ default_roles:
   cluster_admin:
     description: Manager administrator of the system, this role have full access to all manager related functionalities.
 
-  agent_enrol:
+  agent_enroll:
     description: Manager of create new agents into the system.

--- a/framework/wazuh/rbac/default/roles.yaml
+++ b/framework/wazuh/rbac/default/roles.yaml
@@ -22,5 +22,5 @@ default_roles:
   cluster_admin:
     description: Manager administrator of the system, this role have full access to all manager related functionalities.
 
-  agent_register:
+  agent_enrol:
     description: Manager of create new agents into the system.

--- a/framework/wazuh/rbac/default/users.yaml
+++ b/framework/wazuh/rbac/default/users.yaml
@@ -12,6 +12,6 @@ default_users:
     allow_run_as: True
 
   agent-init:
-    description: User to be used to register new agents.
+    description: User capable of enrolling new agents.
     password: agent-init
     allow_run_as: False


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/28228 |

## Description

Replaces the concept `register/registration` with `enroll/enrollment`.

> [!Note]
> There are some parameters that still mention register concepts like `registerIP`, nevertheless, they are legacy and will be removed before the feature complete implementation. I didn't remove them here to maintain the PR scope.

### Tests

<details><summary>Authentication</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ TOKEN=$(curl -u wazuh:wazuh -s -k -X POST https://0.0.0.0:55000/security/user/authenticate | jq -r '.data.token') && echo $TOKEN
eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzM5ODg2NjgzLCJleHAiOjE3Mzk4ODc1ODMsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.LbtvDaekWrzEf6TzVpkDH6dr-23UscTmcRn1HctjIvXYd0-K_akdahaYNfeG3wUbUxJfRPnlAxhNAFY3SlAiBQ
```

</details>

<details><summary>Agent creation</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Tue, 18 Feb 2025 13:51:52 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

</details>

<details><summary>Agent listing</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -X GET -ks https://0.0.0.0:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "x0T7DGXvCFSL36oVOiteIMCtg23GRiYhtrYizSUK1NtA5xGtfw5FDUF9wSQEVD9/",
        "type": "endpoint",
        "version": "5.0.0",
        "status": "never_connected"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}

```

</details>

<details><summary>Unit tests</summary>

`test_agent_controller.py` is expected to fail becasue the unit tests are trying to access a configuration file that does not exist. This will be fixed in https://github.com/wazuh/wazuh/issues/26725.

```console
(venv) gasti@gasti:~/work/wazuh$ pytest apis/server_management/server_management_api/models/test/test_model.py --disable-warnings
===================================================================================================== test session starts ======================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis/server_management/server_management_api
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 27 items                                                                                                                                                                                                             

apis/server_management/server_management_api/models/test/test_model.py ...........................                                                                                                                       [100%]

================================================================================================ 27 passed, 8 warnings in 0.84s ================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest apis/server_management/server_management_api/controllers/test/test_agent_controller.py --disable-warnings
===================================================================================================== test session starts ======================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/apis/server_management/server_management_api
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 0 items / 1 error                                                                                                                                                                                                    

============================================================================================================ ERRORS ============================================================================================================
__________________________________________________________________________________ ERROR collecting controllers/test/test_agent_controller.py __________________________________________________________________________________
apis/server_management/server_management_api/controllers/test/test_agent_controller.py:17: in <module>
    from wazuh import agent
framework/wazuh/agent.py:29: in <module>
    node_id = get_node().get('node')
framework/wazuh/core/cluster/cluster.py:167: in get_node
    server_config = CentralizedConfig.get_server_config()
framework/wazuh/core/config/client.py:124: in get_server_config
    cls.load()
framework/wazuh/core/config/client.py:43: in load
    raise FileNotFoundError(f'Configuration file not found: {WAZUH_SERVER_YML}')
E   FileNotFoundError: Configuration file not found: /etc/wazuh-server/wazuh-server.yml
=================================================================================================== short test summary info ====================================================================================================
ERROR apis/server_management/server_management_api/controllers/test/test_agent_controller.py - FileNotFoundError: Configuration file not found: /etc/wazuh-server/wazuh-server.yml
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================================= 8 warnings, 1 error in 0.34s =================================================================================================
```

</details>