### PR TITLE
Removed stable branch references

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ Here you can find all the automation tools maintained by the Wazuh team.
 
 ## Branches
 
-* `master` branch contains the latest code, be aware of possible bugs on this branch.
-* `stable` branch on correspond to the last Wazuh stable version.
+* `main` branch contains the latest code, be aware of possible bugs on this branch.
 
 ## Software and libraries used
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28358|


## Description

Removes the `stable` branch mention from the `README.md` file. The branch does not exist in the repository.