### PR TITLE
feat: decorate cloudwatch logs with log_group name and source

### DIFF
--- a/wodles/aws/services/cloudwatchlogs.py
+++ b/wodles/aws/services/cloudwatchlogs.py
@@ -301,6 +301,7 @@ class AWSCloudWatchLogs(aws_service.AWSService):
                 aws_tools.debug('+++ Sending events to Analysisd...', 1)
                 for event in response['events']:
                     event_msg = event['message']
+                    json_event = None
                     try:
                         json_event = json.loads(event_msg)
                         if self.event_should_be_skipped(json_event):
@@ -325,7 +326,8 @@ class AWSCloudWatchLogs(aws_service.AWSService):
                                   f'The event will be processed.', 3)
                     aws_tools.debug('The message is "{}"'.format(event_msg), 2)
                     aws_tools.debug('The message\'s timestamp is {}'.format(event["timestamp"]), 3)
-                    self.send_msg(event_msg, dump_json=False)
+                    self.send_msg(dict({'integration': 'aws', 'source': 'cloudwatch', 'log_group': log_group},
+                                       **json_event if json_event else {'message': event_msg}), dump_json=False)
                     sent_events += 1
 
                     if min_start_time is None:


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Update Cloudwatch log ingestion to decorate logs with `integration`, `source` and `log_group`.

The decorated properties are appended to Cloudwatch logs already in JSON format.

For non-JSON logs, the message is added as JSON key. We could make this toggleable so that non-JSON logs can be returned without transformation.

<!--
Add a clear description of how the problem has been solved.
-->


## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors