### PR TITLE
Adapt pid files handling for API auth process pool

### DIFF
--- a/api/scripts/wazuh_apid.py
+++ b/api/scripts/wazuh_apid.py
@@ -5,12 +5,12 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import argparse
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from functools import partial
 import os
 import signal
 import sys
 import warnings
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from functools import partial
 
 SSL_DEPRECATED_MESSAGE = 'The `{ssl_protocol}` SSL protocol is deprecated.'
 CACHE_DELETED_MESSAGE = 'The `cache` API configuration option no longer takes effect since {release} and will ' \

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -30,6 +30,7 @@ from wazuh.core import common, exception
 from wazuh.core.cluster import local_client, common as c_common
 from wazuh.core.cluster.cluster import check_cluster_status
 from wazuh.core.exception import WazuhException, WazuhClusterError, WazuhError
+from wazuh.core.pyDaemonModule import spawn_process_pool_worker, API_AUTHENTICATION_PROCESS
 from wazuh.core.wazuh_socket import wazuh_sendsync
 
 
@@ -43,7 +44,7 @@ if node_info['type'] == 'master':
     with contextlib.suppress(FileNotFoundError, PermissionError):
         pools.update({'authentication_pool': ProcessPoolExecutor(
             max_workers=aconf.api_conf['authentication_pool_size'],
-            initializer=wazuh.core.cluster.utils.spawn_authentication_worker
+            initializer=partial(spawn_process_pool_worker, API_AUTHENTICATION_PROCESS)
         )})
 
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -43,7 +43,7 @@ if node_info['type'] == 'master':
     with contextlib.suppress(FileNotFoundError, PermissionError):
         pools.update({'authentication_pool': ProcessPoolExecutor(
             max_workers=aconf.api_conf['authentication_pool_size'],
-            initializer=wazuh.core.cluster.utils.spawn_authentication_pool
+            initializer=wazuh.core.cluster.utils.spawn_authentication_worker
         )})
 
 

--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -43,7 +43,7 @@ if node_info['type'] == 'master':
     with contextlib.suppress(FileNotFoundError, PermissionError):
         pools.update({'authentication_pool': ProcessPoolExecutor(
             max_workers=aconf.api_conf['authentication_pool_size'],
-            initializer=wazuh.core.cluster.utils.init_auth_worker
+            initializer=wazuh.core.cluster.utils.spawn_authentication_pool
         )})
 
 

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -557,8 +557,8 @@ def raise_if_exc(result: object) -> None:
         raise result
 
 
-def spawn_authentication_pool():
-    """Spawn authentication process pool child."""
+def spawn_authentication_worker():
+    """Spawn authentication process worker."""
 
     API_AUTHENTICATION_PROCESS = 'wazuh-apid_auth'
 

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -555,14 +555,3 @@ def raise_if_exc(result: object) -> None:
     """
     if isinstance(result, Exception):
         raise result
-
-
-def spawn_authentication_worker():
-    """Spawn authentication process worker."""
-
-    API_AUTHENTICATION_PROCESS = 'wazuh-apid_auth'
-
-    auth_pid = os.getpid()
-    pyDaemonModule.create_pid(API_AUTHENTICATION_PROCESS, auth_pid)
-
-    signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -557,7 +557,12 @@ def raise_if_exc(result: object) -> None:
         raise result
 
 
-def init_auth_worker():
-    """Set authentication pool worker to ignore SIGINT signals to avoid 
-    throwing exceptions when shutting down the API in foreground mode."""
+def spawn_authentication_pool():
+    """Spawn authentication process pool child."""
+
+    API_AUTHENTICATION_PROCESS = 'wazuh-apid_auth'
+
+    auth_pid = os.getpid()
+    pyDaemonModule.create_pid(API_AUTHENTICATION_PROCESS, auth_pid)
+
     signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -4,7 +4,7 @@
 
 import json
 import os
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from contextvars import ContextVar
 from copy import deepcopy
 from functools import lru_cache, wraps
@@ -133,10 +133,7 @@ broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
 try:
-    mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
-        'process_pool': ProcessPoolExecutor(max_workers=1),
-        'events_pool': ProcessPoolExecutor(max_workers=1)
-    })
+    mp_pools: ContextVar[Dict] = ContextVar('mp_pools',default={})
 # Handle exception when the user running Wazuh cannot access /dev/shm.
 except (FileNotFoundError, PermissionError):
     mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -4,7 +4,6 @@
 
 import json
 import os
-from concurrent.futures import ThreadPoolExecutor
 from contextvars import ContextVar
 from copy import deepcopy
 from functools import lru_cache, wraps

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -132,13 +132,8 @@ current_user: ContextVar[str] = ContextVar('current_user', default='')
 broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
-try:
-    mp_pools: ContextVar[Dict] = ContextVar('mp_pools',default={})
-# Handle exception when the user running Wazuh cannot access /dev/shm.
-except (FileNotFoundError, PermissionError):
-    mp_pools: ContextVar[Dict] = ContextVar('mp_pools', default={
-        'thread_pool': ThreadPoolExecutor(max_workers=1)
-    })
+mp_pools: ContextVar[Dict] = ContextVar('mp_pools',default={})
+
 _context_cache = dict()
 
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -132,7 +132,6 @@ broadcast: ContextVar[bool] = ContextVar('broadcast', default=False)
 cluster_nodes: ContextVar[list] = ContextVar('cluster_nodes', default=list())
 origin_module: ContextVar[str] = ContextVar('origin_module', default='framework')
 mp_pools: ContextVar[Dict] = ContextVar('mp_pools',default={})
-
 _context_cache = dict()
 
 

--- a/framework/wazuh/core/pyDaemonModule.py
+++ b/framework/wazuh/core/pyDaemonModule.py
@@ -5,8 +5,8 @@
 import glob
 import logging
 import os
-import sys
 import signal
+import sys
 from os import path
 
 import psutil

--- a/framework/wazuh/core/pyDaemonModule.py
+++ b/framework/wazuh/core/pyDaemonModule.py
@@ -6,12 +6,18 @@ import glob
 import logging
 import os
 import sys
+import signal
 from os import path
 
 import psutil
 
 from wazuh.core import common
 from wazuh.core.exception import WazuhInternalError
+
+API_MAIN_PROCESS = 'wazuh-apid'
+API_LOCAL_REQUEST_PROCESS = 'wazuh-apid_exec'
+API_SECURITY_EVENTS_PROCESS = 'wazuh-apid_events'
+API_AUTHENTICATION_PROCESS = 'wazuh-apid_auth'
 
 
 def pyDaemon():
@@ -129,3 +135,18 @@ def delete_child_pids(name: str, ppid: int, logger: logging.Logger):
                 except OSError:
                     pass
                 filenames.remove(filename)
+
+
+def spawn_process_pool_worker(process_name: str) -> None:
+    """Spawn process pool worker.
+
+    Parameters
+    ----------
+    process_name : str
+        Process name.
+    """
+
+    process_pid = os.getpid()
+    create_pid(process_name, process_pid)
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28754 |

## Description

This issue aims to create pid files (`/var/ossec/var/run/wazuh-apid*`) as processes being created by the API. Change motivated by https://github.com/wazuh/wazuh/pull/28653 improvements that could spawn one to 50 processes to handle auth requests.

# Testing

https://jenkins-staging.qa.wazuh.info/job/Test_integration_endpoints/22/

```console
root@wazuh-dev:~/repos/wazuh# grep authentication_pool_size /var/ossec/api/configuration/api.yaml
authentication_pool_size: 50
root@wazuh-dev:~/repos/wazuh# ps -aux | grep wazuh_apid.py | grep -v grep
wazuh     143023 18.9  1.0 848928 107308 ?       Sl   10:43   0:09 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143024  0.0  0.5 139668 60944 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143025  0.0  0.5 139668 60164 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143026  0.0  0.5 139668 60164 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143027  0.0  0.5 139668 60164 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143028  0.0  0.5 139668 60168 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143029  0.0  0.5 139668 60168 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143030  0.0  0.5 139668 59864 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143031  0.0  0.5 139668 59864 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143032  0.0  0.5 139668 59864 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143033  0.0  0.5 139668 59868 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143034  0.0  0.5 139668 60180 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143035  0.0  0.5 139668 60176 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143036  0.0  0.5 139668 60176 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143037  0.0  0.5 139668 60176 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143038  0.0  0.5 139668 60180 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143039  0.0  0.5 139668 60180 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143040  0.0  0.5 139668 60180 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143041  0.0  0.5 139668 60180 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143042  0.0  0.5 139668 60188 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143043  0.0  0.5 139668 60188 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143044  0.0  0.5 139668 60188 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143045  0.0  0.5 139668 60188 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143046  0.0  0.5 139668 60192 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143047  0.0  0.5 139668 60196 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143048  0.0  0.5 139668 60196 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143049  0.0  0.5 139668 60196 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143050  0.0  0.5 139668 60196 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143051  0.0  0.5 139668 60200 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143052  0.0  0.5 139668 60204 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143053  0.0  0.5 139668 60204 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143054  0.0  0.5 139668 60204 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143055  0.0  0.5 139668 60204 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143056  0.0  0.5 139668 60204 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143057  0.0  0.5 139668 60204 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143058  0.0  0.5 139668 60204 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143059  0.0  0.5 139668 60212 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143060  0.0  0.5 139668 60212 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143061  0.0  0.5 139668 60212 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143062  0.0  0.5 139668 60212 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143063  0.0  0.5 139668 60212 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143064  0.0  0.5 139668 60152 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143065  0.0  0.5 139668 60156 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143066  0.0  0.5 139668 60156 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143067  0.0  0.5 139668 60224 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143068  0.0  0.5 139668 60228 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143069  0.0  0.5 139668 60228 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143070  0.0  0.5 139668 60228 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143071  0.0  0.5 139668 60100 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143072  0.0  0.5 139668 60164 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143073  0.0  0.5 139668 60040 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143076  0.0  0.6 287132 61248 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
wazuh     143079  0.0  0.6 369060 61284 ?        S    10:43   0:00 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
root@wazuh-dev:~/repos/wazuh# ps -aux | grep wazuh_apid.py | grep -v grep | wc -l
53
root@wazuh-dev:~/repos/wazuh# ls /var/ossec/var/run/wazuh-apid*.pid
/var/ossec/var/run/wazuh-apid-143023.pid       /var/ossec/var/run/wazuh-apid_auth-143041.pid  /var/ossec/var/run/wazuh-apid_auth-143059.pid
/var/ossec/var/run/wazuh-apid_auth-143024.pid  /var/ossec/var/run/wazuh-apid_auth-143042.pid  /var/ossec/var/run/wazuh-apid_auth-143060.pid
/var/ossec/var/run/wazuh-apid_auth-143025.pid  /var/ossec/var/run/wazuh-apid_auth-143043.pid  /var/ossec/var/run/wazuh-apid_auth-143061.pid
/var/ossec/var/run/wazuh-apid_auth-143026.pid  /var/ossec/var/run/wazuh-apid_auth-143044.pid  /var/ossec/var/run/wazuh-apid_auth-143062.pid
/var/ossec/var/run/wazuh-apid_auth-143027.pid  /var/ossec/var/run/wazuh-apid_auth-143045.pid  /var/ossec/var/run/wazuh-apid_auth-143063.pid
/var/ossec/var/run/wazuh-apid_auth-143028.pid  /var/ossec/var/run/wazuh-apid_auth-143046.pid  /var/ossec/var/run/wazuh-apid_auth-143064.pid
/var/ossec/var/run/wazuh-apid_auth-143029.pid  /var/ossec/var/run/wazuh-apid_auth-143047.pid  /var/ossec/var/run/wazuh-apid_auth-143065.pid
/var/ossec/var/run/wazuh-apid_auth-143030.pid  /var/ossec/var/run/wazuh-apid_auth-143048.pid  /var/ossec/var/run/wazuh-apid_auth-143066.pid
/var/ossec/var/run/wazuh-apid_auth-143031.pid  /var/ossec/var/run/wazuh-apid_auth-143049.pid  /var/ossec/var/run/wazuh-apid_auth-143067.pid
/var/ossec/var/run/wazuh-apid_auth-143032.pid  /var/ossec/var/run/wazuh-apid_auth-143050.pid  /var/ossec/var/run/wazuh-apid_auth-143068.pid
/var/ossec/var/run/wazuh-apid_auth-143033.pid  /var/ossec/var/run/wazuh-apid_auth-143051.pid  /var/ossec/var/run/wazuh-apid_auth-143069.pid
/var/ossec/var/run/wazuh-apid_auth-143034.pid  /var/ossec/var/run/wazuh-apid_auth-143052.pid  /var/ossec/var/run/wazuh-apid_auth-143070.pid
/var/ossec/var/run/wazuh-apid_auth-143035.pid  /var/ossec/var/run/wazuh-apid_auth-143053.pid  /var/ossec/var/run/wazuh-apid_auth-143071.pid
/var/ossec/var/run/wazuh-apid_auth-143036.pid  /var/ossec/var/run/wazuh-apid_auth-143054.pid  /var/ossec/var/run/wazuh-apid_auth-143072.pid
/var/ossec/var/run/wazuh-apid_auth-143037.pid  /var/ossec/var/run/wazuh-apid_auth-143055.pid  /var/ossec/var/run/wazuh-apid_auth-143073.pid
/var/ossec/var/run/wazuh-apid_auth-143038.pid  /var/ossec/var/run/wazuh-apid_auth-143056.pid  /var/ossec/var/run/wazuh-apid_events-143079.pid
/var/ossec/var/run/wazuh-apid_auth-143039.pid  /var/ossec/var/run/wazuh-apid_auth-143057.pid  /var/ossec/var/run/wazuh-apid_exec-143076.pid
/var/ossec/var/run/wazuh-apid_auth-143040.pid  /var/ossec/var/run/wazuh-apid_auth-143058.pid
root@wazuh-dev:~/repos/wazuh# ls /var/ossec/var/run/wazuh-apid*.pid | wc -l
53
root@wazuh-dev:~/repos/wazuh# /var/ossec/bin/wazuh-control stop
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.11.2 Stopped
root@wazuh-dev:~/repos/wazuh# ^C
root@wazuh-dev:~/repos/wazuh# ls -la /var/ossec/var/run/
total 8
drwxrwx--- 2 root wazuh 4096 Mar 26 10:49 .
drwxr-x--- 9 root wazuh 4096 Mar 26 10:49 ..
root@wazuh-dev:~/repos/wazuh# ps -aux | grep wazuh_apid.py | grep -v grep | wc -l
0
```
- api.log
```log
2025/03/26 10:43:23 INFO: Checking RBAC database integrity...
2025/03/26 10:43:23 INFO: /var/ossec/api/configuration/security/rbac.db file was detected
2025/03/26 10:43:23 INFO: RBAC database integrity check finished successfully
2025/03/26 10:43:23 DEBUG2: Creating 'authentication_pool' process pool
2025/03/26 10:43:23 DEBUG2: Creating 'process_pool' process pool
2025/03/26 10:43:23 DEBUG2: Creating 'events_pool' process pool
2025/03/26 10:43:31 DEBUG: Loaded API configuration: {'host': ['0.0.0.0', '::'], 'port': 55000, 'drop_privileges': True, 'experimental_features': False, 'max_upload_size': 10485760, 'authentication_pool_size': 50, 'intervals': {'request_timeout': 10}, 'https': {'enabled': True, 'key': '/var/ossec/api/configuration/ssl/server.key', 'cert': '/var/ossec/api/configuration/ssl/server.crt', 'use_ca': False, 'ca': '/var/ossec/api/configuration/ssl/ca.crt', 'ssl_protocol': 'auto', 'ssl_ciphers': ''}, 'logs': {'level': 'debug2', 'format': 'plain', 'max_size': {'enabled': False, 'size': '1m'}}, 'cors': {'enabled': False, 'source_route': '*', 'expose_headers': '*', 'allow_headers': '*', 'allow_credentials': False}, 'access': {'max_login_attempts': 50, 'block_time': 300, 'max_request_per_minute': 300}, 'upload_configuration': {'remote_commands': {'localfile': {'allow': True, 'exceptions': []}, 'wodle_command': {'allow': True, 'exceptions': []}}, 'limits': {'eps': {'allow': True}}, 'agents': {'allow_higher_versions': {'allow': True}}, 'indexer': {'allow': True}, 'integrations': {'virustotal': {'public_key': {'allow': True, 'minimum_quota': 240}}}}}
2025/03/26 10:43:31 DEBUG: Loaded security API configuration: {'auth_token_exp_timeout': 900, 'rbac_mode': 'white'}
2025/03/26 10:43:32 INFO: Listening on ['0.0.0.0', '::']:55000.
2025/03/26 10:43:32 INFO: Getting installation UID...
2025/03/26 10:43:32 INFO: Getting updates information...
2025/03/26 10:49:53 INFO: Shutdown wazuh-apid server.
```