### PR TITLE
Add has_keys helper function

### DIFF
--- a/src/engine/docs/README.md
+++ b/src/engine/docs/README.md
@@ -8,6 +8,7 @@ This documentation provides an overview of the auxiliary functions available. Au
 - [ends_with](#ends_with)
 - [exists](#exists)
 - [exists_key_in](#exists_key_in)
+- [has_keys](#has_keys)
 - [int_equal](#int_equal)
 - [int_greater](#int_greater)
 - [int_less](#int_less)
@@ -263,6 +264,48 @@ This helper function is typically used in the check stage.
 **Keywords**
 
 - `undefined` 
+
+---
+# has_keys
+
+## Signature
+
+```
+
+field: has_keys(elements)
+```
+
+## Arguments
+
+| parameter | Type | Source | Accepted values |
+| --------- | ---- | ------ | --------------- |
+| elements | array | value or reference | Any string |
+
+
+## Target Field
+
+| Type | Possible values |
+| ---- | --------------- |
+| object | Any object |
+
+
+## Description
+
+Checks if all the specified keys from the target field (an object) are present in the given list.
+It verifies whether the elements in the list are included as keys in the target object.
+If any key from the target object is missing in the list, the validation fails.
+The function does not require that all keys in the list be present in the target field,
+but all keys from the target field must be in the list.
+If any element in the list is not a string, or if the target object is missing any keys from the list, the validation fails.
+This helper is particularly useful for ensuring that all required keys are present in the object and
+are strictly enforced in the list.
+
+
+**Keywords**
+
+- `array` 
+
+- `object` 
 
 ---
 # int_equal
@@ -597,11 +640,10 @@ field: is_ipv6()
 ## Description
 
 Checks if the IP address stored in the field is an IPv6.
-IPv4:
-  - 10.0.0.0
-  - 172.16.0.0
-  - 192.168.0.0
-  - 127.0.0.0
+IPv6:
+  - ::1
+  - fd00:abcd::1234
+  - a03:2880:f10c:83:face:b00c::25de
 This helper function is typically used in the check stage
 
 

--- a/src/engine/docs/keyword_table.md
+++ b/src/engine/docs/keyword_table.md
@@ -6,6 +6,7 @@
 | [ends_with](documentation.md#ends_with) | string |
 | [exists](documentation.md#exists) | undefined |
 | [exists_key_in](documentation.md#exists_key_in) | undefined |
+| [has_keys](documentation.md#has_keys) | array, object |
 | [int_equal](documentation.md#int_equal) | comparison, integer |
 | [int_greater](documentation.md#int_greater) | comparison, integer |
 | [int_less](documentation.md#int_less) | comparison, integer |

--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(builder_utest
     ${UNIT_SRC_DIR}/builders/opfilter/types_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/match_test.cpp
     ${UNIT_SRC_DIR}/builders/opfilter/is_test_session_test.cpp
+    ${UNIT_SRC_DIR}/builders/opfilter/has_keys_test.cpp
 
     # Map Builders
     ${UNIT_SRC_DIR}/builders/opmap/map_test.cpp

--- a/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
+++ b/src/engine/source/builder/src/builders/opfilter/opBuilderHelperFilter.hpp
@@ -627,6 +627,25 @@ FilterOp opBuilderHelperMatchKey(const Reference& targetField,
                                  const std::vector<OpArg>& opArgs,
                                  const std::shared_ptr<const IBuildCtx>& buildCtx);
 
+/**
+ * @brief Checks if all the specified keys from the target field (an object) are present in the given list.
+ * It verifies whether the elements in the list are included as keys in the target object.
+ * If any key from the target object is missing in the list, the validation fails.
+ * The function does not require that all keys in the list be present in the target field,
+ * but all keys from the target field must be in the list.
+ * If any element in the list is not a string, or if the target object is missing any keys from the list, the validation
+ * fails. This helper is particularly useful for ensuring that all required keys are present in the object and are
+ * strictly enforced in the list.
+ *
+ * @param targetField target field of the helper
+ * @param opArgs Vector of operation arguments containing the list of keys to be evaluated
+ * @param buildCtx Shared pointer to the build context used for the conversion operation.
+ * @return FilterOp
+ */
+FilterOp opBuilderHelperKeysExistInList(const Reference& targetField,
+                                        const std::vector<OpArg>& opArgs,
+                                        const std::shared_ptr<const IBuildCtx>& buildCtx);
+
 } // namespace builder::builders::opfilter
 
 #endif // _OP_BUILDER_HELPER_FILTER_H

--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -113,6 +113,9 @@ void registerOpBuilders(const std::shared_ptr<Registry>& registry, const Builder
     registry->template add<builders::OpBuilderEntry>(
         "is_string", {schemf::runtimeValidation(), builders::opfilter::opBuilderHelperIsString});
     registry->template add<builders::OpBuilderEntry>(
+        "has_keys",
+        {schemf::JTypeToken::create(json::Json::Type::Object), builders::opfilter::opBuilderHelperKeysExistInList});
+    registry->template add<builders::OpBuilderEntry>(
         "binary_and",
         {schemf::JTypeToken::create(json::Json::Type::String), builders::opfilter::opBuilderHelperBinaryAnd});
     registry->template add<builders::OpBuilderEntry>(

--- a/src/engine/source/builder/test/src/unit/builders/opfilter/has_keys_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/opfilter/has_keys_test.cpp
@@ -1,0 +1,243 @@
+#include "builders/baseBuilders_test.hpp"
+
+#include "builders/opfilter/opBuilderHelperFilter.hpp"
+
+namespace
+{
+
+auto customRefExpected()
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, validator());
+        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillOnce(testing::Return(false));
+        return None {};
+    };
+}
+
+auto jTypeArrayRefExpected(json::Json::Type jType, bool isArray = true)
+{
+    return [=](const BuildersMocks& mocks)
+    {
+        EXPECT_CALL(*mocks.ctx, validator()).Times(testing::AtLeast(1));
+        EXPECT_CALL(*mocks.validator, hasField(DotPath("ref"))).WillOnce(testing::Return(true));
+        EXPECT_CALL(*mocks.validator, isArray(DotPath("ref"))).WillOnce(testing::Return(isArray));
+        if (isArray)
+        {
+            EXPECT_CALL(*mocks.validator, getJsonType(DotPath("ref"))).WillOnce(testing::Return(jType));
+        }
+        return None {};
+    };
+}
+
+} // namespace
+
+namespace filterbuildtest
+{
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    FilterBuilderTest,
+    testing::Values(
+        // Wrong arguments number
+        FilterT({}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"("string")"), makeValue(R"("string")")},
+                opfilter::opBuilderHelperKeysExistInList,
+                FAILURE()),
+        // Value
+        FilterT({makeValue(R"("string")")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"(2)")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"(1.2)")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"(true)")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"(false)")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"([1, 2, 3])")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"({"a": 1, "b": 2})")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"(null)")}, opfilter::opBuilderHelperKeysExistInList, FAILURE()),
+        FilterT({makeValue(R"(["ts", "host", "wazuh"])")}, opfilter::opBuilderHelperKeysExistInList, SUCCESS()),
+        // Reference
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperKeysExistInList,
+                FAILURE(jTypeArrayRefExpected(json::Json::Type::Number))),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperKeysExistInList,
+                FAILURE(jTypeArrayRefExpected(json::Json::Type::Boolean))),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperKeysExistInList,
+                FAILURE(jTypeArrayRefExpected(json::Json::Type::Array))),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperKeysExistInList,
+                FAILURE(jTypeArrayRefExpected(json::Json::Type::Object))),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperKeysExistInList,
+                FAILURE(jTypeArrayRefExpected(json::Json::Type::Null))),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperKeysExistInList,
+                SUCCESS(jTypeArrayRefExpected(json::Json::Type::String))),
+        FilterT({makeRef("ref")},
+                opfilter::opBuilderHelperKeysExistInList,
+                FAILURE(jTypeArrayRefExpected(json::Json::Type::String, false))),
+        FilterT({makeRef("ref"), makeRef("ref")}, opfilter::opBuilderHelperKeysExistInList, FAILURE())),
+    testNameFormatter<FilterBuilderTest>("HasKeys"));
+} // namespace filterbuildtest
+
+namespace filteroperatestest
+{
+INSTANTIATE_TEST_SUITE_P(
+    Builders,
+    FilterOperationTest,
+    testing::Values(
+        // Value cases
+        FilterT(R"({"target": "value"})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["v", "a", "l", "u", "e"])")},
+                FAILURE()),
+        FilterT(R"({"target": "value"})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["v", "a", "l", "u", "e"])")},
+                FAILURE()),
+        FilterT(R"({"target": 1})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["v", "a", "l", "u", "e"])")},
+                FAILURE()),
+        FilterT(R"({"target": 1.2})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["v", "a", "l", "u", "e"])")},
+                FAILURE()),
+        FilterT(R"({"target": true})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["v", "a", "l", "u", "e"])")},
+                FAILURE()),
+        FilterT(R"({"target": ["t", "a", "r", "g", "e", "t"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["v", "a", "l", "u", "e"])")},
+                FAILURE()),
+        FilterT(R"({})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["v", "a", "l", "u", "e"])")},
+                FAILURE()),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["key"])")},
+                FAILURE()),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["key", "key_not_found"])")},
+                FAILURE()),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["key", "other_key"])")},
+                SUCCESS()),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeValue(R"(["key", "other_key", "more_key"])")},
+                SUCCESS()),
+        // Reference cases
+        FilterT(R"({"target": "value", "ref": ["r", "e", "f"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": "value", "ref": ["r", "e", "f"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": 1, "ref": ["r", "e", "f"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": 1.2, "ref": ["r", "e", "f"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": false, "ref": ["r", "e", "f"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": ["t", "a", "r", "g", "e", "t"], "ref": ["r", "e", "f"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": [1, 2, 3]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": [1.2, 2.5, 3.9]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": [true, false, true]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(
+            R"({"target": {"key": "value", "other_key": "other_value"}, "ref": [{"key": "value"}, {"other_key": "value"}]})",
+            opfilter::opBuilderHelperKeysExistInList,
+            "target",
+            {makeRef("ref")},
+            FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": "key"})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": 1})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": 1.2})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": false})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": {"key": "value"}})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": ["key"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": ["key", "key_not_found"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                FAILURE(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": ["key", "other_key"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                SUCCESS(customRefExpected())),
+        FilterT(R"({"target": {"key": "value", "other_key": "other_value"}, "ref": ["key", "other_key", "more_key"]})",
+                opfilter::opBuilderHelperKeysExistInList,
+                "target",
+                {makeRef("ref")},
+                SUCCESS(customRefExpected()))),
+    testNameFormatter<FilterOperationTest>("HasKeys"));
+
+} // namespace filteroperatestest

