### PR TITLE
Wazuh Agent LogCollector skipping Log Lines

### DIFF
--- a/src/logcollector/read_audit.c
+++ b/src/logcollector/read_audit.c
@@ -63,7 +63,7 @@ void *read_audit(logreader *lf, int *rc, int drop_it) {
     offset = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, offset);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(buffer, OS_MAX_LOG_SIZE, lf->fp) && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && (!maximum_lines || lines < maximum_lines) && offset >= 0 && fgets(buffer, OS_MAX_LOG_SIZE, lf->fp); offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
 
         /* Flow control */

--- a/src/logcollector/read_command.c
+++ b/src/logcollector/read_command.c
@@ -40,7 +40,7 @@ void *read_command(logreader *lf, int *rc, int drop_it) {
              : lf->command);
     cmd_size = strlen(str);
 
-    while (can_read() && fgets(str + cmd_size, OS_MAXSTR - OS_LOG_HEADER - 256, cmd_output) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && (!maximum_lines || lines < maximum_lines) && fgets(str + cmd_size, OS_MAXSTR - OS_LOG_HEADER - 256, cmd_output)) {
 
         lines++;
         /* Get the last occurrence of \n */

--- a/src/logcollector/read_djb_multilog.c
+++ b/src/logcollector/read_djb_multilog.c
@@ -97,7 +97,7 @@ void *read_djbmultilog(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && (!maximum_lines || lines < maximum_lines) && fgets(str, OS_MAX_LOG_SIZE, lf->fp)) {
 
         if (is_valid_context_file) {
             OS_SHA1_Stream(context, NULL, str);

--- a/src/logcollector/read_json.c
+++ b/src/logcollector/read_json.c
@@ -34,7 +34,7 @@ void *read_json(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && (!maximum_lines || lines < maximum_lines) && offset >= 0 && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp); offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
         lines++;
 

--- a/src/logcollector/read_mssql_log.c
+++ b/src/logcollector/read_mssql_log.c
@@ -46,7 +46,7 @@ void *read_mssql_log(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && (!maximum_lines || lines < maximum_lines) && fgets(str, OS_MAX_LOG_SIZE, lf->fp)) {
 
         lines++;
         /* Get buffer size */

--- a/src/logcollector/read_multiline.c
+++ b/src/logcollector/read_multiline.c
@@ -33,7 +33,7 @@ void *read_multiline(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAX_LOG_SIZE, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && (!maximum_lines || lines < maximum_lines) && offset >= 0 && fgets(str, OS_MAX_LOG_SIZE, lf->fp); offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
         lines++;
         linesgot++;

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -153,8 +153,8 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
     read_buffer[OS_MAXSTR] = '\0';
     *rc = 0;
 
-while ((maximum_lines == 0 || count_lines < maximum_lines) &&
-        (rlines = multiline_getlog(read_buffer, max_line_len, lf->fp, lf->multiline), rlines > 0)) {
+    while ((maximum_lines == 0 || count_lines < maximum_lines) &&
+            (rlines = multiline_getlog(read_buffer, max_line_len, lf->fp, lf->multiline), rlines > 0)) {
 
 
         /* Check ignore and restrict log regex, if configured. */

--- a/src/logcollector/read_multiline_regex.c
+++ b/src/logcollector/read_multiline_regex.c
@@ -153,8 +153,9 @@ void * read_multiline_regex(logreader * lf, int * rc, int drop_it) {
     read_buffer[OS_MAXSTR] = '\0';
     *rc = 0;
 
-    while (rlines = multiline_getlog(read_buffer, max_line_len, lf->fp, lf->multiline),
-           rlines > 0 && (maximum_lines == 0 || count_lines < maximum_lines)) {
+while ((maximum_lines == 0 || count_lines < maximum_lines) &&
+        (rlines = multiline_getlog(read_buffer, max_line_len, lf->fp, lf->multiline), rlines > 0)) {
+
 
         /* Check ignore and restrict log regex, if configured. */
         if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, read_buffer)) {

--- a/src/logcollector/read_mysql_log.c
+++ b/src/logcollector/read_mysql_log.c
@@ -35,7 +35,7 @@ void *read_mysql_log(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && (!maximum_lines || lines < maximum_lines) && fgets(str, sizeof(str), lf->fp)) {
 
         lines++;
         /* Get buffer size */

--- a/src/logcollector/read_nmapg.c
+++ b/src/logcollector/read_nmapg.c
@@ -148,7 +148,7 @@ void *read_nmapg(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && (!maximum_lines || lines < maximum_lines) && fgets(str, sizeof(str), lf->fp)) {
 
         lines++;
 

--- a/src/logcollector/read_postgresql_log.c
+++ b/src/logcollector/read_postgresql_log.c
@@ -43,7 +43,7 @@ void *read_postgresql_log(logreader *lf, int *rc, int drop_it) {
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
     /* Get new entry */
-    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && (!maximum_lines || lines < maximum_lines) && fgets(str, sizeof(str), lf->fp)) {
 
         lines++;
         /* Get buffer size */

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -32,7 +32,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    while (can_read() && fgets(str, sizeof(str), lf->fp) != NULL && (!maximum_lines || lines < maximum_lines)) {
+    while (can_read() && (!maximum_lines || lines < maximum_lines) && fgets(str, sizeof(str), lf->fp)) {
 
         lines++;
 

--- a/src/logcollector/read_syslog.c
+++ b/src/logcollector/read_syslog.c
@@ -34,7 +34,7 @@ void *read_syslog(logreader *lf, int *rc, int drop_it) {
     EVP_MD_CTX *context = EVP_MD_CTX_new();
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && (!maximum_lines || lines < maximum_lines) && offset >= 0 && fgets(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp); offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
         lines++;
 

--- a/src/logcollector/read_ucs2_be.c
+++ b/src/logcollector/read_ucs2_be.c
@@ -33,7 +33,7 @@ void *read_ucs2_be(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgets(str, OS_MAXSTR_BE - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && (!maximum_lines || lines < maximum_lines) && offset >= 0 && fgets(str, OS_MAXSTR_BE - OS_LOG_HEADER, lf->fp); offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
         lines++;
 

--- a/src/logcollector/read_ucs2_le.c
+++ b/src/logcollector/read_ucs2_le.c
@@ -33,7 +33,7 @@ void *read_ucs2_le(logreader *lf, int *rc, int drop_it) {
     int64_t current_position = w_ftell(lf->fp);
     bool is_valid_context_file = w_get_hash_context(lf, &context, current_position);
 
-    for (offset = w_ftell(lf->fp); can_read() && fgetws(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp) != NULL && (!maximum_lines || lines < maximum_lines) && offset >= 0; offset += rbytes) {
+    for (offset = w_ftell(lf->fp); can_read() && (!maximum_lines || lines < maximum_lines) && offset >= 0 && fgetws(str, OS_MAXSTR - OS_LOG_HEADER, lf->fp); offset += rbytes) {
         rbytes = w_ftell(lf->fp) - offset;
         lines++;
 

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -136,6 +136,13 @@ else()
                                     -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
                                     -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,pthread_rwlock_wrlock \
                                     -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_Delete")
+    list(APPEND logcollector_names "test_read_syslog")
+    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+                                    -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc \
+                                    -Wl,--wrap,time -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,w_expression_match \
+                                    -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status -Wl,--wrap,_merror \
+                                    -Wl,--wrap=w_get_hash_context -Wl,--wrap=_fseeki64 -Wl,--wrap=OS_SHA1_Stream \
+                                    -Wl,--wrap=w_fseek -Wl,--wrap,wfopen")
 endif()
 
 list(LENGTH logcollector_names count)

--- a/src/unit_tests/logcollector/test_read_syslog.c
+++ b/src/unit_tests/logcollector/test_read_syslog.c
@@ -1,0 +1,242 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "../../logcollector/logcollector.h"
+#include "../../headers/shared.h"
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+#include "../wrappers/libc/string_wrappers.h"
+
+/* Globals*/
+
+extern int maximum_lines;
+
+/* Setup & Teardown */
+
+static int group_setup(void ** state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int group_teardown(void ** state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* Wraps */
+
+int __wrap_can_read() {
+    return mock_type(int);
+}
+
+bool __wrap_w_get_hash_context(const char * path, EVP_MD_CTX * context, int64_t position) {
+    return mock_type(bool);
+}
+
+int __wrap_w_update_file_status(const char * path, int64_t pos, EVP_MD_CTX * context) {
+    bool free_context = mock_type(bool);
+    if (free_context) {
+        EVP_MD_CTX_free(context);
+    }
+    return mock_type(int);
+}
+
+void __wrap_OS_SHA1_Stream(EVP_MD_CTX *c, os_sha1 output, char * buf) {
+    function_called();
+    return;
+}
+
+/* Tests */
+
+void test_read_syslog_empty_file(void **state) {
+    logreader lf = { .file = "test.log" };
+    int rc;
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_w_get_hash_context, true);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, NULL);
+
+    will_return(__wrap_w_update_file_status, true);
+    will_return(__wrap_w_update_file_status, 0);
+
+    read_syslog(&lf, &rc, 1);
+}
+
+void test_read_syslog_success(void **state) {
+    logreader lf = { .file = "test.log" };
+    char line[] = "test line\n";
+    int rc;
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_w_get_hash_context, true);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, line);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line));
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line));
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, NULL);
+
+    will_return(__wrap_w_update_file_status, true);
+    will_return(__wrap_w_update_file_status, 0);
+
+    read_syslog(&lf, &rc, 1);
+}
+
+void test_maximum_lines(void ** state) {
+    logreader lf = { .file = "test" };
+    int rc;
+    char line1[] = "Line 1\n";
+    char line2[] = "Line 2\n";
+    char line3[] = "Line 3\n";
+    maximum_lines = 2;
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_w_get_hash_context, true);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, line1);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1));
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1));
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, line2);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1) + strlen(line2));
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1) + strlen(line2));
+
+    will_return(__wrap_can_read, 1);
+
+    will_return(__wrap_w_update_file_status, true);
+    will_return(__wrap_w_update_file_status, 0);
+
+    read_syslog(&lf, &rc, 1);
+}
+
+void test_maximum_lines_disabled(void ** state) {
+    logreader lf = { .file = "test", .linecount = 3 };
+    int rc;
+    char line1[] = "Line 1\n";
+    char line2[] = "Line 2\n";
+    char line3[] = "Line 3\n";
+    maximum_lines = 0;
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_w_get_hash_context, true);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, line1);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1));
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1));
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, line2);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1) + strlen(line2));
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1) + strlen(line2));
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, line3);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1) + strlen(line2) + strlen(line3));
+
+    expect_function_call(__wrap_OS_SHA1_Stream);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) strlen(line1) + strlen(line2) + strlen(line3));
+
+    will_return(__wrap_can_read, 1);
+
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, NULL);
+
+    will_return(__wrap_w_update_file_status, true);
+    will_return(__wrap_w_update_file_status, 0);
+
+    read_syslog(&lf, &rc, 1);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_read_syslog_empty_file),
+        cmocka_unit_test(test_read_syslog_success),
+        cmocka_unit_test(test_maximum_lines),
+        cmocka_unit_test(test_maximum_lines_disabled)
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/28337 |

## Description

This PR solves the problem of events skipped by _logcollector_. When configuring _logcollector_ to monitor syslog files, if the number of lines to be processed exceeds the value configured in `logcollector.max_lines`, one event is skipped for each iteration.

## Configuration options

```xml
# Logcollector - Maximum number of lines to read from the same file [100..1000000]
# 0. Disable line burst limitation
logcollector.max_lines=10000
```

## Logs/Alerts example

```console
2025/02/19 19:50:31 wazuh-logcollector[6792] read_syslog.c:150 at read_syslog(): DEBUG: Read 10000 lines from /var/demo_logs_30k.log
2025/02/19 19:50:31 wazuh-logcollector[6792] read_syslog.c:150 at read_syslog(): DEBUG: Read 10000 lines from /var/demo_logs_30k.log
2025/02/19 19:50:31 wazuh-logcollector[6792] read_syslog.c:150 at read_syslog(): DEBUG: Read 9998 lines from /var/demo_logs_30k.log
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionalit
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
