### PR TITLE
IP and Date fields for inventory and syscheck revised

### DIFF
--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netElement.hpp
@@ -58,7 +58,10 @@ public:
         }
 
         // Ex: 192.168.0.255
-        element.data.network.broadcast = data->broadcast();
+        if (auto networkBroadcast = data->broadcast(); networkBroadcast.compare(" ") != 0)
+        {
+            element.data.network.broadcast = networkBroadcast;
+        }
 
         // Ex: 192.168.0.30
         element.data.network.ip = data->address();
@@ -67,7 +70,10 @@ public:
         element.data.network.name = data->netAddressName();
 
         // 255.255.255.0
-        element.data.network.netmask = data->netmask();
+        if (auto networkNetmask = data->netmask(); networkNetmask.compare(" ") != 0)
+        {
+            element.data.network.netmask = networkNetmask;
+        }
 
         // Ex: IPv4
         if (!data->protocol())

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/networkProtocolElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/networkProtocolElement.hpp
@@ -61,7 +61,14 @@ public:
         }
 
         element.data.network.dhcp = data->netProtoDhcp().compare("enabled") == 0 ? true : false;
-        element.data.network.gateway = data->netProtoGateway();
+
+        // Gateway separator ","
+        if (auto networkGateway = data->netProtoGateway();
+            networkGateway.compare(" ") != 0 && networkGateway.find(',') == std::string_view::npos)
+        {
+            element.data.network.gateway = networkGateway;
+        }
+
         element.data.network.metric = data->netProtoMetric();
         element.data.network.type = data->netProtoType();
 


### PR DESCRIPTION
|Related issue|
|---|
|#29240|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description 

Some fields expecting certain format (e.g. ip) were returning " " causing indexing errors. Other cases were analyzed here https://github.com/wazuh/wazuh/issues/29240#issuecomment-2818978454

For gateway it was discarded if the field contains more than one gateway. 

## DoD

15 errors before fix all related to protocol gateway and address broadcast 

[errors.log](https://github.com/user-attachments/files/19839379/errors.log)

I could identify these IDs 

```console
001_4c0875658cf376ccec8a0e31c4728b106697b715
001_528a1802119a491c04c22b4d2ca97d8b6010c945
001_52de87779cb1c0b9b15e3bc66350aaccc722f7c2
001_55604a20b704e491c9afb7320962fe4a0d9d6288
001_65cba16a628b8d44376edad047917e02b4ce2934
001_818ec476f1c5add149570bea0ab8b366b8938fc9
001_833209683780c3388298c23e5826678311bd72a1
001_92245c06b5120c62174799e7f531d4df81619672
001_dce561a4dc90d98deddfd902bfc3c0e7988f7b56
001_dfe812552839c6ebe5b27ef2fab4af030cd2d1f4
```

We can see those index now in the wazuh-indexer 

![image](https://github.com/user-attachments/assets/c36e6c92-c335-4e4c-908e-97b9e9f505b0)

[addresses.json](https://github.com/user-attachments/files/19839579/addresses.json)
[protocols.json](https://github.com/user-attachments/files/19839580/protocols.json)

No errors found during indexing 

![image](https://github.com/user-attachments/assets/c6232ebe-1bd8-4f28-af47-b756ab101433)


