### PR TITLE
Add Engine mappings restrictions

### DIFF
--- a/src/engine/source/builder/CMakeLists.txt
+++ b/src/engine/source/builder/CMakeLists.txt
@@ -25,6 +25,7 @@ SET(BUILDER_PRI_INCS
 )
 add_library(builder STATIC
     ${SRC_DIR}/builder.cpp
+    ${SRC_DIR}/allowedFields.cpp
     ${SRC_DIR}/policy/factory.cpp
     ${SRC_DIR}/policy/policy.cpp
     ${SRC_DIR}/policy/assetBuilder.cpp
@@ -101,6 +102,7 @@ gtest_discover_tests(builder_ctest)
 
 ## Unit tests
 add_executable(builder_utest
+    ${UNIT_SRC_DIR}/allowedFields_test.cpp
     ${UNIT_SRC_DIR}/registry_test.cpp
     ${UNIT_SRC_DIR}/policy/factory_test.cpp
     ${UNIT_SRC_DIR}/policy/assetBuilder_test.cpp

--- a/src/engine/source/builder/include/builder/allowedFields.hpp
+++ b/src/engine/source/builder/include/builder/allowedFields.hpp
@@ -1,0 +1,29 @@
+#ifndef BUILDER_ALLOWEDFIELDS_HPP
+#define BUILDER_ALLOWEDFIELDS_HPP
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include <fmt/format.h>
+
+#include <base/json.hpp>
+#include <builder/iallowedFields.hpp>
+
+namespace builder
+{
+class AllowedFields final : public IAllowedFields
+{
+private:
+    std::unordered_map<base::Name, std::unordered_set<DotPath>> m_fields;
+
+public:
+    AllowedFields() = default;
+    ~AllowedFields() override = default;
+
+    AllowedFields(const json::Json& definition);
+
+    bool check(const base::Name& assetType, const DotPath& field) const override;
+};
+} // namespace builder
+
+#endif // BUILDER_ALLOWEDFIELDS_HPP

--- a/src/engine/source/builder/include/builder/builder.hpp
+++ b/src/engine/source/builder/include/builder/builder.hpp
@@ -12,6 +12,7 @@
 #include <schemf/ivalidator.hpp>
 #include <store/istore.hpp>
 
+#include <builder/iallowedFields.hpp>
 #include <builder/ibuilder.hpp>
 #include <builder/ivalidator.hpp>
 
@@ -39,6 +40,7 @@ private:
     std::shared_ptr<store::IStore> m_storeRead;                      ///< Store reader interface
     std::shared_ptr<schemf::IValidator> m_schema;                    ///< Schema validator
     std::shared_ptr<defs::IDefinitionsBuilder> m_definitionsBuilder; ///< Definitions builder
+    std::shared_ptr<IAllowedFields> m_allowedFields; ///< Manages wich fields can be modified by different assets
 
     std::shared_ptr<Registry> m_registry; ///< builders registry
 
@@ -49,6 +51,7 @@ public:
     Builder(const std::shared_ptr<store::IStore>& storeRead,
             const std::shared_ptr<schemf::IValidator>& schema,
             const std::shared_ptr<defs::IDefinitionsBuilder>& definitionsBuilder,
+            const std::shared_ptr<IAllowedFields>& allowedFields,
             const BuilderDeps& builderDeps);
 
     std::shared_ptr<IPolicy>

--- a/src/engine/source/builder/interface/builder/iallowedFields.hpp
+++ b/src/engine/source/builder/interface/builder/iallowedFields.hpp
@@ -1,0 +1,19 @@
+#ifndef _BUILDER_IALLOWEDFIELDS_HPP
+#define _BUILDER_IALLOWEDFIELDS_HPP
+
+#include <base/dotPath.hpp>
+#include <base/name.hpp>
+
+namespace builder
+{
+
+class IAllowedFields
+{
+public:
+    virtual ~IAllowedFields() = default;
+
+    virtual bool check(const base::Name& assetType, const DotPath& field) const = 0;
+};
+} // namespace builder
+
+#endif // _BUILDER_IALLOWEDFIELDS_HPP

--- a/src/engine/source/builder/src/allowedFields.cpp
+++ b/src/engine/source/builder/src/allowedFields.cpp
@@ -1,0 +1,60 @@
+#include <builder/allowedFields.hpp>
+
+#include <fmt/format.h>
+
+#include "syntax.hpp"
+
+namespace builder
+{
+AllowedFields::AllowedFields(const json::Json& definition)
+{
+    if (!definition.isObject())
+    {
+        throw std::runtime_error {"Allowed fields definition must be an object"};
+    }
+
+    auto asObj = definition.getObject().value();
+    for (auto [key, value] : asObj)
+    {
+        if (!syntax::name::isDecoder(base::Name {key}, false) && !syntax::name::isRule(base::Name {key}, false)
+            && !syntax::name::isOutput(base::Name {key}, false) && !syntax::name::isFilter(base::Name {key}, false))
+        {
+            throw std::runtime_error {fmt::format("Unknown asset name '{}' in allowed fields definition", key)};
+        }
+
+        if (!value.isArray())
+        {
+            throw std::runtime_error {fmt::format("Allowed fields for asset '{}' must be an array", key)};
+        }
+
+        auto fields = value.getArray().value();
+        for (const auto& field : fields)
+        {
+            if (!field.isString())
+            {
+                throw std::runtime_error {
+                    fmt::format("Allowed field '{}' for asset '{}' must be a string", field.str(), key)};
+            }
+
+            m_fields[key].insert(field.getString().value());
+        }
+    }
+}
+
+bool AllowedFields::check(const base::Name& assetType, const DotPath& field) const
+{
+    auto it = m_fields.find(assetType);
+    // No restrictions for this asset type
+    if (it == m_fields.end())
+    {
+        return true;
+    }
+
+    if (it->second.find(field) == it->second.end())
+    {
+        return false;
+    }
+
+    return true;
+}
+} // namespace builder

--- a/src/engine/source/builder/src/builder.cpp
+++ b/src/engine/source/builder/src/builder.cpp
@@ -4,6 +4,7 @@
 
 #include <store/utils.hpp>
 
+#include "allowedFields.hpp"
 #include "builders/ibuildCtx.hpp"
 #include "policy/assetBuilder.hpp"
 #include "policy/factory.hpp"
@@ -21,10 +22,12 @@ class Builder::Registry final : public builders::RegistryType
 Builder::Builder(const std::shared_ptr<store::IStore>& storeRead,
                  const std::shared_ptr<schemf::IValidator>& schema,
                  const std::shared_ptr<defs::IDefinitionsBuilder>& definitionsBuilder,
+                 const std::shared_ptr<IAllowedFields>& allowedFields,
                  const BuilderDeps& builderDeps)
     : m_storeRead {storeRead}
     , m_schema {schema}
     , m_definitionsBuilder {definitionsBuilder}
+    , m_allowedFields {allowedFields}
 {
     if (!m_storeRead)
     {

--- a/src/engine/source/builder/src/builders/buildCtx.hpp
+++ b/src/engine/source/builder/src/builders/buildCtx.hpp
@@ -22,6 +22,8 @@ private:
 
     std::shared_ptr<const schemf::ISchema> m_schema; // Schema
 
+    std::shared_ptr<const builder::IAllowedFields> m_allowedFields; // Allowed fields
+
 public:
     BuildCtx()
     {
@@ -30,6 +32,7 @@ public:
         m_registry = nullptr;
         m_definitions = nullptr;
         m_schemaValidator = nullptr;
+        m_allowedFields = nullptr;
     }
 
     ~BuildCtx() = default;
@@ -38,12 +41,14 @@ public:
              const Context& context,
              const std::shared_ptr<const RegistryType>& registry,
              const std::shared_ptr<defs::IDefinitions>& definitions,
-             const std::shared_ptr<const schemf::IValidator>& schemaValidator)
+             const std::shared_ptr<const schemf::IValidator>& schemaValidator,
+             const std::shared_ptr<const builder::IAllowedFields>& allowedFields)
         : m_runState(runState)
         , m_context(context)
         , m_registry(registry)
         , m_definitions(definitions)
         , m_schemaValidator(schemaValidator)
+        , m_allowedFields(allowedFields)
     {
     }
 
@@ -72,6 +77,12 @@ public:
 
     inline std::shared_ptr<const RunState> runState() const override { return m_runState; }
     inline RunState& runState() { return *m_runState; }
+
+    inline const builder::IAllowedFields& allowedFields() const override { return *m_allowedFields; }
+    inline void setAllowedFields(const std::shared_ptr<const builder::IAllowedFields>& allowedFields) override
+    {
+        m_allowedFields = allowedFields;
+    }
 };
 
 } // namespace builder::builders

