### PR TITLE
Remove redundant 'system' parameter from workflow trigger command

### DIFF
--- a/.github/workflows/packages-upload-images.yml
+++ b/.github/workflows/packages-upload-images.yml
@@ -244,6 +244,6 @@ jobs:
       - name: Request commom_wpk_builder update
         if: steps.changes.outputs.commom_wpk_builder == 'true'
         run: |
-          gh workflow run packages-upload-wpk-images.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f system=common -f source_reference=${{ github.ref_name }}
+          gh workflow run packages-upload-wpk-images.yml --repo wazuh/wazuh-agent-packages -r ${{ github.ref_name }} -f docker_image_tag=${{ env.TAG }} -f source_reference=${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.CI_WAZUH_AGENT_PACKAGES }}


### PR DESCRIPTION
## Description

Fixes the step `Request commom_wpk_builder update` in `packages-upload-images.yml` workflow.

Which failed after merging https://github.com/wazuh/wazuh/pull/28634 see: https://github.com/wazuh/wazuh/actions/runs/13956191852

## Tests

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

