### PR TITLE
Generate latest package from wazuh-server

### DIFF
--- a/.github/workflows/packages-build-server.yml
+++ b/.github/workflows/packages-build-server.yml
@@ -212,3 +212,33 @@ jobs:
           aws s3 cp /tmp/${{ env.PACKAGE_SYMBOLS_NAME }} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
           symbols="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${symbols_name}"
           echo "S3 symbols URI: ${symbols}"
+
+      - name: Create latest package copy
+        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' }}
+        run: |
+          LATEST_PACKAGE_NAME=$(echo ${{ env.PACKAGE_NAME }} | sed 's/[a-f0-9]\{7,\}/latest/')
+          cp /tmp/${{ env.PACKAGE_NAME }} /tmp/$LATEST_PACKAGE_NAME
+          echo "LATEST_PACKAGE_NAME=$LATEST_PACKAGE_NAME" >> $GITHUB_ENV
+
+      - name: Upload latest package to GitHub
+        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.LATEST_PACKAGE_NAME }}
+          path: /tmp/${{ env.LATEST_PACKAGE_NAME }}
+          if-no-files-found: error
+
+      - name: Upload latest package to S3
+        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' }}
+        working-directory: packages
+        run: |
+          aws s3 cp /tmp/${{ env.LATEST_PACKAGE_NAME }} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{ env.LATEST_PACKAGE_NAME }}"
+          echo "S3 latest package URI: ${s3uri}"
+
+      - name: Upload latest checksum to S3
+        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' && inputs.checksum }}
+        run: |
+          aws s3 cp /tmp/${{ env.LATEST_PACKAGE_NAME }}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
+          s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{ env.LATEST_PACKAGE_NAME }}.sha512"
+          echo "S3 latest checksum URI: ${s3uri}"

--- a/.github/workflows/packages-build-server.yml
+++ b/.github/workflows/packages-build-server.yml
@@ -214,22 +214,14 @@ jobs:
           echo "S3 symbols URI: ${symbols}"
 
       - name: Create latest package copy
-        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' }}
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/5.') }}
         run: |
           LATEST_PACKAGE_NAME=$(echo ${{ env.PACKAGE_NAME }} | sed 's/[a-f0-9]\{7,\}/latest/')
           cp /tmp/${{ env.PACKAGE_NAME }} /tmp/$LATEST_PACKAGE_NAME
           echo "LATEST_PACKAGE_NAME=$LATEST_PACKAGE_NAME" >> $GITHUB_ENV
 
-      - name: Upload latest package to GitHub
-        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.LATEST_PACKAGE_NAME }}
-          path: /tmp/${{ env.LATEST_PACKAGE_NAME }}
-          if-no-files-found: error
-
       - name: Upload latest package to S3
-        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' }}
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/5.') }}
         working-directory: packages
         run: |
           aws s3 cp /tmp/${{ env.LATEST_PACKAGE_NAME }} s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
@@ -237,7 +229,7 @@ jobs:
           echo "S3 latest package URI: ${s3uri}"
 
       - name: Upload latest checksum to S3
-        if: ${{ github.ref == 'refs/heads/enhancement/28404-add-latest-package' && inputs.checksum }}
+        if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/5.')) && inputs.checksum }}
         run: |
           aws s3 cp /tmp/${{ env.LATEST_PACKAGE_NAME }}.sha512 s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/
           s3uri="s3://packages-dev.internal.wazuh.com/development/wazuh/5.x/main/packages/${{ env.LATEST_PACKAGE_NAME }}.sha512"


### PR DESCRIPTION
|Related issue|
|---|
| #28404  |

## Description

- This PR closes #28404, where final steps were added to generate a copy by modifying the name to 'latest' and upload it alongside the created package to S3.
- This package will only be created for the `main` branch or `5.x.x` branches, as it is the request described in the issue.
- A run of this workflow was tested with the development branch `enhancement/28404-add-latest-package` (this was also added just for testing purposes). Additionally, for the test, the creation of the package was included within the GitHub Actions artifacts to display the name with which this copy is generated (this part was also removed later because we only want this copy to be uploaded to S3).

### Testing

- Workflow execution

![image](https://github.com/user-attachments/assets/810ec324-067d-4003-ac11-6207283dd1f1)

- Generated package

![blurred_final](https://github.com/user-attachments/assets/abe5f1c3-6b2c-452e-beb1-c7f811deb81f)
