### PR TITLE
Add Unit and Integration Tests for Whodata eBPF

### DIFF
--- a/src/headers/sym_load.h
+++ b/src/headers/sym_load.h
@@ -18,8 +18,14 @@
 #include <windows.h>
 #endif
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void* so_get_module_handle_on_path(const char *path, const char *so);
 void* so_get_module_handle(const char *so);
+
 /**
  * @brief Check if a module/library is already loaded. Must call a corresponding so_free_library()
  * if not used in WIN32. If RTLD_NOLOAD isn't found in the system,
@@ -30,6 +36,13 @@ void* so_get_module_handle(const char *so);
  */
 void* so_check_module_loaded(const char *so);
 void* so_get_function_sym(void *handle, const char *function_name);
+
 int so_free_library(void *handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+
 
 #endif //H_SYMLOAD_OS

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -50,6 +50,7 @@
 extern syscheck_config syscheck;
 extern int sys_debug_level;
 extern int audit_queue_full_reported;
+extern int ebpf_kernel_queue_full_reported;
 extern int ebpf_whodata_queue_full_reported;
 
 typedef enum fim_event_type {

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -626,6 +626,7 @@ time_t fim_scan() {
     audit_queue_full_reported = 0;
 
 #ifdef __linux__
+    ebpf_kernel_queue_full_reported = 0;
     ebpf_whodata_queue_full_reported = 0;
 #endif  /* __linux__ */
 

--- a/src/syscheckd/src/ebpf/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/CMakeLists.txt
@@ -11,13 +11,16 @@ include_directories(${SRC_FOLDER}/external/libbpf-bootstrap/build/)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_SOURCE_DIR}/src/db/include/)
 include_directories(${CMAKE_SOURCE_DIR}/src/ebpf/include/)
+include_directories(${SRC_FOLDER}/headers/)
+
 
 set(LIB_DIR ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIB_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIB_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_library(fimebpf SHARED src/ebpf_whodata.cpp)
+add_library(fimebpf SHARED src/ebpf_whodata.cpp )
+target_link_libraries(fimebpf wazuh)
 
 # Set additional compile flags for the loader (if needed)
 target_compile_options(fimebpf PRIVATE -Wall -Wextra)

--- a/src/syscheckd/src/ebpf/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/CMakeLists.txt
@@ -32,5 +32,6 @@ if(UNIT_TEST)
     target_link_libraries(fimebpf gcov)
   endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
-  add_subdirectory(tests)
+  add_subdirectory(tests/fimEbpfWhodataTest)
+  add_subdirectory(tests/unit)
 endif(UNIT_TEST)

--- a/src/syscheckd/src/ebpf/include/bounded_queue.hpp
+++ b/src/syscheckd/src/ebpf/include/bounded_queue.hpp
@@ -63,7 +63,7 @@ public:
      * @param value Element to be pushed.
      * @return true if the element was successfully pushed, false if the queue is full.
      */
-    bool push(T&& value) {
+    virtual bool push(T&& value) {
         std::unique_lock<std::mutex> lock(m_mutex);
         if (m_queue.size() >= m_max_size) {
             return false; // Queue is full
@@ -80,7 +80,7 @@ public:
      * @param timeout_ms Timeout in milliseconds.
      * @return true if an element was successfully popped, false if timeout occurred.
      */
-    bool pop(T& out_value, int timeout_ms) {
+    virtual bool pop(T& out_value, int timeout_ms) {
         std::unique_lock<std::mutex> lock(m_mutex);
         if (!m_cond_var.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] { return !m_queue.empty(); })) {
             return false; // Timeout

--- a/src/syscheckd/src/ebpf/include/bounded_queue.hpp
+++ b/src/syscheckd/src/ebpf/include/bounded_queue.hpp
@@ -26,6 +26,11 @@ public:
     explicit BoundedQueue(size_t max_size = 0) : m_max_size(max_size) {}
 
     /**
+     * @brief Virtual destructor.
+     */
+    virtual ~BoundedQueue() = default;
+
+    /**
      * @brief Set the maximum size of the queue.
      *
      * If the current size of the queue exceeds the new maximum size, the oldest

--- a/src/syscheckd/src/ebpf/include/bpf_helpers.h
+++ b/src/syscheckd/src/ebpf/include/bpf_helpers.h
@@ -52,6 +52,7 @@ int (*bpf_object__attach_skeleton)(struct bpf_object_skeleton *obj) = NULL;
 void (*bpf_object__detach_skeleton)(struct bpf_object_skeleton *obj) = NULL;
 
 typedef int(*init_ring_buffer_t)(ring_buffer** rb, ring_buffer_sample_fn sample_cb);
+typedef void(*pop_events_t)();
 
 /**
  * @brief Store helpers to execute stateless requests to BPF
@@ -77,6 +78,8 @@ typedef struct {
     bpf_object__detach_skeleton_t bpf_object_detach_skeleton;
 
     init_ring_buffer_t init_ring_buffer;
+    pop_events_t ebpf_pop_events;
+    pop_events_t whodata_pop_events;
 
 } w_bpf_helpers_t;
 
@@ -116,7 +119,9 @@ inline bool w_bpf_deinit(std::unique_ptr<w_bpf_helpers_t>& bpf_helpers) {
         bpf_helpers->bpf_object_attach_skeleton = NULL;
         bpf_helpers->bpf_object_detach_skeleton = NULL;
 
-	bpf_helpers->init_ring_buffer = NULL;
+	    bpf_helpers->init_ring_buffer = NULL;
+	    bpf_helpers->ebpf_pop_events = NULL;
+	    bpf_helpers->whodata_pop_events = NULL;
         result = true;
     }
 
@@ -125,6 +130,8 @@ inline bool w_bpf_deinit(std::unique_ptr<w_bpf_helpers_t>& bpf_helpers) {
 
 
 int init_ring_buffer(ring_buffer** rb, ring_buffer_sample_fn sample_cb);
+void ebpf_pop_events();
+void whodata_pop_events();
 
 
 #endif // BPF_HELPERS_H

--- a/src/syscheckd/src/ebpf/include/bpf_helpers.h
+++ b/src/syscheckd/src/ebpf/include/bpf_helpers.h
@@ -53,6 +53,9 @@ void (*bpf_object__detach_skeleton)(struct bpf_object_skeleton *obj) = NULL;
 
 typedef int(*init_ring_buffer_t)(ring_buffer** rb, ring_buffer_sample_fn sample_cb);
 typedef void(*pop_events_t)();
+typedef int(*check_invalid_kernel_version_t)();
+typedef int(*init_libbpf_t)(std::unique_ptr<DynamicLibraryWrapper> sym_load);
+typedef int(*init_bpfobj_t)();
 
 /**
  * @brief Store helpers to execute stateless requests to BPF
@@ -80,6 +83,9 @@ typedef struct {
     init_ring_buffer_t init_ring_buffer;
     pop_events_t ebpf_pop_events;
     pop_events_t whodata_pop_events;
+    check_invalid_kernel_version_t check_invalid_kernel_version;
+    init_libbpf_t init_libbpf;
+    init_bpfobj_t init_bpfobj;
 
 } w_bpf_helpers_t;
 
@@ -119,9 +125,14 @@ inline bool w_bpf_deinit(std::unique_ptr<w_bpf_helpers_t>& bpf_helpers) {
         bpf_helpers->bpf_object_attach_skeleton = NULL;
         bpf_helpers->bpf_object_detach_skeleton = NULL;
 
+        // eBPF FIM generic functions
 	    bpf_helpers->init_ring_buffer = NULL;
 	    bpf_helpers->ebpf_pop_events = NULL;
 	    bpf_helpers->whodata_pop_events = NULL;
+	    bpf_helpers->check_invalid_kernel_version = NULL;
+	    bpf_helpers->init_libbpf = NULL;
+	    bpf_helpers->init_bpfobj = NULL;
+
         result = true;
     }
 
@@ -132,6 +143,9 @@ inline bool w_bpf_deinit(std::unique_ptr<w_bpf_helpers_t>& bpf_helpers) {
 int init_ring_buffer(ring_buffer** rb, ring_buffer_sample_fn sample_cb);
 void ebpf_pop_events();
 void whodata_pop_events();
+int check_invalid_kernel_version();
+int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load);
+int init_bpfobj();
 
 
 #endif // BPF_HELPERS_H

--- a/src/syscheckd/src/ebpf/include/bpf_helpers.h
+++ b/src/syscheckd/src/ebpf/include/bpf_helpers.h
@@ -12,10 +12,34 @@
 
 #include <dlfcn.h>
 #include "logging_helper.h"
+#include <bounded_queue.hpp>
 #include <memory>
+
+using whodata_deleter = std::function<void(whodata_evt*)>;
 
 typedef __attribute__((aligned(4))) unsigned int __u32;
 typedef __attribute__((aligned(8))) unsigned long long __u64;
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define TASK_COMM_LEN 32
+
+
+struct file_event {
+    __u32 pid;
+    __u32 ppid;
+    __u32 uid;
+    __u32 gid;
+    __u64 inode;
+    __u64 dev;
+    char comm[TASK_COMM_LEN];
+    char filename[PATH_MAX];
+    char cwd[PATH_MAX];
+    char parent_cwd[PATH_MAX];
+    char parent_comm[TASK_COMM_LEN];
+};
 
 struct ring_buffer {
         struct epoll_event *events;
@@ -52,7 +76,8 @@ int (*bpf_object__attach_skeleton)(struct bpf_object_skeleton *obj) = NULL;
 void (*bpf_object__detach_skeleton)(struct bpf_object_skeleton *obj) = NULL;
 
 typedef int(*init_ring_buffer_t)(ring_buffer** rb, ring_buffer_sample_fn sample_cb);
-typedef void(*pop_events_t)();
+typedef void(*whodata_pop_events_t)(fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& queue);
+typedef void(*ebpf_pop_events_t)(fim::BoundedQueue<std::unique_ptr<file_event>>& kernel_queue, fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& queue);
 typedef int(*check_invalid_kernel_version_t)();
 typedef int(*init_libbpf_t)(std::unique_ptr<DynamicLibraryWrapper> sym_load);
 typedef int(*init_bpfobj_t)();
@@ -81,8 +106,8 @@ typedef struct {
     bpf_object__detach_skeleton_t bpf_object_detach_skeleton;
 
     init_ring_buffer_t init_ring_buffer;
-    pop_events_t ebpf_pop_events;
-    pop_events_t whodata_pop_events;
+    ebpf_pop_events_t ebpf_pop_events;
+    whodata_pop_events_t whodata_pop_events;
     check_invalid_kernel_version_t check_invalid_kernel_version;
     init_libbpf_t init_libbpf;
     init_bpfobj_t init_bpfobj;
@@ -141,8 +166,8 @@ inline bool w_bpf_deinit(std::unique_ptr<w_bpf_helpers_t>& bpf_helpers) {
 
 
 int init_ring_buffer(ring_buffer** rb, ring_buffer_sample_fn sample_cb);
-void ebpf_pop_events();
-void whodata_pop_events();
+void ebpf_pop_events(fim::BoundedQueue<std::unique_ptr<file_event>>& kernel_queue, fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& queue);
+void whodata_pop_events(fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& queue);
 int check_invalid_kernel_version();
 int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load);
 int init_bpfobj();

--- a/src/syscheckd/src/ebpf/include/dynamic_library_wrapper.h
+++ b/src/syscheckd/src/ebpf/include/dynamic_library_wrapper.h
@@ -8,14 +8,14 @@
 class DynamicLibraryWrapper {
 public:
     virtual ~DynamicLibraryWrapper() = default;
-    virtual void* getModuleHandle(const char* so) = 0;
+    virtual void* so__get_module_handle(const char* so) = 0;
     virtual void* getFunctionSymbol(void* handle, const char* function_name) = 0;
     virtual int freeLibrary(void* handle) = 0;
 };
 
 class DefaultDynamicLibraryWrapper : public DynamicLibraryWrapper {
 public:
-    void* getModuleHandle(const char* so) override {
+    void* so__get_module_handle(const char* so) override {
         return so_get_module_handle(so);
     }
 

--- a/src/syscheckd/src/ebpf/include/dynamic_library_wrapper.h
+++ b/src/syscheckd/src/ebpf/include/dynamic_library_wrapper.h
@@ -1,0 +1,33 @@
+#ifndef DYNAMIC_LIBRARY_WRAPPER_H
+#define DYNAMIC_LIBRARY_WRAPPER_H
+
+#include "sym_load.h"
+
+#ifdef __cplusplus
+
+class DynamicLibraryWrapper {
+public:
+    virtual ~DynamicLibraryWrapper() = default;
+    virtual void* getModuleHandle(const char* so) = 0;
+    virtual void* getFunctionSymbol(void* handle, const char* function_name) = 0;
+    virtual int freeLibrary(void* handle) = 0;
+};
+
+class DefaultDynamicLibraryWrapper : public DynamicLibraryWrapper {
+public:
+    void* getModuleHandle(const char* so) override {
+        return so_get_module_handle(so);
+    }
+
+    void* getFunctionSymbol(void* handle, const char* function_name) override {
+        return so_get_function_sym(handle, function_name);
+    }
+
+    int freeLibrary(void* handle) override {
+        return so_free_library(handle);
+    }
+};
+
+#endif // __cplusplus
+
+#endif // DYNAMIC_LIBRARY_WRAPPER_H

--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.h
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.h
@@ -51,11 +51,9 @@ int ebpf_whodata_healthcheck();
  */
 int ebpf_whodata();
 
-
-int init_libbpf();
-
 int init_bpfobj();
 
+int healthcheck_event(void* ctx, void* data, size_t data_sz);
 
 #ifdef __cplusplus
 }

--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.h
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.h
@@ -51,6 +51,12 @@ int ebpf_whodata_healthcheck();
  */
 int ebpf_whodata();
 
+
+int init_libbpf();
+
+int init_bpfobj();
+
+
 #ifdef __cplusplus
 }
 #endif // _cplusplus

--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 volatile bool event_received = false;
+volatile bool epbf_hc_created = false;
 
 class fimebpf
 {

--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
@@ -14,6 +14,8 @@
 #include "dynamic_library_wrapper.h"
 #include <memory>
 
+volatile bool event_received = false;
+
 class fimebpf
 {
 public:
@@ -55,7 +57,7 @@ public:
         m_fim_shutdown_process_on = fimShutdownProcessOn;
     }
 
-private:
+protected:
     fimebpf() = default;
     ~fimebpf() = default;
     fimebpf(const fimebpf&) = delete;

--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
@@ -11,6 +11,8 @@
 #define EBPF_WHODATA_HPP
 
 #include "ebpf_whodata.h"
+#include "dynamic_library_wrapper.h"
+#include <memory>
 
 class fimebpf
 {
@@ -70,5 +72,8 @@ public:
     unsigned int m_queue_size;
     fimShutdownProcessOn_t m_fim_shutdown_process_on;
 };
+
+int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load);
+
 
 #endif // EBPF_WHODATA_HPP

--- a/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
+++ b/src/syscheckd/src/ebpf/include/ebpf_whodata.hpp
@@ -12,7 +12,7 @@
 
 #include "ebpf_whodata.h"
 
-class fimebpf final
+class fimebpf
 {
 public:
     static fimebpf& instance()

--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -148,42 +148,41 @@ int check_invalid_kernel_version() {
     }
 }
 
-int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load) {
+int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> local_sym_load) {
     auto logFn = fimebpf::instance().m_loggingFunction;
     auto abspathFn = fimebpf::instance().m_abspath;
-    char libbpf_path[PATH_MAX] = {0};
 
     if (!logFn || !abspathFn || !bpf_helpers) {
         return 1;
     }
 
-    if (!sym_load) {
-	sym_load = std::make_unique<DefaultDynamicLibraryWrapper>();
+    if (!local_sym_load) {
+	local_sym_load = std::make_unique<DefaultDynamicLibraryWrapper>();
     }
 
     if (!bpf_helpers->module) {
-	bpf_helpers->module = sym_load->so__get_module_handle(LIB_INSTALL_PATH);
+	bpf_helpers->module = local_sym_load->so__get_module_handle(LIB_INSTALL_PATH);
     }
 
     bpf_helpers->init_ring_buffer            = (init_ring_buffer_t)init_ring_buffer;
     bpf_helpers->ebpf_pop_events             = (ebpf_pop_events_t)ebpf_pop_events;
     bpf_helpers->whodata_pop_events          = (whodata_pop_events_t)whodata_pop_events;
     bpf_helpers->init_bpfobj                 = (init_bpfobj_t)init_bpfobj;
-    bpf_helpers->bpf_object_destroy_skeleton = (bpf_object__destroy_skeleton_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__destroy_skeleton");
-    bpf_helpers->bpf_object_open_skeleton    = (bpf_object__open_skeleton_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__open_skeleton");
-    bpf_helpers->bpf_object_load_skeleton    = (bpf_object__load_skeleton_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__load_skeleton");
-    bpf_helpers->bpf_object_attach_skeleton  = (bpf_object__attach_skeleton_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__attach_skeleton");
-    bpf_helpers->bpf_object_detach_skeleton  = (bpf_object__detach_skeleton_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__detach_skeleton");
+    bpf_helpers->bpf_object_destroy_skeleton = (bpf_object__destroy_skeleton_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__destroy_skeleton");
+    bpf_helpers->bpf_object_open_skeleton    = (bpf_object__open_skeleton_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__open_skeleton");
+    bpf_helpers->bpf_object_load_skeleton    = (bpf_object__load_skeleton_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__load_skeleton");
+    bpf_helpers->bpf_object_attach_skeleton  = (bpf_object__attach_skeleton_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__attach_skeleton");
+    bpf_helpers->bpf_object_detach_skeleton  = (bpf_object__detach_skeleton_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__detach_skeleton");
 
-    bpf_helpers->bpf_object_open_file        = (bpf_object__open_file_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__open_file");
-    bpf_helpers->bpf_object_load             = (bpf_object__load_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__load");
-    bpf_helpers->ring_buffer_new             = (ring_buffer__new_t)sym_load->getFunctionSymbol(bpf_helpers->module, "ring_buffer__new");
-    bpf_helpers->ring_buffer_poll            = (ring_buffer__poll_t)sym_load->getFunctionSymbol(bpf_helpers->module, "ring_buffer__poll");
-    bpf_helpers->ring_buffer_free            = (ring_buffer__free_t)sym_load->getFunctionSymbol(bpf_helpers->module, "ring_buffer__free");
-    bpf_helpers->bpf_object_close            = (bpf_object__close_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__close");
-    bpf_helpers->bpf_object_next_program     = (bpf_object__next_program_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__next_program");
-    bpf_helpers->bpf_program_attach          = (bpf_program__attach_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_program__attach");
-    bpf_helpers->bpf_object_find_map_fd_by_name = (bpf_object__find_map_fd_by_name_t)sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__find_map_fd_by_name");
+    bpf_helpers->bpf_object_open_file        = (bpf_object__open_file_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__open_file");
+    bpf_helpers->bpf_object_load             = (bpf_object__load_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__load");
+    bpf_helpers->ring_buffer_new             = (ring_buffer__new_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "ring_buffer__new");
+    bpf_helpers->ring_buffer_poll            = (ring_buffer__poll_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "ring_buffer__poll");
+    bpf_helpers->ring_buffer_free            = (ring_buffer__free_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "ring_buffer__free");
+    bpf_helpers->bpf_object_close            = (bpf_object__close_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__close");
+    bpf_helpers->bpf_object_next_program     = (bpf_object__next_program_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__next_program");
+    bpf_helpers->bpf_program_attach          = (bpf_program__attach_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_program__attach");
+    bpf_helpers->bpf_object_find_map_fd_by_name = (bpf_object__find_map_fd_by_name_t)local_sym_load->getFunctionSymbol(bpf_helpers->module, "bpf_object__find_map_fd_by_name");
 
 
     /* Load all required symbols */
@@ -207,7 +206,7 @@ int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load) {
         !bpf_helpers->bpf_object_detach_skeleton)
     {
         logFn(LOG_ERROR, FIM_ERROR_EBPF_LIB_LOAD);
-        sym_load->freeLibrary(bpf_helpers->module);
+        local_sym_load->freeLibrary(bpf_helpers->module);
         bpf_helpers.reset();
         return 1;
     }
@@ -217,10 +216,10 @@ int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load) {
     return 0;
 }
 
-void close_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load) {
+void close_libbpf(std::unique_ptr<DynamicLibraryWrapper> local_sym_load) {
     if (bpf_helpers) {
         if (bpf_helpers->module) {
-            sym_load->freeLibrary(bpf_helpers->module);
+            local_sym_load->freeLibrary(bpf_helpers->module);
         }
 	    bpf_helpers.reset();
     }
@@ -238,7 +237,7 @@ int init_bpfobj() {
 
     bpf_object* obj = bpf_helpers->bpf_object_open_file(bpfobj_path, nullptr);
     if (!obj) {
-        char error_message[1024];
+        char error_message[4200];
         snprintf(error_message, sizeof(error_message), FIM_ERROR_EBPF_OBJ_OPEN, bpfobj_path, strerror(errno));
         logFn(LOG_ERROR, error_message);
         return 1;
@@ -292,7 +291,7 @@ int init_ring_buffer(ring_buffer** rb, ring_buffer_sample_fn sample_cb) {
 }
 
 /* Worker thread to pop events from kernelEventQueue */
-void ebpf_pop_events(fim::BoundedQueue<std::unique_ptr<file_event>>& kernelEventQueue, fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& queue) {
+void ebpf_pop_events(fim::BoundedQueue<std::unique_ptr<file_event>>& local_kernelEventQueue, fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& local_whodataEventQueue) {
     auto logFn = fimebpf::instance().m_loggingFunction;
     if (!logFn) {
         return;
@@ -305,7 +304,7 @@ void ebpf_pop_events(fim::BoundedQueue<std::unique_ptr<file_event>>& kernelEvent
     while (!fimebpf::instance().m_fim_shutdown_process_on()) {
         std::unique_ptr<file_event> event;
 
-        if (!kernelEventQueue.pop(event, WAIT_MS)) {
+        if (!local_kernelEventQueue.pop(event, WAIT_MS)) {
             if (fimebpf::instance().m_fim_shutdown_process_on()) {
                 return;
             }
@@ -330,7 +329,7 @@ void ebpf_pop_events(fim::BoundedQueue<std::unique_ptr<file_event>>& kernelEvent
                 w_evt->parent_name = strdup(event->parent_comm);
 
                 auto new_event = std::unique_ptr<whodata_evt, whodata_deleter>(w_evt, deleter);
-                if (!queue.push(std::move(new_event))) {
+                if (!local_whodataEventQueue.push(std::move(new_event))) {
                     if (!ebpf_whodata_queue_full_reported) {
                         logFn(LOG_WARNING, FIM_FULL_EBPF_WHODATA_QUEUE);
                         ebpf_whodata_queue_full_reported = 1;
@@ -342,11 +341,11 @@ void ebpf_pop_events(fim::BoundedQueue<std::unique_ptr<file_event>>& kernelEvent
 }
 
 /* Worker thread to pop events from whodataEventQueue */
-void whodata_pop_events(fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& queue) {
+void whodata_pop_events(fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& local_whodataEventQueue) {
     while (!fimebpf::instance().m_fim_shutdown_process_on()) {
         std::unique_ptr<whodata_evt, whodata_deleter> event;
 
-        if (!queue.pop(event, WAIT_MS)) {
+        if (!local_whodataEventQueue.pop(event, WAIT_MS)) {
             if (fimebpf::instance().m_fim_shutdown_process_on()) {
                 return;
             }
@@ -381,7 +380,7 @@ int ebpf_whodata_healthcheck() {
     auto logFn = fimebpf::instance().m_loggingFunction;
     auto abspathFn = fimebpf::instance().m_abspath;
     char ebpf_hc_abs_path[PATH_MAX] = {0};
-    char error_message[1024];
+    char error_message[4200];
 
     if (!bpf_helpers) {
         bpf_helpers = std::make_unique<w_bpf_helpers_t>();

--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -162,7 +162,7 @@ int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load) {
     }
 
     if (!bpf_helpers->module) {
-	bpf_helpers->module = sym_load->getModuleHandle(LIB_INSTALL_PATH);
+	bpf_helpers->module = sym_load->so__get_module_handle(LIB_INSTALL_PATH);
     }
 
     bpf_helpers->init_ring_buffer            = (init_ring_buffer_t)init_ring_buffer;

--- a/src/syscheckd/src/ebpf/tests/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(unit)
+add_subdirectory(fimebpf)

--- a/src/syscheckd/src/ebpf/tests/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_subdirectory(unit)
-add_subdirectory(fimebpf)
+add_subdirectory(fimEbpfWhodataTest)

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
@@ -15,7 +15,9 @@ set(TEST_FILES
     init_ring_buffer_test.cpp
     init_bpf_obj_test.cpp
     close_libbpf_test.cpp
+    pop_event_test.cpp
 )
+
 
 # Create an executable for each test file
 foreach(TEST_FILE ${TEST_FILES})
@@ -30,6 +32,7 @@ foreach(TEST_FILE ${TEST_FILES})
         optimized gmock
         optimized gtest_main
         optimized gmock_main
+	pthread
         fimebpf
         -fsanitize=address
         -fsanitize=undefined

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.10)
+project(fim_ebpf_whodata_test)
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
+include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
+include_directories(${SRC_FOLDER}/headers/)
+link_directories(${SRC_FOLDER}/external/googletest/lib/)
+
+set(TEST_FILES
+    ebpf_whodata_test.cpp
+    init_libbpf_test.cpp
+    helthcheck_event_test.cpp
+    init_ring_buffer_test.cpp
+    init_bpf_obj_test.cpp
+    close_libbpf_test.cpp
+)
+
+# Create an executable for each test file
+foreach(TEST_FILE ${TEST_FILES})
+    get_filename_component(TEST_NAME "${TEST_FILE}" NAME_WE)
+    add_executable("${TEST_NAME}" "${TEST_FILE}")
+    target_link_libraries(${TEST_NAME}
+        debug gtestd
+        debug gmockd
+        debug gtest_maind
+        debug gmock_maind
+        optimized gtest
+        optimized gmock
+        optimized gtest_main
+        optimized gmock_main
+        fimebpf
+        -fsanitize=address
+        -fsanitize=undefined
+    )
+endforeach()

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(fim_ebpf_whodata_test)
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage")
+
 set(CMAKE_CXX_STANDARD 14)
 
 include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
@@ -32,9 +34,12 @@ foreach(TEST_FILE ${TEST_FILES})
         optimized gmock
         optimized gtest_main
         optimized gmock_main
-	pthread
+	    pthread
         fimebpf
         -fsanitize=address
         -fsanitize=undefined
     )
+
+    add_test(NAME ${TEST_NAME}
+    COMMAND ${TEST_NAME})
 endforeach()

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/CMakeLists.txt
@@ -11,7 +11,7 @@ link_directories(${SRC_FOLDER}/external/googletest/lib/)
 set(TEST_FILES
     ebpf_whodata_test.cpp
     init_libbpf_test.cpp
-    helthcheck_event_test.cpp
+    healthcheck_event_test.cpp
     init_ring_buffer_test.cpp
     init_bpf_obj_test.cpp
     close_libbpf_test.cpp

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/close_libbpf_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/close_libbpf_test.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <memory>
+#include "dynamic_library_wrapper.h"
+#include "ebpf_mock_utils.hpp"
+
+
+// Function under test
+void close_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load);
+
+
+class MockDynamicLibraryWrapper : public DynamicLibraryWrapper {
+public:
+    MOCK_METHOD(void*, getModuleHandle, (const char* so), (override));
+    MOCK_METHOD(void*, getFunctionSymbol, (void* handle, const char* function_name), (override));
+    MOCK_METHOD(int, freeLibrary, (void* handle), (override));
+};
+
+std::unique_ptr<MockDynamicLibraryWrapper> mock_sym_load;
+
+
+class CloseLibbpfTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+        mock_sym_load = std::make_unique<MockDynamicLibraryWrapper>();
+    }
+
+    void TearDown() override {
+        bpf_helpers.reset();
+    }
+};
+
+
+TEST_F(CloseLibbpfTest, ModuleExists) {
+    bpf_helpers->module = reinterpret_cast<void*>(0x1234);
+
+    EXPECT_CALL(*mock_sym_load, freeLibrary(bpf_helpers->module)).Times(1);
+    close_libbpf(std::move(mock_sym_load));
+    EXPECT_EQ(bpf_helpers, nullptr);
+}
+
+TEST_F(CloseLibbpfTest, ModuleNull) {
+
+    bpf_helpers->module = nullptr;
+    close_libbpf(std::move(mock_sym_load));
+    EXPECT_EQ(bpf_helpers, nullptr);
+}
+
+TEST_F(CloseLibbpfTest, HelpersNull) {
+    bpf_helpers.reset();
+    EXPECT_CALL(*mock_sym_load, freeLibrary(::testing::_)).Times(0);
+    close_libbpf(std::move(mock_sym_load));
+    EXPECT_EQ(bpf_helpers, nullptr); 
+}
+
+
+void SetUpModule() {}
+void TearDownModule() {}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    SetUpModule();
+    int result = RUN_ALL_TESTS();
+    TearDownModule();
+    return result;
+}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/close_libbpf_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/close_libbpf_test.cpp
@@ -11,7 +11,7 @@ void close_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load);
 
 class MockDynamicLibraryWrapper : public DynamicLibraryWrapper {
 public:
-    MOCK_METHOD(void*, getModuleHandle, (const char* so), (override));
+    MOCK_METHOD(void*, so__get_module_handle, (const char* so), (override));
     MOCK_METHOD(void*, getFunctionSymbol, (void* handle, const char* function_name), (override));
     MOCK_METHOD(int, freeLibrary, (void* handle), (override));
 };
@@ -51,7 +51,7 @@ TEST_F(CloseLibbpfTest, HelpersNull) {
     bpf_helpers.reset();
     EXPECT_CALL(*mock_sym_load, freeLibrary(::testing::_)).Times(0);
     close_libbpf(std::move(mock_sym_load));
-    EXPECT_EQ(bpf_helpers, nullptr); 
+    EXPECT_EQ(bpf_helpers, nullptr);
 }
 
 

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -50,9 +50,9 @@ fimebpf::abspath_t MockFimebpf::mock_abspath = nullptr;
 
 directory_t* mock_fim_conf_failure([[maybe_unused]] const char* config_path) { return nullptr; }
 directory_t* mock_fim_conf_success([[maybe_unused]] const char* config_path) {
-    directory_t *mockDirectory;
-    mockDirectory->options = WHODATA_ACTIVE | EBPF_DRIVER;
-    return mockDirectory;
+    static directory_t mockDirectory;
+    mockDirectory.options = WHODATA_ACTIVE | EBPF_DRIVER;
+    return &mockDirectory;
 }
 char* mock_get_user([[maybe_unused]] int uid) { return strdup("mock_user"); }
 char* mock_get_group([[maybe_unused]] int gid) { return strdup("mock_group"); }
@@ -82,18 +82,18 @@ ring_buffer* mock_ring_buffer_new_failure([[maybe_unused]] int fd, [[maybe_unuse
     return nullptr;
 }
 
-int mock_ring_buffer_poll_success(ring_buffer* rb, int timeout_ms) [[maybe_unused]] { return 1; }
-int mock_ring_buffer_poll_failure(ring_buffer* rb, int timeout_ms) [[maybe_unused]] { return -1; }
-void mock_ring_buffer_free(ring_buffer* rb) [[maybe_unused]] {}
-void mock_bpf_object_close(void* obj) [[maybe_unused]] {}
-void mock_w_bpf_deinit(void* helpers) [[maybe_unused]] {}
-int mock_init_ring_buffer_success(ring_buffer** rb, ring_buffer_sample_fn sample_cb) [[maybe_unused]] { return 0; }
-int mock_init_ring_buffer_failure(ring_buffer** rb, ring_buffer_sample_fn sample_cb) [[maybe_unused]] { return 1; }
-void mock_ebpf_pop_events() [[maybe_unused]] { return; }
-void mock_whodata_pop_events() [[maybe_unused]] { return; }
-int mock_check_invalid_kernel_version() [[maybe_unused]] { return 0; }
-int mock_init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load) [[maybe_unused]] { return 0; }
-int mock_init_bpfobj() [[maybe_unused]] { return 0; }
+int mock_ring_buffer_poll_success([[maybe_unused]]ring_buffer* rb, [[maybe_unused]]int timeout_ms) { return 1; }
+int mock_ring_buffer_poll_failure([[maybe_unused]]ring_buffer* rb, [[maybe_unused]]int timeout_ms) { return -1; }
+void mock_ring_buffer_free([[maybe_unused]]ring_buffer* rb) {}
+void mock_bpf_object_close([[maybe_unused]]void* obj) {}
+void mock_w_bpf_deinit([[maybe_unused]]void* helpers) {}
+int mock_init_ring_buffer_success([[maybe_unused]]ring_buffer** rb, [[maybe_unused]]ring_buffer_sample_fn sample_cb) { return 0; }
+int mock_init_ring_buffer_failure([[maybe_unused]]ring_buffer** rb, [[maybe_unused]]ring_buffer_sample_fn sample_cb) { return 1; }
+void mock_ebpf_pop_events() { return; }
+void mock_whodata_pop_events() { return; }
+int mock_check_invalid_kernel_version() { return 0; }
+int mock_init_libbpf([[maybe_unused]]std::unique_ptr<DynamicLibraryWrapper> sym_load) { return 0; }
+int mock_init_bpfobj() { return 0; }
 
 
 #endif // BPF_HELPERS_TEST_H

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -17,15 +17,24 @@ public:
     static fimebpf::free_whodata_event_t mock_free_whodata_event;
     static fimebpf::loggingFunction_t mock_loggingFunction;
     static fimebpf::abspath_t mock_abspath;
+    MOCK_METHOD(bool, mock_fim_shutdown_process_on, ());
+
+    static MockFimebpf& GetInstance() {
+        static MockFimebpf instance;
+        return instance;
+    }
 
     static void SetMockFunctions() {
-	fimebpf::instance().m_fim_configuration_directory = mock_fim_conf;
+        fimebpf::instance().m_fim_configuration_directory = mock_fim_conf;
         fimebpf::instance().m_get_user = mock_get_user;
         fimebpf::instance().m_get_group = mock_get_group;
         fimebpf::instance().m_fim_whodata_event = mock_fim_whodata_event;
         fimebpf::instance().m_free_whodata_event = mock_free_whodata_event;
         fimebpf::instance().m_loggingFunction = mock_loggingFunction;
         fimebpf::instance().m_abspath = mock_abspath;
+        fimebpf::instance().m_fim_shutdown_process_on = []() {
+            return MockFimebpf::GetInstance().mock_fim_shutdown_process_on();
+        };
     }
 };
 
@@ -77,6 +86,8 @@ void mock_bpf_object_close(void* obj) [[maybe_unused]] {}
 void mock_w_bpf_deinit(void* helpers) [[maybe_unused]] {}
 int mock_init_ring_buffer_success(ring_buffer** rb, ring_buffer_sample_fn sample_cb) [[maybe_unused]] { return 0; }
 int mock_init_ring_buffer_failure(ring_buffer** rb, ring_buffer_sample_fn sample_cb) [[maybe_unused]] { return 1; }
+void mock_ebpf_pop_events() [[maybe_unused]] { return; }
+void mock_whodata_pop_events() [[maybe_unused]] { return; }
 
 
 #endif // BPF_HELPERS_TEST_H

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -53,12 +53,10 @@ char* mock_get_group([[maybe_unused]] int gid) { return strdup("mock_group"); }
 void mock_fim_whodata_event([[maybe_unused]] whodata_evt* event) { return; }
 void mock_free_whodata_event([[maybe_unused]] whodata_evt* event) { return; }
 void mock_loggingFunction([[maybe_unused]] modules_log_level_t level, [[maybe_unused]] const char* msg) { return; }
-
 char* mock_abspath([[maybe_unused]] const char* path, char* buffer, [[maybe_unused]] size_t size) {
-    std::strcpy(buffer, "/mock/path");
+    std::strcpy(buffer, "/tmp/ebpf_hc");
     return buffer;
 }
-
 void* mock_bpf_object_open_file_success([[maybe_unused]] const char* filename, [[maybe_unused]] void* opts) { return (void*)1; }
 void* mock_bpf_object_open_file_failure([[maybe_unused]] const char* filename, [[maybe_unused]] void* opts) { return nullptr; }
 int mock_bpf_object_load_success([[maybe_unused]] void* obj) { return 0; }
@@ -88,6 +86,9 @@ int mock_init_ring_buffer_success(ring_buffer** rb, ring_buffer_sample_fn sample
 int mock_init_ring_buffer_failure(ring_buffer** rb, ring_buffer_sample_fn sample_cb) [[maybe_unused]] { return 1; }
 void mock_ebpf_pop_events() [[maybe_unused]] { return; }
 void mock_whodata_pop_events() [[maybe_unused]] { return; }
+int mock_check_invalid_kernel_version() [[maybe_unused]] { return 0; }
+int mock_init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load) [[maybe_unused]] { return 0; }
+int mock_init_bpfobj() [[maybe_unused]] { return 0; }
 
 
 #endif // BPF_HELPERS_TEST_H

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_mock_utils.hpp
@@ -1,0 +1,82 @@
+#ifndef BPF_HELPERS_TEST_H
+#define BPF_HELPERS_TEST_H
+#include <cstring>
+#include "ebpf_whodata.hpp"
+#include "bpf_helpers.h"
+#include "dynamic_library_wrapper.h"
+
+extern std::unique_ptr<w_bpf_helpers_t> bpf_helpers;
+
+
+class MockFimebpf : public fimebpf {
+public:
+    static fimebpf::fim_configuration_directory_t mock_fim_conf;
+    static fimebpf::get_user_t mock_get_user;
+    static fimebpf::get_group_t mock_get_group;
+    static fimebpf::fim_whodata_event_t mock_fim_whodata_event;
+    static fimebpf::free_whodata_event_t mock_free_whodata_event;
+    static fimebpf::loggingFunction_t mock_loggingFunction;
+    static fimebpf::abspath_t mock_abspath;
+
+    static void SetMockFunctions() {
+	fimebpf::instance().m_fim_configuration_directory = mock_fim_conf;
+        fimebpf::instance().m_get_user = mock_get_user;
+        fimebpf::instance().m_get_group = mock_get_group;
+        fimebpf::instance().m_fim_whodata_event = mock_fim_whodata_event;
+        fimebpf::instance().m_free_whodata_event = mock_free_whodata_event;
+        fimebpf::instance().m_loggingFunction = mock_loggingFunction;
+        fimebpf::instance().m_abspath = mock_abspath;
+    }
+};
+
+fimebpf::fim_configuration_directory_t MockFimebpf::mock_fim_conf = nullptr;
+fimebpf::get_user_t MockFimebpf::mock_get_user = nullptr;
+fimebpf::get_group_t MockFimebpf::mock_get_group = nullptr;
+fimebpf::fim_whodata_event_t MockFimebpf::mock_fim_whodata_event = nullptr;
+fimebpf::free_whodata_event_t MockFimebpf::mock_free_whodata_event = nullptr;
+fimebpf::loggingFunction_t MockFimebpf::mock_loggingFunction = nullptr;
+fimebpf::abspath_t MockFimebpf::mock_abspath = nullptr;
+
+directory_t* mock_fim_conf([[maybe_unused]] const char* config_path) { return nullptr; }
+
+char* mock_get_user([[maybe_unused]] int uid) { return strdup("mock_user"); }
+char* mock_get_group([[maybe_unused]] int gid) { return strdup("mock_group"); }
+void mock_fim_whodata_event([[maybe_unused]] whodata_evt* event) { return; }
+void mock_free_whodata_event([[maybe_unused]] whodata_evt* event) { return; }
+void mock_loggingFunction([[maybe_unused]] modules_log_level_t level, [[maybe_unused]] const char* msg) { return; }
+
+char* mock_abspath([[maybe_unused]] const char* path, char* buffer, [[maybe_unused]] size_t size) {
+    std::strcpy(buffer, "/mock/path");
+    return buffer;
+}
+
+void* mock_bpf_object_open_file_success([[maybe_unused]] const char* filename, [[maybe_unused]] void* opts) { return (void*)1; }
+void* mock_bpf_object_open_file_failure([[maybe_unused]] const char* filename, [[maybe_unused]] void* opts) { return nullptr; }
+int mock_bpf_object_load_success([[maybe_unused]] void* obj) { return 0; }
+int mock_bpf_object_load_failure([[maybe_unused]] void* obj) { return 1; }
+void mock_bpf_object_close_called([[maybe_unused]] void* obj) { return; }
+bpf_program* mock_bpf_object_next_program([[maybe_unused]] void* obj, [[maybe_unused]] bpf_program* pos) { return nullptr; }
+bpf_program* mock_bpf_object_next_program_in([[maybe_unused]] void* obj, [[maybe_unused]] bpf_program* pos) { return (bpf_program *)1; }
+int mock_bpf_program_attach_success([[maybe_unused]] void* prog) { return 1; }
+int mock_bpf_program_attach_failure([[maybe_unused]] void* prog) { return 0; }
+int mock_bpf_object_find_map_fd_by_name_success([[maybe_unused]] void* obj, [[maybe_unused]] const char* name) { return 1; }
+int mock_bpf_object_find_map_fd_by_name_failure([[maybe_unused]] void* obj, [[maybe_unused]] const char* name) { return -1; }
+
+ring_buffer* mock_ring_buffer_new_success([[maybe_unused]] int fd, [[maybe_unused]] ring_buffer_sample_fn sample_cb, [[maybe_unused]] void* ctx, [[maybe_unused]] void* consumer_ctx) {
+    return (ring_buffer*)1;
+}
+
+ring_buffer* mock_ring_buffer_new_failure([[maybe_unused]] int fd, [[maybe_unused]] ring_buffer_sample_fn sample_cb, [[maybe_unused]] void* ctx, [[maybe_unused]] void* consumer_ctx) {
+    return nullptr;
+}
+
+int mock_ring_buffer_poll_success(ring_buffer* rb, int timeout_ms) [[maybe_unused]] { return 1; }
+int mock_ring_buffer_poll_failure(ring_buffer* rb, int timeout_ms) [[maybe_unused]] { return -1; }
+void mock_ring_buffer_free(ring_buffer* rb) [[maybe_unused]] {}
+void mock_bpf_object_close(void* obj) [[maybe_unused]] {}
+void mock_w_bpf_deinit(void* helpers) [[maybe_unused]] {}
+int mock_init_ring_buffer_success(ring_buffer** rb, ring_buffer_sample_fn sample_cb) [[maybe_unused]] { return 0; }
+int mock_init_ring_buffer_failure(ring_buffer** rb, ring_buffer_sample_fn sample_cb) [[maybe_unused]] { return 1; }
+
+
+#endif // BPF_HELPERS_TEST_H

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
@@ -17,8 +17,8 @@ protected:
         MockFimebpf::mock_abspath = mock_abspath;
         MockFimebpf::SetMockFunctions();
         bpf_helpers = std::make_unique<w_bpf_helpers_t>();
-        bpf_helpers->ebpf_pop_events = (pop_events_t)mock_ebpf_pop_events;
-        bpf_helpers->whodata_pop_events = (pop_events_t)mock_whodata_pop_events;
+        bpf_helpers->ebpf_pop_events = (ebpf_pop_events_t)mock_ebpf_pop_events;
+        bpf_helpers->whodata_pop_events = (whodata_pop_events_t)mock_whodata_pop_events;
         bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
         bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success;
         bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
@@ -23,10 +23,16 @@ int ebpf_whodata();
 
 TEST_F(EbpfWhodataTest, SuccessfulRun) {
 
-    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_failure;
+    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
+    bpf_helpers->ebpf_pop_events = (pop_events_t)mock_ebpf_pop_events;
+    bpf_helpers->whodata_pop_events = (pop_events_t)mock_whodata_pop_events;
+    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success;
     bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
     bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
-    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(false))
+        .WillOnce(::testing::Return(true));
 
     int result = ebpf_whodata();
 
@@ -35,7 +41,6 @@ TEST_F(EbpfWhodataTest, SuccessfulRun) {
 
 TEST_F(EbpfWhodataTest, RingBufferInitError) {
 
-    fimebpf::instance().m_is_fim_shutdown = true;
     bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_failure;
 
     int result = ebpf_whodata();
@@ -43,22 +48,22 @@ TEST_F(EbpfWhodataTest, RingBufferInitError) {
     EXPECT_EQ(result, 1);
 }
 
-/*
 TEST_F(EbpfWhodataTest, RingBufferPollError) {
 
-    fimebpf::instance().m_is_fim_shutdown = false;
-    MockInterface mock;
-
     bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
+    bpf_helpers->ebpf_pop_events = (pop_events_t)mock_ebpf_pop_events;
+    bpf_helpers->whodata_pop_events = (pop_events_t)mock_whodata_pop_events;
     bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_failure;
     bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
     bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(false));
 
     int result = ebpf_whodata();
 
     EXPECT_EQ(result, 0);
 }
-*/
 
 void SetUpModule() {}
 void TearDownModule() {}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
@@ -4,14 +4,28 @@
 #include "ebpf_whodata.h"
 #include "bpf_helpers.h"
 
+extern volatile bool event_received;
+extern volatile bool epbf_hc_created;
+time_t fake_time_now = 0;
+extern time_t (*w_time)(time_t*);
 
 class EbpfWhodataTest : public ::testing::Test {
 protected:
 
     virtual void SetUp() {
         MockFimebpf::mock_loggingFunction = mock_loggingFunction;
+        MockFimebpf::mock_abspath = mock_abspath;
         MockFimebpf::SetMockFunctions();
         bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+        bpf_helpers->ebpf_pop_events = (pop_events_t)mock_ebpf_pop_events;
+        bpf_helpers->whodata_pop_events = (pop_events_t)mock_whodata_pop_events;
+        bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
+        bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success;
+        bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
+        bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
+        bpf_helpers->check_invalid_kernel_version = (check_invalid_kernel_version_t)mock_check_invalid_kernel_version;
+        bpf_helpers->init_libbpf = (init_libbpf_t)mock_init_libbpf;
+        bpf_helpers->init_bpfobj = (init_bpfobj_t)mock_init_bpfobj;
     }
 
     virtual void TearDown() {
@@ -19,16 +33,19 @@ protected:
     }
 };
 
+time_t mock_time(time_t* t) {
+    if (t) {
+        *t = fake_time_now;
+    }
+    return fake_time_now;
+}
+
 int ebpf_whodata();
 
 TEST_F(EbpfWhodataTest, SuccessfulRun) {
 
     bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
-    bpf_helpers->ebpf_pop_events = (pop_events_t)mock_ebpf_pop_events;
-    bpf_helpers->whodata_pop_events = (pop_events_t)mock_whodata_pop_events;
     bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_success;
-    bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
-    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
 
     EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
         .WillOnce(::testing::Return(false))
@@ -50,12 +67,7 @@ TEST_F(EbpfWhodataTest, RingBufferInitError) {
 
 TEST_F(EbpfWhodataTest, RingBufferPollError) {
 
-    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
-    bpf_helpers->ebpf_pop_events = (pop_events_t)mock_ebpf_pop_events;
-    bpf_helpers->whodata_pop_events = (pop_events_t)mock_whodata_pop_events;
     bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_failure;
-    bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
-    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
 
     EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
         .WillOnce(::testing::Return(false));
@@ -63,6 +75,32 @@ TEST_F(EbpfWhodataTest, RingBufferPollError) {
     int result = ebpf_whodata();
 
     EXPECT_EQ(result, 0);
+}
+
+TEST_F(EbpfWhodataTest, EbpfWhodataHealthcheckTestSuccess) {
+
+    event_received = true;
+
+    EXPECT_FALSE(ebpf_whodata_healthcheck());
+}
+
+TEST_F(EbpfWhodataTest, EbpfWhodataHealthcheckTestFailInitRingBuffer) {
+
+    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_failure;
+
+    EXPECT_TRUE(ebpf_whodata_healthcheck());
+}
+
+TEST_F(EbpfWhodataTest, EbpfWhodataHealthcheckTestFailNoEventReceived) {
+
+    event_received = false;
+    w_time = mock_time;
+    bpf_helpers->ring_buffer_poll = [](ring_buffer*, int) {
+        fake_time_now += 5;
+        return 0;
+    };
+
+    EXPECT_TRUE(ebpf_whodata_healthcheck());
 }
 
 void SetUpModule() {}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/ebpf_whodata_test.cpp
@@ -1,0 +1,72 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "ebpf_mock_utils.hpp"
+#include "ebpf_whodata.h"
+#include "bpf_helpers.h"
+
+
+class EbpfWhodataTest : public ::testing::Test {
+protected:
+
+    virtual void SetUp() {
+        MockFimebpf::mock_loggingFunction = mock_loggingFunction;
+        MockFimebpf::SetMockFunctions();
+        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+    }
+
+    virtual void TearDown() {
+        bpf_helpers.reset();
+    }
+};
+
+int ebpf_whodata();
+
+TEST_F(EbpfWhodataTest, SuccessfulRun) {
+
+    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_failure;
+    bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
+    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
+
+    int result = ebpf_whodata();
+
+    EXPECT_EQ(result, 0);
+}
+
+TEST_F(EbpfWhodataTest, RingBufferInitError) {
+
+    fimebpf::instance().m_is_fim_shutdown = true;
+    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_failure;
+
+    int result = ebpf_whodata();
+
+    EXPECT_EQ(result, 1);
+}
+
+/*
+TEST_F(EbpfWhodataTest, RingBufferPollError) {
+
+    fimebpf::instance().m_is_fim_shutdown = false;
+    MockInterface mock;
+
+    bpf_helpers->init_ring_buffer = (init_ring_buffer_t)mock_init_ring_buffer_success;
+    bpf_helpers->ring_buffer_poll = (ring_buffer__poll_t)mock_ring_buffer_poll_failure;
+    bpf_helpers->ring_buffer_free = (ring_buffer__free_t)mock_ring_buffer_free;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close;
+
+    int result = ebpf_whodata();
+
+    EXPECT_EQ(result, 0);
+}
+*/
+
+void SetUpModule() {}
+void TearDownModule() {}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    SetUpModule();
+    int result = RUN_ALL_TESTS();
+    TearDownModule();
+    return result;
+}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/healthcheck_event_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/healthcheck_event_test.cpp
@@ -7,23 +7,6 @@
 extern volatile bool event_received;
 const char* EBPF_HC_FILE = "tmp/ebpf_hc";
 
-
-#define TASK_COMM_LEN 32
-#define PATH_MAX 4096
-struct file_event {
-    __u32 pid;
-    __u32 ppid;
-    __u32 uid;
-    __u32 gid;
-    __u64 inode;
-    __u64 dev;
-    char comm[TASK_COMM_LEN];
-    char filename[PATH_MAX];
-    char cwd[PATH_MAX];
-    char parent_cwd[PATH_MAX];
-    char parent_comm[TASK_COMM_LEN];
-};
-
 void ResetEventReceived() {
     event_received = false;
 }

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/healthcheck_event_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/healthcheck_event_test.cpp
@@ -4,8 +4,8 @@
 #include "dynamic_library_wrapper.h"
 #include "ebpf_mock_utils.hpp"
 
-bool event_received = false;
-const char* EBPF_HC_FILE = "healthcheck.txt";
+extern volatile bool event_received;
+const char* EBPF_HC_FILE = "tmp/ebpf_hc";
 
 
 #define TASK_COMM_LEN 32
@@ -38,16 +38,16 @@ protected:
 
 // Need to review why strstr is returning true when it shouldn't, for the condition:
 //  if (strstr(e->filename, EBPF_HC_FILE))
-/*
+
 TEST_F(HealthcheckEventTest, TestEventReceivedWhenFileNameContainsEBPF_HC_FILE) {
     file_event e;
-    snprintf(e.filename, sizeof(e.filename), "%s", "path/to/healthcheck.txt");
+    snprintf(e.filename, sizeof(e.filename), "%s", EBPF_HC_FILE);
 
     healthcheck_event(nullptr, &e, sizeof(e));
 
     EXPECT_TRUE(event_received);
 }
-*/
+
 
 TEST_F(HealthcheckEventTest, TestEventNotReceivedWhenFileNameDoesNotContainEBPF_HC_FILE) {
     file_event e;

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/healthcheck_event_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/healthcheck_event_test.cpp
@@ -36,9 +36,6 @@ protected:
     void TearDown() override {}
 };
 
-// Need to review why strstr is returning true when it shouldn't, for the condition:
-//  if (strstr(e->filename, EBPF_HC_FILE))
-
 TEST_F(HealthcheckEventTest, TestEventReceivedWhenFileNameContainsEBPF_HC_FILE) {
     file_event e;
     snprintf(e.filename, sizeof(e.filename), "%s", EBPF_HC_FILE);

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/helthcheck_event_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/helthcheck_event_test.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cstring>
+#include "dynamic_library_wrapper.h"
+#include "ebpf_mock_utils.hpp"
+
+bool event_received = false;
+const char* EBPF_HC_FILE = "healthcheck.txt";
+
+
+#define TASK_COMM_LEN 32
+#define PATH_MAX 4096
+struct file_event {
+    __u32 pid;
+    __u32 ppid;
+    __u32 uid;
+    __u32 gid;
+    __u64 inode;
+    __u64 dev;
+    char comm[TASK_COMM_LEN];
+    char filename[PATH_MAX];
+    char cwd[PATH_MAX];
+    char parent_cwd[PATH_MAX];
+    char parent_comm[TASK_COMM_LEN];
+};
+
+void ResetEventReceived() {
+    event_received = false;
+}
+
+class HealthcheckEventTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ResetEventReceived();
+    }
+    void TearDown() override {}
+};
+
+// Need to review why strstr is returning true when it shouldn't, for the condition:
+//  if (strstr(e->filename, EBPF_HC_FILE))
+/*
+TEST_F(HealthcheckEventTest, TestEventReceivedWhenFileNameContainsEBPF_HC_FILE) {
+    file_event e;
+    snprintf(e.filename, sizeof(e.filename), "%s", "path/to/healthcheck.txt");
+
+    healthcheck_event(nullptr, &e, sizeof(e));
+
+    EXPECT_TRUE(event_received);
+}
+*/
+
+TEST_F(HealthcheckEventTest, TestEventNotReceivedWhenFileNameDoesNotContainEBPF_HC_FILE) {
+    file_event e;
+    strcpy(e.filename, "testing.txt");
+
+    healthcheck_event(nullptr, &e, sizeof(e));
+
+    EXPECT_FALSE(event_received);
+}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_bpf_obj_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_bpf_obj_test.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cstring>
+#include "dynamic_library_wrapper.h"
+#include "ebpf_mock_utils.hpp"
+
+void* global_obj = nullptr;
+
+void resetGlobalState() {
+    global_obj = nullptr;
+    if (bpf_helpers) {
+	w_bpf_deinit(bpf_helpers);
+    }
+}
+
+
+class InitBpfobjTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        MockFimebpf::mock_loggingFunction = mock_loggingFunction;
+        MockFimebpf::SetMockFunctions();
+        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+    }
+    void TearDown() override {
+        resetGlobalState();
+    }
+};
+
+TEST_F(InitBpfobjTest, Success) {
+
+    MockFimebpf::mock_abspath = mock_abspath;
+    MockFimebpf::SetMockFunctions();
+
+    bpf_helpers->bpf_object_open_file = (bpf_object__open_file_t)mock_bpf_object_open_file_success;
+    bpf_helpers->bpf_object_load = (bpf_object__load_t)mock_bpf_object_load_success;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
+    bpf_helpers->bpf_program_attach = (bpf_program__attach_t)mock_bpf_program_attach_success;
+    bpf_helpers->bpf_object_next_program = (bpf_object__next_program_t)mock_bpf_object_next_program;
+
+    MockFimebpf::SetMockFunctions();
+    int result = init_bpfobj();
+    ASSERT_EQ(result, 0);
+}
+
+TEST_F(InitBpfobjTest, LoggingPointerFailed) {
+    MockFimebpf::mock_loggingFunction = nullptr;
+    MockFimebpf::SetMockFunctions();
+
+    int result = init_bpfobj();
+    ASSERT_EQ(result, 1);
+}
+
+TEST_F(InitBpfobjTest, FailureDueToFileOpen) {
+
+    MockFimebpf::mock_abspath = mock_abspath;
+    MockFimebpf::SetMockFunctions();
+
+    bpf_helpers->bpf_object_open_file = (bpf_object__open_file_t)mock_bpf_object_open_file_failure;
+
+    int result = init_bpfobj();
+
+    ASSERT_EQ(result, 1);
+}
+
+TEST_F(InitBpfobjTest, FailureDueLoadeBPFobject) {
+    bpf_helpers->bpf_object_open_file = (bpf_object__open_file_t)mock_bpf_object_open_file_success;
+    bpf_helpers->bpf_object_load = (bpf_object__load_t)mock_bpf_object_load_failure;
+    bpf_helpers->bpf_program_attach = (bpf_program__attach_t)mock_bpf_program_attach_failure;
+    bpf_helpers->bpf_object_next_program = (bpf_object__next_program_t)mock_bpf_object_next_program;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
+
+    int result = init_bpfobj();
+    ASSERT_EQ(result, 1);
+}
+
+TEST_F(InitBpfobjTest, FailureDueAttachBPFobject) {
+    bpf_helpers->bpf_object_open_file = (bpf_object__open_file_t)mock_bpf_object_open_file_success;
+    bpf_helpers->bpf_object_load = (bpf_object__load_t)mock_bpf_object_load_success;
+    bpf_helpers->bpf_object_next_program = (bpf_object__next_program_t)mock_bpf_object_next_program_in;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
+    bpf_helpers->bpf_program_attach = (bpf_program__attach_t)mock_bpf_program_attach_failure;
+
+    int result = init_bpfobj();
+    ASSERT_EQ(result, 1);
+}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_libbpf_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_libbpf_test.cpp
@@ -15,9 +15,9 @@ extern int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load);
 
 class MockDynamicLibraryWrapper : public DynamicLibraryWrapper {
 public:
-    MOCK_METHOD(void*, getModuleHandle, (const char* so), (override)); 
-    MOCK_METHOD(void*, getFunctionSymbol, (void* handle, const char* function_name), (override)); 
-    MOCK_METHOD(int, freeLibrary, (void* handle), (override)); 
+    MOCK_METHOD(void*, so__get_module_handle, (const char* so), (override));
+    MOCK_METHOD(void*, getFunctionSymbol, (void* handle, const char* function_name), (override));
+    MOCK_METHOD(int, freeLibrary, (void* handle), (override));
 };
 
 
@@ -40,10 +40,10 @@ TEST_F(InitLibbpfTest, InitLibbpfTestOK) {
     MockFimebpf::mock_abspath = mock_abspath;
     MockFimebpf::SetMockFunctions();
 
-    EXPECT_CALL(*mock_sym_load, getModuleHandle(::testing::_))
+    EXPECT_CALL(*mock_sym_load, so__get_module_handle(::testing::_))
        .WillOnce(::testing::Return((void*)0x1000));
     EXPECT_CALL(*mock_sym_load, getFunctionSymbol(::testing::_, ::testing::_))
-        .WillRepeatedly(::testing::Return((void*)0x1001)); 
+        .WillRepeatedly(::testing::Return((void*)0x1001));
 
     int result = init_libbpf(std::move(mock_sym_load));
 
@@ -65,7 +65,7 @@ TEST_F(InitLibbpfTest, InitLibbpfTestFailed) {
 
     MockFimebpf::SetMockFunctions();
 
-    EXPECT_CALL(*mock_sym_load, getModuleHandle(::testing::_))
+    EXPECT_CALL(*mock_sym_load, so__get_module_handle(::testing::_))
        .WillOnce(::testing::Return((void*)0x1000));
     EXPECT_CALL(*mock_sym_load, getFunctionSymbol(::testing::_, ::testing::_))
         .WillOnce(::testing::Return(nullptr))

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_libbpf_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_libbpf_test.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cstring>
+#include "dynamic_library_wrapper.h"
+#include "ebpf_mock_utils.hpp"
+
+
+void resetGlobalState() {
+    if (bpf_helpers) {
+        bpf_helpers.reset();
+    }
+}
+
+extern int init_libbpf(std::unique_ptr<DynamicLibraryWrapper> sym_load);
+
+class MockDynamicLibraryWrapper : public DynamicLibraryWrapper {
+public:
+    MOCK_METHOD(void*, getModuleHandle, (const char* so), (override)); 
+    MOCK_METHOD(void*, getFunctionSymbol, (void* handle, const char* function_name), (override)); 
+    MOCK_METHOD(int, freeLibrary, (void* handle), (override)); 
+};
+
+
+std::unique_ptr<MockDynamicLibraryWrapper> mock_sym_load;
+
+class InitLibbpfTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        MockFimebpf::mock_loggingFunction = mock_loggingFunction;
+        MockFimebpf::SetMockFunctions();
+        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+        mock_sym_load = std::make_unique<MockDynamicLibraryWrapper>();
+    }
+    void TearDown() override {
+    }
+};
+
+
+TEST_F(InitLibbpfTest, InitLibbpfTestOK) {
+    MockFimebpf::mock_abspath = mock_abspath;
+    MockFimebpf::SetMockFunctions();
+
+    EXPECT_CALL(*mock_sym_load, getModuleHandle(::testing::_))
+       .WillOnce(::testing::Return((void*)0x1000));
+    EXPECT_CALL(*mock_sym_load, getFunctionSymbol(::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Return((void*)0x1001)); 
+
+    int result = init_libbpf(std::move(mock_sym_load));
+
+    ASSERT_EQ(result, 0);
+}
+
+TEST_F(InitLibbpfTest, abspathFailure) {
+    MockFimebpf::mock_abspath = nullptr;
+    MockFimebpf::SetMockFunctions();
+
+    int result = init_libbpf(std::move(mock_sym_load));
+
+    ASSERT_EQ(result, 1);
+}
+
+TEST_F(InitLibbpfTest, InitLibbpfTestFailed) {
+    MockFimebpf::mock_loggingFunction = mock_loggingFunction;
+    MockFimebpf::mock_abspath = mock_abspath;
+
+    MockFimebpf::SetMockFunctions();
+
+    EXPECT_CALL(*mock_sym_load, getModuleHandle(::testing::_))
+       .WillOnce(::testing::Return((void*)0x1000));
+    EXPECT_CALL(*mock_sym_load, getFunctionSymbol(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(nullptr))
+        .WillRepeatedly(::testing::Return((void*)0x1001));
+    EXPECT_CALL(*mock_sym_load, freeLibrary(::testing::_))
+        .WillOnce(::testing::Return(0));
+
+    int result = init_libbpf(std::move(mock_sym_load));
+
+    ASSERT_EQ(result, 1);
+}
+
+void SetUpModule() {}
+void TearDownModule() {}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    SetUpModule();
+    int result = RUN_ALL_TESTS();
+    TearDownModule();
+    return result;
+}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_ring_buffer_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/init_ring_buffer_test.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cstring>
+#include "dynamic_library_wrapper.h"
+#include "ebpf_mock_utils.hpp"
+
+void resetGlobalState() {
+    if (bpf_helpers) {
+	w_bpf_deinit(bpf_helpers);
+    }
+}
+
+
+class RingBufferTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        MockFimebpf::mock_loggingFunction = mock_loggingFunction;
+        MockFimebpf::SetMockFunctions();
+        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+    }
+    void TearDown() override {
+        resetGlobalState();
+    }
+};
+
+
+TEST_F(RingBufferTest, LoggingFailure) {
+    ring_buffer* rb = nullptr;
+    ring_buffer_sample_fn sample_cb = nullptr;
+
+    MockFimebpf::mock_loggingFunction = nullptr;
+    MockFimebpf::SetMockFunctions();
+    ASSERT_EQ(1, init_ring_buffer(&rb, sample_cb));
+}
+
+TEST_F(RingBufferTest, InitSuccess) {
+    ring_buffer* rb = nullptr;
+    ring_buffer_sample_fn sample_cb = nullptr;
+
+    bpf_helpers->bpf_object_find_map_fd_by_name = (bpf_object__find_map_fd_by_name_t)mock_bpf_object_find_map_fd_by_name_success;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
+    bpf_helpers->ring_buffer_new = (ring_buffer__new_t)mock_ring_buffer_new_success;
+
+    ASSERT_EQ(0, init_ring_buffer(&rb, sample_cb));
+}
+
+TEST_F(RingBufferTest, InitMapFdFailure) {
+    ring_buffer* rb = nullptr;
+    ring_buffer_sample_fn sample_cb = nullptr;
+
+    bpf_helpers->bpf_object_find_map_fd_by_name = (bpf_object__find_map_fd_by_name_t)mock_bpf_object_find_map_fd_by_name_failure;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
+
+    ASSERT_EQ(1, init_ring_buffer(&rb, sample_cb));
+}
+
+TEST_F(RingBufferTest, InitRbNewFailure) {
+    ring_buffer* rb = nullptr;
+    ring_buffer_sample_fn sample_cb = nullptr;
+
+    bpf_helpers->bpf_object_find_map_fd_by_name = (bpf_object__find_map_fd_by_name_t)mock_bpf_object_find_map_fd_by_name_success;
+    bpf_helpers->bpf_object_close = (bpf_object__close_t)mock_bpf_object_close_called;
+    bpf_helpers->ring_buffer_new = (ring_buffer__new_t)mock_ring_buffer_new_failure;
+
+    ASSERT_EQ(1, init_ring_buffer(&rb, sample_cb));
+}
+
+void SetUpModule() {}
+void TearDownModule() {}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    SetUpModule();
+    int result = RUN_ALL_TESTS();
+    TearDownModule();
+    return result;
+}

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/pop_event_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/pop_event_test.cpp
@@ -72,7 +72,7 @@ TEST_F(PopEventsTest, PopSucceedsWithEvent) {
     EXPECT_CALL(mock_queue, pop(::testing::_, ::testing::_))
        .WillOnce(::testing::DoAll(
         ::testing::Invoke(
-            [&](std::unique_ptr<whodata_evt, whodata_deleter>& event_arg, int timeout_arg) {
+            [&](std::unique_ptr<whodata_evt, whodata_deleter>& event_arg, [[maybe_unused]]int timeout_arg) {
 		std::unique_ptr<whodata_evt, whodata_deleter> new_event = std::make_unique<whodata_evt>();
                 event_arg = std::make_unique<whodata_evt>();
             }
@@ -117,7 +117,7 @@ TEST_F(PopEventsTest, EbpPopFailsAndShutdown) {
     EXPECT_CALL(mock_kernel_queue, pop(::testing::_, ::testing::_))
        .WillOnce(::testing::DoAll(
         ::testing::Invoke(
-            [&](std::unique_ptr<file_event>& event_arg, int timeout_arg) {
+            [&](std::unique_ptr<file_event>& event_arg, [[maybe_unused]]int timeout_arg) {
 		std::cout << "Update data" << std::endl;
 		std::unique_ptr<file_event> new_event = std::make_unique<file_event>();
                 event_arg = std::make_unique<file_event>();
@@ -142,7 +142,7 @@ TEST_F(PopEventsTest, EbpPopWithEvent) {
     EXPECT_CALL(mock_kernel_queue, pop(::testing::_, ::testing::_))
        .WillOnce(::testing::DoAll(
         ::testing::Invoke(
-            [&](std::unique_ptr<file_event>& event_arg, int timeout_arg) {
+            [&](std::unique_ptr<file_event>& event_arg, [[maybe_unused]]int timeout_arg) {
 		        std::unique_ptr<file_event> new_event = std::make_unique<file_event>();
                 event_arg = std::make_unique<file_event>();
             }

--- a/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/pop_event_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/fimEbpfWhodataTest/pop_event_test.cpp
@@ -1,0 +1,165 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "ebpf_mock_utils.hpp"
+#include "ebpf_whodata.h"
+#include "bpf_helpers.h"
+#include <bounded_queue.hpp>
+#include <iostream>
+
+
+
+class PopEventsTest : public ::testing::Test {
+protected:
+
+    virtual void SetUp() {
+        MockFimebpf::mock_loggingFunction = mock_loggingFunction;
+    	MockFimebpf::mock_fim_conf = mock_fim_conf_success;
+        MockFimebpf::mock_get_user = mock_get_user;
+        MockFimebpf::mock_get_group = mock_get_group;
+        MockFimebpf::SetMockFunctions();
+        bpf_helpers = std::make_unique<w_bpf_helpers_t>();
+    }
+
+    virtual void TearDown() {
+        bpf_helpers.reset();
+    }
+};
+
+void whodata_pop_events(fim::BoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>>& queue);
+
+template <typename T>
+class MockBoundedQueue : public fim::BoundedQueue<T> {
+public:
+    MockBoundedQueue() = default;
+    MockBoundedQueue(size_t max_size) : fim::BoundedQueue<T>(max_size) {}
+    MOCK_METHOD(bool, pop, (T& out_value, int timeout_ms), (override));
+    MOCK_METHOD(bool, push, (T&& in_value), (override));
+};
+
+
+TEST_F(PopEventsTest, ShutdownImmediately) {
+
+    MockBoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>> mock_queue;
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(true));
+
+    whodata_pop_events(mock_queue);
+}
+
+TEST_F(PopEventsTest, PopFailsAndShutdown) {
+
+    MockBoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>> mock_queue;
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(false))
+        .WillOnce(::testing::Return(true));
+
+    EXPECT_CALL(mock_queue, pop(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+
+
+    whodata_pop_events(mock_queue);
+}
+
+TEST_F(PopEventsTest, PopSucceedsWithEvent) {
+
+    MockBoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>> mock_queue;
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(false))
+        .WillOnce(::testing::Return(true));
+
+    EXPECT_CALL(mock_queue, pop(::testing::_, ::testing::_))
+       .WillOnce(::testing::DoAll(
+        ::testing::Invoke(
+            [&](std::unique_ptr<whodata_evt, whodata_deleter>& event_arg, int timeout_arg) {
+		std::unique_ptr<whodata_evt, whodata_deleter> new_event = std::make_unique<whodata_evt>();
+                event_arg = std::make_unique<whodata_evt>();
+            }
+        ),
+        ::testing::Return(true)
+    ));
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), m_fim_whodata_event(::testing::NotNull()));
+
+    whodata_pop_events(mock_queue);
+}
+
+/* TEST: ebpf_pop_events */
+
+TEST_F(PopEventsTest, LoggingPointerFailed) {
+    MockFimebpf::mock_loggingFunction = nullptr;
+    MockFimebpf::SetMockFunctions();
+    MockBoundedQueue<std::unique_ptr<file_event>> mock_kernel_queue;
+    MockBoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>> mock_whodata_queue;
+
+    ebpf_pop_events(mock_kernel_queue, mock_whodata_queue);
+}
+
+TEST_F(PopEventsTest, ShutdownProcessTrue) {
+    MockBoundedQueue<std::unique_ptr<file_event>> mock_kernel_queue;
+    MockBoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>> mock_whodata_queue;
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(true));
+
+    ebpf_pop_events(mock_kernel_queue, mock_whodata_queue);
+}
+
+TEST_F(PopEventsTest, EbpPopFailsAndShutdown) {
+    MockBoundedQueue<std::unique_ptr<file_event>> mock_kernel_queue;
+    MockBoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>> mock_whodata_queue;
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(false))
+        .WillOnce(::testing::Return(true));
+
+    EXPECT_CALL(mock_kernel_queue, pop(::testing::_, ::testing::_))
+       .WillOnce(::testing::DoAll(
+        ::testing::Invoke(
+            [&](std::unique_ptr<file_event>& event_arg, int timeout_arg) {
+		std::cout << "Update data" << std::endl;
+		std::unique_ptr<file_event> new_event = std::make_unique<file_event>();
+                event_arg = std::make_unique<file_event>();
+            }
+        ),
+        ::testing::Return(false)
+    ));
+
+    ebpf_pop_events(mock_kernel_queue, mock_whodata_queue);
+}
+
+TEST_F(PopEventsTest, EbpPopWithEvent) {
+    MockBoundedQueue<std::unique_ptr<file_event>> mock_kernel_queue;
+    MockBoundedQueue<std::unique_ptr<whodata_evt, whodata_deleter>> mock_whodata_queue;
+    MockFimebpf::mock_fim_conf = mock_fim_conf_failure;
+    MockFimebpf::SetMockFunctions();
+
+    EXPECT_CALL(MockFimebpf::GetInstance(), mock_fim_shutdown_process_on())
+        .WillOnce(::testing::Return(false))
+        .WillOnce(::testing::Return(true));
+
+    EXPECT_CALL(mock_kernel_queue, pop(::testing::_, ::testing::_))
+       .WillOnce(::testing::DoAll(
+        ::testing::Invoke(
+            [&](std::unique_ptr<file_event>& event_arg, int timeout_arg) {
+		        std::unique_ptr<file_event> new_event = std::make_unique<file_event>();
+                event_arg = std::make_unique<file_event>();
+            }
+        ),
+        ::testing::Return(true)
+    ));
+
+    ebpf_pop_events(mock_kernel_queue, mock_whodata_queue);
+}
+
+void SetUpModule() {}
+void TearDownModule() {}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    SetUpModule();
+    int result = RUN_ALL_TESTS();
+    TearDownModule();
+    return result;
+}

--- a/src/syscheckd/src/ebpf/tests/unit/CMakeLists.txt
+++ b/src/syscheckd/src/ebpf/tests/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(BoundedQueueTest)
+project(bounded_queue_test)
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -14,3 +14,6 @@ target_link_libraries(bounded_queue_test
     optimized gtest
     optimized gtest_main
 )
+
+add_test(NAME bounded_queue_test
+         COMMAND bounded_queue_test)

--- a/src/syscheckd/src/ebpf/tests/unit/bounded_queue_test.cpp
+++ b/src/syscheckd/src/ebpf/tests/unit/bounded_queue_test.cpp
@@ -41,7 +41,7 @@ TEST(BoundedQueueTest, SetMaxSize) {
     EXPECT_FALSE(queue.push(3)); // Queue is full
 
     queue.setMaxSize(1);
-    EXPECT_EQ(queue.size(), 1);
+    EXPECT_EQ(queue.size(), 1u);
 
     int value;
     EXPECT_TRUE(queue.pop(value, 100));
@@ -53,16 +53,16 @@ TEST(BoundedQueueTest, EmptyAndSize) {
     BoundedQueue<int> queue(3);
 
     EXPECT_TRUE(queue.empty());
-    EXPECT_EQ(queue.size(), 0);
+    EXPECT_EQ(queue.size(), 0u);
 
     EXPECT_TRUE(queue.push(1));
     EXPECT_FALSE(queue.empty());
-    EXPECT_EQ(queue.size(), 1);
+    EXPECT_EQ(queue.size(), 1u);
 
     int value;
     EXPECT_TRUE(queue.pop(value, 100));
     EXPECT_TRUE(queue.empty());
-    EXPECT_EQ(queue.size(), 0);
+    EXPECT_EQ(queue.size(), 0u);
 }
 
 TEST(BoundedQueueTest, Timeout) {

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -110,6 +110,20 @@ if(NOT ${TARGET} STREQUAL "winagent")
 
     target_link_libraries(test_audit_parse "${AUDIT_PARSE_FLAGS}")
     add_test(NAME test_audit_parse COMMAND test_audit_parse)
+
+    # test_syscheck_ebpf tests
+    add_executable(test_syscheck_ebpf test_syscheck_ebpf.c ${SRC_FOLDER}/unit_tests/wrappers/linux/ebpf_wrappers.c)
+    target_compile_options(test_syscheck_ebpf PRIVATE "-Wall")
+    set(SYSCHECK_EBPF_FLAGS "-Wl,--wrap,fimebpf_initialize"
+                            "-Wl,--wrap,ebpf_whodata_healthcheck"
+			    "-Wl,--wrap=_minfo -Wl,--wrap,_merror"
+                            ${DEBUG_OP_WRAPPERS})
+
+    target_link_libraries(test_syscheck_ebpf SYSCHECK_O ${TEST_DEPS} fimdb)
+
+    target_link_libraries(test_syscheck_ebpf "${SYSCHECK_EBPF_FLAGS}")
+    add_test(NAME test_syscheck_ebpf COMMAND test_syscheck_ebpf)
+
 else()
     link_directories(${SRC_FOLDER}/syscheckd/build/bin)
     add_executable(test_win_whodata test_win_whodata.c)
@@ -137,4 +151,5 @@ else()
 
     target_link_libraries(test_win_whodata "${WIN_WHODATA_FLAGS}")
     add_test(NAME test_win_whodata COMMAND test_win_whodata)
+
 endif()

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_ebpf.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_ebpf.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2025, Wazuh Inc.  *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "../../../syscheckd/include/syscheck.h"
+#include "../../../syscheckd/src/ebpf/include/ebpf_whodata.h"
+#include "wrappers/linux/ebpf_wrappers.h"
+#include "wrappers/wazuh/shared/debug_op_wrappers.h"
+
+/* setup/teardown */
+static int setup_group(void **state) {
+    (void) state;
+    test_mode = 1;
+    return 0;
+}
+
+static int teardown_group(void **state) {
+    (void) state;
+    memset(&syscheck, 0, sizeof(syscheck_config));
+    Free_Syscheck(&syscheck);
+    test_mode = 0;
+    return 0;
+}
+
+
+static int setup_syscheck_dir_links(void **state) {
+
+    directory_t *directory0 = fim_create_directory("/test0", WHODATA_ACTIVE | EBPF_DRIVER, NULL, 512,
+                                                NULL, -1, 0);
+    directory_t *directory1 = fim_create_directory("/test1", WHODATA_ACTIVE | EBPF_DRIVER, NULL, 512,
+                                                NULL, -1, 0);
+
+    syscheck.directories = OSList_Create();
+    if (syscheck.directories == NULL) {
+        return (1);
+    }
+
+    OSList_InsertData(syscheck.directories, NULL, directory0);
+    OSList_InsertData(syscheck.directories, NULL, directory1);
+
+    return 0;
+}
+
+static int teardown_syscheck_dir_links(void **state) {
+    OSListNode *node_it;
+
+    if (syscheck.directories) {
+        OSList_foreach(node_it, syscheck.directories) {
+            free_directory(node_it->data);
+            node_it->data = NULL;
+        }
+        OSList_Destroy(syscheck.directories);
+        syscheck.directories = NULL;
+    }
+
+    return 0;
+}
+
+static int teardown_rules_to_realtime(void **state) {
+    free(syscheck.realtime);
+    syscheck.realtime = NULL;
+    teardown_syscheck_dir_links(state);
+    return 0;
+}
+
+void test_check_ebpf_availability_true(void **state) {
+
+    expect_string(__wrap__minfo, formatted_msg, FIM_EBPF_INIT);
+    expect_string(__wrap__merror, formatted_msg, FIM_ERROR_EBPF_HEALTHCHECK);
+
+    will_return(__wrap_ebpf_whodata_healthcheck, 1);
+
+
+    check_ebpf_availability();
+
+    // Verify that EBP_DRIVER was disable
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options & EBPF_DRIVER){
+	fail();
+    }
+
+    // Check that they have been switched to AUDIT_DRIVER.
+    if (!(((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->options & AUDIT_DRIVER)){
+        fail();
+    }
+
+}
+
+void test_check_ebpf_availability_false(void **state) {
+
+    expect_string(__wrap__minfo, formatted_msg, FIM_EBPF_INIT);
+    will_return(__wrap_ebpf_whodata_healthcheck, 0);
+
+    check_ebpf_availability();
+
+    // Verify that EBP_DRIVER was not disable
+    if (!((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 0))->options & EBPF_DRIVER){
+	fail();
+    }
+
+    // Continue with AUDIT_DRIVER.
+    if (((directory_t *)OSList_GetDataFromIndex(syscheck.directories, 1))->options & AUDIT_DRIVER){
+        fail();
+    }
+}
+
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_check_ebpf_availability_true, setup_syscheck_dir_links, teardown_rules_to_realtime),
+        cmocka_unit_test_setup_teardown(test_check_ebpf_availability_false, setup_syscheck_dir_links, teardown_rules_to_realtime),
+        };
+
+    return cmocka_run_group_tests(tests, setup_group, teardown_group);
+}

--- a/src/unit_tests/wrappers/linux/ebpf_wrappers.c
+++ b/src/unit_tests/wrappers/linux/ebpf_wrappers.c
@@ -1,0 +1,32 @@
+/* Copyright (C) 2025, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "../../../syscheckd/include/syscheck.h"
+#include "ebpf_wrappers.h"
+#include <setjmp.h>
+#include <cmocka.h>
+
+
+int __wrap_ebpf_whodata_healthcheck() {
+    // Your function definition goes here
+    return mock_type(int);
+}
+
+typedef void (*FunctionPtr)();
+
+void __wrap_fimebpf_initialize(const char* config_dir,
+                                FunctionPtr get_user,
+                                FunctionPtr get_group,
+                                FunctionPtr whodata_event,
+                                FunctionPtr free_whodata_event,
+                                FunctionPtr loggingFunction,
+                                FunctionPtr abspath,
+                                FunctionPtr is_shutdown,
+                                syscheck_config syscheck) {
+}

--- a/src/unit_tests/wrappers/linux/ebpf_wrappers.h
+++ b/src/unit_tests/wrappers/linux/ebpf_wrappers.h
@@ -1,0 +1,35 @@
+/* Copyright (C) 2025, Wazuh Inc.
+ * All right reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef WRAP_EBPF_FUNCTIONS_H
+#define WRAP_EBPF_FUNCTIONS_H
+
+#include <stddef.h>
+
+// Forward declaration of syscheck_config if it is a struct type
+typedef struct _config syscheck_config;
+
+// Define FunctionPtr as a pointer to a function that returns void and takes no arguments
+typedef void (*FunctionPtr)();
+
+// Declare the wrap functions
+int __wrap_ebpf_whodata_healthcheck(void);
+
+// Declare the wrap version of fimebpf_initialize
+void __wrap_fimebpf_initialize(const char* config_dir,
+                                FunctionPtr get_user,
+                                FunctionPtr get_group,
+                                FunctionPtr whodata_event,
+                                FunctionPtr free_whodata_event,
+                                FunctionPtr loggingFunction,
+                                FunctionPtr abspath,
+                                FunctionPtr is_shutdown,
+                                syscheck_config syscheck);
+
+#endif // WRAP_EBPF_FUNCTIONS_H


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28636|

## Description
This PR adds a set of tests for the eBPF implementation. Currently, we have implemented unit tests for the following methods:

- `ebpf_whodata_test`
- `init_libbpf_test`
- `healthcheck_event_test`
- `init_ring_buffer_test`
- `init_bpf_obj_test`
- `close_libbpf_test`

Additionally, we verify that the configuration works as expected, ensuring that if the eBPF module is not available, it will switch to audit drivers.


<details>
<summary>Configuration tests </summary>

```bash
wazuh/src/unit_tests/build/syscheckd/whodata# ./test_syscheck_ebpf 
[==========] Running 2 test(s).
[ RUN      ] test_check_ebpf_availability_true
[       OK ] test_check_ebpf_availability_true
[ RUN      ] test_check_ebpf_availability_false
[       OK ] test_check_ebpf_availability_false
[==========] 2 test(s) run.
[  PASSED  ] 2 test(s).
```
</details>

```bash
wazuh/src/syscheckd/build/bin# echo 'ebpf_whodata_test
init_libbpf_test
helthcheck_event_test
init_ring_buffer_test
init_bpf_obj_test
close_libbpf_test'|while read line; do ./$line ; done
```



<details>
<summary> ebpf_whodata </summary>

```bash
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from EbpfWhodataTest
[ RUN      ] EbpfWhodataTest.SuccessfulRun
[       OK ] EbpfWhodataTest.SuccessfulRun (0 ms)
[ RUN      ] EbpfWhodataTest.RingBufferInitError
[       OK ] EbpfWhodataTest.RingBufferInitError (0 ms)
[----------] 2 tests from EbpfWhodataTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
```
</details>

<details>
<summary> init_libbpf </summary>

```bash
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from InitLibbpfTest
[ RUN      ] InitLibbpfTest.InitLibbpfTestOK
[       OK ] InitLibbpfTest.InitLibbpfTestOK (0 ms)
[ RUN      ] InitLibbpfTest.abspathFailure
[       OK ] InitLibbpfTest.abspathFailure (0 ms)
[ RUN      ] InitLibbpfTest.InitLibbpfTestFailed
[       OK ] InitLibbpfTest.InitLibbpfTestFailed (0 ms)
[----------] 3 tests from InitLibbpfTest (1 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.
```
</details>

<details>
<summary> healthcheck_event </summary>

```bash
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from HealthcheckEventTest
[ RUN      ] HealthcheckEventTest.TestEventNotReceivedWhenFileNameDoesNotContainEBPF_HC_FILE
[       OK ] HealthcheckEventTest.TestEventNotReceivedWhenFileNameDoesNotContainEBPF_HC_FILE (0 ms)
[----------] 1 test from HealthcheckEventTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
```
</details>

<details>
<summary> init_ring_buffer </summary>

```bash
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from RingBufferTest
[ RUN      ] RingBufferTest.LoggingFailure
[       OK ] RingBufferTest.LoggingFailure (0 ms)
[ RUN      ] RingBufferTest.InitSuccess
[       OK ] RingBufferTest.InitSuccess (0 ms)
[ RUN      ] RingBufferTest.InitMapFdFailure
[       OK ] RingBufferTest.InitMapFdFailure (0 ms)
[ RUN      ] RingBufferTest.InitRbNewFailure
[       OK ] RingBufferTest.InitRbNewFailure (0 ms)
[----------] 4 tests from RingBufferTest (0 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 4 tests.
```
</details>

<details>
<summary> init_bpfobj </summary>

```bash
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from InitBpfobjTest
[ RUN      ] InitBpfobjTest.Success
[       OK ] InitBpfobjTest.Success (0 ms)
[ RUN      ] InitBpfobjTest.LoggingPointerFailed
[       OK ] InitBpfobjTest.LoggingPointerFailed (0 ms)
[ RUN      ] InitBpfobjTest.FailureDueToFileOpen
[       OK ] InitBpfobjTest.FailureDueToFileOpen (0 ms)
[ RUN      ] InitBpfobjTest.FailureDueLoadeBPFobject
[       OK ] InitBpfobjTest.FailureDueLoadeBPFobject (0 ms)
[ RUN      ] InitBpfobjTest.FailureDueAttachBPFobject
[       OK ] InitBpfobjTest.FailureDueAttachBPFobject (0 ms)
[----------] 5 tests from InitBpfobjTest (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
```

</details>

<details>
<summary>close_libbpf </summary>

```bash
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from CloseLibbpfTest
[ RUN      ] CloseLibbpfTest.ModuleExists
[       OK ] CloseLibbpfTest.ModuleExists (0 ms)
[ RUN      ] CloseLibbpfTest.ModuleNull
[       OK ] CloseLibbpfTest.ModuleNull (0 ms)
[ RUN      ] CloseLibbpfTest.HelpersNull
[       OK ] CloseLibbpfTest.HelpersNull (0 ms)
[----------] 3 tests from CloseLibbpfTest (0 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.
```

</details>



