### PR TITLE
Engine catalog now returns original assets when available

### DIFF
--- a/src/engine/test/integration_tests/catalog/features/api.feature
+++ b/src/engine/test/integration_tests/catalog/features/api.feature
@@ -126,7 +126,9 @@ Feature: Catalog API Management
     Then I should receive a success response
     And I should receive the next content
       """
-      name: decoder/testing/0
+      {
+        "name":"decoder/testing/0"
+      }
       """
 
 
@@ -309,9 +311,12 @@ Feature: Catalog API Management
     Then I should receive a success response
     And I should receive the next content
       """
-      name: decoder/testing/0
-      metadata:
-        description: this is a test decoder
+      {
+        "name":"decoder/testing/0",
+        "metadata": {
+          "description": "this is a test decoder"
+        }
+      }
       """
 
 


### PR DESCRIPTION
|Related issue|
|---|
|#28839 |

Updated catalog get method to return the original asset if possible instead of the parsed one.

## Example
```bash
engine-catalog -n system --api-socket /tmp/dbg_env/queue/sockets/engine-api.socket get decoder/test-original/0 
name: decoder/test-original/0

parents:
  # This is a comment
  - decoder/syslog/0

# This is a comment
check:
  - event.original: exists()

normalize:
  - map:
      # This is a comment
      - field: event.original
        target: message
```