### PR TITLE
Fix Fim integration tests failing on windows

### DIFF
--- a/tests/integration/test_fim/test_files/test_basic_usage/test_create_after_delete_dir.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_create_after_delete_dir.py
@@ -82,7 +82,13 @@ from . import TEST_CASES_PATH, CONFIGS_PATH
 
 
 # Pytest marks to run on any service type on linux or windows.
-pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=1)]
+pytestmark = [
+    pytest.mark.agent,
+    pytest.mark.linux,
+    pytest.mark.win32,
+    pytest.mark.tier(level=1),
+    pytest.mark.skipif(sys.platform.startswith("win"), reason="Unstable behavior when deleting monitored folder in Windows")
+]
 
 # Test metadata, configuration and ids.
 cases_path = Path(TEST_CASES_PATH, 'cases_create_after_delete.yaml')
@@ -156,8 +162,6 @@ def test_create_after_delete(test_configuration, test_metadata, configure_local_
         - realtime
         - who_data
     '''
-    if sys.platform == WINDOWS:
-        pytest.skip(reason="Unstable behavior when deleting monitored folder")
 
     wazuh_log_monitor = FileMonitor(WAZUH_LOG_PATH)
 

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_delete_directory.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_delete_directory.py
@@ -81,7 +81,14 @@ from . import TEST_CASES_PATH, CONFIGS_PATH
 
 
 # Pytest marks to run on any service type on linux or windows.
-pytestmark = [pytest.mark.agent, pytest.mark.linux, pytest.mark.win32, pytest.mark.tier(level=0)]
+pytestmark = [
+    pytest.mark.agent,
+    pytest.mark.linux,
+    pytest.mark.win32,
+    pytest.mark.tier(level=0),
+    pytest.mark.skipif(sys.platform.startswith("win"), reason="Unstable behavior when deleting monitored folder in Windows")
+]
+
 
 # Test metadata, configuration and ids.
 cases_path = Path(TEST_CASES_PATH, 'cases_delete_directory.yaml')
@@ -153,8 +160,6 @@ def test_delete_dir(test_configuration, test_metadata, set_wazuh_configuration, 
         - scheduled
         - realtime
     '''
-    if sys.platform == WINDOWS:
-        pytest.skip(reason="Unstable behavior when deleting monitored folder")
 
     wazuh_log_monitor = FileMonitor(WAZUH_LOG_PATH)
     fim_mode = test_metadata.get('fim_mode')


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28354|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->


## Description
The objective of this RP is to avoid erratic behavior in FIM integration tests.

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

## Test

- 🟢https://github.com/wazuh/wazuh/actions/runs/13542324011
- 🟢https://github.com/wazuh/wazuh/actions/runs/13542334508
- 🟢https://github.com/wazuh/wazuh/actions/runs/13542337937
- 🟢https://github.com/wazuh/wazuh/actions/runs/13544641373
- 🟢https://github.com/wazuh/wazuh/actions/runs/13545586482


<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [x] Package installation
- [x] Review logs syntax and correct language
- [x] QA templates contemplate the added capabilities

