### PR TITLE
Improve commands task error handling

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -21,6 +21,7 @@ select = [
 ignore = [
     "F405", # Star imports
     "D100", # Module comment
+    "D104", # Public package comment
     "D107", # Init docstring
     "D203", # Blank line before docstring
     "D204", # Blank line after docstring

--- a/framework/wazuh/core/config/models/ssl_config.py
+++ b/framework/wazuh/core/config/models/ssl_config.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from pathlib import Path
 from typing import List
 
 from pydantic import Field, ValidationInfo, field_validator
@@ -86,7 +87,7 @@ class IndexerSSLConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
     certificate: str = ''
     certificate_authorities: List[str] = Field(default=[''], min_length=1, exclude=True)
     verify_certificates: bool = True
-    certificate_authorities_bundle: str = WAZUH_INDEXER_CA_BUNDLE
+    certificate_authorities_bundle: Path = WAZUH_INDEXER_CA_BUNDLE
 
     @field_validator('key', 'certificate')
     @classmethod

--- a/framework/wazuh/core/indexer/__init__.py
+++ b/framework/wazuh/core/indexer/__init__.py
@@ -101,10 +101,10 @@ class Indexer(MixinBulk):
         logger.debug('Connecting to the indexer client.')
         try:
             return await self._client.info()
+        except (ConnectionError, TransportError) as e:
+            raise WazuhIndexerError(2200, extra_message=e.error)
         except ssl.SSLError as e:
             raise WazuhIndexerError(2200, extra_message=e.reason)
-        except TransportError as e:
-            raise WazuhIndexerError(2200, extra_message=e.error)
         except ImproperlyConfigured as e:
             raise WazuhIndexerError(2200, extra_message=f'{e}. Check your indexer configuration and SSL certificates')
 

--- a/framework/wazuh/core/indexer/commands.py
+++ b/framework/wazuh/core/indexer/commands.py
@@ -84,7 +84,11 @@ class CommandsManager(BaseIndex):
         query = AsyncSearch(using=self._client, index=self.INDEX).filter(
             {IndexerKey.TERM: {f'{COMMAND_KEY}.{IndexerKey.STATUS}': status.value}}
         )
-        response = await query.execute()
+
+        try:
+            response = await query.execute()
+        except (exceptions.RequestError, exceptions.TransportError) as e:
+            raise WazuhError(1761, extra_message=str(e))
 
         commands = []
         for hit in response:

--- a/framework/wazuh/core/task/order.py
+++ b/framework/wazuh/core/task/order.py
@@ -4,7 +4,7 @@ from dataclasses import asdict
 import httpx
 from wazuh.core import common
 from wazuh.core.engine.base import APPLICATION_JSON
-from wazuh.core.exception import WazuhIndexerError
+from wazuh.core.exception import WazuhError, WazuhIndexerError
 from wazuh.core.indexer import get_indexer_client
 from wazuh.core.indexer.models.commands import Status
 from wazuh.core.indexer.utils import convert_enums
@@ -63,5 +63,5 @@ async def get_orders(logger: WazuhLogger):
                         order_ids=processed_commands_ids, status=Status.SENT.value
                     )
 
-        except (httpx.ConnectError, httpx.TimeoutException, WazuhIndexerError) as e:
-            logger.error(f'Failed sending the orders to the Communications API: {str(e)}')
+        except (httpx.ConnectError, httpx.TimeoutException, WazuhError, WazuhIndexerError) as e:
+            logger.error(f'Failed sending orders to the Communications API: {str(e)}', exc_info=False)


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/28159 |

## Description

Improves the error handling of the commands (orders) task by capturing other potential exceptions and excluding the stack trace from the error log.

## Tests

<details><summary>Logs</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ docker logs -f wazuh-manager
2025/02/20 14:47:35 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2025/02/20 14:47:35 DEBUG: [Cluster] [Main] Nothing to remove in '/run/wazuh-server/cluster/'.
2025/02/20 14:47:35 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
2025/02/20 14:47:35 INFO: [Cluster] [Main] Starting server (pid: 12)
2025/02/20 14:47:35 WARNING: [Cluster] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': False, 'wazuh-engined': False}. Sleeping until next checking...
2025/02/20 14:47:35 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/02/20 14:47:35 INFO: [Master] [Config Server] Started server process [12]
2025/02/20 14:47:35 INFO: [Master] [Config Server] Waiting for application startup.
2025/02/20 14:47:35 INFO: [Master] [Config Server] Application startup complete.
2025/02/20 14:47:35 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/02/20 14:47:36 INFO: [Local Server] [Main] Starting wazuh-engined
2025-02-20 14:47:36.696 18:18 info: Logging initialized.
2025/02/20 14:47:36 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
...
2025/02/20 14:47:38 INFO: [Local Server] [Main] Started wazuh-engined (pid: 18)
2025/02/20 14:47:38 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/02/20 14:47:40 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 74)
2025/02/20 14:47:40 INFO: [Local Server] [Main] Starting wazuh-server-management-apid
2025/02/20 14:47:42 INFO: [Local Server] [Main] Started wazuh-server-management-apid (pid: 88)
2025/02/20 14:47:46 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/02/20 14:47:46 DEBUG: [Local Server] [Keep alive] Calculating.
2025/02/20 14:47:46 DEBUG: [Local Server] [Keep alive] Calculated.
2025/02/20 14:47:46 INFO: [Communications API] Starting API
2025/02/20 14:47:46 INFO: [Cluster] [Main] Getting orders from indexer
2025/02/20 14:47:46 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/02/20 14:47:46 WARNING: [Cluster] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': False, 'wazuh-engined': True}. Sleeping until next checking...
2025/02/20 14:47:46 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2025/02/20 14:47:46 DEBUG: [Master] [Keep alive] Calculating.
2025/02/20 14:47:46 DEBUG: [Master] [Keep alive] Calculated.
2025/02/20 14:47:46 INFO: [Master] [Local integrity] Starting.
2025/02/20 14:47:46 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/02/20 14:47:46 WARNING: [Cluster] [Main] Cannot initialize the indexer client.
2025/02/20 14:47:46 INFO: [Cluster] [Main] Sleeping 1.9141061089948286s until next try.
2025/02/20 14:47:46 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/02/20 14:47:46 INFO: [Communications API] Generated private key file in /etc/wazuh-server/certs/api-key.pem
2025/02/20 14:47:46 INFO: [Communications API] Generated certificate file in /etc/wazuh-server/certs/api.pem
2025/02/20 14:47:46 INFO: [Communications API] Starting gunicorn 22.0.0
2025/02/20 14:47:46 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (74)
2025/02/20 14:47:46 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/02/20 14:47:46 INFO: [Communications API] Booting worker with pid: 125
2025/02/20 14:47:46 INFO: [Communications API] Started server process [125]
2025/02/20 14:47:46 INFO: [Communications API] Waiting for application startup.
2025/02/20 14:47:46 INFO: [Communications API] Booting worker with pid: 126
2025/02/20 14:47:46 INFO: [Communications API] Application startup complete.
2025/02/20 14:47:46 INFO: [Communications API] Started server process [126]
2025/02/20 14:47:46 INFO: [Communications API] Waiting for application startup.
2025/02/20 14:47:46 INFO: [Communications API] Application startup complete.
2025/02/20 14:47:46 INFO: [Communications API] Booting worker with pid: 127
2025/02/20 14:47:46 INFO: [Communications API] Started server process [127]
2025/02/20 14:47:46 INFO: [Communications API] Waiting for application startup.
2025/02/20 14:47:46 INFO: [Communications API] Application startup complete.
2025/02/20 14:47:46 INFO: [Management API] Starting API
2025/02/20 14:47:46 INFO: [Management API] Checking RBAC database integrity...
2025/02/20 14:47:46 INFO: [Management API] RBAC database not found. Initializing
2025/02/20 14:47:46 INFO: [Communications API] Booting worker with pid: 128
2025/02/20 14:47:46 INFO: [Communications API] Started server process [128]
2025/02/20 14:47:46 INFO: [Communications API] Waiting for application startup.
2025/02/20 14:47:46 INFO: [Communications API] Application startup complete.
2025/02/20 14:47:48 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/02/20 14:47:48 WARNING: [Cluster] [Main] Cannot initialize the indexer client.
2025/02/20 14:47:48 INFO: [Cluster] [Main] Sleeping 2.5236218873422565s until next try.
2025/02/20 14:47:50 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/02/20 14:47:50 WARNING: [Cluster] [Main] Cannot initialize the indexer client.
2025/02/20 14:47:50 INFO: [Cluster] [Main] Sleeping 4.365350630496084s until next try.
2025/02/20 14:47:54 INFO: [Master] [Local integrity] Starting.
2025/02/20 14:47:54 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
2025/02/20 14:47:55 DEBUG: [Cluster] [Main] Connecting to the indexer client.
2025/02/20 14:47:55 DEBUG: [Cluster] [Main] Closing the indexer client session.
2025/02/20 14:47:55 ERROR: [Cluster] [Main] Failed sending orders to the Communications API: Error 2200 - Could not connect to the indexer: Cannot connect to host wazuh-indexer:9200 ssl:default [Connect call failed ('172.18.0.2', 9200)]
2025/02/20 14:47:56 WARNING: [Cluster] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': True, 'wazuh-engined': True}. Sleeping until next checking...
```

</details>

<details><summary>Unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/indexer/tests/test_commands.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 10 items                                                                                                                                                                                                                           

framework/wazuh/core/indexer/tests/test_commands.py ..........                                                                                                                                                                         [100%]

============================================================================================================= 10 passed in 0.51s =============================================================================================================
(venv) gasti@gasti:~/work/wazuh$ pytest framework/wazuh/core/task/tests/test_order.py --disable-warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 12 items                                                                                                                                                                                                                           

framework/wazuh/core/task/tests/test_order.py ............                                                                                                                                                                             [100%]

============================================================================================================= 12 passed in 0.46s =============================================================================================================
```

</details>