### PR TITLE
Update deprecated runner OS

### DIFF
--- a/.github/workflows/vulnerability-scanner-tests.yml
+++ b/.github/workflows/vulnerability-scanner-tests.yml
@@ -214,7 +214,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28853|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR will update all references to the 20.04 runner OS because it'll be deprecated.
Consider that the Filebeat workflow requires some changes to work but they'll be performed in another issue:
- a change in the `mage` installation method because Ubuntu 24.04 has a newer Go version
- A Python module error `ModuleNotFoundError: No module named 'urllib3.packages.six.moves'`


https://go.dev/doc/go-get-install-deprecation
