### PR TITLE
Fix enrollment failure on Solaris 10 due to unsupported socket timeout

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -116,7 +116,7 @@
 #define RWLOCK_LOCK_RD  "(1336) Cannot lock rwlock for reading: %s (%d)."
 #define RWLOCK_LOCK_WR  "(1337) Cannot lock rwlock for writing: %s (%d)."
 #define RWLOCK_UNLOCK   "(1338) Cannot unlock rwlock: %s (%d)."
-#define SET_TIMEO_ERR   "(1339) Cannot set timeout."
+#define SET_TIMEO_ERR   "(1339) Cannot set timeout: %s (%d)."
 
 /* Mail errors */
 #define CHLDWAIT_ERROR  "(1261): Waiting for child process. (status: %d)."

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -233,7 +233,7 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     }
 
     if (OS_SetRecvTimeout(sock, cfg->recv_timeout, 0) < 0) {
-        merror(SET_TIMEO_ERR);
+        merror(SET_TIMEO_ERR, strerror(errno), errno);
         os_free(ip_address);
         SSL_CTX_free(ctx);
         OS_CloseSocket(sock);

--- a/src/shared/enrollment_op.c
+++ b/src/shared/enrollment_op.c
@@ -233,11 +233,12 @@ static int w_enrollment_connect(w_enrollment_ctx *cfg, const char * server_addre
     }
 
     if (OS_SetRecvTimeout(sock, cfg->recv_timeout, 0) < 0) {
-        merror(SET_TIMEO_ERR, strerror(errno), errno);
-        os_free(ip_address);
-        SSL_CTX_free(ctx);
-        OS_CloseSocket(sock);
-        return ENROLLMENT_CONNECTION_FAILURE;
+#if SUN_MAJOR_VERSION == 10
+        // Solaris 10 does not support SO_RCVTIMEO on sockets
+        mdebug1(SET_TIMEO_ERR, strerror(errno), errno);
+#else
+        mwarn(SET_TIMEO_ERR, strerror(errno), errno);
+#endif
     }
 
     /* Connect the SSL socket */

--- a/src/unit_tests/shared/test_enrollment_op.c
+++ b/src/unit_tests/shared/test_enrollment_op.c
@@ -515,8 +515,17 @@ void test_w_enrollment_connect_set_timeout_error(void **state) {
     will_return(__wrap_OS_ConnectTCP, 5);
     // OS_SetRecvTimeout
     will_return(__wrap_OS_SetRecvTimeout, -1);
+    expect_string(__wrap__mwarn, formatted_msg, "(1339) Cannot set timeout: No such file or directory (2).");
 
-    expect_string(__wrap__merror, formatted_msg, "(1339) Cannot set timeout.");
+    // Connect SSL
+    expect_value(__wrap_SSL_new, ctx, ctx);
+    cfg->ssl = __real_SSL_new(ctx);
+    will_return(__wrap_SSL_new, cfg->ssl);
+    will_return(__wrap_SSL_connect, -1);
+
+    expect_value(__wrap_SSL_get_error, i, -1);
+    will_return(__wrap_SSL_get_error, 100);
+    expect_string(__wrap__merror, formatted_msg, "SSL error (100). Connection refused by the manager. Maybe the port specified is incorrect.");
 
     // Close socket
     expect_value(__wrap_OS_CloseSocket, sock, 5);


### PR DESCRIPTION
## Description

A regression introduced in Wazuh 4.11.1 prevents agents running on Solaris 10 from enrolling to the manager. This issue is caused by a recent change that enforces a connection timeout for enrollment to avoid indefinite blocking in case the manager becomes unreachable. Solaris 10, however, does not support setting socket timeouts on TCP connections, which causes the enrollment to fail prematurely.

## Proposed Changes

1. Relax the agent behavior when setting the timeout fails:
   Log a warning and continue with the connection attempt.
2. On Solaris 10 specifically:
   Downgrade the log level to `debug1` instead of `warning`.

This allows Solaris 10 agents to proceed with the enrollment process even if the timeout configuration is not supported.

> [!IMPORTANT]
> With this proposal, we assume that the agent will not be able to set a connection timeout on Solaris 10.

### Results and Evidence

**Solaris 10 logs (after fix):**
```
DEBUG: (1339) Cannot set timeout: Option not supported by protocol (99).
DEBUG: (1209): Connected to enrollment service at '[172.21.187.131]:1515'
...
INFO: Valid key received
```

**Ubuntu logs (no change):**
```
INFO: Valid key received
INFO: Connected to the server ([manager]:1514/tcp).
```

Enrollment continues to function as expected on supported platforms and is restored on Solaris 10.

### Artifacts Affected

- `wazuh-agentd` (UNIX)
- `wazuh-agent.exe` (Windows)

### Configuration Changes

None.

### Documentation Updates

No documentation changes required.

### Tests Introduced

- `test_w_enrollment_connect_set_timeout_error`:
  - Updated to validate the new behavior.
  - Now expects a debug message and ensures that the connection proceeds even when setting the timeout fails.

## Review Checklist

- [x] Code changes reviewed  
- [x] Relevant evidence provided  
- [x] Tests cover the new functionality  
- [x] Configuration changes documented  
- [x] Developer documentation reflects the changes  
- [x] Meets requirements and/or definition of done  
- [x] No unresolved dependencies with other issues  