### PR TITLE
Add VERSION.json in agent packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-integration-tests.md
+++ b/.github/ISSUE_TEMPLATE/api-integration-tests.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-The following issue aims to run all [API integration tests](https://github.com/wazuh/wazuh/tree/master/api/test/integration) for the current release candidate, report the results, and open new issues for any encountered errors.
+The following issue aims to run all [API integration tests](https://github.com/wazuh/wazuh/tree/main/api/test/integration) for the current release candidate, report the results, and open new issues for any encountered errors.
 
 ## API integration tests information
 |                                          |                                            |

--- a/.github/ISSUE_TEMPLATE/system-tests.md
+++ b/.github/ISSUE_TEMPLATE/system-tests.md
@@ -35,7 +35,7 @@ To run tests in an AWS EC2 virtual environment, the following requirements will 
 
 These requirements should be requested to the @wazuh/devel-devops team via https://github.com/wazuh/internal-devel-requests.
 
-For further information, check https://github.com/wazuh/wazuh-qa/tree/master/tests/system/README.md
+For further information, check https://github.com/wazuh/wazuh-qa/tree/main/tests/system/README.md
 
 ## Test report procedure
 All individual test checks must be marked as:

--- a/.github/actions/test_deploy_win.ps1
+++ b/.github/actions/test_deploy_win.ps1
@@ -4,12 +4,30 @@
 # and/or modify it under the terms of the GNU General Public
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
-(Get-Content VERSION.json) -match '"version":\s*"([^"]+)"' | Out-Null
-$VERSION = "$($matches[1])"
-[version]$VERSION = $VERSION
-$MAJOR=$VERSION.Major
-$MINOR=$VERSION.Minor
-$SHA= git rev-parse --short $args[0]
+$VERSION_JSON = (Get-Content VERSION.json) -join "`n"
+
+if ($VERSION_JSON -match '"version":\s*"([^"]+)"') {
+    $VERSION = $matches[1]
+
+    try {
+        [version]$VERSION_OBJ = $VERSION
+        $MAJOR = $VERSION_OBJ.Major
+        $MINOR = $VERSION_OBJ.Minor
+    } catch {
+        Write-Output "Invalid version format: $VERSION"
+        exit 1
+    }
+
+    try {
+        $SHA= git rev-parse --short $args[0]
+    } catch {
+        Write-Output "Failed to extract commit hash from git"
+        exit 1
+    }
+} else {
+    Write-Output "Failed to extract version from VERSION.json"
+    exit 1
+}
 
 $TEST_ARRAY=@(
               @("WAZUH_MANAGER ", "1.1.1.1", "<address>", "</address>"),

--- a/.github/workflows/packages-retag-images.yml
+++ b/.github/workflows/packages-retag-images.yml
@@ -24,7 +24,7 @@ on:
   push:
     branches:
       - '[0-9]+.[0-9]+.[0-9]+'
-      - 'master'
+      - 'main'
     paths:
       - 'VERSION.json'
       - 'src/VERSION'

--- a/.github/workflows/packages-retag-images.yml
+++ b/.github/workflows/packages-retag-images.yml
@@ -27,6 +27,7 @@ on:
       - 'master'
     paths:
       - 'VERSION.json'
+      - 'src/VERSION'
 
 jobs:
   Upload-package-building-images:
@@ -50,7 +51,18 @@ jobs:
 
       - name: Get old version from VERSION.json
         run: |
-          VERSION="$(grep '"version"' $GITHUB_WORKSPACE/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+          VERSION_FILE="$GITHUB_WORKSPACE/VERSION.json"
+          OLD_VERSION_FILE="$GITHUB_WORKSPACE/src/VERSION"
+
+          if [[ -f "$VERSION_FILE" ]]; then
+            VERSION="$(grep '"version"' $GITHUB_WORKSPACE/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+          elif [[ -f "$OLD_VERSION_FILE" ]]; then
+            VERSION=$(sed 's/^v\([0-9]*\.[0-9]*\.[0-9]*\)/\1/' $GITHUB_WORKSPACE/src/VERSION)
+          else
+            echo "Error: No version file found." >&2
+            exit 1
+          fi
+
           echo "OLD_VERSION=$VERSION" >> $GITHUB_ENV;
 
       - name: Checkout repository

--- a/.github/workflows/packages-upload-images.yml
+++ b/.github/workflows/packages-upload-images.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - '[0-9]+.[0-9]+.[0-9]+'
-      - 'master'
+      - 'main'
     paths:
       - 'packages/**'
 

--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -50,7 +50,7 @@ jobs:
                 DIFFS=$(git diff --name-only origin/${{ env.REF_BRANCH }})
               else
                 # If REF_BRANCH is not set, use main as base
-                DIFFS=$(git diff --name-only origin/master)
+                DIFFS=$(git diff --name-only origin/main)
               fi
             fi
 

--- a/.github/workflows/windows-msi-upgrade-check.yml
+++ b/.github/workflows/windows-msi-upgrade-check.yml
@@ -65,7 +65,14 @@ jobs:
       - name: Create .msi package
         run: |
           cd C:\win-agent-base\src\win32
-          $VERSION = Get-Content ..\VERSION
+          $VERSION_FILE = "..\..\VERSION.json"
+          if (Test-Path $VERSION_FILE) {
+              $json = Get-Content $VERSION_FILE | ConvertFrom-Json
+              $VERSION = $json.version
+          } else {
+              Write-Host "Error: VERSION.json not found."
+              exit 1
+          }
           .\wazuh-installer-build-msi.bat $VERSION 0
           cp *.msi C:\win-agent-base\
       - name: Run tests

--- a/packages/README.md
+++ b/packages/README.md
@@ -25,25 +25,26 @@ wazuh# cd packages
 ```
 
 **Options:**
-| Option     | Description                                            | Default               |
-|------------|----------------------------------------------------------|-----------------------|
-| -b, --branch | Git branch to use (optional)                          | master                |
-| -t, --target | Target package to build (required): manager or agent    | -                     |
-| -a, --architecture | Target architecture (optional): amd64, i386, etc. | -                     |
-| -j, --jobs  | Number of parallel jobs (optional)                       | 2                     |
-| -r, --revision | Package revision (optional)                          | 0                     |
-| -s, --store  | Destination path for the package (optional)            | (output folder created) |
-| -p, --path   | Installation path for the package (optional)           | /var/ossec             |
-| -d, --debug  | Build binaries with debug symbols (optional)           | no                     |
-| -c, --checksum | Generate checksum on the same directory (optional)   | no                     |
-| -l, --legacy | Build package for CentOS 5 (RPM only) (optional)        | no                     |
-| --dont-build-docker | Use a locally built Docker image (optional)      | no   |
-| --tag        | Tag to use with the Docker image (optional)             | -                     |
-| *--sources    | Path containing local Wazuh source code (optional)       | script path            |
-| **--is_stage | Use release name in package (optional)               | no                     |
-| --src        | Generate the source package (optional)                 | no                     |
-| --system | Package format to build (optional): rpm, deb (default)| deb                    |
-| -h, --help   | Show this help message                                 | -                     |
+
+| Option               | Description                                                         | Default                 |
+|----------------------|---------------------------------------------------------------------|-------------------------|
+| -b, --branch         | Git branch to use (optional)                                        | main                    |
+| -t, --target         | Target package to build (required): manager or agent                | -                       |
+| -a, --architecture   | Target architecture (optional): amd64, i386, etc.                   | -                       |
+| -j, --jobs           | Number of parallel jobs (optional)                                  | 2                       |
+| -r, --revision       | Package revision (optional)                                         | 0                       |
+| -s, --store          | Destination path for the package (optional)                         | (output folder created) |
+| -p, --path           | Installation path for the package (optional)                        | /var/ossec              |
+| -d, --debug          | Build binaries with debug symbols (optional)                        | no                      |
+| -c, --checksum       | Generate checksum on the same directory (optional)                  | no                      |
+| -l, --legacy         | Build package for CentOS 5 (RPM only) (optional)                    | no                      |
+| --dont-build-docker  | Use a locally built Docker image (optional)                         | no                      |
+| --tag                | Tag to use with the Docker image (optional)                         | -                       |
+| *--sources           | Path containing local Wazuh source code (optional)                  | script path            |
+| **--is_stage         | Use release name in package (optional)                              | no                      |
+| --src                | Generate the source package (optional)                              | no                      |
+| --system             | Package format to build (optional): rpm, deb (default)              | deb                     |
+| -h, --help           | Show this help message                                              | -                       |
 
 ***Note1:** If we don't use this flag, will the script use the current directory where *generate_package.sh* is located.
 

--- a/packages/aix/generate_wazuh_packages.sh
+++ b/packages/aix/generate_wazuh_packages.sh
@@ -200,6 +200,33 @@ build_package() {
   rm -rf wazuh-wazuh-* wazuh-agent-*
   extracted_directory=$(gunzip -c wazuh.tar.gz | tar -xvf - | tail -n 1 | cut -d' ' -f2 | cut -d'/' -f1)
   wazuh_version=$(awk -F'"' '/"version"[ \t]*:/ {print $4}' $extracted_directory/VERSION.json)
+
+  # Add commit hash to the VERSION.json file
+  pushd $extracted_directory
+  short_commit_hash=$(curl -ks "https://api.github.com/repos/wazuh/wazuh/commits/${reference}" | awk -F '"' '/"sha":/ {print substr($4, 1, 7); exit}')
+  /usr/bin/nawk -v commit="$short_commit_hash" '
+  {
+      lines[NR] = $0  # Store lines in an array
+  }
+  END {
+      last_index = NR  # Save the last line index
+      for (i = 1; i <= last_index; i++) {
+          if (i == last_index) {  # When reaching the last line (assumed to be "}")
+              if (lines[i-1] !~ /,$/)  # If the previous line does not end with a comma, add one
+                  lines[i-1] = lines[i-1] ",";
+
+              print lines[i-1];  # Print the modified previous line
+              print "    \"commit\": \"" commit "\"";  # Insert commit using the passed variable
+              print lines[i];  # Print the closing brace
+          } else if (i < last_index - 1) {
+              print lines[i];  # Print all other lines unchanged
+          }
+      }
+  }
+  ' VERSION.json > VERSION.json.tmp && mv VERSION.json.tmp VERSION.json
+  cat VERSION.json
+  popd
+
   cp -pr ${extracted_directory} wazuh-agent-${wazuh_version}
 
   rpm_build_dir="/opt/freeware/src/packages"

--- a/packages/aix/generate_wazuh_packages.sh
+++ b/packages/aix/generate_wazuh_packages.sh
@@ -14,7 +14,7 @@ set -x
 
 current_path="$( cd $(dirname $0) ; pwd -P )"
 install_path="/var/ossec"
-reference="master"
+reference="main"
 revision="1"
 target_dir="${current_path}/output/"
 compute_checksums="no"

--- a/packages/aix/generate_wazuh_packages.sh
+++ b/packages/aix/generate_wazuh_packages.sh
@@ -225,6 +225,9 @@ build_package() {
   }
   ' VERSION.json > VERSION.json.tmp && mv VERSION.json.tmp VERSION.json
   cat VERSION.json
+
+  # Remove the temporary file after processing (if any remains)
+  [ -f VERSION.json.tmp ] && rm VERSION.json.tmp
   popd
 
   cp -pr ${extracted_directory} wazuh-agent-${wazuh_version}

--- a/packages/aix/generate_wazuh_packages.sh
+++ b/packages/aix/generate_wazuh_packages.sh
@@ -199,7 +199,7 @@ build_package() {
   rm -f wazuh.tar.gz && curl -L ${source_code} -k -o wazuh.tar.gz -s
   rm -rf wazuh-wazuh-* wazuh-agent-*
   extracted_directory=$(gunzip -c wazuh.tar.gz | tar -xvf - | tail -n 1 | cut -d' ' -f2 | cut -d'/' -f1)
-  wazuh_version="$(grep '"version"' $extracted_directory/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+  wazuh_version=$(awk -F'"' '/"version"[ \t]*:/ {print $4}' $extracted_directory/VERSION.json)
   cp -pr ${extracted_directory} wazuh-agent-${wazuh_version}
 
   rpm_build_dir="/opt/freeware/src/packages"

--- a/packages/build.sh
+++ b/packages/build.sh
@@ -92,7 +92,7 @@ if [ ! -d "/wazuh-local-src" ] ; then
                           | grep '"sha"' | head -n 1| cut -d '"' -f 4 | cut -c 1-7)"
 else
     if [ "${legacy}" = "no" ]; then
-      short_commit_hash="$(cd /wazuh-local-src && git rev-parse --short HEAD)"
+      short_commit_hash="$(cd /wazuh-local-src && git rev-parse --short=7 HEAD)"
     else
       # Git package is not available in the CentOS 5 repositories.
       head=$(cat /wazuh-local-src/.git/HEAD)

--- a/packages/build.sh
+++ b/packages/build.sh
@@ -15,7 +15,7 @@ build_directories() {
   local future="$3"
 
   mkdir -p "${build_folder}"
-  wazuh_version="$(grep '"version"' wazuh*/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+  wazuh_version=$(awk -F'"' '/"version"[ \t]*:/ {print $4}' wazuh*/VERSION.json)
 
   if [[ "$future" == "yes" ]]; then
     wazuh_version="$(future_version "$build_folder" "$wazuh_dir" $wazuh_version)"
@@ -104,7 +104,7 @@ fi
 # Build directories
 source_dir=$(build_directories "$build_dir/${BUILD_TARGET}" "wazuh*" $future)
 
-wazuh_version="$(grep '"version"' $source_dir/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+wazuh_version=$(awk -F'"' '/"version"[ \t]*:/ {print $4}' $source_dir/VERSION.json)
 # TODO: Improve how we handle package_name
 # Changing the "-" to "_" between target and version breaks the convention for RPM or DEB packages.
 # For now, I added extra code that fixes it.

--- a/packages/build.sh
+++ b/packages/build.sh
@@ -89,7 +89,7 @@ fi
 if [ ! -d "/wazuh-local-src" ] ; then
     curl -sL https://github.com/wazuh/wazuh/tarball/${WAZUH_BRANCH} | tar zx
     short_commit_hash="$(curl -s https://api.github.com/repos/wazuh/wazuh/commits/${WAZUH_BRANCH} \
-                          | grep '"sha"' | head -n 1| cut -d '"' -f 4 | cut -c 1-11)"
+                          | grep '"sha"' | head -n 1| cut -d '"' -f 4 | cut -c 1-7)"
 else
     if [ "${legacy}" = "no" ]; then
       short_commit_hash="$(cd /wazuh-local-src && git rev-parse --short HEAD)"
@@ -97,7 +97,7 @@ else
       # Git package is not available in the CentOS 5 repositories.
       head=$(cat /wazuh-local-src/.git/HEAD)
       hash_commit=$(echo "$head" | grep "ref: " >/dev/null && cat /wazuh-local-src/.git/$(echo $head | cut -d' ' -f2) || echo $head)
-      short_commit_hash="$(cut -c 1-11 <<< $hash_commit)"
+      short_commit_hash="$(cut -c 1-7 <<< $hash_commit)"
     fi
 fi
 

--- a/packages/hp-ux/generate_wazuh_packages.sh
+++ b/packages/hp-ux/generate_wazuh_packages.sh
@@ -92,8 +92,8 @@ config() {
 }
 
 compute_version_revision() {
-    wazuh_version="$(grep '"version"' $source_directory/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
-    wazuh_revision=`grep '"stage"' VERSION.json | sed -E 's/.*"stage": *"([^"]+)".*/\1/'`
+    wazuh_version="$(awk -F'"' '/"version"[ \t]*:/ {print $4}' $source_directory/VERSION.json)"
+    wazuh_revision=$(awk -F'"' '/"stage"[ \t]*:/ {print $4}' $source_directory/VERSION.json)
 
     echo ${wazuh_version} > /tmp/VERSION
     echo ${wazuh_revision} > /tmp/REVISION
@@ -110,7 +110,7 @@ download_source() {
 }
 
 check_version() {
-    wazuh_version="v$(grep '"version"' $source_directory/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+    wazuh_version="v$(awk -F'"' '/"version"[ \t]*:/ {print $4}' $source_directory/VERSION.json)"
     number_version=`echo "${wazuh_version}" | cut -d v -f 2`
     major=`echo $number_version | cut -d . -f 1`
     minor=`echo $number_version | cut -d . -f 2`
@@ -159,7 +159,7 @@ create_package() {
 
 set_control_binary() {
     if [ -e ${source_directory}/VERSION.json ]; then
-        wazuh_version="v$(grep '"version"' VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+        wazuh_version="v$(awk -F'"' '/"version"[ \t]*:/ {print $4}' ${source_directory}/VERSION.json)"
         number_version=`echo "${wazuh_version}" | cut -d v -f 2`
         major=`echo $number_version | cut -d . -f 1`
         minor=`echo $number_version | cut -d . -f 2`

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -165,7 +165,7 @@ function build_package() {
     else
         WAZUH_PATH="${CURRENT_PATH}/../.."
     fi
-    short_commit_hash="$(cd "${WAZUH_PATH}" && git rev-parse --short HEAD)"
+    short_commit_hash="$(cd "${WAZUH_PATH}" && git rev-parse --short=7 HEAD)"
 
     export CONFIG="${WAZUH_PATH}/etc/preloaded-vars.conf"
     WAZUH_PACKAGES_PATH="${WAZUH_PATH}/packages/macos"

--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -171,7 +171,7 @@ function build_package() {
     WAZUH_PACKAGES_PATH="${WAZUH_PATH}/packages/macos"
     ENTITLEMENTS_PATH="${WAZUH_PACKAGES_PATH}/entitlements.plist"
 
-    VERSION="$(grep '"version"' $WAZUH_PATH/VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+    VERSION="$(awk -F'"' '/"version"[ \t]*:/ {print $4}' $WAZUH_PATH/VERSION.json)"
 
     # Define output package name
     if [ $IS_STAGE == "no" ]; then

--- a/packages/solaris/package_generation/Vagrantfile
+++ b/packages/solaris/package_generation/Vagrantfile
@@ -49,7 +49,7 @@ opts = GetoptLong.new(
 #                  DEFAULT VALUES                 #
 ###################################################
 
-branch_tag="master"
+branch_tag="main"
 ram="1024"
 cpus="1"
 checksum="no"

--- a/packages/solaris/solaris10/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris10/generate_wazuh_packages.sh
@@ -25,7 +25,7 @@ short_version=""
 trap ctrl_c INT
 
 if [ -z "${wazuh_branch}" ]; then
-    wazuh_branch="master"
+    wazuh_branch="main"
 fi
 
 if [ -z "$ARCH" ]; then

--- a/packages/solaris/solaris10/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris10/generate_wazuh_packages.sh
@@ -206,7 +206,7 @@ compute_version_revision()
     echo $revision > /tmp/REVISION
 
     pushd ${SOURCE}
-    short_commit_hash="$(git rev-parse --short HEAD)"
+    short_commit_hash="$(git rev-parse --short=7 HEAD)"
 
     /usr/bin/nawk -v commit="$short_commit_hash" '
     {

--- a/packages/solaris/solaris10/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris10/generate_wazuh_packages.sh
@@ -205,6 +205,36 @@ compute_version_revision()
     echo $wazuh_version > /tmp/VERSION
     echo $revision > /tmp/REVISION
 
+    pushd ${SOURCE}
+    short_commit_hash="$(git rev-parse --short HEAD)"
+
+    /usr/bin/nawk -v commit="$short_commit_hash" '
+    {
+        lines[NR] = $0  # Store lines in an array
+    }
+    END {
+        last_index = NR  # Save the last line index
+        for (i = 1; i <= last_index; i++) {
+            if (i == last_index) {  # When reaching the last line (assumed to be "}")
+                if (lines[i-1] !~ /,$/)  # If the previous line does not end with a comma, add one
+                    lines[i-1] = lines[i-1] ",";
+
+                print lines[i-1];  # Print the modified previous line
+                print "    \"commit\": \"" commit "\"";  # Insert commit using the passed variable
+                print lines[i];  # Print the closing brace
+            } else if (i < last_index - 1) {
+                print lines[i];  # Print all other lines unchanged
+            }
+        }
+    }
+    ' VERSION.json > VERSION.json.tmp && mv VERSION.json.tmp VERSION.json
+
+    # Remove the temporary file after processing (if any remains)
+    [ -f VERSION.json.tmp ] && rm VERSION.json.tmp
+
+    cat VERSION.json
+    popd
+
     return 0
 }
 

--- a/packages/solaris/solaris11/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris11/generate_wazuh_packages.sh
@@ -5,7 +5,7 @@
 # Wazuh Solaris 11 Package builder.
 
 REPOSITORY="https://github.com/wazuh/wazuh"
-wazuh_branch="master"
+wazuh_branch="main"
 install_path="/var/ossec"
 THREADS="4"
 TARGET="agent"
@@ -115,7 +115,7 @@ download_source() {
     cd ${current_path}
     git clone $REPOSITORY $SOURCE
 
-    if [[ "${wazuh_branch}" != "trunk" ]] || [[ "${wazuh_branch}" != "master" ]]; then
+    if [[ "${wazuh_branch}" != "trunk" ]] || [[ "${wazuh_branch}" != "main" ]]; then
         cd $SOURCE
         git checkout $wazuh_branch
     fi

--- a/packages/solaris/solaris11/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris11/generate_wazuh_packages.sh
@@ -73,6 +73,7 @@ build_environment() {
     /opt/csw/bin/pkgutil -y -i gmake
     /opt/csw/bin/pkgutil -y -i gcc5core
     /opt/csw/bin/pkgutil -y -i gcc5g++
+    /opt/csw/bin/pkgutil -y -i jq
 
     # Install precompiled gcc-5.5
     curl -LO http://packages-dev.wazuh.com/deps/solaris/precompiled-solaris-gcc-5.5.0.tar.gz
@@ -99,6 +100,12 @@ compute_version_revision() {
 
     echo $wazuh_version > /tmp/VERSION
     echo $revision > /tmp/REVISION
+
+    pushd ${SOURCE}
+    short_commit_hash="$(git rev-parse --short HEAD)"
+    jq --arg commit "$short_commit_hash" '. + {commit: $commit}' VERSION.json > VERSION.json.tmp && mv VERSION.json.tmp VERSION.json
+    cat VERSION.json
+    popd
 
     return 0
 }

--- a/packages/solaris/solaris11/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris11/generate_wazuh_packages.sh
@@ -102,7 +102,7 @@ compute_version_revision() {
     echo $revision > /tmp/REVISION
 
     pushd ${SOURCE}
-    short_commit_hash="$(git rev-parse --short HEAD)"
+    short_commit_hash="$(git rev-parse --short=7 HEAD)"
     jq --arg commit "$short_commit_hash" '. + {commit: $commit}' VERSION.json > VERSION.json.tmp && mv VERSION.json.tmp VERSION.json
     cat VERSION.json
     popd

--- a/packages/windows/Dockerfile
+++ b/packages/windows/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Installing necessary packages
 RUN apt-get update && \
     apt-get install -y --allow-change-held-packages gcc g++ gcc-mingw-w64 g++-mingw-w64 nsis make wget unzip \
-    curl perl binutils zip libssl-dev && \
+    curl perl binutils zip libssl-dev git jq && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && \

--- a/packages/windows/entrypoint.sh
+++ b/packages/windows/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 # Add commit hash information to VERSION.json
 pushd /wazuh*
-SHORT_COMMIT=$(git rev-parse --short HEAD)
+SHORT_COMMIT=$(git rev-parse --short=7 HEAD)
 if [ -z "$SHORT_COMMIT" ]; then echo "No commit found"; exit 1; fi
 echo "Found commit: $SHORT_COMMIT"
 sed -i '/"stage":/s/$/,/; /"stage":/a \    "commit": "'"$SHORT_COMMIT"'"' VERSION.json || exit 1

--- a/packages/wpk/run.sh
+++ b/packages/wpk/run.sh
@@ -23,7 +23,7 @@ help() {
     echo "Usage: ${0} [OPTIONS]"
     echo "It is required to use -k or --aws-wpk-key, --aws-wpk-cert parameters"
     echo
-    echo "    -b,   --branch <branch>      [Required] Select Git branch or tag e.g. master"
+    echo "    -b,   --branch <branch>      [Required] Select Git branch or tag e.g. main"
     echo "    -o,   --output <name>        [Required] Name to the output package."
     echo "    -pn,  --package-name <name>  [Required] Path to package file (rpm, deb, apk, msi, pkg) to pack in wpk."
     echo "    -c,   --checksum             [Optional] Whether Generate checksum or not."

--- a/src/Makefile
+++ b/src/Makefile
@@ -894,6 +894,7 @@ winagent: external win32/libwinpthread-1.dll win32/libwinpthreadpatched.a ${WAZU
 	cd win32/ && ./unix2dos.pl ../../LICENSE > LICENSE.txt
 	cd win32/ && ./unix2dos.pl ../VERSION > VERSION
 	cd win32/ && ./unix2dos.pl ../REVISION > REVISION
+	cd win32/ && ./unix2dos.pl ../../VERSION.json > VERSION.json
 	cd win32/ && makensis wazuh-installer.nsi
 
 win32/shared_modules: $(WAZUHEXT_LIB)
@@ -2892,6 +2893,7 @@ clean-windows:
 	rm -f win32/version-*.o
 	rm -f win32/VERSION
 	rm -f win32/REVISION
+	rm -f win32/VERSION.json
 	rm -f win32/libstdc++-6.dll
 	rm -f win32/libgcc_s_dw2-1.dll
 	rm -f win32/libgcc_s_sjlj-1.dll

--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -5,8 +5,8 @@
 # Author: Daniel B. Cid <daniel.cid@gmail.com>
 
 ### Setting up variables
-VERSION="v$(grep '"version"' VERSION.json | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
-REVISION=`grep '"stage"' VERSION.json | sed -E 's/.*"stage": *"([^"]+)".*/\1/'`
+VERSION=$(awk -F'"' '/"version"[ \t]*:/ {print $4}' VERSION.json)
+REVISION=$(awk -F'"' '/"stage"[ \t]*:/ {print $4}' VERSION.json)
 UNAME=`uname -snr`
 NUNAME=`uname`
 VUNAME=`uname -r`

--- a/src/init/shared.sh
+++ b/src/init/shared.sh
@@ -5,7 +5,7 @@
 # Author: Daniel B. Cid <daniel.cid@gmail.com>
 
 ### Setting up variables
-VERSION=$(awk -F'"' '/"version"[ \t]*:/ {print $4}' VERSION.json)
+VERSION="v$(awk -F'"' '/"version"[ \t]*:/ {print $4}' VERSION.json)"
 REVISION=$(awk -F'"' '/"stage"[ \t]*:/ {print $4}' VERSION.json)
 UNAME=`uname -snr`
 NUNAME=`uname`

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -107,13 +107,13 @@ function check-process {
 
 # Check new version and restart the Wazuh service
 function check-installation {
-    $actual_version = get_version
+    $actual_version = get-version
     $counter = 5
     while($actual_version -eq $current_version -And $counter -gt 0) {
         write-output "$(Get-Date -format u) - Waiting for the Wazuh-Agent installation to end." >> .\upgrade\upgrade.log
         $counter--
         Start-Sleep 2
-        $actual_version = get_version
+        $actual_version = get-version
     }
     write-output "$(Get-Date -format u) - Starting Wazuh-Agent service." >> .\upgrade\upgrade.log
     Start-Service -Name "Wazuh"
@@ -208,7 +208,7 @@ if ($normalizedWazuhDir -ne $currentDir) {
 }
 
 # Get current version
-$current_version = get_version
+$current_version = get-version
 write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
 
 # Get new msi version
@@ -255,7 +255,7 @@ if ($status -ne "connected") {
 else {
     write-output "0" | out-file ".\upgrade\upgrade_result" -encoding ascii
     write-output "$(Get-Date -format u) - Upgrade finished successfully." >> .\upgrade\upgrade.log
-    $new_version = get_version
+    $new_version = get-version
     write-output "$(Get-Date -format u) - New version: $($new_version)." >> .\upgrade\upgrade.log
 }
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -18,6 +18,38 @@ if (Test-Path "$env:windir\sysnative") {
 }
 
 
+function get-version {
+    # possible version file paths
+    $JsonFile = "VERSION.json"
+    $TextFile = "VERSION"
+    $version = $null
+
+    # first check JSON version file exists
+    if (Test-Path $JsonFile) {
+        $VERSION_JSON = Get-Content $JsonFile -Raw
+
+        if ($VERSION_JSON -match "['""]version['""]\s*:\s*['""]([^'""]+)['""]") {
+            $version = $matches[1]
+            Write-Output "$(Get-Date -format u) - Extracted version from $JsonFile : $version." >> .\upgrade\upgrade.log
+        } else {
+            Write-Output "$(Get-Date -format u) - Failed to extract version from JSON file $JsonFile." >> .\upgrade\upgrade.log
+            exit 1
+        }
+    }
+    # fallback to the plain text VERSION file
+    elseif (Test-Path $TextFile) {
+        $version = Get-Content $TextFile -Raw
+        $version = $version.Trim() -replace "^v", ""
+        Write-Output "$(Get-Date -format u) - Extracted version from $TextFile : $version." >> .\upgrade\upgrade.log
+    } else {
+        Write-Output "$(Get-Date -format u) - Error: No version file found (expected $JsonFile or $TextFile)." >> .\upgrade\upgrade.log
+        exit 1
+    }
+
+    return $version
+}
+
+
 function remove_upgrade_files {
     Remove-Item -Path ".\upgrade\*"  -Exclude "*.log", "upgrade_result" -ErrorAction SilentlyContinue
     Remove-Item -Path ".\wazuh-agent*.msi" -ErrorAction SilentlyContinue
@@ -75,14 +107,13 @@ function check-process {
 
 # Check new version and restart the Wazuh service
 function check-installation {
-
-    $actual_version = (Get-Content VERSION)
+    $actual_version = get_version
     $counter = 5
     while($actual_version -eq $current_version -And $counter -gt 0) {
         write-output "$(Get-Date -format u) - Waiting for the Wazuh-Agent installation to end." >> .\upgrade\upgrade.log
         $counter--
         Start-Sleep 2
-        $actual_version = (Get-Content VERSION)
+        $actual_version = get_version
     }
     write-output "$(Get-Date -format u) - Starting Wazuh-Agent service." >> .\upgrade\upgrade.log
     Start-Service -Name "Wazuh"
@@ -153,7 +184,7 @@ function install {
         if ($msi_new_version -ne $null -and $msi_new_version -eq $current_version) {
             write-output "$(Get-Date -format u) - Reinstalling the same version." >> .\upgrade\upgrade.log
         }
-        
+
         Start-Process -FilePath "msiexec.exe" -ArgumentList @("/i", $msiPath, '-quiet', '-norestart', '-log', 'installer.log') -Wait -NoNewWindow
 
     } catch {
@@ -177,7 +208,7 @@ if ($normalizedWazuhDir -ne $currentDir) {
 }
 
 # Get current version
-$current_version = (Get-Content VERSION)
+$current_version = get_version
 write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
 
 # Get new msi version
@@ -224,7 +255,7 @@ if ($status -ne "connected") {
 else {
     write-output "0" | out-file ".\upgrade\upgrade_result" -encoding ascii
     write-output "$(Get-Date -format u) - Upgrade finished successfully." >> .\upgrade\upgrade.log
-    $new_version = (Get-Content VERSION)
+    $new_version = get_version
     write-output "$(Get-Date -format u) - New version: $($new_version)." >> .\upgrade\upgrade.log
 }
 

--- a/src/win32/qa/test_bin_details.py
+++ b/src/win32/qa/test_bin_details.py
@@ -1,9 +1,11 @@
 import pytest
 import pathlib
 import subprocess
+import shlex
+import json
 
 BIN_PATH = 'C:\\binaries'
-VERSION_FILE = '..\\..\\VERSION'
+VERSION_FILE = '..\\..\\..\VERSION.json'
 
 
 @pytest.fixture(name='current_bin', scope='module', params=list(map(str, list(pathlib.Path(BIN_PATH).glob('*')))))
@@ -11,32 +13,47 @@ def get_bin_path(request):
     return request.param
 
 
+def read_version():
+    """Read the version from VERSION.json and extract the version number."""
+    try:
+        with open(VERSION_FILE, 'r') as f:
+            data = json.load(f)
+            product_version = data.get("version", "").strip()
+
+        file_version_raw = product_version.split('.')
+        if len(file_version_raw) < 3:
+            pytest.fail(f"Invalid version format in {VERSION_FILE}: {product_version}")
+
+        file_version_major, file_version_minor, file_version_build = file_version_raw[:3]
+        file_version_revision = '0'
+
+        return product_version, file_version_major, file_version_minor, file_version_build, file_version_revision
+
+    except (FileNotFoundError, json.JSONDecodeError, ValueError) as e:
+        pytest.fail(f"Error reading {VERSION_FILE}: {str(e)}")
+
+
 def test_bin_details(current_bin):
-    # Get version from VERSION file
-    product_version = ''
-    with open(VERSION_FILE, 'r') as f:
-        product_version = f.readline().strip()
+    """Test if binary metadata matches expected values."""
+    product_version, file_version_major, file_version_minor, file_version_build, file_version_revision = read_version()
 
-    file_version_raw = product_version.replace('v', '').split('.')
-    file_version_major = file_version_raw[0]
-    file_version_minor = file_version_raw[1]
-    file_version_build = file_version_raw[2]
-    file_version_revision = '0'
+    fields_dict = {
+        'FileDescription': 'Wazuh Agent',
+        'ProductName': 'Wazuh Windows Agent',
+        'ProductVersion': f"v{product_version}",
+        'FileVersionRaw.Major': file_version_major,
+        'FileVersionRaw.Minor': file_version_minor,
+        'FileVersionRaw.Build': file_version_build,
+        'FileVersionRaw.Revision': file_version_revision,
+        'OriginalFilename': '',
+        'LegalCopyright': 'Copyright (C) Wazuh, Inc.',
+        'Language': 'English (United States)'
+    }
 
-    fields_dict = {'FileDescription': 'Wazuh Agent',
-                   'ProductName': 'Wazuh Windows Agent',
-                   'ProductVersion': product_version,
-                   'FileVersionRaw.Major': file_version_major,
-                   'FileVersionRaw.Minor': file_version_minor,
-                   'FileVersionRaw.Build': file_version_build,
-                   'FileVersionRaw.Revision': file_version_revision,
-                   'OriginalFilename': '',
-                   'LegalCopyright': 'Copyright (C) Wazuh, Inc.',
-                   'Language': 'English (United States)'}
-
-    for key in fields_dict:
-        cmd = f'(Get-Item "{current_bin}").VersionInfo.{key}'
+    for key, expected_value in fields_dict.items():
+        cmd = f'(Get-Item {shlex.quote(current_bin)}).VersionInfo.{key}'
         result = subprocess.run(
-            ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True)
+            ["powershell", "-Command", cmd], stdout=subprocess.PIPE, check=True
+        )
 
-        assert result.stdout.decode().rstrip() == fields_dict[key], f"Failed in key: '{key}'"
+        assert result.stdout.decode().strip() == expected_value, f"Failed in key: '{key}'"

--- a/src/win32/qa/test_win_upgrade.py
+++ b/src/win32/qa/test_win_upgrade.py
@@ -42,7 +42,7 @@ def test_win_upgrade():
         f"start /wait msiexec /i {str(base_msi.resolve())} /qn /l*v {BASE_PATH}win-agent-base.log")
 
     # Unzip base .msi to folder
-    os.system(f'7z e {str(base_msi.resolve())} "-o{BASE_PATH}"')
+    os.system(f'7z e {str(base_msi.resolve())} "-o{BASE_PATH}" -y')
 
     # List all .exe and .dll files in of the unzipped folder
     exe_to_install = list(pathlib.Path(BASE_PATH).glob('*.exe'))

--- a/src/win32/ui/os_win32ui.h
+++ b/src/win32/ui/os_win32ui.h
@@ -20,7 +20,7 @@
 /* Default values */
 #define CONFIG          "ossec.conf"
 #define LASTCONFIG      "last-ossec.conf"
-#define VERSION_FILE    "VERSION"
+#define VERSION_FILE    "VERSION.json"
 #define REVISION_FILE   "REVISION"
 #define OSSECLOGS       "ossec.log"
 #define HELPTXT         "help.txt"

--- a/src/win32/wazuh-installer.nsi
+++ b/src/win32/wazuh-installer.nsi
@@ -223,6 +223,7 @@ Section "Wazuh Agent (required)" MainSec
     File /oname=queue\syscollector\norm_config.json ..\wazuh_modules\syscollector\norm_config.json
     File VERSION
     File REVISION
+    File VERSION.json
 
     ; Create empty file active-responses.log
     FileOpen $0 "$INSTDIR\active-response\active-responses.log" w

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -308,6 +308,9 @@
                     <Component Id="REVISION" DiskId="1" Guid="89440258-B50F-4926-8068-D1444E31F8E0">
                         <File Id="REVISION" Name="REVISION" Source="REVISION" />
                     </Component>
+                    <Component Id="VERSION.JSON" DiskId="1" Guid="296571f4-2498-4cf6-b286-b2c54430678e">
+                        <File Id="VERSION.JSON" Name="VERSION.json" Source="VERSION.json" />
+                    </Component>
                     <Component Id="WPK_ROOT.PEM" DiskId="1" Guid="EABF8773-57B9-4CD8-A862-87B0E060DBF8">
                         <File Id="WPK_ROOT.PEM" Name="wpk_root.pem" Source="..\..\etc\wpk_root.pem" />
                     </Component>
@@ -685,6 +688,7 @@
             <ComponentRef Id="HELP_WIN.TXT" />
             <ComponentRef Id="VERSION" />
             <ComponentRef Id="REVISION" />
+            <ComponentRef Id="VERSION.JSON" />
             <ComponentRef Id="WPK_ROOT.PEM" />
             <ComponentRef Id="WXP_CONF_SYSCHECK" />
             <ComponentRef Id="WXP_CONF_LOCALFILE" />


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28638|

## Description

This PR introduces the VERSION.json file as requested by issue #28638 .

It works in tandem with https://github.com/wazuh/wazuh-agent-packages/pull/228 to generate packages as well, as they relied on the old VERSION and REVISION files, and they now have the added responsibility of adding the commit hash in the new VERSION.json file while creating the packages.

As many references to the old VERSION and REVISION files changed, some tests and workflows needed to be updated.

### Changes

* References to `master` branches have been changed to `main`.
* Windows upgrade scripts printed information from the previous version being upgraded, for this reason some scripts will check if the old VERSION file exists instead of VERSION.json (for backwards compatibility).
* Scripts and workflows that used to set VERSION variables from the old VERSION file using grep and sed may now sed or awk, depending on the availability of the command in the system since these are not fully portable.
* When possible the commit hash is set through the workflow in `wazuh-agent-packages` but there are some cases where the package generation scripts downloads the tarball, which doesn't include git information. For these, the github api is used through curl to get the last commit hash of the reference branch being used.
* Some python scripts were updated to reflect the use of the new VERSION.json file.

## Configuration options

None

## Logs/Alerts example

See below in comments.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues