### PR TITLE
Add steps in manager package smoke tests

### DIFF
--- a/.github/actions/test-install-components/uninstall_component.sh
+++ b/.github/actions/test-install-components/uninstall_component.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+package_name=$1
+target=$2
+
+if [ -z "$package_name" ] || [ -z "$target" ]; then
+    echo "Error: Both package_name and target must be provided."
+    echo "Usage: $0 <package_name> <target>"
+    exit 1
+fi
+
+echo "Uninstalling Wazuh $target."
+
+if [ -n "$(command -v yum)" ]; then
+    uninstall="yum remove -y"
+    installed_log="/var/log/yum.log"
+elif [ -n "$(command -v dpkg)" ]; then
+    uninstall="dpkg --remove"
+    installed_log="/var/log/dpkg.log"
+else
+    echo "Couldn't find type of system"
+    exit 1
+fi
+
+$uninstall "wazuh-$target" | tee /packages/status.log
+
+if grep -i " removed.*wazuh-$target" $installed_log | tee -a /packages/status.log; then
+    echo "Wazuh $target was uninstalled successfully."
+    exit 0
+else
+    echo "Failed to uninstall Wazuh $target."
+    exit 1
+fi

--- a/.github/workflows/4_builderpackage_manager.yml
+++ b/.github/workflows/4_builderpackage_manager.yml
@@ -175,6 +175,7 @@ jobs:
             fi
           done
 
+          echo "FLAGS=$FLAGS" >> $GITHUB_ENV
           echo "PACKAGE_NAME=${PACKAGE_NAME}" | tee -a $GITHUB_ENV
           echo "PACKAGE_SYMBOLS_NAME=${PACKAGE_SYMBOLS_NAME}" | tee -a $GITHUB_ENV
 
@@ -182,7 +183,11 @@ jobs:
         run: |
           TESTS_PATH=$GITHUB_WORKSPACE/.github/actions/test-install-components/
           if [ -z "${{ env.PACKAGE_NAME }}" ]; then echo "No package found matching the pattern!"; exit 1; fi
-          sudo docker run -v $TESTS_PATH/:/tests -v /tmp/:/packages -v /var/ossec:/var/ossec --entrypoint '/tests/install_component.sh' $CONTAINER_NAME:${{ env.TAG }} $PACKAGE_NAME manager
+          
+          CONTAINER_ID=$(sudo docker run -d -v $TESTS_PATH/:/tests -v /tmp/:/packages -v /var/ossec:/var/ossec \
+            --entrypoint '/bin/sh' $CONTAINER_NAME:${{ env.TAG }} -c "tail -f /dev/null")
+          
+          sudo docker exec $CONTAINER_ID /tests/install_component.sh $PACKAGE_NAME manager
 
           # Check if Wazuh was installed. The /tmp/status.log file was generated in the previous step.
           if grep -iq " installed.*wazuh-manager" /tmp/status.log ; then
@@ -191,9 +196,100 @@ jobs:
             echo "The installation could not be completed. The package will not be uploaded.";
             exit 1;
           fi
-
+          
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
           echo "WAZUH_UID=$(cat $TESTS_PATH/wazuh_uid)" | tee -a $GITHUB_ENV
           echo "WAZUH_GID=$(cat $TESTS_PATH/wazuh_gid)" | tee -a $GITHUB_ENV
+
+      - name: Check installed files
+        uses: ./.github/actions/check_files
+        with:
+          expected_files: manager_base.csv
+          wazuh_uid: ${{ env.WAZUH_UID }}
+          wazuh_gid: ${{ env.WAZUH_GID }}
+          size_check: "false"
+          ignore: "site-packages,/var/ossec/framework/python"
+
+      - name: Test uninstall built manager
+        run: |
+          if [ -z "${{ env.PACKAGE_NAME }}" ] || [ -z "${{ env.CONTAINER_ID }}" ]; then 
+            echo "No package or container found!";
+            exit 1;
+          fi
+
+          sudo docker exec $CONTAINER_ID chmod +x /tests/uninstall_component.sh
+          sudo docker exec $CONTAINER_ID /tests/uninstall_component.sh $PACKAGE_NAME manager
+          sudo docker stop $CONTAINER_ID && sudo docker rm $CONTAINER_ID
+
+      - name: Get latest Wazuh release from GitHub
+        run: |
+          apt-get update && apt-get install -y curl jq
+          LATEST_TAG=$(curl -s https://api.github.com/repos/wazuh/wazuh/releases/latest | jq -r .tag_name | sed 's/^v//')
+          echo "Latest release detected: $LATEST_TAG"
+          echo "PUBLIC_RELEASE_VERSION=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Download latest public wazuh-manager package
+        run: |
+          ARCH=${{ inputs.architecture }}
+          VERSION=${{ env.PUBLIC_RELEASE_VERSION }}
+
+          if [ "${{ inputs.system }}" = "deb" ]; then
+            FILE_NAME_PUBLIC="wazuh-manager_${VERSION}-1_${ARCH}.deb"
+            BASE_URL="https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-manager"
+          elif [ "${{ inputs.system }}" = "rpm" ]; then
+            FILE_NAME_PUBLIC="wazuh-manager-${VERSION}-1.${ARCH}.rpm"
+            BASE_URL="https://packages.wazuh.com/4.x/yum"
+          else
+            echo "Unsupported system type: ${{ inputs.system }}"
+            exit 1
+          fi
+
+          PACKAGE_URL="$BASE_URL/$FILE_NAME_PUBLIC"
+          echo "Downloading: $PACKAGE_URL"
+          curl -fSL "$PACKAGE_URL" -o "/tmp/$FILE_NAME_PUBLIC"
+          echo "PUBLIC_PACKAGE_NAME=$FILE_NAME_PUBLIC" >> $GITHUB_ENV
+
+      - name: Run container and install public wazuh-manager
+        run: |
+          FILE_NAME=${{ env.PUBLIC_PACKAGE_NAME }}
+          SYSTEM=${{ inputs.system }}
+
+          if [ "$SYSTEM" = "deb" ]; then
+            BASE_IMAGE="ubuntu:22.04"
+            INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -f install -y"
+            UPDATE_CMD="apt-get update"
+            docker run --name wazuh_previous -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
+            sleep 5
+          else
+            BASE_IMAGE="centos:8"
+            INSTALL_CMD="yum localinstall -y /packages/$FILE_NAME"
+            UPDATE_CMD="yum update -y"
+            docker run --name wazuh_previous -d -v /tmp:/packages $BASE_IMAGE tail -f /dev/null
+            # Configuring CentOS 8 repositories
+            docker exec wazuh_previous bash -c "sed -i.bak 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*"
+            docker exec wazuh_previous bash -c "sed -i.bak 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*"
+            sleep 5
+          fi
+
+          docker exec wazuh_previous bash -c "$UPDATE_CMD"
+          docker exec wazuh_previous bash -c "$INSTALL_CMD"
+          docker exec wazuh_previous bash -c "/var/ossec/bin/wazuh-control info || echo 'Manager not started yet'"
+
+      - name: Upgrade to current Wazuh version
+        run: |
+          SYSTEM=${{ inputs.system }}
+          FILE_NAME=${{ env.PACKAGE_NAME }}
+
+          if [ "$SYSTEM" = "deb" ]; then
+            INSTALL_CMD="dpkg -i /packages/$FILE_NAME || apt-get -f install -y"
+          else
+            INSTALL_CMD="yum localinstall -y /packages/$FILE_NAME"
+          fi
+
+          echo "Upgrading to current version with package: $FILE_NAME"
+          docker cp /tmp/$FILE_NAME wazuh_previous:/packages/$FILE_NAME
+          docker exec wazuh_previous bash -c "$INSTALL_CMD"
+          docker exec wazuh_previous bash -c "/var/ossec/bin/wazuh-control info || echo 'Manager not started yet after upgrade'"
 
       - name: Upload package to GitHub
         if: always()

--- a/.github/workflows/4_builderpackage_manager.yml
+++ b/.github/workflows/4_builderpackage_manager.yml
@@ -211,15 +211,6 @@ jobs:
           path: /tmp/${{ env.PACKAGE_SYMBOLS_NAME }}
           if-no-files-found: error
 
-      - name: Check installed files
-        uses: ./.github/actions/check_files
-        with:
-          expected_files: manager_base.csv
-          wazuh_uid: ${{ env.WAZUH_UID }}
-          wazuh_gid: ${{ env.WAZUH_GID }}
-          size_check: "false"
-          ignore: "site-packages,/var/ossec/framework/python"
-
       - name: Set up AWS CLI
         if: ${{ env.SHOULD_UPLOAD == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
|Related issue|
|---|
| #28509  |

## Description

This PR closes #28509, where the `4_builderpackage_manager.ym`l workflow was modified by adding test steps for the uninstallation and upgrade of the manager.

It was added:

- `Test uninstall built manager`
```console
Removing wazuh-manager (4.13.0-0) ...
Wazuh manager was uninstalled successfully.
```
- `Get latest Wazuh release from GitHub`
```console
Latest release detected: 4.11.2
```
- `Download latest public wazuh-manager package`
```console
Downloading: https://packages.wazuh.com/4.x/.../wazuh-manager/wazuh-manager_4.11.2-1_xxx.xxx
```
- `Run container and install public wazuh-manager`
```console
Setting up wazuh-manager (4.11.2-1)
WAZUH_VERSION="v4.11.2"
```
- `Upgrade to current Wazuh version`
```console
Unpacking wazuh-manager (4.13.0-0) over (4.11.2-1) ...
WAZUH_VERSION="v4.13.0"
```
![image](https://github.com/user-attachments/assets/d96cffbe-e250-4ad4-b841-14e08c388257)

![image](https://github.com/user-attachments/assets/86e3a4a1-8255-4ba9-8930-7299ecd285b3)

