### PR TITLE
Fix error building sysinfo for legacy Linux

### DIFF
--- a/src/data_provider/src/packages/packageLinuxDataRetriever.h
+++ b/src/data_provider/src/packages/packageLinuxDataRetriever.h
@@ -117,6 +117,19 @@ class FactoryPackagesCreator<LinuxType::STANDARD> final
                 getSnapInfo(callback);
             }
         }
+
+        static void getPythonPackages(std::unordered_set<std::string>& pythonPackages)
+        {
+            if (Utils::existsDir(DPKG_PATH))
+            {
+                getDpkgPythonPackages(pythonPackages);
+            }
+
+            if (Utils::existsDir(RPM_PATH))
+            {
+                getRpmPythonPackages(pythonPackages);
+            }
+        }
 };
 
 // Template to extract package information in partially incompatible Linux systems
@@ -131,6 +144,7 @@ class FactoryPackagesCreator<LinuxType::LEGACY> final
                 getRpmInfoLegacy(callback);
             }
         }
+        static void getPythonPackages(std::unordered_set<std::string>&) {};
 };
 
 #endif // _PACKAGE_LINUX_DATA_RETRIEVER_H

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -604,15 +604,7 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 
     std::unordered_set<std::string> excludePaths;
 
-    if (Utils::existsDir(DPKG_PATH))
-    {
-        getDpkgPythonPackages(excludePaths);
-    }
-
-    if (Utils::existsDir(RPM_PATH))
-    {
-        getRpmPythonPackages(excludePaths);
-    }
+    FactoryPackagesCreator<LINUX_TYPE>::getPythonPackages(excludePaths);
 
     ModernFactoryPackagesCreator<HAS_STDFILESYSTEM>::getPackages(searchPaths, callback, excludePaths);
 }


### PR DESCRIPTION
|Related issue|
|---|
| #29224 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR fixes an error that occurs when building `sysinfo` (data_provider) for legacy Linux systems, such as RedHat 5 and CentOS 5.

## Configuration options

This error can be replicated when generating rpm packages using this command:

```console
gh workflow run packages-build-linux-agent-amd.yml -r 4.12.1 -f architecture=x86_64 -f source_reference=4.1
2.1 -f checksum=true -f system=rpm -f legacy=true
```

## Logs/Alerts example

<details><summary>Before fix</summary>

```log
[100%] Linking CXX executable ../bin/sysinfo_test_tool
../lib/libsysinfo.so: undefined reference to `getRpmPythonPackages(std::unordered_set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)'
../lib/libsysinfo.so: undefined reference to `getDpkgPythonPackages(std::unordered_set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)'
collect2: error: ld returned 1 exit status
make[4]: *** [bin/sysinfo_test_tool] Error 1
make[4]: Leaving directory `/build_wazuh/rpmbuild/BUILD/wazuh-agent-4.12.1/src/data_provider/build'
make[3]: *** [testtool/CMakeFiles/sysinfo_test_tool.dir/all] Error 2
make[3]: Leaving directory `/build_wazuh/rpmbuild/BUILD/wazuh-agent-4.12.1/src/data_provider/build'
make[2]: *** [all] Error 2
make[2]: Leaving directory `/build_wazuh/rpmbuild/BUILD/wazuh-agent-4.12.1/src/data_provider/build'
make[1]: *** [build_sysinfo] Error 2
make[1]: *** Waiting for unfinished jobs....
```

</details> 

<details><summary>After fix</summary>

```log
General settings:
    TARGET:             agent
    V:                  
    DEBUG:              
    DEBUGAD             
    INSTALLDIR:         /var/ossec
    DATABASE:           
    ONEWAY:             no
    CLEANFULL:          no
    RESOURCES_URL:      https://packages.wazuh.com/deps/40
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:75384783d339a817b8d8f13f778051a878d642a6
User settings:
    WAZUH_GROUP:        wazuh
    WAZUH_USER:         wazuh
USE settings:
    USE_ZEROMQ:         no
    USE_GEOIP:          no
    USE_PRELUDE:        no
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        yes
    USE_AUDIT:          no
    DISABLE_SYSC:       no
    DISABLE_CISCAT:     no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Mysql settings:
    includes:           
    libs:               
Pgsql settings:
    includes:           
    libs:               
Defines:
    -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DCLIENT
Compiler:
    CFLAGS            -pthread -Wl,--start-group -DNDEBUG -O2 -DOSSECHIDS -DUSER="wazuh" -DGROUPGLOBAL="wazuh" -DLinux -DINOTIFY_ENABLED -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DIMAGE_TRUST_CHECKS=1 -DCA_NAME='DigiCert Assured ID Root CA' -DENABLE_SYSC -DENABLE_CISCAT -DCLIENT -pipe -Wall -Wextra -std=gnu99 -I./ -I./headers/ -Iexternal/openssl/include -Iexternal/cJSON/ -Iexternal/libyaml/include -Iexternal/curl/include -Iexternal/msgpack/include -Iexternal/bzip2/ -Ishared_modules/common -Ishared_modules/dbsync/include -Ishared_modules/rsync/include -Iwazuh_modules/syscollector/include  -Idata_provider/include  -Iexternal/libpcre2/include -Iexternal/rpm//builddir/output/include -Isyscheckd/include -Ishared_modules/router/include -Ishared_modules/content_manager/include -Iwazuh_modules/vulnerability_scanner/include -I./shared_modules/ 
    LDFLAGS           '-Wl,-rpath,/../lib' -pthread -lrt -ldl -O2 -Lshared_modules/dbsync/build/lib -Lshared_modules/rsync/build/lib  -Lwazuh_modules/syscollector/build/lib -Ldata_provider/build/lib -Lsyscheckd/build/lib
    LIBS              -lrt -ldl -lm 
    CC                gcc
    MAKE              make
make[1]: Leaving directory `/build_wazuh/rpmbuild/BUILD/wazuh-agent-4.12.1/src'

Done building agent

Wait for success...
grep: /etc/os-release: No such file or directory
grep: /etc/os-release: No such file or directory
success
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libwazuhext.so
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libwazuhshared.so
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libdbsync.so
chcon: can't apply partial context to unlabeled file /var/ossec/lib/librsync.so
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libsysinfo.so
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libfimdb.so
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libsyscollector.so
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libstdc++.so.6
chcon: can't apply partial context to unlabeled file /var/ossec/lib/libgcc_s.so.1
Removing old SCA policies...
Installing SCA policies...
ERROR: SCA policy not found: ../ruleset/sca/centos/5/cis_centos5_linux.yml


 - System is Redhat Linux.
 - Init script modified to start Wazuh during boot.

 - Configuration finished properly.

 - To start Wazuh:
      /var/ossec/bin/wazuh-control start

 - To stop Wazuh:
      /var/ossec/bin/wazuh-control stop

 - The configuration can be viewed or modified at /var/ossec/etc/ossec.conf


   Thanks for using Wazuh.
   Please don't hesitate to contact us if you need help or find
   any bugs.

   Use our public Mailing List at:
          https://groups.google.com/forum/#!forum/wazuh

   More information can be found at:
          - http://www.wazuh.com

    ---  Press ENTER to finish (maybe more information below). ---

 - More information at: 
   https://documentation.wazuh.com/

+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/etc
+ touch /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/etc/ossec-init.conf
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/etc/rc.d/init.d
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/.ssh
+ cp -pr /var/ossec/VERSION.json /var/ossec/active-response /var/ossec/agentless /var/ossec/backup /var/ossec/bin /var/ossec/etc /var/ossec/lib /var/ossec/logs /var/ossec/queue /var/ossec/ruleset /var/ossec/tmp /var/ossec/var /var/ossec/wodles /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/usr/lib/systemd/system/
+ sed -i s:WAZUH_HOME_TMP:/var/ossec:g src/init/templates/ossec-hids-rh.init
+ install -m 0755 src/init/templates/ossec-hids-rh.init /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/etc/rc.d/init.d/wazuh-agent
+ sed -i s:WAZUH_HOME_TMP:/var/ossec:g src/init/templates/wazuh-agent.service
+ install -m 0644 src/init/templates/wazuh-agent.service /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/usr/lib/systemd/system/
+ rm -f '/var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/ruleset/sca/*'
+ mkdir -p '/var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/{generic}'
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/amzn/1 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/amzn/2 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/amzn/2023
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/10 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/8 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/7 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/6 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/5
+ mkdir -p '/var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/ol/{9}'
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/9 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/8 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/7 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/6 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/5
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/sles/11 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/sles/12 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/sles/15
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/suse/11 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/suse/12
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/29 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/30 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/31 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/32 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/33 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/34 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/41
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/almalinux/8 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/almalinux/9 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/almalinux/10
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rocky/8 /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rocky/9
+ cp -r ruleset/sca/generic ruleset/sca/centos ruleset/sca/rhel ruleset/sca/ol ruleset/sca/sles ruleset/sca/amazon ruleset/sca/rocky ruleset/sca/almalinux /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp
+ cp etc/templates/config/generic/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/generic
+ cp etc/templates/config/amzn/1/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/amzn/1
+ cp etc/templates/config/amzn/2/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/amzn/2
+ cp etc/templates/config/amzn/2023/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/amzn/2023
+ cp etc/templates/config/centos/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos
+ cp etc/templates/config/centos/10/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/10
+ cp etc/templates/config/centos/8/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/8
+ cp etc/templates/config/centos/7/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/7
+ cp etc/templates/config/centos/6/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/6
+ cp etc/templates/config/centos/5/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/centos/5
+ cp etc/templates/config/ol/9/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/ol/9
+ cp etc/templates/config/rhel/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel
+ cp etc/templates/config/rhel/10/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/10
+ cp etc/templates/config/rhel/9/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/9
+ cp etc/templates/config/rhel/8/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/8
+ cp etc/templates/config/rhel/7/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/7
+ cp etc/templates/config/rhel/6/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/6
+ cp etc/templates/config/rhel/5/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rhel/5
+ cp etc/templates/config/sles/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/sles
+ cp etc/templates/config/sles/11/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/sles/11
+ cp etc/templates/config/sles/12/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/sles/12
+ cp etc/templates/config/sles/15/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/sles/15
+ cp etc/templates/config/suse/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/suse
+ cp etc/templates/config/suse/11/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/suse/11
+ cp etc/templates/config/suse/12/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/suse/12
+ cp etc/templates/config/fedora/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora
+ cp etc/templates/config/fedora/29/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/29
+ cp etc/templates/config/fedora/30/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/30
+ cp etc/templates/config/fedora/31/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/31
+ cp etc/templates/config/fedora/32/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/32
+ cp etc/templates/config/fedora/33/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/33
+ cp etc/templates/config/fedora/34/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/34
+ cp etc/templates/config/fedora/41/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/fedora/41
+ cp etc/templates/config/almalinux/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/almalinux
+ cp etc/templates/config/almalinux/8/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/almalinux/8
+ cp etc/templates/config/almalinux/9/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/almalinux/9
+ cp etc/templates/config/almalinux/10/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/almalinux/10
+ cp etc/templates/config/rocky/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rocky
+ cp etc/templates/config/rocky/8/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rocky/8
+ cp etc/templates/config/rocky/9/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/tmp/sca-4.12.1-0.el5-tmp/rocky/9
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/
+ cp gen_ossec.sh /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/
+ cp add_localfiles.sh /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/src/init
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/generic
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/centos
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/rhel
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/suse
+ mkdir -p /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/sles
+ sed -i s:WAZUH_HOME_TMP:/var/ossec:g src/init/templates/ossec-hids-suse.init
+ cp -rp src/init/templates/ossec-hids-suse.init /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/src/init/
+ cp -rp etc/templates/config/generic/alerts.template etc/templates/config/generic/ar-commands.template etc/templates/config/generic/ar-definitions.template etc/templates/config/generic/auth.template etc/templates/config/generic/cluster.template etc/templates/config/generic/global-ar.template etc/templates/config/generic/global.template etc/templates/config/generic/header-comments.template etc/templates/config/generic/localfile-commands.template etc/templates/config/generic/localfile-logs etc/templates/config/generic/logging.template etc/templates/config/generic/osquery.template etc/templates/config/generic/remote-secure.template etc/templates/config/generic/rootcheck.agent.template etc/templates/config/generic/rootcheck.manager.template etc/templates/config/generic/rule_test.template etc/templates/config/generic/rules.template etc/templates/config/generic/sca.files etc/templates/config/generic/sca.manager.files etc/templates/config/generic/sca.template etc/templates/config/generic/syscheck.agent.template etc/templates/config/generic/syscheck.manager.template etc/templates/config/generic/wodle-ciscat.template etc/templates/config/generic/wodle-indexer.manager.template etc/templates/config/generic/wodle-syscollector.template etc/templates/config/generic/wodle-vulnerability-detection.manager.template /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/generic
+ cp -rp etc/templates/config/centos/10 etc/templates/config/centos/5 etc/templates/config/centos/6 etc/templates/config/centos/7 etc/templates/config/centos/8 etc/templates/config/centos/rootcheck.agent.template etc/templates/config/centos/rootcheck.manager.template etc/templates/config/centos/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/centos
+ cp -rp etc/templates/config/rhel/10 etc/templates/config/rhel/5 etc/templates/config/rhel/6 etc/templates/config/rhel/7 etc/templates/config/rhel/8 etc/templates/config/rhel/9 etc/templates/config/rhel/rootcheck.agent.template etc/templates/config/rhel/rootcheck.manager.template etc/templates/config/rhel/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/rhel
+ cp -rp etc/templates/config/suse/11 etc/templates/config/suse/12 etc/templates/config/suse/15 etc/templates/config/suse/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/suse
+ cp -rp etc/templates/config/sles/11 etc/templates/config/sles/12 etc/templates/config/sles/15 etc/templates/config/sles/sca.files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/etc/templates/config/sles
+ install -m 0440 VERSION.json /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/
+ install -m 0640 src/init/adduser.sh src/init/darwin-addusers.sh src/init/darwin-delete-oldusers.sh src/init/darwin-init.sh src/init/delete-oldusers.sh src/init/dist-detect.sh src/init/functions.sh src/init/fw-check.sh src/init/init.sh src/init/inst-functions.sh src/init/language.sh src/init/pkg_installer.sh src/init/register_configure_agent.sh src/init/replace_manager_ip.sh src/init/shared.sh src/init/template-select.sh src/init/update-indexer.sh src/init/update.sh src/init/wazuh-client.sh src/init/wazuh-local.sh src/init/wazuh-server.sh /var/tmp/wazuh-agent-4.12.1-0.el5-root-root/var/ossec/packages_files/agent_installation_scripts/src/init
+ exit 0
Processing files: wazuh-agent-4.12.1-0.el5
warning: File listed twice: /var/ossec/lib/libdbsync.so
warning: File listed twice: /var/ossec/lib/libfimdb.so
warning: File listed twice: /var/ossec/lib/libgcc_s.so.1
warning: File listed twice: /var/ossec/lib/librsync.so
warning: File listed twice: /var/ossec/lib/libstdc++.so.6
warning: File listed twice: /var/ossec/lib/libsyscollector.so
warning: File listed twice: /var/ossec/lib/libsysinfo.so
warning: File listed twice: /var/ossec/wodles/aws
warning: File listed twice: /var/ossec/wodles/aws/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/aws-s3
warning: File listed twice: /var/ossec/wodles/aws/aws_tools.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/aws_bucket.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/cloudtrail.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/config.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/guardduty.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/load_balancers.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/server_access.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/umbrella.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/vpcflow.py
warning: File listed twice: /var/ossec/wodles/aws/buckets_s3/waf.py
warning: File listed twice: /var/ossec/wodles/aws/services
warning: File listed twice: /var/ossec/wodles/aws/services/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/services/aws_service.py
warning: File listed twice: /var/ossec/wodles/aws/services/cloudwatchlogs.py
warning: File listed twice: /var/ossec/wodles/aws/services/inspector.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers
warning: File listed twice: /var/ossec/wodles/aws/subscribers/__init__.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers/s3_log_handler.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers/sqs_message_processor.py
warning: File listed twice: /var/ossec/wodles/aws/subscribers/sqs_queue.py
warning: File listed twice: /var/ossec/wodles/aws/wazuh_integration.py
warning: File listed twice: /var/ossec/wodles/azure
warning: File listed twice: /var/ossec/wodles/azure/azure-logs
warning: File listed twice: /var/ossec/wodles/azure/azure_services
warning: File listed twice: /var/ossec/wodles/azure/azure_services/__init__.py
warning: File listed twice: /var/ossec/wodles/azure/azure_services/analytics.py
warning: File listed twice: /var/ossec/wodles/azure/azure_services/graph.py
warning: File listed twice: /var/ossec/wodles/azure/azure_services/storage.py
warning: File listed twice: /var/ossec/wodles/azure/azure_utils.py
warning: File listed twice: /var/ossec/wodles/azure/db
warning: File listed twice: /var/ossec/wodles/azure/db/__init__.py
warning: File listed twice: /var/ossec/wodles/azure/db/orm.py
warning: File listed twice: /var/ossec/wodles/azure/db/utils.py
warning: File listed twice: /var/ossec/wodles/docker
warning: File listed twice: /var/ossec/wodles/docker/DockerListener
warning: File listed twice: /var/ossec/wodles/gcloud
warning: File listed twice: /var/ossec/wodles/gcloud/buckets
warning: File listed twice: /var/ossec/wodles/gcloud/buckets/access_logs.py
warning: File listed twice: /var/ossec/wodles/gcloud/buckets/bucket.py
warning: File listed twice: /var/ossec/wodles/gcloud/exceptions.py
warning: File listed twice: /var/ossec/wodles/gcloud/gcloud
warning: File listed twice: /var/ossec/wodles/gcloud/integration.py
warning: File listed twice: /var/ossec/wodles/gcloud/pubsub
warning: File listed twice: /var/ossec/wodles/gcloud/pubsub/subscriber.py
warning: File listed twice: /var/ossec/wodles/gcloud/tools.py
Checking for unpackaged file(s): /usr/lib/rpm/check-files /var/tmp/wazuh-agent-4.12.1-0.el5-root-root
Wrote: /build_wazuh/rpmbuild/SRPMS/wazuh-agent-4.12.1-0.el5.src.rpm
Wrote: /build_wazuh/rpmbuild/RPMS/wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.53607
+ umask 022
+ cd /build_wazuh/rpmbuild/BUILD
+ cd wazuh-agent-4.12.1
+ rm -fr /var/tmp/wazuh-agent-4.12.1-0.el5-root-root
+ exit 0
+ return 0
+ get_package_and_checksum 4.12.1 cbf3be1 no
+ src=no
++ ls -R /build_wazuh/rpmbuild/RPMS
++ grep wazuh-agent
++ grep -v debuginfo
+ RPM_NAME=wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm
++ ls -R /build_wazuh/rpmbuild/RPMS
+ SYMBOLS_NAME='/build_wazuh/rpmbuild/RPMS:
wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm'
++ echo '/build_wazuh/rpmbuild/RPMS:
wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm'
++ grep wazuh-agent-debuginfo
++ true
+ SYMBOLS_NAME=
++ ls -R /build_wazuh/rpmbuild/SRPMS
++ grep '\.src\.rpm$'
+ SRC_NAME=wazuh-agent-4.12.1-0.el5.src.rpm
+ echo 'RPM_NAME: wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm'
RPM_NAME: wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm
+ echo SYMBOLS_NAME:
SYMBOLS_NAME:
+ [[ yes == \y\e\s ]]
+ cd /build_wazuh/rpmbuild/RPMS
+ sha512sum wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm
+ '[' -n '' ']'
+ [[ no == \y\e\s ]]
+ [[ no == \y\e\s ]]
+ mv /build_wazuh/rpmbuild/RPMS/wazuh-agent_4.12.1-0.el5_x86_64_cbf3be1.rpm /var/local/wazuh
+ '[' -n '' ']'
+ return 0
+ return 0
+ clean 0
+ exit_code=0
+ find /home/nbertoldo/workspace/wazuh/packages/rpms/amd64/legacy '(' -name '*.sh' -o -name '*.tar.gz' -o -name 'wazuh-*' ')' '!' -name docker_builder.sh -exec rm -rf '{}' +
+ exit 0
```

</details> 

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

- Package generation
  - DEB: :green_circle: [Packages - Build Wazuh agent Linux amd - agent packages - deb - x86_64 - checksum](https://github.com/wazuh/wazuh-agent-packages/actions/runs/14454616653)

  - RPM Standard: :green_circle: [Packages - Build Wazuh agent Linux amd - agent packages - rpm - x86_64 - checksum](https://github.com/wazuh/wazuh-agent-packages/actions/runs/14454607006)

  - RPM Legacy: :green_circle: [Packages - Build Wazuh agent Linux amd - legacy packages - rpm - x86_64 - checksum](https://github.com/wazuh/wazuh-agent-packages/actions/runs/14454499962)
