### PR TITLE
Update ubuntu in github actions runners

### DIFF
--- a/.github/workflows/build-package-filebeat.yml
+++ b/.github/workflows/build-package-filebeat.yml
@@ -70,7 +70,7 @@ on:
 
 jobs:
   build-and-upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
|Related issue|
|---|
|#28282|

## Description

GitHub has announced the deprecation of the `ubuntu-20.04` runner image in GitHub Actions. The deprecation process starts on **February 1, 2025**, and full removal is scheduled for **April 1, 2025**.  

During this period, workflows using `ubuntu-20.04` will experience:  
- Longer queue times.  
- Scheduled brownouts where jobs using this image will fail.  
