### PR TITLE
Wazuh Server certificates folder permissions - Implementation

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/python-lint.yml'
-      - 'apis/**'
-      - 'framework/**'
+      - 'apis/**/*.py'
+      - 'framework/**/*.py'
 
 jobs:
   lint:

--- a/framework/Makefile
+++ b/framework/Makefile
@@ -19,7 +19,8 @@ CFLAGS       = -pipe -Wall -Wextra
 THREAD_FLAGS = -pthread
 MV_FILE      = mv -f
 RM_FILE      = rm -f
-INSTALL_DIR  = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750  -d
+INSTALL_REGULAR_DIR  = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750  -d
+INSTALL_RESTRICTED_DIR  = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0500  -d
 INSTALL_EXEC = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0750
 INSTALL_FILE = install -o ${WAZUH_USER} -g ${WAZUH_GROUP} -m 0640
 
@@ -37,22 +38,22 @@ all: build
 
 install:
 	# SHARE
-	$(INSTALL_DIR) $(BIN_INSTALLDIR)
-	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework
-	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/scripts
-	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/wazuh
-	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/wazuh/core/cluster
-	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/wazuh/core/cluster/dapi
-	$(INSTALL_DIR) $(SHARE_INSTALLDIR)/framework/wazuh/core/cluster/hap_helper
+	$(INSTALL_REGULAR_DIR) $(BIN_INSTALLDIR)
+	$(INSTALL_REGULAR_DIR) $(SHARE_INSTALLDIR)/framework
+	$(INSTALL_REGULAR_DIR) $(SHARE_INSTALLDIR)/framework/scripts
+	$(INSTALL_REGULAR_DIR) $(SHARE_INSTALLDIR)/framework/wazuh
+	$(INSTALL_REGULAR_DIR) $(SHARE_INSTALLDIR)/framework/wazuh/core/cluster
+	$(INSTALL_REGULAR_DIR) $(SHARE_INSTALLDIR)/framework/wazuh/core/cluster/dapi
+	$(INSTALL_REGULAR_DIR) $(SHARE_INSTALLDIR)/framework/wazuh/core/cluster/hap_helper
 
 	# LOGS
-	$(INSTALL_DIR) $(LOG_INSTALLDIR)
+	$(INSTALL_REGULAR_DIR) $(LOG_INSTALLDIR)
 
 	# ETC
-	$(INSTALL_DIR) $(ETC_INSTALLDIR)
-	$(INSTALL_DIR) $(ETC_INSTALLDIR)/cluster
-	$(INSTALL_DIR) $(ETC_INSTALLDIR)/certs
-	$(INSTALL_DIR) $(ETC_INSTALLDIR)/groups
+	$(INSTALL_REGULAR_DIR) $(ETC_INSTALLDIR)
+	$(INSTALL_REGULAR_DIR) $(ETC_INSTALLDIR)/cluster
+	$(INSTALL_RESTRICTED_DIR) $(ETC_INSTALLDIR)/certs
+	$(INSTALL_REGULAR_DIR) $(ETC_INSTALLDIR)/groups
 
 	# SHARE
 	$(INSTALL_EXEC) scripts/wazuh_server.py ${SHARE_INSTALLDIR}/framework/scripts/wazuh-server.py
@@ -73,7 +74,7 @@ install:
 	$(RM_FILE) ${BIN_INSTALLDIR}/__init__
 
 examples: install
