### PR TITLE
Add reflective JSON unit tests

### DIFF
--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -2,6 +2,28 @@ cmake_minimum_required(VERSION 3.12.4)
 
 project(utils_unit_test)
 
+include(CheckCXXSourceCompiles)
+
+# Check if std::to_chars supports floating-point numbers
+check_cxx_source_compiles("
+    #include <charconv>
+    #include <system_error>
+    int main() {
+        char buffer[32];
+        float f = 3.14f;
+        auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), f);
+        return ec == std::errc() ? 0 : 1;
+    }
+" HAS_TO_CHARS_FLOAT)
+
+if(HAS_TO_CHARS_FLOAT)
+  add_definitions(-DHAS_TO_CHARS_FLOAT=true)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+else()
+  add_definitions(-DHAS_TO_CHARS_FLOAT=false)
+endif()
+
 
 file(GLOB UTIL_CXX_UNITTEST_WINDOWS_SRC
     "windowsHelper_test.cpp"

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ file(GLOB UTIL_CXX_UNITTEST_LINUX_SRC
     "rsaHelper_test.cpp"
     "evpHelper_test.cpp"
     "socketServer_test.cpp"
+    "reflectiveJson_test.cpp"
 )
 
 file(COPY input_files DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/shared_modules/utils/tests/reflectiveJson_test.cpp
+++ b/src/shared_modules/utils/tests/reflectiveJson_test.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "reflectiveJson_test.hpp"
+#if defined(DHAS_TO_CHARS_FLOAT) && DHAS_TO_CHARS_FLOAT == true
 #include "reflectiveJson.hpp"
 
 void ReflectiveJsonTest::SetUp() {};
@@ -214,3 +215,4 @@ TEST_F(ReflectiveJsonTest, NumericBufferZeroing)
     EXPECT_EQ(json.front(), '{');
     EXPECT_EQ(json.back(), '}');
 }
+#endif

--- a/src/shared_modules/utils/tests/reflectiveJson_test.cpp
+++ b/src/shared_modules/utils/tests/reflectiveJson_test.cpp
@@ -1,0 +1,216 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * March 18, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "reflectiveJson_test.hpp"
+#include "reflectiveJson.hpp"
+
+void ReflectiveJsonTest::SetUp() {};
+void ReflectiveJsonTest::TearDown() {};
+
+template<typename TData>
+struct TestData final
+{
+    std::string fieldOne;
+    int fieldTwo;
+    TData fieldThree;
+
+    REFLECTABLE(MAKE_FIELD("fieldOne", &TestData::fieldOne),
+                MAKE_FIELD("fieldTwo", &TestData::fieldTwo),
+                MAKE_FIELD("fieldThree", &TestData::fieldThree));
+};
+
+TEST_F(ReflectiveJsonTest, EmptyMapReturnsEmptyBraces)
+{
+    std::unordered_map<std::string, std::string> emptyMap;
+    std::string result = jsonFieldToString(emptyMap);
+    EXPECT_EQ(result, "{}");
+}
+
+TEST_F(ReflectiveJsonTest, SingleStringEntry)
+{
+    std::unordered_map<std::string, std::string> map {{"key", "value"}};
+    std::string result = jsonFieldToString(map);
+    EXPECT_EQ(result, R"({"key":"value"})");
+}
+
+TEST_F(ReflectiveJsonTest, MultipleStringEntries)
+{
+    std::unordered_map<std::string, std::string> map {{"key1", "value1"}, {"key2", "value2"}};
+    std::string result = jsonFieldToString(map);
+
+    // Order of fields in an unordered_map is not guaranteed.
+    // We check for both valid permutations.
+    bool validPermutation1 = (result == R"({"key1":"value1","key2":"value2"})");
+    bool validPermutation2 = (result == R"({"key2":"value2","key1":"value1"})");
+    EXPECT_TRUE(validPermutation1 || validPermutation2);
+}
+
+TEST_F(ReflectiveJsonTest, NumericValues)
+{
+    std::unordered_map<std::string, int> map {{"intVal", 42}, {"zeroVal", 0}, {"negativeVal", -10}};
+    std::string result = jsonFieldToString(map);
+
+    // Possible orders in the JSON:
+    // {"intVal":42,"zeroVal":0,"negativeVal":-10}
+    // {"intVal":42,"negativeVal":-10,"zeroVal":0}
+    // etc.
+    // We check presence of all fields with correct values.
+    EXPECT_NE(result.find(R"("intVal":42)"), std::string::npos);
+    EXPECT_NE(result.find(R"("zeroVal":0)"), std::string::npos);
+    EXPECT_NE(result.find(R"("negativeVal":-10)"), std::string::npos);
+    EXPECT_EQ(result.front(), '{');
+    EXPECT_EQ(result.back(), '}');
+}
+
+TEST_F(ReflectiveJsonTest, NestedMap)
+{
+    std::unordered_map<std::string, std::unordered_map<std::string, int>> map {{"outerKey", {{"innerKey", 123}}}};
+    std::string result = jsonFieldToString(map);
+
+    EXPECT_EQ(result, "{\"outerKey\":{\"innerKey\":123}}");
+}
+
+TEST_F(ReflectiveJsonTest, EscapedStringValue)
+{
+    std::unordered_map<std::string, std::string> map {{"key", "He said \"Hello\""}};
+
+    std::string result = jsonFieldToString(map);
+
+    EXPECT_NE(result.find(R"("key":"He said \"Hello\"")"), std::string::npos);
+}
+
+TEST_F(ReflectiveJsonTest, BasicStructSerialization)
+{
+    TestData<float> obj;
+    obj.fieldOne = "001";
+    obj.fieldTwo = 30;
+    obj.fieldThree = 1.3;
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    EXPECT_NE(json.find(R"("fieldOne":"001")"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldTwo":30)"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldThree":1.3)"), std::string::npos);
+}
+
+TEST_F(ReflectiveJsonTest, NestedStructSerialization)
+{
+    struct NestedData
+    {
+        std::string innerField;
+        int innerValue;
+
+        REFLECTABLE(MAKE_FIELD("innerField", &NestedData::innerField),
+                    MAKE_FIELD("innerValue", &NestedData::innerValue));
+    };
+
+    TestData<NestedData> obj;
+    obj.fieldOne = "Outer";
+    obj.fieldTwo = 2;
+    obj.fieldThree.innerField = "Inner";
+    obj.fieldThree.innerValue = 42;
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    EXPECT_NE(json.find(R"("fieldOne":"Outer")"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldThree":{"innerField":"Inner","innerValue":42})"), std::string::npos);
+}
+
+TEST_F(ReflectiveJsonTest, BasicStructSerializationWithEmptyFields)
+{
+    TestData<std::string_view> obj;
+    obj.fieldOne = "";
+    obj.fieldTwo = 0;
+    obj.fieldThree = "";
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    EXPECT_EQ(json.find(R"("fieldOne":)"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldTwo":0)"), std::string::npos);
+    EXPECT_EQ(json.find(R"("fieldThree":)"), std::string::npos);
+}
+
+TEST_F(ReflectiveJsonTest, BasicStructSerializationWithQuotes)
+{
+    TestData<float> obj;
+    obj.fieldOne = "\"001\"";
+    obj.fieldTwo = 30;
+    obj.fieldThree = 1.3;
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    EXPECT_NE(json.find(R"("fieldOne":"\"001\"")"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldTwo":30)"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldThree":1.3)"), std::string::npos);
+}
+
+TEST_F(ReflectiveJsonTest, BooleanValues)
+{
+    TestData<bool> obj;
+    obj.fieldOne = "\"001\"";
+    obj.fieldTwo = 30;
+    obj.fieldThree = true;
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    EXPECT_NE(json.find(R"("fieldOne":"\"001\"")"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldTwo":30)"), std::string::npos);
+    EXPECT_NE(json.find(R"("fieldThree":true)"), std::string::npos);
+}
+
+TEST_F(ReflectiveJsonTest, SpecialCharactersInKeysAndValues)
+{
+    std::unordered_map<std::string, std::string> map {{"newline", "Line1\nLine2"},
+                                                      {"tabbed", "A\tB\tC"},
+                                                      {"backslash", "Path\\To\\File"},
+                                                      {"quote", "\"Quoted text\""}};
+    std::string result = jsonFieldToString(map);
+
+    EXPECT_NE(result.find(R"("newline":"Line1\nLine2")"), std::string::npos);
+    EXPECT_NE(result.find(R"("tabbed":"A\tB\tC")"), std::string::npos);
+    EXPECT_NE(result.find(R"("backslash":"Path\\To\\File")"), std::string::npos);
+    EXPECT_NE(result.find(R"("quote":"\"Quoted text\"")"), std::string::npos);
+}
+
+TEST_F(ReflectiveJsonTest, NumericBufferZeroing)
+{
+    struct NumericTest
+    {
+        int firstValue;
+        double secondValue;
+        int thirdValue;
+
+        REFLECTABLE(MAKE_FIELD("firstValue", &NumericTest::firstValue),
+                    MAKE_FIELD("secondValue", &NumericTest::secondValue),
+                    MAKE_FIELD("thirdValue", &NumericTest::thirdValue));
+    };
+
+    NumericTest obj;
+    obj.firstValue = 42;
+    obj.secondValue = 3.1415;
+    obj.thirdValue = -99;
+
+    std::string json;
+    serializeToJSON(obj, json);
+
+    EXPECT_NE(json.find(R"("firstValue":42)"), std::string::npos);
+    EXPECT_NE(json.find(R"("secondValue":3.1415)"), std::string::npos);
+    EXPECT_NE(json.find(R"("thirdValue":-99)"), std::string::npos);
+
+    // Validate JSON starts and ends correctly. If buffer is not zeroed, there will be garbage characters.
+    EXPECT_EQ(json.front(), '{');
+    EXPECT_EQ(json.back(), '}');
+}

--- a/src/shared_modules/utils/tests/reflectiveJson_test.hpp
+++ b/src/shared_modules/utils/tests/reflectiveJson_test.hpp
@@ -1,0 +1,25 @@
+/*
+ * Wazuh shared modules utils
+ * Copyright (C) 2015, Wazuh Inc.
+ * March 18, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+#ifndef REFLECTIVE_JSON_HPP
+#define REFLECTIVE_JSON_HPP
+
+#include "gtest/gtest.h"
+
+class ReflectiveJsonTest : public ::testing::Test
+{
+protected:
+    ReflectiveJsonTest() = default;
+    virtual ~ReflectiveJsonTest() = default;
+
+    void SetUp() override;
+    void TearDown() override;
+};
+#endif // REFLECTIVE_JSON_HPP

--- a/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
@@ -143,5 +143,5 @@ TEST_F(SystemInventoryUpsertElement, validAgentID_Processes)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_1234","operation":"INSERTED","data":{"process":{"args":["processName"],"args_count":1,"command_line":"processCmdline","name":"processName","pid":1234,"start":"processStartISO8601","ppid":1234},"agent":{"id":"001","name":"agentName","ip":"agentIp","version":"agentVersion"}}})");
+        R"({"id":"001_1234","operation":"INSERTED","data":{"process":{"args":["processName"],"args_count":1,"command_line":"processCmdline","name":"processName","pid":1234,"start":"processStartISO8601","ppid":1},"agent":{"id":"001","name":"agentName","ip":"agentIp","version":"agentVersion"}}})");
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28421 |

# Summary
This PR enhances test coverage for the `serializeToJSON` and `jsonFieldToString` functions of `reflectiveJson` implementation, ensuring correctness in various edge cases. The tests validate serialization of primitive types, containers, nested structures, and escaping logic. Additionally, a specific test (`NumericBufferZeroing`) verifies that `std::fill(buffer, buffer + sizeof(buffer), '\0');` correctly resets the buffer during numeric conversions.

## Evidence

```console
└─$ ./utils_unit_test --gtest_filter="ReflectiveJsonTest*"
Note: Google Test filter = ReflectiveJsonTest*
[==========] Running 13 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 13 tests from ReflectiveJsonTest
[ RUN      ] ReflectiveJsonTest.EmptyMapReturnsEmptyBraces
[       OK ] ReflectiveJsonTest.EmptyMapReturnsEmptyBraces (0 ms)
[ RUN      ] ReflectiveJsonTest.SingleStringEntry
[       OK ] ReflectiveJsonTest.SingleStringEntry (0 ms)
[ RUN      ] ReflectiveJsonTest.MultipleStringEntries
[       OK ] ReflectiveJsonTest.MultipleStringEntries (0 ms)
[ RUN      ] ReflectiveJsonTest.NumericValues
[       OK ] ReflectiveJsonTest.NumericValues (0 ms)
[ RUN      ] ReflectiveJsonTest.NestedMap
[       OK ] ReflectiveJsonTest.NestedMap (0 ms)
[ RUN      ] ReflectiveJsonTest.EscapedStringValue
[       OK ] ReflectiveJsonTest.EscapedStringValue (0 ms)
[ RUN      ] ReflectiveJsonTest.BasicStructSerialization
[       OK ] ReflectiveJsonTest.BasicStructSerialization (0 ms)
[ RUN      ] ReflectiveJsonTest.NestedStructSerialization
[       OK ] ReflectiveJsonTest.NestedStructSerialization (0 ms)
[ RUN      ] ReflectiveJsonTest.BasicStructSerializationWithEmptyFields
[       OK ] ReflectiveJsonTest.BasicStructSerializationWithEmptyFields (0 ms)
[ RUN      ] ReflectiveJsonTest.BasicStructSerializationWithQuotes
[       OK ] ReflectiveJsonTest.BasicStructSerializationWithQuotes (0 ms)
[ RUN      ] ReflectiveJsonTest.BooleanValues
[       OK ] ReflectiveJsonTest.BooleanValues (0 ms)
[ RUN      ] ReflectiveJsonTest.SpecialCharactersInKeysAndValues
[       OK ] ReflectiveJsonTest.SpecialCharactersInKeysAndValues (0 ms)
[ RUN      ] ReflectiveJsonTest.NumericBufferZeroing
[       OK ] ReflectiveJsonTest.NumericBufferZeroing (0 ms)
[----------] 13 tests from ReflectiveJsonTest (0 ms total)

[----------] Global test environment tear-down
[==========] 13 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 13 tests.
```