### PR TITLE
Change `registry.mtime` to date

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
@@ -131,7 +131,7 @@
               "type": "keyword"
             },
             "mtime": {
-              "type": "long"
+              "type": "date"
             },
             "owner": {
               "ignore_above": 1024,


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/27898|

## Description

This PR changes the type of field `registry.mtime` in the `states-fim-registries` template from `long` to `date`.