### PR TITLE
fix: download retry included for cmocka repository

### DIFF
--- a/.github/actions/install_build_deps/action.yml
+++ b/.github/actions/install_build_deps/action.yml
@@ -39,15 +39,19 @@ runs:
       run: |
         if [[ "${{ inputs.target }}" == "winagent" ]]; then
           echo "Installing CMocka by sources with 'winagent' required flags"
-          cd /tmp
-          curl -L https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz | \
-          tar zvx -C /tmp/ && \
-          sed -i "s|ON|OFF|g" /tmp/stable-1.1/DefineOptions.cmake && \
-          mkdir /tmp/stable-1.1/build && \
-          cd /tmp/stable-1.1/build && \
-          cmake -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_C_LINK_EXECUTABLE=i686-w64-mingw32-ld -DCMAKE_INSTALL_PREFIX=/usr/i686-w64-mingw32/ -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_BUILD_TYPE=Release .. && \
-          make && \
-          sudo make install && \
+          curl -L --retry 3 --retry-delay 2 -o /tmp/stable-1.1.tar.gz https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz
+          # Verify if the download was successful
+          if [ $? -ne 0 ]; then
+              echo "Error during download. Exiting..."
+              exit 1
+          fi
+          tar -zxf /tmp/stable-1.1.tar.gz -C /tmp/
+          sed -i "s|ON|OFF|g" /tmp/stable-1.1/DefineOptions.cmake
+          mkdir /tmp/stable-1.1/build
+          cd /tmp/stable-1.1/build
+          cmake -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_C_LINK_EXECUTABLE=i686-w64-mingw32-ld -DCMAKE_INSTALL_PREFIX=/usr/i686-w64-mingw32/ -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_BUILD_TYPE=Release ..
+          make
+          sudo make install
           cd $GITHUB_WORKSPACE
         else
           echo "Installing CMocka directly from apt-get"


### PR DESCRIPTION
|Related issue|
|---|
|#28032|


## Description
This pr proposes to include download retries when installing dependencies in the RTR checks for the windows agent (winagent). Where cases of random failures (flaky test) due to errors external to the product are observed.
The idea is to include 3 retries and a waiting time between retries of 2 seconds, increasing the chances of avoiding discharge failure. 

Command proposal:
```yml
curl -L --retry 3 --retry-delay 2 -o /tmp/stable-1.1.tar.gz https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz
```
All tests performed were successful:
https://github.com/wazuh/wazuh/actions/runs/13458316698?pr=28344

## Reviewer Validations

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues