### PR TITLE
Global queries: Index agent tables after upgrade

### DIFF
--- a/src/wazuh_db/schema_agents.sql
+++ b/src/wazuh_db/schema_agents.sql
@@ -339,7 +339,7 @@ CREATE TABLE IF NOT EXISTS sync_info (
 
 BEGIN;
 
-INSERT INTO metadata (key, value) VALUES ('db_version', '14');
+INSERT INTO metadata (key, value) VALUES ('db_version', '15');
 INSERT INTO scan_info (module) VALUES ('fim');
 INSERT INTO scan_info (module) VALUES ('syscollector');
 INSERT INTO sync_info (component) VALUES ('fim');

--- a/src/wazuh_db/schema_upgrade_v15.sql
+++ b/src/wazuh_db/schema_upgrade_v15.sql
@@ -1,0 +1,46 @@
+/*
+ * SQL Schema for upgrading databases
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * April 3, 2025.
+ *
+ * This program is a free software, you can redistribute it
+ * and/or modify it under the terms of GPLv2.
+*/
+
+BEGIN;
+
+/* FIM and syscollector will be indexed. We clean the data. No real schema change.*/
+DELETE FROM fim_entry;
+DELETE FROM sys_netiface;
+DELETE FROM sys_netproto;
+DELETE FROM sys_netaddr;
+DELETE FROM sys_osinfo;
+DELETE FROM sys_hwinfo;
+DELETE FROM sys_ports;
+DELETE FROM sys_programs;
+DELETE FROM sys_hotfixes;
+DELETE FROM sys_processes;
+DELETE FROM scan_info WHERE module IN ('fim', 'syscollector');
+DELETE FROM sync_info;
+
+INSERT OR REPLACE INTO metadata (key, value) VALUES ('db_version', 15);
+
+INSERT INTO scan_info (module) VALUES ('fim');
+INSERT INTO scan_info (module) VALUES ('syscollector');
+INSERT INTO sync_info (component) VALUES ('fim');
+INSERT INTO sync_info (component) VALUES ('fim_file');
+INSERT INTO sync_info (component) VALUES ('fim_registry');
+INSERT INTO sync_info (component) VALUES ('fim_registry_key');
+INSERT INTO sync_info (component) VALUES ('fim_registry_value');
+INSERT INTO sync_info (component) VALUES ('syscollector-processes');
+INSERT INTO sync_info (component) VALUES ('syscollector-packages');
+INSERT INTO sync_info (component) VALUES ('syscollector-hotfixes');
+INSERT INTO sync_info (component) VALUES ('syscollector-ports');
+INSERT INTO sync_info (component) VALUES ('syscollector-netproto');
+INSERT INTO sync_info (component) VALUES ('syscollector-netaddress');
+INSERT INTO sync_info (component) VALUES ('syscollector-netinfo');
+INSERT INTO sync_info (component) VALUES ('syscollector-hwinfo');
+INSERT INTO sync_info (component) VALUES ('syscollector-osinfo');
+
+COMMIT;

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -424,6 +424,7 @@ extern char *schema_upgrade_v11_sql;
 extern char *schema_upgrade_v12_sql;
 extern char *schema_upgrade_v13_sql;
 extern char *schema_upgrade_v14_sql;
+extern char *schema_upgrade_v15_sql;
 extern char *schema_global_upgrade_v1_sql;
 extern char *schema_global_upgrade_v2_sql;
 extern char *schema_global_upgrade_v3_sql;

--- a/src/wazuh_db/wdb_upgrade.c
+++ b/src/wazuh_db/wdb_upgrade.c
@@ -47,6 +47,7 @@ wdb_t * wdb_upgrade(wdb_t *wdb) {
         schema_upgrade_v12_sql,
         schema_upgrade_v13_sql,
         schema_upgrade_v14_sql,
+        schema_upgrade_v15_sql
     };
 
     bool database_updated = false;

--- a/src/wazuh_modules/inventory_harvester/src/common/upgradeAgentDb.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/common/upgradeAgentDb.hpp
@@ -1,0 +1,57 @@
+/*
+ * Wazuh Inventory Harvester - Upgrade agent DB
+ * Copyright (C) 2015, Wazuh Inc.
+ * April 03, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _UPGRADE_AGENT_DB_HPP
+#define _UPGRADE_AGENT_DB_HPP
+
+#include <map>
+#include <memory>
+
+#include "chainOfResponsability.hpp"
+#include "indexerConnector.hpp"
+#include "noData.hpp"
+
+template<typename TContext, typename TIndexerConnector = IndexerConnector>
+class UpgradeAgentDB final : public AbstractHandler<std::shared_ptr<TContext>>
+{
+    const std::map<typename TContext::AffectedComponentType, std::unique_ptr<TIndexerConnector>, std::less<>>&
+        m_indexerConnectorInstances;
+
+public:
+    // LCOV_EXCL_START
+    /**
+     * @brief Class destructor.
+     *
+     */
+    ~UpgradeAgentDB() = default;
+
+    explicit UpgradeAgentDB(
+        const std::map<typename TContext::AffectedComponentType, std::unique_ptr<TIndexerConnector>, std::less<>>&
+            indexerConnectorInstances)
+        : m_indexerConnectorInstances(indexerConnectorInstances)
+    {
+    }
+    // LCOV_EXCL_STOP
+
+    /**
+     * @brief Handles request and passes control to the next step of the chain.
+     *
+     * @param data Scan context.
+     * @return std::shared_ptr<ScanContext> Abstract handler.
+     */
+    std::shared_ptr<TContext> handleRequest(std::shared_ptr<TContext> data) override
+    {
+        // Inventory harvester ignores the upgrade agent DB event.
+        return nullptr;
+    }
+};
+
+#endif // _UPGRADE_AGENT_DB_HPP

--- a/src/wazuh_modules/inventory_harvester/src/fimInventory/fimContext.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/fimInventory/fimContext.hpp
@@ -36,6 +36,7 @@ public:
         DeleteAgent,
         DeleteAllEntries,
         IndexSync,
+        UpgradeAgentDB,
         Invalid,
     };
     enum class AffectedComponentType : std::uint8_t
@@ -903,6 +904,10 @@ private:
             m_operation = Operation::Delete;
             m_affectedComponentType = AffectedComponentType::Registry;
             m_originTable = OriginTable::RegistryValue;
+        }
+        else if (action.compare("upgradeAgentDB") == 0)
+        {
+            m_operation = Operation::UpgradeAgentDB;
         }
         else
         {

--- a/src/wazuh_modules/inventory_harvester/src/fimInventory/fimFactoryOrchestrator.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/fimInventory/fimFactoryOrchestrator.hpp
@@ -16,6 +16,7 @@
 #include "../common/clearElements.hpp"
 #include "../common/elementDispatch.hpp"
 #include "../common/indexSync.hpp"
+#include "../common/upgradeAgentDb.hpp"
 #include "chainOfResponsability.hpp"
 #include "deleteElement.hpp"
 #include "fimContext.hpp"
@@ -67,6 +68,10 @@ public:
         else if (operation == FimContext::Operation::IndexSync)
         {
             orchestration = std::make_shared<IndexSync<FimContext>>(indexerConnectorInstances);
+        }
+        else if (operation == FimContext::Operation::UpgradeAgentDB)
+        {
+            orchestration = std::make_shared<UpgradeAgentDB<FimContext>>(indexerConnectorInstances);
         }
         else
         {

--- a/src/wazuh_modules/inventory_harvester/src/fimInventoryOrchestrator.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/fimInventoryOrchestrator.hpp
@@ -100,6 +100,9 @@ public:
         m_orchestrations[FimContext::Operation::IndexSync] =
             FimFactoryOrchestrator::create(FimContext::Operation::IndexSync, m_indexerConnectorInstances);
 
+        m_orchestrations[FimContext::Operation::UpgradeAgentDB] =
+            FimFactoryOrchestrator::create(FimContext::Operation::UpgradeAgentDB, m_indexerConnectorInstances);
+
         logDebug2(LOGGER_DEFAULT_TAG, "FimInventoryOrchestrator constructor finished");
     }
 };

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/systemContext.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/systemContext.hpp
@@ -38,6 +38,7 @@ public:
         DeleteAgent,
         DeleteAllEntries,
         IndexSync,
+        UpgradeAgentDB,
         Invalid,
     };
     enum class AffectedComponentType : std::uint8_t
@@ -2601,6 +2602,10 @@ private:
             m_operation = Operation::Delete;
             m_affectedComponentType = AffectedComponentType::NetworkAddress;
             m_originTable = OriginTable::NetAddress;
+        }
+        else if (action.compare("upgradeAgentDB") == 0)
+        {
+            m_operation = Operation::UpgradeAgentDB;
         }
         else
         {

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/systemFactoryOrchestrator.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/systemFactoryOrchestrator.hpp
@@ -16,6 +16,7 @@
 #include "../common/clearElements.hpp"
 #include "../common/elementDispatch.hpp"
 #include "../common/indexSync.hpp"
+#include "../common/upgradeAgentDb.hpp"
 #include "chainOfResponsability.hpp"
 #include "deleteElement.hpp"
 #include "indexerConnector.hpp"
@@ -67,6 +68,10 @@ public:
         else if (operation == SystemContext::Operation::IndexSync)
         {
             orchestration = std::make_shared<IndexSync<SystemContext>>(indexerConnectorInstances);
+        }
+        else if (operation == SystemContext::Operation::UpgradeAgentDB)
+        {
+            orchestration = std::make_shared<UpgradeAgentDB<SystemContext>>(indexerConnectorInstances);
         }
         else
         {

--- a/src/wazuh_modules/inventory_harvester/src/systemInventoryOrchestrator.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventoryOrchestrator.hpp
@@ -143,6 +143,10 @@ public:
 
         m_orchestrations[SystemContext::Operation::IndexSync] =
             SystemFactoryOrchestrator::create(SystemContext::Operation::IndexSync, m_indexerConnectorInstances);
+
+        m_orchestrations[SystemContext::Operation::UpgradeAgentDB] =
+            SystemFactoryOrchestrator::create(SystemContext::Operation::UpgradeAgentDB, m_indexerConnectorInstances);
+
         logDebug2(LOGGER_DEFAULT_TAG, "SystemInventoryOrchestrator finished");
     }
 };

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -564,6 +564,10 @@ public:
                         // It handles specific upgrades scenarios.
                         else if (actionValue == "upgradeAgentDB")
                         {
+                            m_messageType = MessageType::DataJSON;
+                            m_type = ScannerType::Unknown;
+                            m_affectedComponentType = AffectedComponentType::Agent;
+
                             int newDBVersion = message->at("/data/new_db_version"_json_pointer).get<int>();
 
                             switch (newDBVersion)
@@ -571,7 +575,6 @@ public:
                                 // Global queries. The agents re-sync all data.
                                 case WazuhDBUpgradeSchemaVersion::V15:
                                     m_type = ScannerType::CleanupSingleAgentData;
-                                    m_messageType = MessageType::DataJSON;
                                     m_affectedComponentType = AffectedComponentType::Agent;
                                     break;
                                 default: break;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -92,6 +92,12 @@ enum class ElementOperation
     Insert = 2,
 };
 
+// Wazuh-DB upgrade schema versions handling
+enum WazuhDBUpgradeSchemaVersion
+{
+    V15 = 15
+};
+
 /**
  * @brief MatchCondition structure.
  */
@@ -546,14 +552,30 @@ public:
                             // Set the affected component type
                             m_affectedComponentType = AffectedComponentType::Agent;
                         }
-                        // This is used to trigger a delete and re-scan for a single agent, used if a database update
-                        // message is received.
-                        else if (actionValue == "upgradeAgentDB" || actionValue == "scanAgent")
+                        // This is used to trigger a delete and re-scan for a single agent.
+                        else if (actionValue == "scanAgent")
                         {
                             m_type = ScannerType::ReScanSingleAgent;
                             m_messageType = MessageType::DataJSON;
                             // Set the affected component type
                             m_affectedComponentType = AffectedComponentType::Agent;
+                        }
+                        // This is used if a database update message is received.
+                        // It handles specific upgrades scenarios.
+                        else if (actionValue == "upgradeAgentDB")
+                        {
+                            int newDBVersion = message->at("/data/new_db_version"_json_pointer).get<int>();
+
+                            switch (newDBVersion)
+                            {
+                                // Global queries. The agents re-sync all data.
+                                case WazuhDBUpgradeSchemaVersion::V15:
+                                    m_type = ScannerType::CleanupSingleAgentData;
+                                    m_messageType = MessageType::DataJSON;
+                                    m_affectedComponentType = AffectedComponentType::Agent;
+                                    break;
+                                default: break;
+                            }
                         }
                         // Used for the RSync deleted events from Wazuh-DB
                         else if (actionValue == "deletePackage")

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cleanAgentInventory_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cleanAgentInventory_test.cpp
@@ -112,7 +112,7 @@ TEST_F(CleanAgentInventoryTest, CleanAgentDataSuccessfulPackage)
 
     nlohmann::json jsonData = nlohmann::json::parse(
         R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",
-"agent_ip":"10.0.0.1"},  "action":"upgradeAgentDB"})");
+"agent_ip":"10.0.0.1"},  "action":"upgradeAgentDB", "data": {"db_version": 14, "new_db_version": 15}})");
 
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> data =
         &jsonData;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/cleanInventory_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/cleanInventory_test.cpp
@@ -112,7 +112,7 @@ TEST_F(CleanInventoryTest, TestCleanAllData)
 
     nlohmann::json jsonData = nlohmann::json::parse(
         R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",
-"agent_ip":"10.0.0.1"},  "action":"upgradeAgentDB"})");
+"agent_ip":"10.0.0.1"},  "action":"upgradeAgentDB", "data": {"db_version": 14, "new_db_version": 15}})");
 
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> data =
         &jsonData;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
@@ -125,7 +125,7 @@ TEST_F(ScanAgentListTest, SingleDeleteAndInsertTest)
         .WillOnce(testing::SetArgReferee<1>(nlohmann::json::parse(PACKAGES_RESPONSE)));
 
     nlohmann::json jsonData = nlohmann::json::parse(
-        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"upgradeAgentDB"})");
+        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"scanAgent"})");
 
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> data =
         &jsonData;
@@ -187,7 +187,7 @@ TEST_F(ScanAgentListTest, EmptyPackagesWDBResponseTest)
         .WillOnce(testing::SetArgReferee<1>(nlohmann::json::parse(RESPONSE_EMPTY)));
 
     nlohmann::json jsonData = nlohmann::json::parse(
-        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"upgradeAgentDB"})");
+        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"scanAgent"})");
 
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> data =
         &jsonData;
@@ -224,7 +224,7 @@ TEST_F(ScanAgentListTest, MutipleRecoverableExceptions)
                                                                                      spPackageInsertOrchestrationMock);
 
     nlohmann::json jsonData = nlohmann::json::parse(
-        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"upgradeAgentDB"})");
+        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"scanAgent"})");
 
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> data =
         &jsonData;
@@ -263,7 +263,7 @@ TEST_F(ScanAgentListTest, OneRecoverableException)
                                                                                      spPackageInsertOrchestrationMock);
 
     nlohmann::json jsonData = nlohmann::json::parse(
-        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"upgradeAgentDB"})");
+        R"({"agent_info":  {"agent_id":"001",  "agent_version":"4.8.0",  "agent_name":"test_agent_name",  "agent_ip":"10.0.0.1",  "node_name":"node01"},  "action":"scanAgent"})");
 
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> data =
         &jsonData;
@@ -301,7 +301,7 @@ TEST_F(ScanAgentListTest, UnrecoverableException)
                                                                                      spPackageInsertOrchestrationMock);
 
     nlohmann::json jsonData = nlohmann::json::parse(
-        R"({"agent_info":{"agent_id":"001","agent_version":"4.8.0","agent_name":"test_agent_name","agent_ip":"10.0.0.1","node_name":"node01"},  "action":"upgradeAgentDB"})");
+        R"({"agent_info":{"agent_id":"001","agent_version":"4.8.0","agent_name":"test_agent_name","agent_ip":"10.0.0.1","node_name":"node01"},  "action":"scanAgent"})");
 
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> data =
         &jsonData;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
@@ -1479,3 +1479,63 @@ TEST_F(ScanContextTest, TestJSONMessageHotfixDelete)
     EXPECT_EQ(scanContext->packageMultiarch(), "");
     EXPECT_EQ(scanContext->packageSource(), "");
 }
+
+TEST_F(ScanContextTest, TestJSONMessageUpgradeDBClean)
+{
+    const auto message = nlohmann::json::parse(
+        R"({
+            "agent_info": {
+                "agent_id" : "001",
+                "agent_ip" : "10.0.0.1",
+                "agent_name" : "agent1",
+                "agent_version" : "v4.8.0"
+            },
+            "action": "upgradeAgentDB",
+            "data": {
+                "db_version" : 14,
+                "new_db_version": 15
+            }
+        })");
+
+    std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> msg =
+        &message;
+    std::shared_ptr<scanContext_t> scanContext;
+    EXPECT_NO_THROW(scanContext = std::make_shared<scanContext_t>(msg));
+
+    EXPECT_EQ(scanContext->getType(), ScannerType::CleanupSingleAgentData);
+    EXPECT_EQ(scanContext->messageType(), MessageType::DataJSON);
+    EXPECT_EQ(scanContext->agentId(), "001");
+    EXPECT_EQ(scanContext->agentIp(), "10.0.0.1");
+    EXPECT_EQ(scanContext->agentName(), "agent1");
+    EXPECT_EQ(scanContext->agentVersion(), "v4.8.0");
+}
+
+TEST_F(ScanContextTest, TestJSONMessageUpgradeDBIgnore)
+{
+    const auto message = nlohmann::json::parse(
+        R"({
+            "agent_info": {
+                "agent_id" : "001",
+                "agent_ip" : "10.0.0.1",
+                "agent_name" : "agent1",
+                "agent_version" : "v4.8.0"
+            },
+            "action": "upgradeAgentDB",
+            "data": {
+                "db_version" : 15,
+                "new_db_version": 16
+            }
+        })");
+
+    std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> msg =
+        &message;
+    std::shared_ptr<scanContext_t> scanContext;
+    EXPECT_NO_THROW(scanContext = std::make_shared<scanContext_t>(msg));
+
+    EXPECT_EQ(scanContext->getType(), ScannerType::Unknown);
+    EXPECT_EQ(scanContext->messageType(), MessageType::DataJSON);
+    EXPECT_EQ(scanContext->agentId(), "001");
+    EXPECT_EQ(scanContext->agentIp(), "10.0.0.1");
+    EXPECT_EQ(scanContext->agentName(), "agent1");
+    EXPECT_EQ(scanContext->agentVersion(), "v4.8.0");
+}

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-004/step_0.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-004/step_0.json
@@ -5,5 +5,9 @@
     "agent_name": "test_agent_name",
     "agent_ip": "10.0.0.1"
   },
-  "action": "upgradeAgentDB"
+  "action": "upgradeAgentDB",
+  "data": {
+    "db_version": 14,
+    "new_db_version": 15
+  }
 }

--- a/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-005/step_1.json
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/scanner/TC-005/step_1.json
@@ -1,9 +1,13 @@
 {
-    "agent_info": {
-      "agent_id": "000",
-      "agent_version": "4.8.0",
-      "agent_name": "test_agent_name",
-      "agent_ip": "10.0.0.1"
-    },
-    "action": "upgradeAgentDB"
+  "agent_info": {
+    "agent_id": "000",
+    "agent_version": "4.8.0",
+    "agent_name": "test_agent_name",
+    "agent_ip": "10.0.0.1"
+  },
+  "action": "upgradeAgentDB",
+  "data": {
+    "db_version": 14,
+    "new_db_version": 15
   }
+}

--- a/tests/integration/test_wazuh_db/test_databases/test_agent_database_version.py
+++ b/tests/integration/test_wazuh_db/test_databases/test_agent_database_version.py
@@ -62,7 +62,7 @@ from wazuh_testing.tools.simulators import agent_simulator as ag
 pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
 
 # Variables
-expected_database_version = '14'
+expected_database_version = '15'
 
 # Test daemons to restart.
 daemons_handler_configuration = {'all_daemons': True}


### PR DESCRIPTION
|Related issue|
|---|
|Closes #27918|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR clears all data from agent tables to force a full re-sync and index FIM and syscollector tables.
The inventory of the VD module is also cleared.

I've added a dummy class in inventory harvester to ignore the message for agent DB upgrade.

> [!IMPORTANT]
> The `run_up()` method upgrades all agents' DBs at startup. This means that the agents' inventory, FIM and vulnerabilities won't be available until the agents  get connected again and send all data.

## Tests

I've deployed Wazuh with Docker repository and connected a parallel manager with Wazuh v4.12.0.
I connected two agents (Windows 10 and Ubuntu 20.04) and waited for all the tables to sync and VD to index vulnerabilities.

<details><summary>Details</summary>
<p>

```
root@f8d4e01554db:/var/ossec# ./bin/wazuh-control info
WAZUH_VERSION="v4.13.0"
WAZUH_REVISION="41300"
WAZUH_TYPE="server"
root@f8d4e01554db:/var/ossec# sqlite3 queue/db/global.db "SELECT name, id , os_name, os_version from agent"
-- Loading resources from /root/.sqliterc
      name = f8d4e01554db
        id = 0
   os_name = Ubuntu
os_version = 24.04.1 LTS

      name = fe94358f3c04
        id = 1
   os_name = Ubuntu
os_version = 20.04.6 LTS

      name = DESKTOP-EQ4F57D
        id = 2
   os_name = Microsoft Windows 10 Pro
os_version = 10.0.19045.5608
```

</p>
</details> 

Then, I upgrade from sources with the development branch:

```
2025/04/04 23:29:30 wazuh-db[3782731] wdb_upgrade.c:67 at wdb_upgrade(): DEBUG: Updating database '001' to version 15

2025/04/04 23:29:32 wazuh-db[3782731] wdb_upgrade.c:67 at wdb_upgrade(): DEBUG: Updating database '002' to version 15
```

The upgrade event is ignored by inventory harvester:

```

2025/04/04 23:29:36 logger-helper[3783060] systemInventoryOrchestrator.hpp:42 at run(): DEBUG: SystemInventoryOrchestrator::run for agent: '001', operation: '5', component: '6'

2025/04/04 23:29:36 logger-helper[3783060] systemInventoryOrchestrator.hpp:42 at run(): DEBUG: SystemInventoryOrchestrator::run for agent: '002', operation: '5', component: '6'

2025/04/04 23:29:36 logger-helper[3783060] fimInventoryOrchestrator.hpp:41 at run(): DEBUG: FimInventoryOrchestrator::run for agent: '001', operation: '5', component: '2'

2025/04/04 23:29:36 logger-helper[3783060] fimInventoryOrchestrator.hpp:41 at run(): DEBUG: FimInventoryOrchestrator::run for agent: '002', operation: '5', component: '2'

```

The VD data is cleared

```
2025/04/04 23:29:36 wazuh-modulesd:vulnerability-scanner[3783060] scanOrchestrator.hpp:336 at run(): DEBUG: Processing 'CleanupSingleAgentData' event for agent '001'

2025/04/04 23:29:36 wazuh-modulesd:vulnerability-scanner[3783060] scanOrchestrator.hpp:336 at run(): DEBUG: Processing 'CleanupSingleAgentData' event for agent '002'

```

Then all information is re-sent, the vulnerabilities are re-indexed and the global inventory is indexed

<details><summary>Details</summary>
<p>

```
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-vulnerabilities-f8d4e01554db/_count?pretty=true
{
  "count" : 212,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-hardware-f8d4e01554db/_count?pretty=true
{
  "count" : 2,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-hotfixes-f8d4e01554db/_count?pretty=true
{
  "count" : 15,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-ports-f8d4e01554db/_count?pretty=true
{
  "count" : 101,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-processes-f8d4e01554db/_count?pretty=true
{
  "count" : 127,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-system-f8d4e01554db/_count?pretty=true
{
  "count" : 2,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-registries-f8d4e01554db/_count?pretty=true
{
  "count" : 4993,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-files-f8d4e01554db/_count?pretty=true
{
  "count" : 940,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
root@f8d4e01554db:/var/ossec# curl --cacert /etc/filebeat/certs/root-ca.pem --cert /etc/filebeat/certs/filebeat.pem --key /etc/filebeat/certs/filebeat-key.pem -u admin:SecretPassword https://wazuh.indexer:9200/wazuh-states-packages-f8d4e01554db/_count?pretty=true
{
  "count" : 197,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}

```

</p>
</details> 
 
[ossec.log.zip](https://github.com/user-attachments/files/19611915/ossec.log.zip)



