### PR TITLE
Change latest tag in GHA workflows

### DIFF
--- a/.github/workflows/manager-build-package.yml
+++ b/.github/workflows/manager-build-package.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   Generate-Packages:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Build DEB Manager
         id: deb

--- a/.github/workflows/packages-filebeat.yml
+++ b/.github/workflows/packages-filebeat.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   Filebeat-module-generation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 1
 
     steps:

--- a/.github/workflows/packages-upload-images.yml
+++ b/.github/workflows/packages-upload-images.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Cancel previous runs


### PR DESCRIPTION
|Related issue|
|---|
|#28898|

This PR changes `ubuntu-latest` to `ubuntu-24.04` in GHA workflows.