--- a/src/engine/test/helper_tests/helpers_description/filter/has_keys.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/has_keys.yml
@@ -1,0 +1,68 @@
+# Name of the helper function
+name: has_keys
+
+metadata:
+  description: |
+    Checks if all the specified keys from the target field (an object) are present in the given list.
+    It verifies whether the elements in the list are included as keys in the target object.
+    If any key from the target object is missing in the list, the validation fails.
+    The function does not require that all keys in the list be present in the target field,
+    but all keys from the target field must be in the list.
+    If any element in the list is not a string, or if the target object is missing any keys from the list, the validation fails.
+    This helper is particularly useful for ensuring that all required keys are present in the object and
+    are strictly enforced in the list.
+
+  keywords:
+    - array
+    - object
+
+helper_type: filter
+
+# Indicates whether the helper function supports a variable number of arguments
+is_variadic: false
+
+# Arguments expected by the helper function
+arguments:
+  elements:
+    type: array  # Expected type is string
+    generate: string
+    source: both # includes values or references (their names start with $)
+
+# do not compare with target field to avoid failure
+skipped:
+  - success_cases
+
+target_field:
+  type: object
+  generate: object
+
+test:
+  - arguments:
+      elements: ["ts", "host"]
+    target_field:
+      ts: "2021-01-03T01:19:32.488179Z"
+      host: 192.168.4.43
+    should_pass: true
+    description: Success keys in list
+  - arguments:
+      elements: ["ts", "host", "other"]
+    target_field:
+      ts: "2021-01-03T01:19:32.488179Z"
+      host: 192.168.4.43
+    should_pass: true
+    description: There are elements in the list that are missing from the target field
+  - arguments:
+      elements: ["ts", "host"]
+    target_field:
+      ts: "2021-01-03T01:19:32.488179Z"
+      host: 192.168.4.43
+      other_key: some_value
+    should_pass: false
+    description: There are keys in the target field that are missing from the list
+  - arguments:
+      elements: ["ts", 9999, "other"]
+    target_field:
+      ts: "2021-01-03T01:19:32.488179Z"
+      host: 192.168.4.43
+    should_pass: false
+    description: Element in array is not a string

--- a/src/engine/test/helper_tests/helpers_description/filter/is_ipv6.yml
+++ b/src/engine/test/helper_tests/helpers_description/filter/is_ipv6.yml
@@ -4,11 +4,10 @@ name: is_ipv6
 metadata:
   description: |
     Checks if the IP address stored in the field is an IPv6.
-    IPv4:
-      - 10.0.0.0
-      - 172.16.0.0
-      - 192.168.0.0
-      - 127.0.0.0
+    IPv6:
+      - ::1
+      - fd00:abcd::1234
+      - a03:2880:f10c:83:face:b00c::25de
     This helper function is typically used in the check stage
 
   keywords:


### PR DESCRIPTION
|Related issue|
|---|
|#28232|

## Description

## Description
There's a need to create a new helper function named `has_keyst` in Wazuh-Engine to enhance asset ruleset functionality. This helper function is intended to check if all the top-level keys of a JSON object (target field) exist within a specified list of keys.

## Function Signature
```yml
targetField: has_keys(list|$ref_to_list)
```