### PR TITLE
Fix number of the Management API expected child processes 

### DIFF
--- a/apis/tools/env/wazuh-server/wazuh-server.yml
+++ b/apis/tools/env/wazuh-server/wazuh-server.yml
@@ -25,8 +25,12 @@ indexer:
       - /etc/wazuh-server/certs/root-ca.pem
     verify_certificates: true
 communications_api:
-  host: '0.0.0.0'
+  host: 0.0.0.0
+  ssl:
+    key: /etc/wazuh-server/certs/server-key.pem
+    cert: /etc/wazuh-server/certs/server.pem
 management_api:
-  host:
-    - '0.0.0.0'
-    - '::'
+  host: 0.0.0.0
+  ssl:
+    key: /etc/wazuh-server/certs/server-key.pem
+    cert: /etc/wazuh-server/certs/server.pem

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -26,7 +26,7 @@ def test_set_logging():
     import wazuh.core.cluster.utils as cluster_utils
 
     wazuh_server.cluster_utils = cluster_utils
-    with patch.object(cluster_utils, 'ClusterLogger') as clusterlogger_mock:
+    with patch.object(cluster_utils, 'ClusterLogger'):
         assert wazuh_server.set_logging(debug_mode=0)
 
 
@@ -166,7 +166,7 @@ def test_shutdown_daemon(os_getpid_mock, os_kill_mock):
 @pytest.mark.asyncio
 @pytest.mark.parametrize('helper_disabled', (True, False))
 @pytest.mark.skip(reason='This test will be refactored')
-async def test_master_main(helper_disabled: bool):
+async def test_master_main(helper_disabled: bool):  # NOQA
     """Check and set the behavior of master_main function."""
     import wazuh.core.cluster.utils as cluster_utils
 
@@ -232,7 +232,7 @@ async def test_master_main(helper_disabled: bool):
 @pytest.mark.asyncio
 @patch('asyncio.sleep', side_effect=IndexError)
 @pytest.mark.skip(reason='This test will be refactored')
-async def test_worker_main(asyncio_sleep_mock):
+async def test_worker_main(asyncio_sleep_mock):  # NOQA
     """Check and set the behavior of worker_main function."""
     import wazuh.core.cluster.utils as cluster_utils
 
@@ -769,7 +769,7 @@ async def test_monitor_server_daemons(sleep_mock, check_daemon_mock, readiness_m
     readiness_mock.assert_called_once_with(
         process_mock,
         {
-            wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15]: 3,
+            wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15]: 5,
             wazuh_server.COMMS_API_DAEMON_NAME: 8,
             wazuh_server.ENGINE_DAEMON_NAME: 0,
         },
@@ -777,7 +777,7 @@ async def test_monitor_server_daemons(sleep_mock, check_daemon_mock, readiness_m
 
     check_daemon_mock.assert_has_calls(
         [
-            call(proc_list, wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15], 3),
+            call(proc_list, wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15], 5),
             call(proc_list, wazuh_server.COMMS_API_DAEMON_NAME, 8),
             call(proc_list, wazuh_server.ENGINE_DAEMON_NAME, 0),
         ],

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -330,7 +330,7 @@ def get_script_arguments() -> argparse.Namespace:
     return parser
 
 
-def start():
+def start():  # NOQA
     """Start function of the wazuh-server script in charge of starting the server process."""
     try:
         server_pid = pyDaemonModule.get_wazuh_server_pid(SERVER_DAEMON_NAME)
