### PR TITLE
Fix diff causing false negatives in rootcheck

### DIFF
--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -40,7 +40,7 @@ sudo        !satori|vejeta|conf\.inv!
 crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
-diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^nf]ull|^/bin/.*sh!
+diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^nf]|/dev/[nf][^u]|/dev/[nf]u[^l]|/dev/[nf]ul[^l]|^/bin/.*sh!
 md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!

--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -40,7 +40,7 @@ sudo        !satori|vejeta|conf\.inv!
 crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
-diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^nf]|/dev/[nf][^u]|/dev/[nf]u[^l]|/dev/[nf]ul[^l]|^/bin/.*sh!
+diff        !bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh!
 md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!


### PR DESCRIPTION
# Description 

A user reported "diff" false negatives in rootkit_trojans.txt in 4.10.1
There is an open public issue https://github.com/wazuh/wazuh/issues/27604 which addresses this but it does not have a fix implemented.

Rule will be modified to exempt '/dev/null' and '/dev/full' only. Which means this will match /dev/, /dev/n, /dev/nu, /dev/nul, /dev/f, /dev/fu, /dev/ful as well to prevent false negative,

### Modified Rule
```
diff        !bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh!
```

## Test

```console
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/full
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/fu
/dev/fu
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/f
/dev/f
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/n
/dev/n
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/nu
/dev/nu
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/nul
/dev/nul
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/null
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/
/dev/
[root@server vagrant]# grep -E 'bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh' <<< /dev/ful
/dev/ful
```