### PR TITLE
Adding error tolerance to unstable tests

### DIFF
--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -180,7 +180,10 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadWithRetryGenericServerError)
     const auto& lastQueryTimestamp {records.back().timestamp};
     const auto milliseconds {
         std::chrono::duration_cast<std::chrono::milliseconds>(lastQueryTimestamp - firstQueryTimestamp).count()};
-    EXPECT_GE(milliseconds, TOO_MANY_REQUESTS_RETRY_TIME_MS * 2);
+    auto minExpectedSleepTime = TOO_MANY_REQUESTS_RETRY_TIME_MS * 2;
+    // We accept a small margin of error in the sleep time.
+    minExpectedSleepTime *= 0.9;
+    EXPECT_GE(milliseconds, minExpectedSleepTime);
 }
 
 /**
@@ -218,7 +221,10 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadWithRetryTooManyRequestsError)
     const auto& lastQueryTimestamp {records.back().timestamp};
     const auto milliseconds {
         std::chrono::duration_cast<std::chrono::milliseconds>(lastQueryTimestamp - firstQueryTimestamp).count()};
-    EXPECT_GE(milliseconds, TOO_MANY_REQUESTS_RETRY_TIME_MS);
+    auto minExpectedSleepTime = TOO_MANY_REQUESTS_RETRY_TIME_MS;
+    // We accept a small margin of error in the sleep time.
+    minExpectedSleepTime *= 0.9;
+    EXPECT_GE(milliseconds, minExpectedSleepTime);
 }
 
 /**
@@ -257,7 +263,10 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadWithRetryDifferentErrors)
     const auto& lastQueryTimestamp {records.back().timestamp};
     const auto milliseconds {
         std::chrono::duration_cast<std::chrono::milliseconds>(lastQueryTimestamp - firstQueryTimestamp).count()};
-    EXPECT_GE(milliseconds, TOO_MANY_REQUESTS_RETRY_TIME_MS * 2 + GENERIC_ERROR_INITIAL_RETRY_TIME_MS);
+    auto minExpectedSleepTime = TOO_MANY_REQUESTS_RETRY_TIME_MS * 2 + GENERIC_ERROR_INITIAL_RETRY_TIME_MS;
+    // We accept a small margin of error in the sleep time.
+    minExpectedSleepTime *= 0.9;
+    EXPECT_GE(milliseconds, minExpectedSleepTime);
 }
 
 /**


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28598 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR adds a %10 error tolerance to the unstable tests.