### PR TITLE
Fix macos package creation

### DIFF
--- a/packages/macos/generate_wazuh_packages.sh
+++ b/packages/macos/generate_wazuh_packages.sh
@@ -206,7 +206,7 @@ function build_package() {
         sign_pkg
         if [[ "${CHECKSUM}" == "yes" ]]; then
             shasum -a512 "${DESTINATION}/${pkg_name}.pkg" > "${DESTINATION}/${pkg_name}.pkg.sha512"
-            shasum -a512 "${DESTINATION}/${symbols_pkg_name}.zip" > "${DESTINATION}/${symbols_pkg_name}.sha512"
+            shasum -a512 "${DESTINATION}/${symbols_pkg_name}.zip" > "${DESTINATION}/${symbols_pkg_name}.zip.sha512"
         fi
         clean_and_exit 0
     else


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28701|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->


This PR fixes the debug symbols packages names to accomplish our new convention.


## Tests

- [Packages - Build Wazuh agent macOS packages - intel64 test_debug_symbols_name](https://github.com/wazuh/wazuh-agent-packages/actions/runs/13971827710)

