### PR TITLE
Added Rule ID 60232 to Ignore all Type Logon 5 login events from known system users

### DIFF
--- a/ruleset/rules/0580-win-security_rules.xml
+++ b/ruleset/rules/0580-win-security_rules.xml
@@ -1362,4 +1362,18 @@
     </mitre>
   </rule>
 
+<!-- Ignore Login events, type 5 for:
+    -  SYSTEM, LOCAL SERVICE and NETWORK SERVICE.
+    -->
+
+  <rule id="60232" level="0">
+    <if_sid>60106</if_sid>
+    <field name="win.system.eventID">^4624$</field>
+    <field name="win.eventdata.logonType">^5$</field>
+    <field name="win.eventdata.targetUserName">^LOCAL SERVICE|^NETWORK SERVICE|^SYSTEM</field>
+    <description>Windows Logon Success 2 (ignored)</description>
+    <options>no_full_log</options>
+    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.9,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
 </group>


### PR DESCRIPTION
# Description

In the Windows environments, the noisiest events are related to Windows logon and logoff events which is creating an impact on Wazuh manager nodes.

Wazuh Rule   ID | Microsoft Event   ID
-- | --
60105 | 529, 530, 531, 532,   533, 534, 535, 536, 537, 539, 4625
60106 | 528, 540, 673, 4624,   4769

- Wazuh Agent was installed on Windows 11 to monitor Rule ID 60105 and 60106

## Observation

<details>

<summary> No rule ID 60105 alerts in 8 hours.</summary>

![Image](https://github.com/user-attachments/assets/036c66ef-183e-4315-87dd-70bccad7cacd)

</details>


<details>

<summary> 111 rule ID 60106 alerts in 8 hours.</summary>

![Image](https://github.com/user-attachments/assets/4b0c97e4-caa4-4747-9df8-5d8638964d46)

</details>


<details>

<summary>All 60106 alerts have event ID 4624.</summary>

```console
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"eventID\":\"4624\"
118
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"eventID\":\"528\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"eventID\":\"540\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"eventID\":\"673\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"eventID\":\"4769\"
```

</details>

<details>

<summary> Most 4624 events have Logon Type 5 - The Service Control Manager started a service (service logon).</summary>

```console
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"1\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"2\"
4
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"3\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"4\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"5\"
118
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"6\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"7\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"8\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"9\"
0
[root@server vagrant]# cat /var/ossec/logs/alerts/alerts.json | grep -c \"logonType\":\"10\"
0
``` 

</details>


- Noise is generated by service logon. 

## Recommendation
- Create a child rule (similar to 60194) with rule alert level=0 for logonType 5 and data.win.eventdata.targetUserName (SYSTEM or LOCAL SERVICE or NETWORK SERVICE). This will filter expected service logons while still detecting suspicious service logon.

```console
  <rule id="60232" level="0">
    <if_sid>60106</if_sid>
    <field name="win.system.eventID">^4624$</field>
    <field name="win.eventdata.logonType">^5$</field>
    <field name="win.eventdata.targetUserName">^LOCAL SERVICE|^NETWORK SERVICE|^SYSTEM</field>
    <description>Windows Logon Success 2 (ignored)</description>
    <options>no_full_log</options>
    <group>pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
  </rule>

```
