### PR TITLE
Increase GET /commands timeout

### DIFF
--- a/apis/communications/comms_api/routers/commands.py
+++ b/apis/communications/comms_api/routers/commands.py
@@ -10,7 +10,7 @@ from comms_api.routers.exceptions import HTTPError
 from comms_api.routers.utils import timeout
 
 
-@timeout(30)
+@timeout(1200)
 async def get_commands(token: Annotated[str, Depends(JWTBearer())], request: Request) -> Commands:
     """Get commands endpoint handler.
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/28302 |

## Description

Increases the `GET /commands` timeout to `20m` so the configurable agent timeout (0-15m) is always inferior and there's no scenario in which the agent stays idle if the server doesn't respond.

## Tests

<details><summary>Get commands timeout</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ time curl -k -H "Authorization: Bearer $TOKEN" https://0.0.0.0:27000/api/v1/commands
{"message":"Request exceeded the processing time limit","code":408}
real	20m0.010s
user	0m0.016s
sys	0m0.022s
```

</details>
