### PR TITLE
Fix multiple checks in RHEL 9, RHEL 10, Rocky Linux 8 and Rocky Linux 9 SCA policies

### DIFF
--- a/ruleset/sca/rhel/10/cis_rhel10_linux.yml
+++ b/ruleset/sca/rhel/10/cis_rhel10_linux.yml
@@ -2437,10 +2437,10 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
       - mitre_techniques: ["T1070", "T1070.002", "T1083"]
       - mitre_tactics: ["TA0007"]
-    condition: all
+    condition: any
     rules:
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0'
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d20|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
 
   # 4.2.1.5 Ensure logging is configured (Manual) - Not implemented
 
@@ -3872,7 +3872,7 @@ checks:
       - mitre_mitigations: ["M1022"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- -> r:\s0 0/root 0/root'
 
   # 6.1.7 Ensure permissions on /etc/gshadow are configured (Automated)
   - id: 28154
@@ -3896,7 +3896,7 @@ checks:
       - mitre_mitigations: ["M1022"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow -> r:\s0 0/root 0/root'
 
   # 6.1.8 Ensure permissions on /etc/gshadow- are configured (Automated)
   - id: 28155
@@ -3920,7 +3920,7 @@ checks:
       - mitre_mitigations: ["M1022"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- -> r:\s0 0/root 0/root'
 
   # 6.1.9 Ensure no world writable files exist (Automated) - Not implemented
   # 6.1.10 Ensure no unowned files or directories exist (Automated) - Not implemented, requires manual operation.

--- a/ruleset/sca/rhel/9/cis_rhel9_linux.yml
+++ b/ruleset/sca/rhel/9/cis_rhel9_linux.yml
@@ -2437,10 +2437,10 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
       - mitre_techniques: ["T1070", "T1070.002", "T1083"]
       - mitre_tactics: ["TA0007"]
-    condition: all
+    condition: any
     rules:
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0'
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d20|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
 
   # 4.2.1.5 Ensure logging is configured (Manual) - Not implemented
 
@@ -3872,7 +3872,7 @@ checks:
       - mitre_mitigations: ["M1022"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/shadow- -> r:\s0 0/root 0/root'
 
   # 6.1.7 Ensure permissions on /etc/gshadow are configured (Automated)
   - id: 28154
@@ -3896,7 +3896,7 @@ checks:
       - mitre_mitigations: ["M1022"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow -> r:\s0 0/root 0/root'
 
   # 6.1.8 Ensure permissions on /etc/gshadow- are configured (Automated)
   - id: 28155
@@ -3920,7 +3920,7 @@ checks:
       - mitre_mitigations: ["M1022"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- ->  r:\s0 0/root 0/root'
+      - 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- -> r:\s0 0/root 0/root'
 
   # 6.1.9 Ensure no world writable files exist (Automated) - Not implemented
   # 6.1.10 Ensure no unowned files or directories exist (Automated) - Not implemented, requires manual operation.

--- a/ruleset/sca/rocky/cis_rocky_linux_8.yml
+++ b/ruleset/sca/rocky/cis_rocky_linux_8.yml
@@ -2786,10 +2786,10 @@ checks:
       - pci_dss_v3.2.1: ["10.2", "10.3", "7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_v4.0: ["1.3.1", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2", "7.1"]
       - soc_2: ["CC5.2", "CC6.1"]
-    condition: all
+    condition: any
     rules:
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0'
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d20|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
 
   # 4.2.1.5 Ensure logging is configured. (Manual) - Not Implemented
   # 4.2.1.6 Ensure rsyslog is configured to send logs to a remote log host. (Manual)

--- a/ruleset/sca/rocky/cis_rocky_linux_9.yml
+++ b/ruleset/sca/rocky/cis_rocky_linux_9.yml
@@ -2600,10 +2600,10 @@ checks:
       - pci_dss_3.2.1: ["10.2", "10.3", "7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_4.0: ["1.3.1", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2", "7.1"]
       - soc_2: ["CC5.2", "CC6.1"]
-    condition: all
+    condition: any
     rules:
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0'
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d20|^\$FileCreateMode 0\d00'
+      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
 
   # 4.2.1.5 Ensure logging is configured. (Manual) - Not Implemented
 


### PR DESCRIPTION
# Description

A customer reported multiple bugs in RHEL 9 and Rocky 9 SCA. The same bug is found in RHEL 10 and Rocky Linux 8.

# Update 

The two identified issues have been reviewed and confirmed as bugs.

This will be addressed as follows:

## RHEL 9 and 10
- Ensure permissions on /etc/gshadow- are configured.

This check is failing currently because of an extra space between -> and r:
Currently
```
- 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- ->  r:\s0 0/root 0/root'
```
Suggested Fix
```
- 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- -> r:\s0 0/root 0/root'
```
- Ensure rsyslog default file permissions configured.
Currently,
```
      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0'
      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d20|^\$FileCreateMode 0\d00'
```

Suggested Fix
```
    condition: any
    rules:
      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
```

## Rocky Linux 8 and 9, RHEL 9 and 10
- Ensure rsyslog default file permissions configured.

Currently,
```
      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0'
      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d20|^\$FileCreateMode 0\d00'
```

Suggested Fix
```
    condition: any
    rules:
      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
```

## SCA Rule Test
- Ensure permissions on /etc/gshadow- are configured. 
### Current rule
```console
2025/04/03 19:16:41 sca[52794] wm_sca.c:1762 at wm_sca_read_command(): DEBUG: Result for ( r:\s0 0/root 0/root)(stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow-) -> 0
2025/04/03 19:16:41 sca[52794] wm_sca.c:1280 at wm_sca_do_scan(): DEBUG: Result for rule 'c:stat -Lc "%n %a %u/%U %g/%G" 
/etc/gshadow- ->  r:\s0 0/root 0/root': 0
2025/04/03 19:16:41 sca[52794] wm_sca.c:1287 at wm_sca_do_scan(): DEBUG: Breaking from rule aggregator 'all' with found = 0
2025/04/03 19:16:41 sca[52794] wm_sca.c:1303 at wm_sca_do_scan(): DEBUG: Result for check id: 6500 'Ensure mounting of cramfs filesystems is disabled.' -> 0
2025/04/03 19:16:41 sca[52794] wm_sca.c:502 at wm_sca_read_files(): DEBUG: Calculating hash for scanned results.
2025/04/03 19:16:41 sca[52794] wm_sca.c:2965 at wm_sca_hash_integrity(): DEBUG: Concatenating check results:
2025/04/03 19:16:41 sca[52794] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6500; Result: 'failed'
2025/04/03 19:16:44 sca[52794] wm_sca.c:2598 at wm_sca_send_summary(): DEBUG: Sending summary event for file: 
```
### Proposed rule
```console
2025/04/03 19:19:43 sca[52857] wm_sca.c:1191 at wm_sca_do_scan(): DEBUG: Command output matched.
2025/04/03 19:19:43 sca[52857] wm_sca.c:1280 at wm_sca_do_scan(): DEBUG: Result for rule 'c:stat -Lc "%n %a %u/%U %g/%G" /etc/gshadow- -> r:\s0 0/root 0/root': 1
2025/04/03 19:19:43 sca[52857] wm_sca.c:1303 at wm_sca_do_scan(): DEBUG: Result for check id: 6500 'Ensure mounting of cramfs filesystems is disabled.' -> 1
2025/04/03 19:19:43 sca[52857] wm_sca.c:502 at wm_sca_read_files(): DEBUG: Calculating hash for scanned results.
2025/04/03 19:19:43 sca[52857] wm_sca.c:2965 at wm_sca_hash_integrity(): DEBUG: Concatenating check results:
2025/04/03 19:19:43 sca[52857] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6500; Result: 'passed'

```

- Ensure rsyslog default file permissions configured.

### Current rule
```console
leCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0': 0
2025/04/03 19:26:04 sca[53212] wm_sca.c:1287 at wm_sca_do_scan(): DEBUG: Breaking from rule aggregator 'all' with found = 0
2025/04/03 19:26:04 sca[53212] wm_sca.c:1303 at wm_sca_do_scan(): DEBUG: Result for check id: 6500 'Ensure mounting of cramfs filesystems is disabled.' -> 0
2025/04/03 19:26:04 sca[53212] wm_sca.c:502 at wm_sca_read_files(): DEBUG: Calculating hash for scanned results.
2025/04/03 19:26:04 sca[53212] wm_sca.c:2965 at wm_sca_hash_integrity(): DEBUG: Concatenating check results:
2025/04/03 19:26:04 sca[53212] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6500; Result: 'failed'
```

### Proposed rule
```console
2025/04/03 19:34:44 sca[53903] wm_sca.c:1280 at wm_sca_do_scan(): DEBUG: Result for rule 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400': 1
2025/04/03 19:34:44 sca[53903] wm_sca.c:1287 at wm_sca_do_scan(): DEBUG: Breaking from rule aggregator 'any' with found = 1
2025/04/03 19:34:44 sca[53903] wm_sca.c:1303 at wm_sca_do_scan(): DEBUG: Result for check id: 6500 'Ensure mounting of cramfs filesystems is disabled.' -> 1
2025/04/03 19:34:44 sca[53903] wm_sca.c:502 at wm_sca_read_files(): DEBUG: Calculating hash for scanned results.
2025/04/03 19:34:44 sca[53903] wm_sca.c:2965 at wm_sca_hash_integrity(): DEBUG: Concatenating check results:
2025/04/03 19:34:44 sca[53903] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 6500; Result: 'passed'
2025/04/03 19:34:47 sca[53903] wm_sca.c:2598 at wm_sca_send_summary(): DEBUG: Sending summary event for file:
```