### PR TITLE
Duplicated SCA check IDs CentOS Linux 10

### DIFF
--- a/ruleset/sca/centos/10/cis_centos10_linux.yml
+++ b/ruleset/sca/centos/10/cis_centos10_linux.yml
@@ -30,7 +30,7 @@ variables:
 
 checks:
   # 1.1.1.1 Ensure mounting of cramfs filesystems is disabled. (Automated)
-  - id: 6500
+  - id: 37500
     title: "Ensure mounting of cramfs filesystems is disabled."
     description: "The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -51,7 +51,7 @@ checks:
       - 'd:/etc/modprobe.d -> r:\.+ -> r:^blacklist\s*\t*cramfs'
 
   # 1.1.1.2 Ensure mounting of squashfs filesystems is disabled. (Automated)
-  - id: 6501
+  - id: 37501
     title: "Ensure mounting of squashfs filesystems is disabled."
     description: "The squashfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A squashfs image can be used without having to first decompress the image."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -73,7 +73,7 @@ checks:
       - 'd:/etc/modprobe.d -> r:\.+ -> r:^blacklist\s*\t*squashfs'
 
   # 1.1.1.3 Ensure mounting of udf filesystems is disabled. (Automated)
-  - id: 6502
+  - id: 37502
     title: "Ensure mounting of udf filesystems is disabled."
     description: "The udf filesystem type is the universal disk format used to implement ISO/IEC 13346 and ECMA-167 specifications. This is an open vendor filesystem type for data storage on a broad range of media. This filesystem type is necessary to support writing DVDs and newer optical disc formats."
     rationale: "Removing support for unneeded filesystem types reduces the local attack surface of the system. If this filesystem type is not needed, disable it."
@@ -95,7 +95,7 @@ checks:
       - 'd:/etc/modprobe.d -> r:\.+ -> r:^blacklist\s*\t*udf'
 
   # 1.1.2.1 Ensure /tmp is a separate partition. (Automated)
-  - id: 6503
+  - id: 37503
     title: "Ensure /tmp is a separate partition."
     description: "The /tmp directory is a world-writable directory used for temporary storage by all users and some applications."
     rationale: "Making /tmp its own file system allows an administrator to set additional mount options such as the noexec option on the mount, making /tmp useless for an attacker to install executable code. It would also prevent an attacker from establishing a hard link to a system setuid program and wait for it to be updated. Once the program was updated, the hard link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw. This can be accomplished by either mounting tmpfs to /tmp, or creating a separate partition for /tmp."
@@ -118,7 +118,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s'
 
   # 1.1.2.2 Ensure nodev option set on /tmp partition. (Automated)
-  - id: 6504
+  - id: 37504
     title: "Ensure nodev option set on /tmp partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /tmp filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /tmp."
@@ -137,7 +137,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && !r:nodev'
 
   # 1.1.2.3 Ensure noexec option set on /tmp partition. (Automated)
-  - id: 6505
+  - id: 37505
     title: "Ensure noexec option set on /tmp partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /tmp."
@@ -158,7 +158,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && !r:noexec'
 
   # 1.1.2.4 Ensure nosuid option set on /tmp partition. (Automated)
-  - id: 6506
+  - id: 37506
     title: "Ensure nosuid option set on /tmp partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /tmp."
@@ -179,7 +179,7 @@ checks:
       - 'c:mount -> r:\s/tmp\s && !r:nosuid'
 
   # 1.1.3.1 Ensure separate partition exists for /var. (Automated)
-  - id: 6507
+  - id: 37507
     title: "Ensure separate partition exists for /var."
     description: "The /var directory is used by daemons and other system services to temporarily store dynamic data. Some directories created by these processes may be world-writable."
     rationale: "The reasoning for mounting /var on a separate partition is as follow. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var and cause unintended behavior across the system as the disk is full. See man auditd.conf for details. Fine grained control over the mount Configuring /var as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behaviour. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection from exploitation An example of exploiting /var may be an attacker establishing a hard-link to a system setuid program and wait for it to be updated. Once the program was updated, the hard-link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -203,7 +203,7 @@ checks:
       - 'c:mount -> r:\s/var\s'
 
   # 1.1.3.2 Ensure nodev option set on /var partition. (Automated)
-  - id: 6508
+  - id: 37508
     title: "Ensure nodev option set on /var partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var."
@@ -224,7 +224,7 @@ checks:
       - 'c:mount -> r:\s/var\s && !r:nodev'
 
   # 1.1.3.3 Ensure noexec option set on /var partition. (Automated)
-  - id: 6509
+  - id: 37509
     title: "Ensure noexec option set on /var partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot run executable binaries from /var."
@@ -245,7 +245,7 @@ checks:
       - 'c:mount -> r:\s/var\s && !r:noexec'
 
   # 1.1.3.4 Ensure nosuid option set on /var partition. (Automated)
-  - id: 6510
+  - id: 37510
     title: "Ensure nosuid option set on /var partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var."
@@ -266,7 +266,7 @@ checks:
       - 'c:mount -> r:\s/var\s && !r:nosuid'
 
   # 1.1.4.1 Ensure separate partition exists for /var/tmp. (Automated)
-  - id: 6511
+  - id: 37511
     title: "Ensure separate partition exists for /var/tmp."
     description: "The /var/tmp directory is a world-writable directory used for temporary storage by all users and some applications. Temporary file residing in /var/tmp is to be preserved between reboots."
     rationale: "The reasoning for mounting /var/tmp on a separate partition is as follow. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var/tmp directory may contain world-writable files and directories, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/tmp and cause the potential disruption to daemons as the disk is full. Fine grained control over the mount Configuring /var/tmp as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection from exploitation An example of exploiting /var/tmp may be an attacker establishing a hard-link to a system setuid program and wait for it to be updated. Once the program was updated, the hard-link would be broken and the attacker would have his own copy of the program. If the program happened to have a security vulnerability, the attacker could continue to exploit the known flaw."
@@ -290,7 +290,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s'
 
   # 1.1.4.2 Ensure noexec option set on /var/tmp partition. (Automated)
-  - id: 6512
+  - id: 37512
     title: "Ensure noexec option set on /var/tmp partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot run executable binaries from /var/tmp."
@@ -311,7 +311,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && !r:noexec'
 
   # 1.1.4.3 Ensure nosuid option set on /var/tmp partition. (Automated)
-  - id: 6513
+  - id: 37513
     title: "Ensure nosuid option set on /var/tmp partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/tmp filesystem is only intended for temporary file storage, set this option to ensure that users cannot create setuid files in /var/tmp."
@@ -332,7 +332,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && !r:nosuid'
 
   # 1.1.4.4 Ensure nodev option set on /var/tmp partition. (Automated)
-  - id: 6514
+  - id: 37514
     title: "Ensure nodev option set on /var/tmp partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/tmp filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var/tmp."
@@ -353,7 +353,7 @@ checks:
       - 'c:mount -> r:\s/var/tmp\s && !r:nodev'
 
   # 1.1.5.1 Ensure separate partition exists for /var/log. (Automated)
-  - id: 6515
+  - id: 37515
     title: "Configure /var/log The /var/log directory is used by system services to store log data. 1.1.5.1 Ensure separate partition exists for /var/log."
     description: "The /var/log directory is used by system services to store log data."
     rationale: "The reasoning for mounting /var/log on a separate partition is as follow. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var/log directory contain the log files that can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. Fine grained control over the mount Configuring /var/log as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection of log data As /var/log contains log files, care should be taken to ensure the security and integrity of the data and mount point."
@@ -373,7 +373,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s'
 
   # 1.1.5.2 Ensure nodev option set on /var/log partition. (Automated)
-  - id: 6516
+  - id: 37516
     title: "Ensure nodev option set on /var/log partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/log filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var/log."
@@ -394,7 +394,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s && !r:nodev'
 
   # 1.1.5.3 Ensure noexec option set on /var/log partition. (Automated)
-  - id: 6517
+  - id: 37517
     title: "Ensure noexec option set on /var/log partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot run executable binaries from /var/log."
@@ -415,7 +415,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s && !r:noexec'
 
   # 1.1.5.4 Ensure nosuid option set on /var/log partition. (Automated)
-  - id: 6518
+  - id: 37518
     title: "Ensure nosuid option set on /var/log partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/log filesystem is only intended for log files, set this option to ensure that users cannot create setuid files in /var/log."
@@ -436,7 +436,7 @@ checks:
       - 'c:mount -> r:\s/var/log\s && !r:noexec'
 
   # 1.1.6.1 Ensure separate partition exists for /var/log/audit. (Automated)
-  - id: 6519
+  - id: 37519
     title: "Ensure separate partition exists for /var/log/audit."
     description: "The auditing daemon, auditd, stores log data in the /var/log/audit directory."
     rationale: "The reasoning for mounting /var/log/audit on a separate partition is as follow. Protection from resource exhaustion The default installation only creates a single / partition. Since the /var/log/audit directory contain the audit.log file that can grow quite large, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /var/log/audit and cause auditd to trigger it's space_left_action as the disk is full. See man auditd.conf for details. Fine grained control over the mount Configuring /var/log/audit as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection of audit data As /var/log/audit contains audit logs, care should be taken to ensure the security and integrity of the data and mount point."
@@ -456,7 +456,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s'
 
   # 1.1.6.2 Ensure noexec option set on /var/log/audit partition. (Automated)
-  - id: 6520
+  - id: 37520
     title: "Ensure noexec option set on /var/log/audit partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Since the /var/log/audit filesystem is only intended for audit logs, set this option to ensure that users cannot run executable binaries from /var/log/audit."
@@ -477,7 +477,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s && !r:noexec'
 
   # 1.1.6.3 Ensure nodev option set on /var/log/audit partition. (Automated)
-  - id: 6521
+  - id: 37521
     title: "Ensure nodev option set on /var/log/audit partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /var/log/audit filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var/log/audit."
@@ -498,7 +498,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s && !r:nodev'
 
   # 1.1.6.4 Ensure nosuid option set on /var/log/audit partition. (Automated)
-  - id: 6522
+  - id: 37522
     title: "Ensure nosuid option set on /var/log/audit partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /var/log/audit filesystem is only intended for variable files such as logs, set this option to ensure that users cannot create setuid files in /var/log/audit."
@@ -519,7 +519,7 @@ checks:
       - 'c:mount -> r:\s/var/log/audit\s && !r:nosuid'
 
   # 1.1.7.1 Ensure separate partition exists for /home. (Automated)
-  - id: 6523
+  - id: 37523
     title: "Ensure separate partition exists for /home."
     description: "The /home directory is used to support disk storage needs of local users."
     rationale: "The reasoning for mounting /home on a separate partition is as follow. Protection from resource exhaustion The default installation only creates a single / partition. Since the /home directory contains user generated data, there is a risk of resource exhaustion. It will essentially have the whole disk available to fill up and impact the system as a whole. In addition, other operations on the system could fill up the disk unrelated to /home and impact all local users. Fine grained control over the mount Configuring /home as its own file system allows an administrator to set additional mount options such as noexec/nosuid/nodev. These options limits an attackers ability to create exploits on the system. In the case of /home options such as usrquota/grpquota may be considered to limit the impact that users can have on each other with regards to disk resource exhaustion. Other options allow for specific behavior. See man mount for exact details regarding filesystem-independent and filesystem-specific options. Protection of user data As /home contains user data, care should be taken to ensure the security and integrity of the data and mount point."
@@ -543,7 +543,7 @@ checks:
       - 'c:mount -> r:\s/home\s'
 
   # 1.1.7.2 Ensure nodev option set on /home partition. (Automated)
-  - id: 6524
+  - id: 37524
     title: "Ensure nodev option set on /home partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /home filesystem is not intended to support devices, set this option to ensure that users cannot create a block or character special devices in /var."
@@ -564,7 +564,7 @@ checks:
       - 'c:mount -> r:\s/home\s && !r:nodev'
 
   # 1.1.7.3 Ensure nosuid option set on /home partition. (Automated)
-  - id: 6525
+  - id: 37525
     title: "Ensure nosuid option set on /home partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Since the /home filesystem is only intended for user file storage, set this option to ensure that users cannot create setuid files in /home."
@@ -585,7 +585,7 @@ checks:
       - 'c:mount -> r:\s/home\s && !r:nodev'
 
   # 1.1.7.4 Ensure usrquota option set on /home partition. (Automated)
-  - id: 6526
+  - id: 37526
     title: "Ensure usrquota option set on /home partition."
     description: "The usrquota mount option allows for the filesystem to have disk quotas configured."
     rationale: "To ensure the availability of disk space on /home, it is important to limit the impact a single user or group can cause for other users (or the wider system) by accidentally filling up the partition. Quotas can also be applied to inodes for filesystems where inode exhaustion is a concern."
@@ -607,7 +607,7 @@ checks:
       - "c:quotaon -p user -> r:user"
 
   # 1.1.7.5 Ensure grpquota option set on /home partition. (Automated)
-  - id: 6527
+  - id: 37527
     title: "Ensure grpquota option set on /home partition."
     description: "The grpquota mount option allows for the filesystem to have disk quotas configured."
     rationale: "To ensure the availability of disk space on /home, it is important to limit the impact a single user or group can cause for other users (or the wider system) by accidentally filling up the partition. Quotas can also be applied to inodes for filesystems where inode exhaustion is a concern."
@@ -629,7 +629,7 @@ checks:
       - "c:quotaon -p group -> r:user"
 
   # 1.1.8.1 Ensure nodev option set on /dev/shm partition. (Automated)
-  - id: 6528
+  - id: 37528
     title: "Configure /dev/shm 1.1.8.1 Ensure nodev option set on /dev/shm partition."
     description: "The nodev mount option specifies that the filesystem cannot contain special devices."
     rationale: "Since the /dev/shm filesystem is not intended to support devices, set this option to ensure that users cannot attempt to create special devices in /dev/shm partitions."
@@ -650,7 +650,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && !r:nodev'
 
   # 1.1.8.2 Ensure noexec option set on /dev/shm partition. (Automated)
-  - id: 6529
+  - id: 37529
     title: "Ensure noexec option set on /dev/shm partition."
     description: "The noexec mount option specifies that the filesystem cannot contain executable binaries."
     rationale: "Setting this option on a file system prevents users from executing programs from shared memory. This deters users from introducing potentially malicious software on the system."
@@ -671,7 +671,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && !r:nodev'
 
   # 1.1.8.3 Ensure nosuid option set on /dev/shm partition. (Automated)
-  - id: 6530
+  - id: 37530
     title: "Ensure nosuid option set on /dev/shm partition."
     description: "The nosuid mount option specifies that the filesystem cannot contain setuid files."
     rationale: "Setting this option on a file system prevents users from introducing privileged programs onto the system and allowing non-root users to execute them."
@@ -692,7 +692,7 @@ checks:
       - 'c:mount -> r:\s/dev/shm\s && !r:nosuid'
 
   # 1.1.9 Disable Automounting. (Automated)
-  - id: 6531
+  - id: 37531
     title: "Disable Automounting."
     description: "autofs allows automatic mounting of devices, typically including CD/DVDs and USB drives."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
@@ -710,7 +710,7 @@ checks:
       - "c:systemctl is-enabled autofs -> r:^enabled"
 
   # 1.1.10 Disable USB Storage. (Automated)
-  - id: 6532
+  - id: 37532
     title: "Disable USB Storage."
     description: "USB storage provides a means to transfer and store files insuring persistence and availability of the files independent of network connection status. Its popularity and utility has led to USB-based malware being a simple and common means for network infiltration and a first step to establishing a persistent threat within a networked environment."
     rationale: "Restricting USB access on the system will decrease the physical attack surface for a device and diminish the possible vectors to introduce malware."
@@ -730,7 +730,7 @@ checks:
   # 1.2.1 Ensure GPG keys are configured. (Manual) - Not Implemented
 
   # 1.2.2 Ensure gpgcheck is globally activated. (Automated)
-  - id: 6533
+  - id: 37533
     title: "Ensure gpgcheck is globally activated."
     description: "The gpgcheck option, found in the main section of the /etc/dnf/dnf.conf and individual /etc/yum.repos.d/* files, determines if an RPM package's signature is checked prior to its installation."
     rationale: "It is important to ensure that an RPM's package signature is always checked prior to installation to ensure that the software is obtained from a trusted source."
@@ -751,7 +751,7 @@ checks:
   # 1.2.3 Ensure package manager repositories are configured. (Manual) - Not Implemented
 
   # 1.3.1 Ensure AIDE is installed. (Automated)
-  - id: 6534
+  - id: 37534
     title: "Ensure AIDE is installed."
     description: "Advanced Intrusion Detection Environment (AIDE) is a intrusion detection tool that uses predefined rules to check the integrity of files and directories in the Linux operating system. AIDE has its own database to check the integrity of files and directories. AIDE takes a snapshot of files and directories including modification times, permissions, and file hashes which can then be used to compare against the current state of the filesystem to detect modifications to the system."
     rationale: "By monitoring the filesystem state compromised files can be detected to prevent or limit the exposure of accidental or malicious misconfigurations or modified binaries."
@@ -774,7 +774,7 @@ checks:
       - "c:rpm -q aide -> r:aide-"
 
   # 1.3.2 Ensure filesystem integrity is regularly checked. (Automated)
-  - id: 6535
+  - id: 37535
     title: "Ensure filesystem integrity is regularly checked."
     description: "Periodic checking of the filesystem integrity is needed to detect changes to the filesystem."
     rationale: "Periodic file checking allows the system administrator to determine on a regular basis if critical files have been changed in an unauthorized fashion."
@@ -800,7 +800,7 @@ checks:
       - "c:systemctl status aidecheck.timer -> r:active"
 
   # 1.4.1 Ensure bootloader password is set. (Automated)
-  - id: 6536
+  - id: 37536
     title: "Ensure bootloader password is set."
     description: "Setting the boot loader password will require that anyone rebooting the system must enter a password before being able to set command line boot parameters."
     rationale: "Requiring a boot password upon execution of the boot loader will prevent an unauthorized user from entering boot parameters or changing the boot partition. This prevents users from weakening security (e.g. turning off SELinux at boot time)."
@@ -823,7 +823,7 @@ checks:
       - 'f:/boot/grub/grub.cfg -> r:^\s*\t*password'
 
   # 1.4.2 Ensure permissions on bootloader config are configured. (Automated)
-  - id: 6537
+  - id: 37537
     title: "Ensure permissions on bootloader config are configured."
     description: "The grub files contain information on boot settings and passwords for unlocking boot options. The grub2 configuration is usually grub.cfg. On newer grub2 systems the encrypted bootloader password is contained in user.cfg. If the system uses UEFI, /boot/efi is a vfat filesystem. The vfat filesystem itself doesn't have the concept of permissions but can be mounted under Linux with whatever permissions desired."
     rationale: "Setting the permissions to read and write for root only prevents non-root users from seeing the boot parameters or changing them. Non-root users who read the boot parameters may be able to identify weaknesses in security upon boot and be able to exploit them."
@@ -846,7 +846,7 @@ checks:
       - 'c:stat -L /boot/grub2/user.cfg -> r:Access:\s*\(0600/-r--------\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   # 1.4.3 Ensure authentication is required when booting into rescue mode. (Automated)
-  - id: 6538
+  - id: 37538
     title: "Ensure authentication is required when booting into rescue mode."
     description: "Rescue mode (former single user mode) is used for recovery when the system detects an issue during boot or by manual selection from the bootloader."
     rationale: "Requiring authentication in rescue mode (former single user mode) prevents an unauthorized user from rebooting the system into rescue mode to gain root privileges without credentials."
@@ -865,7 +865,7 @@ checks:
       - 'd:/etc/systemd/system/rescue.service.d/ -> r:\.+ -> r: systemd-sulogin-shell'
 
   # 1.5.1 Ensure core dump storage is disabled. (Automated)
-  - id: 6539
+  - id: 37539
     title: "Additional Process Hardening 1.5.1 Ensure core dump storage is disabled."
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "A core dump includes a memory image taken at the time the operating system terminates an application. The memory image could contain sensitive data and is generally useful only for developers trying to debug problems."
@@ -879,7 +879,7 @@ checks:
       - 'f:/etc/systemd/coredump.conf -> r:^\s*Storage\s*=\s*none'
 
   # 1.5.2 Ensure core dump backtraces are disabled. (Automated)
-  - id: 6540
+  - id: 37540
     title: "Ensure core dump backtraces are disabled."
     description: "A core dump is the memory of an executable program. It is generally used to determine why a program aborted. It can also be used to glean confidential information from a core file."
     rationale: "A core dump includes a memory image taken at the time the operating system terminates an application. The memory image could contain sensitive data and is generally useful only for developers trying to debug problems, increasing the risk to the system."
@@ -893,7 +893,7 @@ checks:
       - 'f:/etc/systemd/coredump.conf -> r:^\s*ProcessSizeMax\s*=\s*0'
 
   # 1.5.3 Ensure address space layout randomization (ASLR) is enabled. (Automated)
-  - id: 6541
+  - id: 37541
     title: "Ensure address space layout randomization (ASLR) is enabled."
     description: "Address space layout randomization (ASLR) is an exploit mitigation technique which randomly arranges the address space of key data areas of a process."
     rationale: "Randomly placing virtual memory regions will make it difficult to write memory page exploits as the memory placement will be consistently shifting."
@@ -912,7 +912,7 @@ checks:
       - 'd:/etc/sysctl.d/ -> r:\.+ -> r:^\s*kernel.randomize_va_space\s*=\s*2'
 
   # 1.6.1.1 Ensure SELinux is installed. (Automated)
-  - id: 6542
+  - id: 37542
     title: "Ensure SELinux is installed."
     description: "SELinux provides Mandatory Access Control."
     rationale: "Without a Mandatory Access Control system installed only the default Discretionary Access Control system will be available."
@@ -933,7 +933,7 @@ checks:
       - "c:rpm -q libselinux -> r:libselinux-"
 
   # 1.6.1.2 Ensure SELinux is not disabled in bootloader configuration. (Automated)
-  - id: 6543
+  - id: 37543
     title: "Ensure SELinux is not disabled in bootloader configuration."
     description: "Configure SELINUX to be enabled at boot time and verify that it has not been overwritten by the grub boot parameters."
     rationale: "SELinux must be enabled at boot time in your grub configuration to ensure that the controls it provides are not overridden."
@@ -955,7 +955,7 @@ checks:
       - 'not f:/boot/grub2/grubenv -> r:kernelopts=\.*selinux=0|kernelopts=\.*enforcing=0'
 
   # 1.6.1.3 Ensure SELinux policy is configured. (Automated)
-  - id: 6544
+  - id: 37544
     title: "Ensure SELinux policy is configured."
     description: "Configure SELinux to meet or exceed the default targeted policy, which constrains daemons and system software only."
     rationale: "Security configuration requirements vary from site to site. Some sites may mandate a policy that is stricter than the default policy, which is perfectly acceptable. This item is intended to ensure that at least the default recommendations are met."
@@ -977,7 +977,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^\s*SELINUXTYPE\s*=\s*targeted|^\s*SELINUXTYPE\s*=\s*mls'
 
   # 1.6.1.4 Ensure the SELinux mode is not disabled. (Automated)
-  - id: 6545
+  - id: 37545
     title: "Ensure the SELinux mode is not disabled."
     description: "SELinux can run in one of three modes: disabled, permissive, or enforcing: - Enforcing - Is the default, and recommended, mode of operation; in enforcing mode SELinux operates normally, enforcing the loaded security policy on the entire system. - Permissive - The system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not recommended for production systems, permissive mode can be helpful for SELinux policy development. - Disabled - Is strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future Note: you can set individual domains to permissive mode while the system runs in enforcing mode. For example, to make the httpd_t domain permissive: # semanage permissive -a httpd_t."
     rationale: "Running SELinux in disabled mode is strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future."
@@ -1001,7 +1001,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing|\s*SELINUX\s*=\s*permisive'
 
   # 1.6.1.5 Ensure the SELinux mode is enforcing. (Automated)
-  - id: 6546
+  - id: 37546
     title: "Ensure the SELinux mode is enforcing."
     description: "SELinux can run in one of three modes: disabled, permissive, or enforcing: - Enforcing - Is the default, and recommended, mode of operation; in enforcing mode SELinux operates normally, enforcing the loaded security policy on the entire system. - Permissive - The system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not recommended for production systems, permissive mode can be helpful for SELinux policy development. - Disabled - Is strongly discouraged; not only does the system avoid enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future Note: you can set individual domains to permissive mode while the system runs in enforcing mode. For example, to make the httpd_t domain permissive: # semanage permissive -a httpd_t."
     rationale: "Running SELinux in disabled mode the system not only avoids enforcing the SELinux policy, it also avoids labeling any persistent objects such as files, making it difficult to enable SELinux in the future. Running SELinux in Permissive mode, though helpful for developing SELinux policy, only logs access denial entries, but does not deny any operations."
@@ -1025,7 +1025,7 @@ checks:
       - 'f:/etc/selinux/config -> r:^\s*SELINUX\s*=\s*enforcing'
 
   # 1.6.1.6 Ensure no unconfined services exist. (Automated)
-  - id: 6547
+  - id: 37547
     title: "Ensure no unconfined services exist."
     description: "Unconfined processes run in unconfined domains."
     rationale: "For unconfined processes, SELinux policy rules are applied, but policy rules exist that allow processes running in unconfined domains almost all access. Processes running in unconfined domains fall back to using DAC rules exclusively. If an unconfined process is compromised, SELinux does not prevent an attacker from gaining access to system resources and data, but of course, DAC rules are still used. SELinux is a security enhancement on top of DAC rules it does not replace them."
@@ -1046,7 +1046,7 @@ checks:
       - "not c:ps -eZ -> r:unconfined_service_t"
 
   # 1.6.1.7 Ensure SETroubleshoot is not installed. (Automated)
-  - id: 6548
+  - id: 37548
     title: "Ensure SETroubleshoot is not installed."
     description: "The SETroubleshoot service notifies desktop users of SELinux denials through a user-friendly interface. The service provides important information around configuration errors, unauthorized intrusions, and other potential errors."
     rationale: "The SETroubleshoot service is an unnecessary daemon to have running on a server, especially if X Windows is disabled."
@@ -1065,7 +1065,7 @@ checks:
       - "not c:rpm -qa setroubleshoot -> r:^setroubleshoot"
 
   # 1.6.1.8 Ensure the MCS Translation Service (mcstrans) is not installed. (Automated)
-  - id: 6549
+  - id: 37549
     title: "Ensure the MCS Translation Service (mcstrans) is not installed."
     description: "The mcstransd daemon provides category label information to client processes requesting information. The label translations are defined in /etc/selinux/targeted/setrans.conf."
     rationale: "Since this service is not used very often, remove it to reduce the amount of potentially vulnerable code running on the system."
@@ -1084,7 +1084,7 @@ checks:
       - "not c:rpm -qa mcstrans -> r:^mcstrans"
 
   # 1.7.1 Ensure message of the day is configured properly. (Automated)
-  - id: 6550
+  - id: 37550
     title: "Ensure message of the day is configured properly."
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version."
     rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
@@ -1105,7 +1105,7 @@ checks:
       - 'not f:/etc/motd -> r:\\v|\\r|\\m|\\s'
 
   # 1.7.2 Ensure local login warning banner is configured properly. (Automated)
-  - id: 6551
+  - id: 37551
     title: "Ensure local login warning banner is configured properly."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version - or the operating system's name."
     rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
@@ -1125,7 +1125,7 @@ checks:
       - 'not f:/etc/issue -> r:\\v|\\r|\\m|\\s'
 
   # 1.7.3 Ensure remote login warning banner is configured properly. (Automated)
-  - id: 6552
+  - id: 37552
     title: "Ensure remote login warning banner is configured properly."
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services. Unix-based systems have typically displayed information about the OS release and patch level upon logging in to the system. This information can be useful to developers who are developing software for a particular OS platform. If mingetty(8) supports the following options, they display operating system information: \\m - machine architecture \\r - operating system release \\s - operating system name \\v - operating system version."
     rationale: 'Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Displaying OS and patch level information in login banners also has the side effect of providing detailed system information to attackers attempting to target specific exploits of a system. Authorized users can easily get this information by running the " uname -a " command once they have logged in.'
@@ -1145,7 +1145,7 @@ checks:
       - 'f:/etc/issue.net -> r:\\v|\\r|\\m|\\s'
 
   # 1.7.4 Ensure permissions on /etc/motd are configured. (Automated)
-  - id: 6553
+  - id: 37553
     title: "Ensure permissions on /etc/motd are configured."
     description: "The contents of the /etc/motd file are displayed to users after login and function as a message of the day for authenticated users."
     rationale: "If the /etc/motd file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -1166,7 +1166,7 @@ checks:
       - 'c:stat -L /etc/motd -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   # 1.7.5 Ensure permissions on /etc/issue are configured. (Automated)
-  - id: 6554
+  - id: 37554
     title: "Ensure permissions on /etc/issue are configured."
     description: "The contents of the /etc/issue file are displayed to users prior to login for local terminals."
     rationale: "If the /etc/issue file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -1187,7 +1187,7 @@ checks:
       - 'c:stat -L /etc/issue -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   # 1.7.6 Ensure permissions on /etc/issue.net are configured. (Automated)
-  - id: 6555
+  - id: 37555
     title: "Ensure permissions on /etc/issue.net are configured."
     description: "The contents of the /etc/issue.net file are displayed to users prior to login for remote connections from configured services."
     rationale: "If the /etc/issue.net file does not have the correct ownership it could be modified by unauthorized users with incorrect or misleading information."
@@ -1208,7 +1208,7 @@ checks:
       - 'c:stat -L /etc/issue.net -> r:Access:\s*\(0644/-rw-r--r--\)\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)'
 
   # 1.8.1 Ensure GNOME Display Manager is removed. (Manual)
-  - id: 6556
+  - id: 37556
     title: "Ensure GNOME Display Manager is removed."
     description: "The GNOME Display Manager (GDM) is a program that manages graphical display servers and handles graphical user logins."
     rationale: "If a Graphical User Interface (GUI) is not required, it should be removed to reduce the attack surface of the system."
@@ -1230,7 +1230,7 @@ checks:
       - "f:rpm -q gdm -> r:is not installed"
 
   # 1.8.2 Ensure GDM login banner is configured. (Automated)
-  - id: 6557
+  - id: 37557
     title: "Ensure GDM login banner is configured."
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Note: If a graphical login is not required, it should be removed to reduce the attack surface of the system."
@@ -1255,7 +1255,7 @@ checks:
       - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:banner-message-text='
 
   # 1.8.3 Ensure last logged in user display is disabled. (Automated)
-  - id: 6558
+  - id: 37558
     title: "Ensure last logged in user display is disabled."
     description: "GDM is the GNOME Display Manager which handles graphical login for GNOME based systems."
     rationale: "Displaying the last logged in user eliminates half of the Userid/Password equation that an unauthorized person would need to log on. Warning messages inform users who are attempting to login to the system of their legal status regarding the system and must include the name of the organization that owns the system and any monitoring policies that are in place. Notes: - - If a graphical login is not required, it should be removed to reduce the attack surface of the system. If a different GUI login service is in use and required on the system, consult your documentation to disable displaying the last logged on user."
@@ -1279,7 +1279,7 @@ checks:
       - 'd:/etc/dconf/db/gdm.d -> r:\.+ -> r:disable-user-list=true'
 
   # 1.8.4 Ensure XDMCP is not enabled. (Automated)
-  - id: 6559
+  - id: 37559
     title: "Ensure XDMCP is not enabled."
     description: "X Display Manager Control Protocol (XDMCP) is designed to provide authenticated access to display management services for remote displays."
     rationale: "XDMCP is inherently insecure. - XDMCP is not a ciphered protocol. This may allow an attacker to capture keystrokes entered by a user - XDMCP is vulnerable to man-in-the-middle attacks. This may allow an attacker to steal the credentials of legitimate users by impersonating the XDMCP server."
@@ -1300,7 +1300,7 @@ checks:
       - 'not f:/etc/gdm/custom.conf -> r:^\s*Enable\s*=\s*true'
 
   # 1.8.5 Ensure automatic mounting of removable media is disabled. (Automated)
-  - id: 6560
+  - id: 37560
     title: "Ensure automatic mounting of removable media is disabled."
     description: "By default GNOME automatically mounts removable media when inserted as a convenience to the user."
     rationale: "With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves."
@@ -1323,7 +1323,7 @@ checks:
   # 1.9 Ensure updates, patches, and additional security software are installed. (Manual) - Not Implemented
 
   # 1.10 Ensure system-wide crypto policy is not legacy. (Automated)
-  - id: 6562
+  - id: 37561
     title: "Ensure system-wide crypto policy is not legacy."
     description: "The system-wide crypto-policies followed by the crypto core components allow consistently deprecating and disabling algorithms system-wide. The individual policy levels (DEFAULT, LEGACY, FUTURE, and FIPS) are included in the crypto-policies(7) package."
     rationale: "If the Legacy system-wide crypto policy is selected, it includes support for TLS 1.0, TLS 1.1, and SSH2 protocols or later. The algorithms DSA, 3DES, and RC4 are allowed, while RSA and Diffie-Hellman parameters are accepted if larger than 1023-bits. These legacy protocols and algorithms can make the system vulnerable to attacks, including those listed in RFC 7457."
@@ -1346,7 +1346,7 @@ checks:
       - 'f:/etc/crypto-policies/config -> r:^\s*LEGACY'
 
   # 2.1.1 Ensure time synchronization is in use. (Automated)
-  - id: 6563
+  - id: 37562
     title: "Ensure time synchronization is in use."
     description: "System time should be synchronized between all systems in an environment. This is typically done by establishing an authoritative time server or set of servers and having all systems synchronize their clocks to them. Note: If another method for time synchronization is being used, this section may be skipped."
     rationale: "Time synchronization is important to support time sensitive security mechanisms like Kerberos and also ensures log files have consistent time records across the enterprise, which aids in forensic investigations."
@@ -1366,7 +1366,7 @@ checks:
       - "c:rpm -q chrony -> r:^chrony-"
 
   # 2.1.2 Ensure chrony is configured. (Automated)
-  - id: 6564
+  - id: 37563
     title: "Ensure chrony is configured."
     description: "chrony is a daemon which implements the Network Time Protocol (NTP) and is designed to synchronize system clocks across a variety of systems and use a source that is highly accurate. More information on chrony can be found at http://chrony.tuxfamily.org/. chrony can be configured to be a client and/or a server."
     rationale: "If chrony is in use on the system proper configuration is vital to ensuring time synchronization is working properly."
@@ -1388,7 +1388,7 @@ checks:
       - 'f:/etc/sysconfig/chronyd -> r:^\s*\t*OPTIONS\.*-u chrony'
 
   # 2.2.1 Ensure xinetd is not installed. (Automated)
-  - id: 6565
+  - id: 37564
     title: "Ensure xinetd is not installed."
     description: "The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced the original inetd daemon. The xinetd daemon listens for well known services and dispatches the appropriate daemon to properly respond to service requests."
     rationale: "If there are no xinetd services required, it is recommended that the package be removed to reduce the attack surface are of the system. Note: If an xinetd service or services are required, ensure that any xinetd service not required is stopped and disabled."
@@ -1407,7 +1407,7 @@ checks:
       - "c:rpm -q xinetd -> r:^package xinetd is not installed"
 
   # 2.2.2 Ensure xorg-x11-server-common is not installed. (Automated)
-  - id: 6566
+  - id: 37565
     title: "Ensure xorg-x11-server-common is not installed."
     description: "The X Window System provides a Graphical User Interface (GUI) where users can have multiple windows in which to run programs and various add on. The X Windows system is typically used on workstations where users login, but not on servers where users typically do not login."
     rationale: "Unless your organization specifically requires graphical login access via X Windows, remove it to reduce the potential attack surface."
@@ -1427,7 +1427,7 @@ checks:
       - "c:rpm -q xorg-x11-server-common -> r:^package xorg-x11-server-common is not installed"
 
   # 2.2.3 Ensure Avahi Server is not installed. (Automated)
-  - id: 6567
+  - id: 37566
     title: "Ensure Avahi Server is not installed."
     description: "Avahi is a free zeroconf implementation, including a system for multicast DNS/DNS-SD service discovery. Avahi allows programs to publish and discover services and hosts running on a local network with no specific configuration. For example, a user can plug a computer into a network and Avahi automatically finds printers to print to, files to look at and people to talk to, as well as network services running on the machine."
     rationale: "Automatic discovery of network services is not normally required for system functionality. It is recommended to remove this package to reduce the potential attack surface."
@@ -1447,7 +1447,7 @@ checks:
       - "c:rpm -q avahi-autoipd -> r:^package avahi-autoipd is not installed"
 
   # 2.2.4 Ensure CUPS is not installed. (Automated)
-  - id: 6568
+  - id: 37567
     title: "Ensure CUPS is not installed."
     description: "The Common Unix Print System (CUPS) provides the ability to print to both local and network printers. A system running CUPS can also accept print jobs from remote systems and print them to local printers. It also provides a web based remote administration capability."
     rationale: "If the system does not need to print jobs or accept print jobs from other systems, it is recommended that CUPS be removed to reduce the potential attack surface. Note: Removing CUPS will prevent printing from the system."
@@ -1469,7 +1469,7 @@ checks:
       - "c:rpm -q cups -> r:^package cups is not installed"
 
   # 2.2.5 Ensure DHCP Server is not installed. (Automated)
-  - id: 6569
+  - id: 37568
     title: "Ensure DHCP Server is not installed."
     description: "The Dynamic Host Configuration Protocol (DHCP) is a service that allows machines to be dynamically assigned IP addresses."
     rationale: "Unless a system is specifically set up to act as a DHCP server, it is recommended that the rpm -q dhcp-server package be removed to reduce the potential attack surface."
@@ -1488,7 +1488,7 @@ checks:
       - "c:rpm -q dhcp-server -> r:^package dhcp-server is not installed"
 
   # 2.2.6 Ensure DNS Server is not installed. (Automated)
-  - id: 6570
+  - id: 37569
     title: "Ensure DNS Server is not installed."
     description: "The Domain Name System (DNS) is a hierarchical naming system that maps names to IP addresses for computers, services and other resources connected to a network."
     rationale: "Unless a system is specifically designated to act as a DNS server, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1507,7 +1507,7 @@ checks:
       - "c:rpm -q bind -> r:^package bind is not installed"
 
   # 2.2.7 Ensure FTP Server is not installed. (Automated)
-  - id: 6571
+  - id: 37570
     title: "Ensure FTP Server is not installed."
     description: "FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring files between a server and clients over a network, especially where no authentication is necessary (permits anonymous users to connect to a server)."
     rationale: "FTP does not protect the confidentiality of data or authentication credentials. It is recommended SFTP be used if file transfer is required. Unless there is a need to run the system as a FTP server (for example, to allow anonymous downloads), it is recommended that the package be removed to reduce the potential attack surface."
@@ -1526,7 +1526,7 @@ checks:
       - "c:rpm -q ftp -> r:^package ftp is not installed"
 
   # 2.2.8 Ensure VSFTP Server is not installed. (Automated)
-  - id: 6572
+  - id: 37571
     title: "Ensure VSFTP Server is not installed."
     description: "FTP (File Transfer Protocol) is a traditional and widely used standard tool for transferring files between a server and clients over a network, especially where no authentication is necessary (permits anonymous users to connect to a server)."
     rationale: "Unless there is a need to run the system as a FTP server, it is recommended that the package be removed to reduce the potential attack surface."
@@ -1545,7 +1545,7 @@ checks:
       - "c:rpm -q vsftpd -> r:^package vsftpd is not installed"
 
   # 2.2.9 Ensure TFTP Server is not installed. (Automated)
-  - id: 6573
+  - id: 37572
     title: "Ensure TFTP Server is not installed."
     description: "Trivial File Transfer Protocol (TFTP) is a simple protocol for exchanging files between two TCP/IP machines. TFTP servers allow connections from a TFTP Client for sending and receiving files."
     rationale: "TFTP does not have built-in encryption, access control or authentication. This makes it very easy for an attacker to exploit TFTP to gain access to files."
@@ -1564,7 +1564,7 @@ checks:
       - "c:rpm -q tftp-server -> r:^package tftp-server is not installed"
 
   # 2.2.10 Ensure a web server is not installed. (Automated)
-  - id: 6574
+  - id: 37573
     title: "Ensure a web server is not installed."
     description: "Web servers provide the ability to host web site content."
     rationale: "Unless there is a need to run the system as a web server, it is recommended that the packages be removed to reduce the potential attack surface. Note: Several http servers exist. They should also be audited, and removed, if not required."
@@ -1584,7 +1584,7 @@ checks:
       - "c:rpm -q httpd -> r:^package httpd is not installed"
 
   # 2.2.11 Ensure IMAP and POP3 server is not installed. (Automated)
-  - id: 6575
+  - id: 37574
     title: "Ensure IMAP and POP3 server is not installed."
     description: "dovecot is an open source IMAP and POP3 server for Linux based systems."
     rationale: "Unless POP3 and/or IMAP servers are to be provided by this system, it is recommended that the package be removed to reduce the potential attack surface. Note: Several IMAP/POP3 servers exist and can use other service names. These should also be audited and the packages removed if not required."
@@ -1604,7 +1604,7 @@ checks:
       - "c:rpm -q cyrus-imapd -> r:^package cyrus-imapd is not installed"
 
   # 2.2.12 Ensure Samba is not installed. (Automated)
-  - id: 6576
+  - id: 37575
     title: "Ensure Samba is not installed."
     description: "The Samba daemon allows system administrators to configure their Linux systems to share file systems and directories with Windows desktops. Samba will advertise the file systems and directories via the Server Message Block (SMB) protocol. Windows desktop users will be able to mount these directories and file systems as letter drives on their systems."
     rationale: "If there is no need to mount directories and file systems to Windows systems, then this package can be removed to reduce the potential attack surface."
@@ -1623,7 +1623,7 @@ checks:
       - "c:rpm -q samba -> r:^package samba is not installed"
 
   # 2.2.13 Ensure HTTP Proxy Server is not installed. (Automated)
-  - id: 6577
+  - id: 37576
     title: "Ensure HTTP Proxy Server is not installed."
     description: "Squid is a standard proxy server used in many distributions and environments."
     rationale: "Unless a system is specifically set up to act as a proxy server, it is recommended that the squid package be removed to reduce the potential attack surface. Note: Several HTTP proxy servers exist. These should be checked and removed unless required."
@@ -1642,7 +1642,7 @@ checks:
       - "c:rpm -q squid -> r:^package squid is not installed"
 
   # 2.2.14 Ensure net-snmp is not installed. (Automated)
-  - id: 6578
+  - id: 37577
     title: "Ensure net-snmp is not installed."
     description: 'Simple Network Management Protocol (SNMP) is a widely used protocol for monitoring the health and welfare of network equipment, computer equipment and devices like UPSs. Net-SNMP is a suite of applications used to implement SNMPv1 (RFC 1157), SNMPv2 (RFCs 1901-1908), and SNMPv3 (RFCs 3411-3418) using both IPv4 and IPv6. Support for SNMPv2 classic (a.k.a. "SNMPv2 historic" - RFCs 1441-1452) was dropped with the 4.0 release of the UCD-snmp package. The Simple Network Management Protocol (SNMP) server is used to listen for SNMP commands from an SNMP management system, execute the commands or collect the information and then send results back to the requesting system.'
     rationale: "The SNMP server can communicate using SNMPv1, which transmits data in the clear and does not require authentication to execute commands. SNMPv3 replaces the simple/clear text password sharing used in SNMPv2 with more securely encoded parameters. If the the SNMP service is not required, the net-snmp package should be removed to reduce the attack surface of the system. Note: If SNMP is required: - The server should be configured for SNMP v3 only. User Authentication and Message Encryption should be configured. If SNMP v2 is absolutely necessary, modify the community strings' values. -."
@@ -1661,7 +1661,7 @@ checks:
       - "c:rpm -q net-snmp -> r:^package net-snmp is not installed"
 
   # 2.2.15 Ensure NIS server is not installed. (Automated)
-  - id: 6579
+  - id: 37578
     title: "Ensure NIS server is not installed."
     description: "The ypserv package provides the Network Information Service (NIS). This service, formally known as Yellow Pages, is a client-server directory service protocol for distributing system configuration files. The NIS server is a collection of programs that allow for the distribution of configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the ypserv package be removed, and if required a more secure services be used."
@@ -1680,7 +1680,7 @@ checks:
       - "c:rpm -q ypserv -> r:^package ypserv is not installed"
 
   # 2.2.16 Ensure telnet-server is not installed. (Automated)
-  - id: 6580
+  - id: 37579
     title: "Ensure telnet-server is not installed."
     description: "The telnet-server package contains the telnet daemon, which accepts connections from users from other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow a user with access to sniff network traffic the ability to steal credentials. The ssh package provides an encrypted session and stronger security."
@@ -1699,7 +1699,7 @@ checks:
       - "c:rpm -q telnet-server -> r:^package telnet-server is not installed"
 
   # 2.2.17 Ensure mail transfer agent is configured for local-only mode. (Automated)
-  - id: 6581
+  - id: 37580
     title: "Ensure mail transfer agent is configured for local-only mode."
     description: "Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to listen for incoming mail and transfer the messages to the appropriate user or mail server. If the system is not intended to be a mail server, it is recommended that the MTA be configured to only process local mail."
     rationale: "The software for all Mail Transfer Agents is complex and most have a long history of security issues. While it is important to ensure that the system can process local mail messages, it is not necessary to have the MTA's daemon listening on a port unless the server is intended to be a mail server that receives and processes mail from other systems. Notes: - This recommendation is designed around the postfix mail server. - Depending on your environment you may have an alternative MTA installed such as sendmail. If this is the case consult the documentation for your installed MTA to configure the recommended state."
@@ -1718,7 +1718,7 @@ checks:
       - 'not c:ss -lntu -> r:\s*127.0.0.1:25\s*|\s*::1:25\s*'
 
   # 2.2.18 Ensure nfs-utils is not installed or the nfs-server service is masked. (Automated)
-  - id: 6582
+  - id: 37581
     title: "Ensure nfs-utils is not installed or the nfs-server service is masked."
     description: "The Network File System (NFS) is one of the first and most widely distributed file systems in the UNIX environment. It provides the ability for systems to mount file systems of other servers through the network."
     rationale: "If the system does not require network shares, it is recommended that the nfs-utils package be removed to reduce the attack surface of the system."
@@ -1739,7 +1739,7 @@ checks:
       - "c:systemctl is-enabled nfs-server -> r:masked|No such file or directory"
 
   # 2.2.19 Ensure rpcbind is not installed or the rpcbind services are masked. (Automated)
-  - id: 6583
+  - id: 37582
     title: "Ensure rpcbind is not installed or the rpcbind services are masked."
     description: "The rpcbind utility maps RPC services to the ports on which they listen. RPC processes notify rpcbind when they start, registering the ports they are listening on and the RPC program numbers they expect to serve. The client system then contacts rpcbind on the server with a particular RPC program number. The rpcbind service redirects the client to the proper port number so it can communicate with the requested service Portmapper is an RPC service, which always listens on tcp and udp 111, and is used to map other RPC services (such as nfs, nlockmgr, quotad, mountd, etc.) to their corresponding port number on the server. When a remote host makes an RPC call to that server, it first consults with portmap to determine where the RPC server is listening."
     rationale: "A small request (~82 bytes via UDP) sent to the Portmapper generates a large response (7x to 28x amplification), which makes it a suitable tool for DDoS attacks. If rpcbind is not required, it is recommended that the rpcbind package be removed to reduce the attack surface of the system."
@@ -1761,7 +1761,7 @@ checks:
       - "c:systemctl is-enabled rpcbind.socket -> r:masked|No such file or directory"
 
   # 2.2.20 Ensure rsync is not installed or the rsyncd service is masked. (Automated)
-  - id: 6584
+  - id: 37583
     title: "Ensure rsync is not installed or the rsyncd service is masked."
     description: "The rsyncd service can be used to synchronize files between systems over network links."
     rationale: "Unless required, the rsync package should be removed to reduce the attack surface area of the system. The rsyncd service presents a security risk as it uses unencrypted protocols for communication. Note: If a required dependency exists for the rsync package, but the rsyncd service is not required, the service should be masked."
@@ -1782,7 +1782,7 @@ checks:
       - "c:systemctl is-enabled rsyncd -> r:masked|No such file or directory"
 
   # 2.3.1 Ensure NIS Client is not installed. (Automated)
-  - id: 6585
+  - id: 37584
     title: "Ensure NIS Client is not installed."
     description: "The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server directory service protocol used to distribute system configuration files. The NIS client ( ypbind) was used to bind a machine to an NIS server and receive the distributed configuration files."
     rationale: "The NIS service is inherently an insecure system that has been vulnerable to DOS attacks, buffer overflows and has poor authentication for querying NIS maps. NIS generally has been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is recommended that the service be removed."
@@ -1802,7 +1802,7 @@ checks:
       - "c:rpm -q ypbind -> r:^package ypbind is not installed"
 
   # 2.3.2 Ensure rsh client is not installed. (Automated)
-  - id: 6586
+  - id: 37585
     title: "Ensure rsh client is not installed."
     description: "The rsh package contains the client commands for the rsh services."
     rationale: "These legacy clients contain numerous security exposures and have been replaced with the more secure SSH package. Even if the server is removed, it is best to ensure the clients are also removed to prevent users from inadvertently attempting to use these commands and therefore exposing their credentials. Note that removing the rsh package removes the clients for rsh, rcp and rlogin."
@@ -1822,7 +1822,7 @@ checks:
       - "c:rpm -q rsh -> r:^package rsh is not installed"
 
   # 2.3.3 Ensure talk client is not installed. (Automated)
-  - id: 6587
+  - id: 37586
     title: "Ensure talk client is not installed."
     description: "The talk software makes it possible for users to send and receive messages across systems through a terminal session. The talk client, which allows initialization of talk sessions, is installed by default."
     rationale: "The software presents a security risk as it uses unencrypted protocols for communication."
@@ -1842,7 +1842,7 @@ checks:
       - "c:rpm -q talk -> r:^package talk is not installed"
 
   # 2.3.4 Ensure telnet client is not installed. (Automated)
-  - id: 6588
+  - id: 37587
     title: "Ensure telnet client is not installed."
     description: "The telnet package contains the telnet client, which allows users to start connections to other systems via the telnet protocol."
     rationale: "The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission medium could allow an unauthorized user to steal credentials. The ssh package provides an encrypted session and stronger security and is included in most Linux distributions."
@@ -1862,7 +1862,7 @@ checks:
       - "c:rpm -q telnet -> r:^package telnet is not installed"
 
   # 2.3.5 Ensure LDAP client is not installed. (Automated)
-  - id: 6589
+  - id: 37588
     title: "Ensure LDAP client is not installed."
     description: "The Lightweight Directory Access Protocol (LDAP) was introduced as a replacement for NIS/YP. It is a service that provides a method for looking up information from a central database."
     rationale: "If the system will not need to act as an LDAP client, it is recommended that the software be removed to reduce the potential attack surface."
@@ -1882,7 +1882,7 @@ checks:
       - "c:rpm -q openldap-clients -> r:^package openldap-clients is not installed"
 
   # 2.3.6 Ensure TFTP client is not installed. (Automated)
-  - id: 6590
+  - id: 37589
     title: "Ensure TFTP client is not installed."
     description: "Trivial File Transfer Protocol (TFTP) is a simple protocol for exchanging files between two TCP/IP machines. TFTP servers allow connections from a TFTP Client for sending and receiving files."
     rationale: "TFTP does not have built-in encryption, access control or authentication. This makes it very easy for an attacker to exploit TFTP to gain access to files."
@@ -1905,7 +1905,7 @@ checks:
   # 3.1.1 Verify if IPv6 is enabled on the system. (Manual) - Not Implemented
 
   # 3.1.2 Ensure SCTP is disabled. (Automated)
-  - id: 6591
+  - id: 37590
     title: "Ensure SCTP is disabled."
     description: "The Stream Control Transmission Protocol (SCTP) is a transport layer protocol used to support message oriented communication, with several streams of messages in one connection. It serves a similar function as TCP and UDP, incorporating features of both. It is message-oriented like UDP, and ensures reliable in-sequence transport of messages with congestion control like TCP."
     rationale: "If the protocol is not being used, it is recommended that kernel module not be loaded, disabling the service to reduce the potential attack surface."
@@ -1925,7 +1925,7 @@ checks:
       - "not c:lsmod -> r:^sctp"
 
   # 3.1.3 Ensure DCCP is disabled. (Automated)
-  - id: 6592
+  - id: 37591
     title: "Ensure DCCP is disabled."
     description: "The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that supports streaming media and telephony. DCCP provides a way to gain access to congestion control, without having to do it at the application layer, but does not provide in-sequence delivery."
     rationale: "If the protocol is not required, it is recommended that the drivers not be installed to reduce the potential attack surface."
@@ -1959,7 +1959,7 @@ checks:
   # 3.3.9 Ensure IPv6 router advertisements are not accepted. (Automated) - Not Implemented
 
   # 3.4.1.1 Ensure firewalld is installed. (Automated)
-  - id: 6593
+  - id: 37592
     title: "Ensure firewalld is installed."
     description: "firewalld is a firewall management tool for Linux operating systems. It provides firewall features by acting as a front-end for the Linux kernel's netfilter framework via the iptables backend or provides firewall features by acting as a front-end for the Linux kernel's netfilter framework via the nftables utility. firewalld replaces iptables as the default firewall management tool. Use the firewalld utility to configure a firewall for less complex firewalls. The utility is easy to use and covers the typical use cases scenario. FirewallD supports both IPv4 and IPv6 networks and can administer separate firewall zones with varying degrees of trust as defined in zone profiles. Note: Starting in v0.6.0, FirewallD added support for acting as a front-end for the Linux kernel's netfilter framework via the nftables userspace utility, acting as an alternative to the nft command line program."
     rationale: "A firewall utility is required to configure the Linux kernel's netfilter framework via the iptables or nftables back-end. The Linux kernel's netfilter framework host-based firewall can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host. Note: Only one firewall utility should be installed and configured. FirewallD is dependent on the iptables package."
@@ -1981,7 +1981,7 @@ checks:
       - "c:rpm -q iptables -> r:^iptables-"
 
   # 3.4.1.2 Ensure iptables-services not installed with firewalld. (Automated)
-  - id: 6594
+  - id: 37593
     title: "Ensure iptables-services not installed with firewalld."
     description: "The iptables-services package contains the iptables.service and ip6tables.service. These services allow for management of the Host Based Firewall provided by the iptables package."
     rationale: "iptables.service and ip6tables.service are still supported and can be installed with the iptables-services package. Running both firewalld and the services included in the iptables-services package may lead to conflict."
@@ -2002,7 +2002,7 @@ checks:
       - "c:rpm -q iptables-services -> r:^package iptables-services is not installed"
 
   # 3.4.1.3 Ensure nftables either not installed or masked with firewalld. (Automated)
-  - id: 6595
+  - id: 37594
     title: "Ensure nftables either not installed or masked with firewalld."
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables. _Note: Support for using nftables as the back-end for firewalld was added in release v0.6.0. In Fedora 19 Linux derivatives, firewalld utilizes iptables as its back-end by default."
     rationale: "Running both firewalld and nftables may lead to conflict. Note: firewalld may configured as the front-end to nftables. If this case, nftables should be stopped and masked instead of removed."
@@ -2024,7 +2024,7 @@ checks:
       - "c:systemctl is-enabled nftables -> r:^masked"
 
   # 3.4.1.4 Ensure firewalld service enabled and running. (Automated)
-  - id: 6596
+  - id: 37595
     title: "Ensure firewalld service enabled and running."
     description: "firewalld.service enables the enforcement of firewall rules configured through firewalld."
     rationale: "Ensure that the firewalld.service is enabled and running to enforce firewall rules configured through firewalld."
@@ -2051,7 +2051,7 @@ checks:
   # 3.4.1.7 Ensure firewalld drops unnecessary services and ports. (Manual) - Not Implemented
 
   # 3.4.2.1 Ensure nftables is installed. (Automated)
-  - id: 6597
+  - id: 37596
     title: "Ensure nftables is installed."
     description: "nftables provides a new in-kernel packet classification framework that is based on a network-specific Virtual Machine (VM) and a new nft userspace command line tool. nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure, the connection tracking system, NAT, userspace queuing and logging subsystem. Note: - nftables is available in Linux kernel 3.13 and newer. - Only one firewall utility should be installed and configured."
     rationale: "nftables is a subsystem of the Linux kernel that can protect against threats originating from within a corporate network to include malicious mobile code and poorly configured software on a host."
@@ -2072,7 +2072,7 @@ checks:
       - "c:rpm -q nftables -> r:^nftables-"
 
   # 3.4.2.2 Ensure firewalld is either not installed or masked with nftables. (Automated)
-  - id: 6598
+  - id: 37597
     title: "Ensure firewalld is either not installed or masked with nftables."
     description: 'firewalld (Dynamic Firewall Manager) provides a dynamically managed firewall with support for network/firewall "zones" to assign a level of trust to a network and its associated connections, interfaces or sources. It has support for IPv4, IPv6, Ethernet bridges and also for IPSet firewall settings. There is a separation of the runtime and permanent configuration options.'
     rationale: "Running both nftables.service and firewalld.service may lead to conflict and unexpected results."
@@ -2094,7 +2094,7 @@ checks:
       - "c:systemctl is-enabled firewalld -> r:^masked"
 
   # 3.4.2.3 Ensure iptables-services not installed with nftables. (Automated)
-  - id: 6599
+  - id: 37598
     title: "Ensure iptables-services not installed with nftables."
     description: "The iptables-services package contains the iptables.service and ip6tables.service. These services allow for management of the Host Based Firewall provided by the iptables package."
     rationale: "iptables.service and ip6tables.service are still supported and can be installed with the iptables-services package. Running both nftables and the services included in the iptables-services package may lead to conflict."
@@ -2116,7 +2116,7 @@ checks:
   # 3.4.2.4 Ensure iptables are flushed with nftables. (Manual) - Not Implemented
 
   # 3.4.2.5 Ensure an nftables table exists. (Automated)
-  - id: 6600
+  - id: 37599
     title: "Ensure an nftables table exists."
     description: "Tables hold chains. Each table only has one address family and only applies to packets of this family. Tables can have one of five families."
     rationale: "nftables doesn't have any default tables. Without a table being build, nftables will not filter network traffic."
@@ -2137,7 +2137,7 @@ checks:
       - 'c:nft list tables -> r:\w+'
 
   # 3.4.2.6 Ensure nftables base chains exist. (Automated)
-  - id: 6601
+  - id: 37600
     title: "Ensure nftables base chains exist."
     description: "Chains are containers for rules. They exist in two kinds, base chains and regular chains. A base chain is an entry point for packets from the networking stack, a regular chain may be used as jump target and is used for better rule organization."
     rationale: "If a base chain doesn't exist with a hook for input, forward, and delete, packets that would flow through those chains will not be touched by nftables."
@@ -2160,7 +2160,7 @@ checks:
       - "c:nft list ruleset -> r:hook output"
 
   # 3.4.2.7 Ensure nftables loopback traffic is configured. (Automated)
-  - id: 6602
+  - id: 37601
     title: "Ensure nftables loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure."
@@ -2183,7 +2183,7 @@ checks:
   # 3.4.2.8 Ensure nftables outbound and established connections are configured. (Manual) -Not Implemented
 
   # 3.4.2.9 Ensure nftables default deny firewall policy. (Automated)
-  - id: 6603
+  - id: 37602
     title: "Ensure nftables default deny firewall policy."
     description: "Base chain policy is the default verdict that will be applied to packets reaching the end of the chain."
     rationale: "There are two policies: accept (Default) and drop. If the policy is set to accept, the firewall will accept any packet that is not configured to be denied and the packet will continue traversing the network stack. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over the network can result in being locked out of the system."
@@ -2206,7 +2206,7 @@ checks:
       - "c:nft list ruleset -> r:hook output && r:policy drop"
 
   # 3.4.2.10 Ensure nftables service is enabled. (Automated)
-  - id: 6604
+  - id: 37603
     title: "Ensure nftables service is enabled."
     description: "The nftables service allows for the loading of nftables rulesets during boot, or starting on the nftables service."
     rationale: "The nftables service restores the nftables rules from the rules files referenced in the /etc/sysconfig/nftables.conf file during boot or the starting of the nftables service."
@@ -2226,7 +2226,7 @@ checks:
       - "c:systemctl is-enabled nftables -> r:^enabled"
 
   # 3.4.2.11 Ensure nftables rules are permanent. (Automated)
-  - id: 6605
+  - id: 37604
     title: "Ensure nftables rules are permanent."
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames. The nftables service reads the /etc/sysconfig/nftables.conf file for a nftables file or files to include in the nftables ruleset. A nftables ruleset containing the input, forward, and output base chains allow network traffic to be filtered."
     rationale: "Changes made to nftables ruleset only affect the live system, you will also need to configure the nftables ruleset to apply on boot."
@@ -2246,7 +2246,7 @@ checks:
       - "f:/etc/nftables.conf -> r:include *"
 
   # 3.4.3.1.1 Ensure iptables packages are installed. (Automated)
-  - id: 6606
+  - id: 37605
     title: "Ensure iptables packages are installed."
     description: "iptables is a utility program that allows a system administrator to configure the tables provided by the Linux kernel firewall, implemented as different Netfilter modules, and the chains and rules it stores. Different kernel modules and programs are used for different protocols; iptables applies to IPv4, ip6tables to IPv6, arptables to ARP, and ebtables to Ethernet frames."
     rationale: "A method of configuring and maintaining firewall rules is necessary to configure a Host Based Firewall."
@@ -2267,7 +2267,7 @@ checks:
       - "c:rpm -q iptables-services -> r:^iptables-services-"
 
   # 3.4.3.1.2 Ensure nftables is not installed with iptables. (Automated)
-  - id: 6607
+  - id: 37606
     title: "Ensure nftables is not installed with iptables."
     description: "nftables is a subsystem of the Linux kernel providing filtering and classification of network packets/datagrams/frames and is the successor to iptables."
     rationale: "Running both iptables and nftables may lead to conflict."
@@ -2287,7 +2287,7 @@ checks:
       - "c:rpm -q nftables -> r:package nftables is not installed"
 
   # 3.4.3.1.3 Ensure firewalld is either not installed or masked with iptables. (Automated)
-  - id: 6608
+  - id: 37607
     title: "Ensure firewalld is either not installed or masked with iptables."
     description: 'firewalld (Dynamic Firewall Manager) provides a dynamically managed firewall with support for network/firewall "zones" to assign a level of trust to a network and its associated connections, interfaces or sources. It has support for IPv4, IPv6, Ethernet bridges and also for IPSet firewall settings. There is a separation of the runtime and permanent configuration options.'
     rationale: "Running iptables.service and\\or ip6tables.service with firewalld.service may lead to conflict and unexpected results."
@@ -2309,7 +2309,7 @@ checks:
       - "c:systemctl is-enabled firewalld -> r:^masked"
 
   # 3.4.3.2.1 Ensure iptables loopback traffic is configured. (Automated)
-  - id: 6609
+  - id: 37608
     title: "Ensure iptables loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (127.0.0.0/8)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (127.0.0.0/8) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure. Note: Changing firewall settings while connected over network can result in being locked out of the system."
@@ -2334,7 +2334,7 @@ checks:
   # 3.4.3.2.3 Ensure iptables rules exist for all open ports. (Automated) - Not Implemented
 
   # 3.4.3.2.4 Ensure iptables default deny firewall policy. (Automated)
-  - id: 6610
+  - id: 37609
     title: "Ensure iptables default deny firewall policy."
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
@@ -2358,7 +2358,7 @@ checks:
   # 3.4.3.2.5 Ensure iptables rules are saved. (Automated) - Not Implemented
 
   # 3.4.3.2.6 Ensure iptables is enabled and active. (Automated)
-  - id: 6611
+  - id: 37610
     title: "Ensure iptables is enabled and active."
     description: "iptables.service is a utility for configuring and maintaining iptables."
     rationale: "iptables.service will load the iptables rules saved in the file /etc/sysconfig/iptables at boot, otherwise the iptables rules will be cleared during a re-boot of the system."
@@ -2379,7 +2379,7 @@ checks:
       - "c:systemctl is-active iptables -> r:^active"
 
   # 3.4.3.3.1 Ensure ip6tables loopback traffic is configured. (Automated)
-  - id: 6612
+  - id: 37611
     title: "Ensure ip6tables loopback traffic is configured."
     description: "Configure the loopback interface to accept traffic. Configure all other interfaces to deny traffic to the loopback network (::1)."
     rationale: "Loopback traffic is generated between processes on machine and is typically critical to operation of the system. The loopback interface is the only place that loopback network (::1) traffic should be seen, all other interfaces should ignore traffic on this network as an anti-spoofing measure. Note: Changing firewall settings while connected over network can result in being locked out of the system."
@@ -2404,7 +2404,7 @@ checks:
   # 3.4.3.3.3 Ensure ip6tables firewall rules exist for all open ports. (Automated) - Not Implemented
 
   # 3.4.3.3.4 Ensure ip6tables default deny firewall policy. (Automated)
-  - id: 6613
+  - id: 37612
     title: "Ensure ip6tables default deny firewall policy."
     description: "A default deny all policy on connections ensures that any unconfigured network usage will be rejected."
     rationale: "With a default accept policy the firewall will accept any packet that is not configured to be denied. It is easier to white list acceptable usage than to black list unacceptable usage. Note: Changing firewall settings while connected over network can result in being locked out of the system."
@@ -2428,7 +2428,7 @@ checks:
   # 3.4.3.3.5 Ensure ip6tables rules are saved. (Automated) - Not Implemented
 
   # 3.4.3.3.6 Ensure ip6tables is enabled and active. (Automated)
-  - id: 6614
+  - id: 37613
     title: "Ensure ip6tables is enabled and active."
     description: "ip6tables.service is a utility for configuring and maintaining ip6tables."
     rationale: "ip6tables.service will load the iptables rules saved in the file /etc/sysconfig/ip6tables at boot, otherwise the ip6tables rules will be cleared during a re-boot of the system."
@@ -2449,7 +2449,7 @@ checks:
       - "c:systemctl is-active ip6tables -> r:^active"
 
   # 4.1.1.1 Ensure auditd is installed. (Automated)
-  - id: 6615
+  - id: 37614
     title: "Ensure auditd is installed."
     description: "auditd is the userspace component to the Linux Auditing System. It's responsible for writing audit records to the disk."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2470,7 +2470,7 @@ checks:
       - "c:rpm -q audit -> r:^audit-"
 
   # 4.1.1.2 Ensure auditd service is enabled. (Automated)
-  - id: 6616
+  - id: 37615
     title: "Ensure auditd service is enabled."
     description: "Turn on the auditd daemon to record system events."
     rationale: "The capturing of system events provides system administrators with information to allow them to determine if unauthorized access to their system is occurring."
@@ -2490,7 +2490,7 @@ checks:
       - "c:systemctl is-enabled auditd -> r:^enabled"
 
   # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled. (Automated)
-  - id: 6617
+  - id: 37616
     title: "Ensure auditing for processes that start prior to auditd is enabled."
     description: "Configure grub2 so that processes that are capable of being audited can be audited even if they start up prior to auditd startup."
     rationale: "Audit events need to be captured on processes that start up prior to auditd , so that potential malicious activity cannot go undetected."
@@ -2510,7 +2510,7 @@ checks:
       - "not f:/boot/grub2/grubenv -> r:kernelopts= && !r:audit=1"
 
   # 4.1.1.4 Ensure audit_backlog_limit is sufficient. (Automated)
-  - id: 6618
+  - id: 37617
     title: "Ensure audit_backlog_limit is sufficient."
     description: "The backlog limit has a default setting of 64."
     rationale: "During boot if audit=1, then the backlog will hold 64 records. If more that 64 records are created during boot, auditd records will be lost and potential malicious activity could go undetected."
@@ -2530,7 +2530,7 @@ checks:
       - 'f:/boot/grub2/grubenv -> r:kernelopts= && n:audit_backlog_limit=(\d+) compare >= 8192'
 
   # 4.1.2.1 Ensure audit log storage size is configured. (Automated)
-  - id: 6619
+  - id: 37618
     title: "Ensure audit log storage size is configured."
     description: "Configure the maximum size of the audit log file. Once the log reaches the maximum size, it will be rotated and a new log file will be started."
     rationale: "It is important that an appropriate size is determined for log files so that they do not impact the system and audit data is not lost."
@@ -2548,7 +2548,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file\s*\t*=\s*\t*\d+'
 
   # 4.1.2.2 Ensure audit logs are not automatically deleted. (Automated)
-  - id: 6620
+  - id: 37619
     title: "Ensure audit logs are not automatically deleted."
     description: "The max_log_file_action setting determines how to handle the audit log file reaching the max file size. A value of keep_logs will rotate the logs but never delete old logs."
     rationale: "In high security contexts, the benefits of maintaining a long audit history exceed the cost of storing the audit history."
@@ -2566,7 +2566,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*\t*max_log_file_action\s*\t*=\s*\t*keep_logs'
 
   # 4.1.2.3 Ensure system is disabled when audit logs are full. (Automated)
-  - id: 6621
+  - id: 37620
     title: "Ensure system is disabled when audit logs are full."
     description: "The auditd daemon can be configured to halt the system when the audit logs are full. The admin_space_left_action parameter tells the system what action to take when the system has detected that it is low on disk space. Valid values are ignore, syslog, suspend, single, and halt. - ignore, the audit daemon does nothing - Syslog, the audit daemon will issue a warning to syslog - Suspend, the audit daemon will stop writing records to the disk - single, the audit daemon will put the computer system in single user mode - halt, the audit daemon will shutdown the system."
     rationale: "In high security contexts, the risk of detecting unauthorized access or nonrepudiation exceeds the benefit of the system's availability."
@@ -2588,7 +2588,7 @@ checks:
       - 'f:/etc/audit/auditd.conf -> r:^\s*admin_space_left_action\s*=\s*halt|^\s*admin_space_left_action\s*=\s*single'
 
   # 4.1.3.1 Ensure changes to system administration scope (sudoers) is collected. (Automated)
-  - id: 6622
+  - id: 37621
     title: "Ensure changes to system administration scope (sudoers) is collected."
     description: 'Monitor scope changes for system administrators. If the system has been properly configured to force system administrators to log in as themselves first and then use the sudo command to execute privileged commands, it is possible to monitor changes in scope. The file /etc/sudoers, or files in /etc/sudoers.d, will be written to when the file(s) or related attributes have changed. The audit records will be tagged with the identifier "scope".'
     rationale: "Changes in the /etc/sudoers and /etc/sudoers.d files can indicate that an unauthorized change has been made to the scope of system administrator activity."
@@ -2607,7 +2607,7 @@ checks:
       - 'c:auditctl -l -> r:^-w && r:/etc/sudoers.d && r:-p wa && r:-k scope|key=\\s*\t*scope'
 
   # 4.1.3.2 Ensure actions as another user are always logged. (Automated)
-  - id: 6623
+  - id: 37622
     title: "Ensure actions as another user are always logged."
     description: "sudo provides users with temporary elevated privileges to perform operations, either as the superuser or another user."
     rationale: "Creating an audit log of users with temporary elevated privileges and the operation(s) they performed is essential to reporting. Administrators will want to correlate the events written to the audit trail with the records written to sudo's logfile to verify if unauthorized commands have been executed."
@@ -2633,7 +2633,7 @@ checks:
   # 4.1.3.3 Ensure events that modify the sudo log file are collected. (Automated) - Not Implemented
 
   # 4.1.3.4 Ensure events that modify date and time information are collected. (Automated)
-  - id: 6624
+  - id: 37623
     title: "Ensure events that modify date and time information are collected."
     description: 'Capture events where the system date and/or time has been modified. The parameters in this section are set to determine if the; - adjtimex - tune kernel clock - settimeofday - set time using timeval and timezone structures - stime - using seconds since 1/1/1970 - clock_settime - allows for the setting of several internal clocks and timers system calls have been executed. Further, ensure to write an audit record to the configured audit log file upon exit, tagging the records with a unique identifier such as "time-change".'
     rationale: "Unexpected changes in system date and/or time could be a sign of malicious activity on the system."
@@ -2659,7 +2659,7 @@ checks:
       - "c:auditctl -l -> r:^-w && r:/etc/localtime && r:-p wa && r:-k time-change|key=time-change"
 
   # 4.1.3.5 Ensure events that modify the system's network environment are collected. (Automated)
-  - id: 6625
+  - id: 37624
     title: "Ensure events that modify the system's network environment are collected."
     description: "Record changes to network environment files or system calls. The below parameters monitors the following system calls, and write an audit event on system call exit: - sethostname - set the systems host name - setdomainname - set the systems domain name The files being monitored are: - /etc/issue and /etc/issue.net - messages displayed pre-login - /etc/hosts - file containing host names and associated IP addresses - /etc/sysconfig/network - additional information that is valid to all network interfaces - /etc/sysconfig/network-scripts/ - directory containing network interface scripts and configurations files."
     rationale: "Monitoring sethostname and setdomainname will identify potential unauthorized changes to host and domainname of a system. The changing of these names could potentially break security parameters that are set based on those names. The /etc/hosts file is monitored for changes that can indicate an unauthorized intruder is trying to change machine associations with IP addresses and trick users and processes into connecting to unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as intruders could put disinformation into those files and trick users into providing information to the intruder. Monitoring /etc/sysconfig/network is important as it can show if network interfaces or scripts are being modified in a way that can lead to the machine becoming unavailable or compromised. All audit records should have a relevant tag associated with them."
@@ -2691,7 +2691,7 @@ checks:
   # 4.1.3.7 Ensure unsuccessful file access attempts are collected. (Automated) - Not Implemented
 
   # 4.1.3.8 Ensure events that modify user/group information are collected. (Automated)
-  - id: 6626
+  - id: 37625
     title: "Ensure events that modify user/group information are collected."
     description: 'Record events affecting the modification of user or group information, including that of passwords and old passwords if in use. - /etc/group - system groups - /etc/passwd - system users - /etc/gshadow - encrypted password for each group - /etc/shadow - system user passwords - /etc/security/opasswd - storage of old passwords if the relevant PAM module is in use The parameters in this section will watch the files to see if they have been opened for write or have had attribute changes (e.g. permissions) and tag them with the identifier "identity" in the audit log file.'
     rationale: "Unexpected changes to these files could be an indication that the system has been compromised and that an unauthorized user is attempting to hide their activities or compromise additional accounts."
@@ -2717,7 +2717,7 @@ checks:
   # 4.1.3.9 Ensure discretionary access control permission modification events are collected. (Automated) - Not Implemented
 
   # 4.1.3.10 Ensure successful file system mounts are collected. (Automated)
-  - id: 6627
+  - id: 37626
     title: "Ensure successful file system mounts are collected."
     description: "Monitor the use of the mount system call. The mount (and umount) system call controls the mounting and unmounting of file systems. The parameters below configure the system to create an audit record when the mount system call is used by a non-privileged user."
     rationale: "It is highly unusual for a non privileged user to mount file systems to the system. While tracking mount commands gives the system administrator evidence that external media may have been mounted (based on a review of the source of the mount and confirming it's an external media type), it does not conclusively indicate that data was exported to the media. System administrators who wish to determine if data were exported, would also have to track successful open, creat and truncate system calls requiring write access to a file under the mount point of the external media file system. This could give a fair indication that a write occurred. The only way to truly prove it, would be to track successful writes to the external media. Tracking write system calls could quickly fill up the audit log and is not recommended. Recommendations on configuration options to track data export to media is beyond the scope of this document."
@@ -2735,7 +2735,7 @@ checks:
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S mount && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k mounts|key=mounts'
 
   # 4.1.3.11 Ensure session initiation information is collected. (Automated)
-  - id: 6628
+  - id: 37627
     title: "Ensure session initiation information is collected."
     description: 'Monitor session initiation events. The parameters in this section track changes to the files associated with session events. - /var/run/utmp - tracks all currently logged in users. - /var/log/wtmp - file tracks logins, logouts, shutdown, and reboot events. - /var/log/btmp - keeps track of failed login attempts and can be read by entering the command /usr/bin/last -f /var/log/btmp. All audit records will be tagged with the identifier "session.".'
     rationale: "Monitoring these files for changes could alert a system administrator to logins occurring at unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when they do not normally log in)."
@@ -2761,7 +2761,7 @@ checks:
       - "c:auditctl -l -> r:^-w && r:/var/log/btmp && r:-p wa && r:-k session|key=session"
 
   # 4.1.3.12 Ensure login and logout events are collected. (Automated)
-  - id: 6629
+  - id: 37628
     title: "Ensure login and logout events are collected."
     description: "Monitor login and logout events. The parameters below track changes to files associated with login/logout events. - /var/log/lastlog - maintain records of the last time a user successfully logged in. - /var/run/faillock - directory maintains records of login failures via the pam_faillock module."
     rationale: "Monitoring login/logout events could provide a system administrator with information associated with brute force attacks against user logins."
@@ -2785,7 +2785,7 @@ checks:
       - "c:auditctl -l -> r:^-w && r:/var/run/faillock && r:-p wa && r:-k logins|key=logins"
 
   # 4.1.3.13 Ensure file deletion events by users are collected. (Automated)
-  - id: 6630
+  - id: 37629
     title: "Ensure file deletion events by users are collected."
     description: 'Monitor the use of system calls associated with the deletion or renaming of files and file attributes. This configuration statement sets up monitoring for: - unlink - remove a file - unlinkat - remove a file attribute - rename - rename a file - renameat rename a file attribute system calls and tags them with the identifier "delete".'
     rationale: "Monitoring these calls from non-privileged users could provide a system administrator with evidence that inappropriate removal of files and file attributes associated with protected files is occurring. While this audit option will look at all events, system administrators will want to look for specific privileged files that are being deleted or altered."
@@ -2802,7 +2802,7 @@ checks:
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F arch=b32 && r:-S && r:unlink && r:unlinkat && r:rename && r:renameat && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k delete|key=delete'
 
   # 4.1.3.14 Ensure events that modify the system's Mandatory Access Controls are collected. (Automated)
-  - id: 6631
+  - id: 37630
     title: "Ensure events that modify the system's Mandatory Access Controls are collected."
     description: "Monitor SELinux, an implementation of mandatory access controls. The parameters below monitor any write access (potential additional, deletion or modification of files in the directory) or attribute changes to the /etc/selinux/ and /usr/share/selinux/ directories. Note: If a different Mandatory Access Control method is used, changes to the corresponding directories should be audited."
     rationale: "Changes to files in the /etc/selinux/ and /usr/share/selinux/ directories could indicate that an unauthorized user is attempting to modify access controls and change security contexts, leading to a compromise of the system."
@@ -2826,7 +2826,7 @@ checks:
       - "c:auditctl -l -> r:^-w && r:/usr/share/selinux && r:-p wa && r:-k MAC-policy|key=MAC-policy"
 
   # 4.1.3.15 Ensure successful and unsuccessful attempts to use the chcon command are recorded. (Automated)
-  - id: 6632
+  - id: 37631
     title: "Ensure successful and unsuccessful attempts to use the chcon command are recorded."
     description: "The operating system must generate audit records for successful/unsuccessful uses of the chcon command."
     rationale: "Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
@@ -2848,7 +2848,7 @@ checks:
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/chcon && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|key=perm_chng'
 
   # 4.1.3.16 Ensure successful and unsuccessful attempts to use the setfacl command are recorded. (Automated)
-  - id: 6633
+  - id: 37632
     title: "Ensure successful and unsuccessful attempts to use the setfacl command are recorded."
     description: "The operating system must generate audit records for successful/unsuccessful uses of the setfacl command."
     rationale: "Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
@@ -2870,7 +2870,7 @@ checks:
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/setfacl && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|-F key=perm_chng'
 
   # 4.1.3.17 Ensure successful and unsuccessful attempts to use the chacl command are recorded. (Automated)
-  - id: 6634
+  - id: 37633
     title: "Ensure successful and unsuccessful attempts to use the chacl command are recorded."
     description: "The operating system must generate audit records for successful/unsuccessful uses of the chacl command."
     rationale: "Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
@@ -2892,7 +2892,7 @@ checks:
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/bin/chacl && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k perm_chng|-F key=perm_chng'
 
   # 4.1.3.18 Ensure successful and unsuccessful attempts to use the usermod command are recorded. (Automated)
-  - id: 6635
+  - id: 37634
     title: "Ensure successful and unsuccessful attempts to use the usermod command are recorded."
     description: "The operating system must generate audit records for successful/unsuccessful uses of the usermod command."
     rationale: "Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. Audit records can be generated from various components within the information system (e.g., module or policy filter)."
@@ -2914,7 +2914,7 @@ checks:
       - 'c:auditctl -l -> r:^-a && r:always,exit|exit,always && r:-F path=/usr/sbin/usermod && r:-F perm=x && r:-F auid>=\d+ && r:-F auid!=-1|-F auid!=4294967295|-F auid!=unset && r:-k usermod|-F key=usermod'
 
   # 4.1.3.19 Ensure kernel module loading unloading and modification is collected. (Automated)
-  - id: 6636
+  - id: 37635
     title: "Ensure kernel module loading unloading and modification is collected."
     description: "Monitor the loading and unloading of kernel modules. All the loading / listing / dependency checking of modules is done by kmod via symbolic links. The following system calls control loading and unloading of modules: - init_module - load a module - finit_module - load a module (used when the overhead of using cryptographically signed modules to determine the authenticity of a module can be avoided) - delete_module - delete a module - create_module - create a loadable module entry - query_module - query the kernel for various bits pertaining to modules Any execution of the loading and unloading module programs and system calls will trigger an audit record with an identifier of modules."
     rationale: "Monitoring the use of all the various ways to manipulate kernel modules could provide system administrators with evidence that an unauthorized change was made to a kernel module, possibly compromising the security of the system."
@@ -2938,7 +2938,7 @@ checks:
       - "c:ls -l /usr/sbin/depmod -> r:/bin/kmod"
 
   # 4.1.3.20 Ensure the audit configuration is immutable. (Automated)
-  - id: 6637
+  - id: 37636
     title: "Ensure the audit configuration is immutable."
     description: 'Set system audit so that audit rules cannot be modified with auditctl. Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made on system reboot. Note: This setting will require the system to be rebooted to update the active auditd configuration settings.'
     rationale: "In immutable mode, unauthorized users cannot execute changes to the audit system to potentially hide malicious activity and then put the audit rules back. Users would most likely notice a system reboot and that could alert administrators of an attempt to make unauthorized audit changes."
@@ -2959,7 +2959,7 @@ checks:
       - 'c:sh -c "grep -iEh ''^\s*\t*-e 2\s*$'' /etc/audit/rules.d/*.rules | tail -1" -> r:^\s*\t*-e 2\s*$'
 
   # 4.1.3.21 Ensure the running and on disk configuration is the same. (Manual)
-  - id: 6638
+  - id: 37637
     title: "Ensure the running and on disk configuration is the same."
     description: "The Audit system have both on disk and running configuration. It is possible for these configuration settings to differ. Note: Due to the limitations of augenrules and auditctl, it is not absolutely guaranteed that loading the rule sets via augenrules --load will result in all rules being loaded or even that the user will be informed if there was a problem loading the rules."
     rationale: "Configuration differences between what is currently running and what is on disk could cause unexpected problems or may give a false impression of compliance requirements."
@@ -2977,7 +2977,7 @@ checks:
       - 'c:augenrules --check -> r:^\s*/usr/sbin/augenrules && r:No change$'
 
   # 4.2.1.1 Ensure rsyslog is installed. (Automated)
-  - id: 6639
+  - id: 37638
     title: "Ensure rsyslog is installed."
     description: "The rsyslog software is recommended in environments where journald does not meet operation requirements."
     rationale: "The security enhancements of rsyslog such as connection-oriented (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of log data en route to a central logging server) justify installing and configuring the package."
@@ -2997,7 +2997,7 @@ checks:
       - "c:rpm -q rsyslog -> r:^rsyslog-"
 
   # 4.2.1.2 Ensure rsyslog service is enabled. (Automated)
-  - id: 6640
+  - id: 37639
     title: "Ensure rsyslog service is enabled."
     description: "Once the rsyslog package is installed, ensure that the service is enabled."
     rationale: "If the rsyslog service is not enabled to start on boot, the system will not capture logging events."
@@ -3017,7 +3017,7 @@ checks:
       - "c:systemctl is-enabled rsyslog -> r:^enabled"
 
   # 4.2.1.3 Ensure journald is configured to send logs to rsyslog. (Manual)
-  - id: 6641
+  - id: 37640
     title: "Ensure journald is configured to send logs to rsyslog."
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Utilities exist to accept remote export of journald logs, however, use of the RSyslog service provides a consistent means of log collection and export."
     rationale: "IF RSyslog is the preferred method for capturing logs, all logs of the system should be sent to it for further processing."
@@ -3038,7 +3038,7 @@ checks:
       - 'f:/etc/systemd/journald.conf -> r:^\s*\t*ForwardToSyslog\s*=\s*yes'
 
   # 4.2.1.4 Ensure rsyslog default file permissions are configured. (Automated)
-  - id: 6642
+  - id: 37641
     title: "Ensure rsyslog default file permissions are configured."
     description: "RSyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files."
     rationale: "It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected."
@@ -3065,7 +3065,7 @@ checks:
   # 4.2.1.6 Ensure rsyslog is configured to send logs to a remote log host. (Manual) - Not Implemented
 
   # 4.2.1.7 Ensure rsyslog is not configured to recieve logs from a remote client. (Automated) - Not Implemented
-  - id: 6643
+  - id: 37642
     title: "Ensure rsyslog is not configured to recieve logs from a remote client."
     description: "RSyslog supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts."
     rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
@@ -3087,7 +3087,7 @@ checks:
       - 'not f:/etc/rsyslog.conf -> r:^\s*\t*\$ModLoad imtcp|^\s*\t*\$InputTCPServerRun|^\s*\t*module load="imtcp"|^\s*\t*input type="imtcp" port="514"'
 
   # 4.2.2.1 Ensure journald is configured to send logs to a remote log host 4.2.2.1.1 Ensure systemd-journal-remote is installed. (Manual)
-  - id: 6644
+  - id: 37643
     title: "Ensure journald is configured to send logs to a remote log host 4.2.2.1.1 Ensure systemd-journal-remote is installed."
     description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -3107,7 +3107,7 @@ checks:
       - "c:rpm -q systemd-journal-remote -> r:^systemd-journal-remote-"
 
   # 4.2.2.1.2 Ensure systemd-journal-remote is configured. (Manual)
-  - id: 6645
+  - id: 37644
     title: "Ensure systemd-journal-remote is configured."
     description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -3130,7 +3130,7 @@ checks:
       - "f:/etc/systemd/journal-upload.conf -> r:TrustedCertificateFile="
 
   # 4.2.2.1.3 Ensure systemd-journal-remote is enabled. (Manual)
-  - id: 6646
+  - id: 37645
     title: "Ensure systemd-journal-remote is enabled."
     description: "Journald (via systemd-journal-remote) supports the ability to send log events it gathers to a remote log host or to receive messages from remote hosts, thus enabling centralised log management."
     rationale: "Storing log data on a remote host protects log integrity from local attacks. If an attacker gains root access on the local system, they could tamper with or remove log data that is stored on the local system."
@@ -3150,7 +3150,7 @@ checks:
       - "c:systemctl is-enabled systemd-journal-upload.service -> r:^enabled"
 
   # 4.2.2.1.4 Ensure journald is not configured to recieve logs from a remote client. (Automated)
-  - id: 6647
+  - id: 37646
     title: "Ensure journald is not configured to recieve logs from a remote client."
     description: "Journald supports the ability to receive messages from remote hosts, thus acting as a log server. Clients should not receive data from other hosts. NOTE: - The same package, systemd-journal-remote, is used for both sending logs to remote hosts and receiving incoming logs. - With regards to receiving logs, there are two services; systemd-journal- remote.socket and systemd-journal-remote.service."
     rationale: "If a client is configured to also receive data, thus turning it into a server, the client system is acting outside it's operational boundary."
@@ -3171,7 +3171,7 @@ checks:
       - "c:systemctl is-enabled systemd-journal-remote.socket -> r:^masked"
 
   # 4.2.2.2 Ensure journald service is enabled. (Automated)
-  - id: 6648
+  - id: 37647
     title: "Ensure journald service is enabled."
     description: "Ensure that the systemd-journald service is enabled to allow capturing of logging events."
     rationale: "If the systemd-journald service is not enabled to start on boot, the system will not capture logging events."
@@ -3191,7 +3191,7 @@ checks:
       - "c:systemctl is-enabled systemd-journald.service -> r:^static"
 
   # 4.2.2.3 Ensure journald is configured to compress large log files. (Automated)
-  - id: 6649
+  - id: 37648
     title: "Ensure journald is configured to compress large log files."
     description: "The journald system includes the capability of compressing overly large files to avoid filling up the system with logs or making the logs unmanageably large."
     rationale: "Uncompressed large files may unexpectedly fill a filesystem leading to resource unavailability. Compressing logs prior to write can prevent sudden, unexpected filesystem impacts."
@@ -3212,7 +3212,7 @@ checks:
       - "f:/etc/systemd/journald.conf -> r:^Compress=yes"
 
   # 4.2.2.4 Ensure journald is configured to write logfiles to persistent disk. (Automated)
-  - id: 6650
+  - id: 37649
     title: "Ensure journald is configured to write logfiles to persistent disk."
     description: "Data from journald may be stored in volatile memory or persisted locally on the server. Logs in memory will be lost upon a system reboot. By persisting logs to local disk on the server they are protected from loss due to a reboot."
     rationale: "Writing log data to disk will provide the ability to forensically reconstruct events which may have impacted the operations or security of a system even after a system crash or reboot."
@@ -3232,7 +3232,7 @@ checks:
       - "f:/etc/systemd/journald.conf -> r:^Storage=persistent"
 
   # 4.2.2.5 Ensure journald is not configured to send logs to rsyslog. (Manual)
-  - id: 6651
+  - id: 37650
     title: "Ensure journald is not configured to send logs to rsyslog."
     description: "Data from journald should be kept in the confines of the service and not forwarded on to other services."
     rationale: "IF journald is the method for capturing logs, all logs of the system should be handled by journald and not forwarded to other logging mechanisms."
@@ -3253,7 +3253,7 @@ checks:
       - 'not f:/etc/systemd/journald.conf -> !r:^# && r:ForwardToSyslog\s*=\s*yes'
 
   # 4.2.2.6 Ensure journald log rotation is configured per site policy. (Manual)
-  - id: 6652
+  - id: 37651
     title: "Ensure journald log rotation is configured per site policy."
     description: "Journald includes the capability of rotating log files regularly to avoid filling up the system with logs or making the logs unmanageably large. The file /etc/systemd/journald.conf is the configuration file used to specify how logs generated by Journald should be rotated."
     rationale: "By keeping the log files smaller and more manageable, a system administrator can easily archive these files to another system and spend less time looking through inordinately large log files."
@@ -3281,7 +3281,7 @@ checks:
   # 4.3 Ensure logrotate is configured. (Manual) - Not Implemented
 
   # 5.1.1 Ensure cron daemon is enabled. (Automated)
-  - id: 6653
+  - id: 37652
     title: "Ensure cron daemon is enabled."
     description: "The cron daemon is used to execute batch jobs on the system."
     rationale: "While there may not be user jobs that need to be run on the system, the system does have maintenance jobs that may include security monitoring that have to run, and cron is used to execute them."
@@ -3301,7 +3301,7 @@ checks:
       - "c:systemctl is-enabled crond -> r:^enabled"
 
   # 5.1.2 Ensure permissions on /etc/crontab are configured. (Automated)
-  - id: 6654
+  - id: 37653
     title: "Ensure permissions on /etc/crontab are configured."
     description: "The /etc/crontab file is used by cron to control its own jobs. The commands in this item make sure that root is the user and group owner of the file and that only the owner can access the file."
     rationale: "This file contains information on what system jobs are run by cron. Write access to these files could provide unprivileged users with the ability to elevate their privileges. Read access to these files could provide users with the ability to gain insight on system jobs that run on the system and could provide them a way to gain unauthorized privileged access."
@@ -3322,7 +3322,7 @@ checks:
       - 'c:sh -c "stat -Lc ''%a %A %u %U  %g %G'' /etc/crontab" -> r:600\s*\t*-rw------- && r:0\s*\t*root\s*\t*0\s*\t*root'
 
   # 5.1.3 Ensure permissions on /etc/cron.hourly are configured. (Automated)
-  - id: 6655
+  - id: 37654
     title: "Ensure permissions on /etc/cron.hourly are configured."
     description: "This directory contains system cron jobs that need to run on an hourly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -3343,7 +3343,7 @@ checks:
       - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.hourly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
   # 5.1.4 Ensure permissions on /etc/cron.daily are configured. (Automated)
-  - id: 6656
+  - id: 37655
     title: "Ensure permissions on /etc/cron.daily are configured."
     description: "The /etc/cron.daily directory contains system cron jobs that need to run on a daily basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -3364,7 +3364,7 @@ checks:
       - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.daily/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
   # 5.1.5 Ensure permissions on /etc/cron.weekly are configured. (Automated)
-  - id: 6657
+  - id: 37656
     title: "Ensure permissions on /etc/cron.weekly are configured."
     description: "The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -3385,7 +3385,7 @@ checks:
       - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.weekly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
   # 5.1.6 Ensure permissions on /etc/cron.monthly are configured. (Automated)
-  - id: 6658
+  - id: 37657
     title: "Ensure permissions on /etc/cron.monthly are configured."
     description: "The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly basis. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -3406,7 +3406,7 @@ checks:
       - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.monthly/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
   # 5.1.7 Ensure permissions on /etc/cron.d are configured. (Automated)
-  - id: 6659
+  - id: 37658
     title: "Ensure permissions on /etc/cron.d are configured."
     description: "The /etc/cron.d directory contains system cron jobs that need to run in a similar manner to the hourly, daily weekly and monthly jobs from /etc/crontab , but require more granular control as to when they run. The files in this directory cannot be manipulated by the crontab command, but are instead edited by system administrators using a text editor. The commands below restrict read/write and search access to user and group root, preventing regular users from accessing this directory."
     rationale: "Granting write access to this directory for non-privileged users could provide them the means for gaining unauthorized elevated privileges. Granting read access to this directory could give an unprivileged user insight in how to gain elevated privileges or circumvent auditing controls."
@@ -3427,7 +3427,7 @@ checks:
       - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.d/ -> r:700\s*\t*drwx------\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
   # 5.1.8 Ensure cron is restricted to authorized users. (Automated)
-  - id: 6660
+  - id: 37659
     title: "Ensure cron is restricted to authorized users."
     description: "If cron is installed in the system, configure /etc/cron.allow to allow specific users to use these services. If /etc/cron.allow does not exist, then /etc/cron.deny is checked. Any user not specifically defined in those files is allowed to use cron. By removing the file, only users in /etc/cron.allow are allowed to use cron. Note: Even though a given user is not listed in cron.allow, cron jobs can still be run as that user. The cron.allow file only controls administrative access to the crontab command for scheduling and modifying cron jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule cron jobs. Using the cron.allow file to control who can run cron jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -3449,7 +3449,7 @@ checks:
       - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/cron.allow -> r:640\s*\t*-rw-r-----\s*\t*0\s*\t*root\s*\t*0\s*\t*crontab'
 
   # 5.1.9 Ensure at is restricted to authorized users. (Automated)
-  - id: 6661
+  - id: 37660
     title: "Ensure at is restricted to authorized users."
     description: "If at is installed in the system, configure /etc/at.allow to allow specific users to use these services. If /etc/at.allow does not exist, then /etc/at.deny is checked. Any user not specifically defined in those files is allowed to use at. By removing the file, only users in /etc/at.allow are allowed to use at. Note: Even though a given user is not listed in at.allow, at jobs can still be run as that user. The at.allow file only controls administrative access to the at command for scheduling and modifying at jobs."
     rationale: "On many systems, only the system administrator is authorized to schedule at jobs. Using the at.allow file to control who can run at jobs enforces this policy. It is easier to manage an allow list than a deny list. In a deny list, you could potentially add a user ID to the system and forget to add it to the deny files."
@@ -3471,7 +3471,7 @@ checks:
       - 'c:stat -Lc "%a %A %u %U  %g %G" /etc/at.allow -> r:640\s*\t*-rw-r-----\s*\t*0\s*\t*root\s*\t*0\s*\t*root'
 
   # 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured. (Automated)
-  - id: 6662
+  - id: 37661
     title: "Ensure permissions on /etc/ssh/sshd_config are configured."
     description: "The /etc/ssh/sshd_config file contains configuration specifications for sshd. The command below sets the owner and group of the file to root."
     rationale: "The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by non-privileged users."
@@ -3496,7 +3496,7 @@ checks:
   # 5.2.3 Ensure permissions on SSH public host key files are configured. (Automated) - Not Implemented
 
   # 5.2.4 Ensure SSH access is limited. (Automated)
-  - id: 6663
+  - id: 37662
     title: "Ensure SSH access is limited."
     description: "There are several options available to limit which users and group can access the system via SSH. It is recommended that at least one of the following options be leveraged: - AllowUsers: o The AllowUsers variable gives the system administrator the option of allowing specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by only allowing the allowed users to log in from a particular host, the entry can be specified in the form of user@host. - AllowGroups: o The AllowGroups variable gives the system administrator the option of allowing specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable. - DenyUsers: o The DenyUsers variable gives the system administrator the option of denying specific users to ssh into the system. The list consists of space separated user names. Numeric user IDs are not recognized with this variable. If a system administrator wants to restrict user access further by specifically denying a user's access from a particular host, the entry can be specified in the form of user@host. - DenyGroups: o The DenyGroups variable gives the system administrator the option of denying specific groups of users to ssh into the system. The list consists of space separated group names. Numeric group IDs are not recognized with this variable."
     rationale: "Restricting which users can remotely access the system via SSH will help ensure that only authorized users access the system."
@@ -3518,7 +3518,7 @@ checks:
       - 'f:/etc/ssh/sshd_config -> r:^\s*AllowUsers\s+\w+|^\s*AllowGroups\s+\w+|^\s*DenyUsers\s+\w+|^\s*DenyGroups\s+\w+'
 
   # 5.2.5 Ensure SSH LogLevel is appropriate. (Automated)
-  - id: 6664
+  - id: 37663
     title: "Ensure SSH LogLevel is appropriate."
     description: "INFO level is the basic level that only records login activity of SSH users. In many situations, such as Incident Response, it is important to determine when a particular user was active on a system. The logout record can eliminate those users who disconnected, which helps narrow the field. VERBOSE level specifies that login and logout activity as well as the key fingerprint for any SSH key used for login will be logged. This information is important for SSH key management, especially in legacy environments."
     rationale: "SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically not recommended other than strictly for debugging SSH communications since it provides so much data that it is difficult to identify important security information."
@@ -3542,7 +3542,7 @@ checks:
       - 'not d:/etc/ssh/sshd_config.d/ -> r:\.*.conf$ -> !r:^\s*LogLevel\s+INFO|^\s*LogLevel\s+VERBOSE'
 
   # 5.2.6 Ensure SSH PAM is enabled. (Automated)
-  - id: 6665
+  - id: 37664
     title: "Ensure SSH PAM is enabled."
     description: 'UsePAM Enables the Pluggable Authentication Module interface. If set to "yes" this will enable PAM authentication using ChallengeResponseAuthentication and PasswordAuthentication in addition to PAM account and session module processing for all authentication types.'
     rationale: "When usePAM is set to yes, PAM runs through account and session types properly. This is important if you want to restrict access to services based off of IP, time or other factors of the account. Additionally, you can make sure users inherit certain environment variables on login or disallow access to the server."
@@ -3564,7 +3564,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*usepam\s+no'
 
   # 5.2.7 Ensure SSH root login is disabled. (Automated)
-  - id: 6666
+  - id: 37665
     title: "Ensure SSH root login is disabled."
     description: "The PermitRootLogin parameter specifies if the root user can log in using ssh. The default is no."
     rationale: "Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su. This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident."
@@ -3584,7 +3584,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitRootLogin\s+yes'
 
   # 5.2.8 Ensure SSH HostbasedAuthentication is disabled. (Automated)
-  - id: 6667
+  - id: 37666
     title: "Ensure SSH HostbasedAuthentication is disabled."
     description: "The HostbasedAuthentication parameter specifies if authentication is allowed through trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public key client host authentication. This option only applies to SSH Protocol Version 2."
     rationale: "Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, disabling the ability to use .rhosts files in SSH provides an additional layer of protection."
@@ -3604,7 +3604,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*HostbasedAuthentication\s+yes'
 
   # 5.2.9 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
-  - id: 6668
+  - id: 37667
     title: "Ensure SSH PermitEmptyPasswords is disabled."
     description: "The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts with empty password strings."
     rationale: "Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system."
@@ -3624,7 +3624,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitEmptyPasswords\s+yes'
 
   # 5.2.10 Ensure SSH PermitUserEnvironment is disabled. (Automated)
-  - id: 6669
+  - id: 37668
     title: "Ensure SSH PermitUserEnvironment is disabled."
     description: "The PermitUserEnvironment option allows users to present environment options to the ssh daemon."
     rationale: "Permitting users the ability to set environment variables through the SSH daemon could potentially allow users to bypass security controls (e.g. setting an execution path that has ssh executing trojan'd programs)."
@@ -3645,7 +3645,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*PermitUserEnvironment\s+yes'
 
   # 5.2.11 Ensure SSH IgnoreRhosts is enabled. (Automated)
-  - id: 6670
+  - id: 37669
     title: "Ensure SSH IgnoreRhosts is enabled."
     description: "The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in RhostsRSAAuthentication or HostbasedAuthentication."
     rationale: "Setting this parameter forces users to enter a password when authenticating with ssh."
@@ -3666,7 +3666,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*IgnoreRhosts\s+no'
 
   # 5.2.12 Ensure SSH X11 forwarding is disabled. (Automated)
-  - id: 6671
+  - id: 37670
     title: "Ensure SSH X11 forwarding is disabled."
     description: "The X11Forwarding parameter provides the ability to tunnel X11 traffic through the connection to enable remote graphic connections."
     rationale: "Disable X11 forwarding unless there is an operational requirement to use X11 applications directly. There is a small risk that the remote X11 servers of users who are logged in via SSH with X11 forwarding could be compromised by other users on the X11 server. Note that even if X11 forwarding is disabled, users can always install their own forwarders."
@@ -3686,7 +3686,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*X11Forwarding\s+yes'
 
   # 5.2.13 Ensure SSH AllowTcpForwarding is disabled. (Automated)
-  - id: 6672
+  - id: 37671
     title: "Ensure SSH AllowTcpForwarding is disabled."
     description: "SSH port forwarding is a mechanism in SSH for tunneling application ports from the client to the server, or servers to clients. It can be used for adding encryption to legacy applications, going through firewalls, and some system administrators and IT professionals use it for opening backdoors into the internal network from their home machines."
     rationale: "Leaving port forwarding enabled can expose the organization to security risks and back-doors. SSH connections are protected with strong encryption. This makes their contents invisible to most deployed network monitoring and traffic filtering solutions. This invisibility carries considerable risk potential if it is used for malicious purposes such as data exfiltration. Cybercriminals or malware could exploit SSH to hide their unauthorized communications, or to exfiltrate stolen data from the target network."
@@ -3710,7 +3710,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*AllowTcpForwarding\s+yes'
 
   # 5.2.14 Ensure system-wide crypto policy is not over-ridden. (Automated)
-  - id: 6673
+  - id: 37672
     title: "Ensure system-wide crypto policy is not over-ridden."
     description: "System-wide Crypto policy can be over-ridden or opted out of for openSSH."
     rationale: "Over-riding or opting out of the system-wide crypto policy could allow for the use of less secure Ciphers, MACs, KexAlgorithms and GSSAPIKexAlgorithm."
@@ -3730,7 +3730,7 @@ checks:
       - 'not f:/etc/sysconfig/sshd -> ^\s*CRYPTO_POLICY='
 
   # 5.2.15 Ensure SSH warning banner is configured. (Automated)
-  - id: 6674
+  - id: 37673
     title: "Ensure SSH warning banner is configured."
     description: "The Banner parameter specifies a file whose contents must be sent to the remote user before authentication is permitted. By default, no banner is displayed."
     rationale: "Banners are used to warn connecting users of the particular site's policy regarding connection. Presenting a warning message prior to the normal user login may assist the prosecution of trespassers on the computer system."
@@ -3750,7 +3750,7 @@ checks:
       - 'c:sshd -T -> r:^\s*banner\s*\t*/etc/issue.net'
 
   # 5.2.16 Ensure SSH MaxAuthTries is set to 4 or less. (Automated)
-  - id: 6675
+  - id: 37674
     title: "Ensure SSH MaxAuthTries is set to 4 or less."
     description: "The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure."
     rationale: "Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. While the recommended setting is 4, set the number based on site policy."
@@ -3770,7 +3770,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> n:^MaxAuthTries\s*\t*(\d+) compare > 4'
 
   # 5.2.17 Ensure SSH MaxStartups is configured. (Automated)
-  - id: 6676
+  - id: 37675
     title: "Ensure SSH MaxStartups is configured."
     description: "The MaxStartups parameter specifies the maximum number of concurrent unauthenticated connections to the SSH daemon."
     rationale: "To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon."
@@ -3791,7 +3791,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*maxstartups\s+(((1[1-9]|[1-9][0-9][0-9]+):([0-9]+):([0-9]+))|(([0-9]+):(3[1-9]|[4-9][0-9]|[1-9][0-9][0-9]+):([0-9]+))|(([0-9]+):([0-9]+):(6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+)))'
 
   # 5.2.18 Ensure SSH MaxSessions is set to 10 or less. (Automated)
-  - id: 6677
+  - id: 37676
     title: "Ensure SSH MaxSessions is set to 10 or less."
     description: "The MaxSessions parameter specifies the maximum number of open sessions permitted from a given connection."
     rationale: "To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon."
@@ -3812,7 +3812,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:^\s*MaxSessions\s+(1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)'
 
   # 5.2.19 Ensure SSH LoginGraceTime is set to one minute or less. (Automated)
-  - id: 6678
+  - id: 37677
     title: "Ensure SSH LoginGraceTime is set to one minute or less."
     description: "The LoginGraceTime parameter specifies the time allowed for successful authentication to the SSH server. The longer the Grace period is the more open unauthenticated connections can exist. Like other session controls in this session the Grace Period should be limited to appropriate organizational limits to ensure the service is available for needed access."
     rationale: "Setting the LoginGraceTime parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. It will also limit the number of concurrent unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set the number based on site policy."
@@ -3833,7 +3833,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> r:\s*LoginGraceTime\s+(0|6[1-9]|[7-9][0-9]|[1-9][0-9][0-9]+|[^1]m)'
 
   # 5.2.20 Ensure SSH Idle Timeout Interval is configured. (Automated)
-  - id: 6679
+  - id: 37678
     title: "Ensure SSH Idle Timeout Interval is configured."
     description: "The two options ClientAliveInterval and ClientAliveCountMax control the timeout of ssh sessions. - ClientAliveInterval sets a timeout interval in seconds after which if no data has been received from the client, sshd will send a message through the encrypted channel to request a response from the client. The default is 0, indicating that these messages will not be sent to the client. - ClientAliveCountMax sets the number of client alive messages which may be sent without sshd receiving any messages back from the client. If this threshold is reached while client alive messages are being sent, sshd will disconnect the client, terminating the session. The default value is 3. o The client alive messages are sent through the encrypted channel o Setting ClientAliveCountMax to 0 disables connection termination Example: The default value is 3. If ClientAliveInterval is set to 15, and ClientAliveCountMax is left at the default, unresponsive SSH clients will be disconnected after approximately 45 seconds."
     rationale: "Having no timeout value associated with a connection could allow an unauthorized user access to another user's ssh session (e.g. user walks away from their computer and doesn't lock the screen). Setting a timeout value reduces this risk. - The recommended ClientAliveInterval setting is no greater than 900 seconds (15 minutes) - The recommended ClientAliveCountMax setting is 0 - At the 15 minute interval, if the ssh session is inactive, the session will be terminated."
@@ -3861,7 +3861,7 @@ checks:
       - 'not f:/etc/ssh/sshd_config -> n:^clientalivecountmax\s*\t*(\d+) > 0'
 
   # 5.3.1 Ensure sudo is installed. (Automated)
-  - id: 6680
+  - id: 37679
     title: "Ensure sudo is installed."
     description: "sudo allows a permitted user to execute a command as the superuser or another user, as specified by the security policy. The invoking user's real (not effective) user ID is used to determine the user name with which to query the security policy."
     rationale: "sudo supports a plug-in architecture for security policies and input/output logging. Third parties can develop and distribute their own policy and I/O logging plug-ins to work seamlessly with the sudo front end. The default security policy is sudoers, which is configured via the file /etc/sudoers and any entries in /etc/sudoers.d. The security policy determines what privileges, if any, a user has to run sudo. The policy may require that users authenticate themselves with a password or another authentication mechanism. If authentication is required, sudo will exit if the user's password is not entered within a configurable time limit. This limit is policy-specific."
@@ -3880,7 +3880,7 @@ checks:
       - "c:dnf list sudo -> r:^sudo.x86_64"
 
   # 5.3.2 Ensure sudo commands use pty. (Automated)
-  - id: 6681
+  - id: 37680
     title: "Ensure sudo commands use pty."
     description: "sudo can be configured to run only from a pseudo terminal (pseudo-pty)."
     rationale: "Attackers can run a malicious program using sudo which would fork a background process that remains even when the main program has finished executing."
@@ -3901,7 +3901,7 @@ checks:
       - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*use_pty'
 
   # 5.3.3 Ensure sudo log file exists. (Automated)
-  - id: 6682
+  - id: 37681
     title: "Ensure sudo log file exists."
     description: "sudo can use a custom log file."
     rationale: "A sudo log file simplifies auditing of sudo commands."
@@ -3923,7 +3923,7 @@ checks:
       - 'd:/etc/sudoers.d -> r:\.* -> r:^\s*\t*Defaults\s*\t*logfile='
 
   # 5.3.4 Ensure users must provide password for escalation. (Automated)
-  - id: 6683
+  - id: 37682
     title: "Ensure users must provide password for escalation."
     description: "The operating system must be configured so that users must provide a password for privilege escalation."
     rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
@@ -3944,7 +3944,7 @@ checks:
       - 'not d:/etc/sudoers.d -> r:\.* -> !r:^# && r:*NOPASSWD'
 
   # 5.3.5 Ensure re-authentication for privilege escalation is not disabled globally. (Automated)
-  - id: 6684
+  - id: 37683
     title: "Ensure re-authentication for privilege escalation is not disabled globally."
     description: "The operating system must be configured so that users must re-authenticate for privilege escalation."
     rationale: "Without re-authentication, users may access resources or perform tasks for which they do not have authorization. When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate."
@@ -3964,7 +3964,7 @@ checks:
       - 'not d:/etc/sudoers.d -> r:\.* -> !r:^# && r:*\!authenticate'
 
   # 5.3.6 Ensure sudo authentication timeout is configured correctly. (Automated)
-  - id: 6685
+  - id: 37684
     title: "Ensure sudo authentication timeout is configured correctly."
     description: "sudo caches used credentials for a default of 5 minutes. This is for ease of use when there are multiple administrative tasks to perform. The timeout can be modified to suit local security policies."
     rationale: "Setting a timeout value reduces the window of opportunity for unauthorized privileged access to another user."
@@ -3986,7 +3986,7 @@ checks:
       - 'c:sudo -V -> r:Authentication timestamp timeout:\s*\t*5.0 minutes'
 
   # 5.3.7 Ensure access to the su command is restricted. (Automated)
-  - id: 6686
+  - id: 37685
     title: "Ensure access to the su command is restricted."
     description: "The su command allows a user to run a command or shell as another user. The program has been superseded by sudo, which allows for more granular control over privileged access. Normally, the su command can be executed by any user. By uncommenting the pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in a specific groups to execute su. This group should be empty to reinforce the use of sudo for privileged access."
     rationale: "Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program."
@@ -4009,7 +4009,7 @@ checks:
   # 5.4.1 Ensure custom authselect profile is used. (Manual) - Not Implemented
 
   # 5.4.2 Ensure authselect includes with-faillock. (Automated)
-  - id: 6687
+  - id: 37686
     title: "Ensure authselect includes with-faillock."
     description: "The pam_faillock.so module maintains a list of failed authentication attempts per user during a specified interval and locks the account in case there were more than deny consecutive failed authentications. It stores the failure records into per-user files in the tally directory."
     rationale: "Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems."
@@ -4030,7 +4030,7 @@ checks:
       - "f:/etc/pam.d/system-auth -> r:required && r:pam_faillock.so"
 
   # 5.5.1 Ensure password creation requirements are configured. (Automated)
-  - id: 6688
+  - id: 37687
     title: "Ensure password creation requirements are configured."
     description: "The pam_pwquality.so module checks the strength of passwords. It performs checks such as making sure a password is not a dictionary word, it is a certain length, contains a mix of characters (e.g. alphabet, numeric, other) and more. The following are definitions of the pam_pwquality.so options. - try_first_pass - retrieve the password from a previous stacked PAM module. If not available, then prompt the user for a password. - retry=3 - Allow 3 tries before sending back a failure. - minlen=14 - password must be 14 characters or more ** Either of the following can be used to enforce complex passwords:** - minclass=4 - provide at least four classes of characters for the new password OR - dcredit=-1 - provide at least one digit - ucredit=-1 - provide at least one uppercase character - ocredit=-1 - provide at least one special character - lcredit=-1 - provide at least one lowercase character The settings shown above are one possible policy. Alter these values to conform to your own organization's password policies."
     rationale: "Strong passwords protect systems from being hacked through brute force methods."
@@ -4053,7 +4053,7 @@ checks:
   # 5.5.2 Ensure lockout for failed password attempts is configured. (Automated) - Not Implemented
 
   # 5.5.3 Ensure password reuse is limited. (Automated)
-  - id: 6689
+  - id: 37688
     title: "Ensure password reuse is limited."
     description: "The /etc/security/opasswd file stores the users' old passwords and can be checked to ensure that users are not recycling recent passwords. - remember=<5> - Number of old passwords to remember."
     rationale: "Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be able to guess the password. Note: These change only apply to accounts configured on the local system."
@@ -4071,7 +4071,7 @@ checks:
       - 'f:/etc/pam.d/system-auth -> !r:^\s*\t*# && r:password\s*\t*requisite|password\s*\t*sufficient && r:pam_pwhistory.so|pam_unix.so && n:remember\s*\t*=\s*\t*(\d+) compare => 5'
 
   # 5.5.4 Ensure password hashing algorithm is SHA-512. (Automated)
-  - id: 6690
+  - id: 37689
     title: "Ensure password hashing algorithm is SHA-512."
     description: "A cryptographic hash function converts an arbitrary-length input into a fixed length output. Password hashing performs a one-way transformation of a password, turning the password into another string, called the hashed password."
     rationale: "The SHA-512 algorithm provides stronger hashing than other hashing algorithms used for password hashing with Linux, providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords. Note: These changes only apply to accounts configured on the local system."
@@ -4095,7 +4095,7 @@ checks:
       - 'f:/etc/pam.d/system-auth -> r:\s*password && r:requisite|required|sufficient && r:pam_unix.so && r:sha512'
 
   # 5.6.1.1 Ensure password expiration is 365 days or less. (Automated)
-  - id: 6691
+  - id: 37690
     title: "Ensure password expiration is 365 days or less."
     description: "The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force passwords to expire once they reach a defined age. It is recommended that the PASS_MAX_DAYS parameter be set to less than or equal to 365 days."
     rationale: "The window of opportunity for an attacker to leverage compromised credentials or successfully compromise credentials via an online brute force attack is limited by the age of the password. Therefore, reducing the maximum age of a password also reduces an attacker's window of opportunity."
@@ -4116,7 +4116,7 @@ checks:
       - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:\d+:(\d+): compare > 365'
 
   # 5.6.1.2 Ensure minimum days between password changes is 7 or more. (Automated)
-  - id: 6692
+  - id: 37691
     title: "Ensure minimum days between password changes is 7 or more."
     description: "The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent users from changing their password until a minimum number of days have passed since the last time the user changed their password. It is recommended that PASS_MIN_DAYS parameter be set to 7 or more days."
     rationale: "By restricting the frequency of password changes, an administrator can prevent users from repeatedly changing their password in an attempt to circumvent password reuse controls."
@@ -4137,7 +4137,7 @@ checks:
       - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:(\d+): compare < 7'
 
   # 5.6.1.3 Ensure password expiration warning days is 7 or more. (Automated)
-  - id: 6693
+  - id: 37692
     title: "Ensure password expiration warning days is 7 or more."
     description: "The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users that their password will expire in a defined number of days. It is recommended that the PASS_WARN_AGE parameter be set to 7 or more days."
     rationale: "Providing an advance warning that a password will be expiring gives users time to think of a secure password. Users caught unaware may choose a simple password or write it down where it may be discovered."
@@ -4158,7 +4158,7 @@ checks:
       - 'not f:/etc/shadow -> n:^\w+:\$\.*:\d+:\d+:\d+:(\d+): compare < 7'
 
   # 5.6.1.4 Ensure inactive password lock is 30 days or less. (Automated)
-  - id: 6694
+  - id: 37693
     title: "Ensure inactive password lock is 30 days or less."
     description: "User accounts that have been inactive for over a given period of time can be automatically disabled. It is recommended that accounts that are inactive for 30 days after password expiration be disabled."
     rationale: "Inactive accounts pose a threat to system security since the users are not logging in to notice failed login attempts or other anomalies."
@@ -4183,7 +4183,7 @@ checks:
   # 5.6.3 Ensure default user shell timeout is 900 seconds or less. (Automated) - Not Implemented
 
   # 5.6.4 Ensure default group for the root account is GID 0. (Automated)
-  - id: 6695
+  - id: 37694
     title: "Ensure default group for the root account is GID 0."
     description: "The usermod command can be used to specify which group the root account belongs to. This affects permissions of files that are created by the root account."
     rationale: "Using GID 0 for the root account helps prevent root -owned files from accidentally becoming accessible to non-privileged users."
@@ -4208,7 +4208,7 @@ checks:
   # 6.1.2 Ensure sticky bit is set on all world-writable directories. (Automated) - Not Implemented
 
   # 6.1.3 Ensure permissions on /etc/passwd are configured. (Automated)
-  - id: 6696
+  - id: 37695
     title: "Ensure permissions on /etc/passwd are configured."
     description: "The /etc/passwd file contains user account information that is used by many system utilities and therefore must be readable for these utilities to operate."
     rationale: "It is critical to ensure that the /etc/passwd file is protected from unauthorized write access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -4229,7 +4229,7 @@ checks:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/passwd -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.4 Ensure permissions on /etc/shadow are configured. (Automated)
-  - id: 6697
+  - id: 37696
     title: "Ensure permissions on /etc/shadow are configured."
     description: "The /etc/shadow file is used to store the information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/shadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the user accounts."
@@ -4250,7 +4250,7 @@ checks:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow -> r:0 root 0 root && n:shadow (\d+) compare == 0'
 
   # 6.1.5 Ensure permissions on /etc/group are configured. (Automated)
-  - id: 6698
+  - id: 37697
     title: "Ensure permissions on /etc/group are configured."
     description: "The /etc/group file contains a list of all the valid groups defined in the system. The command below allows read/write access for root and read access for everyone else."
     rationale: "The /etc/group file needs to be protected from unauthorized changes by non-privileged users, but needs to be readable as this information is used with many non-privileged programs."
@@ -4271,7 +4271,7 @@ checks:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/group -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.6 Ensure permissions on /etc/gshadow are configured. (Automated)
-  - id: 6699
+  - id: 37698
     title: "Ensure permissions on /etc/gshadow are configured."
     description: "The /etc/gshadow file is used to store the information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "If attackers can gain read access to the /etc/gshadow file, they can easily run a password cracking program against the hashed password to break it. Other security information that is stored in the /etc/gshadow file (such as group administrators) could also be useful to subvert the group."
@@ -4292,7 +4292,7 @@ checks:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/gshadow -> r:0 root 0 root && n:gshadow (\d+) compare == 0'
 
   # 6.1.7 Ensure permissions on /etc/passwd- are configured. (Automated)
-  - id: 6700
+  - id: 37699
     title: "Ensure permissions on /etc/passwd- are configured."
     description: "The /etc/passwd- file contains backup user account information."
     rationale: "It is critical to ensure that the /etc/passwd- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -4313,7 +4313,7 @@ checks:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/passwd- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.8 Ensure permissions on /etc/shadow- are configured. (Automated)
-  - id: 6701
+  - id: 37700
     title: "Ensure permissions on /etc/shadow- are configured."
     description: "The /etc/shadow- file is used to store backup information about user accounts that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/shadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -4334,7 +4334,7 @@ checks:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow- -> r:0 root 0 root && n:shadow- (\d+) compare == 0'
 
   # 6.1.9 Ensure permissions on /etc/group- are configured. (Automated)
-  - id: 6702
+  - id: 37701
     title: "Ensure permissions on /etc/group- are configured."
     description: "The /etc/group- file contains a backup list of all the valid groups defined in the system."
     rationale: "It is critical to ensure that the /etc/group- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -4355,7 +4355,7 @@ checks:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/group- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.10 Ensure permissions on /etc/gshadow- are configured. (Automated)
-  - id: 6703
+  - id: 37702
     title: "Ensure permissions on /etc/gshadow- are configured."
     description: "The /etc/gshadow- file is used to store backup information about groups that is critical to the security of those accounts, such as the hashed password and other security information."
     rationale: "It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
@@ -4382,7 +4382,7 @@ checks:
   # 6.1.15 Audit SGID executables. (Manual) - Not Implemented
 
   # 6.2.1 Ensure password fields are not empty. (Automated)
-  - id: 6704
+  - id: 37703
     title: "Ensure password fields are not empty."
     description: "An account with an empty password field means that anybody may log in as that user without providing a password."
     rationale: "All accounts must have passwords or be locked to prevent the account from being used by an unauthorized user."
@@ -4406,7 +4406,7 @@ checks:
   # 6.2.7 Ensure root PATH Integrity. (Automated) - Not Implemented
 
   # 6.2.8 Ensure root is the only UID 0 account. (Automated)
-  - id: 6705
+  - id: 37704
     title: "Ensure root is the only UID 0 account."
     description: "Any account with UID 0 has superuser privileges on the system."
     rationale: 'This access must be limited to only the default root account and only from the system console. Administrative access must be through an unprivileged account using an approved mechanism as noted in recommendation "Ensure access to the su command is restricted".'


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/29174|

# Description

CentOS 10 has similar IDs as CentOS 9. This may lead to duplicated check IDs in upgraded environment.

## Fix

- Re-assign ID 37500 > to CentOS 10 SCA checks