### PR TITLE
Fix false positive in configuration uploading.

### DIFF
--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -886,11 +886,11 @@ def check_remote_commands(data: str):
             pass
 
     if not blocked_configurations['remote_commands']['localfile']['allow']:
-        command_section = re.compile(r"<localfile>.*?</localfile>", flags=re.MULTILINE | re.DOTALL)
+        command_section = re.compile(r"<localfile>(.*?)</localfile>", flags=re.MULTILINE | re.DOTALL)
         check_section(command_section, section='localfile', split_section='</localfile>')
 
     if not blocked_configurations['remote_commands']['wodle_command']['allow']:
-        command_section = re.compile(r"<wodle name=\"command\">.*?</wodle>", flags=re.MULTILINE | re.DOTALL)
+        command_section = re.compile(r"<wodle name=\"command\">(.*?)</wodle>", flags=re.MULTILINE | re.DOTALL)
         check_section(command_section, section='wodle_command', split_section='<wodle name=\"command\">')
 
 


### PR DESCRIPTION
|Related issue|
|---|
| #28635  |

## Description

The false positive mentioned in https://github.com/wazuh/wazuh/issues/28635 was fixed and tests were carried out to verify correct functionality.

## Tests

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3.10 -m pytest framework/wazuh/core/tests/test_utils.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 294 items                                                                                                                                                                                               

framework/wazuh/core/tests/test_utils.py .................................................................................................................................................................. [ 55%]
....................................................................................................................................                                                                        [100%]

========================================================================================= 294 passed, 8 warnings in 1.29s =========================================================================================
```