### PR TITLE
Add support to 'riskDetections' relationship

### DIFF
--- a/ruleset/rules/0995-microsoft-graph_rules.xml
+++ b/ruleset/rules/0995-microsoft-graph_rules.xml
@@ -866,7 +866,7 @@
 <!--End of Alerts&Incidents -->
 
 
-<!--MDM Intune 99651-99700-->
+<!--MDM Intune 99651-99655-->
 
 
     <rule id="99651" level="3">
@@ -897,6 +897,31 @@
         <description>MS Graph message: MDM Intune app.</description>
     </rule>
 
-<!--MDM Intune 99651-99700-->
+<!--MDM Intune 99651-99655-->
+
+<!--Identity protection 99656-99700-->
+
+    <rule id="99656" level="3">
+        <if_sid>99500</if_sid>
+        <options>no_full_log</options>
+        <field name="ms-graph.resource">identityProtection</field>
+        <description>MS Graph message: Identity protection event.</description>
+    </rule>
+
+    <rule id="99657" level="3">
+        <if_sid>99656</if_sid>
+        <options>no_full_log</options>
+        <field name="ms-graph.relationship">riskDetections</field>
+        <description>MS Graph message: Risk detection event.</description>
+    </rule>
+
+    <rule id="99658" level="3">
+        <if_sid>99656</if_sid>
+        <options>no_full_log</options>
+        <field name="ms-graph.relationship">servicePrincipalRiskDetections</field>
+        <description>MS Graph message: Service principal risk detection event.</description>
+    </rule>
+
+<!--Identity protection 99656-99700-->
 
 </group>

--- a/src/config/wmodules-ms-graph.c
+++ b/src/config/wmodules-ms-graph.c
@@ -48,7 +48,7 @@ int wm_ms_graph_read(const OS_XML* xml, xml_node** nodes, wmodule* module) {
 	ms_graph->only_future_events = WM_MS_GRAPH_DEFAULT_ONLY_FUTURE_EVENTS;
 	ms_graph->curl_max_size = WM_MS_GRAPH_DEFAULT_CURL_MAX_SIZE;
 	ms_graph->page_size = WM_MS_GRAPH_ITEM_PER_PAGE;
-    ms_graph->time_delay = WM_MS_GRAPH_DEFAULT_DELAY;
+	ms_graph->time_delay = WM_MS_GRAPH_DEFAULT_DELAY;
 	ms_graph->run_on_start = WM_MS_GRAPH_DEFAULT_RUN_ON_START;
 	os_strdup(WM_MS_GRAPH_DEFAULT_VERSION, ms_graph->version);
 

--- a/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
+++ b/src/unit_tests/wazuh_modules/ms_graph/test_wm_ms_graph.c
@@ -3234,8 +3234,8 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
       <api_type>global</api_type>
     </api_auth>
     <resource>
-      <name>security</name>
-      <relationship>alerts_v2</relationship>
+      <name>identityProtection</name>
+      <relationship>riskDetections</relationship>
     </resource>
     <resource>
       <name>deviceManagement</name>
@@ -3263,11 +3263,11 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     os_strdup(WM_MS_GRAPH_GLOBAL_API_LOGIN_FQDN, module_data->auth_config[0]->login_fqdn);
     os_strdup(WM_MS_GRAPH_GLOBAL_API_QUERY_FQDN, module_data->auth_config[0]->query_fqdn);
     os_malloc(sizeof(wm_ms_graph_resource) * 2, module_data->resources);
-    os_strdup("security", module_data->resources[0].name);
+    os_strdup("identityProtection", module_data->resources[0].name);
     os_strdup("deviceManagement", module_data->resources[1].name);
     module_data->num_resources = 2;
     os_malloc(sizeof(char*) * 2, module_data->resources[0].relationships);
-    os_strdup("alerts_v2", module_data->resources[0].relationships[0]);
+    os_strdup("riskDetections", module_data->resources[0].relationships[0]);
     module_data->resources[0].num_relationships = 1;
     os_malloc(sizeof(char*) * 2, module_data->resources[1].relationships);
     os_strdup("auditEvents", module_data->resources[1].relationships[0]);
@@ -3289,7 +3289,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_os_random, 12345);
 #endif
 
-    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
+    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-identityProtection-riskDetections");
     expect_value(__wrap_wm_state_io, op, WM_IO_READ);
     expect_any(__wrap_wm_state_io, state);
     expect_any(__wrap_wm_state_io, size);
@@ -3309,7 +3309,7 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_strftime, 20);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/security/alerts_v2?$top=200&$filter=createdDateTime+ge+2023-02-08T12:24:56Z+and+createdDateTime+lt+2023-02-08T12:25:56Z'");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/identityProtection/riskDetections?$top=200&$filter=activityDateTime+ge+2023-02-08T12:24:56Z+and+activityDateTime+lt+2023-02-08T12:25:56Z'");
 
     expect_any(__wrap_wurl_http_request, method);
     expect_any(__wrap_wurl_http_request, header);