-	$(INSTALL_DIR) $(INSTALLDIR)/framework/examples
+	$(INSTALL_REGULAR_DIR) $(INSTALLDIR)/framework/examples
 	$(INSTALL_EXEC) examples/*.py ${INSTALLDIR}/framework/examples
 
 clean:

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -94,8 +94,6 @@ override_dh_fixperms:
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
-	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server
-	find $(TARGET_DIR)$(INSTALLATION_DIR)etc/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 
 	# Binaries
 	chown $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/wazuh-server/bin/wazuh-keystore

--- a/packages/debs/SPECS/debian/rules
+++ b/packages/debs/SPECS/debian/rules
@@ -76,7 +76,6 @@ override_dh_install:
 	cp -pr $(INSTALLATION_DIR)var/lib/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/
 	cp -pr $(INSTALLATION_DIR)usr/share/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)usr/share/
 	cp -pr $(INSTALLATION_DIR)etc/wazuh-server $(TARGET_DIR)$(INSTALLATION_DIR)etc/
-
 	# Copying init.d script
 	mkdir -p ${TARGET_DIR}/etc/init.d/
 	sed -i "s:WAZUH_HOME_TMP:${INSTALLATION_DIR}:g" src/init/templates/wazuh-server-debian.init
@@ -88,7 +87,7 @@ override_dh_install:
 	install -m 0644 src/init/templates/wazuh-server.service ${TARGET_DIR}/usr/lib/systemd/system/
 
 override_dh_fixperms:
-	dh_fixperms
+	dh_fixperms -X /etc/wazuh-server
 	# Folders
 	chown -R $(WAZUH_USER):$(WAZUH_GROUP) $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server
 	find $(TARGET_DIR)$(INSTALLATION_DIR)var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -238,14 +238,14 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server
-%dir %attr(500, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
+%attr(640, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/wazuh-server.yml
+%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/cluster
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/groups
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/lib
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/framework
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/apis
 %{_localstatedir}var/lib/wazuh-server/engine/tzdb/*
-%{_localstatedir}etc/wazuh-server/*
 %{_localstatedir}usr/share/wazuh-server/lib/*
 %{_localstatedir}usr/share/wazuh-server/framework/*
 %{_localstatedir}usr/share/wazuh-server/apis/*

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -238,7 +238,7 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
+%dir %attr(500, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/cluster
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/groups
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/lib

--- a/packages/rpms/SPECS/wazuh-server.spec
+++ b/packages/rpms/SPECS/wazuh-server.spec
@@ -198,8 +198,6 @@ chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}var/lib/wazuh-server
 find %{_localstatedir}var/lib/wazuh-server -type d -exec chmod 750 {} \; -o -type f -exec chmod 640 {} \;
 chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}usr/share/wazuh-server
 find %{_localstatedir}usr/share/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
-chown -R %{_wazuh_user}:%{_wazuh_group} %{_localstatedir}etc/wazuh-server
-find %{_localstatedir}etc/wazuh-server -type d -exec chmod 755 {} \; -o -type f -exec chmod 644 {} \;
 
 # Binaries
 chmod 750 %{_localstatedir}usr/share/wazuh-server/bin/wazuh-engine
@@ -239,7 +237,7 @@ rm -fr %{buildroot}
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}var/lib/wazuh-server/engine/tzdb
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server
 %attr(640, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/wazuh-server.yml
-%dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
+%dir %attr(500, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/certs
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/cluster
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}etc/wazuh-server/groups
 %dir %attr(750, %{_wazuh_user}, %{_wazuh_group}) %{_localstatedir}usr/share/wazuh-server/lib


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28692|

## Description

This PR aims to restrict the permissions for `/etc/wazuh-server/certs` folder

## Test

- Installation from sources
```console
 - Configuration finished properly.

 - To start Wazuh:
      //bin/wazuh-control start

 - To stop Wazuh:
      //bin/wazuh-control stop



   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

 - In order to connect agent and server, you need to add each agent to the server.

   More information at: 
   https://documentation.wazuh.com/

root@wazuh-dev:~/repos/wazuh# ls  /etc/wazuh-server/
certs/            cluster/          groups/           wazuh-server.yml  
root@wazuh-dev:~/repos/wazuh# ls  -la /etc/wazuh-server/
total 32
drwxr-x---   5 wazuh-server wazuh-server  4096 Mar 18 08:31 .
drwxr-xr-x 149 root         root         12288 Mar 18 07:53 ..
dr-x------   2 wazuh-server wazuh-server  4096 Feb 12 10:11 certs
drwxr-x---   2 wazuh-server wazuh-server  4096 Feb 12 10:11 cluster
drwxr-x---   2 wazuh-server wazuh-server  4096 Feb 12 10:11 groups
-rw-r-----   1 wazuh-server wazuh-server   972 Mar 18 08:31 wazuh-server.yml
```
- DEB
```console
vagrant@vagrant:~$ sudo apt install ./wazuh-server_5.0.0-0_amd64_cc9c93b.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-server' instead of './wazuh-server_5.0.0-0_amd64_cc9c93b.deb'
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-server
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/314 MB of archives.
After this operation, 572 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-server_5.0.0-0_amd64_cc9c93b.deb wazuh-server amd64 5.0.0-0 [314 MB]
Selecting previously unselected package wazuh-server.
(Reading database ... 46826 files and directories currently installed.)
Preparing to unpack .../wazuh-server_5.0.0-0_amd64_cc9c93b.deb ...
Unpacking wazuh-server (5.0.0-0) ...
Setting up wazuh-server (5.0.0-0) ...
Processing triggers for libc-bin (2.39-0ubuntu8.1) ...
Scanning processes...                                                                                                                                                                                              
Scanning linux images...                                                                                                                                                                                           

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
N: Download is performed unsandboxed as root as file '/home/vagrant/wazuh-server_5.0.0-0_amd64_cc9c93b.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
vagrant@vagrant:~$ sudo ls -la /etc/wazuh-server/
total 24
drwxr-x---   5 wazuh-server wazuh-server 4096 Mar 18 18:56 .
drwxr-xr-x 109 root         root         4096 Mar 18 18:56 ..
dr-x------   2 wazuh-server wazuh-server 4096 Mar 18 18:40 certs
drwxr-x---   2 wazuh-server wazuh-server 4096 Mar 18 18:40 cluster
drwxr-x---   2 wazuh-server wazuh-server 4096 Mar 18 18:40 groups
-rw-r-----   1 wazuh-server wazuh-server  972 Mar 18 18:40 wazuh-server.yml
```
- RPM
```console
[wazuh-user@wazuh-server ~]$ sudo rpm -i wazuh-server_5.0.0-0_x86_64_cc9c93b.rpm 
[wazuh-user@wazuh-server ~]$ sudo ls -l /etc/wazuh-server/
total 4
dr-x------ 2 wazuh-server wazuh-server   6 Mar 18 18:40 certs
drwxr-x--- 2 wazuh-server wazuh-server   6 Mar 18 18:40 cluster
drwxr-x--- 2 wazuh-server wazuh-server   6 Mar 18 18:40 groups
-rw-r----- 1 wazuh-server wazuh-server 972 Mar 18 18:40 wazuh-server.yml

```