### PR TITLE
Fix special characters in `reflectiveJson`

### DIFF
--- a/src/shared_modules/utils/reflectiveJson.hpp
+++ b/src/shared_modules/utils/reflectiveJson.hpp
@@ -62,6 +62,7 @@ static std::array<const char*, CHAR_SIZE> ESCAPE_TABLE = []
 
 inline bool needEscape(std::string_view input)
 {
+    // Kept the unsigned char to avoid errors with unicode characters
     for (unsigned char chr : input)
     {
         if (ESCAPE_TABLE[chr])
@@ -73,7 +74,7 @@ inline bool needEscape(std::string_view input)
 }
 inline void escapeJSONString(std::string_view input, std::string& output)
 {
-
+    // Kept the unsigned char to avoid errors with unicode characters
     for (unsigned char chr : input)
     {
         if (ESCAPE_TABLE[chr])

--- a/src/shared_modules/utils/reflectiveJson.hpp
+++ b/src/shared_modules/utils/reflectiveJson.hpp
@@ -62,9 +62,9 @@ static std::array<const char*, CHAR_SIZE> ESCAPE_TABLE = []
 
 inline bool needEscape(std::string_view input)
 {
-    for (auto c : input)
+    for (unsigned char chr : input)
     {
-        if (ESCAPE_TABLE[c])
+        if (ESCAPE_TABLE[chr])
         {
             return true;
         }
@@ -74,15 +74,15 @@ inline bool needEscape(std::string_view input)
 inline void escapeJSONString(std::string_view input, std::string& output)
 {
 
-    for (auto c : input)
+    for (unsigned char chr : input)
     {
-        if (ESCAPE_TABLE[c])
+        if (ESCAPE_TABLE[chr])
         {
-            output.append(ESCAPE_TABLE[c]);
+            output.append(ESCAPE_TABLE[chr]);
         }
         else
         {
-            output.push_back(c);
+            output.push_back(chr);
         }
     }
 }
@@ -136,7 +136,7 @@ constexpr bool IS_REFLECTABLE_MEMBER =
     std::is_same_v<std::decay_t<T>, std::int64_t>;
 
 template<typename C, typename T>
-constexpr auto makeFieldChecked(const char* keyLiteral, const char* keyLiteralField, T C::*member)
+constexpr auto makeFieldChecked(const char* keyLiteral, const char* keyLiteralField, T C::* member)
 {
     static_assert(IS_REFLECTABLE_MEMBER<T>, "Invalid member type for reflection");
     return std::make_tuple(std::string_view {keyLiteral}, std::string_view {keyLiteralField}, member);
@@ -290,8 +290,8 @@ std::enable_if_t<IsReflectable<T>::value, void> serializeToJSON(const T& obj, st
                              json.push_back('"');
                          }
                          else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(data)>> ||
-                                             std::is_same_v<double, std::decay_t<decltype(data)>>)&&!std::
-                                                is_same_v<bool, std::decay_t<decltype(data)>>)
+                                             std::is_same_v<double, std::decay_t<decltype(data)>>) &&
+                                            !std::is_same_v<bool, std::decay_t<decltype(data)>>)
                          {
 
                              auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), data);
@@ -338,8 +338,8 @@ std::enable_if_t<IsReflectable<T>::value, void> serializeToJSON(const T& obj, st
                                      json.push_back('\"');
                                  }
                                  else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(value)>> ||
-                                                     std::is_same_v<double, std::decay_t<decltype(value)>>)&&!std::
-                                                        is_same_v<bool, std::decay_t<decltype(value)>>)
+                                                     std::is_same_v<double, std::decay_t<decltype(value)>>) &&
+                                                    !std::is_same_v<bool, std::decay_t<decltype(value)>>)
                                  {
                                      auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), value);
                                      if (ec == std::errc())
@@ -387,8 +387,8 @@ std::enable_if_t<IsReflectable<T>::value, void> serializeToJSON(const T& obj, st
                                      json.push_back('\"');
                                  }
                                  else if constexpr ((std::is_arithmetic_v<decltype(v)> ||
-                                                     std::is_same_v<const double&, decltype(v)>)&&!std::
-                                                        is_same_v<bool, std::decay_t<decltype(v)>>)
+                                                     std::is_same_v<const double&, decltype(v)>) &&
+                                                    !std::is_same_v<bool, std::decay_t<decltype(v)>>)
                                  {
                                      auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), v);
                                      if (ec == std::errc())