@@ -3321,24 +3321,24 @@ void test_wm_ms_graph_scan_relationships_single_success_two_resources(void **sta
     will_return(__wrap_wurl_http_request, response);
 
     expect_string(__wrap__mtdebug2, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}'");
+    expect_string(__wrap__mtdebug2, formatted_msg, "Sending log: '{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"identityProtection\",\"relationship\":\"riskDetections\"}}'");
 
     queue_fd = 0;
     expect_value(__wrap_wm_sendmsg, usec, 1000000);
     expect_value(__wrap_wm_sendmsg, queue, queue_fd);
-    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"security\",\"relationship\":\"alerts_v2\"}}");
+    expect_string(__wrap_wm_sendmsg, message, "{\"integration\":\"ms-graph\",\"ms-graph\":{\"full_log\":\"log1\",\"resource\":\"identityProtection\",\"relationship\":\"riskDetections\"}}");
     expect_string(__wrap_wm_sendmsg, locmsg, "ms-graph");
     expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
     will_return(__wrap_wm_sendmsg, 1);
 
-    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-security-alerts_v2");
+    expect_string(__wrap_wm_state_io, tag, "ms-graph-example_tenant-identityProtection-riskDetections");
     expect_value(__wrap_wm_state_io, op, WM_IO_WRITE);
     expect_any(__wrap_wm_state_io, state);
     expect_any(__wrap_wm_state_io, size);
     will_return(__wrap_wm_state_io, 1);
 
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:ms-graph");
-    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'security' and relationship 'alerts_v2', waiting '60' seconds to run next scan.");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Bookmark updated to '2023-02-08T12:25:56Z' for tenant 'example_tenant' resource 'identityProtection' and relationship 'riskDetections', waiting '60' seconds to run next scan.");
 
     // resource auditlogs
     os_calloc(1, sizeof(curl_response), response);

--- a/src/wazuh_modules/wm_ms_graph.h
+++ b/src/wazuh_modules/wm_ms_graph.h
@@ -49,6 +49,11 @@
 #define WM_MS_GRAPH_RELATIONSHIP_MANAGED_DEVICES "managedDevices"
 #define WM_MS_GRAPH_RELATIONSHIP_DETECTED_APPS "detectedApps"
 
+// Identity protection
+#define WM_MS_GRAPH_RESOURCE_IDENTITY_PROTECTION "identityProtection"
+#define WM_MS_GRAPH_RELATIONSHIP_RISK_DETECTIONS "riskDetections"
+#define WM_MS_GRAPH_RELATIONSHIP_SERVICE_PRINCIPAL_RISK_DETECTIONS "servicePrincipalRiskDetections"
+
 typedef struct wm_ms_graph_state_t {
 	time_t next_time;
 } wm_ms_graph_state_t;


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28048|

## Description

This PR adds official support for the `riskDetections` relationship as part of the `ms-graph` integration.

Since these logs require the `activityDateTime` filter to be queried, appropriate modifications have been added to support this.

## Configuration options

```
  <ms-graph>
    <enabled>yes</enabled>
    <only_future_events>yes</only_future_events>
    <curl_max_size>10M</curl_max_size>
    <page_size>50</page_size>
    <time_delay>45s</time_delay>
    <run_on_start>yes</run_on_start>
    <interval>30s</interval>
    <version>v1.0</version>
    <api_auth>
      <client_id>xxxxx</client_id>
      <tenant_id>yyyyy</tenant_id>
      <secret_value>zzzzz</secret_value>
      <api_type>global</api_type>
    </api_auth>
    <resource>
      <name>identityProtection</name>
      <relationship>riskDetections</relationship>
      <relationship>servicePrincipalRiskDetections</relationship>
    </resource>
  </ms-graph>
```

## Logs/Alerts example

```
2025/02/27 16:29:06 wazuh-modulesd:ms-graph[36419] wm_ms_graph.c:83 at wm_ms_graph_main(): INFO: Scanning tenant '0fea4e03-8146-453b-b889-54b4bd11565b'
2025/02/27 16:29:11 wazuh-modulesd:ms-graph[36419] wm_ms_graph.c:298 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/identityProtection/riskDetections?$top=50&$filter=activityDateTime+ge+2025-02-27T16:27:55Z+and+activityDateTime+lt+2025-02-27T16:28:26Z'
2025/02/27 16:29:12 wazuh-modulesd:ms-graph[36419] wm_ms_graph.c:387 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-27T16:28:26Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'identityProtection' and relationship 'riskDetections', waiting '30' seconds to run next scan.
2025/02/27 16:29:12 wazuh-modulesd:ms-graph[36419] wm_ms_graph.c:298 at wm_ms_graph_scan_relationships(): DEBUG: Microsoft Graph API Log URL: 'https://graph.microsoft.com/v1.0/identityProtection/servicePrincipalRiskDetections?$top=50&$filter=activityDateTime+ge+2025-02-27T16:27:56Z+and+activityDateTime+lt+2025-02-27T16:28:27Z'
2025/02/27 16:29:13 wazuh-modulesd:ms-graph[36419] wm_ms_graph.c:387 at wm_ms_graph_scan_relationships(): DEBUG: Bookmark updated to '2025-02-27T16:28:27Z' for tenant '0fea4e03-8146-453b-b889-54b4bd11565b' resource 'identityProtection' and relationship 'servicePrincipalRiskDetections', waiting '30' seconds to run next scan.
2025/02/27 16:29:14 wazuh-modulesd:ms-graph[36419] wm_ms_graph.c:69 at wm_ms_graph_main(): DEBUG: Waiting until: 2025/02/27 16:29:36
```

## Tests

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues