### PR TITLE
stringHelper UTs

### DIFF
--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -158,10 +158,7 @@ namespace Utils
 
         while (std::getline(tokenStream, token, delimiter))
         {
-            if (!token.empty())
-            {
-                tokens.push_back(token);
-            }
+            tokens.push_back(token);
         }
 
         return tokens;
@@ -567,16 +564,10 @@ namespace Utils
         while ((pos = str.find(delimiter)) != std::string::npos)
         {
             token = str.substr(0, pos);
-            if (!token.empty())
-            {
-                tokens.push_back(token);
-            }
+            tokens.push_back(token);
             str.remove_prefix(pos + 1);
         }
-        if (!str.empty())
-        {
-            tokens.push_back(str);
-        }
+        tokens.push_back(str);
         return tokens;
     }
 #endif

--- a/src/shared_modules/utils/stringHelper.h
+++ b/src/shared_modules/utils/stringHelper.h
@@ -158,7 +158,10 @@ namespace Utils
 
         while (std::getline(tokenStream, token, delimiter))
         {
-            tokens.push_back(token);
+            if (!token.empty())
+            {
+                tokens.push_back(token);
+            }
         }
 
         return tokens;
@@ -564,8 +567,15 @@ namespace Utils
         while ((pos = str.find(delimiter)) != std::string::npos)
         {
             token = str.substr(0, pos);
-            tokens.push_back(token);
+            if (!token.empty())
+            {
+                tokens.push_back(token);
+            }
             str.remove_prefix(pos + 1);
+        }
+        if (!str.empty())
+        {
+            tokens.push_back(str);
         }
         return tokens;
     }

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -12,6 +12,10 @@
 #include "stringHelper_test.h"
 #include "stringHelper.h"
 #include <sstream>
+#if __cplusplus >= 201703L
+#include <string_view>
+using namespace std::string_view_literals;
+#endif
 
 void StringUtilsTest::SetUp() {};
 
@@ -72,6 +76,22 @@ TEST_F(StringUtilsTest, SplitDelimiterNoCoincidence)
 TEST_F(StringUtilsTest, SplitDelimiterCoincidence)
 {
     const auto splitTextVector {Utils::split("hello.world", '.')};
+    EXPECT_EQ(2ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "hello");
+    EXPECT_EQ(splitTextVector[1], "world");
+}
+
+TEST_F(StringUtilsTest, SplitDelimiterAtTheBeginningCoincidence)
+{
+    const auto splitTextVector {Utils::split(".hello.world", '.')};
+    EXPECT_EQ(2ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "hello");
+    EXPECT_EQ(splitTextVector[1], "world");
+}
+
+TEST_F(StringUtilsTest, SplitDelimiterAtTheEndCoincidence)
+{
+    const auto splitTextVector {Utils::split("hello.world.", '.')};
     EXPECT_EQ(2ull, splitTextVector.size());
     EXPECT_EQ(splitTextVector[0], "hello");
     EXPECT_EQ(splitTextVector[1], "world");
@@ -640,3 +660,84 @@ TEST_F(StringUtilsTest, splitToNumbers)
 
     EXPECT_ANY_THROW({ ret = Utils::splitToNumbers("1.1.1", ' '); });
 }
+
+#if __cplusplus >= 201703L
+
+TEST_F(StringUtilsTest, SplitEmptyStringSV)
+{
+    auto splitTextVector {Utils::splitView(""sv, '.')};
+    EXPECT_EQ(0ull, splitTextVector.size());
+}
+
+TEST_F(StringUtilsTest, SplitDelimiterNoCoincidenceSV)
+{
+    const auto splitTextVector {Utils::splitView("hello_world"sv, '.')};
+    EXPECT_EQ(1ull, splitTextVector.size());
+}
+
+TEST_F(StringUtilsTest, SplitDelimiterCoincidenceSV)
+{
+    const auto splitTextVector {Utils::splitView("hello.world"sv, '.')};
+    EXPECT_EQ(2ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "hello");
+    EXPECT_EQ(splitTextVector[1], "world");
+}
+
+TEST_F(StringUtilsTest, SplitDelimiterAtTheBeginningCoincidenceSV)
+{
+    const auto splitTextVector {Utils::splitView(".hello.world"sv, '.')};
+    EXPECT_EQ(2ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "hello");
+    EXPECT_EQ(splitTextVector[1], "world");
+}
+
+TEST_F(StringUtilsTest, SplitDelimiterAtTheEndCoincidenceSV)
+{
+    const auto splitTextVector {Utils::splitView("hello.world."sv, '.')};
+    EXPECT_EQ(2ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "hello");
+    EXPECT_EQ(splitTextVector[1], "world");
+}
+
+TEST_F(StringUtilsTest, StartsWithSV)
+{
+    const std::string_view start {"Package_"};
+    const std::string_view item1 {"Package_6_for_KB4565554~31bf3856ad364e35~amd64~~18362.957.1.3"};
+    const std::string_view item2 {"Package_5_for_KB4569073~31bf3856ad364e35~amd64~~18362.1012.1.1"};
+    const std::string_view item3 {
+        "Microsoft-Windows-IIS-WebServer-AddOn-Package~31bf3856ad364e35~amd64~~10.0.18362.815"};
+    const std::string_view item4 {
+        "Microsoft-Windows-HyperV-OptionalFeature-VirtualMachinePlatform-Package_31bf3856ad364e35~"
+        "amd64~~10.0.18362.1139.mum"};
+    EXPECT_TRUE(Utils::startsWith(start, start));
+    EXPECT_TRUE(Utils::startsWith(item1, start));
+    EXPECT_TRUE(Utils::startsWith(item2, start));
+    EXPECT_FALSE(Utils::startsWith(""sv, start));
+    EXPECT_FALSE(Utils::startsWith(item3, start));
+    EXPECT_FALSE(Utils::startsWith(item4, start));
+}
+
+TEST_F(StringUtilsTest, CheckFirstReplacementSV)
+{
+    std::string string_base {"bye_bye"};
+    const auto retVal {Utils::replaceFirstView(string_base, "bye"sv, "hello"sv)};
+    EXPECT_EQ(string_base, "hello_bye");
+    EXPECT_TRUE(retVal);
+}
+
+TEST_F(StringUtilsTest, CheckNotFirstReplacementSV)
+{
+    std::string string_base {"hello_world"};
+    const auto retVal {Utils::replaceFirstView(string_base, "nothing_"sv, "bye_"sv)};
+    EXPECT_EQ(string_base, "hello_world");
+    EXPECT_FALSE(retVal);
+}
+
+TEST_F(StringUtilsTest, ToLowerCaseSV)
+{
+    EXPECT_EQ("", Utils::toLowerCaseView(""sv));
+    EXPECT_EQ("hello world", Utils::toLowerCaseView("HeLlO WoRlD"sv));
+    EXPECT_EQ("123", Utils::toLowerCaseView("123"sv));
+}
+
+#endif

--- a/src/shared_modules/utils/tests/stringHelper_test.cpp
+++ b/src/shared_modules/utils/tests/stringHelper_test.cpp
@@ -84,9 +84,10 @@ TEST_F(StringUtilsTest, SplitDelimiterCoincidence)
 TEST_F(StringUtilsTest, SplitDelimiterAtTheBeginningCoincidence)
 {
     const auto splitTextVector {Utils::split(".hello.world", '.')};
-    EXPECT_EQ(2ull, splitTextVector.size());
-    EXPECT_EQ(splitTextVector[0], "hello");
-    EXPECT_EQ(splitTextVector[1], "world");
+    EXPECT_EQ(3ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "");
+    EXPECT_EQ(splitTextVector[1], "hello");
+    EXPECT_EQ(splitTextVector[2], "world");
 }
 
 TEST_F(StringUtilsTest, SplitDelimiterAtTheEndCoincidence)
@@ -666,7 +667,8 @@ TEST_F(StringUtilsTest, splitToNumbers)
 TEST_F(StringUtilsTest, SplitEmptyStringSV)
 {
     auto splitTextVector {Utils::splitView(""sv, '.')};
-    EXPECT_EQ(0ull, splitTextVector.size());
+    EXPECT_EQ(1ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "");
 }
 
 TEST_F(StringUtilsTest, SplitDelimiterNoCoincidenceSV)
@@ -686,17 +688,19 @@ TEST_F(StringUtilsTest, SplitDelimiterCoincidenceSV)
 TEST_F(StringUtilsTest, SplitDelimiterAtTheBeginningCoincidenceSV)
 {
     const auto splitTextVector {Utils::splitView(".hello.world"sv, '.')};
-    EXPECT_EQ(2ull, splitTextVector.size());
-    EXPECT_EQ(splitTextVector[0], "hello");
-    EXPECT_EQ(splitTextVector[1], "world");
+    EXPECT_EQ(3ull, splitTextVector.size());
+    EXPECT_EQ(splitTextVector[0], "");
+    EXPECT_EQ(splitTextVector[1], "hello");
+    EXPECT_EQ(splitTextVector[2], "world");
 }
 
 TEST_F(StringUtilsTest, SplitDelimiterAtTheEndCoincidenceSV)
 {
     const auto splitTextVector {Utils::splitView("hello.world."sv, '.')};
-    EXPECT_EQ(2ull, splitTextVector.size());
+    EXPECT_EQ(3ull, splitTextVector.size());
     EXPECT_EQ(splitTextVector[0], "hello");
     EXPECT_EQ(splitTextVector[1], "world");
+    EXPECT_EQ(splitTextVector[2], "");
 }
 
 TEST_F(StringUtilsTest, StartsWithSV)


### PR DESCRIPTION
|Related issue|
|---|
|#28422|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description 

This PR adds test for new string_view helper functions and fixes some cases. 

> [!NOTE]
> There are many implementations that need to be merged before this one. 

## DoD 

