### PR TITLE
Update syslog rule 5104 interface entered promiscuous mode

### DIFF
--- a/ruleset/rules/0020-syslog_rules.xml
+++ b/ruleset/rules/0020-syslog_rules.xml
@@ -310,7 +310,7 @@
   <rule id="5104" level="8">
     <if_sid>5100</if_sid>
     <regex>Promiscuous mode enabled|</regex>
-    <regex>device \S+ entered promiscuous mode</regex>
+    <regex>\S+ entered promiscuous mode</regex>
     <description>Interface entered in promiscuous(sniffing) mode.</description>
     <mitre>
       <id>T1040</id>


### PR DESCRIPTION
The promiscuous mode kernel message was changed in Linux 6.3 (https://github.com/torvalds/linux/commit/3ba0bf47edf955d6f52fdb16b54acd1932cb9445). This PR updates the promiscuous mode rule to match the new message as well.