### PR TITLE
Add missing known fields

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -159,6 +159,7 @@
       "data.docker.Actor.Attributes.name",
       "data.docker.Actor.ID",
       "data.docker.id",
+      "data.docker.from",
       "data.docker.message",
       "data.docker.status",
       "data.dstip",
@@ -488,6 +489,7 @@
       "data.vulnerability.package.name",
       "data.vulnerability.package.version",
       "data.vulnerability.rationale",
+      "data.vulnerability.reference",
       "data.vulnerability.severity",
       "data.vulnerability.status",
       "data.vulnerability.title",
@@ -2486,6 +2488,9 @@
               "rationale": {
                 "type": "keyword"
               },
+              "reference": {
+                "type": "keyword"
+              },
               "severity": {
                 "type": "keyword"
               },
@@ -2642,6 +2647,9 @@
                     }
                   }
                 }
+              },
+              "from": {
+                "type": "keyword"
               },
               "Type": {
                 "type": "keyword"


### PR DESCRIPTION
## Related issue

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/7266

## Description

Added  `data.docker.from` , `data.vulnerability.reference` fields to `wazuh-template.json`.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors