### PR TITLE
Refactor Management API to not rely on the DAPI - Implementation

### DIFF
--- a/apis/server_management/scripts/wazuh_server_management_apid.py
+++ b/apis/server_management/scripts/wazuh_server_management_apid.py
@@ -71,14 +71,6 @@ def spawn_process_pool():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
-def spawn_events_pool():
-    """Spawn events process pool child."""
-    events_pid = os.getpid()
-    pyDaemonModule.create_pid(API_SECURITY_EVENTS_PROCESS, events_pid)
-
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-
 def spawn_authentication_pool():
     """Spawn authentication process pool child."""
     auth_pid = os.getpid()

--- a/apis/server_management/server_management_api/authentication.py
+++ b/apis/server_management/server_management_api/authentication.py
@@ -15,11 +15,11 @@ import wazuh.rbac.utils as rbac_utils
 from connexion.exceptions import Unauthorized
 from connexion.lifecycle import ConnexionRequest
 from wazuh.core.authentication import JWT_ALGORITHM, JWT_ISSUER, get_keypair
-from wazuh.core.task_dispatcher import TaskDispatcher
 from wazuh.core.common import rbac_manager
 from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.exception import WazuhResourceNotFound
 from wazuh.core.rbac import RBACManager
+from wazuh.core.task_dispatcher import TaskDispatcher
 from wazuh.rbac.preprocessor import optimize_resources
 
 from server_management_api.util import raise_if_exc
@@ -218,7 +218,7 @@ def decode_token(token: str, request: ConnexionRequest = None) -> dict:
                 'token_nbf_time': payload['nbf'],
                 'run_as': payload['run_as'],
             },
-                is_async=True,
+            is_async=True,
             wait_for_complete=False,
             logger=logging.getLogger('wazuh-api'),
             rbac_manager=request.state.rbac_manager if request else None,
@@ -233,7 +233,7 @@ def decode_token(token: str, request: ConnexionRequest = None) -> dict:
         # Detect local changes
         dispatcher = TaskDispatcher(
             f=get_security_conf,
-                is_async=False,
+            is_async=False,
             wait_for_complete=False,
             logger=logging.getLogger('wazuh-api'),
         )

--- a/apis/server_management/server_management_api/authentication.py
+++ b/apis/server_management/server_management_api/authentication.py
@@ -86,7 +86,7 @@ def check_user(name: str, password: str, request: ConnexionRequest = None) -> Un
         logger=logging.getLogger('wazuh-api'),
         rbac_manager=request.state.rbac_manager if request else None,
     )
-    data = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result())
+    data = raise_if_exc(pool.submit(asyncio.run, dispatcher.execute_function()).result())
 
     if data['result']:
         return {'sub': name, 'active': True}
@@ -130,7 +130,7 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
         wait_for_complete=False,
         logger=logging.getLogger('wazuh-api'),
     )
-    result = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result()).dikt
+    result = raise_if_exc(pool.submit(asyncio.run, dispatcher.execute_function()).result()).dikt
     timestamp = int(core_utils.get_utc_now().timestamp())
 
     payload = {
@@ -223,7 +223,7 @@ def decode_token(token: str, request: ConnexionRequest = None) -> dict:
             logger=logging.getLogger('wazuh-api'),
             rbac_manager=request.state.rbac_manager if request else None,
         )
-        data = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result()).to_dict()
+        data = raise_if_exc(pool.submit(asyncio.run, dispatcher.execute_function()).result()).to_dict()
 
         if not data['result']['valid']:
             raise Unauthorized(INVALID_TOKEN)
@@ -237,7 +237,7 @@ def decode_token(token: str, request: ConnexionRequest = None) -> dict:
             wait_for_complete=False,
             logger=logging.getLogger('wazuh-api'),
         )
-        result = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result())
+        result = raise_if_exc(pool.submit(asyncio.run, dispatcher.execute_function()).result())
 
         current_rbac_mode = result['rbac_mode']
         current_expiration_time = result['auth_token_exp_timeout']

--- a/apis/server_management/server_management_api/authentication.py
+++ b/apis/server_management/server_management_api/authentication.py
@@ -15,7 +15,7 @@ import wazuh.rbac.utils as rbac_utils
 from connexion.exceptions import Unauthorized
 from connexion.lifecycle import ConnexionRequest
 from wazuh.core.authentication import JWT_ALGORITHM, JWT_ISSUER, get_keypair
-from wazuh.core.cluster.dapi.dapi import DistributedAPI
+from wazuh.core.task_dispatcher import TaskDispatcher
 from wazuh.core.common import rbac_manager
 from wazuh.core.config.client import CentralizedConfig
 from wazuh.core.exception import WazuhResourceNotFound
@@ -78,16 +78,15 @@ def check_user(name: str, password: str, request: ConnexionRequest = None) -> Un
     dict or None
         Dictionary with the username and its status or None.
     """
-    dapi = DistributedAPI(
+    dispatcher = TaskDispatcher(
         f=check_user_master,
         f_kwargs={'name': name, 'password': password},
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=logging.getLogger('wazuh-api'),
         rbac_manager=request.state.rbac_manager if request else None,
     )
-    data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())
+    data = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result())
 
     if data['result']:
         return {'sub': name, 'active': True}
@@ -125,14 +124,13 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
     str
         Encoded JWT token.
     """
-    dapi = DistributedAPI(
+    dispatcher = TaskDispatcher(
         f=get_security_conf,
-        request_type='local_master',
         is_async=False,
         wait_for_complete=False,
         logger=logging.getLogger('wazuh-api'),
     )
-    result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).dikt
+    result = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result()).dikt
     timestamp = int(core_utils.get_utc_now().timestamp())
 
     payload = {
@@ -212,7 +210,7 @@ def decode_token(token: str, request: ConnexionRequest = None) -> dict:
         payload = jwt.decode(token, public_key, algorithms=[JWT_ALGORITHM], audience='Wazuh API REST')
 
         # Check token and add processed policies
-        dapi = DistributedAPI(
+        dispatcher = TaskDispatcher(
             f=check_token,
             f_kwargs={
                 'username': payload['sub'],
@@ -220,13 +218,12 @@ def decode_token(token: str, request: ConnexionRequest = None) -> dict:
                 'token_nbf_time': payload['nbf'],
                 'run_as': payload['run_as'],
             },
-            request_type='local_master',
-            is_async=True,
+                is_async=True,
             wait_for_complete=False,
             logger=logging.getLogger('wazuh-api'),
             rbac_manager=request.state.rbac_manager if request else None,
         )
-        data = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result()).to_dict()
+        data = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result()).to_dict()
 
         if not data['result']['valid']:
             raise Unauthorized(INVALID_TOKEN)
@@ -234,14 +231,13 @@ def decode_token(token: str, request: ConnexionRequest = None) -> dict:
         payload['rbac_policies']['rbac_mode'] = payload.pop('rbac_mode')
 
         # Detect local changes
-        dapi = DistributedAPI(
+        dispatcher = TaskDispatcher(
             f=get_security_conf,
-            request_type='local_master',
-            is_async=False,
+                is_async=False,
             wait_for_complete=False,
             logger=logging.getLogger('wazuh-api'),
         )
-        result = raise_if_exc(pool.submit(asyncio.run, dapi.distribute_function()).result())
+        result = raise_if_exc(pool.submit(asyncio.run, dapi.execute_function()).result())
 
         current_rbac_mode = result['rbac_mode']
         current_expiration_time = result['auth_token_exp_timeout']

--- a/apis/server_management/server_management_api/controllers/agent_controller.py
+++ b/apis/server_management/server_management_api/controllers/agent_controller.py
@@ -8,8 +8,8 @@ from typing import Union
 from connexion import request
 from connexion.lifecycle import ConnexionResponse
 from wazuh import agent
-from wazuh.core.task_dispatcher import TaskDispatcher
 from wazuh.core.common import DATABASE_LIMIT
+from wazuh.core.task_dispatcher import TaskDispatcher
 
 from server_management_api.controllers.util import JSON_CONTENT_TYPE, json_response
 from server_management_api.models.agent_enrollment_model import AgentEnrollmentModel

--- a/apis/server_management/server_management_api/controllers/agent_controller.py
+++ b/apis/server_management/server_management_api/controllers/agent_controller.py
@@ -235,11 +235,9 @@ async def reconnect_agents(
     dispatcher = TaskDispatcher(
         f=agent.reconnect_agents,
         f_kwargs=remove_nones_to_dict(f_kwargs),
-        request_type='distributed_master',
         is_async=False,
         wait_for_complete=wait_for_complete,
         rbac_permissions=request.context['token_info']['rbac_policies'],
-        broadcasting=agents_list == '*',
         logger=logger,
     )
     data = raise_if_exc(await dispatcher.execute_function())

--- a/apis/server_management/server_management_api/controllers/manager_controller.py
+++ b/apis/server_management/server_management_api/controllers/manager_controller.py
@@ -7,8 +7,8 @@ import logging
 import wazuh.manager as manager
 from connexion.lifecycle import ConnexionResponse
 from wazuh.core import configuration
-from wazuh.core.task_dispatcher import TaskDispatcher
 from wazuh.core.manager import query_update_check_service
+from wazuh.core.task_dispatcher import TaskDispatcher
 
 from server_management_api.constants import INSTALLATION_UID_KEY, UPDATE_INFORMATION_KEY
 from server_management_api.controllers.util import json_response
@@ -41,7 +41,7 @@ async def check_available_version(pretty: bool = False, force_query: bool = Fals
         dispatcher = TaskDispatcher(
             f=query_update_check_service,
             f_kwargs={INSTALLATION_UID_KEY: installation_uid},
-                is_async=True,
+            is_async=True,
             logger=logger,
         )
         update_information = raise_if_exc(await dispatcher.execute_function())

--- a/apis/server_management/server_management_api/controllers/security_controller.py
+++ b/apis/server_management/server_management_api/controllers/security_controller.py
@@ -6,9 +6,9 @@ import logging
 
 from connexion import request
 from connexion.lifecycle import ConnexionResponse
-from wazuh.core.task_dispatcher import TaskDispatcher
 from wazuh.core.exception import WazuhException
 from wazuh.core.results import WazuhResult
+from wazuh.core.task_dispatcher import TaskDispatcher
 from wazuh.rbac import preprocessor
 
 from server_management_api.authentication import generate_token

--- a/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
@@ -45,13 +45,13 @@ with patch('wazuh.common.wazuh_uid'):
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
 @pytest.mark.parametrize('mock_alist', (['0191480e-7f67-7fd3-8c52-f49a3176360b'], ['all']))
-async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_alist, mock_request):
+async def test_delete_agents(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_alist, mock_request):
     """Verify 'delete_agents' endpoint is working as expected."""
     filters = {
         'name': 'test',
@@ -78,7 +78,7 @@ async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
         },
     }
 
-    mock_dapi.awaited_once_with(
+    mock_task_dispatcher.awaited_once_with(
         f=agent.delete_agents,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -94,12 +94,12 @@ async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_get_agents(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'get_agents' endpoint is working as expected."""
     result = await get_agents()
 
@@ -121,7 +121,7 @@ async def test_get_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
         'sort': None,
     }
 
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.get_agents,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -137,12 +137,12 @@ async def test_get_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_add_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_add_agent(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'add_agent' endpoint is working as expected."""
     with patch('server_management_api.controllers.agent_controller.Body.validate_content_type'):
         with patch(
@@ -150,7 +150,7 @@ async def test_add_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
             return_value=AsyncMock(),
         ) as mock_getkwargs:
             result = await add_agent()
-            mock_dapi.assert_called_once_with(
+            mock_task_dispatcher.assert_called_once_with(
                 f=agent.add_agent,
                 f_kwargs=mock_remove.return_value,
                         is_async=True,
@@ -167,22 +167,20 @@ async def test_add_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_reconnect_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_reconnect_agents(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'reconnect_agents' endpoint is working as expected."""
     result = await reconnect_agents()
     f_kwargs = {'agent_list': '*'}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.reconnect_agents,
         f_kwargs=mock_remove.return_value,
-        request_type='distributed_master',
         is_async=False,
         wait_for_complete=False,
-        broadcasting=True,
         logger=ANY,
         rbac_permissions=mock_request.context['token_info']['rbac_policies'],
     )
@@ -194,15 +192,15 @@ async def test_reconnect_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_restart_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_restart_agents(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'restart_agents' endpoint is working as expected."""
     result = await restart_agents()
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.restart_agents,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -218,20 +216,19 @@ async def test_restart_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
 @pytest.mark.skip('To be implemented')
-async def test_restart_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_restart_agent(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'restart_agent' endpoint is working as expected."""
     result = await restart_agent(agent_id='001')
     f_kwargs = {'agent_list': ['001']}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.restart_agents,
         f_kwargs=mock_remove.return_value,
-        request_type='distributed_master',
         is_async=False,
         wait_for_complete=False,
         logger=ANY,
@@ -245,21 +242,21 @@ async def test_restart_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
 @pytest.mark.parametrize('mock_alist', ['001', 'all'])
 async def test_delete_multiple_agent_single_group(
-    mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_alist, mock_request
+    mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_alist, mock_request
 ):
     """Verify 'delete_multiple_agent_single_group' endpoint is working as expected."""
     result = await delete_multiple_agent_single_group(agents_list=mock_alist, group_id='001')
     if 'all' in mock_alist:
         mock_alist = None
     f_kwargs = {'agent_list': mock_alist, 'group_list': ['001']}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.remove_agents_from_group,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -275,16 +272,16 @@ async def test_delete_multiple_agent_single_group(
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_put_multiple_agent_single_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_put_multiple_agent_single_group(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'put_multiple_agent_single_group' endpoint is working as expected."""
     result = await put_multiple_agent_single_group(group_id='001', agents_list='001')
     f_kwargs = {'agent_list': '001', 'group_list': ['001'], 'replace': False}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.assign_agents_to_group,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -300,19 +297,19 @@ async def test_put_multiple_agent_single_group(mock_exc, mock_dapi, mock_remove,
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
 @pytest.mark.parametrize('mock_alist', ['001', 'all'])
-async def test_delete_groups(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_alist, mock_request):
+async def test_delete_groups(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_alist, mock_request):
     """Verify 'delete_groups' endpoint is working as expected."""
     result = await delete_groups(groups_list=mock_alist)
     if 'all' in mock_alist:
         mock_alist = None
     f_kwargs = {'group_list': mock_alist}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.delete_groups,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -328,12 +325,12 @@ async def test_delete_groups(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_list_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_get_list_group(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'get_list_group' endpoint is working as expected."""
     result = await get_list_group()
     hash_ = mock_request.query_params.get('hash', 'md5')
@@ -350,7 +347,7 @@ async def test_get_list_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
         'select': None,
         'distinct': False,
     }
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.get_agent_groups,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -366,12 +363,12 @@ async def test_get_list_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_agents_in_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_get_agents_in_group(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'get_agents_in_group' endpoint is working as expected."""
     result = await get_agents_in_group(group_id='001')
     f_kwargs = {
@@ -386,7 +383,7 @@ async def test_get_agents_in_group(mock_exc, mock_dapi, mock_remove, mock_dfunc,
         'select': None,
         'distinct': False,
     }
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.get_agents_in_group,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -402,19 +399,19 @@ async def test_get_agents_in_group(mock_exc, mock_dapi, mock_remove, mock_dfunc,
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_post_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_post_group(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'post_group' endpoint is working as expected."""
     with patch('server_management_api.controllers.agent_controller.Body.validate_content_type'):
         with patch(
             'server_management_api.controllers.agent_controller.GroupAddedModel.get_kwargs', return_value=AsyncMock()
         ) as mock_getkwargs:
             result = await post_group()
-            mock_dapi.assert_called_once_with(
+            mock_task_dispatcher.assert_called_once_with(
                 f=agent.create_group,
                 f_kwargs=mock_remove.return_value,
                         is_async=True,
@@ -430,16 +427,16 @@ async def test_post_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_group_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_get_group_config(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'get_group_config' endpoint is working as expected."""
     result = await get_group_config(group_id='001')
     f_kwargs = {'group_list': ['001']}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=agent.get_group_conf,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -455,18 +452,18 @@ async def test_get_group_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.agent_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_put_group_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
+async def test_put_group_config(mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_request):
     """Verify 'put_group_config' endpoint is working as expected."""
     with patch('server_management_api.controllers.agent_controller.Body.validate_content_type'):
         with patch('server_management_api.controllers.agent_controller.Body.decode_body') as mock_dbody:
             result = await put_group_config(group_id='001', body={})
             f_kwargs = {'group_list': ['001'], 'file_data': mock_dbody.return_value}
-            mock_dapi.assert_called_once_with(
+            mock_task_dispatcher.assert_called_once_with(
                 f=agent.update_group_file,
                 f_kwargs=mock_remove.return_value,
                         is_async=True,

--- a/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_agent_controller.py
@@ -45,7 +45,7 @@ with patch('wazuh.common.wazuh_uid'):
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -81,7 +81,6 @@ async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
     mock_dapi.awaited_once_with(
         f=agent.delete_agents,
         f_kwargs=mock_remove.return_value,
-        request_type='local_any',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -95,7 +94,7 @@ async def test_delete_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -125,7 +124,6 @@ async def test_get_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
     mock_dapi.assert_called_once_with(
         f=agent.get_agents,
         f_kwargs=mock_remove.return_value,
-        request_type='local_any',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -139,7 +137,7 @@ async def test_get_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -155,8 +153,7 @@ async def test_add_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
             mock_dapi.assert_called_once_with(
                 f=agent.add_agent,
                 f_kwargs=mock_remove.return_value,
-                request_type='local_any',
-                is_async=True,
+                        is_async=True,
                 wait_for_complete=False,
                 logger=ANY,
                 rbac_permissions=mock_request.context['token_info']['rbac_policies'],
@@ -170,7 +167,7 @@ async def test_add_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_requ
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -197,7 +194,7 @@ async def test_reconnect_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -208,7 +205,6 @@ async def test_restart_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
     mock_dapi.assert_called_once_with(
         f=agent.restart_agents,
         f_kwargs=mock_remove.return_value,
-        request_type='local_any',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -222,7 +218,7 @@ async def test_restart_agents(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -249,7 +245,7 @@ async def test_restart_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -266,7 +262,6 @@ async def test_delete_multiple_agent_single_group(
     mock_dapi.assert_called_once_with(
         f=agent.remove_agents_from_group,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -280,7 +275,7 @@ async def test_delete_multiple_agent_single_group(
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -292,7 +287,6 @@ async def test_put_multiple_agent_single_group(mock_exc, mock_dapi, mock_remove,
     mock_dapi.assert_called_once_with(
         f=agent.assign_agents_to_group,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -306,7 +300,7 @@ async def test_put_multiple_agent_single_group(mock_exc, mock_dapi, mock_remove,
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -321,7 +315,6 @@ async def test_delete_groups(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
     mock_dapi.assert_called_once_with(
         f=agent.delete_groups,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -335,7 +328,7 @@ async def test_delete_groups(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -360,7 +353,6 @@ async def test_get_list_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
     mock_dapi.assert_called_once_with(
         f=agent.get_agent_groups,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -374,7 +366,7 @@ async def test_get_list_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -397,7 +389,6 @@ async def test_get_agents_in_group(mock_exc, mock_dapi, mock_remove, mock_dfunc,
     mock_dapi.assert_called_once_with(
         f=agent.get_agents_in_group,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -411,7 +402,7 @@ async def test_get_agents_in_group(mock_exc, mock_dapi, mock_remove, mock_dfunc,
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -426,8 +417,7 @@ async def test_post_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
             mock_dapi.assert_called_once_with(
                 f=agent.create_group,
                 f_kwargs=mock_remove.return_value,
-                request_type='local_master',
-                is_async=True,
+                        is_async=True,
                 wait_for_complete=False,
                 logger=ANY,
                 rbac_permissions=mock_request.context['token_info']['rbac_policies'],
@@ -440,7 +430,7 @@ async def test_post_group(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_req
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -452,7 +442,6 @@ async def test_get_group_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
     mock_dapi.assert_called_once_with(
         f=agent.get_group_conf,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
@@ -466,7 +455,7 @@ async def test_get_group_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
 @pytest.mark.asyncio
 @pytest.mark.parametrize('mock_request', ['agent_controller'], indirect=True)
 @patch(
-    'server_management_api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.agent_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.agent_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
@@ -480,8 +469,7 @@ async def test_put_group_config(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
             mock_dapi.assert_called_once_with(
                 f=agent.update_group_file,
                 f_kwargs=mock_remove.return_value,
-                request_type='local_master',
-                is_async=True,
+                        is_async=True,
                 wait_for_complete=False,
                 logger=ANY,
                 rbac_permissions=mock_request.context['token_info']['rbac_policies'],

--- a/apis/server_management/server_management_api/controllers/test/test_manager_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_manager_controller.py
@@ -34,7 +34,7 @@ with patch('wazuh.common.wazuh_uid'):
 @pytest.mark.asyncio
 @patch('server_management_api.controllers.manager_controller.configuration.update_check_is_enabled')
 @patch(
-    'server_management_api.controllers.manager_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.manager_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.manager_controller.DistributedAPI.__init__', return_value=None)
 @patch('server_management_api.controllers.manager_controller.raise_if_exc', return_value=CustomAffectedItems())
@@ -59,8 +59,7 @@ async def test_check_available_version(
             mock_dapi.assert_any_call(
                 f=query_update_check_service,
                 f_kwargs={INSTALLATION_UID_KEY: cti_context[INSTALLATION_UID_KEY]},
-                request_type='local_master',
-                is_async=True,
+                        is_async=True,
                 logger=ANY,
             )
             mock_exc.assert_any_call(mock_dfunc.return_value)
@@ -71,8 +70,7 @@ async def test_check_available_version(
                 INSTALLATION_UID_KEY: cti_context[INSTALLATION_UID_KEY],
                 UPDATE_INFORMATION_KEY: cti_context[UPDATE_INFORMATION_KEY],
             },
-            request_type='local_master',
-            is_async=False,
+                is_async=False,
             logger=ANY,
         )
         mock_exc.assert_called_with(mock_dfunc.return_value)

--- a/apis/server_management/server_management_api/controllers/test/test_security_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_security_controller.py
@@ -51,17 +51,17 @@ def mock_request():
 @pytest.mark.asyncio
 @pytest.mark.parametrize('raw', [True, False])
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.security_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
 @patch('server_management_api.controllers.security_controller.generate_token', return_value='token')
-async def test_login_user(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfunc, raw, mock_request):
+async def test_login_user(mock_token, mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, raw, mock_request):
     """Verify 'login_user' endpoint is working as expected."""
     result = await login_user(user='001', raw=raw)
     f_kwargs = {'user_id': '001'}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -77,19 +77,19 @@ async def test_login_user(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfu
 
 @pytest.mark.asyncio
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.security_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
 @patch('server_management_api.controllers.security_controller.generate_token', return_value='token')
 @pytest.mark.parametrize('mock_bool', [True, False])
-async def test_login_user_ko(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool):
+async def test_login_user_ko(mock_token, mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_bool):
     """Verify 'login_user' endpoint is handling WazuhException as expected."""
     mock_token.side_effect = WazuhException(999)
     result = await login_user(user='001', raw=mock_bool)
     f_kwargs = {'user_id': '001'}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -105,18 +105,18 @@ async def test_login_user_ko(mock_token, mock_exc, mock_dapi, mock_remove, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('raw', [True, False])
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.security_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
 @patch('server_management_api.controllers.security_controller.generate_token', return_value='token')
-async def test_run_as_login(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfunc, raw, mock_request):
+async def test_run_as_login(mock_token, mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, raw, mock_request):
     """Verify 'run_as_login' endpoint is working as expected."""
     result = await run_as_login(user='001', raw=raw)
     auth_context = await mock_request.json()
     f_kwargs = {'user_id': '001', 'auth_context': auth_context}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
         is_async=True,
@@ -134,19 +134,19 @@ async def test_run_as_login(mock_token, mock_exc, mock_dapi, mock_remove, mock_d
 
 @pytest.mark.asyncio
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.TaskDispatcher.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
-@patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
+@patch('server_management_api.controllers.security_controller.TaskDispatcher.__init__', return_value=None)
 @patch('server_management_api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
 @patch('server_management_api.controllers.security_controller.generate_token', return_value='token')
 @pytest.mark.parametrize('mock_bool', [True, False])
-async def test_run_as_login_ko(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool, mock_request):
+async def test_run_as_login_ko(mock_token, mock_exc, mock_task_dispatcher, mock_remove, mock_dfunc, mock_bool, mock_request):
     """Verify 'run_as_login' endpoint is handling WazuhException as expected."""
     mock_token.side_effect = WazuhException(999)
     result = await run_as_login(user='001', raw=mock_bool)
     f_kwargs = {'user_id': '001', 'auth_context': await mock_request.json()}
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
         is_async=True,

--- a/apis/server_management/server_management_api/controllers/test/test_security_controller.py
+++ b/apis/server_management/server_management_api/controllers/test/test_security_controller.py
@@ -51,7 +51,7 @@ def mock_request():
 @pytest.mark.asyncio
 @pytest.mark.parametrize('raw', [True, False])
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
@@ -64,7 +64,6 @@ async def test_login_user(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfu
     mock_dapi.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         logger=ANY,
         rbac_manager=mock_request.state.rbac_manager,
@@ -78,7 +77,7 @@ async def test_login_user(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfu
 
 @pytest.mark.asyncio
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
@@ -93,7 +92,6 @@ async def test_login_user_ko(mock_token, mock_exc, mock_dapi, mock_remove, mock_
     mock_dapi.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         logger=ANY,
         rbac_manager=ANY,
@@ -107,7 +105,7 @@ async def test_login_user_ko(mock_token, mock_exc, mock_dapi, mock_remove, mock_
 @pytest.mark.asyncio
 @pytest.mark.parametrize('raw', [True, False])
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
@@ -121,7 +119,6 @@ async def test_run_as_login(mock_token, mock_exc, mock_dapi, mock_remove, mock_d
     mock_dapi.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         logger=ANY,
         rbac_manager=mock_request.state.rbac_manager,
@@ -137,7 +134,7 @@ async def test_run_as_login(mock_token, mock_exc, mock_dapi, mock_remove, mock_d
 
 @pytest.mark.asyncio
 @patch(
-    'server_management_api.controllers.security_controller.DistributedAPI.distribute_function', return_value=AsyncMock()
+    'server_management_api.controllers.security_controller.DistributedAPI.execute_function', return_value=AsyncMock()
 )
 @patch('server_management_api.controllers.security_controller.remove_nones_to_dict')
 @patch('server_management_api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
@@ -152,7 +149,6 @@ async def test_run_as_login_ko(mock_token, mock_exc, mock_dapi, mock_remove, moc
     mock_dapi.assert_called_once_with(
         f=preprocessor.get_permissions,
         f_kwargs=mock_remove.return_value,
-        request_type='local_master',
         is_async=True,
         logger=ANY,
         rbac_manager=mock_request.state.rbac_manager,

--- a/apis/server_management/server_management_api/spec/spec.yaml
+++ b/apis/server_management/server_management_api/spec/spec.yaml
@@ -185,9 +185,6 @@ components:
             on how to set up permissions, please visit
             https://documentation.wazuh.com/5.0/user-manual/api/rbac/configuration.html"
             error: 4000
-            dapi_errors:
-              unknown-node:
-                error: "Permission denied: Resource type: *:*"
 
     UnauthorizedResponse:
       description: "Response to report an unauthorized request"
@@ -265,9 +262,6 @@ components:
             remediation: "Please, use `GET /groups` to find all available groups:
             https://documentation.wazuh.com/5.0/user-manual/api/rbac/configuration.html"
             code: 1710
-            dapi_errors:
-              unknown-node:
-                error: "The group does not exist"
 
   schemas:
     ## Common models
@@ -320,16 +314,6 @@ components:
           format: int32
         remediation:
           type: string
-        dapi_errors:
-          type: object
-          additionalProperties:
-            type: object
-            properties:
-              error:
-                type: string
-              logfile:
-                type: string
-                format: path
 
     RequestError:
       type: object

--- a/apis/server_management/server_management_api/test/test_authentication.py
+++ b/apis/server_management/server_management_api/test/test_authentication.py
@@ -60,9 +60,9 @@ async def test_check_user_master(rbac_manager_var_mock):
 
 
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
+@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', side_effect=None)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
-async def test_check_user(mock_raise_if_exc, mock_distribute_function, mock_dapi):
+async def test_check_user(mock_raise_if_exc, mock_execute_function, mock_dapi):
     """Verify if result is as expected."""
     mock_request = MagicMock()
     mock_state = MagicMock()
@@ -73,13 +73,12 @@ async def test_check_user(mock_raise_if_exc, mock_distribute_function, mock_dapi
     mock_dapi.assert_called_once_with(
         f=ANY,
         f_kwargs={'name': 'test_user', 'password': 'test_pass'},
-        request_type='local_master',
         is_async=True,
         wait_for_complete=False,
         logger=ANY,
         rbac_manager=mock_state.rbac_manager,
     )
-    mock_distribute_function.assert_called_once_with()
+    mock_execute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
 
 
@@ -98,10 +97,10 @@ def test_get_security_conf():
     return_value=('-----BEGIN PRIVATE KEY-----', '-----BEGIN PUBLIC KEY-----'),
 )
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
+@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', side_effect=None)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
 async def test_generate_token(
-    mock_raise_if_exc, mock_distribute_function, mock_dapi, mock_get_keypair, mock_encode, auth_context
+    mock_raise_if_exc, mock_execute_function, mock_dapi, mock_get_keypair, mock_encode, auth_context
 ):
     """Verify if result is as expected."""
 
@@ -118,7 +117,7 @@ async def test_generate_token(
     mock_dapi.assert_called_once_with(
         f=ANY, request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY
     )
-    mock_distribute_function.assert_called_once_with()
+    mock_execute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
     mock_get_keypair.assert_called_once()
     expected_payload = original_payload | (
@@ -149,9 +148,9 @@ async def test_check_token(rbac_manager_var_mock):
     return_value=('-----BEGIN PRIVATE KEY-----', '-----BEGIN PUBLIC KEY-----'),
 )
 @patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', return_value=True)
+@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', return_value=True)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
-async def test_decode_token(mock_raise_if_exc, mock_distribute_function, mock_dapi, mock_get_keypair, mock_decode):
+async def test_decode_token(mock_raise_if_exc, mock_execute_function, mock_dapi, mock_get_keypair, mock_decode):
     """Validate that the `decode_token` function works as expected."""
     mock_decode.return_value = deepcopy(original_payload)
     mock_raise_if_exc.side_effect = [
@@ -175,8 +174,7 @@ async def test_decode_token(mock_raise_if_exc, mock_distribute_function, mock_da
                 'run_as': False,
                 'roles': tuple(original_payload['rbac_roles']),
             },
-            request_type='local_master',
-            is_async=True,
+                is_async=True,
             wait_for_complete=False,
             logger=ANY,
             rbac_manager=mock_state.rbac_manager,
@@ -188,18 +186,18 @@ async def test_decode_token(mock_raise_if_exc, mock_distribute_function, mock_da
     mock_decode.assert_called_once_with(
         'test_token', '-----BEGIN PUBLIC KEY-----', algorithms=['RS256'], audience='Wazuh API REST'
     )
-    assert mock_distribute_function.call_count == 2
+    assert mock_execute_function.call_count == 2
     assert mock_raise_if_exc.call_count == 2
 
 
 @pytest.mark.asyncio
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function', side_effect=None)
+@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', side_effect=None)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
 @patch(
     'server_management_api.authentication.get_keypair',
     return_value=('-----BEGIN PRIVATE KEY-----', '-----BEGIN PUBLIC KEY-----'),
 )
-async def test_decode_token_ko(mock_get_keypair, mock_raise_if_exc, mock_distribute_function):
+async def test_decode_token_ko(mock_get_keypair, mock_raise_if_exc, mock_execute_function):
     """Assert exceptions are handled as expected inside decode_token()."""
     mock_request = MagicMock()
     mock_state = MagicMock()
@@ -214,7 +212,7 @@ async def test_decode_token_ko(mock_get_keypair, mock_raise_if_exc, mock_distrib
             return_value=('-----BEGIN PRIVATE KEY-----', '-----BEGIN PUBLIC KEY-----'),
         ):
             with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
-                with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.distribute_function'):
+                with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function'):
                     with patch('server_management_api.authentication.raise_if_exc') as mock_raise_if_exc:
                         mock_decode.return_value = deepcopy(original_payload)
 

--- a/apis/server_management/server_management_api/test/test_authentication.py
+++ b/apis/server_management/server_management_api/test/test_authentication.py
@@ -59,10 +59,10 @@ async def test_check_user_master(rbac_manager_var_mock):
     assert result == {'result': True}
 
 
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', side_effect=None)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.__init__', return_value=None)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_function', side_effect=None)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
-async def test_check_user(mock_raise_if_exc, mock_execute_function, mock_dapi):
+async def test_check_user(mock_raise_if_exc, mock_execute_function, mock_task_dispatcher):
     """Verify if result is as expected."""
     mock_request = MagicMock()
     mock_state = MagicMock()
@@ -70,7 +70,7 @@ async def test_check_user(mock_raise_if_exc, mock_execute_function, mock_dapi):
     result = authentication.check_user('test_user', 'test_pass', request=mock_request)
 
     assert result == {'sub': 'test_user', 'active': True}, 'Result is not as expected'
-    mock_dapi.assert_called_once_with(
+    mock_task_dispatcher.assert_called_once_with(
         f=ANY,
         f_kwargs={'name': 'test_user', 'password': 'test_pass'},
         is_async=True,
@@ -96,11 +96,11 @@ def test_get_security_conf():
     'server_management_api.authentication.get_keypair',
     return_value=('-----BEGIN PRIVATE KEY-----', '-----BEGIN PUBLIC KEY-----'),
 )
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', side_effect=None)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.__init__', return_value=None)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_function', side_effect=None)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
 async def test_generate_token(
-    mock_raise_if_exc, mock_execute_function, mock_dapi, mock_get_keypair, mock_encode, auth_context
+    mock_raise_if_exc, mock_execute_function, mock_task_dispatcher, mock_get_keypair, mock_encode, auth_context
 ):
     """Verify if result is as expected."""
 
@@ -114,8 +114,8 @@ async def test_generate_token(
     assert result == 'test_token', 'Result is not as expected'
 
     # Check all functions are called with expected params
-    mock_dapi.assert_called_once_with(
-        f=ANY, request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY
+    mock_task_dispatcher.assert_called_once_with(
+        f=ANY, is_async=False, wait_for_complete=False, logger=ANY
     )
     mock_execute_function.assert_called_once_with()
     mock_raise_if_exc.assert_called_once()
@@ -147,10 +147,10 @@ async def test_check_token(rbac_manager_var_mock):
     'server_management_api.authentication.get_keypair',
     return_value=('-----BEGIN PRIVATE KEY-----', '-----BEGIN PUBLIC KEY-----'),
 )
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None)
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', return_value=True)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.__init__', return_value=None)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_function', return_value=True)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
-async def test_decode_token(mock_raise_if_exc, mock_execute_function, mock_dapi, mock_get_keypair, mock_decode):
+async def test_decode_token(mock_raise_if_exc, mock_execute_function, mock_task_dispatcher, mock_get_keypair, mock_decode):
     """Validate that the `decode_token` function works as expected."""
     mock_decode.return_value = deepcopy(original_payload)
     mock_raise_if_exc.side_effect = [
@@ -179,9 +179,9 @@ async def test_decode_token(mock_raise_if_exc, mock_execute_function, mock_dapi,
             logger=ANY,
             rbac_manager=mock_state.rbac_manager,
         ),
-        call(f=ANY, request_type='local_master', is_async=False, wait_for_complete=False, logger=ANY),
+        call(f=ANY, is_async=False, wait_for_complete=False, logger=ANY),
     ]
-    mock_dapi.assert_has_calls(calls)
+    mock_task_dispatcher.assert_has_calls(calls)
     mock_get_keypair.assert_called_once()
     mock_decode.assert_called_once_with(
         'test_token', '-----BEGIN PUBLIC KEY-----', algorithms=['RS256'], audience='Wazuh API REST'
@@ -191,7 +191,7 @@ async def test_decode_token(mock_raise_if_exc, mock_execute_function, mock_dapi,
 
 
 @pytest.mark.asyncio
-@patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function', side_effect=None)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_function', side_effect=None)
 @patch('server_management_api.authentication.raise_if_exc', side_effect=None)
 @patch(
     'server_management_api.authentication.get_keypair',
@@ -211,8 +211,8 @@ async def test_decode_token_ko(mock_get_keypair, mock_raise_if_exc, mock_execute
             'server_management_api.authentication.get_keypair',
             return_value=('-----BEGIN PRIVATE KEY-----', '-----BEGIN PUBLIC KEY-----'),
         ):
-            with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.__init__', return_value=None):
-                with patch('wazuh.core.cluster.dapi.dapi.DistributedAPI.execute_function'):
+            with patch('wazuh.core.task_dispatcher.TaskDispatcher.__init__', return_value=None):
+                with patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_function'):
                     with patch('server_management_api.authentication.raise_if_exc') as mock_raise_if_exc:
                         mock_decode.return_value = deepcopy(original_payload)
 

--- a/apis/server_management/server_management_api/util.py
+++ b/apis/server_management/server_management_api/util.py
@@ -354,8 +354,7 @@ def _create_problem(exc: Exception, code: int = None):
         ext = remove_nones_to_dict(
             {
                 'remediation': exc.remediation,
-                'code': exc.code,
-                'dapi_errors': exc.dapi_errors if exc.dapi_errors != {} else None,
+                'code': exc.code
             }
         )
 

--- a/apis/server_management/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/apis/server_management/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -961,6 +961,3 @@ stages:
       status_code: 403
       json:
         error: 4000
-        dapi_errors:
-          master-node: # We have permission to see node name
-            error: !anystr

--- a/apis/server_management/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/apis/server_management/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -39,9 +39,6 @@ stages:
       status_code: 403
       json:
         error: 4000
-        dapi_errors:
-          unknown-node: # No permission to see node
-            error: !anystr
 
   - name: Get a list of agents (Partially allowed, user aware)
     request:

--- a/docs/ref/modules/communications/spec.yaml
+++ b/docs/ref/modules/communications/spec.yaml
@@ -187,21 +187,26 @@ components:
           type: string
           title: Order Id
         source:
-          $ref: '#/components/schemas/Source'
+          allOf:
+          - $ref: '#/components/schemas/Source'
         user:
           type: string
           title: User
         target:
-          $ref: '#/components/schemas/Target'
+          allOf:
+          - $ref: '#/components/schemas/Target'
         action:
-          $ref: '#/components/schemas/Action'
+          allOf:
+          - $ref: '#/components/schemas/Action'
         timeout:
           type: integer
           title: Timeout
         status:
-          $ref: '#/components/schemas/Status'
+          allOf:
+          - $ref: '#/components/schemas/Status'
         result:
-          $ref: '#/components/schemas/Result'
+          allOf:
+          - $ref: '#/components/schemas/Result'
       type: object
       title: Command
     Commands:
@@ -367,14 +372,16 @@ components:
           type: array
           title: Packages
         agent:
-          $ref: '#/components/schemas/Agent'
+          allOf:
+          - $ref: '#/components/schemas/Agent'
         hotfixes:
           items:
             type: string
           type: array
           title: Hotfixes
         os:
-          $ref: '#/components/schemas/OS'
+          allOf:
+          - $ref: '#/components/schemas/OS'
       type: object
       required:
       - type

--- a/framework/scripts/tests/test_wazuh_server.py
+++ b/framework/scripts/tests/test_wazuh_server.py
@@ -559,7 +559,7 @@ async def test_monitor_server_daemons(sleep_mock, check_daemon_mock, readiness_m
     readiness_mock.assert_called_once_with(
         process_mock,
         {
-            wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15]: 5,
+            wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15]: 4,
             wazuh_server.COMMS_API_DAEMON_NAME: 8,
             wazuh_server.ENGINE_DAEMON_NAME: 0,
         },
@@ -567,7 +567,7 @@ async def test_monitor_server_daemons(sleep_mock, check_daemon_mock, readiness_m
 
     check_daemon_mock.assert_has_calls(
         [
-            call(proc_list, wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15], 5),
+            call(proc_list, wazuh_server.MANAGEMENT_API_DAEMON_NAME[:15], 4),
             call(proc_list, wazuh_server.COMMS_API_DAEMON_NAME, 8),
             call(proc_list, wazuh_server.ENGINE_DAEMON_NAME, 0),
         ],

--- a/framework/scripts/wazuh_server.py
+++ b/framework/scripts/wazuh_server.py
@@ -354,7 +354,7 @@ async def monitor_server_daemons(loop: asyncio.BaseEventLoop, server_process: ps
     """
     comms_api_config = CentralizedConfig.get_comms_api_config()
     process_children = {
-        MANAGEMENT_API_DAEMON_NAME[:15]: 5,
+        MANAGEMENT_API_DAEMON_NAME[:15]: 4,
         COMMS_API_DAEMON_NAME: comms_api_config.workers + 4,
         ENGINE_DAEMON_NAME: 0,
     }

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 from server_management_api.models.agent_enrollment_model import Host
 from wazuh.core import common, configuration
 from wazuh.core.agent import AGENT_FIELDS, delete_single_group, get_groups, group_exists
+from wazuh.core.cluster.cluster import get_node
 from wazuh.core.exception import WazuhError, WazuhException, WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.indexer import get_indexer_client
 from wazuh.core.indexer.agent import DEFAULT_GROUP
@@ -20,6 +21,7 @@ from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.utils import get_group_file_path, get_hash, process_array
 from wazuh.rbac.decorators import expose_resources
 
+node_id = get_node().get('node')
 
 def build_agents_query(agent_list: list, filters: dict) -> dict:
     """Build the query to filter agents.

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -8,7 +8,6 @@ from typing import Optional, Union
 from server_management_api.models.agent_enrollment_model import Host
 from wazuh.core import common, configuration
 from wazuh.core.agent import AGENT_FIELDS, delete_single_group, get_groups, group_exists
-from wazuh.core.cluster.cluster import get_node
 from wazuh.core.exception import WazuhError, WazuhException, WazuhInternalError, WazuhResourceNotFound
 from wazuh.core.indexer import get_indexer_client
 from wazuh.core.indexer.agent import DEFAULT_GROUP
@@ -20,8 +19,6 @@ from wazuh.core.InputValidator import InputValidator
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
 from wazuh.core.utils import get_group_file_path, get_hash, process_array
 from wazuh.rbac.decorators import expose_resources
-
-node_id = get_node().get('node')
 
 
 def build_agents_query(agent_list: list, filters: dict) -> dict:

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -175,7 +175,6 @@ try:
         default={
             'process_pool': ProcessPoolExecutor(max_workers=1),
             'authentication_pool': ProcessPoolExecutor(max_workers=1),
-            'events_pool': ProcessPoolExecutor(max_workers=1),
         },
     )
 # Handle exception when the user running Wazuh cannot access /dev/shm.

--- a/framework/wazuh/core/config/models/server.py
+++ b/framework/wazuh/core/config/models/server.py
@@ -114,14 +114,11 @@ class CommunicationsTimeoutConfig(WazuhConfigBaseModel):
     ----------
     cluster_request : PositiveInt
         The timeout for cluster requests in seconds. Default is 20.
-    dapi_request : PositiveInt
-        The timeout for DAPI requests in seconds. Default is 200.
     receiving_file : PositiveInt
         The timeout for receiving files in seconds. Default is 120.
     """
 
     cluster_request: PositiveInt = 20
-    dapi_request: PositiveInt = 200
     receiving_file: PositiveInt = 120
 
 

--- a/framework/wazuh/core/config/models/tests/test_server.py
+++ b/framework/wazuh/core/config/models/tests/test_server.py
@@ -175,10 +175,10 @@ def test_zip_config_invalid_values(values):
 @pytest.mark.parametrize(
     'init_values, expected',
     [
-        ({}, {'dapi_request': 200, 'cluster_request': 20, 'receiving_file': 120}),
+        ({}, {'cluster_request': 20, 'receiving_file': 120}),
         (
-            {'dapi_request': 100, 'cluster_request': 30, 'receiving_file': 20},
-            {'dapi_request': 100, 'cluster_request': 30, 'receiving_file': 20},
+            {'cluster_request': 30, 'receiving_file': 20},
+            {'cluster_request': 30, 'receiving_file': 20},
         ),
     ],
 )
@@ -186,7 +186,6 @@ def test_communications_timeout_config_default_values(init_values, expected):
     """Check the correct initialization of the `CommunicationsTimeoutConfig` class."""
     config = CommunicationsTimeoutConfig(**init_values)
 
-    assert config.dapi_request == expected['dapi_request']
     assert config.cluster_request == expected['cluster_request']
     assert config.receiving_file == expected['receiving_file']
 
@@ -194,8 +193,6 @@ def test_communications_timeout_config_default_values(init_values, expected):
 @pytest.mark.parametrize(
     'values',
     [
-        {'dapi_request': 0},
-        {'dapi_request': -20},
         {'cluster_request': 0},
         {'cluster_request': -30},
         {'receiving_file': 0},
@@ -213,8 +210,8 @@ def test_communications_timeout_config_invalid_values(values):
     [
         ({}, {'zip': {}, 'timeouts': {}}),
         (
-            {'zip': {'max_size': 40}, 'timeouts': {'dapi_request': 100}},
-            {'zip': {'max_size': 40}, 'timeouts': {'dapi_request': 100}},
+            {'zip': {'max_size': 40}, 'timeouts': {}},
+            {'zip': {'max_size': 40}, 'timeouts': {}},
         ),
     ],
 )

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -297,7 +297,6 @@ class WazuhException(Exception):
             f'{DOCU_VERSION}/user-manual/configuring-cluster/index.html)'
             ' to get more information about how to configure a cluster',
         },
-        3009: {'message': 'Error executing distributed API request', 'remediation': ''},
         3015: 'Cannot access directory',
         3016: 'Received an error response',
         3018: 'Error sending request',
@@ -328,7 +327,6 @@ class WazuhException(Exception):
             'remediation': f'[Update](https://documentation.wazuh.com/{DOCU_VERSION}/upgrade-guide/index.html)'
             ' master and workers to the same version.',
         },
-        3032: 'Could not forward DAPI request. Connection not available.',
         3034: 'Error sending file. File not found.',
         3036: "JSON couldn't be loaded",
         3038: 'Error while processing extra-valid files',
@@ -400,7 +398,6 @@ class WazuhException(Exception):
         extra_message: str = None,
         extra_remediation: str = None,
         cmd_error: bool = False,
-        dapi_errors: dict = None,
         title: str = None,
         type: str = None,
     ):
@@ -416,9 +413,6 @@ class WazuhException(Exception):
             Adds an extra description to remediation.
         cmd_error : bool
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
-        dapi_errors : dict
-            Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': 'Refer to the server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str
@@ -430,7 +424,6 @@ class WazuhException(Exception):
         self._extra_message = extra_message
         self._extra_remediation = extra_remediation
         self._cmd_error = cmd_error
-        self._dapi_errors = {} if dapi_errors is None else deepcopy(dapi_errors)
 
         if not cmd_error and self._code in self.ERRORS:
             error_details = self.ERRORS[self._code]
@@ -482,7 +475,6 @@ class WazuhException(Exception):
     def __or__(self, other):
         if isinstance(other, WazuhException):
             result = self.__class__(**self.to_dict())
-            result.dapi_errors = {**self._dapi_errors, **other.dapi_errors}
         else:
             result = other | self
         return result
@@ -507,7 +499,6 @@ class WazuhException(Exception):
             'extra_message': self._extra_message,
             'extra_remediation': self._extra_remediation,
             'cmd_error': self._cmd_error,
-            'dapi_errors': self._dapi_errors,
         }
 
     @property
@@ -555,21 +546,6 @@ class WazuhException(Exception):
         return self._remediation
 
     @property
-    def dapi_errors(self) -> dict | Any:
-        """Get distributed API errors.
-
-        Returns
-        -------
-        dict | Any
-            DAPI errors.
-        """
-        return self._dapi_errors
-
-    @dapi_errors.setter
-    def dapi_errors(self, value: dict | Any):
-        self._dapi_errors = value
-
-    @property
     def code(self) -> int:
         """Get code.
 
@@ -604,7 +580,6 @@ class WazuhInternalError(WazuhException):
         extra_message: str = None,
         extra_remediation: str = None,
         cmd_error: bool = False,
-        dapi_errors: dict = None,
         ids: Union[list, set] = None,
         title: str = None,
         type: str = None,
@@ -621,9 +596,6 @@ class WazuhInternalError(WazuhException):
             Adds an extra description to remediation.
         cmd_error : bool
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
-        dapi_errors : dict
-            Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': 'Refer to the server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str
@@ -636,7 +608,6 @@ class WazuhInternalError(WazuhException):
             extra_message=extra_message,
             extra_remediation=extra_remediation,
             cmd_error=cmd_error,
-            dapi_errors=dapi_errors,
             title=title if title else self._default_title,
             type=type if type else self._default_type,
         )
@@ -697,7 +668,6 @@ class WazuhError(WazuhException):
         extra_message: str = None,
         extra_remediation: str = None,
         cmd_error: bool = False,
-        dapi_errors: dict = None,
         ids: Union[list, set] = None,
         title: str = None,
         type: str = None,
@@ -714,9 +684,6 @@ class WazuhError(WazuhException):
             Adds an extra description to remediation.
         cmd_error : bool
             If it is a custom error code (i.e. ossec commands), the error description will be the message.
-        dapi_errors : dict
-            Dictionary with details about node and logfile. I.e.: {'master-node': {'error': 'Wazuh Internal error',
-            'logfile': 'Refer to the server logs for more details.'}}
         title : str
             Name of the exception to be shown.
         type : str
@@ -729,7 +696,6 @@ class WazuhError(WazuhException):
             extra_message=extra_message,
             extra_remediation=extra_remediation,
             cmd_error=cmd_error,
-            dapi_errors=dapi_errors,
             title=title if title else self._default_title,
             type=type if type else self._default_type,
         )

--- a/framework/wazuh/core/task_dispatcher.py
+++ b/framework/wazuh/core/task_dispatcher.py
@@ -19,8 +19,6 @@ from wazuh.core.rbac import RBACManager
 pools = common.mp_pools.get()
 
 authentication_funcs = {'check_token', 'check_user_master', 'get_permissions', 'get_security_conf'}
-events_funcs = {'send_event_to_analysisd'}
-
 
 class TaskDispatcher:
     """Represents a distributed API request."""
@@ -187,8 +185,6 @@ class TaskDispatcher:
                         pool = pools.get('thread_pool')
                     elif self.f.__name__ in authentication_funcs:
                         pool = pools.get('authentication_pool')
-                    elif self.f.__name__ in events_funcs:
-                        pool = pools.get('events_pool')
                     else:
                         pool = pools.get('process_pool')
 

--- a/framework/wazuh/core/task_dispatcher.py
+++ b/framework/wazuh/core/task_dispatcher.py
@@ -235,24 +235,6 @@ class TaskDispatcher:
                 cls=WazuhJSONEncoder,
             )
 
-    def to_dict(self):
-        """Convert object into a dictionary.
-
-        Returns
-        -------
-        dict
-            Dictionary containing the key values.
-        """
-        return {
-            'f': self.f,
-            'f_kwargs': self.f_kwargs,
-            'wait_for_complete': self.wait_for_complete,
-            'is_async': self.is_async,
-            'rbac_permissions': self.rbac_permissions,
-            'current_user': self.current_user,
-            'api_timeout': self.api_request_timeout,
-        }
-
 
 class WazuhJSONEncoder(json.JSONEncoder):
     """Define special JSON encoder for Wazuh."""

--- a/framework/wazuh/core/task_dispatcher.py
+++ b/framework/wazuh/core/task_dispatcher.py
@@ -214,6 +214,14 @@ class TaskDispatcher:
 
             self.debug_log(f'Time calculating request result: {time.time() - before:.3f}s')
             return data
+        except exception.WazuhInternalError as e:
+            self.logger.error(
+                f'{e.message}',
+                exc_info=e.code not in {3021, 3036, 1913, 1017},
+            )
+            if self.debug:
+                raise
+            return json.dumps(e, cls=WazuhJSONEncoder)
         except (exception.WazuhError, exception.WazuhResourceNotFound) as e:
             if self.debug:
                 raise

--- a/framework/wazuh/core/task_dispatcher.py
+++ b/framework/wazuh/core/task_dispatcher.py
@@ -1,0 +1,366 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import time
+from concurrent.futures import process
+from functools import partial
+from typing import Callable, Dict
+import wazuh.core.cluster.cluster
+import wazuh.core.cluster.utils
+import wazuh.core.manager
+import wazuh.core.results as wresults
+from sqlalchemy.exc import OperationalError
+from wazuh.core import common, exception
+from wazuh.core.config.client import CentralizedConfig
+from wazuh.core.exception import WazuhException
+from wazuh.core.rbac import RBACManager
+
+pools = common.mp_pools.get()
+
+authentication_funcs = {'check_token', 'check_user_master', 'get_permissions', 'get_security_conf'}
+events_funcs = {'send_event_to_analysisd'}
+
+
+class TaskDispatcher:
+    """Represents a distributed API request."""
+
+    def __init__(
+        self,
+        f: Callable,
+        logger: logging.getLogger,
+        f_kwargs: Dict = None,
+        debug: bool = False,
+        current_user: str = '',
+        wait_for_complete: bool = False,
+        is_async: bool = False,
+        broadcasting: bool = False,
+        basic_services: tuple = None,
+        rbac_permissions: Dict = None,
+        api_timeout: int = None,
+        rbac_manager: RBACManager = None,
+    ):
+        """Class constructor.
+
+        Parameters
+        ----------
+        f : callable
+            Function to be executed.
+        logger : logging.getLogger
+            Logging logger to use.
+        f_kwargs : dict, optional
+            Arguments to be passed to function `f`. Default `None`
+        debug : bool, optional
+            Enable debug messages and raise exceptions. Default `False`
+        wait_for_complete : bool, optional
+            True to disable timeout, false otherwise. Default `False`
+        from_cluster : bool, optional
+            Default `False`, specify if the request goes from cluster or not
+        is_async : bool, optional
+            Default `False`, specify if the request is asynchronous or not
+        broadcasting : bool, optional
+            Default `False`, True if the request need to be executed in all managers
+        basic_services : tuple, optional
+            Default `None`, services that must be started for correct behaviour
+        local_client_arg: str, optional
+            Default `None`, LocalClient additional arguments
+        rbac_permissions : dict, optional
+            Default `None`, RBAC user's permissions
+        current_user : str
+            User who started the request
+        api_timeout : int
+            Timeout set in source API for the request
+        remove_denied_nodes : bool
+            Whether to remove denied (RBAC) nodes from response's failed items or not.
+        rbac_manager : RBACManager
+            RBAC manager.
+        """
+        self.logger = logger
+        self.f = f
+        self.f_kwargs = f_kwargs if f_kwargs is not None else {}
+        self.server_config = CentralizedConfig.get_server_config() if node is None else node.server_config
+        self.debug = debug
+        self.node_info = wazuh.core.cluster.cluster.get_node() if node is None else node.get_node()
+        self.wait_for_complete = wait_for_complete
+        self.is_async = is_async
+        self.broadcasting = broadcasting
+        self.rbac_permissions = rbac_permissions if rbac_permissions is not None else {'rbac_mode': 'black'}
+        self.current_user = current_user
+        self.origin_module = 'API'
+        if not basic_services:
+            self.basic_services = ('wazuh-server',)
+        else:
+            self.basic_services = basic_services
+
+        self.local_clients = []
+        api_request_timeout = CentralizedConfig.get_management_api_config().intervals.request_timeout
+        self.api_request_timeout = max(api_timeout, api_request_timeout) if api_timeout else api_request_timeout
+        self.rbac_manager = rbac_manager
+
+    def debug_log(self, message):
+        """Use debug or debug2 depending on the log type.
+
+        Parameters
+        ----------
+        message : str
+            Full log message.
+        """
+        if self.logger.name == 'wazuh-api':
+            self.logger.debug2(message)
+        else:
+            self.logger.debug(message)
+
+    async def execute_function(self) -> Dict | exception.WazuhException:  # noqa: C901
+        """Distribute an API call.
+
+        Returns
+        -------
+        dict or WazuhException
+            Dictionary with API response or WazuhException in case of error.
+        """
+        try:
+            if 'password' in self.f_kwargs:
+                self.debug_log(f'Receiving parameters { {**self.f_kwargs, "password": "****"} }')
+            elif 'token_nbf_time' in self.f_kwargs:
+                self.logger.debug(f'Decoded token {self.f_kwargs}')
+            else:
+                self.debug_log(f'Receiving parameters {self.f_kwargs}')
+
+            response = await self.execute_local_request()
+
+            try:
+                response = (
+                    json.loads(response, object_hook=c_common.as_wazuh_object)
+                    if isinstance(response, str)
+                    else response
+                )
+            except json.decoder.JSONDecodeError:
+                response = {'message': response}
+
+            return (
+                response
+                if isinstance(response, (wresults.AbstractWazuhResult, exception.WazuhException))
+                else wresults.WazuhResult(response)
+            )
+
+        except json.decoder.JSONDecodeError:
+            e = exception.WazuhInternalError(3036)
+            e.dapi_errors = await self.get_error_info(e)
+            if self.debug:
+                raise
+            self.logger.error(f'{e.message}')
+            return e
+        except exception.WazuhInternalError as e:
+            e.dapi_errors = await self.get_error_info(e)
+            if self.debug:
+                raise
+            self.logger.error(f'{e.message}', exc_info=not isinstance(e, exception.WazuhClusterError))
+            return e
+        except exception.WazuhError as e:
+            e.dapi_errors = await self.get_error_info(e)
+            return e
+        except Exception as e:
+            if self.debug:
+                raise
+
+            self.logger.error(f'Unhandled exception: {str(e)}', exc_info=True)
+            return exception.WazuhInternalError(1000, dapi_errors=await self.get_error_info(e))
+
+    def check_wazuh_status(self):
+        """There are some services that are required for wazuh to correctly process API requests. If any of those services
+        is not running, the API must raise an exception indicating that:
+            * It's not ready yet to process requests if services are restarting
+            * There's an error in any of those services that must be addressed before using the API if any service is
+              in failed status.
+            * Wazuh must be started before using the API is the services are stopped.
+
+        The basic service wazuh needs to be running is: wazuh-clusterd.
+        """
+        if self.f == wazuh.core.manager.status:
+            return
+
+        status = wazuh.core.manager.status()
+
+        not_ready_daemons = {
+            k: status[k] for k in self.basic_services if status[k] in ('failed', 'restarting', 'stopped')
+        }
+
+        if not_ready_daemons:
+            extra_info = {
+                'node_name': self.node_info.get('node', 'UNKNOWN NODE'),
+                'not_ready_daemons': ', '.join([f'{key}->{value}' for key, value in not_ready_daemons.items()]),
+            }
+            raise exception.WazuhInternalError(1017, extra_message=extra_info)
+
+    @staticmethod
+    def run_local(f, f_kwargs, rbac_permissions, broadcasting, nodes, current_user, origin_module, rbac_manager):
+        """Run framework SDK function locally in another process."""
+        common.rbac.set(rbac_permissions)
+        common.broadcast.set(broadcasting)
+        common.cluster_nodes.set(nodes)
+        common.current_user.set(current_user)
+        common.origin_module.set(origin_module)
+        common.rbac_manager.set(rbac_manager)
+        data = f(**f_kwargs)
+        common.reset_context_cache()
+        return data
+
+    async def execute_local_request(self) -> str:  # noqa: C901
+        """Execute an API request locally.
+
+        Returns
+        -------
+        str
+            JSON response.
+        """
+        try:
+            if self.f_kwargs.get('agent_list') == '*':
+                del self.f_kwargs['agent_list']
+
+            before = time.time()
+            self.check_wazuh_status()
+
+            timeout = self.api_request_timeout if not self.wait_for_complete else None
+
+            try:
+                if self.is_async:
+                    task = self.run_local(
+                        self.f,
+                        self.f_kwargs,
+                        self.rbac_permissions,
+                        self.broadcasting,
+                        self.current_user,
+                        self.origin_module,
+                        self.rbac_manager,
+                    )
+
+                else:
+                    loop = asyncio.get_event_loop()
+                    if 'thread_pool' in pools:
+                        pool = pools.get('thread_pool')
+                    elif self.f.__name__ in authentication_funcs:
+                        pool = pools.get('authentication_pool')
+                    elif self.f.__name__ in events_funcs:
+                        pool = pools.get('events_pool')
+                    else:
+                        pool = pools.get('process_pool')
+
+                    task = loop.run_in_executor(
+                        pool,
+                        partial(
+                            self.run_local,
+                            self.f,
+                            self.f_kwargs,
+                            self.rbac_permissions,
+                            self.broadcasting,
+                            self.nodes,
+                            self.current_user,
+                            self.origin_module,
+                            self.rbac_manager,
+                        ),
+                    )
+                try:
+                    self.debug_log('Starting to execute request locally')
+                    data = await asyncio.wait_for(task, timeout=timeout)
+                    self.debug_log('Finished executing request locally')
+                except asyncio.TimeoutError:
+                    raise exception.WazuhInternalError(3021)
+                except OperationalError as exc:
+                    raise exception.WazuhInternalError(2008, extra_message=str(exc.orig))
+                except process.BrokenProcessPool:
+                    raise exception.WazuhInternalError(901)
+            except json.decoder.JSONDecodeError:
+                raise exception.WazuhInternalError(3036)
+            except process.BrokenProcessPool:
+                raise exception.WazuhInternalError(900)
+
+            self.debug_log(f'Time calculating request result: {time.time() - before:.3f}s')
+            return data
+        except exception.WazuhInternalError as e:
+            e.dapi_errors = await self.get_error_info(e)
+            # Avoid exception info if it is an asyncio timeout error, JSONDecodeError, /proc availability error or
+            # WazuhClusterError
+            self.logger.error(
+                f'{e.message}',
+                exc_info=e.code not in {3021, 3036, 1913, 1017} and not isinstance(e, exception.WazuhClusterError),
+            )
+            if self.debug:
+                raise
+            return json.dumps(e, cls=c_common.WazuhJSONEncoder)
+        except (exception.WazuhError, exception.WazuhResourceNotFound) as e:
+            e.dapi_errors = await self.get_error_info(e)
+            if self.debug:
+                raise
+            return json.dumps(e, cls=c_common.WazuhJSONEncoder)
+        except Exception as e:
+            self.logger.error(f'Error executing API request locally: {str(e)}', exc_info=True)
+            if self.debug:
+                raise
+            return json.dumps(
+                exception.WazuhInternalError(1000, dapi_errors=await self.get_error_info(e)),
+                cls=c_common.WazuhJSONEncoder,
+            )
+
+    def to_dict(self):
+        """Convert object into a dictionary.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the key values.
+        """
+        return {
+            'f': self.f,
+            'f_kwargs': self.f_kwargs,
+            'wait_for_complete': self.wait_for_complete,
+            'is_async': self.is_async,
+            'local_client_arg': self.local_client_arg,
+            'basic_services': self.basic_services,
+            'rbac_permissions': self.rbac_permissions,
+            'current_user': self.current_user,
+            'broadcasting': self.broadcasting,
+            'api_timeout': self.api_request_timeout,
+        }
+
+    async def get_error_info(self, e: Exception) -> Dict:
+        """Build a response given an Exception.
+
+        Parameters
+        ----------
+        e : Exception
+            Exception to parse.
+
+        Returns
+        -------
+        dict
+            Dict where keys are nodes and values are error information.
+        """
+        try:
+            common.rbac.set(self.rbac_permissions)
+            node_wrapper = await get_node_wrapper()
+            node = node_wrapper.affected_items[0]['node']
+        except exception.WazuhException as rbac_exception:
+            if rbac_exception.code == 4000:
+                node = 'unknown-node'
+            else:
+                raise rbac_exception
+        except IndexError:
+            raise list(node_wrapper.failed_items.keys())[0]
+
+        error_message = e.message if isinstance(e, exception.WazuhException) else exception.GENERIC_ERROR_MSG
+        result = {node: {'error': error_message}}
+
+        # Give log path only in case of WazuhInternalError
+        if isinstance(e, exception.WazuhInternalError):
+            log_filename = None
+            for h in self.logger.handlers or self.logger.parent.handlers:
+                if hasattr(h, 'baseFilename'):
+                    log_filename = os.path.join('WAZUH_LOG', os.path.relpath(h.baseFilename, start=common.WAZUH_LOG))
+            result[node]['logfile'] = log_filename
+
+        return result

--- a/framework/wazuh/core/task_dispatcher.py
+++ b/framework/wazuh/core/task_dispatcher.py
@@ -200,9 +200,9 @@ class TaskDispatcher:
                         ),
                     )
                 try:
-                    self.debug_log('Starting to execute request locally')
+                    self.debug_log(f'Starting to execute request `{self.f.__name__}` locally')
                     data = await asyncio.wait_for(task, timeout=timeout)
-                    self.debug_log('Finished executing request locally')
+                    self.debug_log(f'Finished executing request `{self.f.__name__}` locally')
                 except asyncio.TimeoutError:
                     raise exception.WazuhInternalError(3021)
                 except process.BrokenProcessPool:
@@ -212,7 +212,7 @@ class TaskDispatcher:
             except process.BrokenProcessPool:
                 raise exception.WazuhInternalError(900)
 
-            self.debug_log(f'Time calculating request result: {time.time() - before:.3f}s')
+            self.debug_log(f'Time calculating `{self.f.__name__}` request result: {time.time() - before:.3f}s')
             return data
         except exception.WazuhInternalError as e:
             self.logger.error(

--- a/framework/wazuh/core/tests/test_exception.py
+++ b/framework/wazuh/core/tests/test_exception.py
@@ -45,14 +45,11 @@ from wazuh.core.exception import WazuhError, WazuhException
             None,
             None,
             None,
-            None,
             'Error 1017 - Some Wazuh daemons are not ready yet',
         ),
     ],
 )
-def test_wazuh_exception_to_string(
-    code, extra_message, extra_remediation, cmd_error, title, type, exc_string
-):
+def test_wazuh_exception_to_string(code, extra_message, extra_remediation, cmd_error, title, type, exc_string):
     """Check object constructor."""
     exc = WazuhException(code, extra_message, extra_remediation, cmd_error, title, type)
     assert str(exc) == exc_string

--- a/framework/wazuh/core/tests/test_exception.py
+++ b/framework/wazuh/core/tests/test_exception.py
@@ -7,14 +7,14 @@ from wazuh.core.exception import WazuhError, WazuhException
 
 
 @pytest.mark.parametrize(
-    'code, extra_message, extra_remediation, cmd_error, dapi_errors, title, type, exc_string',
+    'code, extra_message, extra_remediation, cmd_error, title, type, exc_string',
     [
         # code not found in ERRORS - use extra_message
-        (9999, 'External exception', None, None, None, None, None, 'Error 9999 - External exception'),
+        (9999, 'External exception', None, None, None, None, 'Error 9999 - External exception'),
         # code found in ERRORS - cmd_error True
-        (999, 'Code found with cmd_error', None, True, None, None, None, 'Error 999 - Code found with cmd_error'),
+        (999, 'Code found with cmd_error', None, True, None, None, 'Error 999 - Code found with cmd_error'),
         # code found in ERRORS - dictionary entry of string type
-        (999, None, None, None, None, None, None, 'Error 999 - Incompatible version of Python'),
+        (999, None, None, None, None, None, 'Error 999 - Incompatible version of Python'),
         # code found in ERRORS - dictionary entry of dictionary type - without remediation key
         (
             3050,
@@ -23,16 +23,14 @@ from wazuh.core.exception import WazuhError, WazuhException
             None,
             None,
             None,
-            None,
             'Error 3050 - Error while sending orders to the Communications API unix server',
         ),
         # code found in ERRORS - dictionary entry of dictionary type - with remediation key
-        (4000, None, None, None, None, None, None, 'Error 4000 - Permission denied'),
+        (4000, None, None, None, None, None, 'Error 4000 - Permission denied'),
         # code found in ERRORS - extra_message parameter of string type
         (
             4027,
             {'entity': 'User'},
-            None,
             None,
             None,
             None,
@@ -53,21 +51,11 @@ from wazuh.core.exception import WazuhError, WazuhException
     ],
 )
 def test_wazuh_exception_to_string(
-    code, extra_message, extra_remediation, cmd_error, dapi_errors, title, type, exc_string
+    code, extra_message, extra_remediation, cmd_error, title, type, exc_string
 ):
     """Check object constructor."""
-    exc = WazuhException(code, extra_message, extra_remediation, cmd_error, dapi_errors, title, type)
+    exc = WazuhException(code, extra_message, extra_remediation, cmd_error, title, type)
     assert str(exc) == exc_string
-
-
-def test_wazuh_exception__or__():
-    """Check that WazuhException's | operator performs the join of dapi errors properly."""
-    excp1 = WazuhException(1307)
-    excp1._dapi_errors = {'test1': 'test error'}
-    excp2 = WazuhException(1307)
-    excp2._dapi_errors = {'test2': 'test error'}
-    excp3 = excp2 | excp1
-    assert excp3._dapi_errors == {'test1': 'test error', 'test2': 'test error'}
 
 
 def test_wazuh_exception__deepcopy__():

--- a/framework/wazuh/core/tests/test_task_dispatcher.py
+++ b/framework/wazuh/core/tests/test_task_dispatcher.py
@@ -17,7 +17,9 @@ def logger():
 @pytest.fixture
 def funct():
     """Fixture that returns a MagicMock instance to simulate a callable function."""
-    return MagicMock()
+    f = MagicMock()
+    f.__name__ = 'default_function_name'
+    return f
 
 
 @pytest.mark.asyncio
@@ -213,9 +215,9 @@ async def test_execute_local_request_handle_agent_wildcard(mock_time, mock_debug
     assert result == 'retval'
     mock_debug_log.assert_has_calls(
         [
-            call('Starting to execute request locally'),
-            call('Finished executing request locally'),
-            call('Time calculating request result: 5.000s'),
+            call(f'Starting to execute request `{funct.__name__}` locally'),
+            call(f'Finished executing request `{funct.__name__}` locally'),
+            call(f'Time calculating `{funct.__name__}` request result: 5.000s'),
         ]
     )
 
@@ -245,9 +247,9 @@ async def test_execute_local_request_sync(mock_time, mock_debug_log, mock_get_lo
         assert result == 'mocked_result'
         mock_debug_log.assert_has_calls(
             [
-                call('Starting to execute request locally'),
-                call('Finished executing request locally'),
-                call('Time calculating request result: 5.000s'),
+                call(f'Starting to execute request `{funct.__name__}` locally'),
+                call(f'Finished executing request `{funct.__name__}` locally'),
+                call(f'Time calculating `{funct.__name__}` request result: 5.000s'),
             ]
         )
         loop.run_in_executor.assert_called_once()
@@ -285,7 +287,7 @@ async def test_execute_local_request_broken_process_pool(mock_debug_log, mock_ge
 
     assert result == json.dumps(exception.WazuhInternalError(901), cls=WazuhJSONEncoder)
     logger.error.assert_called_once_with(exception.WazuhException.ERRORS[901], exc_info=True)
-    mock_debug_log.assert_called_once_with('Starting to execute request locally')
+    mock_debug_log.assert_called_once_with(f'Starting to execute request `{funct.__name__}` locally')
     loop.run_in_executor.assert_called_once()
 
 

--- a/framework/wazuh/core/tests/test_task_dispatcher.py
+++ b/framework/wazuh/core/tests/test_task_dispatcher.py
@@ -1,0 +1,184 @@
+import json
+from concurrent.futures import process
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from wazuh.core import exception
+from wazuh.core.results import WazuhResult
+from wazuh.core.task_dispatcher import TaskDispatcher, WazuhJSONEncoder
+
+
+@pytest.fixture
+def logger():
+    """Fixture that returns a MagicMock instance to simulate a logger."""
+    return MagicMock()
+
+
+@pytest.fixture
+def funct():
+    """Fixture that returns a MagicMock instance to simulate a callable function."""
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_success(mock_exec, mock_debug_log, funct, logger):
+    """Test that `execute_function` returns the expected result and logs parameters."""
+    mock_exec.return_value = WazuhResult({'result': 'result-value'})
+    funct_kwargs = {'param': 'param-value'}
+    dispatcher = TaskDispatcher(f=funct, logger=logger, f_kwargs=funct_kwargs)
+
+    result = await dispatcher.execute_function()
+
+    assert result == WazuhResult({'result': 'result-value'})
+    mock_debug_log.assert_called_once_with(f'Receiving parameters {funct_kwargs}')
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_masks_password(mock_exec, mock_debug_log, funct, logger):
+    """Test that passwords are masked in parameter logging."""
+    mock_exec.return_value = WazuhResult({'result': 'result-value'})
+    funct_kwargs = {'param': 'param-value', 'password': 'password-value'}
+    masked_kwargs = {**funct_kwargs, 'password': '****'}
+    dispatcher = TaskDispatcher(f=funct, logger=logger, f_kwargs=funct_kwargs)
+
+    await dispatcher.execute_function()
+
+    mock_debug_log.assert_called_once_with(f'Receiving parameters {masked_kwargs}')
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_logs_token_nbf_time(mock_exec, funct, logger):
+    """Test that `token_nbf_time` is logged correctly by the logger."""
+    mock_exec.return_value = WazuhResult({'result': 'result-value'})
+    funct_kwargs = {'param': 'param-value', 'token_nbf_time': 1234}
+    dispatcher = TaskDispatcher(f=funct, logger=logger, f_kwargs=funct_kwargs)
+
+    await dispatcher.execute_function()
+
+    logger.debug.assert_called_with(f'Decoded token {funct_kwargs}')
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_handle_non_wazuh_return(mock_exec, funct, logger):
+    """Test that `execute_function` wraps non-Wazuh return values into a WazuhResult."""
+    mock_exec.return_value = 'non-json-return'
+    dispatcher = TaskDispatcher(f=funct, logger=logger)
+
+    result = await dispatcher.execute_function()
+
+    assert result == WazuhResult({'message': 'non-json-return'})
+
+
+def test_debug_log_as_wazuh_api(funct):
+    """Test that `debug_log` uses `debug2` method when logger is 'wazuh-api'."""
+    message = 'test message'
+    logger = MagicMock(name='wazuh-api')
+    logger.name = 'wazuh-api'
+    dispatcher = TaskDispatcher(f=funct, logger=logger)
+
+    dispatcher.debug_log(message)
+
+    logger.debug2.assert_called_once_with(message)
+
+
+def test_debug_log_as_not_wazuh_api(funct):
+    """Test that `debug_log` uses standard `debug` method when logger is not 'wazuh-api'."""
+    message = 'test message'
+    logger = MagicMock(name='other-component')
+    logger.name = 'other-component'
+    dispatcher = TaskDispatcher(f=funct, logger=logger)
+
+    dispatcher.debug_log(message)
+
+    logger.debug.assert_called_once_with(message)
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.run_local', new_callable=AsyncMock)
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
+@patch('wazuh.core.task_dispatcher.time.time')
+async def test_execute_local_request_async(mock_time, mock_debug_log, mock_run_local, funct, logger):
+    """Test that `execute_local_request` calculates and logs execution time."""
+    mock_time.side_effect = [10, 15]
+    dispatcher = TaskDispatcher(f=funct, logger=logger, is_async=True)
+    mock_run_local.return_value = 'retval'
+
+    result = await dispatcher.execute_local_request()
+
+    assert result == 'retval'
+    mock_debug_log.assert_has_calls(
+        [
+            call('Starting to execute request locally'),
+            call('Finished executing request locally'),
+            call('Time calculating request result: 5.000s'),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.asyncio.get_event_loop')
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
+@patch('wazuh.core.task_dispatcher.pools', {'thread_pool': 'fake_pool'})
+@patch('wazuh.core.task_dispatcher.time.time')
+async def test_execute_local_request_sync(mock_time, mock_debug_log, mock_get_loop, funct, logger):
+    """Test sync execution flow with timing and debug logging."""
+    mock_time.side_effect = [10, 15]
+    dispatcher = TaskDispatcher(f=funct, logger=logger, is_async=False)
+
+    loop = MagicMock()
+    loop.run_in_executor.return_value = AsyncMock(return_value='mocked_result')()
+    mock_get_loop.return_value = loop
+
+    result = await dispatcher.execute_local_request()
+
+    assert result == 'mocked_result'
+    mock_debug_log.assert_has_calls(
+        [
+            call('Starting to execute request locally'),
+            call('Finished executing request locally'),
+            call('Time calculating request result: 5.000s'),
+        ]
+    )
+    loop.run_in_executor.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.run_local', new_callable=AsyncMock)
+async def test_execute_local_request_timeout(mock_run_local, funct, logger):
+    """Test that `execute_local_request` handles timeout and returns WazuhInternalError."""
+    dispatcher = TaskDispatcher(f=funct, logger=logger, is_async=True)
+    dispatcher.api_request_timeout = 0.0
+
+    result = await dispatcher.execute_local_request()
+
+    assert result == json.dumps(exception.WazuhInternalError(3021), cls=WazuhJSONEncoder)
+    logger.error.assert_called_once_with(exception.WazuhException.ERRORS[3021], exc_info=False)
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.asyncio.get_event_loop')
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
+@patch('wazuh.core.task_dispatcher.pools', {'thread_pool': 'fake_pool'})
+async def test_execute_local_request_broken_process_pool(mock_debug_log, mock_get_loop, funct, logger):
+    """Test handling of broken process pool."""
+    dispatcher = TaskDispatcher(f=funct, logger=logger, is_async=False)
+
+    exploding_task = AsyncMock()
+    exploding_task.side_effect = process.BrokenProcessPool('Simulated crash')
+
+    loop = MagicMock()
+    loop.run_in_executor.return_value = exploding_task()
+    mock_get_loop.return_value = loop
+
+    result = await dispatcher.execute_local_request()
+
+    assert result == json.dumps(exception.WazuhInternalError(901), cls=WazuhJSONEncoder)
+    logger.error.assert_called_once_with(exception.WazuhException.ERRORS[901], exc_info=True)
+    mock_debug_log.assert_called_once_with('Starting to execute request locally')
+    loop.run_in_executor.assert_called_once()

--- a/framework/wazuh/core/tests/test_task_dispatcher.py
+++ b/framework/wazuh/core/tests/test_task_dispatcher.py
@@ -75,6 +75,102 @@ async def test_execute_function_handle_non_wazuh_return(mock_exec, funct, logger
     assert result == WazuhResult({'message': 'non-json-return'})
 
 
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_jsondecode_error(mock_exec, funct, logger):
+    """Test that JSONDecodeError raised by `execute_local_request` is handled and returns WazuhInternalError(3036)."""
+    mock_exec.side_effect = json.decoder.JSONDecodeError('msg', '', 0)
+    dispatcher = TaskDispatcher(f=funct, logger=logger, debug=False)
+
+    result = await dispatcher.execute_function()
+
+    assert isinstance(result, exception.WazuhInternalError)
+    assert result.code == 3036
+    logger.error.assert_called_once_with(result.message)
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_wazuh_internal_error(mock_exec, funct, logger):
+    """Test that WazuhInternalError is caught and returned."""
+    err = exception.WazuhInternalError(3027)
+    mock_exec.side_effect = err
+    dispatcher = TaskDispatcher(f=funct, logger=logger, debug=False)
+
+    result = await dispatcher.execute_function()
+
+    assert result == err
+    logger.error.assert_called_once_with(exception.WazuhInternalError.ERRORS[3027], exc_info=True)
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_wazuh_error(mock_exec, mock_debug_log, funct, logger):
+    """Test that WazuhError (not internal) is caught and returned."""
+    err = exception.WazuhResourceNotFound(1000, 'whatever')
+    mock_exec.side_effect = err
+    dispatcher = TaskDispatcher(f=funct, logger=logger, debug=False)
+
+    result = await dispatcher.execute_function()
+
+    assert result == err
+    logger.error.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_unhandled_exception(mock_exec, mock_debug_log, funct, logger):
+    """Test that unhandled exceptions are caught and wrapped as WazuhInternalError(1000)."""
+    mock_exec.side_effect = RuntimeError('unexpected')
+    dispatcher = TaskDispatcher(f=funct, logger=logger, debug=False)
+
+    result = await dispatcher.execute_function()
+
+    assert isinstance(result, exception.WazuhInternalError)
+    assert result.code == 1000
+    logger.error.assert_called_once_with('Unhandled exception: unexpected', exc_info=True)
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_jsondecode_error_debug_true(mock_exec, funct, logger):
+    """Test that JSONDecodeError is raised when debug=True."""
+    mock_exec.side_effect = json.decoder.JSONDecodeError('msg', '', 0)
+    dispatcher = TaskDispatcher(f=funct, logger=logger, debug=True)
+
+    with pytest.raises(json.decoder.JSONDecodeError):
+        await dispatcher.execute_function()
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_wazuh_internal_error_debug_true(mock_exec, funct, logger):
+    """Test that WazuhInternalError is raised when debug=True."""
+    err = exception.WazuhInternalError(3027)
+    mock_exec.side_effect = err
+    dispatcher = TaskDispatcher(f=funct, logger=logger, debug=True)
+
+    with pytest.raises(exception.WazuhInternalError) as exc:
+        await dispatcher.execute_function()
+
+    assert exc.value.code == 3027
+
+
+@pytest.mark.asyncio
+@patch('wazuh.core.task_dispatcher.TaskDispatcher.execute_local_request', new_callable=AsyncMock)
+async def test_execute_function_unhandled_exception_debug_true(mock_exec, funct, logger):
+    """Test that unhandled exception is raised when debug=True."""
+    mock_exec.side_effect = RuntimeError('unexpected')
+    dispatcher = TaskDispatcher(f=funct, logger=logger, debug=True)
+
+    with pytest.raises(RuntimeError) as exc:
+        await dispatcher.execute_function()
+
+    assert str(exc.value) == 'unexpected'
+
+
 def test_debug_log_as_wazuh_api(funct):
     """Test that `debug_log` uses `debug2` method when logger is 'wazuh-api'."""
     message = 'test message'
@@ -103,14 +199,17 @@ def test_debug_log_as_not_wazuh_api(funct):
 @patch('wazuh.core.task_dispatcher.TaskDispatcher.run_local', new_callable=AsyncMock)
 @patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
 @patch('wazuh.core.task_dispatcher.time.time')
-async def test_execute_local_request_async(mock_time, mock_debug_log, mock_run_local, funct, logger):
-    """Test that `execute_local_request` calculates and logs execution time."""
+async def test_execute_local_request_handle_agent_wildcard(mock_time, mock_debug_log, mock_run_local, funct, logger):
+    """Test `execute_local_request` remove agents wildcard."""
     mock_time.side_effect = [10, 15]
-    dispatcher = TaskDispatcher(f=funct, logger=logger, is_async=True)
+    funct_kwargs = {'param': 'param-value', 'agent_list': '*'}
+    dispatcher = TaskDispatcher(f=funct, f_kwargs=funct_kwargs, logger=logger, is_async=True)
     mock_run_local.return_value = 'retval'
 
     result = await dispatcher.execute_local_request()
 
+    expected_run_local_f_fkwords_index = 1
+    assert mock_run_local.call_args.args[expected_run_local_f_fkwords_index] == {'param': 'param-value'}
     assert result == 'retval'
     mock_debug_log.assert_has_calls(
         [
@@ -122,30 +221,36 @@ async def test_execute_local_request_async(mock_time, mock_debug_log, mock_run_l
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'pool_key, func_name',
+    [('thread_pool', 'any_func'), ('authentication_pool', 'check_token'), ('process_pool', 'non_matching_func')],
+)
 @patch('wazuh.core.task_dispatcher.asyncio.get_event_loop')
 @patch('wazuh.core.task_dispatcher.TaskDispatcher.debug_log')
-@patch('wazuh.core.task_dispatcher.pools', {'thread_pool': 'fake_pool'})
 @patch('wazuh.core.task_dispatcher.time.time')
-async def test_execute_local_request_sync(mock_time, mock_debug_log, mock_get_loop, funct, logger):
+async def test_execute_local_request_sync(mock_time, mock_debug_log, mock_get_loop, funct, logger, pool_key, func_name):
     """Test sync execution flow with timing and debug logging."""
     mock_time.side_effect = [10, 15]
+    funct.__name__ = func_name
+
     dispatcher = TaskDispatcher(f=funct, logger=logger, is_async=False)
 
     loop = MagicMock()
     loop.run_in_executor.return_value = AsyncMock(return_value='mocked_result')()
     mock_get_loop.return_value = loop
 
-    result = await dispatcher.execute_local_request()
+    with patch.dict('wazuh.core.task_dispatcher.pools', {pool_key: 'mocked_pool'}, clear=True):
+        result = await dispatcher.execute_local_request()
 
-    assert result == 'mocked_result'
-    mock_debug_log.assert_has_calls(
-        [
-            call('Starting to execute request locally'),
-            call('Finished executing request locally'),
-            call('Time calculating request result: 5.000s'),
-        ]
-    )
-    loop.run_in_executor.assert_called_once()
+        assert result == 'mocked_result'
+        mock_debug_log.assert_has_calls(
+            [
+                call('Starting to execute request locally'),
+                call('Finished executing request locally'),
+                call('Time calculating request result: 5.000s'),
+            ]
+        )
+        loop.run_in_executor.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -182,3 +287,45 @@ async def test_execute_local_request_broken_process_pool(mock_debug_log, mock_ge
     logger.error.assert_called_once_with(exception.WazuhException.ERRORS[901], exc_info=True)
     mock_debug_log.assert_called_once_with('Starting to execute request locally')
     loop.run_in_executor.assert_called_once()
+
+
+@patch('wazuh.core.task_dispatcher.common.rbac', new_callable=MagicMock)
+@patch('wazuh.core.task_dispatcher.common.current_user', new_callable=MagicMock)
+@patch('wazuh.core.task_dispatcher.common.origin_module', new_callable=MagicMock)
+@patch('wazuh.core.task_dispatcher.common.rbac_manager', new_callable=MagicMock)
+@patch('wazuh.core.task_dispatcher.common.reset_context_cache', new_callable=MagicMock)
+def test_run_local_sets_contextvars_and_returns_data(
+    mock_reset, mock_rbac_manager, mock_origin_module, mock_current_user, mock_rbac, funct
+):
+    """Test that `run_local` sets contextvars, calls the function and resets the context cache."""
+    f_kwargs = {'arg': 'val'}
+    rbac_permissions = {'rule': 'allowed'}
+    current_user_val = 'test-user'
+    origin_module_val = 'test-module'
+    rbac_manager_val = 'mock-manager'
+
+    # Mocking the set method of ContextVar
+    mock_rbac.set = MagicMock()
+    mock_current_user.set = MagicMock()
+    mock_origin_module.set = MagicMock()
+    mock_rbac_manager.set = MagicMock()
+
+    # Setup mock function to return a value
+    funct.return_value = 'dummy-result'
+
+    result = TaskDispatcher.run_local(
+        f=funct,
+        f_kwargs=f_kwargs,
+        rbac_permissions=rbac_permissions,
+        current_user=current_user_val,
+        origin_module=origin_module_val,
+        rbac_manager=rbac_manager_val,
+    )
+
+    assert result == 'dummy-result'
+    funct.assert_called_once_with(**f_kwargs)
+    mock_rbac.set.assert_called_once_with(rbac_permissions)
+    mock_current_user.set.assert_called_once_with(current_user_val)
+    mock_origin_module.set.assert_called_once_with(origin_module_val)
+    mock_rbac_manager.set.assert_called_once_with(rbac_manager_val)
+    mock_reset.assert_called_once()


### PR DESCRIPTION
|Related issue|
|---|
|#28705|

## Description

This PR aims to create a framework request handling mechanism similar to DAPI, but without the logic needed to distribute them across the cluster, since Wazuh Indexer will be used instead

## Changes highlights

- Create TaskDispatcher based on a lightweight copy of DistributedAPI, that only allows local executions
- Preserve the DistributedAPI facade signature, only the naming, to avoid modifying the callers
- Remove DAPI information from responses, and schemas adaptation as well. Fixed UT
- Remove event ingestion endpoint backend support and reduce by one the expected wazuh-server pid count for management-api damon
- Fix coding style for modified files (all of it)

## Known issues

- Framework tests failing: https://github.com/wazuh/wazuh/pull/29141

##  Manual test
<details><summary>Starting Wazuh server without create agents</summary>

```console
root@wazuh-dev:/# /usr/share/wazuh-server/bin/wazuh-server start
2025/04/21 10:48:20 INFO: [Server] [Main] Starting server (pid: 620058)
2025/04/21 10:48:20 INFO: [Server] [Main] Configuration server is not available, retrying...
2025/04/21 10:48:20 INFO: [Server] [Config Server] Started server process [620058]
2025/04/21 10:48:20 INFO: [Server] [Config Server] Waiting for application startup.
2025/04/21 10:48:20 INFO: [Server] [Config Server] Application startup complete.
2025/04/21 10:48:20 INFO: [Server] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/04/21 10:48:21 INFO: [Server] [Main] Starting wazuh-engined
2025-04-21 10:48:21.347 620075:620075 info: Logging initialized.
2025/04/21 10:48:21 INFO: [Server] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-04-21 10:48:21.350 620075:620075 info: Metrics manager configured successfully
2025-04-21 10:48:21.350 620075:620075 info: Metrics initialized.
2025-04-21 10:48:21.350 620075:620075 info: Metrics disabled.
2025-04-21 10:48:21.350 620075:620075 info: Store initialized.
2025-04-21 10:48:21.350 620075:620075 info: RBAC initialized.
2025-04-21 10:48:21.409 620075:620075 info: KVDB initialized.
2025-04-21 10:48:21.409 620075:620075 info: Geo initialized.
2025-04-21 10:48:21.428 620075:620075 info: Schema initialized.
2025-04-21 10:48:21.446 620075:620075 info: Loaded timezone database version: '2024a'
2025-04-21 10:48:21.446 620075:620075 info: HLP initialized.
2025-04-21 10:48:21.511 620075:620075 info: Indexer Connector initialized.
2025-04-21 10:48:21.513 620075:620075 info: Builder initialized.
2025-04-21 10:48:21.513 620075:620075 info: Catalog initialized.
2025-04-21 10:48:21.513 620075:620075 info: Policy manager initialized.
2025-04-21 10:48:21.514 620075:620075 info: No flooding file provided, the queue will not be flooded.
2025-04-21 10:48:21.526 620075:620075 info: No flooding file provided, the queue will not be flooded.
2025-04-21 10:48:21.526 620075:620075 warning: Router: router/router/0 table is empty
2025-04-21 10:48:21.526 620075:620075 warning: Router: router/tester/0 table is empty
2025-04-21 10:48:21.526 620075:620075 info: Router initialized.
2025-04-21 10:48:21.571 620075:620075 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-04-21 10:48:21.573 620075:620075 info: Server API_SRV started in thread 139638941361728 at /run/wazuh-server/engine-api.socket
2025-04-21 10:48:21.573 620075:620075 info: Starting server EVENT_SRV at /run/wazuh-server/engine.socket
2025/04/21 10:48:23 INFO: [Server] [Main] Started wazuh-engined (pid: 620075)
2025/04/21 10:48:23 INFO: [Server] [Main] Starting wazuh-comms-apid
2025/04/21 10:48:25 INFO: [Server] [Main] Started wazuh-comms-apid (pid: 620174)
2025/04/21 10:48:25 INFO: [Server] [Main] Starting wazuh-server-management-apid
2025/04/21 10:48:25 INFO: [Communications API] Starting API
2025/04/21 10:48:25 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/04/21 10:48:25 INFO: [Communications API] Starting gunicorn 22.0.0
2025/04/21 10:48:25 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (620174)
2025/04/21 10:48:25 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/04/21 10:48:25 INFO: [Communications API] Booting worker with pid: 620220
2025/04/21 10:48:25 INFO: [Communications API] Started server process [620174]
2025/04/21 10:48:25 INFO: [Communications API] Waiting for application startup.
2025/04/21 10:48:25 INFO: [Communications API] Application startup complete.
2025/04/21 10:48:25 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/04/21 10:48:25 INFO: [Communications API] Booting worker with pid: 620221
2025/04/21 10:48:25 INFO: [Communications API] Started server process [620221]
2025/04/21 10:48:25 INFO: [Communications API] Waiting for application startup.
2025/04/21 10:48:25 INFO: [Communications API] Application startup complete.
2025/04/21 10:48:26 INFO: [Communications API] Booting worker with pid: 620222
2025/04/21 10:48:26 INFO: [Communications API] Started server process [620222]
2025/04/21 10:48:26 INFO: [Communications API] Waiting for application startup.
2025/04/21 10:48:26 INFO: [Communications API] Application startup complete.
2025/04/21 10:48:26 INFO: [Communications API] Booting worker with pid: 620223
2025/04/21 10:48:26 INFO: [Communications API] Started server process [620223]
2025/04/21 10:48:26 INFO: [Communications API] Waiting for application startup.
2025/04/21 10:48:26 INFO: [Communications API] Application startup complete.
2025/04/21 10:48:27 INFO: [Server] [Main] Started wazuh-server-management-apid (pid: 620184)
2025/04/21 10:48:27 WARNING: [Server] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': True, 'wazuh-engined': True}. Sleeping until next checking...
2025/04/21 10:48:27 INFO: [Management API] Starting API
2025/04/21 10:48:28 INFO: [Management API] Updating RBAC information
2025/04/21 10:48:28 DEBUG: [Management API] Connecting to the indexer client.
2025/04/21 10:48:28 INFO: [Management API] Listening on 0.0.0.0:55000.
2025/04/21 10:48:28 INFO: [Management API] Getting installation UID...
2025/04/21 10:48:28 INFO: [Management API] Getting updates information...
2025/04/21 10:48:28 DEBUG: [Management API] Closing the indexer client session.
2025/04/21 10:48:37 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 10:48:47 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 10:48:57 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 10:49:07 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 10:49:17 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 10:49:28 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 10:49:38 INFO: [Server] [Main] Getting orders from indexer
```
</details>

<details><summary>Auth against the Management API</summary>

```console
root@wazuh-dev:~# TOKEN=$(curl -u wazuh:wazuh -s -k -X POST https://0.0.0.0:55000/security/user/authenticate | jq -r '.data.token') && echo $TOKENi
eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzQ1MjQ0NjcxLCJleHAiOjE3NDUyNDU1NzEsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WyJhZG1pbmlzdHJhdG9yIl0sInJiYWNfbW9kZSI6IndoaXRlIn0.V4Wt-dLpC-50mt8_ndMfQWml52pewkmD9IXkUtQbNPDVS-gzmx509Z3lW3UQwFivU5NZb2UX6J28bc4qlEuGRDLUpK4JBf7jglSujXmtul_nYl5skI7uKWujQAkij8kLyvjwNoVIdF91qQo5ZsSLzNvmfQBMRaTpjWId2TVrsXN14h8k40yKbVD7-tP9FvvxeJf8vjfUrMqD583WvfdBmy7QHVdSWYjrWhmXNQW26hZtJTgkMUfxqYmgbCDTM6Cj2FhmSejiyVsPsntvXjEqgrwUJPNavISXPAJDPsm6wDqreypAC_NtvEcXZz-4S7fabra0Oab-ogOHWxZEZsBwrQ
```
</details>

<details><summary>Get Wazuh indexer user</summary>

```console
root@wazuh-dev:~/repos/wazuh# curl -X GET -H "$CONTENT_TYPE" -ksu $INDEXER_USERNAME:$INDEXER_PASSWORD -w "\n" $INDEXER_URL/wazuh-internal-users/_do
c/wazuh
{"_index":"wazuh-internal-users","_id":"wazuh","_version":2,"_seq_no":1,"_primary_term":1,"found":true,"_source":{"user":{"id":"wazuh","name":"wazuh","password":"9UwarPXx85C67NpZPnkBKMM1By19GWSUnmAwyOP51EQC3ml4tM8CM9a1TFw0JRjs","allow_run_as":true,"created_at":"2025-04-21T14:05:56.941741049Z","roles":[{"name":"administrator","level":0,"policies":[{"name":"agents_all","actions":["agent:read","agent:delete","agent:modify_group","agent:reconnect","agent:restart"],"resources":["*:*:*"],"effect":"allow","level":0},{"name":"groups_all","actions":["group:read","group:delete","group:update_config","group:modify_assignments"],"resources":["*:*:*"],"effect":"allow","level":0},{"name":"security_all","actions":["security:create","security:create_user","security:read_config","security:update_config","security:revoke","security:edit_run_as","security:read","security:update","security:delete"],"resources":["*:*:*"],"effect":"allow","level":0}],"rules":[]}]}}}
```
</details>

<details><summary>Get agents</summary>

```console
root@wazuh-dev:~# curl -H "Authorization: Bearer $TOKEN" -X GET -ks https://0.0.0.0:55000/agents | jq
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "No agent information was returned",
  "error": 0
}
```
</details>

<details><summary>Add a new agent (expected to fail)</summary>

```console
root@wazuh-dev:~# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 403 Forbidden
date: Mon, 21 Apr 2025 14:12:21 GMT
content-type: application/problem+json; charset=utf-8
content-length: 325

{"title": "Permission Denied", "detail": "Permission denied: Resource type: *:*", "remediation": "Please, make sure you have permissions to execute the current request. For more information on how to set up permissions, please visit https://documentation.wazuh.com/5.0/user-manual/api/rbac/configuration.html", "error": 4000}
```
</details>

<details><summary>Add  agent creation permissions</summary>

```console
root@wazuh-dev:~/repos/wazuh# curl -X POST -H "$CONTENT_TYPE" -ksu $INDEXER_USERNAME:$INDEXER_PASSWORD -w "\n" $INDEXER_URL/wazuh-internal-users/_doc/wazuh -d'
{
    "user": {
        "id": "wazuh",
        "name": "wazuh",
        "password": "9UwarPXx85C67NpZPnkBKMM1By19GWSUnmAwyOP51EQC3ml4tM8CM9a1TFw0JRjs",
        "allow_run_as": true,
        "created_at": 0,
        "roles": [
            {
                "name": "administrator",
                "level": 0,
                "policies": [
                    {
                        "name": "agents_all",
                        "actions": ["agent:create", "agent:read", "agent:delete", "agent:modify_group", "agent:reconnect", "agent:restart"],
                        "resources": ["*:*:*"],
                        "effect": "allow",
                        "level": 0
                    },
                    {
                        "name": "groups_all",
                        "actions": ["group:read", "group:delete", "group:update_config", "group:modify_assignments"],
                        "resources": ["*:*:*"],
                        "effect": "allow",
}'  }   ]   }   "rules": []vel": 0
{"_index":"wazuh-internal-users","_id":"wazuh","_version":3,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1}
```
</details>

<details><summary>Restart the Wazuh server to reload permissions</summary>

```console
root@wazuh-dev:/# /usr/share/wazuh-server/bin/wazuh-server start
2025/04/21 11:15:18 INFO: [Server] [Main] Starting server (pid: 634992)
2025/04/21 11:15:18 INFO: [Server] [Main] Configuration server is not available, retrying...
2025/04/21 11:15:18 INFO: [Server] [Config Server] Started server process [634992]
2025/04/21 11:15:18 INFO: [Server] [Config Server] Waiting for application startup.
2025/04/21 11:15:18 INFO: [Server] [Config Server] Application startup complete.
2025/04/21 11:15:18 INFO: [Server] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
2025/04/21 11:15:19 INFO: [Server] [Main] Starting wazuh-engined
2025-04-21 11:15:19.889 635009:635009 info: Logging initialized.
2025/04/21 11:15:19 INFO: [Server] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
2025-04-21 11:15:19.894 635009:635009 info: Metrics manager configured successfully
2025-04-21 11:15:19.894 635009:635009 info: Metrics initialized.
2025-04-21 11:15:19.894 635009:635009 info: Metrics disabled.
2025-04-21 11:15:19.894 635009:635009 info: Store initialized.
2025-04-21 11:15:19.894 635009:635009 info: RBAC initialized.
2025-04-21 11:15:19.937 635009:635009 info: KVDB initialized.
2025-04-21 11:15:19.937 635009:635009 info: Geo initialized.
2025-04-21 11:15:19.954 635009:635009 info: Schema initialized.
2025-04-21 11:15:19.969 635009:635009 info: Loaded timezone database version: '2024a'
2025-04-21 11:15:19.969 635009:635009 info: HLP initialized.
2025-04-21 11:15:20.027 635009:635009 info: Indexer Connector initialized.
2025-04-21 11:15:20.029 635009:635009 info: Builder initialized.
2025-04-21 11:15:20.029 635009:635009 info: Catalog initialized.
2025-04-21 11:15:20.029 635009:635009 info: Policy manager initialized.
2025-04-21 11:15:20.030 635009:635009 info: No flooding file provided, the queue will not be flooded.
2025-04-21 11:15:20.038 635009:635009 info: No flooding file provided, the queue will not be flooded.
2025-04-21 11:15:20.038 635009:635009 warning: Router: router/router/0 table is empty
2025-04-21 11:15:20.038 635009:635009 warning: Router: router/tester/0 table is empty
2025-04-21 11:15:20.038 635009:635009 info: Router initialized.
2025-04-21 11:15:20.077 635009:635009 error: Error opening the database: Couldn't find column family: 'vendor_map', trying to re-download the feed.
2025-04-21 11:15:20.079 635009:635009 info: Server API_SRV started in thread 139643924235840 at /run/wazuh-server/engine-api.socket
2025-04-21 11:15:20.079 635009:635009 info: Starting server EVENT_SRV at /run/wazuh-server/engine.socket
2025/04/21 11:15:21 INFO: [Server] [Main] Started wazuh-engined (pid: 635009)
2025/04/21 11:15:21 INFO: [Server] [Main] Starting wazuh-comms-apid
2025/04/21 11:15:23 INFO: [Communications API] Starting API
2025/04/21 11:15:23 INFO: [Communications API] Listening on 0.0.0.0:27000
2025/04/21 11:15:23 INFO: [Communications API] Starting gunicorn 22.0.0
2025/04/21 11:15:23 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (635135)
2025/04/21 11:15:23 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
2025/04/21 11:15:23 INFO: [Communications API] Booting worker with pid: 635171
2025/04/21 11:15:23 INFO: [Server] [Main] Started wazuh-comms-apid (pid: 635135)
2025/04/21 11:15:23 INFO: [Server] [Main] Starting wazuh-server-management-apid
2025/04/21 11:15:23 INFO: [Communications API] Booting worker with pid: 635173
2025/04/21 11:15:23 INFO: [Communications API] Started server process [635135]
2025/04/21 11:15:23 INFO: [Communications API] Waiting for application startup.
2025/04/21 11:15:23 INFO: [Communications API] Application startup complete.
2025/04/21 11:15:23 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
2025/04/21 11:15:23 INFO: [Communications API] Booting worker with pid: 635174
2025/04/21 11:15:23 INFO: [Communications API] Started server process [635174]
2025/04/21 11:15:23 INFO: [Communications API] Waiting for application startup.
2025/04/21 11:15:23 INFO: [Communications API] Application startup complete.
2025/04/21 11:15:23 INFO: [Communications API] Booting worker with pid: 635175
2025/04/21 11:15:23 INFO: [Communications API] Started server process [635175]
2025/04/21 11:15:23 INFO: [Communications API] Waiting for application startup.
2025/04/21 11:15:23 INFO: [Communications API] Application startup complete.
2025/04/21 11:15:25 INFO: [Management API] Starting API
2025/04/21 11:15:25 INFO: [Server] [Main] Started wazuh-server-management-apid (pid: 635172)
2025/04/21 11:15:26 INFO: [Management API] Updating RBAC information
2025/04/21 11:15:26 INFO: [Management API] Listening on 0.0.0.0:55000.
2025/04/21 11:15:26 DEBUG: [Management API] Connecting to the indexer client.
2025/04/21 11:15:26 INFO: [Management API] Getting installation UID...
2025/04/21 11:15:26 INFO: [Management API] Getting updates information...
2025/04/21 11:15:26 DEBUG: [Management API] Closing the indexer client session.
2025/04/21 11:15:35 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:15:45 INFO: [Management API] wazuh 127.0.0.1 "POST /security/user/authenticate" with parameters {} and body {} done in 0.132s: 200
2025/04/21 11:15:46 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:15:47 DEBUG: [Management API] Decoded token {'username': 'wazuh', 'roles': ('administrator',), 'token_nbf_time': 1745244945, 'run_as': False}
2025/04/21 11:15:47 DEBUG: [Management API] Connecting to the indexer client.
2025/04/21 11:15:48 DEBUG: [Management API] Closing the indexer client session.
2025/04/21 11:15:48 INFO: [Management API] wazuh 127.0.0.1 "POST /agents" with parameters {} and body {"id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0", "name": "test", "key": "****", "type": "endpoint", "version": "5.0.0"} done in 0.144s: 201
2025/04/21 11:15:56 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:16:06 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:16:16 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:16:26 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:16:33 DEBUG: [Management API] Decoded token {'username': 'wazuh', 'roles': ('administrator',), 'token_nbf_time': 1745244945, 'run_as': False}
2025/04/21 11:16:33 DEBUG: [Management API] Connecting to the indexer client.
2025/04/21 11:16:33 DEBUG: [Management API] Closing the indexer client session.
2025/04/21 11:16:33 INFO: [Management API] wazuh 127.0.0.1 "GET /agents" with parameters {} and body {} done in 0.095s: 200
2025/04/21 11:16:36 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:16:46 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:16:56 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:17:06 INFO: [Server] [Main] Getting orders from indexer
2025/04/21 11:17:16 INFO: [Server] [Main] Getting orders from indexer
```
</details>

<details><summary>Add agent</summary>

```console
root@wazuh-dev:~# TOKEN=$(curl -u wazuh:wazuh -s -k -X POST https://0.0.0.0:55000/security/user/authenticate | jq -r '.data.token') && echo $TOKENi
eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzQ1MjQ0OTQ1LCJleHAiOjE3NDUyNDU4NDUsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WyJhZG1pbmlzdHJhdG9yIl0sInJiYWNfbW9kZSI6IndoaXRlIn0.Rp9PVWPc7IoFIWFj99R9oZjRgkRlr4Bjfw0lNQIfwvevv-pBn5KwpSbTjWhYUVxymK5bAbxA6x3WRIUR3cK6H5bxL5tCNRIsvWIPpcdNgw4aM-XcuD5jxweCpB6ib0EBnSC2GQmj5YTe88gMe-JeJOTobP32l-SrCv3RT-vG4Fky4RMyZwBK1jD7i5lJ3GHWb0qgKve0ufyY4xhDX3OAI07Be27GxoT3CzxWwAaJxYaxe4TP2jid3rsuB4Ocu9_uGgJJohCpe1zexLI9sXdg0cAKyiYRCOewx02V0zK9_UZcn6hiXQvBYadJjqkNdX5p9c_OYOSgQUrLx-G16nyK6g
root@wazuh-dev:~# curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55000/agents -d '
{
  "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
  "name": "test",
  "key": "7b8276c3bf96aff5709346d368f04fed",
  "type": "endpoint",
  "version": "5.0.0"
}
'
HTTP/1.1 201 Created
date: Mon, 21 Apr 2025 14:15:47 GMT
content-length: 0
server: Wazuh
strict-transport-security: max-age=63072000; includeSubdomains
x-frame-options: deny
x-xss-protection: 0
x-content-type-options: nosniff
content-security-policy: none
referrer-policy: no-referrer, strict-origin-when-cross-origin
cache-control: no-store
```

</details>

<details><summary>Check agent creation</summary>

```console
root@wazuh-dev:~# curl -H "Authorization: Bearer $TOKEN" -X GET -ks https://0.0.0.0:55000/agents | jq
{
  "data": {
    "affected_items": [
      {
        "id": "0a96a0ab-5bef-415c-bb3c-ea3e294215a0",
        "name": "test",
        "key": "deRfRSPRpqO+Cy+2vcqGRbwodm57UtyLYc7zAbjXAX4qvBZjamyq0tIrHHrbGC2Z",
        "type": "endpoint",
        "version": "5.0.0",
        "status": "never_connected"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```