### PR TITLE
Fix runner OS tag

### DIFF
--- a/.github/workflows/build-package-filebeat.yml
+++ b/.github/workflows/build-package-filebeat.yml
@@ -70,7 +70,7 @@ on:
 
 jobs:
   build-and-upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28853 |

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR replaces the `latest` tag because it can unexpectedly fail when a new OS version is released.