### PR TITLE
Fix wrong camel casing in ownCloud ruleset header

### DIFF
--- a/ruleset/rules/0500-owncloud_rules.xml
+++ b/ruleset/rules/0500-owncloud_rules.xml
@@ -1,5 +1,5 @@
 <!--
-  -  OwnCloud ruleset
+  -  ownCloud ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.


### PR DESCRIPTION
|Related issue|
|---|
|None|

## Description

The product was named `ownCloud` since ever as seen in other parts of the file or at e.g. https://owncloud.com/

## Configuration options

Irrelevant

## Logs/Alerts example

Irrelevant

## Tests

Irrelevant