### PR TITLE
Fix Microsoft windows 11 enterprise benchmark v3.0.0 SCA check ID 26009 issue

### DIFF
--- a/ruleset/sca/windows/cis_win10_enterprise.yml
+++ b/ruleset/sca/windows/cis_win10_enterprise.yml
@@ -163,9 +163,10 @@ checks:
     compliance:
       - cis: ["2.3.1.3"]
       - cis_csc: ["4.7"]
-    condition: all
+    condition: any
     rules:
       - 'c:net user guest -> r:Account active\s+No'
+      - "c:net user guest -> r:The user name could not be found."
 
   - id: 15512
     title: "Ensure 'Accounts: Limit local account use of blank passwords to console logon only' is set to 'Enabled'."

--- a/ruleset/sca/windows/cis_win11_enterprise.yml
+++ b/ruleset/sca/windows/cis_win11_enterprise.yml
@@ -278,7 +278,7 @@ checks:
       - pci_dss_v3.2.1: ["2.1", "2.1.1"]
       - pci_dss_v4.0: ["2.2.2", "2.3.1"]
       - soc_2: ["CC6.3"]
-    condition: all
+    condition: any
     rules:
       - 'c:net user guest -> r:Account active\s+No'
       - 'c:net user guest -> r:The user name could not be found.'

--- a/ruleset/sca/windows/cis_win2012r2.yml
+++ b/ruleset/sca/windows/cis_win2012r2.yml
@@ -252,7 +252,7 @@ checks:
       - pci_dss_v3.2.1: ["2.1", "2.1.1"]
       - pci_dss_v4.0: ["2.2.2", "2.3.1"]
       - soc_2: ["CC6.3"]
-    condition: all
+    condition: any
     rules:
       - 'c:net user guest -> r:Account active\s+No'
       - "c:net user guest -> r:The user name could not be found."


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/external-devel-requests/issues/5648|

# Description

A customer reported  customer having issues with SCA ID 46009. The check fails due to apparent contradictory conditions that should be met.

- The correct check is meant to be:

```console
    condition: any
    rules:
      - 'c:net user guest -> r:Account active\s+No'
      - 'c:net user guest -> r:The user name could not be found.'
```

- Other affected OS - Windows server 2012 R@ and windows 10