### PR TITLE
Build OS CPE for package scans with data from Wazuh-DB

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/osDataCache.hpp
@@ -95,7 +95,7 @@ private:
         osData.sysName = data.value("sysname", "");
         osData.kernelVersion = data.value("version", "");
         osData.kernelRelease = data.value("release", "");
-        osData.cpeName = data.value("cpe_name", "");
+        // CPE must be built, it isn't present at the Wazuh-DB response.
 
         return osData;
     }
@@ -104,10 +104,11 @@ public:
     /**
      * @brief This method returns the os data.
      * @param agentId agent id.
+     * @param osData OS data to fill.
      *
-     * @return Os
+     * @return True if the OS data was found in the cache, false in case of Wazuh-DB query
      */
-    Os getOsData(const std::string& agentId)
+    bool getOsData(const std::string& agentId, Os& osData)
     {
         const auto getValue = [this](const std::string& agentIdValue) -> std::optional<Os>
         {
@@ -119,15 +120,15 @@ public:
             return std::nullopt;
         };
 
-        if (const auto osData = getValue(agentId); osData != std::nullopt)
+        if (const auto optOsData = getValue(agentId); optOsData != std::nullopt)
         {
-            return *osData;
+            osData = *optOsData;
+            return true;
         }
 
         // This may throw an exception that will be captured by the caller method.
-        const auto osData = getOsDataFromWdb(agentId);
-        setOsData(agentId, osData);
-        return osData;
+        osData = getOsDataFromWdb(agentId);
+        return false;
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -260,7 +260,13 @@ public:
                             {
                                 m_type = ScannerType::PackageDelete;
                             }
-                            m_osData = TOsDataCache::instance().getOsData(agentId().data());
+
+                            // If data comes from Wdb, we build the CPE and update the cache
+                            if (!TOsDataCache::instance().getOsData(agentId().data(), m_osData))
+                            {
+                                buildCPEName();
+                                TOsDataCache::instance().setOsData(agentId().data(), m_osData);
+                            }
                         }
                         else if (delta->data_type() == SyscollectorDeltas::Provider_dbsync_osinfo)
                         {
@@ -339,7 +345,12 @@ public:
                                 m_type = ScannerType::HotfixDelete;
                             }
 
-                            m_osData = TOsDataCache::instance().getOsData(agentId().data());
+                            // If data comes from Wdb, we build the CPE and update the cache
+                            if (!TOsDataCache::instance().getOsData(agentId().data(), m_osData))
+                            {
+                                buildCPEName();
+                                TOsDataCache::instance().setOsData(agentId().data(), m_osData);
+                            }
                         }
                     }
                     else
@@ -445,7 +456,12 @@ public:
                             // Set the affected component type
                             m_affectedComponentType = AffectedComponentType::Package;
 
-                            m_osData = TOsDataCache::instance().getOsData(agentId().data());
+                            // If data comes from Wdb, we build the CPE and update the cache
+                            if (!TOsDataCache::instance().getOsData(agentId().data(), m_osData))
+                            {
+                                buildCPEName();
+                                TOsDataCache::instance().setOsData(agentId().data(), m_osData);
+                            }
                         }
                         else if (syncMsg->data_as_state()->attributes_type() ==
                                  SyscollectorSynchronization::AttributesUnion_syscollector_hotfixes)
@@ -461,7 +477,12 @@ public:
                             TRemediationDataCache::instance().addRemediationData(agentId().data(),
                                                                                  std::move(remediation));
 
-                            m_osData = TOsDataCache::instance().getOsData(agentId().data());
+                            // If data comes from Wdb, we build the CPE and update the cache
+                            if (!TOsDataCache::instance().getOsData(agentId().data(), m_osData))
+                            {
+                                buildCPEName();
+                                TOsDataCache::instance().setOsData(agentId().data(), m_osData);
+                            }
                         }
                     }
                     else if (syncMsg->data_type() == SyscollectorSynchronization::DataUnion_integrity_clear)

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockOsDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockOsDataCache.hpp
@@ -43,7 +43,7 @@ public:
      *
      * @note This method is intended for testing purposes and does not perform any real action.
      */
-    MOCK_METHOD(Os, getOsData, (const std::string& agentId), ());
+    MOCK_METHOD(bool, getOsData, (const std::string& agentId, Os& osData), ());
 
     /**
      * @brief Mock method for setOsData.

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineOsDataCache.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineOsDataCache.hpp
@@ -38,12 +38,13 @@ public:
      * @brief Trampoline to method getOsData.
      *
      * @param agentId
+     * @param osData
      *
-     * @return Os
+     * @return bool
      */
-    Os getOsData(const std::string& agentId)
+    bool getOsData(const std::string& agentId, Os& osData)
     {
-        return spOsDataCacheMock->getOsData(agentId);
+        return spOsDataCacheMock->getOsData(agentId, osData);
     }
 
     /**

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/alertClearBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/alertClearBuilder_test.cpp
@@ -82,25 +82,6 @@ void AlertClearBuilderTest::TearDown()
 
 TEST_F(AlertClearBuilderTest, TestSuccessfulIntegrityClear)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
-
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/arrayResultIndexer_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/arrayResultIndexer_test.cpp
@@ -60,6 +60,36 @@ namespace NSArrayResultIndexerTest
         )";
 
     const std::string CVEID {"CVE-2024-1234"};
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
 } // namespace NSArrayResultIndexerTest
 
 using namespace NSArrayResultIndexerTest;
@@ -85,24 +115,7 @@ TEST_F(ArrayResultIndexerTest, TestHandleRequest)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -133,24 +146,7 @@ TEST_F(ArrayResultIndexerTest, TestHandleRequestNoOperation)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -179,24 +175,7 @@ TEST_F(ArrayResultIndexerTest, TestHandleRequestNoId)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -225,24 +204,7 @@ TEST_F(ArrayResultIndexerTest, PublishObjectInsteadOfArray)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/clearSendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/clearSendReport_test.cpp
@@ -29,8 +29,11 @@ const size_t MAX_RETRIES {10};
 auto constexpr TEST_REPORTS_QUEUE_PATH {"queue/vd/reports"};
 auto constexpr TEST_REPORTS_BULK_SIZE {1};
 
-const std::string INTEGRITY_CLEAR_MSG_PACKAGES {
-    R"(
+namespace NSClearSendReportTest
+{
+
+    const std::string INTEGRITY_CLEAR_MSG_PACKAGES {
+        R"(
             {
                 "agent_info": {
                     "agent_id": "001",
@@ -45,8 +48,8 @@ const std::string INTEGRITY_CLEAR_MSG_PACKAGES {
             }
         )"};
 
-const std::string INTEGRITY_CLEAR_MSG_OS {
-    R"(
+    const std::string INTEGRITY_CLEAR_MSG_OS {
+        R"(
             {
                 "agent_info": {
                     "agent_id": "001",
@@ -61,8 +64,8 @@ const std::string INTEGRITY_CLEAR_MSG_OS {
             }
         )"};
 
-const std::string INTEGRITY_CLEAR_MSG_UNEXPECTED {
-    R"(
+    const std::string INTEGRITY_CLEAR_MSG_UNEXPECTED {
+        R"(
             {
                 "agent_info": {
                     "agent_id": "001",
@@ -77,6 +80,40 @@ const std::string INTEGRITY_CLEAR_MSG_UNEXPECTED {
             }
         )"};
 
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
+} // namespace NSClearSendReportTest
+
+using namespace NSClearSendReportTest;
+
 TEST_F(ClearSendReportTest, SendFormattedMsgPackages)
 {
     // Mock report dispatcher.
@@ -85,25 +122,6 @@ TEST_F(ClearSendReportTest, SendFormattedMsgPackages)
     TClearSendReport<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
                      MockReportDispatcher>
         sendReport(reportDispatcher);
-
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -135,25 +153,6 @@ TEST_F(ClearSendReportTest, SendFormattedMsgOsInfo)
                      MockReportDispatcher>
         sendReport(reportDispatcher);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
-
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
@@ -184,25 +183,6 @@ TEST_F(ClearSendReportTest, SendFormattedMsgUnexpected)
                      MockReportDispatcher>
         sendReport(reportDispatcher);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
-
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
@@ -232,25 +212,6 @@ TEST_F(ClearSendReportTest, SendFormattedMsgThrow)
     TClearSendReport<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>,
                      MockReportDispatcher>
         sendReport(reportDispatcher);
-
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDeleteInventory_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDeleteInventory_test.cpp
@@ -130,7 +130,13 @@ TEST_F(EventDeleteInventoryTest, TestHandleRequestPackageDelete)
                .kernelRelease = "osdata_kernelRelease"};
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+        .WillOnce(testing::Invoke(
+            [&osData](const std::string&, Os& osDataResult)
+            {
+                osDataResult = osData;
+                return true;
+            }));
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDetailsBuilder_test.cpp
@@ -161,6 +161,37 @@ namespace NSEventDetailsBuilderTest
     const std::string CVEID {"CVE-2024-1234"};
 
     const std::string DESCRIPTIONS_COLUMN_DEFAULT {"descriptions_nvd"};
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
 } // namespace NSEventDetailsBuilderTest
 
 const nlohmann::json ADP_DESCRIPTIONS =
@@ -306,24 +337,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     }
     m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -506,24 +520,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     }
     m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -709,24 +706,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulPackageDeleted)
     }
     m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -830,7 +810,6 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulOsInserted)
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -997,24 +976,7 @@ TEST_F(EventDetailsBuilderTest, TestSuccessfulVulnerabilityStatus)
     }
     m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1198,24 +1160,7 @@ TEST_F(EventDetailsBuilderTest, TestNoSuccessfulVulnerabilityStatus)
     }
     m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1414,24 +1359,7 @@ void EventDetailsBuilderAdpTest::SetUp(const std::string& adp)
     }
     m_rocksDbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventInsertInventory_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventInsertInventory_test.cpp
@@ -61,6 +61,36 @@ namespace NSEventInsertInventoryTest
 
     const std::string CVEID1 {"CVE-2024-5678"};
     const std::string CVEID2 {"CVE-2023-5362"};
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
 } // namespace NSEventInsertInventoryTest
 
 using namespace NSEventInsertInventoryTest;
@@ -111,24 +141,7 @@ TEST_F(EventInsertInventoryTest, TestHandleRequestPackageInsertNonExisting)
         TEventInsertInventory<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>>(
         *m_inventoryDatabase);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -172,24 +185,7 @@ TEST_F(EventInsertInventoryTest, TestHandleRequestPackageInsertAlreadyExisting)
         TEventInsertInventory<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>>(
         *m_inventoryDatabase);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventPackageAlertDetailsBuilder_test.cpp
@@ -181,6 +181,36 @@ namespace NSEventPackageAlertDetailsBuilderTest
   }
         }
     )#"_json;
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
 } // namespace NSEventPackageAlertDetailsBuilderTest
 
 using namespace NSEventPackageAlertDetailsBuilderTest;
@@ -245,24 +275,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS2)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -442,24 +455,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -643,24 +639,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedDefault
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -747,24 +726,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedLessTha
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -851,24 +813,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageDeleted)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -989,24 +934,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestFailedInvalidOperation)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1088,24 +1016,7 @@ TEST_F(EventPackageAlertDetailsBuilderTest, TestSuccessfulPackageInsertedCVSS3Wi
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventSendReport_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventSendReport_test.cpp
@@ -28,8 +28,11 @@ auto constexpr TEST_REPORTS_QUEUE_PATH {"queue/vd/reports"};
 auto constexpr TEST_REPORTS_BULK_SIZE {1};
 auto constexpr TEST_REPORTS_THREADS_NUMBER {1};
 
-const std::string SYNC_STATE_MSG {
-    R"(
+namespace NSEventSendReportTest
+{
+
+    const std::string SYNC_STATE_MSG {
+        R"(
             {
                 "agent_info": {
                     "agent_id": "001",
@@ -62,8 +65,8 @@ const std::string SYNC_STATE_MSG {
             }
         )"};
 
-const std::string SYNC_STATE_ALERT {
-    R"(
+    const std::string SYNC_STATE_ALERT {
+        R"(
         {
             "vulnerability": {
                 "category": "Packages",
@@ -99,8 +102,8 @@ const std::string SYNC_STATE_ALERT {
         }
     )"};
 
-const std::string DELTA_DELETE_MSG {
-    R"(
+    const std::string DELTA_DELETE_MSG {
+        R"(
             {
                 "agent_info": {
                     "agent_id": "001",
@@ -128,8 +131,8 @@ const std::string DELTA_DELETE_MSG {
             }
     )"};
 
-const std::string DELTA_DELETE_ALERT {
-    R"(
+    const std::string DELTA_DELETE_ALERT {
+        R"(
             {
                 "vulnerability": {
                     "category": "Packages",
@@ -153,8 +156,8 @@ const std::string DELTA_DELETE_ALERT {
             }
         )"};
 
-const std::string DELTA_INSERT_OS {
-    R"({
+    const std::string DELTA_INSERT_OS {
+        R"({
           "agent_info": {
             "agent_id": "001",
             "agent_ip": "192.168.33.20",
@@ -177,8 +180,8 @@ const std::string DELTA_INSERT_OS {
           "operation": "INSERTED"
        })"};
 
-const std::string DELTA_UPDATE_HOTFIX {
-    R"({
+    const std::string DELTA_UPDATE_HOTFIX {
+        R"({
           "agent_info": {
             "agent_id": "001",
             "agent_ip": "192.168.33.20",
@@ -193,6 +196,40 @@ const std::string DELTA_UPDATE_HOTFIX {
           "operation":"MODIFIED"
         })"};
 
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
+
+} // namespace NSEventSendReportTest
+
+using namespace NSEventSendReportTest;
+
 TEST_F(EventSendReportTest, SendFormattedMsg)
 {
     // Mock report dispatcher.
@@ -202,24 +239,7 @@ TEST_F(EventSendReportTest, SendFormattedMsg)
                      MockReportDispatcher>
         sendReport(reportDispatcher);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -252,24 +272,7 @@ TEST_F(EventSendReportTest, InvalidEncodingValue)
                      MockReportDispatcher>
         sendReport(reportDispatcher);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -280,7 +283,7 @@ TEST_F(EventSendReportTest, InvalidEncodingValue)
     ASSERT_TRUE(parser.Parse(DELTA_DELETE_MSG.c_str()));
     const uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const SyscollectorSynchronization::SyncMsg*, const nlohmann::json*>
-        syscollectorSync = SyscollectorSynchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
+        syscollectorSync = SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
     auto scanContext =
         std::make_shared<TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>>(
             syscollectorSync);
@@ -303,24 +306,7 @@ TEST_F(EventSendReportTest, SendFormattedDeltaMsg)
                      MockReportDispatcher>
         sendReport(reportDispatcher);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -371,7 +357,6 @@ TEST_F(EventSendReportTest, SendFormattedDeltaMsgOS)
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     // Mock scanContext.
     flatbuffers::Parser parser;
@@ -400,24 +385,7 @@ TEST_F(EventSendReportTest, SendFormattedDeltaMsgHotfix)
                      MockReportDispatcher>
         sendReport(reportDispatcher);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/globalSyncInventory_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/globalSyncInventory_test.cpp
@@ -19,8 +19,10 @@
 
 using ::testing::_;
 
-const std::string SYNCHRONIZATION_INTEGRITY_GLOBAL_000_MSG =
-    R"(
+namespace NSGlobalSyncInventoryTest
+{
+    const std::string SYNCHRONIZATION_INTEGRITY_GLOBAL_000_MSG =
+        R"(
             {
                 "agent_info": {
                     "agent_id": "000",
@@ -35,8 +37,8 @@ const std::string SYNCHRONIZATION_INTEGRITY_GLOBAL_000_MSG =
             }
         )";
 
-const std::string SYNCHRONIZATION_INTEGRITY_GLOBAL_001_MSG =
-    R"(
+    const std::string SYNCHRONIZATION_INTEGRITY_GLOBAL_001_MSG =
+        R"(
             {
                 "agent_info": {
                     "agent_id": "001",
@@ -50,6 +52,40 @@ const std::string SYNCHRONIZATION_INTEGRITY_GLOBAL_001_MSG =
                 }
             }
         )";
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
+
+} // namespace NSGlobalSyncInventoryTest
+
+using namespace NSGlobalSyncInventoryTest;
 
 /**
  * @brief Test the sync message with the agent 000 and cluster enabled.
@@ -76,25 +112,6 @@ TEST_F(GlobalSyncInventoryTest, SyncMessageWithClusterEnabled)
     EXPECT_CALL(*spIndexerConnectorMock, sync("node01_000")).Times(1);
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
-
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
 
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
@@ -136,25 +153,6 @@ TEST_F(GlobalSyncInventoryTest, SyncMessageWithClusterEnabledWithoutNodeName)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
-
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(syscollector_synchronization_SCHEMA));
     ASSERT_TRUE(parser.Parse(SYNCHRONIZATION_INTEGRITY_GLOBAL_001_MSG.c_str()));
@@ -169,4 +167,6 @@ TEST_F(GlobalSyncInventoryTest, SyncMessageWithClusterEnabledWithoutNodeName)
 
     EXPECT_NO_THROW(spGlobalSyncInventory->handleRequest(scanContextOriginal));
     PolicyManager::instance().teardown();
+
+    spIndexerConnectorMock.reset();
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/osDataCache_test.cpp
@@ -23,9 +23,10 @@ TEST_F(OsDataCacheTest, TestSetAndGetSuccess)
         .WillOnce(testing::SetArgReferee<1>(nlohmann::json::object()));
 
     std::string agentId {"1"};
+    Os osDataRetrieved;
 
     // Try to get value from empty cache
-    EXPECT_THROW(cache.getOsData(agentId), WdbDataException);
+    EXPECT_THROW(cache.getOsData(agentId, osDataRetrieved), WdbDataException);
 
     // Set value in cache
     Os osData {.hostName = "hostName",
@@ -47,7 +48,8 @@ TEST_F(OsDataCacheTest, TestSetAndGetSuccess)
     cache.setOsData(agentId, osData);
 
     // Get value from cache
-    const auto osDataRetrieved = cache.getOsData(agentId);
+    const auto result = cache.getOsData(agentId, osDataRetrieved);
+    EXPECT_TRUE(result);
 
     // Verify that the returned value is the same as the one set
     ASSERT_EQ(osDataRetrieved.hostName, osData.hostName);
@@ -98,9 +100,11 @@ TEST_F(OsDataCacheTest, TestDbQuery)
         .WillOnce(testing::SetArgReferee<1>(response));
 
     std::string agentId {"1"};
+    Os osDataRetrieved;
 
     // Get value from cache
-    auto osDataRetrieved = cache.getOsData(agentId);
+    const auto result = cache.getOsData(agentId, osDataRetrieved);
+    EXPECT_FALSE(result);
 
     // Verify that the returned value is the one returned by the server
     ASSERT_EQ(osDataRetrieved.hostName, "hostName");
@@ -132,9 +136,10 @@ TEST_F(OsDataCacheTest, EmptyResponse)
         .WillOnce(testing::SetArgReferee<1>(queryResponse));
 
     std::string agentId {"1"};
+    Os osData;
 
     // Try to get value from empty cache
-    EXPECT_THROW(cache.getOsData(agentId), WdbDataException);
+    EXPECT_THROW(cache.getOsData(agentId, osData), WdbDataException);
 }
 
 TEST_F(OsDataCacheTest, UnrecoverableExceptionOnDB)
@@ -147,8 +152,9 @@ TEST_F(OsDataCacheTest, UnrecoverableExceptionOnDB)
         .WillOnce(testing::Throw(std::runtime_error("Error on DB")));
 
     std::string agentId {"1"};
+    Os osData;
 
-    EXPECT_THROW(cache.getOsData(agentId), std::runtime_error);
+    EXPECT_THROW(cache.getOsData(agentId, osData), std::runtime_error);
     spSocketDBWrapperMock.reset();
 }
 
@@ -162,7 +168,8 @@ TEST_F(OsDataCacheTest, RecoverableExceptionOnDB)
         .WillOnce(testing::Throw(SocketDbWrapperException("Warning on DB")));
 
     std::string agentId {"1"};
+    Os osData;
 
-    EXPECT_THROW(cache.getOsData(agentId), WdbDataException);
+    EXPECT_THROW(cache.getOsData(agentId, osData), WdbDataException);
     spSocketDBWrapperMock.reset();
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/packageScanner_test.cpp
@@ -398,6 +398,18 @@ namespace NSPackageScannerTest
     }
     )***"_json;
 
+    void expectOsData(const Os& osData)
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [&osData](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
+
 } // namespace NSPackageScannerTest
 
 using namespace NSPackageScannerTest;
@@ -464,8 +476,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualTo)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -563,8 +574,7 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedEqualTo)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -652,8 +662,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThan)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -751,8 +760,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMissing)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -840,8 +848,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMismatch)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -929,8 +936,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanVendorMatch)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1028,8 +1034,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanOrEqual)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1127,8 +1132,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedLessThanWithVersionNotZero)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1226,8 +1230,7 @@ TEST_F(PackageScannerTest, TestPackageUnaffectedLessThan)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1315,8 +1318,7 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusAffected)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1413,8 +1415,7 @@ TEST_F(PackageScannerTest, TestPackageDefaultStatusUnaffected)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1476,8 +1477,7 @@ TEST_F(PackageScannerTest, TestPackageGetVulnerabilitiesCandidatesGeneratesExcep
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1529,8 +1529,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlma8)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1577,8 +1576,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas1)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1625,8 +1623,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1673,8 +1670,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToAlas2022)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1721,8 +1717,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToRedHat7)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1769,8 +1764,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLED)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1817,8 +1811,7 @@ TEST_F(PackageScannerTest, TestPackageAffectedEqualToSLES)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1901,8 +1894,7 @@ TEST_F(PackageScannerTest, TestGetTranslationFromL2)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2003,8 +1995,7 @@ TEST_F(PackageScannerTest, TestVersionTranslation)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2108,8 +2099,7 @@ TEST_F(PackageScannerTest, TestVendorTranslation)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2212,8 +2202,7 @@ TEST_F(PackageScannerTest, TestVendorAndVersionTranslation)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2280,8 +2269,7 @@ TEST_F(PackageScannerTest, TestGetCnaNameByPrefix)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2330,8 +2318,7 @@ TEST_F(PackageScannerTest, TestGetCnaNameByContains)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2381,8 +2368,7 @@ TEST_F(PackageScannerTest, TestGetCnaNameBySource)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2432,8 +2418,7 @@ TEST_F(PackageScannerTest, TestGetDefaultCna)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2524,8 +2509,7 @@ TEST_F(PackageScannerTest, TestDefaultCnaArrayFirstCnaMatch)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2631,8 +2615,7 @@ TEST_F(PackageScannerTest, TestDefaultCnaArraySecondCnaMatch)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2738,8 +2721,7 @@ TEST_F(PackageScannerTest, TestDefaultCnaArrayMixedCnaMatch)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2838,8 +2820,7 @@ TEST_F(PackageScannerTest, TestDefaultCnaArrayOnlyOneValue)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -2898,8 +2879,7 @@ TEST_F(PackageScannerTest, TestDefaultCnaArrayEmpty)
                .kernelVersion = "osdata_kernelVersion",
                .kernelRelease = "osdata_kernelRelease"};
 
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData(osData);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/resultIndexer_test.cpp
@@ -59,6 +59,36 @@ namespace NSResultIndexerTest
         )";
 
     const std::string CVEID {"CVE-2024-1234"};
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
 } // namespace NSResultIndexerTest
 
 using namespace NSResultIndexerTest;
@@ -86,24 +116,7 @@ TEST_F(ResultIndexerTest, TestHandleRequest)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -136,24 +149,7 @@ TEST_F(ResultIndexerTest, TestHandleRequestNoOperation)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -186,24 +182,7 @@ TEST_F(ResultIndexerTest, TestHandleRequestNoId)
 
     auto pIndexerConnectorTrap = std::make_shared<TrampolineIndexerConnector>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
@@ -20,16 +20,53 @@
 using testing::_;
 using TrampolineScanContext = TScanContext<TrampolineOsDataCache, GlobalData, TrampolineRemediationDataCache>;
 
-const std::string EXPECTED_QUERY_PACKAGE {"agent 001 package get "};
-const std::string EXPECTED_QUERY_OS {"agent 001 osinfo get "};
-const std::string EXPECTED_QUERY_MANAGER {"agent 0 package get "};
-const std::string PACKAGES_RESPONSE {
-    R"([{"architecture":"x86_64","checksum":"qwerty","description":"Web Browser","format":"deb","groups":"","install_time":"02/22/2024 00:00:00","item_id":"ytrewq","location":"","multiarch":"","name":"Firefox","priority":"","scan_time":"02/21/2024 00:00:00","size":0,"source":"","vendor":"canonical","version":"122.0.1"},{"architecture":"x86_64","checksum":"asdfgh","description":"Text editor","format":"deb","groups":"","install_time":"02/22/2024 00:00:00","item_id":"hgfdsa","location":"","multiarch":"","name":"Neovim","priority":"","scan_time":"02/21/2024 00:00:00","size":0,"source":"","vendor":"canonical","version":"0.9.5"}])"};
+namespace NSScanAgentListTest
+{
 
-const std::string OS_RESPONSE {
-    R"([{"checksum":"qwerty","hostname":"osdata_hostname","os_build":"osdata_build","os_codename":"upstream","os_display_version":"osdata_displayVersion","os_major":"osdata_majorVersion","os_minor":"osdata_minorVersion","os_name":"osdata_name","os_patch":"osdata_patch","os_platform":"osdata_platform","os_release":"osdata_release","os_version":"osdata_version","release":"osdata_release","scan_time":"02/21/2024 00:00:00","sysname":"osdata_sysName","version":"osdata_version"}])"};
+    const std::string EXPECTED_QUERY_PACKAGE {"agent 001 package get "};
+    const std::string EXPECTED_QUERY_OS {"agent 001 osinfo get "};
+    const std::string EXPECTED_QUERY_MANAGER {"agent 0 package get "};
+    const std::string PACKAGES_RESPONSE {
+        R"([{"architecture":"x86_64","checksum":"qwerty","description":"Web Browser","format":"deb","groups":"","install_time":"02/22/2024 00:00:00","item_id":"ytrewq","location":"","multiarch":"","name":"Firefox","priority":"","scan_time":"02/21/2024 00:00:00","size":0,"source":"","vendor":"canonical","version":"122.0.1"},{"architecture":"x86_64","checksum":"asdfgh","description":"Text editor","format":"deb","groups":"","install_time":"02/22/2024 00:00:00","item_id":"hgfdsa","location":"","multiarch":"","name":"Neovim","priority":"","scan_time":"02/21/2024 00:00:00","size":0,"source":"","vendor":"canonical","version":"0.9.5"}])"};
 
-const std::string RESPONSE_EMPTY {R"([])"};
+    const std::string OS_RESPONSE {
+        R"([{"checksum":"qwerty","hostname":"osdata_hostname","os_build":"osdata_build","os_codename":"upstream","os_display_version":"osdata_displayVersion","os_major":"osdata_majorVersion","os_minor":"osdata_minorVersion","os_name":"osdata_name","os_patch":"osdata_patch","os_platform":"osdata_platform","os_release":"osdata_release","os_version":"osdata_version","release":"osdata_release","scan_time":"02/21/2024 00:00:00","sysname":"osdata_sysName","version":"osdata_version"}])"};
+
+    const std::string RESPONSE_EMPTY {R"([])"};
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "upstream",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
+
+} // namespace NSScanAgentListTest
+
+using namespace NSScanAgentListTest;
 
 TEST_F(ScanAgentListTest, SingleDeleteAndInsertTest)
 {
@@ -52,7 +89,14 @@ TEST_F(ScanAgentListTest, SingleDeleteAndInsertTest)
                .kernelRelease = "osdata_kernelRelease"};
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+        .Times(2)
+        .WillRepeatedly(testing::Invoke(
+            [&osData](const std::string&, Os& osDataResult)
+            {
+                osDataResult = osData;
+                return true;
+            }));
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
@@ -114,7 +158,6 @@ TEST_F(ScanAgentListTest, EmptyPackagesWDBResponseTest)
                .kernelRelease = "osdata_kernelRelease"};
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
     EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
@@ -126,7 +169,6 @@ TEST_F(ScanAgentListTest, EmptyPackagesWDBResponseTest)
 
     auto spOsOrchestrationMock = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineScanContext>>>();
 
-    // Called twice because the server socket response has two packages.
     EXPECT_CALL(*spPackageInsertOrchestrationMock, handleRequest(testing::_)).Times(0);
 
     EXPECT_CALL(*spOsOrchestrationMock, handleRequest(testing::_)).Times(1);
@@ -159,25 +201,6 @@ TEST_F(ScanAgentListTest, EmptyPackagesWDBResponseTest)
 TEST_F(ScanAgentListTest, MutipleRecoverableExceptions)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
-
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "upstream",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(testing::_))
@@ -218,25 +241,6 @@ TEST_F(ScanAgentListTest, OneRecoverableException)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "upstream",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
-
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(testing::_))
         .WillRepeatedly(testing::Return(Remediation {}));
@@ -274,25 +278,6 @@ TEST_F(ScanAgentListTest, OneRecoverableException)
 TEST_F(ScanAgentListTest, UnrecoverableException)
 {
     spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
-
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "upstream",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(testing::_))
@@ -351,7 +336,13 @@ TEST_F(ScanAgentListTest, DISABLED_InsertAllTestNotSyncedResponse)
                .kernelRelease = "osdata_kernelRelease"};
 
     spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(testing::_)).WillRepeatedly(testing::Return(osData));
+    EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+        .WillOnce(testing::Invoke(
+            [&osData](const std::string&, Os& osDataResult)
+            {
+                osDataResult = osData;
+                return true;
+            }));
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(testing::_))

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
@@ -274,6 +274,36 @@ namespace NSScanContextTest
                 }
             }
         )";
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    // Helpers
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
 } // namespace NSScanContextTest
 
 using namespace NSScanContextTest;
@@ -292,24 +322,7 @@ const char* ScanContextTest::fbStringGetHelper(const flatbuffers::String* pStr)
 
 TEST_F(ScanContextTest, TestSyscollectorDeltasPackagesInserted)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillOnce(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -413,24 +426,7 @@ TEST_F(ScanContextTest, TestSyscollectorDeltasPackagesInserted)
 
 TEST_F(ScanContextTest, TestSyscollectorDeltasPackagesDeleted)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillOnce(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -626,24 +622,7 @@ TEST_F(ScanContextTest, TestSyscollectorDeltasOsInfo)
 
 TEST_F(ScanContextTest, TestSyscollectorDeltasHotfixesInserted)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillOnce(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -694,24 +673,7 @@ TEST_F(ScanContextTest, TestSyscollectorDeltasHotfixesInserted)
 
 TEST_F(ScanContextTest, TestSyscollectorDeltasHotfixesDeleted)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillOnce(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -883,24 +845,7 @@ TEST_F(ScanContextTest, TestSyscollectorSynchronizationStateOsInfo)
 
 TEST_F(ScanContextTest, TestSyscollectorSynchronizationStatePackages)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillOnce(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -1023,24 +968,7 @@ TEST_F(ScanContextTest, TestSyscollectorSynchronizationStatePackages)
 
 TEST_F(ScanContextTest, TestSyscollectorSynchronizationStateHotfixes)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillOnce(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -177,6 +177,36 @@ namespace NSScanOrchestratorTest
             }
         )";
 
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, getOsData(_, _))
+            .WillOnce(testing::Invoke(
+                [](const std::string&, Os& osDataResult)
+                {
+                    osDataResult = osData;
+                    return true;
+                }));
+    }
+
 } // namespace NSScanOrchestratorTest
 
 // Shared pointers definitions
@@ -200,24 +230,7 @@ void ScanOrchestratorTest::TearDown()
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -323,24 +336,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsert)
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -446,24 +442,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageDelete)
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -570,24 +549,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixInsert)
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypeHotfixDelete)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -799,25 +761,6 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeOs)
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
-
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
 
@@ -925,24 +868,7 @@ TEST_F(ScanOrchestratorTest, TestRunScannerTypeIntegrityClear)
 
 TEST_F(ScanOrchestratorTest, TestRunScannerTypePackageInsertInDelayed)
 {
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOsAlertDetailsBuilder_test.cpp
@@ -142,6 +142,31 @@ namespace NSScanOsAlertDetailsBuilderTest
   }
         }
     )#"_json;
+
+    // Helpers
+
+    const Os osData {.hostName = "osdata_hostname",
+                     .architecture = "osdata_architecture",
+                     .name = "osdata_name",
+                     .codeName = "osdata_codeName",
+                     .majorVersion = "osdata_majorVersion",
+                     .minorVersion = "osdata_minorVersion",
+                     .patch = "osdata_patch",
+                     .build = "osdata_build",
+                     .platform = "osdata_platform",
+                     .version = "osdata_version",
+                     .release = "osdata_release",
+                     .displayVersion = "osdata_displayVersion",
+                     .sysName = "osdata_sysName",
+                     .kernelVersion = "osdata_kernelVersion",
+                     .kernelRelease = "osdata_kernelRelease"};
+
+    void expectOsData()
+    {
+        spOsDataCacheMock = std::make_shared<MockOsDataCache>();
+        EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
+    }
+
 } // namespace NSScanOsAlertDetailsBuilderTest
 
 // Shared pointers definitions
@@ -211,25 +236,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertAffects)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -344,25 +351,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestVulnerabilityCvss2)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -477,25 +466,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestSuccessfulScanOsAlertWasSolved)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -610,25 +581,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestFirstScanNoAlerts)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
@@ -716,25 +669,7 @@ TEST_F(ScanOsAlertDetailsBuilderTest, TestUnknownOperation)
     }
     dbWrapper->put(CVEID, dbValue, DESCRIPTIONS_COLUMN_DEFAULT);
 
-    Os osData {.hostName = "osdata_hostname",
-               .architecture = "osdata_architecture",
-               .name = "osdata_name",
-               .codeName = "osdata_codeName",
-               .majorVersion = "osdata_majorVersion",
-               .minorVersion = "osdata_minorVersion",
-               .patch = "osdata_patch",
-               .build = "osdata_build",
-               .platform = "osdata_platform",
-               .version = "osdata_version",
-               .release = "osdata_release",
-               .displayVersion = "osdata_displayVersion",
-               .sysName = "osdata_sysName",
-               .kernelVersion = "osdata_kernelVersion",
-               .kernelRelease = "osdata_kernelRelease"};
-
-    spOsDataCacheMock = std::make_shared<MockOsDataCache>();
-    EXPECT_CALL(*spOsDataCacheMock, setOsData(_, _)).Times(1);
-    EXPECT_CALL(*spOsDataCacheMock, getOsData(_)).WillRepeatedly(testing::Return(osData));
+    expectOsData();
 
     spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
     EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28279 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR updates the OS data cache class to:
- Inform the caller if the data comes from `wazuh-db` or not
- Avoids updating the cache for each get call

And now the `scanContext` class:
- Considers the source of data and builds the OS CPE in all required cases

UT updated, many of them had errors that had to be fixed.