### PR TITLE
Tighten file open permissions

### DIFF
--- a/apis/tools/doc/generate_comms_api_spec.py
+++ b/apis/tools/doc/generate_comms_api_spec.py
@@ -2,6 +2,7 @@
 
 import argparse
 import filecmp
+import os
 from pathlib import Path
 
 import yaml
@@ -25,7 +26,8 @@ def main(spec_path):  # NOQA
     )
     app.include_router(router)
 
-    with open(TMP_SPEC, 'w') as f:
+    fd = os.open(TMP_SPEC, os.O_WRONLY | os.O_CREAT, 0o600)
+    with os.fdopen(fd, 'w') as f:
         yaml.dump(app.openapi(), f, sort_keys=False)
 
     if not filecmp.cmp(TMP_SPEC, spec_path):


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/28951 |

## Description

Tightens file open operation permissions to avoid other users manipulating the file.

Fixes https://github.com/wazuh/wazuh/security/code-scanning/3498.

## Tests

<details><summary>Hook execution logs</summary>

```console
> git -c user.useConfigOnly=true commit --quiet --allow-empty-message --file -
ruff.....................................................................Passed
ruff-format..............................................................Passed
Check Comms API spec.....................................................Failed
- hook id: check-comms-api-spec
- exit code: 1
- files were modified by this hook
```

</details>
