### PR TITLE
Remove JSON building in favor to use built-in types

### DIFF
--- a/.github/actions/legacy_unit_tests_build/action.yml
+++ b/.github/actions/legacy_unit_tests_build/action.yml
@@ -1,5 +1,5 @@
-name: "Legacy unit tests build for Wazuh agent"
-description: "This action builds legacy Unit Tests for Wazuh agent on Ubuntu Linux/Windows"
+name: "Legacy unit tests build for Wazuh"
+description: "This action builds legacy Unit Tests for Wazuh on Ubuntu Linux/Windows"
 inputs:
    target:
      required: true
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         chmod +x .github/actions/legacy_unit_tests.sh
-    - name: Build Wazuh Agent Unit Tests
+    - name: Build Wazuh Unit Tests
       shell: bash
       run: |
         source .github/actions/legacy_unit_tests.sh

--- a/.github/actions/legacy_unit_tests_run/action.yml
+++ b/.github/actions/legacy_unit_tests_run/action.yml
@@ -1,5 +1,5 @@
-name: "Legacy unit tests run for Wazuh agent"
-description: "This action runs Wazuh agent unit tests on Ubuntu Linux/Windows"
+name: "Legacy unit tests run for Wazuh"
+description: "This action runs Wazuh unit tests on Ubuntu Linux/Windows"
 inputs:
    target:
      required: true
@@ -22,7 +22,7 @@ runs:
         source .github/actions/legacy_unit_tests.sh
         format_display_test_results ${{ inputs.target }}
     - name: Format and Display Test Coverage
-      if: ${{ inputs.target == 'agent' }}
+      if: ${{ inputs.target != 'winagent' }}
       shell: bash
       run: |
         source .github/actions/legacy_unit_tests.sh

--- a/.github/workflows/legacy-unit-tests.yml
+++ b/.github/workflows/legacy-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Legacy unit tests for wazuh agent
+name: Legacy unit tests for wazuh
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ jobs:
     strategy:
           fail-fast: false
           matrix:
-              target: [agent, winagent]
+              target: [agent, winagent, server]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
@@ -26,15 +26,15 @@ jobs:
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
-      - name: "Build wazuh agent"
+      - name: "Build wazuh"
         uses: ./.github/actions/build_test_flags
         with:
           target: ${{ matrix.target }}
-      - name: "Build wazuh agent legacy unit tests"
+      - name: "Build wazuh legacy unit tests"
         uses: ./.github/actions/legacy_unit_tests_build
         with:
           target: ${{ matrix.target }}
-      - name: "Run wazuh agent legacy unit tests"
+      - name: "Run wazuh legacy unit tests"
         uses: ./.github/actions/legacy_unit_tests_run
         with:
           target: ${{ matrix.target }}

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -95,7 +95,7 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg -Wl,-
                             -Wl,--wrap,sqlite3_prepare_v2 -Wl,--wrap,w_get_timestamp -Wl,--wrap,wdb_exec_stmt_silent -Wl,--wrap,w_compress_gzfile \
                             -Wl,--wrap,sqlite3_finalize -Wl,--wrap,popen -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,opendir -Wl,--wrap,closedir -Wl,--wrap,readdir \
                             -Wl,--wrap,stat -Wl,--wrap,w_uncompress_gzfile -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_close -Wl,--wrap,rename -Wl,--wrap,time \
-                            -Wl,--wrap,wdb_exec_stmt_single_column -Wl,--wrap,w_is_single_node ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
+                            -Wl,--wrap,wdb_exec_stmt_single_column -Wl,--wrap,w_is_single_node -Wl,--wrap,sqlite3_column_text ${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_agents")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_init_stmt_in_cache -Wl,--wrap,sqlite3_bind_text -Wl,--wrap,wdb_exec_stmt_silent  -Wl,--wrap,sqlite3_step \

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -199,6 +199,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_UPDATE_AGENT_INFO] = "UPDATE agent SET config_sum = :config_sum, ip = :ip, manager_host = :manager_host, merged_sum = :merged_sum, name = :name, node_name = :node_name, os_arch = :os_arch, os_build = :os_build, os_codename = :os_codename, os_major = :os_major, os_minor = :os_minor, os_name = :os_name, os_platform = :os_platform, os_uname = :os_uname, os_version = :os_version, version = :version, last_keepalive = :last_keepalive, connection_status = :connection_status, disconnection_time = :disconnection_time, group_config_status = :group_config_status, status_code= :status_code, sync_status = :sync_status WHERE id = :id;",
     [WDB_STMT_GLOBAL_GET_GROUPS] = "SELECT DISTINCT `group`, group_hash from agent WHERE id > 0 AND group_hash > ? ORDER BY group_hash;",
     [WDB_STMT_GLOBAL_GET_AGENTS] = "SELECT id FROM agent WHERE id > ?;",
+    [WDB_STMT_GLOBAL_GET_AGENTS_AND_GROUP] = "SELECT id, `group` FROM agent WHERE id > ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_CONTEXT] = "SELECT id,version,name,ip FROM agent;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS] = "SELECT id FROM agent WHERE id > ? AND connection_status = ?;",
     [WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE] = "SELECT id FROM agent WHERE id > ? AND connection_status = ? AND node_name = ? ORDER BY id LIMIT ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -257,6 +257,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_UPDATE_AGENT_INFO,
     WDB_STMT_GLOBAL_GET_GROUPS,
     WDB_STMT_GLOBAL_GET_AGENTS,
+    WDB_STMT_GLOBAL_GET_AGENTS_AND_GROUP,
     WDB_STMT_GLOBAL_GET_AGENTS_CONTEXT,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_GET_AGENTS_BY_CONNECTION_STATUS_AND_NODE,
@@ -1352,7 +1353,7 @@ int wdb_global_recalculate_agent_groups_hash(wdb_t* wdb, int agent_id, char* syn
  * @return WDBC_OK Success.
  *         WDBC_ERROR On error.
  */
-int wdb_global_recalculate_agent_groups_hash_without_sync_status(wdb_t* wdb, int agent_id);
+int wdb_global_recalculate_agent_groups_hash_without_sync_status(wdb_t* wdb, int agent_id, char * group);
 
 /**
  * @brief Function to recalculate the agent group hash for all agents.

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1058,17 +1058,45 @@ wdbc_result wdb_global_sync_agent_info_get(wdb_t *wdb, int* last_agent_id, char 
 }
 
 char* wdb_global_calculate_agent_group_csv(wdb_t *wdb, int id) {
-    cJSON* j_agent_groups = wdb_global_select_group_belong(wdb, id);
     char* result = NULL;
-    if (j_agent_groups) {
-        cJSON* j_group_name = NULL;
-        cJSON_ArrayForEach(j_group_name, j_agent_groups) {
-            wm_strcat(&result, cJSON_GetStringValue(j_group_name), MULTIGROUP_SEPARATOR);
-        }
-        cJSON_Delete(j_agent_groups);
+    sqlite3_stmt *stmt = NULL;
+
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("Cannot begin transaction");
+        return NULL;
     }
-    else {
-        mdebug1("Unable to get groups of agent '%03d'", id);
+
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_SELECT_GROUP_BELONG) < 0) {
+        mdebug1("Cannot cache statement");
+        return NULL;
+    }
+
+    stmt = wdb->stmt[WDB_STMT_GLOBAL_SELECT_GROUP_BELONG];
+
+    if (sqlite3_bind_int(stmt, 1, id) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return NULL;
+    }
+
+    int _status = SQLITE_ROW;
+
+    while ((_status = wdb_step(stmt)) == SQLITE_ROW) {
+        char * group_hash = (char *) sqlite3_column_text(stmt, 0);
+
+        if (group_hash == NULL) {
+            mdebug1("Group hash is NULL");
+            continue;
+        }
+
+        if (result != NULL && WDB_MAX_RESPONSE_SIZE < strlen(result) + strlen(group_hash) + 1) {
+            mdebug1("The agent's groups exceed the socket maximum response size.");
+            break;
+        }
+        wm_strcat(&result, group_hash, MULTIGROUP_SEPARATOR);
+    }
+
+    if (SQLITE_DONE != _status) {
+        mdebug1("SQL statement execution failed");
     }
     return result;
 }
@@ -1407,7 +1435,7 @@ int wdb_global_recalculate_agent_groups_hash(wdb_t* wdb, int agent_id, char* syn
     return result;
 }
 
-int wdb_global_recalculate_agent_groups_hash_without_sync_status(wdb_t* wdb, int agent_id) {
+int wdb_global_recalculate_agent_groups_hash_without_sync_status(wdb_t* wdb, int agent_id, char* group) {
     int result = WDBC_OK;
     char* agent_groups_csv = wdb_global_calculate_agent_group_csv(wdb, agent_id);
     char groups_hash[WDB_GROUP_HASH_SIZE+1] = {0};
@@ -1418,9 +1446,12 @@ int wdb_global_recalculate_agent_groups_hash_without_sync_status(wdb_t* wdb, int
         mdebug1("No groups in belongs table for agent '%03d'", agent_id);
     }
 
-    if (WDBC_ERROR == wdb_global_set_agent_group_hash(wdb, agent_id, agent_groups_csv, agent_groups_csv ? groups_hash : NULL)) {
-        result = WDBC_ERROR;
-        merror("There was an error assigning the groups hash to agent '%03d'", agent_id);
+    // if the previous group is different from the new one, we update the agent group context
+    if ((group && !agent_groups_csv) || (!group && agent_groups_csv) || (group && agent_groups_csv && strcmp(group, agent_groups_csv))) {
+        if (WDBC_ERROR == wdb_global_set_agent_group_hash(wdb, agent_id, agent_groups_csv, agent_groups_csv ? groups_hash : NULL)) {
+            result = WDBC_ERROR;
+            merror("There was an error assigning the groups hash to agent '%03d'", agent_id);
+        }
     }
 
     os_free(agent_groups_csv);
@@ -1437,11 +1468,11 @@ int wdb_global_recalculate_all_agent_groups_hash(wdb_t* wdb) {
         return OS_INVALID;
     }
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS) < 0) {
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS_AND_GROUP) < 0) {
         mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
-    sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS];
+    sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS_AND_GROUP];
 
     if (sqlite3_bind_int(stmt, 1, 0) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
@@ -1449,24 +1480,21 @@ int wdb_global_recalculate_all_agent_groups_hash(wdb_t* wdb) {
     }
 
     //Get agents to recalculate hash
-    cJSON* j_stmt_result = wdb_exec_stmt(stmt);
-    cJSON* agent = NULL;
-    cJSON_ArrayForEach(agent, j_stmt_result) {
-        cJSON* id = cJSON_GetObjectItem(agent, "id");
-        if (cJSON_IsNumber(id)) {
-            if (WDBC_ERROR == wdb_global_recalculate_agent_groups_hash_without_sync_status(wdb, id->valueint)) {
-                merror("Couldn't recalculate hash group for agent: '%03d'", id->valueint);
-                cJSON_Delete(j_stmt_result);
-                return OS_INVALID;
-            }
-        }
-        else {
-            merror("Invalid element returned by get all agents query");
-            cJSON_Delete(j_stmt_result);
+    int _status = SQLITE_ROW;
+
+    while ((_status = wdb_step(stmt)) == SQLITE_ROW) {
+        int id = sqlite3_column_int(stmt, 0);
+        char * group = (char *) sqlite3_column_text(stmt, 1);
+
+        if (WDBC_ERROR == wdb_global_recalculate_agent_groups_hash_without_sync_status(wdb, id, group)) {
+            merror("Couldn't recalculate hash group for agent: '%03d'", id);
             return OS_INVALID;
         }
     }
-    cJSON_Delete(j_stmt_result);
+
+    if (SQLITE_DONE != _status) {
+        mdebug1("SQL statement execution failed");
+    }
 
     return OS_SUCCESS;
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes https://github.com/wazuh/devel-major-incidents/issues/15|

## Description

This PR aims to use the built-in types in favour the get better performance results in the usage.
In other side, if we get the current hash, we can check if after the calculation the number change, to decide if the update query will be processed.

### Results previous the change
2079149 / 246 -> 8451 ms
### Results after the change
427208 / 2197 -> 194 ms