### PR TITLE
Apply timeout to enrollment process in the agent

### DIFF
--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -62,6 +62,7 @@ int ClientConf(const char *cfgfile)
     // Initialize enrollment_cfg
     agt->enrollment_cfg = w_enrollment_init(target_cfg, cert_cfg, &keys);
     agt->enrollment_cfg->allow_localhost = false; // Localhost not allowed in auto-enrollment
+    agt->enrollment_cfg->recv_timeout = getDefine_Int("agent", "recv_timeout", 1, 600);
 
     if (ReadConfig(modules, cfgfile, agt, NULL) < 0 ||
         ReadConfig(CLABELS | CBUFFER, cfgfile, &agt->labels, agt) < 0) {

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -116,6 +116,7 @@
 #define RWLOCK_LOCK_RD  "(1336) Cannot lock rwlock for reading: %s (%d)."
 #define RWLOCK_LOCK_WR  "(1337) Cannot lock rwlock for writing: %s (%d)."
 #define RWLOCK_UNLOCK   "(1338) Cannot unlock rwlock: %s (%d)."
+#define SET_TIMEO_ERR   "(1339) Cannot set timeout."
 
 /* Mail errors */
 #define CHLDWAIT_ERROR  "(1261): Waiting for child process. (status: %d)."

--- a/src/headers/enrollment_op.h
+++ b/src/headers/enrollment_op.h
@@ -73,6 +73,7 @@ typedef struct _enrollment_ctx {
     bool allow_localhost;               /**< true by default. If this flag is false, using agent_name "localhost" will not be allowed */
     time_t delay_after_enrollment;      /**< 20 by default, number of seconds to wait for enrollment */
     char *agent_version;                /**< will hold the __ossec_version value*/
+    int recv_timeout;                   /**< reception timeout, in seconds */
 } w_enrollment_ctx;
 
 /**

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -232,6 +232,14 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
         return ENROLLMENT_CONNECTION_FAILURE;
     }
 
+    if (OS_SetRecvTimeout(sock, cfg->recv_timeout, 0) < 0) {
+        merror(SET_TIMEO_ERR);
+        os_free(ip_address);
+        SSL_CTX_free(ctx);
+        OS_CloseSocket(sock);
+        return ENROLLMENT_CONNECTION_FAILURE;
+    }
+
     /* Connect the SSL socket */
     cfg->ssl = SSL_new(ctx);
     BIO * sbio = BIO_new_socket(sock, BIO_NOCLOSE);

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -134,7 +134,8 @@ set(ENROLLMENT_OP_BASE_FLAGS "-Wl,--wrap=OS_IsValidIP,--wrap=_merror,--wrap=_mwa
                               -Wl,--wrap=SSL_write,--wrap=fopen,--wrap=fclose,--wrap=SSL_read \
                               -Wl,--wrap=BIO_new_socket,--wrap=_merror_exit,--wrap=TempFile,--wrap=OS_MoveFile \
                               -Wl,--wrap=fgets -Wl,--wrap,OS_CloseSocket,--wrap=wfopen,--wrap=fflush,--wrap=fgetpos \
-                              -Wl,--wrap=fread,--wrap=fseek,--wrap=fwrite,--wrap=remove,--wrap=fgetc -Wl,--wrap,popen")
+                              -Wl,--wrap=fread,--wrap=fseek,--wrap=fwrite,--wrap=remove,--wrap=fgetc -Wl,--wrap,popen \
+                              -Wl,--wrap=OS_SetRecvTimeout")
 
 if(${TARGET} STREQUAL "winagent")
     list(APPEND shared_tests_flags "${ENROLLMENT_OP_BASE_FLAGS} -Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -513,6 +513,8 @@ void test_w_enrollment_connect_SSL_connect_error(void **state) {
     expect_string(__wrap_OS_ConnectTCP, _ip, "127.0.0.1");
     expect_value(__wrap_OS_ConnectTCP, ipv6, 0);
     will_return(__wrap_OS_ConnectTCP, 5);
+    // OS_SetRecvTimeout
+    will_return(__wrap_OS_SetRecvTimeout, 0);
     // Connect SSL
     expect_value(__wrap_SSL_new, ctx, ctx);
     cfg->ssl = __real_SSL_new(ctx);
@@ -551,6 +553,8 @@ void test_w_enrollment_connect_success(void **state) {
     expect_string(__wrap_OS_ConnectTCP, _ip, "127.0.0.1");
     expect_value(__wrap_OS_ConnectTCP, ipv6, 0);
     will_return(__wrap_OS_ConnectTCP, 5);
+    // OS_SetRecvTimeout
+    will_return(__wrap_OS_SetRecvTimeout, 0);
     // Connect SSL
     expect_value(__wrap_SSL_new, ctx, ctx);
     cfg->ssl = __real_SSL_new(ctx);
@@ -1039,6 +1043,8 @@ void test_w_enrollment_request_key(void **state) {
         expect_string(__wrap_OS_ConnectTCP, _ip, "192.168.1.1");
         expect_value(__wrap_OS_ConnectTCP, ipv6, 0);
         will_return(__wrap_OS_ConnectTCP, 5);
+        // OS_SetRecvTimeout
+        will_return(__wrap_OS_SetRecvTimeout, 0);
         // Connect SSL
         expect_value(__wrap_SSL_new, ctx, ctx);
         cfg->ssl = __real_SSL_new(ctx);


### PR DESCRIPTION
## Description

This PR ensures that the internal option `agent.recv_timeout` is applied not only to agent communication but also to the enrollment process. This change prevents the agent from indefinitely waiting for a response during enrollment when the manager is unresponsive or experiencing delays.

## Proposed Changes

- Apply `agent.recv_timeout` to the enrollment process (`w_enrollment_process_response`).
- Modify the connection logic to respect the configured timeout, ensuring the agent does not freeze indefinitely.
- Maintain consistency with the timeout handling used in `wazuh-authd` and `wazuh-remoted`.

### Results and Evidence

After implementing the change, the agent now properly times out when waiting for an enrollment response. In this example, `agent.recv_timeout` was set to `10` (seconds).

```
2025/03/07 13:02:49 wazuh-agent: INFO: Requesting a key from server: 172.21.187.131
2025/03/07 13:02:49 wazuh-agent: INFO: Using password specified on file: authd.pass
2025/03/07 13:02:49 wazuh-agent: INFO: Using agent name as: test-agent
2025/03/07 13:02:49 wazuh-agent: INFO: Waiting for server reply
           --------
2025/03/07 13:02:59 wazuh-agent: ERROR: SSL read (unable to receive message)
           --------
2025/03/07 13:02:59 wazuh-agent: ERROR: If Agent verification is enabled, agent key and certificates may be incorrect!
2025/03/07 13:03:00 wazuh-agent: WARNING: (4101): Waiting for server reply (not started). Tried: '172.21.187.131'. Ensure that the manager version is 'v4.11.1' or higher.
2025/03/07 13:03:00 wazuh-agent: WARNING: Unable to connect to any server.
2025/03/07 13:03:00 wazuh-agent: INFO: Closing connection to server ([172.21.187.131]:1514/tcp).
2025/03/07 13:03:00 wazuh-agent: INFO: Trying to connect to server ([172.21.187.131]:1514/tcp).
```

### Artifacts affected

- wazuh-agentd (UNIX)
- wazuh-agent.exe (Windows)

### Configuration changes

None. The internal option `agent.recv_timeout` now applies in both communication and enrollment.

### Tests Introduced

- Unit test `test_w_enrollment_connect_set_timeout_error`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] Test on UNIX agent
- [x] Simulate a connection freeze (e.g., using `iptables`)