### PR TITLE
Fixed mix same/diff - static & dinamic rule option

### DIFF
--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -43,13 +43,18 @@ size_t field_offset[] = {
 };
 
 
-// Function to check for repetitions from same fields
+// Function to check for repetitions from same static fields
 
 bool same_loop(RuleInfo *rule, Eventinfo *lf, Eventinfo *my_lf) {
+
+    if ((rule->same_field & ALL_FIELDS) == 0x0) {
+        return TRUE; // No need to check anything
+    }
+
     int i;
     u_int32_t same = rule->same_field >> 2;
 
-    for (i = 2; same != 0; i++) {
+    for (i = 2; same != 0 && i < N_FIELDS; i++) {
         if ((same & 1) == 1) {
             char * field1 = *(char **)((void *)lf + field_offset[i]);
             char * field2 = *(char **)((void *)my_lf + field_offset[i]);
@@ -63,13 +68,18 @@ bool same_loop(RuleInfo *rule, Eventinfo *lf, Eventinfo *my_lf) {
     return TRUE;
 }
 
-// Function to check for repetitions from different fields
+// Function to check for repetitions from different static fields
 
 bool different_loop(RuleInfo *rule, Eventinfo *lf, Eventinfo *my_lf) {
+
+    if ((rule->different_field & ALL_FIELDS) == 0x0) {
+        return TRUE; // No need to check anything
+    }
+
     int i;
     u_int32_t different = rule->different_field;
 
-    for (i = 0; different != 0; i++) {
+    for (i = 0; different != 0 && i < N_FIELDS; i++) {
         if ((different & 1) == 1) {
             char * field1 = *(char **)((void *)lf + field_offset[i]);
             char * field2 = *(char **)((void *)my_lf + field_offset[i]);

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -39,6 +39,7 @@
 #define FIELD_DSTGEOIP   0x8000
 #define FIELD_LOCATION   0x10000
 #define N_FIELDS         17
+#define ALL_FIELDS       ((1U << N_FIELDS) - 1) /* All merged fields 0x1FFFF */
 
 #define FIELD_DYNAMICS   0x20000
 #define FIELD_AGENT      0x40000

--- a/src/unit_tests/analysisd/test_same_different_loop.c
+++ b/src/unit_tests/analysisd/test_same_different_loop.c
@@ -152,11 +152,36 @@ void test_different(void **state)
     os_free(different_lf);
 }
 
+
+void test_static_out_of_bound(void **state)
+{
+    (void) state;
+    bool ret;
+    RuleInfo *rule = state[0];
+    Eventinfo *lf = state[1];
+    Eventinfo *same_lf = state[2];
+    Eventinfo *different_lf = state[3];
+    rule->different_field = 0b1 << N_FIELDS;
+
+    ret = different_loop(rule, lf, same_lf);
+    assert_true(ret); // Nothing to compare, return true
+
+    ret = same_loop(rule, lf, different_lf);
+    assert_true(ret);
+
+
+    os_free(rule);
+    os_free(lf);
+    os_free(same_lf);
+    os_free(different_lf);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         /* Tests for same loop function */
         cmocka_unit_test_setup(test_same, testSetup),
-        cmocka_unit_test_setup(test_different, testSetup)
+        cmocka_unit_test_setup(test_different, testSetup),
+        cmocka_unit_test_setup(test_static_out_of_bound, testSetup),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Closes #28871

## Description

This PR fixes the memory problem when a rule mixes same_static fields with diff_dinamic fields or diff_static with same_dinamic.

## Tests

[scan-build-2025-04-04-191158-173858-1.zip](https://github.com/user-attachments/files/19609837/scan-build-2025-04-04-191158-173858-1.zip)



<details><summary>runtest.py</summary>

```
╰─# python2 ./runtests.py   
- [ File = ./tests/apparmor.ini ] ---------
.....


- [ File = ./tests/squid_rules.ini ] ---------
..


- [ File = ./tests/pfsense.ini ] ---------
..


- [ File = ./tests/win-generic_rules.ini ] ---------
.


- [ File = ./tests/huawei_usg.ini ] ---------
...


- [ File = ./tests/test_osmatch_regex.ini ] ---------
......


- [ File = ./tests/fortiddos.ini ] ---------
...


- [ File = ./tests/f5_big_ip.ini ] ---------
................................................


- [ File = ./tests/cisco_ios.ini ] ---------
.................


- [ File = ./tests/systemd.ini ] ---------
..


- [ File = ./tests/macos.ini ] ---------
...........


- [ File = ./tests/amazon_sec_lake.ini ] ---------
....................


- [ File = ./tests/glpi.ini ] ---------
...


- [ File = ./tests/pix.ini ] ---------
......................


- [ File = ./tests/sysmon_eid_3.ini ] ---------
..........


- [ File = ./tests/cisco_asa.ini ] ---------
....................................................................................... .


- [ File = ./tests/sysmon_eid_20.ini ] ---------
 ..


- [ File = ./tests/firewalld.ini ] ---------
..


- [ File = ./tests/dovecot.ini ] ---------
...............


- [ File = ./tests/doas.ini ] ---------
....


- [ File = ./tests/test_static_filters.ini ] ---------
............................


- [ File = ./tests/cpanel.ini ] ---------
.......


- [ File = ./tests/office365.ini ] ---------
................................................................................................................................


- [ File = ./tests/web_appsec.ini ] ---------
...............................


- [ File = ./tests/cisco_ftd.ini ] ---------
..........................................


- [ File = ./tests/sophos_fw.ini ] ---------
..........


- [ File = ./tests/test_pcre2_regex.ini ] ---------
.................................


- [ File = ./tests/sysmon.ini ] ---------
.........................


- [ File = ./tests/fortiauth.ini ] ---------
....


- [ File = ./tests/web_rules.ini ] ---------
..........


- [ File = ./tests/win_application.ini ] ---------



- [ File = ./tests/win_security.ini ] ---------
.........


- [ File = ./tests/modsecurity.ini ] ---------
......


- [ File = ./tests/named.ini ] ---------
.....


- [ File = ./tests/sysmon_eid_7.ini ] ---------
......


- [ File = ./tests/sudo.ini ] ---------
........


- [ File = ./tests/aws_security_hub.ini ] ---------
.........................


- [ File = ./tests/audit_scp.ini ] ---------
........


- [ File = ./tests/mailscanner.ini ] ---------
.


- [ File = ./tests/apache.ini ] ---------
............


- [ File = ./tests/vsftpd.ini ] ---------
....


- [ File = ./tests/rsh.ini ] ---------
..


- [ File = ./tests/overwrite.ini ] ---------
..........


- [ File = ./tests/sysmon_eid_10.ini ] ---------
....


- [ File = ./tests/gcp.ini ] ---------
...............................


- [ File = ./tests/unbound.ini ] ---------



- [ File = ./tests/proftpd.ini ] ---------
.......


- [ File = ./tests/checkpoint_smart1.ini ] ---------
..................


- [ File = ./tests/vuln_detector.ini ] ---------
..


- [ File = ./tests/test_features.ini ] ---------
.......


- [ File = ./tests/sysmon_eid_1.ini ] ---------
...............................................................


- [ File = ./tests/owlh.ini ] ---------
....


- [ File = ./tests/junos.ini ] ---------
...


- [ File = ./tests/github.ini ] ---------
....................................................................................................................................................................................................................................................................................................................................


- [ File = ./tests/samba.ini ] ---------
....


- [ File = ./tests/eset.ini ] ---------
........


- [ File = ./tests/ossec.ini ] ---------
.....


- [ File = ./tests/openldap.ini ] ---------
.........


- [ File = ./tests/cimserver.ini ] ---------
..


- [ File = ./tests/dropbear.ini ] ---------
...


- [ File = ./tests/opensmtpd.ini ] ---------
.......


- [ File = ./tests/windows_baseline_intrusion_detection.ini ] ---------
.............................


- [ File = ./tests/syslog.ini ] ---------
......


- [ File = ./tests/test_osregex_regex.ini ] ---------
............................


- [ File = ./tests/nextcloud.ini ] ---------
........


- [ File = ./tests/panda_paps.ini ] ---------
........


- [ File = ./tests/su.ini ] ---------
.....


- [ File = ./tests/sysmon_eid_8.ini ] ---------
....


- [ File = ./tests/SonicWall.ini ] ---------
...........


- [ File = ./tests/pam.ini ] ---------
.....


- [ File = ./tests/aws_s3_access.ini ] ---------
..........


- [ File = ./tests/fortigate.ini ] ---------
.............................................


- [ File = ./tests/powershell.ini ] ---------
................................


- [ File = ./tests/arbor.ini ] ---------
..


- [ File = ./tests/test_expr_negation.ini ] ---------
........................................................


- [ File = ./tests/api.ini ] ---------
.....................


- [ File = ./tests/fireeye.ini ] ---------
...


- [ File = ./tests/mcafee_epo.ini ] ---------
.


- [ File = ./tests/openvpn_ldap.ini ] ---------
..


- [ File = ./tests/oscap.ini ] ---------
................................


- [ File = ./tests/sysmon_eid_13.ini ] ---------
.........


- [ File = ./tests/php.ini ] ---------
..


- [ File = ./tests/fortimail.ini ] ---------
......


- [ File = ./tests/auditd.ini ] ---------
...............................


- [ File = ./tests/win_event_channel.ini ] ---------
........


- [ File = ./tests/sysmon_eid_11.ini ] ---------
............................


- [ File = ./tests/paloalto.ini ] ---------
................


- [ File = ./tests/cloudflare-waf.ini ] ---------
.............


- [ File = ./tests/postfix.ini ] ---------
..


- [ File = ./tests/freepbx.ini ] ---------
......


- [ File = ./tests/iptables.ini ] ---------
.........


- [ File = ./tests/kernel_usb.ini ] ---------
......


- [ File = ./tests/exim.ini ] ---------
.......


- [ File = ./tests/sophos.ini ] ---------
........


- [ File = ./tests/sshd.ini ] ---------
.................................................


- [ File = ./tests/nginx.ini ] ---------
............


- [ File = ./tests/gitlab.ini ] ---------
...........................


- [ File = ./tests/exchange.ini ] ---------
..


- [ File = ./tests/netscreen.ini ] ---------
....


|Component |  Tested  |  Total   | Coverage |
| -------- | -------- | -------- | -------- |
|  Rules   |   1442   |   4492   |  32.10%  |
| Decoders |   125    |   171    |  73.10%  |


|          File           |  Passed  |  Failed  |  Status  |
|        --------         | -------- | -------- | -------- |
|./tests/proftpd.ini      |    7     |    0     |   ✅    |
|./tests/exim.ini         |    7     |    0     |   ✅    |
|./tests/squid_rules.ini  |    2     |    0     |   ✅    |
|./tests/sysmon_eid_3.ini |    10    |    0     |   ✅    |
|./tests/amazon_sec_lake.ini|    20    |    0     |   ✅    |
|./tests/checkpoint_smart1.ini|    18    |    0     |   ✅    |
|./tests/iptables.ini     |    9     |    0     |   ✅    |
|./tests/sysmon_eid_10.ini|    4     |    0     |   ✅    |
|./tests/SonicWall.ini    |    11    |    0     |   ✅    |
|./tests/panda_paps.ini   |    8     |    0     |   ✅    |
|./tests/fortiauth.ini    |    4     |    0     |   ✅    |
|./tests/openldap.ini     |    9     |    0     |   ✅    |
|./tests/f5_big_ip.ini    |    48    |    0     |   ✅    |
|./tests/sophos.ini       |    8     |    0     |   ✅    |
|./tests/opensmtpd.ini    |    7     |    0     |   ✅    |
|./tests/netscreen.ini    |    4     |    0     |   ✅    |
|./tests/rsh.ini          |    2     |    0     |   ✅    |
|./tests/arbor.ini        |    2     |    0     |   ✅    |
|./tests/web_rules.ini    |    10    |    0     |   ✅    |
|./tests/exchange.ini     |    2     |    0     |   ✅    |
|./tests/vuln_detector.ini|    2     |    0     |   ✅    |
|./tests/win-generic_rules.ini|    1     |    0     |   ✅    |
|./tests/sysmon_eid_7.ini |    6     |    0     |   ✅    |
|./tests/macos.ini        |    11    |    0     |   ✅    |
|./tests/samba.ini        |    4     |    0     |   ✅    |
|./tests/apparmor.ini     |    5     |    0     |   ✅    |
|./tests/test_osmatch_regex.ini|    6     |    0     |   ✅    |
|./tests/test_features.ini|    7     |    0     |   ✅    |
|./tests/aws_security_hub.ini|    25    |    0     |   ✅    |
|./tests/pam.ini          |    5     |    0     |   ✅    |
|./tests/apache.ini       |    12    |    0     |   ✅    |
|./tests/fireeye.ini      |    3     |    0     |   ✅    |
|./tests/sysmon.ini       |    25    |    0     |   ✅    |
|./tests/dovecot.ini      |    15    |    0     |   ✅    |
|./tests/nginx.ini        |    12    |    0     |   ✅    |
|./tests/nextcloud.ini    |    8     |    0     |   ✅    |
|./tests/unbound.ini      |    0     |    0     |   ✅    |
|./tests/paloalto.ini     |    16    |    0     |   ✅    |
|./tests/sysmon_eid_13.ini|    9     |    0     |   ✅    |
|./tests/ossec.ini        |    5     |    0     |   ✅    |
|./tests/test_osregex_regex.ini|    28    |    0     |   ✅    |
|./tests/cisco_ftd.ini    |    42    |    0     |   ✅    |
|./tests/sysmon_eid_1.ini |    63    |    0     |   ✅    |
|./tests/github.ini       |   324    |    0     |   ✅    |
|./tests/gitlab.ini       |    27    |    0     |   ✅    |
|./tests/fortimail.ini    |    6     |    0     |   ✅    |
|./tests/named.ini        |    5     |    0     |   ✅    |
|./tests/powershell.ini   |    32    |    0     |   ✅    |
|./tests/openvpn_ldap.ini |    2     |    0     |   ✅    |
|./tests/sysmon_eid_8.ini |    4     |    0     |   ✅    |
|./tests/cloudflare-waf.ini|    13    |    0     |   ✅    |
|./tests/huawei_usg.ini   |    3     |    0     |   ✅    |
|./tests/eset.ini         |    8     |    0     |   ✅    |
|./tests/test_expr_negation.ini|    56    |    0     |   ✅    |
|./tests/gcp.ini          |    31    |    0     |   ✅    |
|./tests/cpanel.ini       |    7     |    0     |   ✅    |
|./tests/pfsense.ini      |    2     |    0     |   ✅    |
|./tests/cisco_asa.ini    |    88    |    0     |   ✅    |
|./tests/systemd.ini      |    2     |    0     |   ✅    |
|./tests/web_appsec.ini   |    31    |    0     |   ✅    |
|./tests/sysmon_eid_11.ini|    28    |    0     |   ✅    |
|./tests/cisco_ios.ini    |    17    |    0     |   ✅    |
|./tests/pix.ini          |    22    |    0     |   ✅    |
|./tests/php.ini          |    2     |    0     |   ✅    |
|./tests/office365.ini    |   128    |    0     |   ✅    |
|./tests/fortigate.ini    |    45    |    0     |   ✅    |
|./tests/postfix.ini      |    2     |    0     |   ✅    |
|./tests/audit_scp.ini    |    8     |    0     |   ✅    |
|./tests/win_application.ini|    0     |    0     |   ✅    |
|./tests/fortiddos.ini    |    3     |    0     |   ✅    |
|./tests/cimserver.ini    |    2     |    0     |   ✅    |
|./tests/freepbx.ini      |    6     |    0     |   ✅    |
|./tests/overwrite.ini    |    10    |    0     |   ✅    |
|./tests/sshd.ini         |    49    |    0     |   ✅    |
|./tests/test_pcre2_regex.ini|    33    |    0     |   ✅    |
|./tests/windows_baseline_intrusion_detection.ini|    29    |    0     |   ✅    |
|./tests/glpi.ini         |    3     |    0     |   ✅    |
|./tests/api.ini          |    21    |    0     |   ✅    |
|./tests/dropbear.ini     |    3     |    0     |   ✅    |
|./tests/win_security.ini |    9     |    0     |   ✅    |
|./tests/firewalld.ini    |    2     |    0     |   ✅    |
|./tests/mailscanner.ini  |    1     |    0     |   ✅    |
|./tests/owlh.ini         |    4     |    0     |   ✅    |
|./tests/sysmon_eid_20.ini|    2     |    0     |   ✅    |
|./tests/auditd.ini       |    31    |    0     |   ✅    |
|./tests/mcafee_epo.ini   |    1     |    0     |   ✅    |
|./tests/doas.ini         |    4     |    0     |   ✅    |
|./tests/junos.ini        |    3     |    0     |   ✅    |
|./tests/sudo.ini         |    8     |    0     |   ✅    |
|./tests/syslog.ini       |    6     |    0     |   ✅    |
|./tests/sophos_fw.ini    |    10    |    0     |   ✅    |
|./tests/vsftpd.ini       |    4     |    0     |   ✅    |
|./tests/win_event_channel.ini|    8     |    0     |   ✅    |
|./tests/modsecurity.ini  |    6     |    0     |   ✅    |
|./tests/su.ini           |    5     |    0     |   ✅    |
|./tests/kernel_usb.ini   |    6     |    0     |   ✅    |
|./tests/aws_s3_access.ini|    10    |    0     |   ✅    |
|./tests/test_static_filters.ini|    28    |    0     |   ✅    |
|./tests/oscap.ini        |    32    |    0     |   ✅    |

```

</details>




<details><summary>Unit test</summary>


```bash
╰─# ctest                                                
Test project /workspaces/wazuh-manager-4.x/src/unit_tests/build
        Start   1: test_analysisd_syscheck
  1/178 Test   #1: test_analysisd_syscheck .................................   Passed    0.04 sec
        Start   2: test_cleanevent
  2/178 Test   #2: test_cleanevent .........................................   Passed    0.03 sec
        Start   3: test_dbsync
  3/178 Test   #3: test_dbsync .............................................   Passed    0.03 sec
        Start   4: test_exec
  4/178 Test   #4: test_exec ...............................................   Passed    0.03 sec
        Start   5: test_log
  5/178 Test   #5: test_log ................................................   Passed    0.03 sec
        Start   6: test_labels
  6/178 Test   #6: test_labels .............................................   Passed    0.04 sec
        Start   7: test_mitre
  7/178 Test   #7: test_mitre ..............................................   Passed    0.02 sec
        Start   8: test_rules
  8/178 Test   #8: test_rules ..............................................   Passed    0.03 sec
        Start   9: test_same_different_loop
  9/178 Test   #9: test_same_different_loop ................................   Passed    0.03 sec
        Start  10: test_logtest
 10/178 Test  #10: test_logtest ............................................   Passed    0.03 sec
        Start  11: test_logtest-config
 11/178 Test  #11: test_logtest-config .....................................   Passed    0.02 sec
        Start  12: test_decoder_list
 12/178 Test  #12: test_decoder_list .......................................   Passed    0.02 sec
        Start  13: test_decode-xml
 13/178 Test  #13: test_decode-xml .........................................   Passed    0.03 sec
        Start  14: test_lists_list
 14/178 Test  #14: test_lists_list .........................................   Passed    0.02 sec
        Start  15: test_rule_list
 15/178 Test  #15: test_rule_list ..........................................   Passed    0.02 sec
        Start  16: test_eventinfo_list
 16/178 Test  #16: test_eventinfo_list .....................................   Passed    0.02 sec
        Start  17: test_logmsg
 17/178 Test  #17: test_logmsg .............................................   Passed    0.02 sec
        Start  18: test_decoder_rootcheck
 18/178 Test  #18: test_decoder_rootcheck ..................................   Passed    0.03 sec
        Start  19: test_decoder_syscollector
 19/178 Test  #19: test_decoder_syscollector ...............................   Passed    0.04 sec
        Start  20: test_decoder_winevtchannel
 20/178 Test  #20: test_decoder_winevtchannel ..............................   Passed    0.03 sec
        Start  21: test_decoder_winevtchannel_input
 21/178 Test  #21: test_decoder_winevtchannel_input ........................   Passed    0.03 sec
        Start  22: test_analysis-state
 22/178 Test  #22: test_analysis-state .....................................   Passed    0.03 sec
        Start  23: test_asyscom
 23/178 Test  #23: test_asyscom ............................................   Passed    0.03 sec
        Start  24: test_limits
 24/178 Test  #24: test_limits .............................................   Passed    0.01 sec
        Start  25: test_manager
 25/178 Test  #25: test_manager ............................................   Passed    0.03 sec
        Start  26: test_secure
 26/178 Test  #26: test_secure .............................................   Passed    0.03 sec
        Start  27: test_netbuffer
 27/178 Test  #27: test_netbuffer ..........................................   Passed    0.03 sec
        Start  28: test_sendmsg
 28/178 Test  #28: test_sendmsg ............................................   Passed    0.04 sec
        Start  29: test_remote-config
 29/178 Test  #29: test_remote-config ......................................   Passed    0.02 sec
        Start  30: test_syslogtcp
 30/178 Test  #30: test_syslogtcp ..........................................   Passed    0.02 sec
        Start  31: test_remote-state
 31/178 Test  #31: test_remote-state .......................................   Passed    0.02 sec
        Start  32: test_remcom
 32/178 Test  #32: test_remcom .............................................   Passed    0.03 sec
        Start  33: test_wdb_integrity
 33/178 Test  #33: test_wdb_integrity ......................................   Passed    0.02 sec
        Start  34: test_wdb_fim
 34/178 Test  #34: test_wdb_fim ............................................   Passed    0.02 sec
        Start  35: test_wdb_parser
 35/178 Test  #35: test_wdb_parser .........................................   Passed    0.03 sec
        Start  36: test_wdb_global_parser
 36/178 Test  #36: test_wdb_global_parser ..................................   Passed    0.04 sec
        Start  37: test_wdb_global
 37/178 Test  #37: test_wdb_global .........................................   Passed    0.14 sec
        Start  38: test_wdb_agents
 38/178 Test  #38: test_wdb_agents .........................................   Passed    0.01 sec
        Start  39: test_wdb_global_helpers
 39/178 Test  #39: test_wdb_global_helpers .................................   Passed    0.02 sec
        Start  40: test_wdb_agents_helpers
 40/178 Test  #40: test_wdb_agents_helpers .................................   Passed    0.02 sec
        Start  41: test_wdb
 41/178 Test  #41: test_wdb ................................................   Passed    0.02 sec
        Start  42: test_wdb_upgrade
 42/178 Test  #42: test_wdb_upgrade ........................................   Passed    0.01 sec
        Start  43: test_wdb_metadata
 43/178 Test  #43: test_wdb_metadata .......................................   Passed    0.01 sec
        Start  44: test_wdb_task_parser
 44/178 Test  #44: test_wdb_task_parser ....................................   Passed    0.01 sec
        Start  45: test_wdb_rootcheck
 45/178 Test  #45: test_wdb_rootcheck ......................................   Passed    0.02 sec
        Start  46: test_wdb_syscollector
 46/178 Test  #46: test_wdb_syscollector ...................................   Passed    0.02 sec
        Start  47: test_wdb_task
 47/178 Test  #47: test_wdb_task ...........................................   Passed    0.02 sec
        Start  48: test_wdb_delta_event
 48/178 Test  #48: test_wdb_delta_event ....................................   Passed    0.03 sec
        Start  49: test_wazuh_db-config
 49/178 Test  #49: test_wazuh_db-config ....................................   Passed    0.02 sec
        Start  50: test_wazuh_db_state
 50/178 Test  #50: test_wazuh_db_state .....................................   Passed    0.03 sec
        Start  51: test_wdb_com
 51/178 Test  #51: test_wdb_com ............................................   Passed    0.02 sec
        Start  52: test_wdb_pool
 52/178 Test  #52: test_wdb_pool ...........................................   Passed    0.02 sec
        Start  53: test_create_agent_db
 53/178 Test  #53: test_create_agent_db ....................................   Passed    0.02 sec
        Start  54: test_auth_parse
 54/178 Test  #54: test_auth_parse .........................................   Passed    0.02 sec
        Start  55: test_auth_validate
 55/178 Test  #55: test_auth_validate ......................................   Passed    0.03 sec
        Start  56: test_auth_add
 56/178 Test  #56: test_auth_add ...........................................   Passed    0.03 sec
        Start  57: test_ssl
 57/178 Test  #57: test_ssl ................................................   Passed    0.01 sec
        Start  58: test_auth_key_request
 58/178 Test  #58: test_auth_key_request ...................................   Passed    0.03 sec
        Start  59: test_auth
 59/178 Test  #59: test_auth ...............................................   Passed    0.03 sec
        Start  60: test_generate_cert
 60/178 Test  #60: test_generate_cert ......................................   Passed    1.29 sec
        Start  61: test_authd-config
 61/178 Test  #61: test_authd-config .......................................   Passed    0.01 sec
        Start  62: test_aes_op
 62/178 Test  #62: test_aes_op .............................................   Passed    0.01 sec
        Start  63: test_hmac_op
 63/178 Test  #63: test_hmac_op ............................................   Passed    0.02 sec
        Start  64: test_msgs
 64/178 Test  #64: test_msgs ...............................................   Passed    0.02 sec
        Start  65: test_keys
 65/178 Test  #65: test_keys ...............................................   Passed    0.03 sec
        Start  66: test_sha1_op
 66/178 Test  #66: test_sha1_op ............................................   Passed    0.02 sec
        Start  67: test_blowfish_op
 67/178 Test  #67: test_blowfish_op ........................................   Passed    0.02 sec
        Start  68: test_md5_op
 68/178 Test  #68: test_md5_op .............................................   Passed    0.02 sec
        Start  69: test_md5_sha1_op
 69/178 Test  #69: test_md5_sha1_op ........................................   Passed    0.03 sec
        Start  70: test_md5_sha1_sha256_op
 70/178 Test  #70: test_md5_sha1_sha256_op .................................   Passed    0.03 sec
        Start  71: test_sha256_op
 71/178 Test  #71: test_sha256_op ..........................................   Passed    0.03 sec
        Start  72: test_sha512_op
 72/178 Test  #72: test_sha512_op ..........................................   Passed    0.03 sec
        Start  73: test_wm_aws
 73/178 Test  #73: test_wm_aws .............................................   Passed    0.03 sec
        Start  74: test_wm_azure
 74/178 Test  #74: test_wm_azure ...........................................   Passed    0.02 sec
        Start  75: test_wm_ciscat
 75/178 Test  #75: test_wm_ciscat ..........................................   Passed    0.02 sec
        Start  76: test_wm_command
 76/178 Test  #76: test_wm_command .........................................   Passed    0.03 sec
        Start  77: test_wm_database
 77/178 Test  #77: test_wm_database ........................................   Passed    0.02 sec
        Start  78: test_wm_docker
 78/178 Test  #78: test_wm_docker ..........................................   Passed    0.03 sec
        Start  79: test_wm_gcp
 79/178 Test  #79: test_wm_gcp .............................................   Passed    0.15 sec
        Start  80: test_wmodules_gcp
 80/178 Test  #80: test_wmodules_gcp .......................................   Passed    0.04 sec
        Start  81: test_wm_oscap
 81/178 Test  #81: test_wm_oscap ...........................................   Passed    0.02 sec
        Start  82: test_wm_sca
 82/178 Test  #82: test_wm_sca .............................................   Passed    0.02 sec
        Start  83: test_wmodules_scheduling
 83/178 Test  #83: test_wmodules_scheduling ................................   Passed    0.02 sec
        Start  84: test_wm_vulnerability_detection
 84/178 Test  #84: test_wm_vulnerability_detection .........................   Passed    0.04 sec
        Start  85: test_wm_task_manager
 85/178 Test  #85: test_wm_task_manager ....................................   Passed    0.03 sec
        Start  86: test_wm_task_manager_parsing
 86/178 Test  #86: test_wm_task_manager_parsing ............................   Passed    0.02 sec
        Start  87: test_wm_task_manager_commands
 87/178 Test  #87: test_wm_task_manager_commands ...........................   Passed    0.02 sec
        Start  88: test_wm_agent_upgrade
 88/178 Test  #88: test_wm_agent_upgrade ...................................   Passed    0.02 sec
        Start  89: test_wm_agent_upgrade_manager
 89/178 Test  #89: test_wm_agent_upgrade_manager ...........................   Passed    0.04 sec
        Start  90: test_wm_agent_upgrade_parsing
 90/178 Test  #90: test_wm_agent_upgrade_parsing ...........................   Passed    0.03 sec
        Start  91: test_wm_agent_upgrade_validate
 91/178 Test  #91: test_wm_agent_upgrade_validate ..........................   Passed    0.02 sec
        Start  92: test_wm_agent_upgrade_tasks
 92/178 Test  #92: test_wm_agent_upgrade_tasks .............................   Passed    0.02 sec
        Start  93: test_wm_agent_upgrade_tasks_callbacks
 93/178 Test  #93: test_wm_agent_upgrade_tasks_callbacks ...................   Passed    0.03 sec
        Start  94: test_wm_agent_upgrade_commands
 94/178 Test  #94: test_wm_agent_upgrade_commands ..........................   Passed    0.02 sec
        Start  95: test_wm_agent_upgrade_upgrades
 95/178 Test  #95: test_wm_agent_upgrade_upgrades ..........................   Passed    0.03 sec
        Start  96: test_wmodules
 96/178 Test  #96: test_wmodules ...........................................   Passed    0.02 sec
        Start  97: test_wm_control
 97/178 Test  #97: test_wm_control .........................................   Passed    0.02 sec
        Start  98: test_wm_github
 98/178 Test  #98: test_wm_github ..........................................   Passed    0.03 sec
        Start  99: test_wm_office365
 99/178 Test  #99: test_wm_office365 .......................................   Passed    0.04 sec
        Start 100: test_wm_ms_graph
100/178 Test #100: test_wm_ms_graph ........................................   Passed    0.04 sec
        Start 101: test_wm_osquery_already_running
101/178 Test #101: test_wm_osquery_already_running .........................   Passed    0.02 sec
        Start 102: test_wm_exec
102/178 Test #102: test_wm_exec ............................................   Passed    0.02 sec
        Start 103: test_monitord
103/178 Test #103: test_monitord ...........................................   Passed    0.01 sec
        Start 104: test_monitor_actions
104/178 Test #104: test_monitor_actions ....................................   Passed    0.02 sec
        Start 105: test_logcollector
105/178 Test #105: test_logcollector .......................................   Passed    0.03 sec
        Start 106: test_read_multiline_regex
106/178 Test #106: test_read_multiline_regex ...............................   Passed    0.04 sec
        Start 107: test_localfile-config
107/178 Test #107: test_localfile-config ...................................   Passed    0.03 sec
        Start 108: test_state
108/178 Test #108: test_state ..............................................   Passed    0.01 sec
        Start 109: test_lccom
109/178 Test #109: test_lccom ..............................................   Passed    0.05 sec
        Start 110: test_macos_log
110/178 Test #110: test_macos_log ..........................................   Passed    0.02 sec
        Start 111: test_read_macos
111/178 Test #111: test_read_macos .........................................   Passed    0.03 sec
        Start 112: test_read_multiline
112/178 Test #112: test_read_multiline .....................................   Passed    0.02 sec
        Start 113: test_read_journal
113/178 Test #113: test_read_journal .......................................   Passed    0.02 sec
        Start 114: test_journal_log
114/178 Test #114: test_journal_log ........................................   Passed    0.02 sec
        Start 115: test_read_syslog
115/178 Test #115: test_read_syslog ........................................   Passed    0.02 sec
        Start 116: test_execd
116/178 Test #116: test_execd ..............................................   Passed    0.01 sec
        Start 117: test_get_command_by_name
117/178 Test #117: test_get_command_by_name ................................   Passed    0.01 sec
        Start 118: test_integrator
118/178 Test #118: test_integrator .........................................   Passed    0.01 sec
        Start 119: test_manage_keys
119/178 Test #119: test_manage_keys ........................................   Passed    0.01 sec
        Start 120: test_printtable
120/178 Test #120: test_printtable .........................................   Passed    0.01 sec
        Start 121: test_csyslogd
121/178 Test #121: test_csyslogd ...........................................   Passed    0.01 sec
        Start 122: test_syscom
122/178 Test #122: test_syscom .............................................   Passed    0.02 sec
        Start 123: test_fim_diff_changes
123/178 Test #123: test_fim_diff_changes ...................................   Passed    0.02 sec
        Start 124: test_run_realtime
124/178 Test #124: test_run_realtime .......................................   Passed    0.03 sec
        Start 125: test_config
125/178 Test #125: test_config .............................................   Passed    0.04 sec
        Start 126: test_syscheck
126/178 Test #126: test_syscheck ...........................................   Passed    0.02 sec
        Start 127: test_run_check
127/178 Test #127: test_run_check ..........................................   Passed    0.03 sec
        Start 128: test_create_db
128/178 Test #128: test_create_db ..........................................   Passed    0.04 sec
        Start 129: test_audit_healthcheck
129/178 Test #129: test_audit_healthcheck ..................................   Passed    0.02 sec
        Start 130: test_audit_rule_handling
130/178 Test #130: test_audit_rule_handling ................................   Passed    0.02 sec
        Start 131: test_syscheck_audit
131/178 Test #131: test_syscheck_audit .....................................   Passed    0.03 sec
        Start 132: test_audit_parse
132/178 Test #132: test_audit_parse ........................................   Passed    0.03 sec
        Start 133: test_syscheck_ebpf
133/178 Test #133: test_syscheck_ebpf ......................................   Passed    0.04 sec
        Start 134: test_list_op
134/178 Test #134: test_list_op ............................................   Passed    0.03 sec
        Start 135: test_file_op
135/178 Test #135: test_file_op ............................................   Passed    0.01 sec
        Start 136: test_integrity_op
136/178 Test #136: test_integrity_op .......................................   Passed    0.02 sec
        Start 137: test_rbtree_op
137/178 Test #137: test_rbtree_op ..........................................   Passed    0.01 sec
        Start 138: test_validate_op
138/178 Test #138: test_validate_op ........................................   Passed    0.01 sec
        Start 139: test_string_op
139/178 Test #139: test_string_op ..........................................   Passed    0.01 sec
        Start 140: test_expression
140/178 Test #140: test_expression .........................................   Passed    0.02 sec
        Start 141: test_version_op
141/178 Test #141: test_version_op .........................................   Passed    0.03 sec
        Start 142: test_queue_op
142/178 Test #142: test_queue_op ...........................................   Passed    0.01 sec
        Start 143: test_queue_linked_op
143/178 Test #143: test_queue_linked_op ....................................   Passed    0.01 sec
        Start 144: test_agent_op
144/178 Test #144: test_agent_op ...........................................   Passed    0.01 sec
        Start 145: test_enrollment_op
145/178 Test #145: test_enrollment_op ......................................   Passed    0.02 sec
        Start 146: test_time_op
146/178 Test #146: test_time_op ............................................   Passed    0.01 sec
        Start 147: test_buffer_op
147/178 Test #147: test_buffer_op ..........................................   Passed    0.01 sec
        Start 148: test_utf8_op
148/178 Test #148: test_utf8_op ............................................   Passed    0.01 sec
        Start 149: test_log_builder
149/178 Test #149: test_log_builder ........................................   Passed    0.01 sec
        Start 150: test_custom_output_search_replace
150/178 Test #150: test_custom_output_search_replace .......................   Passed    0.01 sec
        Start 151: test_binaries_op
151/178 Test #151: test_binaries_op ........................................   Passed    0.01 sec
        Start 152: test_bzip2_op
152/178 Test #152: test_bzip2_op ...........................................   Passed    0.01 sec
        Start 153: test_schedule_scan
153/178 Test #153: test_schedule_scan ......................................   Passed    0.02 sec
        Start 154: test_rootcheck_op
154/178 Test #154: test_rootcheck_op .......................................   Passed    0.01 sec
        Start 155: test_fs_op
155/178 Test #155: test_fs_op ..............................................   Passed    0.01 sec
        Start 156: test_wazuhdb_op
156/178 Test #156: test_wazuhdb_op .........................................   Passed    0.01 sec
        Start 157: test_syscheck_op
157/178 Test #157: test_syscheck_op ........................................   Passed    0.03 sec
        Start 158: test_json_op
158/178 Test #158: test_json_op ............................................   Passed    0.01 sec
        Start 159: test_audit_op
159/178 Test #159: test_audit_op ...........................................   Passed    0.01 sec
        Start 160: test_privsep_op
160/178 Test #160: test_privsep_op .........................................   Passed    0.02 sec
        Start 161: test_mq_op
161/178 Test #161: test_mq_op ..............................................   Passed    0.02 sec
        Start 162: test_remoted_op
162/178 Test #162: test_remoted_op .........................................   Passed    0.03 sec
        Start 163: test_json-queue
163/178 Test #163: test_json-queue .........................................   Passed    0.02 sec
        Start 164: test_bqueue
164/178 Test #164: test_bqueue .............................................   Passed    0.02 sec
        Start 165: test_atomic
165/178 Test #165: test_atomic .............................................   Passed    0.02 sec
        Start 166: test_url
166/178 Test #166: test_url ................................................   Passed    0.03 sec
        Start 167: test_sysinfo_utils
167/178 Test #167: test_sysinfo_utils ......................................   Passed    0.02 sec
        Start 168: test_rwlock_op
168/178 Test #168: test_rwlock_op ..........................................   Passed    0.05 sec
        Start 169: test_os_xml
169/178 Test #169: test_os_xml .............................................   Passed    0.05 sec
        Start 170: test_os_regex
170/178 Test #170: test_os_regex ...........................................   Passed    0.01 sec
        Start 171: test_os_regex_match
171/178 Test #171: test_os_regex_match .....................................   Passed    0.01 sec
        Start 172: test_os_regex_execute
172/178 Test #172: test_os_regex_execute ...................................   Passed    0.02 sec
        Start 173: test_os_zlib
173/178 Test #173: test_os_zlib ............................................   Passed    0.01 sec
        Start 174: test_client-config_validate_ipv6_link_local_interface
174/178 Test #174: test_client-config_validate_ipv6_link_local_interface ...   Passed    0.02 sec
        Start 175: test_indexer
175/178 Test #175: test_indexer ............................................   Passed    0.02 sec
        Start 176: test_os_net
176/178 Test #176: test_os_net .............................................   Passed    0.01 sec
        Start 177: test_fluentd_forwarder
177/178 Test #177: test_fluentd_forwarder ..................................   Passed    0.02 sec
        Start 178: test_active-response
178/178 Test #178: test_active-response ....................................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 178

Total Test time (real) =   5.62 sec
```


</details>


<details><summary>Logtest + ASAN</summary>

**Logtest**

```bash
╰─# /var/ossec/bin/wazuh-logtest             
Starting wazuh-logtest v4.12.0
Type one log per line

logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=192.168.1.2 tunnelip=10.xxx.xxx.xxx user="user.name2" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"

**Phase 1: Completed pre-decoding.
        full event: 'logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=192.168.1.2 tunnelip=10.xxx.xxx.xxx user="user.name2" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"'

**Phase 2: Completed decoding.
        name: 'fortigate-firewall-v6'
        action: 'tunnel-up'
        dstuser: 'user.name2'
        eventtime: '1743087789977146265'
        ip: '192.168.1.2'
        level: 'information'
        logdesc: 'SSL VPN tunnel up'
        logid: '0101039947'
        msg: 'SSL tunnel established'
        reason: 'tunnel established'
        subtype: 'vpn'
        time: '16:03:09'
        type: 'event'
        vd: 'root'

**Phase 3: Completed filtering (rules).
        id: '81622'
        level: '3'
        description: 'Fortigate: VPN user connected.'
        groups: '['fortigate', 'syslog', 'authentication_success']'
        firedtimes: '1'
        gdpr: '['IV_32.2']'
        gpg13: '['7.1']'
        hipaa: '['164.312.b']'
        mail: 'False'
        mitre.id: '['T1078']'
        mitre.tactic: '['Defense Evasion', 'Persistence', 'Privilege Escalation', 'Initial Access']'
        mitre.technique: '['Valid Accounts']'
        nist_800_53: '['AC.7', 'AU.14']'
        pci_dss: '['10.2.5']'
**Alert to be generated.

logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=10.0.0.1 tunnelip=10.xxx.xxx.xxx user="user.name" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"

**Phase 1: Completed pre-decoding.
        full event: 'logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=10.0.0.1 tunnelip=10.xxx.xxx.xxx user="user.name" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"'

**Phase 2: Completed decoding.
        name: 'fortigate-firewall-v6'
        action: 'tunnel-up'
        dstuser: 'user.name'
        eventtime: '1743087789977146265'
        ip: '10.0.0.1'
        level: 'information'
        logdesc: 'SSL VPN tunnel up'
        logid: '0101039947'
        msg: 'SSL tunnel established'
        reason: 'tunnel established'
        subtype: 'vpn'
        time: '16:03:09'
        type: 'event'
        vd: 'root'

**Phase 3: Completed filtering (rules).
        id: '201600'
        level: '12'
        description: 'SSL-VPN. Same user, different source'
        groups: '['local', 'syslog', 'sshd', 'firewall_drop']'
        firedtimes: '1'
        frequency: '2'
        gdpr: '['IV_35.7.d']'
        hipaa: '['164.312.b']'
        mail: 'True'
        nist_800_53: '['AU.6']'
        pci_dss: '['10.6.1']'
**Alert to be generated.

^C
╭─root@eeb1a4a06248 /workspaces/wazuh-manager-4.x/src/unit_tests/build ‹4.12.0●› 
╰─# /var/ossec/bin/wazuh-logtest                                                                                                                          130 ↵
Starting wazuh-logtest v4.12.0
Type one log per line

logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=192.168.1.2 tunnelip=10.xxx.xxx.xxx user="user.name" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"


**Phase 1: Completed pre-decoding.
        full event: 'logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=192.168.1.2 tunnelip=10.xxx.xxx.xxx user="user.name" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"'

**Phase 2: Completed decoding.
        name: 'fortigate-firewall-v6'
        action: 'tunnel-up'
        dstuser: 'user.name'
        eventtime: '1743087789977146265'
        ip: '192.168.1.2'
        level: 'information'
        logdesc: 'SSL VPN tunnel up'
        logid: '0101039947'
        msg: 'SSL tunnel established'
        reason: 'tunnel established'
        subtype: 'vpn'
        time: '16:03:09'
        type: 'event'
        vd: 'root'

**Phase 3: Completed filtering (rules).
        id: '81622'
        level: '3'
        description: 'Fortigate: VPN user connected.'
        groups: '['fortigate', 'syslog', 'authentication_success']'
        firedtimes: '1'
        gdpr: '['IV_32.2']'
        gpg13: '['7.1']'
        hipaa: '['164.312.b']'
        mail: 'False'
        mitre.id: '['T1078']'
        mitre.tactic: '['Defense Evasion', 'Persistence', 'Privilege Escalation', 'Initial Access']'
        mitre.technique: '['Valid Accounts']'
        nist_800_53: '['AC.7', 'AU.14']'
        pci_dss: '['10.2.5']'
**Alert to be generated.


logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=10.0.0.1 tunnelip=10.xxx.xxx.xxx user="user.name" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"

**Phase 1: Completed pre-decoding.
        full event: 'logver=702111740 timestamp=1743091389 devname="fortigate" devid="FG200FTXXXXXXXXX" vd="root" date=2025-03-27 time=16:03:09 eventtime=1743087789977146265 tz="+0100" logid="0101039947" type="event" subtype="vpn" level="information" logdesc="SSL VPN tunnel up" action="tunnel-up" tunneltype="ssl-tunnel" tunnelid=4215812345 remip=10.0.0.1 tunnelip=10.xxx.xxx.xxx user="user.name" group="SSLVPN" dst_host="N/A" reason="tunnel established" msg="SSL tunnel established"'

**Phase 2: Completed decoding.
        name: 'fortigate-firewall-v6'
        action: 'tunnel-up'
        dstuser: 'user.name'
        eventtime: '1743087789977146265'
        ip: '10.0.0.1'
        level: 'information'
        logdesc: 'SSL VPN tunnel up'
        logid: '0101039947'
        msg: 'SSL tunnel established'
        reason: 'tunnel established'
        subtype: 'vpn'
        time: '16:03:09'
        type: 'event'
        vd: 'root'

**Phase 3: Completed filtering (rules).
        id: '201600'
        level: '12'
        description: 'SSL-VPN. Same user, different source'
        groups: '['local', 'syslog', 'sshd', 'firewall_drop']'
        firedtimes: '1'
        frequency: '2'
        gdpr: '['IV_35.7.d']'
        hipaa: '['164.312.b']'
        mail: 'True'
        nist_800_53: '['AU.6']'
        pci_dss: '['10.6.1']'
**Alert to be generated.
```

**ASAN**

```bash
╰─# /var/ossec/bin/wazuh-analysisd -f -u root              
2025/04/04 19:06:05 wazuh-analysisd: INFO: Total rules enabled: '7018'
2025/04/04 19:06:05 wazuh-analysisd: INFO: Started (pid: 170650).
2025/04/04 19:06:05 wazuh-analysisd: INFO: EPS limit disabled
2025/04/04 19:06:05 wazuh-analysisd: INFO: (7200): Logtest started
^C2025/04/04 19:06:57 wazuh-analysisd: INFO: (1225): SIGNAL [(2)-(Interrupt)] Received. Exit Cleaning...

=================================================================
==170650==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 74 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff76279a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x555555718096 in Read_Global config/global-config.c:210
    #2 0x55555570af04 in read_main_elements config/config.c:85
    #3 0x55555570d648 in ReadConfig config/config.c:372
    #4 0x555555627af9 in GlobalConf analysisd/config.c:97
    #5 0x55555568f961 in main analysisd/analysisd.c:406
    #6 0x7ffff6866d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

SUMMARY: AddressSanitizer: 74 byte(s) leaked in 1 allocation(s).
```

Know leak.

</details>