--- a/src/engine/source/builder/src/builders/ibuildCtx.hpp
+++ b/src/engine/source/builder/src/builders/ibuildCtx.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 
+#include <builder/iallowedFields.hpp>
 #include <defs/idefinitions.hpp>
 #include <schemf/ivalidator.hpp>
 
@@ -56,6 +57,9 @@ public:
     virtual Context& context() = 0;
 
     virtual std::shared_ptr<const RunState> runState() const = 0;
+
+    virtual const builder::IAllowedFields& allowedFields() const = 0;
+    virtual void setAllowedFields(const std::shared_ptr<const builder::IAllowedFields>& allowedFields) = 0;
 };
 
 } // namespace builder::builders

--- a/src/engine/source/builder/test/mocks/builder/mockAllowedFields.hpp
+++ b/src/engine/source/builder/test/mocks/builder/mockAllowedFields.hpp
@@ -1,0 +1,17 @@
+#ifndef BUILDER_TEST_SRC_MOCKS_MOCKSALLOWEDFIELDS_HPP
+#define BUILDER_TEST_SRC_MOCKS_MOCKSALLOWEDFIELDS_HPP
+
+#include <gmock/gmock.h>
+
+#include <builder/iallowedFields.hpp>
+
+namespace builder::mocks
+{
+class MockAllowedFields : public IAllowedFields
+{
+public:
+    MOCK_METHOD(bool, check, (const base::Name& assetType, const DotPath& field), (const, override));
+};
+} // namespace builder::mocks
+
+#endif // BUILDER_TEST_SRC_MOCKS_MOCKSALLOWEDFIELDS_HPP

