### PR TITLE
Update purge param description

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6084,7 +6084,9 @@ components:
     purge:
       in: query
       name: purge
-      description: "Permanently delete an agent from the key store"
+      description: |
+        Permanently delete an agent from the key store. The wazuh-authd `purge` configuration option has 
+        precedence over this parameter, when enabled, agents will be permanently deleted regardless of this value.
       schema:
         type: boolean
         default: false


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/28804 |

## Description

Updates the `DELETE /agents` `purge` parameter description to clarify that the option from wazuh-authd has precedence over its value.