@@ -467,8 +467,8 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                              json.push_back('"');
                          }
                          else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(data)>> ||
-                                             std::is_same_v<double, std::decay_t<decltype(data)>>)&&!std::
-                                                is_same_v<bool, std::decay_t<decltype(data)>>)
+                                             std::is_same_v<double, std::decay_t<decltype(data)>>) &&
+                                            !std::is_same_v<bool, std::decay_t<decltype(data)>>)
                          {
 
                              auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), data);
@@ -516,8 +516,8 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                                      json.push_back('\"');
                                  }
                                  else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(value)>> ||
-                                                     std::is_same_v<double, std::decay_t<decltype(value)>>)&&!std::
-                                                        is_same_v<bool, std::decay_t<decltype(value)>>)
+                                                     std::is_same_v<double, std::decay_t<decltype(value)>>) &&
+                                                    !std::is_same_v<bool, std::decay_t<decltype(value)>>)
                                  {
                                      auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), value);
                                      if (ec == std::errc())
@@ -558,9 +558,8 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                                              json.push_back('\"');
                                          }
                                          else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(value)>> ||
-                                                             std::is_same_v<double,
-                                                                            std::decay_t<decltype(value)>>)&&!std::
-                                                                is_same_v<bool, std::decay_t<decltype(value)>>)
+                                                             std::is_same_v<double, std::decay_t<decltype(value)>>) &&
+                                                            !std::is_same_v<bool, std::decay_t<decltype(value)>>)
                                          {
                                              auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), v);
                                              if (ec == std::errc())

--- a/src/shared_modules/utils/tests/reflectiveJson_test.cpp
+++ b/src/shared_modules/utils/tests/reflectiveJson_test.cpp
@@ -219,6 +219,7 @@ TEST_F(ReflectiveJsonTest, FullEscapeTableCoverage)
         {"formfeed", "Page\fBreak"},
         {"newline", "Line1\nLine2"},
         {"carriage_return", "Line\rReset"},
+        {"unicode_text", "NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem"},
         {"tabbed", "A\tB\tC"},
         {"ET", "🏠"} // Unicode emoji
     };


### PR DESCRIPTION
|Related issue|
|---|
|Closes #29142 |

# Objective

Ensure proper escaping of UTF-8 encoded input characters in JSON serialization routines by explicitly casting characters to `unsigned char` prior to indexing into the `ESCAPE_TABLE`.

## Description

This change addresses a subtle but critical correctness issue in the `needEscape()` and `escapeJSONString()` functions, where each character from a `std::string_view` was previously used as an index into `ESCAPE_TABLE` without casting. In C++, `char` may be signed or unsigned depending on the implementation, and on most systems using GCC < 11.1 with `-O3` optimizations, signed characters with negative values can result in **undefined behavior** when used as array indices.

By explicitly casting each character to `unsigned char`, we ensure that values fall in the valid range of 0–255 before being used to index `ESCAPE_TABLE`. 

This issue is particularly critical when processing UTF-8 encoded input that contains extended byte sequences (e.g., multi-byte characters such as `ő`, `ü`, or emoji), which encode values above 127. On compilers such as GCC 9.4 or earlier with `-O3`, these could be miscompiled due to the assumption of signed `char`, leading to incorrect or unsafe memory access.

##### Before change

![image](https://github.com/user-attachments/assets/c1389b8b-ec23-42c3-b897-f44d5458c71c)


##### After change

![image](https://github.com/user-attachments/assets/db415f63-5e57-43aa-86bc-4a8f47d670ec)


### Key changes

- Explicitly cast characters to `unsigned char` in `needEscape()` and `escapeJSONString()` to guarantee safe indexing into the 256-entry `ESCAPE_TABLE`.
- Prevents undefined behavior and ensures correctness of UTF-8 escaping logic on GCC versions prior to 11.1, especially under aggressive optimization (`-O3`).
- Ensures that escaping logic remains robust and safe for all valid UTF-8 input, regardless of platform default `char` signedness.







