### PR TITLE
Fixed engine policy warning showing name error

### DIFF
--- a/src/engine/source/builder/src/policy/factory.cpp
+++ b/src/engine/source/builder/src/policy/factory.cpp
@@ -421,10 +421,11 @@ Graph<base::Name, Asset> buildSubgraph(const std::string& subgraphName,
         if (!subgraph.hasNode(parent))
         {
             auto childrenNames = std::string("[");
-            childrenNames += std::accumulate(children.cbegin() + 1,
-                                             children.cend(),
-                                             children.front(),
-                                             [](auto& acc, auto& child) { return acc.toStr() + ", " + child.toStr(); });
+            childrenNames += std::accumulate<decltype(children.cbegin()), std::string>(
+                children.cbegin() + 1,
+                children.cend(),
+                children.front(),
+                [](std::string& acc, auto& child) { return acc + ", " + child.toStr(); });
             childrenNames += "]";
             throw std::runtime_error(fmt::format("Parent '{}' does not exist, required by {}", parent, childrenNames));
         }


### PR DESCRIPTION
|Related issue|
|---|
|#28794|

There was an error on the accumulator function which gathers all asset children depending on a missing asset parent, accumulating on base::Name instead of a std::string, which in the end will trigger the maximum allowed name parts instead of the intended error message.

Now it works correctly:
```bash
engine-policy --api-socket /tmp/dbg_env/queue/sockets/engine-api.socket asset-remove -p policy/wazuh/0 -n system integration/wazuh-core/0
Warning: Saved invalid policy: Parent 'decoder/integrations/0' does not exist, required by [decoder/zeek-x509/0, decoder/zeek-weird/0, decoder/zeek-traceroute/0, decoder/zeek-stats/0, decoder/zeek-software/0, decoder/zeek-socks/0, decoder/zeek-snmp/0, decoder/zeek-smb_mapping/0, decoder/zeek-smb_files/0, decoder/modsecurity-apache/0, decoder/apache-error/0, decoder/zeek-smb_cmd/0, decoder/zeek-ssl/0, decoder/snort-json/0, decoder/modsecurity-nginx/0, decoder/zeek-signature/0, decoder/zeek-conn/0, decoder/zeek-modbus/0, decoder/zeek-pe/0, decoder/microsoft-dhcp/0, decoder/squid-access/0, decoder/apache-access/0, decoder/pfsense-php-fpm/0, decoder/microsoft-exchange-server-messagetracking/0, decoder/microsoft-exchange-server-httpproxy/0, decoder/zeek-kerberos/0, decoder/windows-event/0, decoder/pfsense-firewall/0, decoder/microsoft-exchange-server-imap4-pop3/0, decoder/zeek-known_certs/0, decoder/zeek-sip/0, decoder/pfsense-unbound/0, decoder/iis/0, decoder/snort-plaintext-csv/0, decoder/snort-plaintext/0, decoder/microsoft-exchange-server-smtp/0, decoder/suricata/0, decoder/zeek-irc/0, decoder/pfsense-dhcp/0, decoder/microsoft-dhcpv6/0, decoder/zeek-capture_loss/0, decoder/zeek-dhcp/0, decoder/zeek-dnp3/0, decoder/zeek-dns/0, decoder/zeek-smtp/0, decoder/zeek-http/0, decoder/zeek-rfb/0, decoder/zeek-files/0, decoder/zeek-ftp/0, decoder/zeek-ssh/0, decoder/zeek-ocsp/0, decoder/zeek-dce_rpc/0, decoder/zeek-intel/0, decoder/zeek-syslog/0, decoder/zeek-known_hosts/0, decoder/zeek-dpd/0, decoder/zeek-known_services/0, decoder/zeek-mysql/0, decoder/zeek-ntlm/0, decoder/zeek-tunnel/0, decoder/zeek-notice/0, decoder/zeek-ntp/0, decoder/zeek-radius/0, decoder/syslog/0, decoder/zeek-rdp/0]
```