### PR TITLE
Fix HPUX are being generated with release stage instead of revision

### DIFF
--- a/packages/hp-ux/generate_wazuh_packages.sh
+++ b/packages/hp-ux/generate_wazuh_packages.sh
@@ -14,7 +14,7 @@ source_directory=/wazuh-sources
 configuration_file="${source_directory}/etc/preloaded-vars.conf"
 target_dir="${current_path}/output/"
 wazuh_version=""
-wazuh_revision="1"
+wazuh_revision=""
 depot_path=""
 control_binary=""
 compute_checksums="no"
@@ -93,7 +93,11 @@ config() {
 
 compute_version_revision() {
     wazuh_version="$(awk -F'"' '/"version"[ \t]*:/ {print $4}' $source_directory/VERSION.json)"
-    wazuh_revision=$(awk -F'"' '/"stage"[ \t]*:/ {print $4}' $source_directory/VERSION.json)
+
+    if [ -z "$wazuh_revision" ]; then
+        stage_value=$(awk -F'"' '/"stage"[ \t]*:/ {print $4}' $source_directory/VERSION.json)
+        wazuh_revision=$(echo "$stage_value" | sed 's/[^0-9]*\([0-9][0-9]*\).*/\1/')
+    fi
 
     # Add commit hash to the VERSION.json file
     short_commit_hash=$(/usr/local/bin/curl -ks "https://api.github.com/repos/wazuh/wazuh/commits/${wazuh_branch}" | awk -F '"' '/"sha":/ {print substr($4, 1, 7); exit}')


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/260|

## Description

This PR changes the revision value used for naming the HP/UX packages. It will now use only the numeric part of the stage value, as taken from VERSION.json.

Also fixed in this PR is using the revision passed as an argument to the HP/UX package generation script, which was previously being ignored.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
