### PR TITLE
Add `4_builderpackage_get-last-stable-version` composite action

### DIFF
--- a/.github/actions/4_builderpackage_get-last-stable-version/action.yml
+++ b/.github/actions/4_builderpackage_get-last-stable-version/action.yml
@@ -1,0 +1,32 @@
+name: "Get last stable version"
+description: "Get last stable version for the given arguments"
+
+inputs:
+  repo_owner:
+    required: true
+    description: "Repository owner"
+  repo_name:
+    required: true
+    description: "Repository name"
+  testing_version:
+    required: true
+    description: "Version of the tested package"
+
+outputs:
+  latest_stable_version:
+    description: "Latest stable version before given testing_version"
+    value: ${{ steps.latest-stable-release.outputs.latest-stable-release }}
+
+runs:
+  using: "composite"
+  steps:
+  - name: Get previous last stable release
+    id: latest-stable-release
+    shell: bash
+    run: |
+      version=$(.github/actions/4_builderpackage_get-last-stable-version/get_last_stable_version.py \
+          -o "${{ inputs.repo_owner }}" \
+          -r "${{ inputs.repo_name }}" \
+          -v "${{ inputs.testing_version }}"
+      )
+      echo latest-stable-release=$version >> $GITHUB_OUTPUT

--- a/.github/actions/4_builderpackage_get-last-stable-version/get_last_stable_version.py
+++ b/.github/actions/4_builderpackage_get-last-stable-version/get_last_stable_version.py
@@ -1,0 +1,78 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Module providing a function to get the last stable version for a given 
+owner, repository and target_version combination.
+"""
+import argparse
+import requests
+from packaging import version
+
+def get_previous_stable_version(owner: str, repository: str,
+                               target_version: str) -> str | None:
+    """Returns the previous stable version for the given arguments.
+    Args:
+        owner: (str): Repository owner.
+        repository: (str): Repository name.
+        target_version: (str): Version on the basis of which we are looking for
+          the most recent previous stable version.
+    Returns:
+        ver: (str): Most recent stable version.
+    """
+    url = f"https://api.github.com/repos/{owner}/{repository}/releases"
+    try:
+        # Get GitHub releases
+        response = requests.get(url, timeout=20)
+        response.raise_for_status()
+        releases = response.json()
+
+        # Extract stable versions
+        stable_versions = []
+        for release in releases:
+            tag = release['tag_name']
+            if not any(x in tag for x in ['-alpha', '-rc', '-beta']):
+                try:
+                    ver = version.parse(tag[1:])  # Remove initial 'v'
+                    stable_versions.append(ver)
+                except version.InvalidVersion:
+                    continue
+
+        # Sort versions
+        stable_versions.sort(reverse=True)
+
+        target_ver = version.parse(target_version)
+
+        # Find the first version lower than the target
+        for ver in stable_versions:
+            if ver < target_ver:
+                return str(ver)
+
+        return None
+
+    except requests.Timeout:
+        print("Error: Request timed out.")
+
+    except requests.RequestException as e:
+        print(f"Request error: {e}")
+
+def main():
+    """Main function."""
+    script_description = (
+        "Get the last stable version for a given owner, repository and \
+        target_version combination."
+    )
+
+    parser = argparse.ArgumentParser(description=script_description)
+    parser.add_argument("-o", "--owner", type=str, action="store",
+                        required=True, help="Repository owner.")
+    parser.add_argument("-r",  "--repository", type=str, action="store",
+                        required=True, help="Repository name.")
+    parser.add_argument("-v", "--version", type=str, action="store",
+                        required=True, help="Generates JSON file output.")
+
+    args = parser.parse_args()
+
+    print(get_previous_stable_version(args.owner, args.repository,
+                                       args.version))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/29110|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Hi team,

This PR adds a new composite action to be used in our GitHub Actions. This action allows us to detect the last released version of Wazuh and implement an upgrade smoke test.

To implement a reusable actions regarding wazuh/wazuh-agent repository, the inputs contemplate the following fields:
* `repo_owner`: the repository owner, in our case, wazuh.
* `repo_name`: the name of the repo, it will be wazuh, or wazuh-agent in the future.
* `testing_version`: the base version used to get the last previously released version.

The output is a string which will contemplate the following values:
* string version: as `4.11.2` if there is a version that satisfies our case.
* `None` if there is no version that covers our case.

## Tests

I have tested it in a repo fork:
* https://github.com/mjcr99/wazuh/actions/runs/14355860003