### PR TITLE
Support package upgrade testing on Linux agent packages

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/control
+++ b/packages/debs/SPECS/wazuh-agent/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.wazuh.com
 
 Package: wazuh-agent
 Architecture: any
-Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser
+Depends: ${shlibs:Depends}, libc6 (>= 2.7), lsb-release, debconf, adduser, procps
 Conflicts: ossec-hids-agent, wazuh-manager, ossec-hids, wazuh-api
 Breaks: ossec-hids-agent, wazuh-manager, ossec-hids
 Description: Wazuh agent

--- a/packages/debs/arm64/agent/Dockerfile
+++ b/packages/debs/arm64/agent/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list && \
     echo "deb-src http://archive.debian.org/debian stretch main" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --allow-change-held-packages apt apt-utils  \
-    curl gcc g++ make sudo expect gnupg \
+    curl gcc g++ make sudo expect gnupg procps \
     perl-base perl wget libc-bin libc6 libc6-dev \
     build-essential cdbs devscripts equivs automake \
     autoconf libtool libaudit-dev selinux-basics \

--- a/packages/debs/ppc64le/agent/Dockerfile
+++ b/packages/debs/ppc64le/agent/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "deb http://archive.debian.org/debian stretch contrib main non-free" > 
     curl gcc make sudo expect gnupg perl-base perl wget \
     libc-bin libc6 libc6-dev build-essential \
     cdbs devscripts equivs automake autoconf libtool libaudit-dev selinux-basics \
-    libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2
+    libdb5.3 libdb5.3 libssl1.0.2 gawk libsigsegv2 procps
 
 RUN apt-get update && apt-get build-dep python3.5 -y --allow-change-held-packages
 


### PR DESCRIPTION
|Related issues|
|---|
|https://github.com/wazuh/wazuh/issues/29113|
|https://github.com/wazuh/wazuh/issues/29114|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

This PR adds some GitHub composite actions and utilities to implement the package upgrade smoke test in our package building system.

All the available Wazuh agent Linux package architectures are covered and can be upgraded and tested.

Performed test can be seen in the following PR:
* https://github.com/wazuh/wazuh-agent-packages/pull/266