### PR TITLE
Fix Wazuh manager failure due to log directory existence or permission issues

### DIFF
--- a/src/analysisd/alerts/getloglocation.h
+++ b/src/analysisd/alerts/getloglocation.h
@@ -14,6 +14,9 @@
 #include "eventinfo.h"
 #include "analysisd.h"
 
+/* Make sure to include this for the definition of USER and GROUPGLOBAL, anong with Privsep_GetUser and Privsep_GetGroup functions */
+#include "shared.h"
+
 /* Start the log location (need to be called before getlog) */
 void OS_InitLog(void);
 void OS_InitFwLog(void);
@@ -25,12 +28,14 @@ int OS_GetLogLocation(int day,int year,char *mon);
 
 /* Global declarations */
 extern FILE *_eflog;
-extern FILE *_ejflog;
 extern FILE *_aflog;
 extern FILE *_fflog;
 extern FILE *_jflog;
 extern FILE *_ejflog;
 
 void OS_RotateLogs(int day,int year,char *mon);
+
+/* Function checks if the parent path exists before writing logs */
+void ensure_path(const char *path, mode_t desired_mode, const char *username, const char *groupname);
 
 #endif /* GETLL_H */


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/16315 |

## Description

**N.B:** Original PR https://github.com/wazuh/wazuh/pull/22515 closed due to branch rename master to main. I reopened the PR.

When default log directories ([defined in defs.h](https://github.com/wazuh/wazuh/blob/6f672d01053d274eab8f6d5622e995f6a588f6f8/src/headers/defs.h#L282)) are removed or directory permissions are changed, Wazuh manager fails. It occurs when the log cleanup scripts are not written properly. Sometimes it is just admins remove the folder itself instead of the content. But the Wazuh manager runs in a failed state. It will just work and logs received afterwards are lost.

Currently, the said folders are created by a bash script.
https://github.com/wazuh/wazuh/blob/6f672d01053d274eab8f6d5622e995f6a588f6f8/src/init/inst-functions.sh#L1015

I added C function called `ensure_path` that accepts the path and its desired state by means of permission and ownership. This will prevent the accidents and improve resilience of Wazuh manager service.

## Configuration options

N/A

## Logs/Alerts example

N/A

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors