### PR TITLE
Improve agent connectivity

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -17,8 +17,6 @@
     #define STATIC
     #ifdef WIN32
             #include "unit_tests/wrappers/wazuh/client-agent/start_agent.h"
-            #undef CloseSocket
-            #define CloseSocket wrap_closesocket
             #define recv wrap_recv
     #endif
 
@@ -53,7 +51,7 @@ bool connect_server(int server_id, bool verbose)
 
     /* Close socket if available */
     if (agt->sock >= 0) {
-        CloseSocket(agt->sock);
+        OS_CloseSocket(agt->sock);
         agt->sock = -1;
 
         if (agt->server[agt->rip_id].rip) {

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -180,6 +180,11 @@ void start_agent(int is_startup)
         } else {
             current_server_id = 0;
             mwarn("Unable to connect to any server.");
+            if (!is_startup && agt->flags.auto_restart) {
+                minfo("Agent is restarting because there may be a problem with the previous connection.");
+                restartAgent();
+                sleep(10);
+            }
         }
     }
 }

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -152,10 +152,6 @@ typedef uint8_t u_int8_t;
 typedef int sock2len_t;
 #endif
 
-#ifndef WIN32
-#define CloseSocket(x) shutdown(x, SHUT_RDWR); close(x)
-#endif
-
 #ifdef WIN32
 typedef int uid_t;
 typedef int gid_t;
@@ -163,7 +159,6 @@ typedef int socklen_t;
 #define sleep(x) Sleep((x) * 1000)
 #define srandom(x) srand(x)
 #define lstat(x,y) stat(x,y)
-#define CloseSocket(x) shutdown(x, SD_BOTH); closesocket(x)
 void WinSetError();
 typedef uint32_t u_int32_t;
 typedef uint16_t u_int16_t;

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -153,7 +153,7 @@ typedef int sock2len_t;
 #endif
 
 #ifndef WIN32
-#define CloseSocket(x) close(x)
+#define CloseSocket(x) shutdown(x, SHUT_RDWR); close(x)
 #endif
 
 #ifdef WIN32
@@ -163,7 +163,7 @@ typedef int socklen_t;
 #define sleep(x) Sleep((x) * 1000)
 #define srandom(x) srand(x)
 #define lstat(x,y) stat(x,y)
-#define CloseSocket(x) closesocket(x)
+#define CloseSocket(x) shutdown(x, SD_BOTH); closesocket(x)
 void WinSetError();
 typedef uint32_t u_int32_t;
 typedef uint16_t u_int16_t;

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -39,23 +39,23 @@ set(START_AGENT_BASE_FLAGS "-Wl,--wrap,w_rotate_log -Wl,--wrap,getDefine_Int -Wl
                             -Wl,--wrap,fprintf -Wl,--wrap,fflush -Wl,--wrap,ReadSecMSG -Wl,--wrap,wnet_select \
                             -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_SendUDPbySize -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS} \
                             -Wl,--wrap,w_calloc_expression_t -Wl,--wrap,w_expression_compile -Wl,--wrap,w_expression_match \
-                            -Wl,--wrap,w_free_expression_t")
+                            -Wl,--wrap,w_free_expression_t -Wl,--wrap,OS_CloseSocket")
 if(${TARGET} STREQUAL "winagent")
     list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS} -Wl,--wrap,os_random -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck")
 else()
-    list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS} -Wl,--wrap=close")
+    list(APPEND client-agent_flags "${START_AGENT_BASE_FLAGS}")
 endif()
 
 list(APPEND client-agent_names "test_notify")
 if(${TARGET} STREQUAL "winagent")
