### PR TITLE
Enable use of `rule_normalize` instead of `normalize` in rule assets

### DIFF
--- a/src/engine/source/builder/src/register.hpp
+++ b/src/engine/source/builder/src/register.hpp
@@ -345,6 +345,7 @@ void registerStageBuilders(const std::shared_ptr<Registry>& registry, const Buil
     registry->template add<builders::StageBuilder>(syntax::asset::CHECK_KEY, builders::checkBuilder);
     registry->template add<builders::StageBuilder>(syntax::asset::MAP_KEY, builders::mapBuilder);
     registry->template add<builders::StageBuilder>(syntax::asset::NORMALIZE_KEY, builders::normalizeBuilder);
+    registry->template add<builders::StageBuilder>(syntax::asset::RULE_NORMALIZE_KEY, builders::normalizeBuilder);
     registry->template add<builders::StageBuilder>(syntax::asset::PARSE_KEY,
                                                    builders::getParseBuilder(deps.logpar, deps.logparDebugLvl));
     registry->template add<builders::StageBuilder>(syntax::asset::OUTPUTS_KEY, builders::outputsBuilder);

--- a/src/engine/source/builder/src/syntax.hpp
+++ b/src/engine/source/builder/src/syntax.hpp
@@ -16,19 +16,20 @@ namespace builder::syntax
 // Asset syntax
 namespace asset
 {
-constexpr auto NAME_KEY = "name";                    ///< Key for the name field in an asset.
-constexpr auto METADATA_KEY = "metadata";            ///< Key for the metadata field in an asset.
-constexpr auto PARENTS_KEY = "parents";              ///< Key for the parents field in an asset.
-constexpr auto CHECK_KEY = "check";                  ///< Key for the check stage in an asset.
-constexpr auto PARSE_KEY = "parse";                  ///< Key for the parse stage in an asset.
-constexpr auto NORMALIZE_KEY = "normalize";          ///< Key for the normalize stage in an asset.
-constexpr auto MAP_KEY = "map";                      ///< Key for the map stage in an asset.
-constexpr auto DEFINITIONS_KEY = "definitions";      ///< Key for the definitions stage in an asset.
-constexpr auto OUTPUTS_KEY = "outputs";              ///< Key for the outputs stage in an asset.
-constexpr auto FILE_OUTPUT_KEY = "file";             ///< Key for the file output stage in an asset.
-constexpr auto FILE_OUTPUT_PATH_KEY = "path";        ///< Key for the file output path in an asset.
-constexpr auto INDEXER_OUTPUT_KEY = "wazuh-indexer"; ///< Key for the INDEXER output stage in an asset.
-constexpr auto INDEXER_OUTPUT_INDEX_KEY = "index";   ///< Key for the INDEXER output stage in an asset.
+constexpr auto NAME_KEY = "name";                     ///< Key for the name field in an asset.
+constexpr auto METADATA_KEY = "metadata";             ///< Key for the metadata field in an asset.
+constexpr auto PARENTS_KEY = "parents";               ///< Key for the parents field in an asset.
+constexpr auto CHECK_KEY = "check";                   ///< Key for the check stage in an asset.
+constexpr auto PARSE_KEY = "parse";                   ///< Key for the parse stage in an asset.
+constexpr auto NORMALIZE_KEY = "normalize";           ///< Key for the normalize stage in an asset.
+constexpr auto RULE_NORMALIZE_KEY = "rule_normalize"; ///< Key for the normalize stage in an asset.
+constexpr auto MAP_KEY = "map";                       ///< Key for the map stage in an asset.
+constexpr auto DEFINITIONS_KEY = "definitions";       ///< Key for the definitions stage in an asset.
+constexpr auto OUTPUTS_KEY = "outputs";               ///< Key for the outputs stage in an asset.
+constexpr auto FILE_OUTPUT_KEY = "file";              ///< Key for the file output stage in an asset.
+constexpr auto FILE_OUTPUT_PATH_KEY = "path";         ///< Key for the file output path in an asset.
+constexpr auto INDEXER_OUTPUT_KEY = "wazuh-indexer";  ///< Key for the INDEXER output stage in an asset.
+constexpr auto INDEXER_OUTPUT_INDEX_KEY = "index";    ///< Key for the INDEXER output stage in an asset.
 
 constexpr auto CONDITION_NAME =
     "condition"; ///< Name of the condition expression in the asset to be displayed in traces.


### PR DESCRIPTION
|Related issue|
|---|
|#28599|

This PR allows the use of rule_normalize instead of normalize in rule assets within Wazuh-Engine. This change improves clarity by explicitly defining the stage's purpose, which is to enrich alerts rather than perform general data normalization.