### PR TITLE
Remove wrong RPM file spec for kvdb

### DIFF
--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -252,7 +252,7 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/store
 %{_localstatedir}var/lib/wazuh-server/engine/store/*
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/kvdb
-%ghost %{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
+%{_localstatedir}var/lib/wazuh-server/engine/kvdb/*
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/indexer-connector
 
 %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine


### PR DESCRIPTION
|Related issue|
|---|
|#28287|

## Description

This PR aims to fix a wrong RPM file spec for kvdb folder and files when the package is created using the GitHub workflow https://github.com/wazuh/wazuh/blob/main/.github/workflows/packages-build-server.yml, leading to errors during wazuh-server runtime

## Fix proposal

According to [RPM Virtual File Attribute(s)](https://rpm-software-management.github.io/rpm/manual/spec.html), ghost directive will cause the exclusion of those files from the package.

## Fix cons

Including files wildcards on packages is a not recommended situation at `%files` directive, since we are not getting noticed if those files were, in fact, part of our package. This could lead to silent bugs due to undeployed files.

That's why RPM is stringent on check-files step.

We should move the S3_PRECOMPILED_STORE fetching from workflows to a more deeper mechanism, such as SPECS or source code installation/compilation. With this approach, we will include the storage for packages (created by workflow or locally) and source code installation

**TL;DR:
:warning: 
After merging this issue, https://github.com/wazuh/wazuh/issues/27954 should be opened again**

## Testing

- With engine storage (GHA):  https://github.com/wazuh/wazuh/actions/runs/13435081427