### PR TITLE
Add logic of remove of delete by query when indexer is disabled

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -818,6 +818,14 @@ IndexerConnector::IndexerConnector(
                 {
                     m_db->delete_(id);
                 }
+                // We made the same operation for DELETED_BY_QUERY as for DELETED
+                else if (parsedData.at("operation").get_ref<const std::string&>().compare("DELETED_BY_QUERY") == 0)
+                {
+                    for (const auto& [key, _] : m_db->seek(id))
+                    {
+                        m_db->delete_(key);
+                    }
+                }
                 else
                 {
                     const auto dataString = parsedData.at("data").dump();

--- a/src/shared_modules/indexer_connector/src/indexerConnector.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnector.cpp
@@ -828,6 +828,12 @@ IndexerConnector::IndexerConnector(
                 }
                 else
                 {
+                    // If the data does not contain the required fields, log a warning and continue.
+                    if (!parsedData.contains("data"))
+                    {
+                        logWarn(IC_NAME, "Event required field (data) is missing required fields: %s", data.c_str());
+                        continue;
+                    }
                     const auto dataString = parsedData.at("data").dump();
                     m_db->put(id, dataString);
                 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28286 |

# Objective

This PR aims to add the missing logic when the indexer is disabled and delete by query operation is received.

## Testing

> [!NOTE]
> Disable index status on vulnerability detection configuration

### Steps
- Start manager and enable debug logging
- Connect an agent
- Remove the agent

![image](https://github.com/user-attachments/assets/ad44409a-308e-4d73-84f3-1e724e2be887)

> [!NOTE]
> Log entries were added only for testing purposes

