### PR TITLE
Use single string in `management_api.host` configuration

### DIFF
--- a/etc/wazuh-server.yml
+++ b/etc/wazuh-server.yml
@@ -29,9 +29,7 @@ communications_api:
     use_ca: false
     ca: /etc/wazuh-server/certs/root-ca.pem
 management_api:
-  host:
-    - "0.0.0.0"
-    - "::"
+  host: 0.0.0.0
   port: 55000
   ssl:
     key: /etc/wazuh-server/certs/server-1-key.pem

--- a/framework/wazuh/core/config/models/comms_api.py
+++ b/framework/wazuh/core/config/models/comms_api.py
@@ -44,7 +44,7 @@ class CommsAPIConfig(WazuhConfigBaseModel):
         SSL configuration for the communications API. Default is an instance of APISSLConfig.
     """
 
-    host: str = 'localhost'
+    host: str = '0.0.0.0'
     port: PositiveInt = 27000
     workers: PositiveInt = 4
 

--- a/framework/wazuh/core/config/models/management_api.py
+++ b/framework/wazuh/core/config/models/management_api.py
@@ -1,7 +1,6 @@
 from enum import Enum
-from typing import List
 
-from pydantic import Field, PositiveInt
+from pydantic import PositiveInt
 from server_management_api.constants import API_CERT_PATH, API_KEY_PATH
 from wazuh.core.config.models.base import WazuhConfigBaseModel
 from wazuh.core.config.models.logging import APILoggingConfig
@@ -98,7 +97,7 @@ class ManagementAPIConfig(WazuhConfigBaseModel):
         Logging configuration for the management API. Default is an instance of APILoggingConfig.
     """
 
-    host: List[str] = Field(default=['localhost', '::1'], min_length=2)
+    host: str = '0.0.0.0'
     port: PositiveInt = 55000
     drop_privileges: bool = True
     max_upload_size: PositiveInt = 10485760

--- a/framework/wazuh/core/config/models/tests/test_comms_api.py
+++ b/framework/wazuh/core/config/models/tests/test_comms_api.py
@@ -37,7 +37,7 @@ def test_batcher_config_invalid_values(init_values):
 @pytest.mark.parametrize(
     'init_values, expected',
     [
-        ({}, {'host': 'localhost', 'port': 27000, 'workers': 4}),
+        ({}, {'host': '0.0.0.0', 'port': 27000, 'workers': 4}),
         ({'host': '127.0.0.1', 'port': 27001, 'workers': 2}, {'host': '127.0.0.1', 'port': 27001, 'workers': 2}),
     ],
 )

--- a/framework/wazuh/core/config/models/tests/test_management_api.py
+++ b/framework/wazuh/core/config/models/tests/test_management_api.py
@@ -109,7 +109,7 @@ def test_access_config_invalid_values(values):
         (
             {},
             {
-                'host': ['localhost', '::1'],
+                'host': '0.0.0.0',
                 'port': 55000,
                 'drop_privileges': True,
                 'max_upload_size': 10485760,
@@ -122,7 +122,7 @@ def test_access_config_invalid_values(values):
         ),
         (
             {
-                'host': ['example', '::'],
+                'host': 'example',
                 'port': 55050,
                 'drop_privileges': False,
                 'max_upload_size': 101,
@@ -133,7 +133,7 @@ def test_access_config_invalid_values(values):
                 'access': {'max_login_attempts': 4},
             },
             {
-                'host': ['example', '::'],
+                'host': 'example',
                 'port': 55050,
                 'drop_privileges': False,
                 'max_upload_size': 101,


### PR DESCRIPTION
|Related issue|
|---|
|#28798|

## Description

This PR closes #28798. Changes the type of `management_api.host` to a string and sets the default to `0.0.0.0`.

## Configuration options

Default configuration

```yaml
server:
  nodes:
    - master
  node:
    name: server-1
    type: master
    ssl:
      key: /etc/wazuh-server/certs/server-1-key.pem
      cert: /etc/wazuh-server/certs/server-1.pem
      ca: /etc/wazuh-server/certs/root-ca.pem
indexer:
  hosts:
    - host: 127.0.0.1
      port: 9200
  username: admin
  password: admin
  ssl:
    use_ssl: true
    key: /etc/wazuh-server/certs/server-1-key.pem
    certificate: /etc/wazuh-server/certs/server-1.pem
    certificate_authorities:
      - /etc/wazuh-server/certs/root-ca.pem
communications_api:
  host: 0.0.0.0
  port: 27000
  ssl:
    key: /etc/wazuh-server/certs/server-1-key.pem
    cert: /etc/wazuh-server/certs/server-1.pem
    use_ca: false
    ca: /etc/wazuh-server/certs/root-ca.pem
management_api:
  host: 0.0.0.0
  port: 55000
  ssl:
    key: /etc/wazuh-server/certs/server-1-key.pem
    cert: /etc/wazuh-server/certs/server-1.pem
    use_ca: false
    ca: /etc/wazuh-server/certs/root-ca.pem
```

## Logs/Alerts example

```bash
root@wazuh-manager:/# /usr/share/wazuh-server/bin/wazuh-server start
2025/03/31 13:33:23 DEBUG: [Cluster] [Main] Removing '/run/wazuh-server/cluster/'.
2025/03/31 13:33:23 DEBUG: [Cluster] [Main] Nothing to remove in '/run/wazuh-server/cluster/'.
2025/03/31 13:33:23 DEBUG: [Cluster] [Main] Removed '/run/wazuh-server/cluster/'.
2025/03/31 13:33:23 INFO: [Cluster] [Main] Starting server (pid: 4556)
2025/03/31 13:33:23 WARNING: [Cluster] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': False, 'wazuh-engined': False}. Sleeping until next checking...
2025/03/31 13:33:23 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/03/31 13:33:23 INFO: [Master] [Config Server] Started server process [4556]
2025/03/31 13:33:23 INFO: [Master] [Config Server] Waiting for application startup.
2025/03/31 13:33:23 INFO: [Master] [Config Server] Application startup complete.
2025/03/31 13:33:23 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/03/31 13:33:24 INFO: [Local Server] [Main] Starting wazuh-engined
2025-03-31 13:33:24.493 4575:4575 info: Logging initialized.
2025/03/31 13:33:24 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-03-31 13:33:24.497 4575:4575 info: Metrics manager configured successfully
2025-03-31 13:33:24.498 4575:4575 info: Metrics initialized.
2025-03-31 13:33:24.498 4575:4575 info: Metrics disabled.
2025-03-31 13:33:24.498 4575:4575 info: Store initialized.
2025-03-31 13:33:24.498 4575:4575 info: RBAC initialized.
2025-03-31 13:33:24.507 4575:4575 info: KVDB initialized.
2025-03-31 13:33:24.507 4575:4575 info: Geo initialized.
2025-03-31 13:33:24.521 4575:4575 info: Schema initialized.
2025-03-31 13:33:24.537 4575:4575 info: Loaded timezone database version: '2024a'
2025-03-31 13:33:24.537 4575:4575 info: HLP initialized.
2025-03-31 13:33:24.558 4575:4575 info: Indexer Connector initialized.
2025-03-31 13:33:24.558 4575:4575 info: Builder initialized.
2025-03-31 13:33:24.558 4575:4575 info: Catalog initialized.
2025-03-31 13:33:24.558 4575:4575 info: Policy manager initialized.
2025-03-31 13:33:24.559 4575:4575 info: No flooding file provided, the queue will not be flooded.
2025-03-31 13:33:24.567 4575:4575 info: No flooding file provided, the queue will not be flooded.
2025-03-31 13:33:24.567 4575:4575 warning: Router: router/router/0 table is empty
2025-03-31 13:33:24.567 4575:4575 warning: Router: router/tester/0 table is empty
2025-03-31 13:33:24.568 4575:4575 info: Router initialized.
2025-03-31 13:33:24.576 4575:4575 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-03-31 13:33:24.577 4575:4575 info: Server API_SRV started in thread 137555519473344 at /run/wazuh-server/engine-api.socket
2025-03-31 13:33:24.577 4575:4575 info: Starting server EVENT_SRV at /run/wazuh-server/engine.socket
2025/03/31 13:33:26 INFO: [Local Server] [Main] Started wazuh-engined (pid: 4575)
2025/03/31 13:33:26 INFO: [Local Server] [Main] Starting wazuh-comms-apid
025/03/31 13:33:27 INFO: [Communications API] Starting API
2025/03/31 13:33:27 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/03/31 13:33:27 INFO: [Communications API] Starting gunicorn 22.0.0
2025/03/31 13:33:27 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (4677)
2025/03/31 13:33:27 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/03/31 13:33:27 INFO: [Communications API] Booting worker with pid: 4713
2025/03/31 13:33:27 INFO: [Communications API] Started server process [4677]
2025/03/31 13:33:27 INFO: [Communications API] Waiting for application startup.
2025/03/31 13:33:27 INFO: [Communications API] Application startup complete.
2025/03/31 13:33:27 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/03/31 13:33:27 INFO: [Communications API] Booting worker with pid: 4714
2025/03/31 13:33:27 INFO: [Communications API] Started server process [4714]
2025/03/31 13:33:27 INFO: [Communications API] Waiting for application startup.
2025/03/31 13:33:27 INFO: [Communications API] Application startup complete.
2025/03/31 13:33:27 INFO: [Communications API] Booting worker with pid: 4715
2025/03/31 13:33:27 INFO: [Communications API] Started server process [4715]
2025/03/31 13:33:27 INFO: [Communications API] Waiting for application startup.
2025/03/31 13:33:27 INFO: [Communications API] Application startup complete.
2025/03/31 13:33:27 INFO: [Communications API] Booting worker with pid: 4716
2025/03/31 13:33:27 INFO: [Communications API] Started server process [4716]
2025/03/31 13:33:27 INFO: [Communications API] Waiting for application startup.
2025/03/31 13:33:27 INFO: [Communications API] Application startup complete.
2025/03/31 13:33:28 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 4677)
2025/03/31 13:33:28 INFO: [Local Server] [Main] Starting wazuh-server-management-apid
2025/03/31 13:33:29 INFO: [Management API] Starting API
2025/03/31 13:33:29 INFO: [Management API] Checking RBAC database integrity...
2025/03/31 13:33:29 INFO: [Management API] /var/lib/wazuh-server/rbac.db file was detected
2025/03/31 13:33:29 INFO: [Management API] RBAC database integrity check finished successfully
2025/03/31 13:33:30 INFO: [Local Server] [Main] Started wazuh-server-management-apid (pid: 4717)
2025/03/31 13:33:30 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/03/31 13:33:30 DEBUG: [Local Server] [Keep alive] Calculating.
2025/03/31 13:33:30 DEBUG: [Local Server] [Keep alive] Calculated.
2025/03/31 13:33:30 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2025/03/31 13:33:30 DEBUG: [Master] [Keep alive] Calculating.
2025/03/31 13:33:30 DEBUG: [Master] [Keep alive] Calculated.
2025/03/31 13:33:30 INFO: [Master] [Local integrity] Starting.
2025/03/31 13:33:30 INFO: [Master] [Local integrity] Finished in 0.001s. Calculated metadata of 0 files.
2025/03/31 13:33:30 INFO: [Management API] Listening on 0.0.0.0:55000.
2025/03/31 13:33:30 INFO: [Management API] Getting installation UID...
2025/03/31 13:33:30 INFO: [Management API] Getting updates information...
2025/03/31 13:33:33 INFO: [Cluster] [Main] Getting orders from indexer
2025/03/31 13:33:33 DEBUG: [Cluster] [Main] Connecting to the indexer client.
```
