### PR TITLE
Standardise debug symbols naming convention

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -199,7 +199,7 @@ function build_package() {
     if munkipkg $CURRENT_PATH/wazuh-agent ; then
         echo "The wazuh agent package for macOS has been successfully built."
         mv $CURRENT_PATH/wazuh-agent/build/* $DESTINATION/
-        symbols_pkg_name="${pkg_name}_debug_symbols"
+        symbols_pkg_name="wazuh-agent-debug-symbols-${VERSION}-${REVISION}-${ARCH}-macos"
         cp -R "${WAZUH_PATH}/src/symbols"  "${DESTINATION}"
         zip -r "${DESTINATION}/${symbols_pkg_name}.zip" "${DESTINATION}/symbols"
         rm -rf "${DESTINATION}/symbols"

--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -136,12 +136,10 @@ function ExtractDebugSymbols(){
   #compress every pdb file in current folder
 	$pdbFiles = Get-ChildItem -Filter ".\*.pdb"
 
-  $ZIP_NAME = "$($MSI_NAME.Replace('.msi', '-debug-symbols.zip'))"
+    $ZIP_NAME = $MSI_NAME -replace 'wazuh-agent', 'wazuh-agent-debug-symbols' -replace '\.msi$', '.zip'
 
 	Write-Host "Compressing debug symbols to $ZIP_NAME"
 	Compress-Archive -Path $pdbFiles -Force -DestinationPath "$ZIP_NAME"
-
-  dir "*debug-symbols.zip"
 
 	Remove-Item -Path "*.pdb"
 }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/215|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team,

this PR updates the debug symbols packages names to accomplish our new convention.

## Tests

:green_circle: [Packages - Build Wazuh agent macOS packages - intel64 test_debug_symbols_name](https://github.com/wazuh/wazuh-agent-packages/actions/runs/13632760817)

:green_circle: [Packages - Build Wazuh agent Windows - test_debug_symbols_name](https://github.com/wazuh/wazuh-agent-packages/actions/runs/13862789213) - Needs the branch `enhancement/28223-version-file-standarization` to be merged to work properly.