### PR TITLE
Handle case when version is missing

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/buildAllAgentListContext.hpp
@@ -82,10 +82,11 @@ public:
                 // If the agent is the manager and the manager scan is disabled, skip it
                 if (!(isManagerScanDisabled && agent.at("id").get<int>() == 0))
                 {
-                    data->m_agents.push_back({Utils::padString(std::to_string(agent.at("id").get<int>()), '0', 3),
-                                              agent.at("name"),
-                                              Utils::leftTrim(agent.at("version"), "Wazuh "),
-                                              agent.at("ip")});
+                    data->m_agents.push_back(
+                        {Utils::padString(std::to_string(agent.at("id").get<int>()), '0', 3),
+                         agent.at("name"),
+                         agent.contains("version") ? Utils::leftTrim(agent.at("version"), "Wazuh ") : "",
+                         agent.at("ip")});
                 }
                 else
                 {

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/buildAllAgentListContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/buildAllAgentListContext_test.cpp
@@ -91,6 +91,39 @@ TEST_F(BuildAllAgentListContextTest, BuildAllAgentListContextWithElements)
     EXPECT_EQ(scanContext->m_agents.size(), 1);
 }
 
+TEST_F(BuildAllAgentListContextTest, BuildAllAgentListNoVersion)
+{
+    spSocketDBWrapperMock = std::make_shared<MockSocketDBWrapper>();
+
+    const nlohmann::json queryResult = nlohmann::json::parse(R"(
+    [
+        {
+            "id": 1,
+            "name": "name",
+            "ip": "192.168.0.1",
+            "node_name": "node_1"
+        }
+    ])");
+
+    EXPECT_CALL(*spSocketDBWrapperMock, query(testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::SetArgReferee<1>(queryResult));
+
+    auto allAgentContext =
+        std::make_shared<TBuildAllAgentListContext<TrampolineScanContext, TrampolineSocketDBWrapper>>();
+
+    auto scanContext = std::make_shared<TrampolineScanContext>();
+
+    // Context is not used
+    EXPECT_NO_THROW(allAgentContext->handleRequest(scanContext));
+
+    EXPECT_EQ(scanContext->m_agents.size(), 1);
+    EXPECT_EQ(scanContext->m_agents[0].version, "");
+    EXPECT_EQ(scanContext->m_agents[0].name, "name");
+    EXPECT_EQ(scanContext->m_agents[0].id, "001");
+    EXPECT_EQ(scanContext->m_agents[0].ip, "192.168.0.1");
+}
+
 TEST_F(BuildAllAgentListContextTest, MissingField)
 {
     // Initialize policy manager


### PR DESCRIPTION
|Related issue|
|---|
|Closes #29102|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR handles the case when Wazuh-DB doesn't send the agent version.
This can happen if the agent is registered but didn't send the first keepalive.