```console
root@jammy:/home/vagrant/wazuh/src/build/shared_modules/utils/tests# ./utils_unit_test --gtest_filter=StringUtilsTest.*
Note: Google Test filter = StringUtilsTest.*
[==========] Running 75 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 75 tests from StringUtilsTest
[ RUN      ] StringUtilsTest.CheckReplacement
[       OK ] StringUtilsTest.CheckReplacement (0 ms)
[ RUN      ] StringUtilsTest.CheckNotReplacement
[       OK ] StringUtilsTest.CheckNotReplacement (0 ms)
[ RUN      ] StringUtilsTest.CheckUnchanged
[       OK ] StringUtilsTest.CheckUnchanged (0 ms)
[ RUN      ] StringUtilsTest.CheckQuoteEscape
[       OK ] StringUtilsTest.CheckQuoteEscape (0 ms)
[ RUN      ] StringUtilsTest.CheckUnquoteEscape
[       OK ] StringUtilsTest.CheckUnquoteEscape (0 ms)
[ RUN      ] StringUtilsTest.SplitEmptyString
[       OK ] StringUtilsTest.SplitEmptyString (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterNoCoincidence
[       OK ] StringUtilsTest.SplitDelimiterNoCoincidence (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterCoincidence
[       OK ] StringUtilsTest.SplitDelimiterCoincidence (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterAtTheBeginningCoincidence
[       OK ] StringUtilsTest.SplitDelimiterAtTheBeginningCoincidence (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterAtTheEndCoincidence
[       OK ] StringUtilsTest.SplitDelimiterAtTheEndCoincidence (0 ms)
[ RUN      ] StringUtilsTest.SplitIndex
[       OK ] StringUtilsTest.SplitIndex (0 ms)
[ RUN      ] StringUtilsTest.SplitIndexRuntimeError
[       OK ] StringUtilsTest.SplitIndexRuntimeError (0 ms)
[ RUN      ] StringUtilsTest.AsciiToHexString
[       OK ] StringUtilsTest.AsciiToHexString (0 ms)
[ RUN      ] StringUtilsTest.CheckFirstReplacement
[       OK ] StringUtilsTest.CheckFirstReplacement (0 ms)
[ RUN      ] StringUtilsTest.CheckNotFirstReplacement
[       OK ] StringUtilsTest.CheckNotFirstReplacement (0 ms)
[ RUN      ] StringUtilsTest.RightTrim
[       OK ] StringUtilsTest.RightTrim (0 ms)
[ RUN      ] StringUtilsTest.LeftTrim
[       OK ] StringUtilsTest.LeftTrim (0 ms)
[ RUN      ] StringUtilsTest.Trim
[       OK ] StringUtilsTest.Trim (0 ms)
[ RUN      ] StringUtilsTest.ToUpperCase
[       OK ] StringUtilsTest.ToUpperCase (0 ms)
[ RUN      ] StringUtilsTest.ToLowerCase
[       OK ] StringUtilsTest.ToLowerCase (0 ms)
[ RUN      ] StringUtilsTest.ToSentenceCase
[       OK ] StringUtilsTest.ToSentenceCase (0 ms)
[ RUN      ] StringUtilsTest.StartsWith
[       OK ] StringUtilsTest.StartsWith (0 ms)
[ RUN      ] StringUtilsTest.EndsWith
[       OK ] StringUtilsTest.EndsWith (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterNullTerminated
[       OK ] StringUtilsTest.SplitDelimiterNullTerminated (0 ms)
[ RUN      ] StringUtilsTest.SplitMapKeyValue
[       OK ] StringUtilsTest.SplitMapKeyValue (0 ms)
[ RUN      ] StringUtilsTest.CheckMultiReplacement
[       OK ] StringUtilsTest.CheckMultiReplacement (0 ms)
[ RUN      ] StringUtilsTest.substrOnFirstOccurrenceCorrect
[       OK ] StringUtilsTest.substrOnFirstOccurrenceCorrect (0 ms)
[ RUN      ] StringUtilsTest.substrOnFirstOccurrenceCorrectEmpty
[       OK ] StringUtilsTest.substrOnFirstOccurrenceCorrectEmpty (0 ms)
[ RUN      ] StringUtilsTest.substrOnFirstOccurrenceNoOccurrences
[       OK ] StringUtilsTest.substrOnFirstOccurrenceNoOccurrences (0 ms)
[ RUN      ] StringUtilsTest.substrOnFirstOccurrenceCorrectEndText
[       OK ] StringUtilsTest.substrOnFirstOccurrenceCorrectEndText (0 ms)
[ RUN      ] StringUtilsTest.substrOnFirstOccurrenceCorrectFirstText
[       OK ] StringUtilsTest.substrOnFirstOccurrenceCorrectFirstText (0 ms)
[ RUN      ] StringUtilsTest.substrOnFirstOccurrenceCorrectEscapeCharacter
[       OK ] StringUtilsTest.substrOnFirstOccurrenceCorrectEscapeCharacter (0 ms)
[ RUN      ] StringUtilsTest.substrOnFirstOccurrenceCorrectEscapeCharacterEmptyResult
[       OK ] StringUtilsTest.substrOnFirstOccurrenceCorrectEscapeCharacterEmptyResult (0 ms)
[ RUN      ] StringUtilsTest.splitKeyValueNonEscapedSimple
[       OK ] StringUtilsTest.splitKeyValueNonEscapedSimple (0 ms)
[ RUN      ] StringUtilsTest.splitKeyValueNonEscapedSimpleEnd
[       OK ] StringUtilsTest.splitKeyValueNonEscapedSimpleEnd (0 ms)
[ RUN      ] StringUtilsTest.splitKeyValueNonEscapedSimpleDoubleDelimiterEnd
[       OK ] StringUtilsTest.splitKeyValueNonEscapedSimpleDoubleDelimiterEnd (0 ms)
[ RUN      ] StringUtilsTest.splitKeyValueNonEscapedSimpleDoubleEnd
[       OK ] StringUtilsTest.splitKeyValueNonEscapedSimpleDoubleEnd (0 ms)
[ RUN      ] StringUtilsTest.splitKeyValueNonEscapedSimpleEmptyDoubleEnd
[       OK ] StringUtilsTest.splitKeyValueNonEscapedSimpleEmptyDoubleEnd (0 ms)
[ RUN      ] StringUtilsTest.splitKeyValueNonEscapedComplex
[       OK ] StringUtilsTest.splitKeyValueNonEscapedComplex (0 ms)
[ RUN      ] StringUtilsTest.splitKeyValueNonEscapedComplexEnd
[       OK ] StringUtilsTest.splitKeyValueNonEscapedComplexEnd (0 ms)
[ RUN      ] StringUtilsTest.findRegexInStringNotStartWith
[       OK ] StringUtilsTest.findRegexInStringNotStartWith (0 ms)
[ RUN      ] StringUtilsTest.findRegexInStringStartWith
[       OK ] StringUtilsTest.findRegexInStringStartWith (0 ms)
[ RUN      ] StringUtilsTest.findRegexInStringMatchingRegexWithoutGroup
[       OK ] StringUtilsTest.findRegexInStringMatchingRegexWithoutGroup (0 ms)
[ RUN      ] StringUtilsTest.findRegexInStringNoExtractingFirstGroup
[       OK ] StringUtilsTest.findRegexInStringNoExtractingFirstGroup (0 ms)
[ RUN      ] StringUtilsTest.findRegexInStringExtractingFirstGroup
[       OK ] StringUtilsTest.findRegexInStringExtractingFirstGroup (0 ms)
[ RUN      ] StringUtilsTest.findRegexInStringExtractingSecondGroup
[       OK ] StringUtilsTest.findRegexInStringExtractingSecondGroup (0 ms)
[ RUN      ] StringUtilsTest.convertToUTF8NoChanges
[       OK ] StringUtilsTest.convertToUTF8NoChanges (0 ms)
[ RUN      ] StringUtilsTest.rawUnicodeToUTF8
[       OK ] StringUtilsTest.rawUnicodeToUTF8 (0 ms)
[ RUN      ] StringUtilsTest.stringIsNumberFalse1
[       OK ] StringUtilsTest.stringIsNumberFalse1 (0 ms)
[ RUN      ] StringUtilsTest.stringIsNumberFalse2
[       OK ] StringUtilsTest.stringIsNumberFalse2 (0 ms)
[ RUN      ] StringUtilsTest.stringIsNumberFalse3
[       OK ] StringUtilsTest.stringIsNumberFalse3 (0 ms)
[ RUN      ] StringUtilsTest.stringIsNumberTrue
[       OK ] StringUtilsTest.stringIsNumberTrue (0 ms)
[ RUN      ] StringUtilsTest.parseStrToBoolYes
[       OK ] StringUtilsTest.parseStrToBoolYes (0 ms)
[ RUN      ] StringUtilsTest.parseStrToBoolNo
[       OK ] StringUtilsTest.parseStrToBoolNo (0 ms)
[ RUN      ] StringUtilsTest.parseStrToBoolSarasa
[       OK ] StringUtilsTest.parseStrToBoolSarasa (0 ms)
[ RUN      ] StringUtilsTest.parseStrToTimeEmpty
[       OK ] StringUtilsTest.parseStrToTimeEmpty (0 ms)
[ RUN      ] StringUtilsTest.parseStrToTimeOneSec
[       OK ] StringUtilsTest.parseStrToTimeOneSec (0 ms)
[ RUN      ] StringUtilsTest.parseStrToTimeOneMin
[       OK ] StringUtilsTest.parseStrToTimeOneMin (0 ms)
[ RUN      ] StringUtilsTest.parseStrToTimeOneHour
[       OK ] StringUtilsTest.parseStrToTimeOneHour (0 ms)
[ RUN      ] StringUtilsTest.parseStrToTimeOneDay
[       OK ] StringUtilsTest.parseStrToTimeOneDay (0 ms)
[ RUN      ] StringUtilsTest.parseStrToTimeOneWeek
[       OK ] StringUtilsTest.parseStrToTimeOneWeek (0 ms)
[ RUN      ] StringUtilsTest.parseStrToTimeOneSarasa
[       OK ] StringUtilsTest.parseStrToTimeOneSarasa (0 ms)
[ RUN      ] StringUtilsTest.IsAlphaNumericWithSpecialCharacters
[       OK ] StringUtilsTest.IsAlphaNumericWithSpecialCharacters (0 ms)
[ RUN      ] StringUtilsTest.padString
[       OK ] StringUtilsTest.padString (0 ms)
[ RUN      ] StringUtilsTest.haveUpperCaseCharacters
[       OK ] StringUtilsTest.haveUpperCaseCharacters (0 ms)
[ RUN      ] StringUtilsTest.splitToNumbers
[       OK ] StringUtilsTest.splitToNumbers (0 ms)
[ RUN      ] StringUtilsTest.SplitEmptyStringSV
[       OK ] StringUtilsTest.SplitEmptyStringSV (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterNoCoincidenceSV
[       OK ] StringUtilsTest.SplitDelimiterNoCoincidenceSV (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterCoincidenceSV
[       OK ] StringUtilsTest.SplitDelimiterCoincidenceSV (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterAtTheBeginningCoincidenceSV
[       OK ] StringUtilsTest.SplitDelimiterAtTheBeginningCoincidenceSV (0 ms)
[ RUN      ] StringUtilsTest.SplitDelimiterAtTheEndCoincidenceSV
[       OK ] StringUtilsTest.SplitDelimiterAtTheEndCoincidenceSV (0 ms)
[ RUN      ] StringUtilsTest.StartsWithSV
[       OK ] StringUtilsTest.StartsWithSV (0 ms)
[ RUN      ] StringUtilsTest.CheckFirstReplacementSV
[       OK ] StringUtilsTest.CheckFirstReplacementSV (0 ms)
[ RUN      ] StringUtilsTest.CheckNotFirstReplacementSV
[       OK ] StringUtilsTest.CheckNotFirstReplacementSV (0 ms)
[ RUN      ] StringUtilsTest.ToLowerCaseSV
[       OK ] StringUtilsTest.ToLowerCaseSV (0 ms)
[----------] 75 tests from StringUtilsTest (2 ms total)

[----------] Global test environment tear-down
[==========] 75 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 75 tests.
```