### PR TITLE
Reverting automatic agent restart when connectivity is lost

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -178,11 +178,6 @@ void start_agent(int is_startup)
         } else {
             current_server_id = 0;
             mwarn("Unable to connect to any server.");
-            if (!is_startup && agt->flags.auto_restart) {
-                minfo("Agent is restarting because there may be a problem with the previous connection.");
-                restartAgent();
-                sleep(10);
-            }
         }
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28338|

## Description

This PR reverts commit 5aa9b5b4ebd69e6b774bdc128a30ba187d2eb3e6.

## Configuration options

N/A

## Logs/Alerts example

N/A

## Tests

- [x] Code changes reviewed