### PR TITLE
Detecting Journald Rotation in Logcollector

### DIFF
--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -77,8 +77,7 @@
 #define LOGCOLLECTOR_ONLY_MACOS             "(9201): 'macos' log format is only supported on macOS."
 #define LOGCOLLECTOR_JOURNALD_ONLY_LINUX    "(9202): 'Journald' log format is only available on Linux."
 #define LOGCOLLECTOR_JOURNALD_MONITORING    "(9203): Monitoring journal entries."
-#define LOGCOLLECTOR_ROTATION_DETECTED      "(9204): 'Journald' files rotation detected."
-#define LOGCOLLECTOR_CONTEXT_RECREATION     "(9205): 'Journald' context was recreated."
+#define LOGCOLLECTOR_TIMESTAMP_REFRESHED    "(9204): 'Journald' timestamp was refreshed due to rotation."
 
 /* Agent info messages */
 #define AG_UNINSTALL_VALIDATION_START       "(9500): Starting user validation to uninstall the Wazuh agent package."

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -78,6 +78,7 @@
 #define LOGCOLLECTOR_JOURNALD_ONLY_LINUX    "(9202): 'Journald' log format is only available on Linux."
 #define LOGCOLLECTOR_JOURNALD_MONITORING    "(9203): Monitoring journal entries."
 #define LOGCOLLECTOR_ROTATION_DETECTED      "(9204): 'Journald' files rotation detected."
+#define LOGCOLLECTOR_CONTEXT_RECREATION     "(9205): 'Journald' context was recreated."
 
 /* Agent info messages */
 #define AG_UNINSTALL_VALIDATION_START       "(9500): Starting user validation to uninstall the Wazuh agent package."

--- a/src/error_messages/information_messages.h
+++ b/src/error_messages/information_messages.h
@@ -77,6 +77,7 @@
 #define LOGCOLLECTOR_ONLY_MACOS             "(9201): 'macos' log format is only supported on macOS."
 #define LOGCOLLECTOR_JOURNALD_ONLY_LINUX    "(9202): 'Journald' log format is only available on Linux."
 #define LOGCOLLECTOR_JOURNALD_MONITORING    "(9203): Monitoring journal entries."
+#define LOGCOLLECTOR_ROTATION_DETECTED      "(9204): 'Journald' files rotation detected."
 
 /* Agent info messages */
 #define AG_UNINSTALL_VALIDATION_START       "(9500): Starting user validation to uninstall the Wazuh agent package."

--- a/src/logcollector/journal_log.c
+++ b/src/logcollector/journal_log.c
@@ -22,8 +22,9 @@
 #define INLINE inline
 #endif
 
-// SD_JOURNAL_INVALIDATE indicates the journal files have changed on disk.
-#define SD_JOURNAL_INVALIDATE 2
+STATIC const int W_SD_JOURNAL_NOP = 0;        ///< The journal did not change since the last invocation.
+STATIC const int W_SD_JOURNAL_APPEND = 1;     ///< New entries have been appended to the end of the journal.
+STATIC const int W_SD_JOURNAL_INVALIDATE = 2; ///< Indicates the journal files have changed on disk.
 
 STATIC const int W_SD_JOURNAL_LOCAL_ONLY = 1 << 0;     ///< Open the journal log for the local machine
 STATIC const char * W_LIB_SYSTEMD = "libsystemd.so.0"; ///< Name of the systemd library
@@ -420,6 +421,13 @@ int w_journal_context_get_oldest_timestamp(w_journal_context_t * ctx, uint64_t *
     return ctx->lib->get_cutoff_timestamp(ctx->journal, timestamp, NULL);
 }
 
+int w_journal_context_recreate(w_journal_context_t** ctx)
+{
+    w_journal_context_free((*ctx));
+
+    return w_journal_context_create(ctx);
+}
+
 /**********************************************************
  *                   Entry related
  **********************************************************/
@@ -731,8 +739,7 @@ bool w_journal_rotation_detected(w_journal_context_t *ctx) {
 
     int r = ctx->lib->process(ctx->journal);
 
-    // SD_JOURNAL_INVALIDATE indicates the journal files have changed on disk
-    return (r == SD_JOURNAL_INVALIDATE);
+    return (r == W_SD_JOURNAL_INVALIDATE);
 }
 
 #endif

--- a/src/logcollector/journal_log.c
+++ b/src/logcollector/journal_log.c
@@ -421,13 +421,6 @@ int w_journal_context_get_oldest_timestamp(w_journal_context_t * ctx, uint64_t *
     return ctx->lib->get_cutoff_timestamp(ctx->journal, timestamp, NULL);
 }
 
-int w_journal_context_recreate(w_journal_context_t** ctx)
-{
-    w_journal_context_free((*ctx));
-
-    return w_journal_context_create(ctx);
-}
-
 /**********************************************************
  *                   Entry related
  **********************************************************/

--- a/src/logcollector/journal_log.h
+++ b/src/logcollector/journal_log.h
@@ -187,4 +187,12 @@ char * w_journal_entry_to_string(w_journal_entry_t * entry);
  */
 int w_journal_filter_apply(w_journal_context_t * ctx, w_journal_filter_t * filter);
 
+/**
+ * @brief Detects changes on the journald files
+ *
+ * The context pointer is invalid after the call.
+ * @param ctx Journal log context
+*/
+bool w_journal_rotation_detected(w_journal_context_t *ctx);
+
 #endif // w_journal_H

--- a/src/logcollector/journal_log.h
+++ b/src/logcollector/journal_log.h
@@ -121,6 +121,15 @@ int w_journal_context_next_newest_filtered(w_journal_context_t * ctx, w_journal_
  */
 int w_journal_context_get_oldest_timestamp(w_journal_context_t * ctx, uint64_t * timestamp);
 
+/**
+ * @brief Closes and reopens the context
+ *
+ * The caller is responsible for freeing the returned context.
+ * @param ctx Journal log context
+ * @return int 0 on success or -1 on error
+ * @note The context should be created and used by a single thread only.
+ */
+int w_journal_context_recreate(w_journal_context_t** ctx);
 /**********************************************************
  *                   Entry related
  **********************************************************/

--- a/src/logcollector/journal_log.h
+++ b/src/logcollector/journal_log.h
@@ -122,14 +122,11 @@ int w_journal_context_next_newest_filtered(w_journal_context_t * ctx, w_journal_
 int w_journal_context_get_oldest_timestamp(w_journal_context_t * ctx, uint64_t * timestamp);
 
 /**
- * @brief Closes and reopens the context
+ * @brief seeks timestamp for journald messages.
  *
- * The caller is responsible for freeing the returned context.
- * @param ctx Journal log context
  * @return int 0 on success or -1 on error
- * @note The context should be created and used by a single thread only.
  */
-int w_journal_context_recreate(w_journal_context_t** ctx);
+int seek_and_refresh_timestamp();
 /**********************************************************
  *                   Entry related
  **********************************************************/

--- a/src/logcollector/read_journald.c
+++ b/src/logcollector/read_journald.c
@@ -118,6 +118,11 @@ bool w_journald_can_read(unsigned long owner_id) {
 
     } else if (gs_journald_global.owner_id != owner_id) {
         return false;
+    } else if (w_journal_rotation_detected(gs_journald_global.journal_ctx)) {
+        minfo(LOGCOLLECTOR_ROTATION_DETECTED);
+        gs_journald_global.journal_ctx = NULL;
+        gs_journald_global.owner_id = 0;
+        return false;
     }
 
     return true;

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -120,7 +120,7 @@ else()
                                     -Wl,--wrap,w_journal_entry_to_string -Wl,--wrap,w_journal_entry_free \
                                     -Wl,--wrap,w_journal_context_next_newest_filtered -Wl,--wrap,_merror -Wl,--wrap,_minfo \
                                     -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,isDebug -Wl,--wrap,w_msg_hash_queues_push \
-                                    -Wl,--wrap,can_read -Wl,--wrap,w_journal_rotation_detected")
+                                    -Wl,--wrap,can_read -Wl,--wrap,w_journal_rotation_detected -Wl,--wrap,w_journal_context_recreate")
 
     list(APPEND logcollector_names "test_journal_log")
     list(APPEND logcollector_flags "-Wl,--wrap,stat -Wl,--wrap,_mwarn -Wl,--wrap,dlsym -Wl,--wrap,dlerror -Wl,--wrap,gettimeofday \

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -131,11 +131,13 @@ else()
                                     -Wl,--wrap,sd_journal_open -Wl,--wrap,sd_journal_close -Wl,--wrap,sd_journal_previous \
                                     -Wl,--wrap,sd_journal_next -Wl,--wrap,sd_journal_seek_tail \
                                     -Wl,--wrap,sd_journal_seek_realtime_usec -Wl,--wrap,sd_journal_get_realtime_usec \
-                                    -Wl,--wrap,sd_journal_process -Wl,--wrap,sd_journal_get_data -Wl,--wrap,sd_journal_restart_data \
-                                    -Wl,--wrap,sd_journal_enumerate_data -Wl,--wrap,sd_journal_get_cutoff_realtime_usec \
-                                    -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
-                                    -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,pthread_rwlock_wrlock \
-                                    -Wl,--wrap,cJSON_PrintUnformatted -Wl,--wrap,cJSON_Delete")
+                                    -Wl,--wrap,sd_journal_process -Wl,--wrap,sd_journal_get_fd -Wl,--wrap,sd_journal_get_data \
+                                    -Wl,--wrap,sd_journal_restart_data -Wl,--wrap,sd_journal_enumerate_data \
+                                    -Wl,--wrap,sd_journal_get_cutoff_realtime_usec -Wl,--wrap,cJSON_CreateObject \
+                                    -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
+                                    -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,cJSON_PrintUnformatted \
+                                    -Wl,--wrap,cJSON_Delete")
+
     list(APPEND logcollector_names "test_read_syslog")
     list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
                                     -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc \
@@ -143,6 +145,7 @@ else()
                                     -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status -Wl,--wrap,_merror \
                                     -Wl,--wrap=w_get_hash_context -Wl,--wrap=_fseeki64 -Wl,--wrap=OS_SHA1_Stream \
                                     -Wl,--wrap=w_fseek -Wl,--wrap,wfopen")
+
 endif()
 
 list(LENGTH logcollector_names count)

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -131,7 +131,7 @@ else()
                                     -Wl,--wrap,sd_journal_open -Wl,--wrap,sd_journal_close -Wl,--wrap,sd_journal_previous \
                                     -Wl,--wrap,sd_journal_next -Wl,--wrap,sd_journal_seek_tail \
                                     -Wl,--wrap,sd_journal_seek_realtime_usec -Wl,--wrap,sd_journal_get_realtime_usec \
-                                    -Wl,--wrap,sd_journal_get_data -Wl,--wrap,sd_journal_restart_data \
+                                    -Wl,--wrap,sd_journal_process -Wl,--wrap,sd_journal_get_data -Wl,--wrap,sd_journal_restart_data \
                                     -Wl,--wrap,sd_journal_enumerate_data -Wl,--wrap,sd_journal_get_cutoff_realtime_usec \
                                     -Wl,--wrap,cJSON_CreateObject -Wl,--wrap,cJSON_AddArrayToObject -Wl,--wrap,cJSON_AddStringToObject \
                                     -Wl,--wrap,cJSON_AddStringToObject -Wl,--wrap,cJSON_AddItemToArray -Wl,--wrap,pthread_rwlock_wrlock \

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -120,7 +120,7 @@ else()
                                     -Wl,--wrap,w_journal_entry_to_string -Wl,--wrap,w_journal_entry_free \
                                     -Wl,--wrap,w_journal_context_next_newest_filtered -Wl,--wrap,_merror -Wl,--wrap,_minfo \
                                     -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,isDebug -Wl,--wrap,w_msg_hash_queues_push \
-                                    -Wl,--wrap,can_read -Wl,--wrap,w_journal_rotation_detected -Wl,--wrap,w_journal_context_recreate")
+                                    -Wl,--wrap,can_read -Wl,--wrap,w_journal_rotation_detected")
 
     list(APPEND logcollector_names "test_journal_log")
     list(APPEND logcollector_flags "-Wl,--wrap,stat -Wl,--wrap,_mwarn -Wl,--wrap,dlsym -Wl,--wrap,dlerror -Wl,--wrap,gettimeofday \

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -120,7 +120,7 @@ else()
                                     -Wl,--wrap,w_journal_entry_to_string -Wl,--wrap,w_journal_entry_free \
                                     -Wl,--wrap,w_journal_context_next_newest_filtered -Wl,--wrap,_merror -Wl,--wrap,_minfo \
                                     -Wl,--wrap,_mdebug1 -Wl,--wrap,_mdebug2 -Wl,--wrap,isDebug -Wl,--wrap,w_msg_hash_queues_push \
-                                    -Wl,--wrap,can_read")
+                                    -Wl,--wrap,can_read -Wl,--wrap,w_journal_rotation_detected")
 
     list(APPEND logcollector_names "test_journal_log")
     list(APPEND logcollector_flags "-Wl,--wrap,stat -Wl,--wrap,_mwarn -Wl,--wrap,dlsym -Wl,--wrap,dlerror -Wl,--wrap,gettimeofday \

--- a/src/unit_tests/logcollector/test_journal_log.c
+++ b/src/unit_tests/logcollector/test_journal_log.c
@@ -102,6 +102,8 @@ int __wrap_sd_journal_get_cutoff_realtime_usec(sd_journal * j, uint64_t * from, 
 
 int __wrap_sd_journal_process(sd_journal * j) { return mock_type(int); }
 
+int __wrap_sd_journal_get_fd(sd_journal * j) { return mock_type(int); }
+
 extern unsigned int __real_gmtime_r(const time_t * t, struct tm * tm);
 unsigned int __wrap_gmtime_r(__attribute__((__unused__)) const time_t * t, __attribute__((__unused__)) struct tm * tm) {
     unsigned int mock = mock_type(unsigned int);
@@ -532,6 +534,8 @@ static void setup_dlsym_expectations(const char * symbol) {
         mock_function = (void *) __wrap_sd_journal_get_cutoff_realtime_usec;
     } else if (strcmp(symbol, "sd_journal_process") == 0) {
         mock_function = (void *) __wrap_sd_journal_process;
+    } else if (strcmp(symbol, "sd_journal_get_fd") == 0) {
+        mock_function = (void *) __wrap_sd_journal_get_fd;
     } else {
         // Invalid symbol
         assert_true(false);
@@ -590,6 +594,7 @@ static void test_w_journal_lib_init_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     // Act
     w_journal_lib_t * result = w_journal_lib_init();
@@ -652,6 +657,7 @@ static void test_w_journal_context_create_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     // Open the journal
     will_return(__wrap_sd_journal_open, 0);
@@ -750,6 +756,7 @@ static void test_w_journal_context_create_journal_open_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, -1); // Fail w_journal_lib_open
     expect_string(__wrap__mwarn, formatted_msg, "(8010): Failed open journal log: 'Operation not permitted'.");
@@ -829,6 +836,7 @@ static void test_w_journal_context_free_valid(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -897,6 +905,7 @@ static void test_w_journal_context_update_timestamp_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -977,6 +986,7 @@ static void test_w_journal_context_update_timestamp_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1051,6 +1061,7 @@ static void test_w_journal_context_seek_most_recent_update_tamestamp(void ** sta
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1124,6 +1135,7 @@ static void test_w_journal_context_seek_most_recent_seek_tail_fail(void ** state
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1195,6 +1207,7 @@ static void test_w_journal_context_seek_most_recent_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1286,6 +1299,7 @@ static void test_w_journal_context_seek_timestamp_future_timestamp(void ** state
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1362,6 +1376,7 @@ static void test_w_journal_context_seek_timestamp_fail_read_old_ts(void ** state
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1442,6 +1457,7 @@ static void test_w_journal_context_seek_timestamp_change_ts(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1523,6 +1539,7 @@ static void test_w_journal_context_seek_timestamp_seek_timestamp_fail(void ** st
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1599,6 +1616,7 @@ static void test_w_journal_context_seek_timestamp_fail_seek(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1675,6 +1693,7 @@ static void test_w_journal_context_seek_timestamp_next_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1752,6 +1771,7 @@ static void test_w_journal_context_seek_timestamp_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1828,6 +1848,7 @@ static void test_w_journal_context_seek_timestamp_success_new_entry(void ** stat
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1919,6 +1940,7 @@ static void test_w_journal_context_next_newest_update_timestamp(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1992,6 +2014,7 @@ static void test_w_journal_context_next_newest_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2061,6 +2084,7 @@ void test_w_journal_filter_apply_fail_get_data_ignore_test(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2140,6 +2164,7 @@ void test_w_journal_filter_apply_fail_parse(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2210,6 +2235,7 @@ void test_w_journal_filter_apply_empty_field(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2280,6 +2306,7 @@ void test_w_journal_filter_apply_match_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2350,6 +2377,7 @@ void test_w_journal_filter_apply_match_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2434,6 +2462,7 @@ static void test_w_journal_context_next_newest_filtered_null_filters(void ** sta
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2505,6 +2534,7 @@ static void test_w_journal_context_next_newest_filtered_no_filters(void ** state
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2576,6 +2606,7 @@ static void test_w_journal_context_next_newest_filtered_one_filter(void ** state
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2654,6 +2685,7 @@ static void test_w_journal_context_next_newest_filtered_is_debug(void ** state) 
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2740,6 +2772,7 @@ static void test_w_journal_context_next_newest_filtered_is_debug_false(void ** s
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2822,6 +2855,7 @@ static void test_w_journal_context_next_newest_filtered_filter_apply(void ** sta
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2914,6 +2948,7 @@ static void test_w_journal_context_next_newest_filtered_filter_apply_fail(void *
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2996,6 +3031,7 @@ void test_entry_as_json_empty(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3056,6 +3092,7 @@ void test_entry_as_json_fail_parse_field(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3118,6 +3155,7 @@ void test_entry_as_json_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3196,6 +3234,7 @@ void test_get_field_ptr_fail_get_data(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3253,6 +3292,7 @@ void test_get_field_ptr_fail_parse(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3311,6 +3351,7 @@ void test_get_field_ptr_empty_field(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3372,6 +3413,7 @@ void test_get_field_ptr_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3451,6 +3493,7 @@ void test_entry_as_syslog_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3531,6 +3574,7 @@ void test_entry_as_syslog_success_system_pid(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3614,6 +3658,7 @@ void test_entry_as_syslog_success_no_pid(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3697,6 +3742,7 @@ void test_entry_as_syslog_missing_hostname(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3779,6 +3825,7 @@ void test_entry_as_syslog_missing_tag(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3860,6 +3907,7 @@ void test_entry_as_syslog_missing_message(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3944,6 +3992,7 @@ void test_entry_as_syslog_missing_timestamp(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4035,6 +4084,7 @@ void test_w_journal_entry_dump_invalid_type(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4097,6 +4147,7 @@ void test_w_journal_entry_dump_json_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4184,6 +4235,7 @@ void test_w_journal_entry_dump_syslog_fail_json(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4250,6 +4302,7 @@ void test_w_journal_entry_dump_syslog_success(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4335,6 +4388,7 @@ void test_w_journal_entry_dump_syslog_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4423,6 +4477,7 @@ void test_w_journal_entry_to_string_syslog(void ** state) {
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
     setup_dlsym_expectations("sd_journal_process");
+    setup_dlsym_expectations("sd_journal_get_fd");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt

--- a/src/unit_tests/logcollector/test_journal_log.c
+++ b/src/unit_tests/logcollector/test_journal_log.c
@@ -100,6 +100,8 @@ int __wrap_sd_journal_get_cutoff_realtime_usec(sd_journal * j, uint64_t * from, 
     return ret;
 }
 
+int __wrap_sd_journal_process(sd_journal * j) { return mock_type(int); }
+
 extern unsigned int __real_gmtime_r(const time_t * t, struct tm * tm);
 unsigned int __wrap_gmtime_r(__attribute__((__unused__)) const time_t * t, __attribute__((__unused__)) struct tm * tm) {
     unsigned int mock = mock_type(unsigned int);
@@ -528,6 +530,8 @@ static void setup_dlsym_expectations(const char * symbol) {
         mock_function = (void *) __wrap_sd_journal_enumerate_data;
     } else if (strcmp(symbol, "sd_journal_get_cutoff_realtime_usec") == 0) {
         mock_function = (void *) __wrap_sd_journal_get_cutoff_realtime_usec;
+    } else if (strcmp(symbol, "sd_journal_process") == 0) {
+        mock_function = (void *) __wrap_sd_journal_process;
     } else {
         // Invalid symbol
         assert_true(false);
@@ -585,6 +589,7 @@ static void test_w_journal_lib_init_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     // Act
     w_journal_lib_t * result = w_journal_lib_init();
@@ -646,6 +651,7 @@ static void test_w_journal_context_create_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     // Open the journal
     will_return(__wrap_sd_journal_open, 0);
@@ -743,6 +749,7 @@ static void test_w_journal_context_create_journal_open_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, -1); // Fail w_journal_lib_open
     expect_string(__wrap__mwarn, formatted_msg, "(8010): Failed open journal log: 'Operation not permitted'.");
@@ -821,6 +828,7 @@ static void test_w_journal_context_free_valid(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -888,6 +896,7 @@ static void test_w_journal_context_update_timestamp_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -967,6 +976,7 @@ static void test_w_journal_context_update_timestamp_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1040,6 +1050,7 @@ static void test_w_journal_context_seek_most_recent_update_tamestamp(void ** sta
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1112,6 +1123,7 @@ static void test_w_journal_context_seek_most_recent_seek_tail_fail(void ** state
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1182,6 +1194,7 @@ static void test_w_journal_context_seek_most_recent_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1272,6 +1285,7 @@ static void test_w_journal_context_seek_timestamp_future_timestamp(void ** state
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1347,6 +1361,7 @@ static void test_w_journal_context_seek_timestamp_fail_read_old_ts(void ** state
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1426,6 +1441,7 @@ static void test_w_journal_context_seek_timestamp_change_ts(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1506,6 +1522,7 @@ static void test_w_journal_context_seek_timestamp_seek_timestamp_fail(void ** st
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1581,6 +1598,7 @@ static void test_w_journal_context_seek_timestamp_fail_seek(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1656,6 +1674,7 @@ static void test_w_journal_context_seek_timestamp_next_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1732,6 +1751,7 @@ static void test_w_journal_context_seek_timestamp_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1807,6 +1827,7 @@ static void test_w_journal_context_seek_timestamp_success_new_entry(void ** stat
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1897,6 +1918,7 @@ static void test_w_journal_context_next_newest_update_timestamp(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -1969,6 +1991,7 @@ static void test_w_journal_context_next_newest_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2037,6 +2060,7 @@ void test_w_journal_filter_apply_fail_get_data_ignore_test(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2115,6 +2139,7 @@ void test_w_journal_filter_apply_fail_parse(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2184,6 +2209,7 @@ void test_w_journal_filter_apply_empty_field(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2253,6 +2279,7 @@ void test_w_journal_filter_apply_match_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2322,6 +2349,7 @@ void test_w_journal_filter_apply_match_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -2405,6 +2433,7 @@ static void test_w_journal_context_next_newest_filtered_null_filters(void ** sta
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2475,6 +2504,7 @@ static void test_w_journal_context_next_newest_filtered_no_filters(void ** state
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2545,6 +2575,7 @@ static void test_w_journal_context_next_newest_filtered_one_filter(void ** state
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2622,6 +2653,7 @@ static void test_w_journal_context_next_newest_filtered_is_debug(void ** state) 
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2707,6 +2739,7 @@ static void test_w_journal_context_next_newest_filtered_is_debug_false(void ** s
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2788,6 +2821,7 @@ static void test_w_journal_context_next_newest_filtered_filter_apply(void ** sta
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2879,6 +2913,7 @@ static void test_w_journal_context_next_newest_filtered_filter_apply_fail(void *
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
 
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
@@ -2960,6 +2995,7 @@ void test_entry_as_json_empty(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3019,6 +3055,7 @@ void test_entry_as_json_fail_parse_field(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3080,6 +3117,7 @@ void test_entry_as_json_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3157,6 +3195,7 @@ void test_get_field_ptr_fail_get_data(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3213,6 +3252,7 @@ void test_get_field_ptr_fail_parse(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3270,6 +3310,7 @@ void test_get_field_ptr_empty_field(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3330,6 +3371,7 @@ void test_get_field_ptr_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3408,6 +3450,7 @@ void test_entry_as_syslog_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3487,6 +3530,7 @@ void test_entry_as_syslog_success_system_pid(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3569,6 +3613,7 @@ void test_entry_as_syslog_success_no_pid(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3651,6 +3696,7 @@ void test_entry_as_syslog_missing_hostname(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3732,6 +3778,7 @@ void test_entry_as_syslog_missing_tag(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3812,6 +3859,7 @@ void test_entry_as_syslog_missing_message(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3895,6 +3943,7 @@ void test_entry_as_syslog_missing_timestamp(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -3985,6 +4034,7 @@ void test_w_journal_entry_dump_invalid_type(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4046,6 +4096,7 @@ void test_w_journal_entry_dump_json_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4132,6 +4183,7 @@ void test_w_journal_entry_dump_syslog_fail_json(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4197,6 +4249,7 @@ void test_w_journal_entry_dump_syslog_success(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4281,6 +4334,7 @@ void test_w_journal_entry_dump_syslog_fail(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt
@@ -4368,6 +4422,7 @@ void test_w_journal_entry_to_string_syslog(void ** state) {
     setup_dlsym_expectations("sd_journal_restart_data");
     setup_dlsym_expectations("sd_journal_enumerate_data");
     setup_dlsym_expectations("sd_journal_get_cutoff_realtime_usec");
+    setup_dlsym_expectations("sd_journal_process");
     will_return(__wrap_sd_journal_open, 0);
     w_journal_context_create(&ctx);
     // <<<< End init conetxt


### PR DESCRIPTION
|Related issue|
|---|
|solves #26778|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Using `sd_journal_get_fd()` and `sd_journal_process()` the unrecognized rotation of journals files was solved.
 * Library docs [here](https://manpages.debian.org/jessie/libsystemd-dev/SD_JOURNAL_INVALIDATE.3.en.html):
   * **SD_JOURNAL_NOP** is returned: the journal did not change since the last invocation. 
   * **SD_JOURNAL_APPEND** is returned, when new entries have been appended to the end of the journal.
   * **SD_JOURNAL_INVALIDATE** is returned when journal files were added or removed (possibly due to rotation).
* After the recognition of that scenario the journal's context is recreated (closed and reopened) repeating the same steps done at the beginning of the module.

## Evidence

Agent's log:

Where it can be seen rotation events and login and logout of an administrator user.

<details><summary>Details</summary>
<p>

```console
root@pm-debian-12:/var/ossec/bin# ./wazuh-logcollector -dd -f
2025/02/27 17:57:59 wazuh-logcollector[392769] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/02/27 17:57:59 wazuh-logcollector[392769] main.c:126 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/02/27 17:57:59 wazuh-logcollector[392769] agent_op.c:218 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2025/02/27 17:57:59 wazuh-logcollector[392769] agent_op.c:237 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [debian, debian12]
2025/02/27 17:57:59 wazuh-logcollector[392769] config.c:465 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2025/02/27 17:57:59 wazuh-logcollector[392769] mq_op.c:52 at StartMQWithSpecificOwnerAndPerms(): DEBUG: Connected succesfully to 'queue/sockets/queue' after 0 attempts
2025/02/27 17:57:59 wazuh-logcollector[392769] mq_op.c:53 at StartMQWithSpecificOwnerAndPerms(): DEBUG: (unix_domain) Maximum send buffer set to: '212992'.
2025/02/27 17:57:59 wazuh-logcollector[392769] read_journald.c:271 at w_journald_set_status_from_JSON(): DEBUG: (9009): Setting last read timestamp to '1740689722916025'
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:273 at LogCollectorStart(): DEBUG: Entering LogCollectorStart().
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:419 at LogCollectorStart(): DEBUG: (9001): Socket target for 'journald' -> agent
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:1236 at set_read(): DEBUG: Socket target for '/var/ossec/logs/active-responses.log' -> agent
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:435 at LogCollectorStart(): INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:1236 at set_read(): DEBUG: Socket target for '/var/log/dpkg.log' -> agent
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:435 at LogCollectorStart(): INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:342 at LogCollectorStart(): INFO: Monitoring output of command(360): df -P
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:346 at LogCollectorStart(): DEBUG: Socket target for 'df -P' -> agent
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:370 at LogCollectorStart(): INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:374 at LogCollectorStart(): DEBUG: Socket target for 'netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d' -> agent
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:370 at LogCollectorStart(): INFO: Monitoring full output of command(360): last -n 20
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:374 at LogCollectorStart(): DEBUG: Socket target for 'last -n 20' -> agent
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:486 at LogCollectorStart(): INFO: Started (pid: 392769).
2025/02/27 17:57:59 wazuh-logcollector[392769] logcollector.c:487 at LogCollectorStart(): DEBUG: (1961): Files being monitored: 3/1000.
2025/02/27 17:57:59 wazuh-logcollector[392769] lccom.c:511 at lccom_main(): DEBUG: Local requests thread ready
2025/02/27 17:58:19 wazuh-logcollector[392769] read_journald.c:120 at w_journald_can_read(): INFO: (9203): Monitoring journal entries.
2025/02/27 17:58:19 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 17:58:19 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:58:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:58:39 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:58:31 pm-debian-12 su[392780]: pam_unix(su:session): session closed for user root'.
2025/02/27 17:58:39 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:58:31 pm-debian-12 sudo[392778]: pam_unix(sudo:session): session closed for user root'.
2025/02/27 17:58:39 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 17:58:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:58:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:58:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:58:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:03 wazuh-logcollector[392769] logcollector.c:531 at LogCollectorStart(): DEBUG: Performing file check.
2025/02/27 17:59:19 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:19 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:19 wazuh-logcollector[392769] read_journald.c:129 at w_journald_can_read(): DEBUG: (9204): 'Journald' files rotation detected.
2025/02/27 17:59:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:58:46 pm-debian-12 systemd-journald[296]: System Journal (/var/log/journal/c742f3e5dfc04641b84e9f335aa43edc) is 276.7M, max 3.0G, 2.7G free.'.
2025/02/27 17:59:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:58:46 pm-debian-12 systemd-journald[296]: Received client request to rotate journal, rotating.'.
2025/02/27 17:59:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:58:46 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1000@9a610126929147159f74120b3aa0941e-0000000000000000-0000000000000000.journal (3.5M).'.
2025/02/27 17:59:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:58:46 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1001@65f51970754647d38be4aeae58f3abcb-0000000000000000-0000000000000000.journal (3.5M).'.
2025/02/27 17:59:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:58:46 pm-debian-12 systemd-journald[296]: Vacuuming done, freed 7.1M of archived journals from /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc.'.
2025/02/27 17:59:19 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 17:59:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:39 wazuh-logcollector[392769] read_journald.c:156 at w_journald_can_read(): DEBUG: (9205): 'Journald' context was recreated.
2025/02/27 17:59:39 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 17:59:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 17:59:59 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:59:44 pm-debian-12 sudo[392797]:     root : TTY=pts/22 ; PWD=/home/vagrant/workspace/wazuh/src ; USER=root ; COMMAND=/usr/bin/su'.
2025/02/27 17:59:59 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:59:44 pm-debian-12 sudo[392797]: pam_unix(sudo:session): session opened for user root(uid=0) by root(uid=0)'.
2025/02/27 17:59:59 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:59:44 pm-debian-12 su[392799]: (to root) root on pts/23'.
2025/02/27 17:59:59 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 20:59:44 pm-debian-12 su[392799]: pam_unix(su:session): session opened for user root(uid=0) by root(uid=0)'.
2025/02/27 17:59:59 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 18:00:07 wazuh-logcollector[392769] logcollector.c:531 at LogCollectorStart(): DEBUG: Performing file check.
2025/02/27 18:00:19 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:00:19 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:00:19 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 18:00:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:00:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:00:39 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 18:00:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:00:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:00:59 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 18:01:11 wazuh-logcollector[392769] logcollector.c:531 at LogCollectorStart(): DEBUG: Performing file check.
2025/02/27 18:01:19 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:01:19 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:01:19 wazuh-logcollector[392769] read_journald.c:129 at w_journald_can_read(): DEBUG: (9204): 'Journald' files rotation detected.
2025/02/27 18:01:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 21:01:10 pm-debian-12 systemd-journald[296]: System Journal (/var/log/journal/c742f3e5dfc04641b84e9f335aa43edc) is 280.3M, max 3.0G, 2.7G free.'.
2025/02/27 18:01:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 21:01:10 pm-debian-12 systemd-journald[296]: Received client request to rotate journal, rotating.'.
2025/02/27 18:01:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 21:01:10 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1000@9a610126929147159f74120b3aa0941e-0000000000000000-0000000000000000.journal (3.5M).'.
2025/02/27 18:01:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 21:01:10 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1001@65f51970754647d38be4aeae58f3abcb-0000000000000000-0000000000000000.journal (3.5M).'.
2025/02/27 18:01:19 wazuh-logcollector[392769] read_journald.c:204 at read_journald(): DEBUG: (9008): Reading from journal: 'Feb 27 21:01:10 pm-debian-12 systemd-journald[296]: Vacuuming done, freed 7.1M of archived journals from /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc.'.
2025/02/27 18:01:19 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 18:01:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:01:39 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:01:39 wazuh-logcollector[392769] read_journald.c:156 at w_journald_can_read(): DEBUG: (9205): 'Journald' context was recreated.
2025/02/27 18:01:39 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
2025/02/27 18:01:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:01:59 wazuh-logcollector[392769] logcollector.c:2123 at w_input_thread(): DEBUG: (9005): Skipping is not the owner of the journal log.
2025/02/27 18:01:59 wazuh-logcollector[392769] read_journald.c:178 at read_journald(): DEBUG: (9006): No new entries in the journal.
^C2025/02/27 18:02:15 wazuh-logcollector[392769] sig_op.c:49 at HandleSIG(): INFO: (1225): SIGNAL [(2)-(Interrupt)] Received. Exit Cleaning...
root@pm-debian-12:/var/ossec/bin# 


``` 

</p>
</details> 

`Journalctl -f` while the above was executed

<details><summary>Details</summary>
<p>


```console
root@pm-debian-12:/var/ossec/bin# journalctl -f
Feb 27 17:58:09 pm-debian-12 sudo[392778]:     root : TTY=pts/22 ; PWD=/home/vagrant/workspace/wazuh/src ; USER=root ; COMMAND=/usr/bin/su
Feb 27 17:58:09 pm-debian-12 sudo[392778]: pam_unix(sudo:session): session opened for user root(uid=0) by root(uid=0)
Feb 27 17:58:09 pm-debian-12 su[392780]: (to root) root on pts/23
Feb 27 17:58:09 pm-debian-12 su[392780]: pam_unix(su:session): session opened for user root(uid=0) by root(uid=0)
^[[AFeb 27 17:58:31 pm-debian-12 su[392780]: pam_unix(su:session): session closed for user root
Feb 27 17:58:31 pm-debian-12 sudo[392778]: pam_unix(sudo:session): session closed for user root
Feb 27 17:58:46 pm-debian-12 systemd-journald[296]: System Journal (/var/log/journal/c742f3e5dfc04641b84e9f335aa43edc) is 276.7M, max 3.0G, 2.7G free.
Feb 27 17:58:46 pm-debian-12 systemd-journald[296]: Received client request to rotate journal, rotating.
Feb 27 17:58:46 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1000@9a610126929147159f74120b3aa0941e-0000000000000000-0000000000000000.journal (3.5M).
Feb 27 17:58:46 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1001@65f51970754647d38be4aeae58f3abcb-0000000000000000-0000000000000000.journal (3.5M).
Feb 27 17:58:46 pm-debian-12 systemd-journald[296]: Vacuuming done, freed 7.1M of archived journals from /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc.
Feb 27 17:59:44 pm-debian-12 sudo[392797]:     root : TTY=pts/22 ; PWD=/home/vagrant/workspace/wazuh/src ; USER=root ; COMMAND=/usr/bin/su
Feb 27 17:59:44 pm-debian-12 sudo[392797]: pam_unix(sudo:session): session opened for user root(uid=0) by root(uid=0)
Feb 27 17:59:44 pm-debian-12 su[392799]: (to root) root on pts/23
Feb 27 17:59:44 pm-debian-12 su[392799]: pam_unix(su:session): session opened for user root(uid=0) by root(uid=0)
Feb 27 18:01:10 pm-debian-12 systemd-journald[296]: System Journal (/var/log/journal/c742f3e5dfc04641b84e9f335aa43edc) is 280.3M, max 3.0G, 2.7G free.
Feb 27 18:01:10 pm-debian-12 systemd-journald[296]: Received client request to rotate journal, rotating.
Feb 27 18:01:10 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1000@9a610126929147159f74120b3aa0941e-0000000000000000-0000000000000000.journal (3.5M).
Feb 27 18:01:10 pm-debian-12 systemd-journald[296]: Deleted empty archived journal /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc/user-1001@65f51970754647d38be4aeae58f3abcb-0000000000000000-0000000000000000.journal (3.5M).
Feb 27 18:01:10 pm-debian-12 systemd-journald[296]: Vacuuming done, freed 7.1M of archived journals from /var/log/journal/c742f3e5dfc04641b84e9f335aa43edc.
Feb 27 18:01:38 pm-debian-12 sudo[392807]:     root : TTY=pts/23 ; PWD=/home/vagrant/workspace/wazuh/src ; USER=root ; COMMAND=/usr/bin/su
Feb 27 18:01:38 pm-debian-12 sudo[392807]: pam_unix(sudo:session): session opened for user root(uid=0) by root(uid=0)
Feb 27 18:01:38 pm-debian-12 su[392809]: (to root) root on pts/24
Feb 27 18:01:38 pm-debian-12 su[392809]: pam_unix(su:session): session opened for user root(uid=0) by root(uid=0)

``` 


</p>
</details> 

<!--
Add a clear description of how the problem has been solved.
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Source upgrade
- [x] Package upgrade
- [x] Review logs syntax and correct language

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Scan-build report
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
- [x] Added unit tests (for new features)