-list(APPEND client-agent_flags "-Wl,--wrap,control_check_connection,--wrap,OS_SendUnix,--wrap,OS_RecvUnix,--wrap,close \
+list(APPEND client-agent_flags "-Wl,--wrap,control_check_connection,--wrap,OS_SendUnix,--wrap,OS_RecvUnix \
                                 -Wl,--wrap,strftime -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck \
                                 -Wl,--wrap=is_fim_shutdown -Wl,--wrap=fim_db_teardown \
                                 -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize \
                                 -Wl,--wrap=getsockname -Wl,--wrap,get_ipv4_string -Wl,--wrap,get_ipv6_string \
                                 -Wl,--wrap,sleep,--wrap,w_rotate_log,--wrap,getpid,--wrap,time ${DEBUG_OP_WRAPPERS}")
 else()
-list(APPEND client-agent_flags "-Wl,--wrap,control_check_connection,--wrap,OS_SendUnix,--wrap,OS_RecvUnix,--wrap,close \
+list(APPEND client-agent_flags "-Wl,--wrap,control_check_connection,--wrap,OS_SendUnix,--wrap,OS_RecvUnix \
                                 -Wl,--wrap=getsockname -Wl,--wrap,get_ipv4_string -Wl,--wrap,get_ipv6_string \
                                 -Wl,--wrap,sleep,--wrap,w_rotate_log,--wrap,getpid,--wrap,time ${DEBUG_OP_WRAPPERS}")
 endif()

--- a/src/unit_tests/os_net/test_os_net.c
+++ b/src/unit_tests/os_net/test_os_net.c
@@ -132,6 +132,7 @@ void test_connect_TCP_ipv4(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 4);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);
@@ -144,6 +145,7 @@ void test_connect_TCP_ipv6(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 3);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);
@@ -156,6 +158,7 @@ void test_connect_TCP_ipv6_link_local_no_interface(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 3);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);
@@ -170,6 +173,7 @@ void test_connect_TCP_ipv6_link_local_with_interface(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 3);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);
@@ -320,6 +324,7 @@ void test_connect_UDP_ipv4(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 4);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);
@@ -332,6 +337,7 @@ void test_connect_UDP_ipv6(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 4);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);
@@ -344,6 +350,7 @@ void test_connect_UDP_ipv6_link_local_no_interface(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 3);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);
@@ -358,6 +365,7 @@ void test_connect_UDP_ipv6_link_local_with_interface(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
 
     will_return(__wrap_socket, 3);
+    will_return(__wrap_bind, 0);
     will_return(__wrap_connect, 0);
     will_return(__wrap_getsockopt, 0);
     will_return(__wrap_getsockopt, 0);

--- a/src/unit_tests/wrappers/wazuh/client-agent/start_agent.c
+++ b/src/unit_tests/wrappers/wazuh/client-agent/start_agent.c
@@ -15,11 +15,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-int wrap_closesocket(int fd) {
-    check_expected(fd);
-    return 0;
-}
-
 ssize_t wrap_recv(__attribute__((unused)) int __fd, __attribute__((unused)) void *__buf,
                   __attribute__((unused)) size_t __n, __attribute__((unused)) int __flags) {
     char* rcv = (char*) mock_ptr_type(char*);

--- a/src/unit_tests/wrappers/wazuh/client-agent/start_agent.h
+++ b/src/unit_tests/wrappers/wazuh/client-agent/start_agent.h
@@ -9,9 +9,6 @@
 #ifndef UNIT_TEST_START_AGENT
 #define UNIT_TEST_START_AGENT
 
-int wrap_closesocket(int fd);
-
 ssize_t wrap_recv(int __fd, void *__buf, size_t __n, int __flags);
-
 
 #endif

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -125,11 +125,6 @@ int __wrap_wnet_select(__attribute__((unused)) int sock,
     return (int)mock();
 }
 
-int __wrap_OS_CloseSocket(int sock) {
-    check_expected(sock);
-    return mock();
-}
-
 uint32_t __wrap_wnet_order(uint32_t value) {
     check_expected(value);
     return mock();
@@ -215,5 +210,10 @@ int __wrap_OS_RecvSecureClusterTCP(int sock, char *ret, size_t length) {
 
     strncpy(ret, mock_type(char*), length);
 
+    return mock();
+}
+
+int __wrap_OS_CloseSocket(int sock) {
+    check_expected(sock);
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
@@ -65,4 +65,7 @@ int __wrap_get_ipv6_string(struct in6_addr addr6, char *address, size_t address_
 int __wrap_OS_SendSecureTCPCluster(int sock, const void *command, const void *payload, size_t length);
 
 int __wrap_OS_RecvSecureClusterTCP(int sock, char *ret, size_t length);
+
+int __wrap_OS_CloseSocket(int sock);
+
 #endif


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28338|

## Description

This PR includes the following improvements in agents connectivity:

- Add `shutdown()` before closing the socket.
- Implement proper ephemeral port selection.
- Implement Agent Auto-Restart Mechanism.
  - This only happens if it is not a startup and the agent has already exhausted all connection attempts.
  - Also, the [auto_restart](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html#auto-restart) setting has to be enabled (by default).

## Results and Evidence

Linux with `auto-restart`:

<details>

```
2025/02/20 17:47:39 wazuh-agentd: INFO: Using AES as encryption method.
2025/02/20 17:47:39 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:47:39 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.0.236]:1514/tcp).
2025/02/20 17:47:40 wazuh-syscheckd: INFO: Started (pid: 469156).
...
2025/02/20 17:47:40 wazuh-logcollector: INFO: Started (pid: 469167).
2025/02/20 17:47:45 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2025/02/20 17:47:45 wazuh-modulesd: INFO: Started (pid: 469194).
2025/02/20 17:47:45 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2025/02/20 17:47:45 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/02/20 17:47:45 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/02/20 17:47:45 sca: INFO: Module started.
2025/02/20 17:47:45 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:47:45 sca: INFO: Starting Security Configuration Assessment scan.
2025/02/20 17:47:45 wazuh-modulesd:control: INFO: Starting control thread.
2025/02/20 17:47:45 wazuh-modulesd:syscollector: INFO: Module started.
2025/02/20 17:47:45 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/02/20 17:47:45 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:47:45 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2025/02/20 17:47:46 wazuh-syscheckd: INFO: FIM sync module started.
2025/02/20 17:47:46 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/02/20 17:47:51 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:47:51 sca: INFO: Security Configuration Assessment scan finished. Duration: 6 seconds.
2025/02/20 17:48:09 rootcheck: INFO: Ending rootcheck scan.
2025/02/20 17:49:10 wazuh-agentd: WARNING: Server unavailable. Setting lock.
2025/02/20 17:49:10 wazuh-agentd: INFO: Closing connection to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:49:10 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:49:29 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:49:39 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:49:42 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:49:52 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:49:55 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:50:05 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:50:08 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:50:18 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:50:21 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:50:21 wazuh-agentd: INFO: Requesting a key from server: 192.168.0.236
2025/02/20 17:50:24 wazuh-agentd: ERROR: (1208): Unable to connect to enrollment service at '[192.168.0.236]:1515'
2025/02/20 17:50:34 wazuh-agentd: WARNING: (4101): Waiting for server reply (not started). Tried: '192.168.0.236'. Ensure that the manager version is 'v4.11.1' or higher.
2025/02/20 17:50:34 wazuh-agentd: WARNING: Unable to connect to any server.
2025/02/20 17:50:34 wazuh-agentd: INFO: Agent is restarting because there may be a problem with the previous connection.
2025/02/20 17:50:34 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/02/20 17:50:34 wazuh-modulesd:syscollector: INFO: Module finished.
2025/02/20 17:50:35 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/02/20 17:50:35 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2025/02/20 17:50:35 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/02/20 17:50:35 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/02/20 17:50:35 wazuh-agentd: WARNING: (1218): Unable to send message to 'server': Success
2025/02/20 17:50:36 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2025/02/20 17:50:36 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/02/20 17:50:37 wazuh-execd: INFO: Started (pid: 470153).
2025/02/20 17:50:38 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2025/02/20 17:50:38 wazuh-agentd: INFO: Using notify time: 10 and max time to reconnect: 60
2025/02/20 17:50:38 wazuh-agentd: INFO: Version detected -> Linux |vagrant |5.15.0-83-generic |#92-Ubuntu SMP Mon Aug 14 09:30:42 UTC 2023 |x86_64 [Ubuntu|ubuntu: 22.04.3 LTS (Jammy Jellyfish)] - Wazuh v4.11.1
2025/02/20 17:50:38 wazuh-agentd: INFO: Started (pid: 470164).
2025/02/20 17:50:38 wazuh-agentd: INFO: Using AES as encryption method.
2025/02/20 17:50:38 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:50:39 wazuh-syscheckd: INFO: Started (pid: 470176).
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6000): Starting daemon...
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 3600 seconds
2025/02/20 17:50:39 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2025/02/20 17:50:40 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2025/02/20 17:50:40 wazuh-logcollector: INFO: (1950): Analyzing file: '/home/vagrant/test-s'.
2025/02/20 17:50:40 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2025/02/20 17:50:40 wazuh-logcollector: INFO: Monitoring output of command(360): df -P
2025/02/20 17:50:40 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2025/02/20 17:50:40 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20
2025/02/20 17:50:40 wazuh-logcollector: INFO: Started (pid: 470190).
2025/02/20 17:50:41 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:50:41 wazuh-modulesd: INFO: Started (pid: 470206).
2025/02/20 17:50:41 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/02/20 17:50:41 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2025/02/20 17:50:41 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/02/20 17:50:41 sca: INFO: Module started.
2025/02/20 17:50:41 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:50:41 sca: INFO: Starting Security Configuration Assessment scan.
2025/02/20 17:50:41 wazuh-modulesd:control: INFO: Starting control thread.
2025/02/20 17:50:41 wazuh-modulesd:syscollector: INFO: Module started.
2025/02/20 17:50:41 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/02/20 17:50:41 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:50:42 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/02/20 17:50:42 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2025/02/20 17:50:51 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:50:54 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:51:04 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:51:07 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:51:17 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:51:21 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:51:31 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:51:34 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:51:34 wazuh-agentd: INFO: Requesting a key from server: 192.168.0.236
2025/02/20 17:51:37 wazuh-agentd: ERROR: (1208): Unable to connect to enrollment service at '[192.168.0.236]:1515'
2025/02/20 17:51:47 wazuh-agentd: WARNING: (4101): Waiting for server reply (not started). Tried: '192.168.0.236'. Ensure that the manager version is 'v4.11.1' or higher.
2025/02/20 17:51:47 wazuh-agentd: WARNING: Unable to connect to any server.
2025/02/20 17:51:47 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:51:50 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:52:00 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:52:03 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
```

</details>

Linux without `auto-restart`:

<details>

```
2025/02/20 17:54:38 wazuh-agentd: INFO: Started (pid: 471541).
2025/02/20 17:54:38 wazuh-agentd: INFO: Using AES as encryption method.
2025/02/20 17:54:38 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:54:38 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.0.236]:1514/tcp).
2025/02/20 17:54:39 wazuh-syscheckd: INFO: Started (pid: 471555).
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6000): Starting daemon...
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 3600 seconds
2025/02/20 17:54:39 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2025/02/20 17:54:39 rootcheck: INFO: Starting rootcheck scan.
2025/02/20 17:54:41 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2025/02/20 17:54:41 wazuh-logcollector: INFO: (1950): Analyzing file: '/home/vagrant/test-s'.
2025/02/20 17:54:41 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2025/02/20 17:54:41 wazuh-logcollector: INFO: Monitoring output of command(360): df -P
2025/02/20 17:54:41 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2025/02/20 17:54:41 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20
2025/02/20 17:54:41 wazuh-logcollector: INFO: Started (pid: 471569).
2025/02/20 17:54:42 wazuh-modulesd: INFO: Started (pid: 471587).
2025/02/20 17:54:42 sca: INFO: Module started.
2025/02/20 17:54:42 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/02/20 17:54:42 wazuh-modulesd:control: INFO: Starting control thread.
2025/02/20 17:54:42 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:54:42 sca: INFO: Starting Security Configuration Assessment scan.
2025/02/20 17:54:42 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2025/02/20 17:54:42 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/02/20 17:54:42 wazuh-modulesd:syscollector: INFO: Module started.
2025/02/20 17:54:42 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/02/20 17:54:42 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:54:42 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/02/20 17:54:43 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2025/02/20 17:54:44 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2025/02/20 17:54:46 wazuh-syscheckd: INFO: FIM sync module started.
2025/02/20 17:54:48 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/02/20 17:54:48 sca: INFO: Security Configuration Assessment scan finished. Duration: 6 seconds.
2025/02/20 17:55:08 rootcheck: INFO: Ending rootcheck scan.
2025/02/20 17:55:54 wazuh-agentd: WARNING: Server unavailable. Setting lock.
2025/02/20 17:55:54 wazuh-agentd: INFO: Closing connection to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:55:54 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:55:57 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:56:07 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:56:09 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:56:19 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:56:22 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:56:32 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:56:33 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:56:43 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:56:46 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:56:46 wazuh-agentd: INFO: Requesting a key from server: 192.168.0.236
2025/02/20 17:56:49 wazuh-agentd: ERROR: (1208): Unable to connect to enrollment service at '[192.168.0.236]:1515'
2025/02/20 17:56:59 wazuh-agentd: WARNING: (4101): Waiting for server reply (not started). Tried: '192.168.0.236'. Ensure that the manager version is 'v4.11.1' or higher.
2025/02/20 17:56:59 wazuh-agentd: WARNING: Unable to connect to any server.
2025/02/20 17:56:59 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:57:02 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:57:12 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:57:15 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:57:25 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:57:29 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:57:39 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:57:42 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:57:52 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:57:55 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:57:55 wazuh-agentd: INFO: Requesting a key from server: 192.168.0.236
2025/02/20 17:57:58 wazuh-agentd: ERROR: (1208): Unable to connect to enrollment service at '[192.168.0.236]:1515'
2025/02/20 17:58:08 wazuh-agentd: WARNING: (4101): Waiting for server reply (not started). Tried: '192.168.0.236'. Ensure that the manager version is 'v4.11.1' or higher.
2025/02/20 17:58:08 wazuh-agentd: WARNING: Unable to connect to any server.
2025/02/20 17:58:08 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 17:58:11 wazuh-agentd: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Transport endpoint is not connected'.
2025/02/20 17:58:21 wazuh-agentd: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
```

</details>

Windows with `auto-restart`:

<details>

```
2025/02/20 19:01:08 wazuh-agent: INFO: Started (pid: 15012).
2025/02/20 19:01:08 wazuh-agent: INFO: No authentication password provided
2025/02/20 19:01:08 wazuh-agent: INFO: Using agent name as: LAPTOP-SI21F60O
2025/02/20 19:01:08 wazuh-agent: INFO: Waiting for server reply
2025/02/20 19:01:08 wazuh-agent: INFO: Valid key received
2025/02/20 19:01:08 wazuh-agent: INFO: Waiting 20 seconds before server connection
2025/02/20 19:01:09 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/02/20 19:01:28 wazuh-agent: INFO: (1410): Reading authentication keys file.
2025/02/20 19:01:28 wazuh-agent: INFO: Using AES as encryption method.
2025/02/20 19:01:28 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:01:28 wazuh-agent: INFO: (4102): Connected to the server ([192.168.0.236]:1514/tcp).
2025/02/20 19:01:29 wazuh-agent: INFO: Agent is now online. Process unlocked, continuing...
2025/02/20 19:01:32 wazuh-agent: INFO: Agent is now online. Process unlocked, continuing...
2025/02/20 19:01:32 sca: INFO: Evaluation finished for policy 'C:\Program Files (x86)\ossec-agent\ruleset\sca\cis_win11_enterprise.yml'
2025/02/20 19:01:32 sca: INFO: Security Configuration Assessment scan finished. Duration: 24 seconds.
2025/02/20 19:01:33 wazuh-agent: INFO: Agent is now online. Process unlocked, continuing...
2025/02/20 19:01:33 wazuh-agent: INFO: Agent is now online. Process unlocked, continuing...
2025/02/20 19:01:33 rootcheck: INFO: Starting rootcheck scan.
2025/02/20 19:01:38 rootcheck: INFO: Ending rootcheck scan.
2025/02/20 19:02:14 wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
2025/02/20 19:02:14 wazuh-agent: INFO: FIM sync module started.
2025/02/20 19:02:17 wazuh-agent: INFO: (6012): Real-time file integrity monitoring started.
2025/02/20 19:02:55 wazuh-agent: WARNING: (1218): Unable to send message to 'server': Une connexion existante a dû être fermée par l’hôte distant.
2025/02/20 19:02:55 wazuh-agent: WARNING: (1218): Unable to send message to 'server': Une connexion existante a dû être fermée par l’hôte distant.
2025/02/20 19:02:56 wazuh-agent: WARNING: (1218): Unable to send message to 'server': Une connexion existante a dû être fermée par l’hôte distant.
2025/02/20 19:02:56 wazuh-agent: ERROR: Connection socket: Une connexion existante a dû être fermée par l’hôte distant. (10054)
2025/02/20 19:02:56 wazuh-agent: ERROR: (1137): Lost connection with manager. Setting lock.
2025/02/20 19:02:56 wazuh-agent: INFO: Closing connection to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:02:56 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:02:57 wazuh-agent: WARNING: Process locked due to agent is offline. Waiting for connection...
2025/02/20 19:02:57 wazuh-agent: WARNING: Process locked due to agent is offline. Waiting for connection...
2025/02/20 19:03:15 wazuh-agent: WARNING: Process locked due to agent is offline. Waiting for connection...
2025/02/20 19:03:17 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:03:27 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:03:48 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:03:58 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:04:19 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:04:29 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:04:50 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:05:00 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:05:21 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:05:21 wazuh-agent: INFO: Requesting a key from server: 192.168.0.236
2025/02/20 19:05:42 wazuh-agent: ERROR: (1208): Unable to connect to enrollment service at '[192.168.0.236]:1515'
2025/02/20 19:05:52 wazuh-agent: WARNING: (4101): Waiting for server reply (not started). Tried: '192.168.0.236'. Ensure that the manager version is 'v4.11.1' or higher.
2025/02/20 19:05:52 wazuh-agent: WARNING: Unable to connect to any server.
2025/02/20 19:05:52 wazuh-agent: INFO: Agent is restarting because there may be a problem with the previous connection.
2025/02/20 19:05:52 wazuh-agent: INFO: Received exit signal. Starting exit process.
2025/02/20 19:05:52 wazuh-agent: INFO: Set pending exit signal.
2025/02/20 19:05:52 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/02/20 19:05:52 wazuh-modulesd:syscollector: INFO: Module finished.
2025/02/20 19:05:54 wazuh-agent: WARNING: Process locked due to agent is offline. Waiting for connection...
2025/02/20 19:05:57 wazuh-agent: INFO: Agent is now online. Process unlocked, continuing...
2025/02/20 19:05:57 wazuh-agent: INFO: Exit completed successfully.
2025/02/20 19:05:57 wazuh-agent: WARNING: (1218): Unable to send message to 'server': Impossible de créer un fichier déjà existant.
2025/02/20 19:05:57 wazuh-agent: INFO: (1410): Reading authentication keys file.
2025/02/20 19:05:57 wazuh-agent: INFO: Using notify time: 10 and max time to reconnect: 60
2025/02/20 19:05:57 wazuh-agent: INFO: Started (pid: 4400).
2025/02/20 19:05:57 rootcheck: INFO: Started (pid: 4400).
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\batfile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\cmdfile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\comfile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\exefile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\piffile', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\AllFilesystemObjects', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Directory', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Folder', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Protocols [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Classes\Protocols', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Policies [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Policies', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Security', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\KnownDLLs', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\winreg', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\URL [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\URL', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Windows [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Windows', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Active Setup\Installed Components [x64]', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6002): Monitoring registry entry: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Active Setup\Installed Components', with options 'size | permissions | owner | group | mtime | hash_md5 | hash_sha1 | hash_sha256'
2025/02/20 19:05:57 wazuh-agent: INFO: (6003): Monitoring path: 'c:\programdata\microsoft\windows\start menu\programs\startup', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | realtime'.
2025/02/20 19:05:57 wazuh-agent: INFO: (6003): Monitoring path: 'c:\windows', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | scheduled'.
2025/02/20 19:05:57 wazuh-agent: INFO: (6003): Monitoring path: 'c:\windows\system32', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | scheduled'.
2025/02/20 19:05:57 wazuh-agent: INFO: (6003): Monitoring path: 'c:\windows\system32\drivers\etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | scheduled'.
2025/02/20 19:05:57 wazuh-agent: INFO: (6003): Monitoring path: 'c:\windows\system32\wbem', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | scheduled'.
2025/02/20 19:05:57 wazuh-agent: INFO: (6003): Monitoring path: 'c:\windows\system32\windowspowershell\v1.0', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | attributes | scheduled'.
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'file' entry 'c:\programdata\microsoft\windows\start menu\programs\startup\desktop.ini'
2025/02/20 19:05:57 wazuh-agent: INFO: (6207): Ignore 'file' sregex '.log$|.htm$|.jpg$|.png$|.chm$|.pnf$|.evtx$'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\Security\Policy\Secrets'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\Security\SAM\Domains\Account\Users'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\AppCs'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\DHCP'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\IPTLSIn'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\IPTLSOut'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\RPC-EPMap'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\Teredo'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\PolicyAgent\Parameters\Cache'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx'
2025/02/20 19:05:57 wazuh-agent: INFO: (6206): Ignore 'registry' entry 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\ADOVMPPackage\Final'
2025/02/20 19:05:57 wazuh-agent: INFO: (6207): Ignore 'registry' sregex '\Enum$'
2025/02/20 19:05:57 wazuh-agent: INFO: Started (pid: 4400).
2025/02/20 19:05:57 wazuh-agent: INFO: Windows version is 6.0 or newer. (Microsoft Windows 11 Home [Ver: 10.0.26100.3194] - Wazuh v4.11.1).
2025/02/20 19:05:57 wazuh-agent: INFO: (1951): Analyzing event log: 'Application'.
2025/02/20 19:05:57 wazuh-agent: INFO: (1951): Analyzing event log: 'Security'.
2025/02/20 19:05:57 wazuh-agent: INFO: (1951): Analyzing event log: 'System'.
2025/02/20 19:05:57 wazuh-agent: INFO: (1950): Analyzing file: 'active-response\active-responses.log'.
2025/02/20 19:05:57 wazuh-agent: INFO: Using AES as encryption method.
2025/02/20 19:05:57 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:05:57 sca: INFO: Module started.
2025/02/20 19:05:57 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2025/02/20 19:05:57 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/02/20 19:05:57 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/02/20 19:05:57 sca: INFO: Loaded policy 'C:\Program Files (x86)\ossec-agent\ruleset\sca\cis_win11_enterprise.yml'
2025/02/20 19:05:57 sca: INFO: Starting Security Configuration Assessment scan.
2025/02/20 19:05:57 wazuh-agent: INFO: (6000): Starting daemon...
2025/02/20 19:05:57 wazuh-agent: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/02/20 19:05:57 wazuh-agent: INFO: (6008): File integrity monitoring scan started.
2025/02/20 19:05:57 wazuh-modulesd:syscollector: INFO: Module started.
2025/02/20 19:05:57 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/02/20 19:05:57 sca: INFO: Starting evaluation of policy: 'C:\Program Files (x86)\ossec-agent\ruleset\sca\cis_win11_enterprise.yml'
2025/02/20 19:05:57 wazuh-agent: INFO: Started (pid: 4400).
2025/02/20 19:05:58 wazuh-agent: INFO: (1314): Shutdown received. Deleting responses.
2025/02/20 19:05:58 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/02/20 19:06:18 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:06:28 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:06:49 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:06:59 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:07:20 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:07:30 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:07:51 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:08:01 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:08:22 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:08:22 wazuh-agent: INFO: Requesting a key from server: 192.168.0.236
2025/02/20 19:08:43 wazuh-agent: ERROR: (1208): Unable to connect to enrollment service at '[192.168.0.236]:1515'
2025/02/20 19:08:53 wazuh-agent: WARNING: (4101): Waiting for server reply (not started). Tried: '192.168.0.236'. Ensure that the manager version is 'v4.11.1' or higher.
2025/02/20 19:08:53 wazuh-agent: WARNING: Unable to connect to any server.
2025/02/20 19:08:53 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:09:14 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n’a pas répondu convenablement au-delà d’une certaine durée ou une connexion établie a échoué car l’hôte de connexion n’a pas répondu.'.
2025/02/20 19:09:24 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).

```

</details>

Windows without `auto-restart`:

<details>

```
2025/02/20 19:19:39 wazuh-agent: INFO: Started (pid: 15284).
2025/02/20 19:19:39 wazuh-agent: INFO: Using AES as encryption method.
2025/02/20 19:19:39 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:19:39 wazuh-modulesd:syscollector: INFO: Module started.
2025/02/20 19:19:39 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/02/20 19:19:39 wazuh-agent: INFO: (4102): Connected to the server ([192.168.0.236]:1514/tcp).
2025/02/20 19:19:39 wazuh-agent: INFO: (6000): Starting daemon...
2025/02/20 19:19:39 wazuh-agent: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/02/20 19:19:39 wazuh-agent: INFO: (6008): File integrity monitoring scan started.
2025/02/20 19:19:39 sca: INFO: Starting evaluation of policy: 'C:\Program Files (x86)\ossec-agent\ruleset\sca\cis_win11_enterprise.yml'
2025/02/20 19:19:39 rootcheck: INFO: Starting rootcheck scan.
2025/02/20 19:19:39 wazuh-agent: INFO: Started (pid: 15284).
2025/02/20 19:19:40 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/02/20 19:19:43 sca: INFO: Evaluation finished for policy 'C:\Program Files (x86)\ossec-agent\ruleset\sca\cis_win11_enterprise.yml'
2025/02/20 19:19:43 sca: INFO: Security Configuration Assessment scan finished. Duration: 4 seconds.
2025/02/20 19:19:44 rootcheck: INFO: Ending rootcheck scan.
2025/02/20 19:20:14 wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
2025/02/20 19:20:14 wazuh-agent: INFO: FIM sync module started.
2025/02/20 19:20:15 wazuh-agent: INFO: (6012): Real-time file integrity monitoring started.
2025/02/20 19:20:39 wazuh-agent: ERROR: Connection socket: Une connexion existante a dû être fermée par l'hôte distant. (10054)
2025/02/20 19:20:39 wazuh-agent: ERROR: (1137): Lost connection with manager. Setting lock.
2025/02/20 19:20:39 wazuh-agent: INFO: Closing connection to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:20:39 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:20:43 wazuh-agent: WARNING: Process locked due to agent is offline. Waiting for connection...
2025/02/20 19:21:00 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n'a pas répondu convenablement au-delà d'une certaine durée ou une connexion établie a échoué car l'hôte de connexion n'a pas répondu.'.
2025/02/20 19:21:10 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:21:31 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n'a pas répondu convenablement au-delà d'une certaine durée ou une connexion établie a échoué car l'hôte de connexion n'a pas répondu.'.
2025/02/20 19:21:41 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:22:02 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n'a pas répondu convenablement au-delà d'une certaine durée ou une connexion établie a échoué car l'hôte de connexion n'a pas répondu.'.
2025/02/20 19:22:12 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:22:33 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n'a pas répondu convenablement au-delà d'une certaine durée ou une connexion établie a échoué car l'hôte de connexion n'a pas répondu.'.
2025/02/20 19:22:43 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:23:04 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n'a pas répondu convenablement au-delà d'une certaine durée ou une connexion établie a échoué car l'hôte de connexion n'a pas répondu.'.
2025/02/20 19:23:04 wazuh-agent: INFO: Requesting a key from server: 192.168.0.236
2025/02/20 19:23:25 wazuh-agent: ERROR: (1208): Unable to connect to enrollment service at '[192.168.0.236]:1515'
2025/02/20 19:23:35 wazuh-agent: WARNING: (4101): Waiting for server reply (not started). Tried: '192.168.0.236'. Ensure that the manager version is 'v4.11.1' or higher.
2025/02/20 19:23:35 wazuh-agent: WARNING: Unable to connect to any server.
2025/02/20 19:23:35 wazuh-agent: INFO: Trying to connect to server ([192.168.0.236]:1514/tcp).
2025/02/20 19:23:56 wazuh-agent: ERROR: (1216): Unable to connect to '[192.168.0.236]:1514/tcp': 'Une tentative de connexion a échoué car le parti connecté n'a pas répondu convenablement au-delà d'une certaine durée ou une connexion établie a échoué car l'hôte de connexion n'a pas répondu.'.
```

</details>

## Tests

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues