### PR TITLE
Syntax highlight .conf files as XML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+etc/*.conf linguist-language=XML


### PR DESCRIPTION
|Related issue|
|---|
| #16660 |

## Description

Display .conf file as XML here on GitHub

https://github.com/github/linguist/blob/master/docs/overrides.md#summary

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities
