### PR TITLE
Fix Memory Bug in wazuh-agentd Long Options

### DIFF
--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -79,10 +79,11 @@ int main(int argc, char **argv)
 
 #if !defined(HPUX) && !defined(AIX) && !defined(SOLARIS)
     struct option long_opts[] = {
-        {"uninstall-auth-login", 1, NULL, 1},
-        {"uninstall-auth-token", 1, NULL, 2},
-        {"uninstall-auth-host", 1, NULL, 3},
-        {"uninstall-ssl-verify", 2, NULL, 4}
+        {"uninstall-auth-login", required_argument, NULL, 1},
+        {"uninstall-auth-token", required_argument, NULL, 2},
+        {"uninstall-auth-host", required_argument, NULL, 3},
+        {"uninstall-ssl-verify", optional_argument, NULL, 4},
+        {NULL, no_argument, NULL, 0}
     };
 
     while ((c = getopt_long(argc, argv, "Vtdfhu:g:D:c:", long_opts, NULL)) != -1) {


### PR DESCRIPTION
## Description

Fixes a memory bug in `wazuh-agentd` where unrecognized long options (e.g., `--version`) cause uninitialized memory access, potentially leading to a segmentation fault.

## Proposed Changes

- Added a terminating element to the `long_options` array in `main.c` to prevent out-of-bounds access.
- Updated the help message output for `wazuh-agentd -h` to ensure all options are clearly documented.

### Results and Evidence

Valgrind output for `wazuh-agentd --version` shows no memory errors:
```
==23693== Command: /var/ossec/bin/wazuh-agentd --version
==23693==
/var/ossec/bin/wazuh-agentd: unrecognized option '--version'
==23693==
==23693== HEAP SUMMARY:
==23693==     in use at exit: 0 bytes in 0 blocks
==23693==   total heap usage: 6 allocs, 6 frees, 13,234 bytes allocated
==23693==
==23693== All heap blocks were freed -- no leaks are possible
```

### Artifacts Affected

- wazuh-agentd (UNIX version)

### Configuration Changes

None required.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues