### PR TITLE
Fixed Engine httpsrv being stopped twice

### DIFF
--- a/src/engine/source/httpsrv/src/server.cpp
+++ b/src/engine/source/httpsrv/src/server.cpp
@@ -113,6 +113,11 @@ void Server::stop() noexcept
 {
     try
     {
+        if (!isRunning())
+        {
+            return;
+        }
+
         m_srv->stop();
 
         if (m_thread.joinable())

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -55,7 +55,6 @@ void sigintHandler(const int signum)
 {
     if (g_engineServer)
     {
-        g_engineServer->stop();
         g_engineServer.reset();
     }
 }


### PR DESCRIPTION
|Related issue|
|---|
|#29184|

Httpsrv is now stopped only if it is running, avoiding the duplicate logging information when the shared_ptr was released, that was causing an unhandled exception since the logger was already destroyed.

```bash
root@WazPc:/home/test# WAZUH_CONFIG_SKIP_API=true /usr/share/wazuh-server/bin/wazuh-engine
2025-04-11 16:57:28.169 1498:1498 info: Logging initialized.
2025-04-11 16:57:28.169 1498:1498 info: Skipping configuration from API.
2025-04-11 16:57:28.169 1498:1498 info: Metrics manager configured successfully
2025-04-11 16:57:28.170 1498:1498 info: Metrics initialized.
2025-04-11 16:57:28.170 1498:1498 info: Metrics disabled.
2025-04-11 16:57:28.171 1498:1498 info: Store initialized.
2025-04-11 16:57:28.171 1498:1498 info: RBAC initialized.
2025-04-11 16:57:28.239 1498:1498 info: KVDB initialized.
2025-04-11 16:57:28.239 1498:1498 info: Geo initialized.
2025-04-11 16:57:28.251 1498:1498 info: Schema initialized.
2025-04-11 16:57:28.260 1498:1498 info: Loaded timezone database version: '2024a'
2025-04-11 16:57:28.260 1498:1498 info: HLP initialized.
2025-04-11 16:57:28.291 1498:1498 info: Indexer Connector initialized.
2025-04-11 16:57:28.293 1498:1498 info: Builder initialized.
2025-04-11 16:57:28.293 1498:1498 info: Catalog initialized.
2025-04-11 16:57:28.293 1498:1498 info: Policy manager initialized.
2025-04-11 16:57:28.293 1498:1498 info: No flooding file provided, the queue will not be flooded.
2025-04-11 16:57:28.298 1498:1498 info: No flooding file provided, the queue will not be flooded.
2025-04-11 16:57:28.298 1498:1498 warning: Router: router/tester/0 table is empty
2025-04-11 16:57:28.502 1498:1498 info: Router initialized.
2025-04-11 16:57:28.585 1498:1498 info: Server API_SRV started in thread 140606827394624 at /run/wazuh-server/engine-api.socket
2025-04-11 16:57:28.585 1498:1498 info: Starting server EVENT_SRV at /run/wazuh-server/engine.socket
^C2025-04-11 16:57:30.058 1498:1498 info: Server EVENT_SRV stopped
2025-04-11 16:57:30.058 1498:1498 info: Server EVENT_SRV stopped
2025-04-11 16:57:30.058 1498:1498 info: Server API_SRV stopped
2025-04-11 16:57:30.107 1498:1498 info: KVDB terminated.
```