### PR TITLE
Change to stable OS version in workflows

### DIFF
--- a/.github/workflows/api-unit-tests.yml
+++ b/.github/workflows/api-unit-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/external-integrations-unit-tests.yml
+++ b/.github/workflows/external-integrations-unit-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/framework-unit-tests.yml
+++ b/.github/workflows/framework-unit-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-code-analysis.yml
+++ b/.github/workflows/python-code-analysis.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: write
       actions: read
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Bandit Scan

--- a/.github/workflows/wodles-unit-tests.yml
+++ b/.github/workflows/wodles-unit-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build: 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
|Related issue|
|---|
| #28896  |

## Description

- The OS version of the workflows corresponding to the server-div2 team was modified to a stable version (`ubuntu-24.04`).
- The tests for proper functionality can be observed once these tests pass in the checks of this pull request, as they are triggered when these workflows are modified.

## Tests 

![image](https://github.com/user-attachments/assets/0878ab57-245d-4aeb-b02c-a200845f02ca)
