### PR TITLE
Handle Azure's blob race condition

### DIFF
--- a/wodles/azure/azure_services/storage.py
+++ b/wodles/azure/azure_services/storage.py
@@ -12,7 +12,8 @@ from hashlib import md5
 from json import JSONDecodeError, dumps, loads
 from os.path import abspath, dirname
 
-from azure.core.exceptions import AzureError, ClientAuthenticationError, HttpResponseError
+from azure.core.exceptions import AzureError, ClientAuthenticationError, HttpResponseError, ResourceExistsError, \
+    ResourceModifiedError
 from azure.storage.blob import BlobServiceClient
 from dateutil.parser import parse
 
@@ -204,8 +205,9 @@ def get_blobs(
 
             # Get the blob data
             try:
-                logging.info(f"Getting data from blob {blob.name}")
-                data = container_client.download_blob(blob, encoding="UTF-8", max_concurrency=2)
+                data = download_blob(container_client, blob)
+            except ResourceModifiedError as e:
+                logging.error(f'Storage: Error downloading blob "{blob.name}" after multiple retries: {e}')
             except (ValueError, AzureError, HttpResponseError) as e:
                 logging.error(f'Storage: Error reading the blob data: "{e}".')
                 continue
@@ -255,3 +257,35 @@ def get_blobs(
                 new_min=last_modified.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                 new_max=last_modified.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             )
+
+def download_blob(container_client, blob, number_of_retries=3):
+    """
+    Downloads a blob from Azure Storage with retry logic on ResourceModifiedError.
+
+    Parameters:
+        container_client: The Azure container client instance.
+        blob: The blob object or name to download.
+        number_of_retries: Maximum number of retry attempts (default: 3).
+
+    Returns:
+        The downloaded blob data on success.
+
+    Raises:
+        ResourceModifiedError: If the blob keeps being modified after all retries.
+        ValueError, AzureError, HttpResponseError: For other download errors.
+    """
+    attempt = 1
+
+    while attempt <= number_of_retries:
+        try:
+            logging.info(f"Getting data from blob {blob.name}")
+            data = container_client.download_blob(blob, encoding="UTF-8", max_concurrency=2)
+            return data
+        except ResourceModifiedError as e:
+            if attempt == number_of_retries:
+                raise e
+            logging.info(f"Blob {blob.name} was modified while downloading, retrying download.")
+            attempt += 1
+
+        except (ValueError, AzureError, HttpResponseError) as e:
+            raise e


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28386|



## Description

Add a retry logic for cases where an Azure blob is being modified while the download is in progress.