@@ -503,7 +503,7 @@ async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_process: ps
     """
     comms_api_config = CentralizedConfig.get_comms_api_config()
     process_children = {
-        MANAGEMENT_API_DAEMON_NAME[:15]: 3,
+        MANAGEMENT_API_DAEMON_NAME[:15]: 5,
         COMMS_API_DAEMON_NAME: comms_api_config.workers + 4,
         ENGINE_DAEMON_NAME: 0,
     }


### PR DESCRIPTION
|Related issue|
|---|
|#28927|

## Description

This PR closes #28976. Updates the expected number of child processes for the Management API from 3 to 5.

After investigating, the inclusion of the `CommandsManager` (#28621) and `RBACManager` (#28852) were added one child process each.

## Logs/Alerts example

<details><summary>Server Startup</summary>
<p>

```console
root@wazuh-manager:/# /usr/share/wazuh-server/bin/wazuh-server start -r
2025/04/04 19:30:27 INFO: [Cluster] [Main] Starting server (pid: 9252)
2025/04/04 19:30:27 WARNING: [Cluster] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': False, 'wazuh-engined': False}. Sleeping until next checking...
2025/04/04 19:30:28 INFO: [Master] [Main] Configuration server is not available, retrying...
2025/04/04 19:30:28 INFO: [Master] [Config Server] Started server process [9252]
2025/04/04 19:30:28 INFO: [Master] [Config Server] Waiting for application startup.
2025/04/04 19:30:28 INFO: [Master] [Config Server] Application startup complete.
2025/04/04 19:30:28 INFO: [Master] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/04/04 19:30:29 INFO: [Local Server] [Main] Starting wazuh-engined
2025-04-04 19:30:29.031 9271:9271 info: Logging initialized.
2025/04/04 19:30:29 INFO: [Master] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-04-04 19:30:29.035 9271:9271 info: Metrics manager configured successfully
2025-04-04 19:30:29.035 9271:9271 info: Metrics initialized.
2025-04-04 19:30:29.035 9271:9271 info: Metrics disabled.
2025-04-04 19:30:29.035 9271:9271 info: Store initialized.
2025-04-04 19:30:29.036 9271:9271 info: RBAC initialized.
2025-04-04 19:30:29.055 9271:9271 info: KVDB initialized.
2025-04-04 19:30:29.055 9271:9271 info: Geo initialized.
2025-04-04 19:30:29.069 9271:9271 info: Schema initialized.
2025-04-04 19:30:29.080 9271:9271 info: Loaded timezone database version: '2024a'
2025-04-04 19:30:29.081 9271:9271 info: HLP initialized.
2025-04-04 19:30:29.096 9271:9271 info: Indexer Connector initialized.
2025-04-04 19:30:29.096 9271:9271 info: Builder initialized.
2025-04-04 19:30:29.096 9271:9271 info: Catalog initialized.
2025-04-04 19:30:29.096 9271:9271 info: Policy manager initialized.
2025-04-04 19:30:29.097 9271:9271 info: No flooding file provided, the queue will not be flooded.
2025-04-04 19:30:29.105 9271:9271 info: No flooding file provided, the queue will not be flooded.
2025-04-04 19:30:29.105 9271:9271 warning: Router: router/router/0 table is empty
2025-04-04 19:30:29.105 9271:9271 warning: Router: router/tester/0 table is empty
2025-04-04 19:30:29.105 9271:9271 info: Router initialized.
2025-04-04 19:30:29.112 9271:9271 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-04-04 19:30:29.113 9271:9271 info: Server API_SRV started in thread 133915369014976 at /run/wazuh-server/engine-api.socket
2025-04-04 19:30:29.113 9271:9271 info: Starting server EVENT_SRV at /run/wazuh-server/engine.socket
2025/04/04 19:30:31 INFO: [Local Server] [Main] Started wazuh-engined (pid: 9271)
2025/04/04 19:30:31 INFO: [Local Server] [Main] Starting wazuh-comms-apid
2025/04/04 19:30:32 INFO: [Communications API] Starting API as root
2025/04/04 19:30:32 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/04/04 19:30:32 INFO: [Communications API] Starting gunicorn 22.0.0
2025/04/04 19:30:32 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (9373)
2025/04/04 19:30:32 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/04/04 19:30:32 INFO: [Communications API] Booting worker with pid: 9409
2025/04/04 19:30:32 INFO: [Communications API] Started server process [9373]
2025/04/04 19:30:32 INFO: [Communications API] Waiting for application startup.
2025/04/04 19:30:32 INFO: [Communications API] Application startup complete.
2025/04/04 19:30:32 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/04/04 19:30:32 INFO: [Communications API] Booting worker with pid: 9410
2025/04/04 19:30:32 INFO: [Communications API] Started server process [9410]
2025/04/04 19:30:32 INFO: [Communications API] Waiting for application startup.
2025/04/04 19:30:32 INFO: [Communications API] Application startup complete.
2025/04/04 19:30:32 INFO: [Communications API] Booting worker with pid: 9411
2025/04/04 19:30:32 INFO: [Communications API] Started server process [9411]
2025/04/04 19:30:32 INFO: [Communications API] Waiting for application startup.
2025/04/04 19:30:32 INFO: [Communications API] Application startup complete.
2025/04/04 19:30:32 INFO: [Communications API] Booting worker with pid: 9412
2025/04/04 19:30:32 INFO: [Communications API] Started server process [9412]
2025/04/04 19:30:32 INFO: [Communications API] Waiting for application startup.
2025/04/04 19:30:32 INFO: [Communications API] Application startup complete.
2025/04/04 19:30:32 INFO: [Communications API] Handling signal: winch
2025/04/04 19:30:32 INFO: [Communications API] Handling signal: winch
2025/04/04 19:30:33 INFO: [Local Server] [Main] Started wazuh-comms-apid (pid: 9373)
2025/04/04 19:30:33 INFO: [Local Server] [Main] Starting wazuh-server-management-apid
2025/04/04 19:30:34 INFO: [Management API] Starting API as root
2025/04/04 19:30:34 INFO: [Management API] Checking RBAC database integrity...
2025/04/04 19:30:34 INFO: [Management API] /var/lib/wazuh-server/rbac.db file was detected
2025/04/04 19:30:34 INFO: [Management API] RBAC database integrity check finished successfully
2025/04/04 19:30:35 INFO: [Local Server] [Main] Started wazuh-server-management-apid (pid: 9413)
2025/04/04 19:30:35 INFO: [Local Server] [Main] Serving on /run/wazuh-server/local-server.sock
2025/04/04 19:30:35 INFO: [Master] [Main] Serving on ('0.0.0.0', 1516)
2025/04/04 19:30:35 INFO: [Master] [Local integrity] Starting.
2025/04/04 19:30:35 INFO: [Master] [Local integrity] Finished in 0.002s. Calculated metadata of 0 files.
2025/04/04 19:30:35 INFO: [Management API] Updating RBAC information
2025/04/04 19:30:35 INFO: [Management API] Listening on 0.0.0.0:55000.
2025/04/04 19:30:35 INFO: [Management API] Getting installation UID...
2025/04/04 19:30:35 INFO: [Management API] Getting updates information...
2025/04/04 19:30:37 INFO: [Cluster] [Main] Getting orders from indexer
```

</p>
</details> 

<details><summary>Processes List</summary>
<p>

```console
root@wazuh-manager:/# ps auxf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root        9229  0.0  0.0   4588  3840 pts/1    SNs  19:30   0:00 bash
root        9473  0.0  0.0   7888  3968 pts/1    RN+  19:30   0:00  \_ ps auxf
root           1  0.0  0.0   4588  3456 pts/0    SNs  18:33   0:00 bash
root        9250  0.0  0.0   2800  1792 pts/0    SN+  19:30   0:00 /bin/sh /usr/share/wazuh-server/bin/wazuh-server start -r
root        9252 11.9  0.4 388824 102132 pts/0   SNl+ 19:30   0:01  \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/framework/scripts/wazuh-server.py start -r
root        9267  0.0  0.3 241360 84868 pts/0    SN+  19:30   0:00      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/framework/scripts/wazuh-server.py start -r
root        9268  0.0  0.3 241360 84868 pts/0    SN+  19:30   0:00      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/framework/scripts/wazuh-server.py start -r
root        9271  0.6  0.2 2229320 50432 pts/0   SNl+ 19:30   0:00      \_ /usr/share/wazuh-server/bin/wazuh-engine server -l info start
root        9373 19.7  0.4 234944 95744 pts/0    SNl+ 19:30   0:01      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9374  4.7  0.3 600036 74884 pts/0    SNl+ 19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9391  0.0  0.3 157664 73008 pts/0    SN+  19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9393  3.4  0.3 157664 74416 pts/0    SN+  19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9397  0.0  0.3 305128 74032 pts/0    SNl+ 19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9409  0.0  0.3 235196 80156 pts/0    SN+  19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9410  0.0  0.3 235216 81368 pts/0    SN+  19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9411  0.0  0.3 235216 81368 pts/0    SN+  19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9412  0.0  0.3 235216 81372 pts/0    SN+  19:30   0:00      |   \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py -r
root        9413 52.9  0.5 1009336 122724 pts/0  SNl+ 19:30   0:02      \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py -r
root        9426  0.0  0.3 178288 88048 pts/0    SN+  19:30   0:00          \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py -r
root        9429  0.0  0.3 325752 88228 pts/0    SN+  19:30   0:00          \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py -r
root        9432  0.0  0.3 473216 88320 pts/0    SN+  19:30   0:00          \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py -r
root        9435  0.0  0.3 612484 90328 pts/0    SNl+ 19:30   0:00          \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py -r
root        9449  0.0  0.3 612484 89968 pts/0    SNl+ 19:30   0:00          \_ /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py -r
```

</p>
</details> 

Also, I noted that when the server receives `SIGTERM`, there are some unhandled exceptions related to the cluster. Given that there aren't any functional implications, it's not worth fixing that now since we are removing the cluster.
