### PR TITLE
Update index templates for global queries

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
@@ -14,9 +14,6 @@
           "agent.id",
           "agent.name",
           "agent.version",
-          "data_stream.type",
-          "event.action",
-          "event.type",
           "file.gid",
           "file.group",
           "file.hash.md5",
@@ -26,8 +23,12 @@
           "file.mtime",
           "file.owner",
           "file.path",
+          "file.path.fields.text",
           "file.size",
-          "file.uid"
+          "file.uid",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }
@@ -61,25 +62,6 @@
               "type": "keyword"
             },
             "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "data_stream": {
-          "properties": {
-            "type": {
-              "type": "keyword"
-            }
-          }
-        },
-        "event": {
-          "properties": {
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
               "ignore_above": 1024,
               "type": "keyword"
             }

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
@@ -14,24 +14,26 @@
           "agent.id",
           "agent.name",
           "agent.version",
-          "data_stream.type",
+          "event.action",
           "event.category",
-          "event.type",
-          "registry.data.type",
-          "registry.gid",
-          "registry.group",
+          "registry.architecture",
           "registry.data.hash.md5",
           "registry.data.hash.sha1",
           "registry.data.hash.sha256",
+          "registry.data.type",
+          "registry.gid",
+          "registry.group",
           "registry.hive",
-          "registry.inode",
           "registry.key",
           "registry.mtime",
           "registry.owner",
           "registry.path",
           "registry.size",
           "registry.uid",
-          "registry.value"
+          "registry.value",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }
@@ -70,13 +72,6 @@
             }
           }
         },
-        "data_stream": {
-          "properties": {
-            "type": {
-              "type": "keyword"
-            }
-          }
-        },
         "event": {
           "properties": {
             "action": {
@@ -86,15 +81,15 @@
             "category": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "registry": {
           "properties": {
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "data": {
               "properties": {
                 "hash": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
@@ -9,10 +9,27 @@
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
+          "agent.host.architecture",
+          "agent.host.ip",
           "agent.id",
+          "agent.name",
+          "agent.version",
           "package.architecture",
+          "package.category",
+          "package.description",
+          "package.installed",
+          "package.multiarch",
           "package.name",
-          "package.version"
+          "package.path",
+          "package.priority",
+          "package.size",
+          "package.source",
+          "package.type",
+          "package.vendor",
+          "package.version",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }
@@ -68,11 +85,30 @@
             "installed": {
               "type": "date"
             },
+            "multiarch": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "name": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "priority": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "size": {
+              "type": "long"
+            },
+            "source": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
@@ -9,10 +9,24 @@
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
+          "agent.host.architecture",
+          "agent.host.ip",
           "agent.id",
+          "agent.name",
+          "agent.version",
+          "process.args",
+          "process.args_count",
+          "process.command_line",
           "process.name",
+          "process.parent.pid",
           "process.pid",
-          "process.command_line"
+          "process.start",
+          "process.state",
+          "process.stime",
+          "process.utime",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }
@@ -57,6 +71,9 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "args_count": {
+              "type": "long"
+            },
             "command_line": {
               "fields": {
                 "text": {
@@ -83,6 +100,9 @@
             },
             "pid": {
               "type": "long"
+            },
+            "start": {
+              "type": "date"
             },
             "state": {
               "ignore_above": 1024,

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
@@ -9,7 +9,30 @@
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
-          "observer.board_serial"
+          "agent.host.architecture",
+          "agent.host.ip",
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "host.architecture",
+          "host.hostname",
+          "host.os.build",
+          "host.os.codename",
+          "host.os.distribution.release",
+          "host.os.full",
+          "host.os.kernel.name",
+          "host.os.kernel.release",
+          "host.os.kernel.version",
+          "host.os.major",
+          "host.os.minor",
+          "host.os.name",
+          "host.os.patch",
+          "host.os.platform",
+          "host.os.type",
+          "host.os.version",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }
@@ -113,6 +136,10 @@
                   "type": "keyword"
                 },
                 "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },


### PR DESCRIPTION
|Related issue|
|---|
| #27898 |

## Description

This PR updates index templates for indices in the list below in order to correct problems [pointed out in the issue](https://github.com/wazuh/wazuh/issues/27898#issuecomment-2752443579).

- `wazuh-states-fim-files`
- `wazuh-states-fim-registries`
- `wazuh-states-inventory-packages`
- `wazuh-states-inventory-processes`
- `wazuh-states-inventory-system`

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors