### PR TITLE
Update offset DB only after processing

### DIFF
--- a/src/shared_modules/content_manager/doc/components/CTI_OFFSET_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/CTI_OFFSET_DOWNLOADER.md
@@ -10,8 +10,8 @@ The output content files will be stored in any of the following output directori
 
 The download process can be summarized as follows:
 1. Get the last CTI API consumer offset. This is done by performing an HTTP GET query to CTI. This value will be used as the last possible offset to query.
-2. Set the range of offsets to be downloaded, starting from `currentOffset` (set in the context) and with a range-width of `1000`. So, for example, if the current offset is equal to `N`, the range will be from offset `N` to offset `N + 1000`. 
-3. Download the offsets range from **step 2** and update `currentOffset` with the last downloaded offset. The download will be retried indefinitely if the server responds with an 5xx HTTP error code.
+2. Set the range of offsets to be downloaded, starting from `currentOffset` (set in the context) and with a range-width of `1000`. So, for example, if the current offset is equal to `N`, the range will be from offset `N` to offset `N + 1000`.
+3. Download the offsets range from **step 2**. The download will be retried indefinitely if the server responds with an 5xx HTTP error code. The `currentOffset` isn't updated in this phase but in the processing callback.
 4. Dump the downloaded offsets into an output file. This file path will be generated as `<output-folder>/<currentOffset>-<contentFileName>`.
 5. Push the new file path (from **step 4**) to the context [data paths](../../src/components/updaterContext.hpp).
 6. If the last possible offset (from **step 1**) has been downloaded, the process finishes. Otherwise, the process continues with the **step 2**.
@@ -20,7 +20,7 @@ The download process can be summarized as follows:
 
 Given the following conditions:
 - Last possible offset: `3200`.
-- Initial current offset: `0` (first execution ever). 
+- Initial current offset: `0` (first execution ever).
 - Content compressed: No.
 - Output folder: `/tmp/`.
 - Content filename: `data.json`.
@@ -43,4 +43,4 @@ The context fields related to this stage are:
 - `contentsFolder`: Used as output folder when the input file is not compressed.
 - `data`: Used to read and update the paths under the `paths` key. The stage status is also updated on this member.
 - `outputFolder`: Used as the destination file path base.
-- `currentOffset`: Used as the first offset that will be fetched from the API. It is also updated with the last offset fetched, so next time the download begins with the new offset value.
+- `currentOffset`: Used as the first offset that will be fetched from the API. The next time the download begins from the offset read from the DB, only the processing data callback after a successful operation updates the value in the context.

--- a/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
+++ b/src/shared_modules/content_manager/src/components/pubSubPublisher.hpp
@@ -63,7 +63,7 @@ private:
             // Update the offset and hash
             context.currentOffset = offset;
             context.spUpdaterBaseContext->downloadedFileHash = hash;
-            logDebug2(WM_CONTENTUPDATER, "Data published");
+            logDebug2(WM_CONTENTUPDATER, "Data published. Offset: '%d', Hash: '%s'", offset, hash.c_str());
         }
         else
         {

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -214,6 +214,7 @@ public:
             }
 
             // Return the current offset and an empty hash.
+            logDebug2(WM_VULNSCAN_LOGTAG, "Last offset processed: %lld", currentOffset);
             return {currentOffset, "", true};
         }
         else if (parsedMessage.at("type") == "raw")
@@ -359,6 +360,10 @@ public:
                     // If the process was interrupted or it failed, we return prematurely.
                     if (shouldStop->check() || !std::get<FileProcessingResultFields::STATUS>(processMessageResult))
                     {
+                        logDebug2(WM_VULNSCAN_LOGTAG,
+                                  "Feed update process interrupted or failed. Offset: %d, Hash: %s.",
+                                  std::get<FileProcessingResultFields::OFFSET>(processMessageResult),
+                                  std::get<FileProcessingResultFields::HASH>(processMessageResult).c_str());
                         return processMessageResult;
                     }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #28462  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR updates the content manager to stop updating the offset DB after the download and only changing its value when an offset is processed.

Some extra debugging messages were added to have more information in the future.

## Tests

I've performed some manual tests.
This sequence of steps the reproduces the bug in v4.12.0.
I've installed a manager by sources with `DOWNLOAD_CONTENT` enabled and performed several restarts during the offsets download and processing

**First restart**

Here no offset is processed, the download was interrupted.
It can be seen that the same value is saved

```
root@f8d4e01554db:/workspaces/wazuh.worktrees/4.12.0/src/build/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery# ./rocks_db_query_testtool -d /var/ossec/queue/vd_updater/rocksdb/updater_vulnerability_feed_manager_metadata/ -c current_offset
20250410003936 ==> 0
20250410005457 ==> 1712396
20250410192846 ==> 1712396
```

<details><summary>Details</summary>
<p>

```
2025/04/10 19:28:43 wazuh-modulesd:content-updater[2541264] actionOrchestrator.hpp:278 at runContentUpdate(): DEBUG: Current offset: '1712396'. Current hash: ''. ContentSource: 'cti-offset'
2025/04/10 19:28:43 wazuh-modulesd:content-updater[2541264] CtiDownloader.hpp:314 at handleRequest(): DEBUG: CtiOffsetDownloader - Starting process
2025/04/10 19:28:43 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:44 at download(): DEBUG: Initial API offset: 1712396
2025/04/10 19:28:43 wazuh-modulesd:vulnerability-scanner[2541264] vulnerabilityScannerFacade.cpp:512 at start(): INFO: Vulnerability scanner module started.
2025/04/10 19:28:43 wazuh-modulesd:content-updater[2541264] CtiDownloader.hpp:121 at operator()(): DEBUG: CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2025-04-10T13:38:47.047189Z","paths_filter":null,"last_offset":1731046,"changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_snapshot_at":"2025-04-09T13:22:51.804201Z","last_snapshot_link":"https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/1712396_1744204971.zip","last_snapshot_offset":1712396}}'
2025/04/10 19:28:43 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1712396&to_offset=1713396'
2025/04/10 19:28:45 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1713396&to_offset=1714396'
2025/04/10 19:28:45 wazuh-modulesd[2541264] main.c:215 at wm_handler(): DEBUG: Signal received: 15, handling.
2025/04/10 19:28:45 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1714396&to_offset=1715396'
2025/04/10 19:28:46 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1715396&to_offset=1716396'
2025/04/10 19:28:46 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1716396&to_offset=1717396'
2025/04/10 19:28:46 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1717396&to_offset=1718396'
2025/04/10 19:28:46 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1718396&to_offset=1719396'
2025/04/10 19:28:46 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1719396&to_offset=1720396'
2025/04/10 19:28:46 wazuh-modulesd:content-updater[2541264] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1720396&to_offset=1721396'


2025/04/10 19:28:46 wazuh-modulesd:content-updater[2541264] updateCtiApiOffset.hpp:42 at update(): DEBUG: Updating offset with value: '1712396'

```

</p>
</details> 

**Second restart**

Here only a few offsets were processed.
The orchestration resumes from the last one 

```
root@f8d4e01554db:/workspaces/wazuh.worktrees/4.12.0/src/build/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery# ./rocks_db_query_testtool -d /var/ossec/queue/vd_updater/rocksdb/updater_vulnerability_feed_manager_metadata/ -c current_offset
20250410003936 ==> 0
20250410005457 ==> 1712396
20250410192846 ==> 1712396
20250410193122 ==> 1712510

```

<details><summary>Details</summary>
<p>

```
2025/04/10 19:31:15 wazuh-modulesd:content-updater[2542726] actionOrchestrator.hpp:278 at runContentUpdate(): DEBUG: Current offset: '1712396'. Current hash: ''. ContentSource: 'cti-offset'
2025/04/10 19:31:15 wazuh-modulesd:content-updater[2542726] CtiDownloader.hpp:314 at handleRequest(): DEBUG: CtiOffsetDownloader - Starting process
2025/04/10 19:31:15 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:44 at download(): DEBUG: Initial API offset: 1712396
2025/04/10 19:31:15 wazuh-modulesd:vulnerability-scanner[2542726] vulnerabilityScannerFacade.cpp:512 at start(): INFO: Vulnerability scanner module started.
2025/04/10 19:31:16 wazuh-modulesd:content-updater[2542726] CtiDownloader.hpp:121 at operator()(): DEBUG: CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2025-04-10T13:38:47.047189Z","changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_offset":1731046,"last_snapshot_at":"2025-04-09T13:22:51.804201Z","last_snapshot_link":"https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/1712396_1744204971.zip","last_snapshot_offset":1712396,"paths_filter":null}}'
2025/04/10 19:31:16 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1712396&to_offset=1713396'
2025/04/10 19:31:17 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1713396&to_offset=1714396'
2025/04/10 19:31:18 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1714396&to_offset=1715396'
2025/04/10 19:31:18 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1715396&to_offset=1716396'
2025/04/10 19:31:18 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1716396&to_offset=1717396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1717396&to_offset=1718396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1718396&to_offset=1719396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1719396&to_offset=1720396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1720396&to_offset=1721396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1721396&to_offset=1722396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1722396&to_offset=1723396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1723396&to_offset=1724396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1724396&to_offset=1725396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1725396&to_offset=1726396'
2025/04/10 19:31:19 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1726396&to_offset=1727396'
2025/04/10 19:31:20 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1727396&to_offset=1728396'
2025/04/10 19:31:20 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1728396&to_offset=1729396'
2025/04/10 19:31:20 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1729396&to_offset=1730396'
2025/04/10 19:31:20 wazuh-modulesd:content-updater[2542726] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1730396&to_offset=1731046'
2025/04/10 19:31:20 wazuh-modulesd:content-updater[2542726] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2025/04/10 19:31:20 wazuh-modulesd:content-updater[2542726] pubSubPublisher.hpp:83 at handleRequest(): DEBUG: PubSubPublisher - Starting process


2025/04/10 19:31:20 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:358 at operator()(): INFO: Initiating update feed process.
2025/04/10 19:31:20 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:189 at processMessage(): DEBUG: Processing file: queue/vd_updater/tmp/contents/1713396-api_file.json
2025/04/10 19:31:20 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712397
2025/04/10 19:31:20 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712398

...

2025/04/10 19:31:21 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712472
2025/04/10 19:31:21 wazuh-modulesd[2542726] main.c:215 at wm_handler(): DEBUG: Signal received: 15, handling.

...

2025/04/10 19:31:22 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712508
2025/04/10 19:31:22 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712509
2025/04/10 19:31:22 wazuh-modulesd[2542726] main.c:229 at wm_handler(): INFO: Shutting down Wazuh modules.
2025/04/10 19:31:22 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712510


2025/04/10 19:31:22 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:218 at processMessage(): DEBUG: Current offset processed: 1712510
2025/04/10 19:31:22 wazuh-modulesd:vulnerability-scanner[2542726] databaseFeedManager.hpp:364 at operator()(): DEBUG: Feed update process interrupted or failed. Offset: 1712510, Hash: .
2025/04/10 19:31:22 wazuh-modulesd:content-updater[2542726] pubSubPublisher.hpp:66 at publish(): DEBUG: Data published. Offset: '1712510', Hash: ''
2025/04/10 19:31:22 wazuh-modulesd:content-updater[2542726] updateCtiApiOffset.hpp:70 at handleRequest(): DEBUG: UpdateCtiApiOffset - Starting process
2025/04/10 19:31:22 wazuh-modulesd:content-updater[2542726] updateCtiApiOffset.hpp:42 at update(): DEBUG: Updating offset with value: '1712510'
```

</p>
</details> 

**Third restart**

The process resumes again as expected

```
root@f8d4e01554db:/workspaces/wazuh.worktrees/4.12.0/src/build/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery# ./rocks_db_query_testtool -d /var/ossec/queue/vd_updater/rocksdb/updater_vulnerability_feed_manager_metadata/ -c current_offset
20250410003936 ==> 0
20250410005457 ==> 1712396
20250410192846 ==> 1712396
20250410193122 ==> 1712510
20250410193558 ==> 1712568
```

<details><summary>Details</summary>
<p>

```
2025/04/10 19:35:28 wazuh-modulesd:content-updater[2544370] actionOrchestrator.hpp:278 at runContentUpdate(): DEBUG: Current offset: '1712510'. Current hash: ''. ContentSource: 'cti-offset'
2025/04/10 19:35:28 wazuh-modulesd:content-updater[2544370] CtiDownloader.hpp:314 at handleRequest(): DEBUG: CtiOffsetDownloader - Starting process
2025/04/10 19:35:28 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:44 at download(): DEBUG: Initial API offset: 1712510
2025/04/10 19:35:28 wazuh-modulesd:vulnerability-scanner[2544370] vulnerabilityScannerFacade.cpp:512 at start(): INFO: Vulnerability scanner module started.
2025/04/10 19:35:28 wazuh-modulesd:content-updater[2544370] CtiDownloader.hpp:121 at operator()(): DEBUG: CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2025-04-10T13:38:47.047189Z","changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_offset":1731046,"last_snapshot_at":"2025-04-09T13:22:51.804201Z","last_snapshot_link":"https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/1712396_1744204971.zip","last_snapshot_offset":1712396,"paths_filter":null}}'
2025/04/10 19:35:28 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1712510&to_offset=1713510'
2025/04/10 19:35:30 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2025/04/10 19:35:33 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1713510&to_offset=1714510'
2025/04/10 19:35:35 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1714510&to_offset=1715510'
2025/04/10 19:35:36 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1715510&to_offset=1716510'
2025/04/10 19:35:37 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1716510&to_offset=1717510'
2025/04/10 19:35:39 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1717510&to_offset=1718510'
2025/04/10 19:35:40 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1718510&to_offset=1719510'
2025/04/10 19:35:41 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1719510&to_offset=1720510'
2025/04/10 19:35:42 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1720510&to_offset=1721510'
2025/04/10 19:35:44 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1721510&to_offset=1722510'
2025/04/10 19:35:46 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1722510&to_offset=1723510'
2025/04/10 19:35:47 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1723510&to_offset=1724510'
2025/04/10 19:35:48 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1724510&to_offset=1725510'
2025/04/10 19:35:50 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1725510&to_offset=1726510'
2025/04/10 19:35:51 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1726510&to_offset=1727510'
2025/04/10 19:35:52 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1727510&to_offset=1728510'
2025/04/10 19:35:52 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1728510&to_offset=1729510'
2025/04/10 19:35:54 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1729510&to_offset=1730510'
2025/04/10 19:35:55 wazuh-modulesd:content-updater[2544370] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1730510&to_offset=1731046'
2025/04/10 19:35:56 wazuh-modulesd:content-updater[2544370] skipStep.hpp:48 at handleRequest(): DEBUG: SkipStep - Starting process
2025/04/10 19:35:56 wazuh-modulesd:content-updater[2544370] pubSubPublisher.hpp:83 at handleRequest(): DEBUG: PubSubPublisher - Starting process

2025/04/10 19:35:56 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:358 at operator()(): INFO: Initiating update feed process.
2025/04/10 19:35:56 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:189 at processMessage(): DEBUG: Processing file: queue/vd_updater/tmp/contents/1713510-api_file.json
2025/04/10 19:35:56 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712511

...

2025/04/10 19:35:57 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712536
2025/04/10 19:35:57 wazuh-modulesd[2544370] main.c:215 at wm_handler(): DEBUG: Signal received: 15, handling.
2025/04/10 19:35:57 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712537

...

2025/04/10 19:35:58 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712567

2025/04/10 19:35:58 wazuh-modulesd[2544370] main.c:229 at wm_handler(): INFO: Shutting down Wazuh modules.
2025/04/10 19:35:58 wazuh-modulesd:syscollector[2544370] wm_syscollector.c:296 at wm_sys_stop(): INFO: Stop received for Syscollector.
2025/04/10 19:35:58 wazuh-modulesd:vulnerability-scanner[2544370] wm_vulnerability_scanner.c:146 at wm_vulnerability_scanner_stop(): INFO: Stopping vulnerability_scanner module.
2025/04/10 19:35:58 wazuh-modulesd:content-updater[2544370] onDemandManager.cpp:96 at stopServer(): DEBUG: Server stopped
2025/04/10 19:35:58 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1712568
2025/04/10 19:35:58 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:218 at processMessage(): DEBUG: Current offset processed: 1712568
2025/04/10 19:35:58 wazuh-modulesd:vulnerability-scanner[2544370] databaseFeedManager.hpp:364 at operator()(): DEBUG: Feed update process interrupted or failed. Offset: 1712568, Hash: .
2025/04/10 19:35:58 wazuh-modulesd:content-updater[2544370] pubSubPublisher.hpp:66 at publish(): DEBUG: Data published. Offset: '1712568', Hash: ''
2025/04/10 19:35:58 wazuh-modulesd:content-updater[2544370] updateCtiApiOffset.hpp:70 at handleRequest(): DEBUG: UpdateCtiApiOffset - Starting process
2025/04/10 19:35:58 wazuh-modulesd:content-updater[2544370] updateCtiApiOffset.hpp:42 at update(): DEBUG: Updating offset with value: '1712568'
```


</p>
</details> 

**Final restart**

I let the process ends

```
root@f8d4e01554db:/workspaces/wazuh.worktrees/4.12.0/src/build/wazuh_modules/vulnerability_scanner/testtool/rocksDBQuery# ./rocks_db_query_testtool -d /var/ossec/queue/vd_updater/rocksdb/updater_vulnerability_feed_manager_metadata/ -c current_offset
20250410003936 ==> 0
20250410005457 ==> 1712396
20250410192846 ==> 1712396
20250410193122 ==> 1712510
20250410193558 ==> 1712568
20250410194402 ==> 1731046
```

<details><summary>Details</summary>
<p>

```
2025/04/10 19:38:55 wazuh-modulesd:content-updater[2545877] actionOrchestrator.hpp:259 at runContentUpdate(): DEBUG: Running 'vulnerability_feed_manager' content update
2025/04/10 19:38:55 wazuh-modulesd:content-updater[2545877] actionOrchestrator.hpp:278 at runContentUpdate(): DEBUG: Current offset: '1712568'. Current hash: ''. ContentSource: 'cti-offset'
2025/04/10 19:38:55 wazuh-modulesd:content-updater[2545877] CtiDownloader.hpp:314 at handleRequest(): DEBUG: CtiOffsetDownloader - Starting process
2025/04/10 19:38:55 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:44 at download(): DEBUG: Initial API offset: 1712568

2025/04/10 19:38:55 wazuh-modulesd:vulnerability-scanner[2545877] vulnerabilityScannerFacade.cpp:512 at start(): INFO: Vulnerability scanner module started.
2025/04/10 19:38:56 wazuh-modulesd:content-updater[2545877] CtiDownloader.hpp:121 at operator()(): DEBUG: CTI raw metadata: '{"data":{"id":4,"name":"vd_4.8.0","context":"vd_1.0.0","operations":null,"inserted_at":"2023-11-23T19:34:18.698495Z","updated_at":"2025-04-10T13:38:47.047189Z","paths_filter":null,"last_offset":1731046,"changes_url":"cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes","last_snapshot_at":"2025-04-09T13:22:51.804201Z","last_snapshot_link":"https://cti.wazuh.com/store/contexts/vd_1.0.0/consumers/vd_4.8.0/1712396_1744204971.zip","last_snapshot_offset":1712396}}'
2025/04/10 19:38:56 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1712568&to_offset=1713568'
2025/04/10 19:38:56 wazuh-logcollector: INFO: (9203): Monitoring journal entries.
2025/04/10 19:39:00 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1713568&to_offset=1714568'
2025/04/10 19:39:02 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1714568&to_offset=1715568'
2025/04/10 19:39:03 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1715568&to_offset=1716568'
2025/04/10 19:39:04 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1716568&to_offset=1717568'
2025/04/10 19:39:06 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1717568&to_offset=1718568'
2025/04/10 19:39:07 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1718568&to_offset=1719568'
2025/04/10 19:39:08 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1719568&to_offset=1720568'
2025/04/10 19:39:10 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1720568&to_offset=1721568'
2025/04/10 19:39:12 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1721568&to_offset=1722568'
2025/04/10 19:39:14 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1722568&to_offset=1723568'
2025/04/10 19:39:15 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1723568&to_offset=1724568'
2025/04/10 19:39:16 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1724568&to_offset=1725568'
2025/04/10 19:39:18 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1725568&to_offset=1726568'
2025/04/10 19:39:19 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1726568&to_offset=1727568'
2025/04/10 19:39:20 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1727568&to_offset=1728568'
2025/04/10 19:39:22 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1728568&to_offset=1729568'
2025/04/10 19:39:23 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1729568&to_offset=1730568'
2025/04/10 19:39:24 wazuh-modulesd:content-updater[2545877] CtiOffsetDownloader.hpp:137 at downloadContent(): DEBUG: Downloading offsets from: 'https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0/changes?from_offset=1730568&to_offset=1731046'

2025/04/10 19:44:02 wazuh-modulesd:vulnerability-scanner[2545877] databaseFeedManager.hpp:203 at operator()(): DEBUG: Current offset being processed: 1731046
2025/04/10 19:44:02 wazuh-modulesd:vulnerability-scanner[2545877] databaseFeedManager.hpp:218 at processMessage(): DEBUG: Current offset processed: 1731046
2025/04/10 19:44:02 wazuh-modulesd:content-updater[2545877] pubSubPublisher.hpp:66 at publish(): DEBUG: Data published. Offset: '1731046', Hash: ''
2025/04/10 19:44:02 wazuh-modulesd:content-updater[2545877] updateCtiApiOffset.hpp:70 at handleRequest(): DEBUG: UpdateCtiApiOffset - Starting process
2025/04/10 19:44:02 wazuh-modulesd:content-updater[2545877] updateCtiApiOffset.hpp:42 at update(): DEBUG: Updating offset with value: '1731046'
```

</p>
</details> 