--- a/src/engine/source/builder/test/src/component/definitions.hpp
+++ b/src/engine/source/builder/test/src/component/definitions.hpp
@@ -2,6 +2,7 @@
 #define _BUILDER_TEST_DEFINITIONS_HPP
 
 #include <base/behaviour.hpp>
+#include <builder/allowedFields.hpp>
 #include <builder/builder.hpp>
 #include <defs/mockDefinitions.hpp>
 #include <logpar/logpar.hpp>
@@ -340,8 +341,10 @@ public:
         builderDeps.kvdbScopeName = "builder";
         builderDeps.kvdbManager = nullptr;
 
+        auto emptyAllowedFields = std::make_shared<builder::AllowedFields>();
+
         m_spBuilder = std::make_shared<builder::Builder>(
-            m_spMocks->m_spStore, m_spMocks->m_spSchemf, m_spMocks->m_spDefBuilder, builderDeps);
+            m_spMocks->m_spStore, m_spMocks->m_spSchemf, m_spMocks->m_spDefBuilder, emptyAllowedFields, builderDeps);
     }
 };
 

--- a/src/engine/source/builder/test/src/unit/allowedFields_test.cpp
+++ b/src/engine/source/builder/test/src/unit/allowedFields_test.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <builder/allowedFields.hpp>
+
+using namespace builder;
+
+TEST(AllowedFieldsTest, DefaultConstructor)
+{
+    ASSERT_NO_THROW(AllowedFields {});
+}
+
+TEST(AllowedFieldsTest, Constructor)
+{
+    json::Json definition {
+        R"({
+            "decoder": ["field1", "field2"],
+            "rule": ["field1", "field2"],
+            "filter": ["field1", "field2"],
+            "output": ["field1", "field2"]
+        })"};
+
+    ASSERT_NO_THROW(AllowedFields {definition});
+}
+
+TEST(AllowedFieldsTest, ConstructorNotObject)
+{
+    json::Json definition;
+    definition.setArray();
+    ASSERT_THROW(AllowedFields {definition}, std::runtime_error);
+}
+
+TEST(AllowedFieldsTest, ConstructorNotFieldArray)
+{
+    json::Json definition1 {
+        R"({
+            "decoder": "field1"
+        })"};
+    json::Json definition2 {
+        R"({
+            "decoder": ["field1"],
+            "rule": "field1"
+        })"};
+
+    ASSERT_THROW(AllowedFields {definition1}, std::runtime_error);
+    ASSERT_THROW(AllowedFields {definition2}, std::runtime_error);
+}
+
+TEST(AllowedFieldsTest, ConstructorNotFieldString)
+{
+    json::Json definition1 {
+        R"({
+            "decoder": [1]
+        })"};
+    json::Json definition2 {
+        R"({
+            "decoder": ["field1"],
+            "rule": [1]
+        })"};
+
+    ASSERT_THROW(AllowedFields {definition1}, std::runtime_error);
+    ASSERT_THROW(AllowedFields {definition2}, std::runtime_error);
+}
+
+TEST(AllowedFieldsTest, ConstructorUnknownAsset)
+{
+    json::Json definition1 {
+        R"({
+            "unknown": ["field1"]
+        })"};
+
+    json::Json definition2 {
+        R"({
+            "decoder": ["field1"],
+            "unknown": ["field1"]
+        })"};
+
+    ASSERT_THROW(AllowedFields {definition1}, std::runtime_error);
+    ASSERT_THROW(AllowedFields {definition2}, std::runtime_error);
+}
+
+TEST(AllowedFieldsTest, Check)
+{
+    json::Json definition {
+        R"({
+            "decoder": ["field1", "field2"],
+            "rule": ["field1", "field2"],
+            "filter": ["field1", "field2"],
+            "output": ["field1", "field2"]
+        })"};
+
+    AllowedFields allowedFields {definition};
+
+    auto fields = std::vector<std::string> {"field1", "field2"};
+    for (const auto& field : fields)
+    {
+        ASSERT_TRUE(allowedFields.check("decoder", field));
+        ASSERT_TRUE(allowedFields.check("rule", field));
+        ASSERT_TRUE(allowedFields.check("filter", field));
+        ASSERT_TRUE(allowedFields.check("output", field));
+    }
+}
+
+TEST(AllowedFieldsTest, CheckUnknownAsset)
+{
+    json::Json definition {
+        R"({
+            "decoder": ["field1", "field2"],
+            "rule": ["field1", "field2"],
+            "filter": ["field1", "field2"],
+            "output": ["field1", "field2"]
+        })"};
+
+    AllowedFields allowedFields {definition};
+
+    ASSERT_TRUE(allowedFields.check("unknown", "field1"));
+}
+
+TEST(AllowedFieldsTest, CheckNotAllowed)
+{
+    json::Json definition {
+        R"({
+            "decoder": ["field1", "field2"],
+            "rule": ["field1", "field2"],
+            "filter": ["field1", "field2"],
+            "output": ["field1", "field2"]
+        })"};
+
+    AllowedFields allowedFields {definition};
+
+    ASSERT_FALSE(allowedFields.check("decoder", "field3"));
+    ASSERT_FALSE(allowedFields.check("rule", "field3"));
+    ASSERT_FALSE(allowedFields.check("filter", "field3"));
+    ASSERT_FALSE(allowedFields.check("output", "field3"));
+}

--- a/src/engine/source/builder/test/src/unit/builders/baseBuilders_test.hpp
+++ b/src/engine/source/builder/test/src/unit/builders/baseBuilders_test.hpp
@@ -9,6 +9,7 @@
 #include "mockBuildCtx.hpp"
 #include "mockRegistry.hpp"
 
+#include <builder/mockAllowedFields.hpp>
 #include <defs/mockDefinitions.hpp>
 #include <schemf/mockSchema.hpp>
 
@@ -37,6 +38,7 @@ struct BuildersMocks
     std::shared_ptr<MockSchema> validator;
     std::shared_ptr<MockMetaRegistry<OpBuilderEntry, StageBuilder>> registry;
     std::shared_ptr<MockDefinitions> definitions;
+    std::shared_ptr<MockAllowedFields> allowedFields;
     Context context;
 };
 
@@ -53,10 +55,12 @@ protected:
         mocks->validator = std::make_shared<MockSchema>();
         mocks->registry = MockMetaRegistry<OpBuilderEntry, StageBuilder>::createMock();
         mocks->definitions = std::make_shared<MockDefinitions>();
+        mocks->allowedFields = std::make_shared<MockAllowedFields>();
 
         ON_CALL(*mocks->ctx, context()).WillByDefault(testing::ReturnRef(mocks->context));
         ON_CALL(*mocks->ctx, runState()).WillByDefault(testing::Return(mocks->runState));
         ON_CALL(*mocks->ctx, validator()).WillByDefault(testing::ReturnRef(*(mocks->validator)));
+        ON_CALL(*mocks->ctx, allowedFields()).WillByDefault(testing::ReturnRef(*(mocks->allowedFields)));
     }
 
     void expectBuildSuccess()

--- a/src/engine/source/builder/test/src/unit/mockBuildCtx.hpp
+++ b/src/engine/source/builder/test/src/unit/mockBuildCtx.hpp
@@ -22,6 +22,8 @@ public:
     MOCK_METHOD((const Context&), context, (), (const));
     MOCK_METHOD((Context&), context, (), ());
     MOCK_METHOD((std::shared_ptr<const RunState>), runState, (), (const));
+    MOCK_METHOD((const builder::IAllowedFields&), allowedFields, (), (const));
+    MOCK_METHOD(void, setAllowedFields, (const std::shared_ptr<const builder::IAllowedFields>& allowedFields), ());
 };
 
 } // namespace builder::builders::mocks


### PR DESCRIPTION
|Related issue|
|---|
|#28610|

This PR adds the ability to restrict which target fields are allowed to be mapped by distinct asset types. Only rules are restricted as requested.