### PR TITLE
Update stateless events error formatting

### DIFF
--- a/apis/tools/env/wazuh-server/scripts/rbac-setup.sh
+++ b/apis/tools/env/wazuh-server/scripts/rbac-setup.sh
@@ -27,7 +27,7 @@ curl -X POST -H "$CONTENT_TYPE" -ksu $INDEXER_USERNAME:$INDEXER_PASSWORD -w "\n"
                 "policies": [
                     {
                         "name": "agents_all",
-                        "actions": ["agent:read", "agent:delete", "agent:modify_group", "agent:reconnect", "agent:restart"],
+                        "actions": ["agent:create", "agent:read", "agent:delete", "agent:modify_group", "agent:reconnect", "agent:restart"],
                         "resources": ["*:*:*"],
                         "effect": "allow",
                         "level": 0

--- a/framework/wazuh/core/engine/events.py
+++ b/framework/wazuh/core/engine/events.py
@@ -36,7 +36,7 @@ class EventsModule(BaseModule):
 
             if response.is_error:
                 error = ErrorResponse(**response.json())
-                raise WazuhError(2710, extra_message=': '.join(error.error))
+                raise WazuhError(2710, extra_message=error.error)
 
         except RequestError as exc:
             raise WazuhEngineError(2803, extra_message=str(exc))

--- a/framework/wazuh/core/engine/tests/test_events.py
+++ b/framework/wazuh/core/engine/tests/test_events.py
@@ -33,7 +33,7 @@ class TestEventsModule:
         response = mock.MagicMock()
         response.is_error = True
         response.json = mock.MagicMock()
-        response.json.return_value = {'error': ['Service Unavailable', 'failure'], 'code': 400}
+        response.json.return_value = {'error': 'Service Unavailable: failure', 'code': 400}
         client_mock.post.return_value = response
 
         expected_error_msg = 'Error 2710 - Invalid stateless events request: Service Unavailable: failure'


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/28970 |

## Description

Adds the `agent:create` permission to the admin user and updates the engine error formatting

## Tests

<details><summary>Agent enrollment </summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Mon, 14 Apr 2025 17:36:08 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

</details>

<details><summary>Display engine error</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -sSki -H "Authorization: Bearer $TOKEN"  -H "Content-Type: application/json" -H "Transfer-Encoding: chunked" -X POST https://0.0.0.0:27000/api/v1/events/stateless -d '{"agent": {"id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0", "name": "example", "type": "endpoint", "version": "5.0.0", "groups": ["group1"], "host": {"hostname": "myhost", "os": {"name": "Amazon Linux 2", "platform": "Linux"}, "ip": ["192.168.1.2"], "architecture": "x86_64"}}}
{"module": "sca"}
{"event": {"created": "2025-03-11T19:35:58.237Z", "category": ["configuration"], "type": ["change"], "action": "check-updated", "changed_fields": ["policy.name", "check.condition", "check.result"]}, "policy": {"id": "cis_win11_enterprise_21H2", "name": "CIS Microsoft Windows 11 Enterprise Benchmark v1.0.1", "file": "cis_win11_enterprise.yml", "description": "This document provides prescriptive guidance f...", "references": ["https://www.cisecurity.org/cis-benchmarks/"], "previous": {"name": "CIS Microsoft Windows 11 Enterprise Benchmark v1.0.0"}}, "check": {"id": "26000", "name": "name", "description": "This policy setting determines ...", "rationale": "The longer a user uses the same password ...", "remediation": "To establish the recommended configuration ...", "references": ["https://workbench.cisecurity.org"], "condition": "all", "compliance": ["cis:1.1.1","cis_csc:5.2"], "rules": [], "result": "failed", "reason": null, "previous": {"result": "passed", "condition": "any"}}}
'
HTTP/1.1 400 Bad Request
date: Mon, 14 Apr 2025 18:07:21 GMT
server: uvicorn
content-length: 303
content-type: application/json
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store

{"message":"Invalid stateless events request: NDJson parser error, invalid subheader, expected '/module' and '/collector' fields","code":400}
```

</details>