### PR TITLE
proftpd rule 11219 (sreaddir realloc)-level,desc.

### DIFF
--- a/ruleset/rules/0175-proftpd_rules.xml
+++ b/ruleset/rules/0175-proftpd_rules.xml
@@ -150,10 +150,10 @@
     <group>gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.6,pci_dss_10.6.1,service_availability,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
-  <rule id="11219" level="12">
+  <rule id="11219" level="2">
     <if_sid>11200</if_sid>
     <match>Reallocating sreaddir buffer</match>
-    <description>ProFTPD: FTP server Buffer overflow attempt.</description>
+    <description>ProFTPD: directory list buffer reallocation.</description>
     <mitre>
       <id>T1499</id>
     </mitre>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In ProFTPD, when listing a directory, the following error may appear in the log: `Reallocating sreaddir buffer.`
This was evaluated as an attempted buffer overflow with level 12.

The size of the `sreaddir` buffer in ProFTPD is inaccurately estimated based on the directory size. Additionally, after allocation, more files may be added to the directory, requiring ProFTPD to respond by reallocating space. In ProFTPD, this is properly handled, and if more space is needed, additional memory is allocated for the sreaddir buffer. See the code below:

```
  /* It doesn't matter if the following guesses are wrong, but it slows
   * the system a bit and wastes some memory if they are wrong, so
   * don't guess *too* naively!
   *
   * 'dsize' must be greater than zero or we loop forever.
   */
 
  /* Guess the number of entries in the directory. */
  dsize = (((size_t) st.st_size) / 4) + 10;
  if (dsize > LS_MAX_DSIZE) {
    dsize = LS_MAX_DSIZE;
  }
 
  /* Allocate first block for holding filenames.  Yes, we are explicitly using
   * malloc (and realloc, and calloc, later) rather than the memory pools.
   * Recursive directory listings would eat up a lot of pool memory that is
   * only freed when the _entire_ directory structure has been parsed.  Also,
   * this helps to keep the memory footprint a little smaller.
   */
  pr_trace_msg("data", 8, "allocating readdir buffer of %lu bytes",
    (unsigned long) (dsize * sizeof(char *)));
 
  p = malloc(dsize * sizeof(char *));
  if (p == NULL) {
    pr_log_pri(PR_LOG_ALERT, "Out of memory!");
    exit(1);
  }
 
  i = 0;
 
  while ((de = pr_fsio_readdir(d)) != NULL) {
    pr_signals_handle();
 
    if ((size_t) i >= dsize - 1) {
      char **newp;
 
      /* The test above goes off one item early in case this is the last item
       * in the directory and thus next time we will want to NULL-terminate
       * the array.
       */
      pr_log_debug(DEBUG0, "Reallocating sreaddir buffer from %lu entries to "
        "%lu entries", (unsigned long) dsize, (unsigned long) dsize * 2);
 
      /* Allocate bigger array for pointers to filenames */
      pr_trace_msg("data", 8, "allocating readdir buffer of %lu bytes",
        (unsigned long) (2 * dsize * sizeof(char *)));
 
      newp = (char **) realloc(p, 2 * dsize * sizeof(char *));
      if (newp == NULL) {
        pr_log_pri(PR_LOG_ALERT, "Out of memory!");
        exit(1);
      }
      p = newp;
      dsize *= 2;
    }
```

This changes the level to 2 and the message to `ProFTPD: directory list buffer reallocation.` to better match the description.

## Logs/Alerts example

2025-02-28 10:50:03,102 x proftpd[29713] x (x[x]): Reallocating sreaddir buffer from 13 entries to 26 entries

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [x] runtests.py executed without errors