### PR TITLE
Sign JWT tokens with the API keys

### DIFF
--- a/apis/communications/comms_api/authentication/test/test_authentication.py
+++ b/apis/communications/comms_api/authentication/test/test_authentication.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi import status
 from freezegun import freeze_time
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 from comms_api.authentication.test.conftest import get_default_configuration
 

--- a/apis/communications/scripts/wazuh_comms_apid.py
+++ b/apis/communications/scripts/wazuh_comms_apid.py
@@ -37,7 +37,6 @@ from server_management_api.configuration import generate_private_key, generate_s
 from server_management_api.middlewares import SecureHeadersMiddleware
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from wazuh.core import common, pyDaemonModule, utils
-from wazuh.core.authentication import load_jwt_keys
 from wazuh.core.batcher.mux_demux import MuxDemuxManager, MuxDemuxQueue
 from wazuh.core.commands_manager import CommandsManager
 from wazuh.core.config.client import CentralizedConfig
@@ -339,7 +338,6 @@ if __name__ == '__main__':
     try:
         app = create_app(mux_demux_manager.get_queue(), commands_manager)
         options = get_gunicorn_options(pid, log_config_dict, comms_api_config)
-        load_jwt_keys(comms_api_config)
         StandaloneApplication(app, options).run()
     except WazuhCommsAPIError as e:
         logger.error(f'Error when trying to start the Wazuh Communications API. {e}')

--- a/apis/server_management/scripts/wazuh_server_management_apid.py
+++ b/apis/server_management/scripts/wazuh_server_management_apid.py
@@ -38,7 +38,6 @@ from server_management_api.signals import lifespan_handler
 from server_management_api.uri_parser import APIUriParser
 from starlette.middleware.cors import CORSMiddleware
 from wazuh.core import common, pyDaemonModule, utils
-from wazuh.core.authentication import load_jwt_keys
 from wazuh.core.commands_manager import CommandsManager
 from wazuh.core.common import WAZUH_SERVER_YML
 from wazuh.core.config.client import CentralizedConfig
@@ -328,7 +327,6 @@ if __name__ == '__main__':
     logger = logging.getLogger('wazuh-api')
 
     configure_ssl(uvicorn_params, management_config.ssl)
-    load_jwt_keys(management_config)
 
     # Check for unused PID files
     utils.clean_pid_files(API_MAIN_PROCESS)

--- a/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY, AsyncMock, patch
 import pytest
 from connexion.lifecycle import ConnexionResponse
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 from server_management_api.controllers.test.utils import CustomAffectedItems, get_default_configuration
 

--- a/apis/server_management/server_management_api/controllers/test/test_manager_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_manager_controller.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY, AsyncMock, patch
 import pytest
 from connexion.lifecycle import ConnexionResponse
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 from server_management_api.constants import INSTALLATION_UID_KEY, UPDATE_INFORMATION_KEY
 from server_management_api.controllers.test.utils import CustomAffectedItems, get_default_configuration

--- a/apis/server_management/server_management_api/controllers/test/test_security_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_security_controller.py
@@ -8,7 +8,7 @@ import pytest
 from connexion.lifecycle import ConnexionResponse
 from connexion.testing import TestContext
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 from server_management_api.controllers.test.utils import CustomAffectedItems, get_default_configuration
 from server_management_api.controllers.util import JSON_CONTENT_TYPE

--- a/apis/server_management/server_management_api/test/test_error_handler.py
+++ b/apis/server_management/server_management_api/test/test_error_handler.py
@@ -11,7 +11,7 @@ import pytest
 from connexion.exceptions import HTTPException, ProblemException, Unauthorized
 from freezegun import freeze_time
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 from server_management_api.api_exception import ExpectFailedException
 from server_management_api.controllers.test.utils import get_default_configuration

--- a/apis/server_management/server_management_api/test/test_middlewares.py
+++ b/apis/server_management/server_management_api/test/test_middlewares.py
@@ -15,7 +15,7 @@ from freezegun import freeze_time
 from starlette.responses import Response
 from wazuh.core.authentication import JWT_ALGORITHM
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 from server_management_api.api_exception import ExpectFailedException
 from server_management_api.controllers.test.utils import get_default_configuration

--- a/apis/tools/env/README.md
+++ b/apis/tools/env/README.md
@@ -54,8 +54,6 @@ drwxr-xr-x 7 wazuh wazuh     4096 Nov 28 09:01 ..
 -rw-r--r-- 1 wazuh wazuh     1415 Nov 28 13:12 wazuh-manager.pem
 ```
 
-> In case the JWT keys are required as part of the Server configuration, use the `--with-jwt` option when running the script. The key file `private-key.pem` will be generated.
-
 ### Setting up indexer plugins
 
 Download the latest plugins from the wazuh-indexer GitHub repository, decompress and include them in the `wazuh-indexer` directory. The directory should end up with the following files

--- a/apis/tools/env/certs/gen_certs.sh
+++ b/apis/tools/env/certs/gen_certs.sh
@@ -69,22 +69,7 @@ EOF
 openssl pkcs8 -topk8 -inform pem -in $name-key.pem -outform pem -nocrypt -out $name.key
 }
 
-gen_server_key() {
-  openssl genpkey -algorithm RSA -out private-key.pem -pkeyopt rsa_keygen_bits:2048  > /dev/null 2>&1
-}
-
 hosts=(wazuh-indexer wazuh-manager wazuh-worker1 wazuh-worker2)
 for i in "${hosts[@]}"; do
     gencert $i www
 done
-# Parse command-line arguments
-while [[ "$#" -gt 0 ]]; do
-    case "$1" in
-        --with-jwt) with_jwt=true ;;
-        *) echo "Unknown option: $1" ;;
-    esac
-    shift
-done
-if [[ "$with_jwt" == true ]]; then
-    gen_server_key
-fi

--- a/apis/tools/env/certs/gen_certs.sh
+++ b/apis/tools/env/certs/gen_certs.sh
@@ -69,7 +69,7 @@ EOF
 openssl pkcs8 -topk8 -inform pem -in $name-key.pem -outform pem -nocrypt -out $name.key
 }
 
-hosts=(wazuh-indexer wazuh-manager wazuh-worker1 wazuh-worker2)
+hosts=(wazuh-indexer wazuh-manager)
 for i in "${hosts[@]}"; do
     gencert $i www
 done

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -11,7 +11,7 @@ from scripts.tests.conftest import get_default_configuration
 from wazuh.core import pyDaemonModule
 from wazuh.core.common import CONFIG_SERVER_SOCKET_PATH
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 wazuh_server.pyDaemonModule = pyDaemonModule
 

--- a/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
+++ b/framework/wazuh/core/cluster/dapi/tests/test_dapi.py
@@ -17,7 +17,7 @@ from sqlalchemy.exc import OperationalError
 from wazuh.core import common
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../../../../api'))
 

--- a/framework/wazuh/core/cluster/hap_helper/tests/test_hap_helper.py
+++ b/framework/wazuh/core/cluster/hap_helper/tests/test_hap_helper.py
@@ -26,7 +26,7 @@ from wazuh.core.cluster.utils import (
     REMOVE_DISCONNECTED_NODE_AFTER,
 )
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.core.exception import WazuhException
 
 with patch.object(ValidateFilePathMixin, '_validate_file_path', return_value=None):

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -14,7 +14,7 @@ from jsonschema import validators
 from wazuh.core import common
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -20,7 +20,7 @@ from wazuh import Wazuh
 from wazuh.core import exception
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.core.exception import WazuhClusterError
 
 with patch('wazuh.common.getgrnam'):

--- a/framework/wazuh/core/cluster/tests/test_local_client.py
+++ b/framework/wazuh/core/cluster/tests/test_local_client.py
@@ -11,7 +11,7 @@ import pytest
 from uvloop import EventLoopPolicy, new_event_loop
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):

--- a/framework/wazuh/core/cluster/tests/test_local_server.py
+++ b/framework/wazuh/core/cluster/tests/test_local_server.py
@@ -11,7 +11,7 @@ import pytest
 from uvloop import Loop
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -16,7 +16,7 @@ from freezegun import freeze_time
 from wazuh.core import exception
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -13,7 +13,7 @@ from freezegun import freeze_time
 from uvloop import EventLoopPolicy
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.common.wazuh_uid'):
     with patch('wazuh.common.wazuh_gid'):

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.core.common.getgrnam'):
     with patch('wazuh.core.common.getpwnam'):

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -14,7 +14,7 @@ import wazuh.core.exception as exception
 from freezegun import freeze_time
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):

--- a/framework/wazuh/core/config/models/server.py
+++ b/framework/wazuh/core/config/models/server.py
@@ -1,9 +1,9 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import Field, PositiveInt, PrivateAttr, ValidationInfo, confloat, conint, field_validator
+from pydantic import Field, PositiveInt, PrivateAttr, confloat, conint
 from wazuh.core.common import WAZUH_GROUPS
-from wazuh.core.config.models.base import ValidateFilePathMixin, WazuhConfigBaseModel
+from wazuh.core.config.models.base import WazuhConfigBaseModel
 from wazuh.core.config.models.logging import LoggingConfig, LoggingLevel
 from wazuh.core.config.models.ssl_config import SSLConfig
 
@@ -274,66 +274,6 @@ class CTIConfig(WazuhConfigBaseModel):
     url: str = DEFAULT_CTI_URL
 
 
-class JWTConfig(WazuhConfigBaseModel, ValidateFilePathMixin):
-    """Configuration for JWT key pair.
-
-    Parameters
-    ----------
-    private_key : str
-        The path to the private JTW key file.
-    _public_key : str
-        The public JWT key.
-    """
-
-    private_key: str = ''
-    _public_key: str = ''
-
-    def get_public_key(self) -> str:
-        """Retrieve the stored public key.
-
-        Returns
-        -------
-        str
-            Public key string.
-        """
-        return self._public_key
-
-    def set_public_key(self, public_key: str):
-        """Set the public key.
-
-        Parameters
-        ----------
-        public_key : str
-            The public key to be set.
-        """
-        self._public_key = public_key
-
-    @field_validator('private_key')
-    @classmethod
-    def validate_key_files(cls, path: str, info: ValidationInfo) -> str:
-        """Validate that the private key file exists if the path is not empty.
-
-        Parameters
-        ----------
-        path : str
-            Path to the JTW key.
-        info : ValidationInfo
-            Validation context information.
-
-        Raises
-        ------
-        ValueError
-            Invalid JWT file path.
-
-        Returns
-        -------
-        str
-            JWT key path.
-        """
-        cls._validate_file_path(path, info.field_name)
-        return path
-
-
 DEFAULT_SERVER_INTERNAL_CONFIG = ServerSyncConfig(
     files=[
         SharedFiles(
@@ -396,7 +336,6 @@ class ServerConfig(WazuhConfigBaseModel):
     communications: CommunicationsConfig = CommunicationsConfig()
     logging: LoggingConfig = LoggingConfig(level=LoggingLevel.info)
     cti: CTIConfig = CTIConfig()
-    jwt: JWTConfig = JWTConfig()
     _internal: ServerSyncConfig = PrivateAttr(DEFAULT_SERVER_INTERNAL_CONFIG)
 
     def get_internal_config(self) -> ServerSyncConfig:

--- a/framework/wazuh/core/config/models/tests/test_central_config.py
+++ b/framework/wazuh/core/config/models/tests/test_central_config.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.core.config.models.central_config import (
     CommsAPIConfig,
     Config,
@@ -9,7 +10,6 @@ from wazuh.core.config.models.central_config import (
     IndexerConfig,
     ManagementAPIConfig,
 )
-from wazuh.core.config.models.server import ValidateFilePathMixin
 
 
 def test_config_sections_ko():

--- a/framework/wazuh/core/config/models/tests/test_server.py
+++ b/framework/wazuh/core/config/models/tests/test_server.py
@@ -7,7 +7,6 @@ from wazuh.core.config.models.server import (
     CommunicationsConfig,
     CommunicationsTimeoutConfig,
     CTIConfig,
-    JWTConfig,
     MasterConfig,
     MasterIntervalsConfig,
     MasterProcesses,
@@ -388,15 +387,6 @@ def test_cti_config_default_values(init_values, expected):
     assert config.url == expected['url']
 
 
-@pytest.mark.parametrize('init_values', [{'private_key': 'private_key_example'}])
-@patch('os.path.isfile', return_value=True)
-def test_jwt_config_default_values(file_exists_mock, init_values):
-    """Check the correct initialization of the `JWTConfig` class."""
-    jwt_config = JWTConfig(**init_values)
-
-    assert jwt_config.private_key == init_values['private_key']
-
-
 @pytest.mark.parametrize(
     'init_values, expected',
     [
@@ -404,7 +394,6 @@ def test_jwt_config_default_values(file_exists_mock, init_values):
             {
                 'nodes': ['master'],
                 'node': {'name': 'example', 'type': 'master', 'ssl': {'key': 'value', 'cert': 'value', 'ca': 'value'}},
-                'jwt': {'public_key': 'value', 'private_key': 'value'},
             },
             {
                 'port': 1516,

--- a/framework/wazuh/core/config/tests/test_client.py
+++ b/framework/wazuh/core/config/tests/test_client.py
@@ -2,6 +2,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 from wazuh.core.config.client import CentralizedConfig
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.core.config.models.central_config import (
     CommsAPIConfig,
     Config,
@@ -10,7 +11,7 @@ from wazuh.core.config.models.central_config import (
     IndexerConfig,
     ManagementAPIConfig,
 )
-from wazuh.core.config.models.server import DEFAULT_SERVER_INTERNAL_CONFIG, ServerConfig, ValidateFilePathMixin
+from wazuh.core.config.models.server import DEFAULT_SERVER_INTERNAL_CONFIG, ServerConfig
 
 mock_config_data = {
     'server': {

--- a/framework/wazuh/core/engine/tests/test_init.py
+++ b/framework/wazuh/core/engine/tests/test_init.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient, Timeout, TimeoutException
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.core.engine import Engine, get_engine_client
 from wazuh.core.engine.tests.conftest import get_default_configuration
 from wazuh.core.exception import WazuhEngineError

--- a/framework/wazuh/core/server/unix_server/tests/test_config.py
+++ b/framework/wazuh/core/server/unix_server/tests/test_config.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 import pytest
 from fastapi import status
 from wazuh.core.config.client import CentralizedConfig
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.core.config.models.central_config import Config
-from wazuh.core.config.models.server import ValidateFilePathMixin
 from wazuh.core.server.unix_server.config import get_config
 
 mock_config_data = {

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):

--- a/framework/wazuh/core/tests/test_authentication.py
+++ b/framework/wazuh/core/tests/test_authentication.py
@@ -5,9 +5,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from framework.wazuh.core.authentication import (
-    derive_public_key,
     get_keypair,
-    load_jwt_keys,
 )
 
 
@@ -28,88 +26,37 @@ def mock_private_key_pem():
     ).decode('utf-8')
 
 
-@patch('wazuh.core.authentication.CentralizedConfig.get_server_config')
-@patch('builtins.open', new_callable=mock_open, read_data='dummy_private_key_content')
-def test_get_keypair(mock_open_obj, get_server_config_mock):
+def setup_function():
+    """Avoid the `lru_cache` decorator to cause tests that interfere with one another."""
+    get_keypair.cache_clear()
+
+
+@patch('wazuh.core.authentication.CentralizedConfig.get_management_api_config')
+def test_get_keypair(get_management_api_config_mock, mock_private_key_pem):
     """Verify that get_keypair correctly reads the private key file and retrieves the public key."""
     # Setup a fake configuration
+    open_mock = mock_open(read_data=mock_private_key_pem)
     config_mock = MagicMock()
-    config_mock.jwt.private_key = 'dummy_private_key_path'
-    config_mock.jwt.get_public_key.return_value = 'dummy_public_key'
-    get_server_config_mock.return_value = config_mock
+    get_management_api_config_mock.return_value = config_mock
 
-    private_key, public_key = get_keypair()
+    with patch('builtins.open', open_mock):
+        private_key, public_key = get_keypair()
 
     # Check that open was called with the private key path
-    mock_open_obj.assert_called_once_with('dummy_private_key_path', mode='r')
+    open_mock.assert_called_once_with(config_mock.ssl.key, mode='r')
     # Verify that the returned values match the expected ones
-    assert private_key == 'dummy_private_key_content'
-    assert public_key == 'dummy_public_key'
+    assert 'BEGIN PRIVATE KEY' in private_key
+    assert 'BEGIN PUBLIC KEY' in public_key
 
 
-def test_load_jwt_keys_already_configured():
-    """Verify no key generation occurs if JWT keys are already configured."""
-    mock_api_config = MagicMock()
-    mock_config = MagicMock()
-    mock_config.jwt.private_key = 'some_private_key'
-    mock_config.jwt.public_key = 'some_public_key'
+@patch('wazuh.core.authentication.CentralizedConfig.get_management_api_config')
+def test_get_keypair_ko(get_management_api_config_mock):
+    """Verify function `get_keypair` raises FileNotFoundError when private key file is missing."""
+    open_mock = mock_open()
+    open_mock.side_effect = FileNotFoundError
 
-    with (
-        patch(
-            'wazuh.core.config.client.CentralizedConfig.get_server_config',
-            return_value=mock_config,
-        ) as mock_get_config,
-        patch('framework.wazuh.core.authentication.derive_public_key') as mock_generate,
-    ):
-        load_jwt_keys(mock_api_config)
+    get_management_api_config_mock.ssl.key = 'non_existent_path'
 
-        mock_get_config.assert_called_once()
-        mock_generate.assert_not_called()
-
-
-def test_load_jwt_keys_generate_when_missing():
-    """Verify key generation occurs if JWT keys are missing."""
-    mock_api_config = MagicMock()
-    mock_api_config.ssl.key = 'ssl_private_key_path'
-    mock_config = MagicMock()
-    # Initially, keys are missing.
-    mock_config.jwt.private_key = None
-    mock_config.jwt.public_key = None
-
-    # Patch derive_public_key to return a dummy public key.
-    with (
-        patch(
-            'wazuh.core.config.client.CentralizedConfig.get_server_config',
-            return_value=mock_config,
-        ) as mock_get_config,
-        patch(
-            'framework.wazuh.core.authentication.derive_public_key',
-            return_value='generated_public_key',
-        ) as mock_generate,
-    ):
-        load_jwt_keys(mock_api_config)
-
-        assert mock_config.jwt.private_key == 'ssl_private_key_path'
-        # Verify that set_public_key was called with the generated public key.
-        mock_config.jwt.set_public_key.assert_called_once_with('generated_public_key')
-        mock_generate.assert_called_once_with('ssl_private_key_path')
-
-
-def test_derive_public_key(mock_private_key_pem):
-    """Verify that derive_public_key opens the file correctly and returns a valid public key."""
-    m_open = mock_open(read_data=mock_private_key_pem)
-    with patch('builtins.open', m_open):
-        public_key = derive_public_key('dummy_private_key_path')
-        m_open.assert_called_once_with('dummy_private_key_path', mode='r')
-        # Verify that the returned public key contains the PEM header.
-        assert 'BEGIN PUBLIC KEY' in public_key
-
-
-def test_derive_public_key_read_error():
-    """Verify function raises FileNotFoundError when private key file is missing."""
-    m_open = mock_open()
-    m_open.side_effect = FileNotFoundError
-
-    with patch('builtins.open', m_open):
+    with patch('builtins.open', open_mock):
         with pytest.raises(FileNotFoundError):
-            derive_public_key('non_existent_path')
+            get_keypair()

--- a/framework/wazuh/core/tests/test_exception.py
+++ b/framework/wazuh/core/tests/test_exception.py
@@ -48,7 +48,7 @@ from wazuh.core.exception import WazuhError, WazuhException
             None,
             None,
             None,
-            'Error 1017 - Some Wazuh daemons are not ready yet in node "Node Name" (not ready daemons)',
+            'Error 1017 - Some Wazuh daemons are not ready yet',
         ),
     ],
 )

--- a/framework/wazuh/core/tests/test_manager.py
+++ b/framework/wazuh/core/tests/test_manager.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 import pytest
 from wazuh.core.cluster.tests.conftest import get_default_configuration
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 
 with patch('wazuh.core.common.wazuh_uid'):
     with patch('wazuh.core.common.wazuh_gid'):
@@ -149,7 +149,6 @@ def test_get_logs_summary(mock_exists, mock_active_logging_format):
             'warning': 0,
             'debug': 2,
         }
-
 
 
 @patch('wazuh.core.manager.exists', return_value=True)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.tests.util import get_default_configuration
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.tests.util import get_default_configuration
 
 with patch('wazuh.core.common.wazuh_uid'):

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 from wazuh.core.config.client import CentralizedConfig
-from wazuh.core.config.models.server import ValidateFilePathMixin
+from wazuh.core.config.models.base import ValidateFilePathMixin
 from wazuh.tests.util import get_default_configuration
 
 with patch('wazuh.core.common.wazuh_uid'):


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/28415 |

## Description

Introduces changes to replace the key used to sign JWT tokens with the ones provided by the user in the configuration.

> Cluster configuration removal was performed in https://github.com/wazuh/wazuh/issues/28702. 

## Tests

<details><summary>Framework unit tests</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ pytest framework --disable-warnings --ignore framework/wazuh/core/cluster/
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/framework
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 969 items                                                                                                                                                                                                                          

framework/scripts/tests/test_wazuh_server.py .........................                                                                                                                                                                 [  2%]
framework/wazuh/core/batcher/tests/test_buffer.py .............                                                                                                                                                                        [  3%]
framework/wazuh/core/batcher/tests/test_client.py ..                                                                                                                                                                                   [  4%]
framework/wazuh/core/batcher/tests/test_mux_demux.py ................                                                                                                                                                                  [  5%]
framework/wazuh/core/batcher/tests/test_timer.py ...                                                                                                                                                                                   [  6%]
framework/wazuh/core/config/models/tests/test_central_config.py ..                                                                                                                                                                     [  6%]
framework/wazuh/core/config/models/tests/test_comms_api.py ............                                                                                                                                                                [  7%]
framework/wazuh/core/config/models/tests/test_engine.py ..........                                                                                                                                                                     [  8%]
framework/wazuh/core/config/models/tests/test_indexer.py .......                                                                                                                                                                       [  9%]
framework/wazuh/core/config/models/tests/test_logging.py .................                                                                                                                                                             [ 11%]
framework/wazuh/core/config/models/tests/test_management_api.py ..........................                                                                                                                                             [ 13%]
framework/wazuh/core/config/models/tests/test_server.py ..................................................................                                                                                                             [ 20%]
framework/wazuh/core/config/models/tests/test_ssl_config.py .................                                                                                                                                                          [ 22%]
framework/wazuh/core/config/tests/test_client.py ...........                                                                                                                                                                           [ 23%]
framework/wazuh/core/engine/tests/test_base.py ..                                                                                                                                                                                      [ 23%]
framework/wazuh/core/engine/tests/test_events.py ..                                                                                                                                                                                    [ 23%]
framework/wazuh/core/engine/tests/test_init.py ......                                                                                                                                                                                  [ 24%]
framework/wazuh/core/engine/tests/test_vulnerability.py .                                                                                                                                                                              [ 24%]
framework/wazuh/core/indexer/models/test/test_agent.py ......                                                                                                                                                                          [ 25%]
framework/wazuh/core/indexer/models/test/test_commands.py .                                                                                                                                                                            [ 25%]
framework/wazuh/core/indexer/models/test/test_event.py .............                                                                                                                                                                   [ 26%]
framework/wazuh/core/indexer/models/test/test_rbac.py .....                                                                                                                                                                            [ 27%]
framework/wazuh/core/indexer/tests/test_agent.py .............                                                                                                                                                                         [ 28%]
framework/wazuh/core/indexer/tests/test_base.py ...                                                                                                                                                                                    [ 28%]
framework/wazuh/core/indexer/tests/test_bulk.py ...........                                                                                                                                                                            [ 29%]
framework/wazuh/core/indexer/tests/test_commands.py ..........                                                                                                                                                                         [ 30%]
framework/wazuh/core/indexer/tests/test_init.py ..............                                                                                                                                                                         [ 32%]
framework/wazuh/core/indexer/tests/test_users.py ...                                                                                                                                                                                   [ 32%]
framework/wazuh/core/indexer/tests/test_utils.py ....                                                                                                                                                                                  [ 33%]
framework/wazuh/core/server/tests/test_utils.py .......                                                                                                                                                                                [ 33%]
framework/wazuh/core/server/unix_server/tests/test_config.py .........                                                                                                                                                                 [ 34%]
framework/wazuh/core/server/unix_server/tests/test_server.py ..                                                                                                                                                                        [ 34%]
framework/wazuh/core/task/tests/test_order.py ............                                                                                                                                                                             [ 36%]
framework/wazuh/core/task/tests/test_rbac.py ....                                                                                                                                                                                      [ 36%]
framework/wazuh/core/tests/test_agent.py .........                                                                                                                                                                                     [ 37%]
framework/wazuh/core/tests/test_authentication.py ..                                                                                                                                                                                   [ 37%]
framework/wazuh/core/tests/test_commands_manager.py ....                                                                                                                                                                               [ 38%]
framework/wazuh/core/tests/test_common.py ........                                                                                                                                                                                     [ 39%]
framework/wazuh/core/tests/test_configuration.py ...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.......................                                                                                                                             [ 44%]
framework/wazuh/core/tests/test_exception.py ..........                                                                                                                                                                                [ 45%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                                                 [ 46%]
framework/wazuh/core/tests/test_manager.py ..............................                                                                                                                                                              [ 49%]
framework/wazuh/core/tests/test_pyDaemonModule.py .............                                                                                                                                                                        [ 50%]
framework/wazuh/core/tests/test_rbac.py ................                                                                                                                                                                               [ 52%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                                                    [ 56%]
framework/wazuh/core/tests/test_utils.py ..................................................................................................................                                                                            [ 68%]
framework/wazuh/core/tests/test_wazuh_queue.py .......................                                                                                                                                                                 [ 70%]
framework/wazuh/core/tests/test_wazuh_socket.py ................................                                                                                                                                                       [ 73%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                                                 [ 77%]
framework/wazuh/core/tests/test_wlogging.py ..........                                                                                                                                                                                 [ 78%]
framework/wazuh/core/unix_server/test/test_commands.py .                                                                                                                                                                               [ 78%]
framework/wazuh/core/unix_server/test/test_server.py ..                                                                                                                                                                                [ 78%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                                                     [ 78%]
framework/wazuh/rbac/tests/test_decorators.py ...............................................................................................................                                                                          [ 90%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                                                            [ 91%]
framework/wazuh/tests/test_agent.py ss.....................................................                                                                                                                                            [ 96%]
framework/wazuh/tests/test_cluster.py ...                                                                                                                                                                                              [ 97%]
framework/wazuh/tests/test_manager.py ...........................                                                                                                                                                                      [100%]

========================================================================================== 936 passed, 2 skipped, 31 xfailed, 12 warnings in 6.17s ===========================================================================================
```

</details>

<details><summary>API authentication</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ TOKEN=$(curl -u wazuh:wazuh -s -k -X POST https://0.0.0.0:55000/security/user/authenticate | jq -r '.data.token') && echo $TOKEN
eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzQ0ODA3NTUxLCJleHAiOjE3NDQ4MDg0NTEsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WyJhZG1pbmlzdHJhdG9yIl0sInJiYWNfbW9kZSI6IndoaXRlIn0.g-DLRaoCF0TEvwkg-iKgPTVVxB1VzZMwlwY3Bc_GeZBXU0bWawxtaidXXgsRyDrvDqXlRMTPdO_MrFSOsHT6QjtA0ckz6NoUpYg2PeKqE8hoiv8AAABQGPwRa7B4FYTLvA7zf8m2aR4D044YvtJwskqTowwbD8eOat2xHhDe92VvEFrNPVQeT1P5d-NdgLJno3Tvo_j9We6Uw_lZI1QVtnRWsoWF-tluh4UMc3b-7CsMszLFEeskcT_SC2TKvXVnVjvsp40Y1UcjXxy0EaBmlsf8VhnqKqvYGe2x3kFhBlAV7CWdLxFle6cFfst95mB9kDkcBzEYz16wAjw9G3uUSA
```

</details>

<details><summary>Create agent</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Wed, 16 Apr 2025 12:46:08 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

</details>

<details><summary>Get agents</summary>

```console
gasti@gasti:~/work/wazuh/apis/tools/env$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "do4CjWVpCqrn2vMbZWk21b19wUPxweD3EccCh8zM/EkE1Y/5jbm4yu4woHzb2FBc",
        "type": "endpoint",
        "version": "5.0.0",
        "status": "never_connected"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

> [!Note]
> The lint check is expected to fail. I was forced to modify over 30 tests files due to an incorrect import and most of the errors are from the cluster folder that will be removed soon.