### PR TITLE
Improve sessions management in health tests

### DIFF
--- a/src/engine/test/engine-test-utils/src/engine_handler/handler.py
+++ b/src/engine/test/engine-test-utils/src/engine_handler/handler.py
@@ -7,6 +7,7 @@ from typing import Optional
 from api_communication.client import APIClient
 from api_communication.proto import router_pb2 as api_router
 
+DEFAULT_ENGINE_RETRY_SLEEP: int = 2
 
 class EngineHandler:
     """EngineHandler class is responsible for starting and stopping an Engine process"""
@@ -97,7 +98,7 @@ class EngineHandler:
             if error == None:
                 break
 
-            time.sleep(1)
+            time.sleep(DEFAULT_ENGINE_RETRY_SLEEP)
             current_attempt += 1
 
         if current_attempt == max_attempts:

--- a/src/engine/test/health_test/engine-health-test/src/health_test/coverage_validate.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/coverage_validate.py
@@ -4,6 +4,7 @@ import shared.resource_handler as rs
 import sys
 from typing import List, Tuple, Optional, Union
 from engine_handler.handler import EngineHandler
+from shared.default_settings import Constants
 import json
 import subprocess
 
@@ -341,7 +342,7 @@ def run_test(test_parent_path: Path, engine_api_socket: str, debug_mode: str, ta
 
         ns = "wazuh system" if target == 'rule' else "wazuh"
         engine_test_command = f"engine-test -c {engine_test_conf.resolve().as_posix()} "
-        engine_test_command += f"run {test_name} --api-socket {engine_api_socket} -n {ns} {debug_mode} -j"
+        engine_test_command += f"run {test_name} -s {Constants.DEFAULT_SESSION} --api-socket {engine_api_socket} -n {ns} {debug_mode} -j"
         command = f"cat {input_file.resolve().as_posix()} | {engine_test_command}"
         test_result = test(input_file, command, engine_api_socket, asset_traces_by_stage)
         if test_result:

--- a/src/engine/test/health_test/engine-health-test/src/health_test/test_suite.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/test_suite.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List, Tuple, Optional, Union
 from abc import ABC, abstractmethod
 from engine_handler.handler import EngineHandler
-
+from shared.default_settings import Constants
 
 class UnitOutput:
     def __init__(self, index: int, result: Union[str, dict]):
@@ -188,7 +188,7 @@ def run_test(test_parent_path: Path, engine_api_socket: str, unit_result: type, 
 
         ns = "wazuh system" if target == 'rule' else "wazuh"
         engine_test_command = f"engine-test -c {engine_test_conf.resolve().as_posix()} "
-        engine_test_command += f"run {test_name} --api-socket {engine_api_socket} -n {ns} {debug_mode} -j"
+        engine_test_command += f"run {test_name} -s {Constants.DEFAULT_SESSION} --api-socket {engine_api_socket} -n {ns} {debug_mode} -j"
         command = f"cat {input_file.resolve().as_posix()} | {engine_test_command}"
         test_result = test(input_file, expected_file,
                            unit_result, command, target, help)

--- a/src/engine/test/health_test/engine-health-test/src/health_test/validate_event_indexing.py
+++ b/src/engine/test/health_test/engine-health-test/src/health_test/validate_event_indexing.py
@@ -9,6 +9,8 @@ import sys
 import subprocess
 from engine_handler.handler import EngineHandler
 from shared.default_settings import Constants, CONFIG_ENV_KEYS
+from api_communication.proto import tester_pb2 as api_tester
+
 import yaml
 from api_communication.proto import catalog_pb2 as api_catalog
 from api_communication.proto import engine_pb2 as api_engine
@@ -307,7 +309,7 @@ def run_all_tests(test_parent_paths: List[Path], engine_api_socket: str) -> Dict
             test_name = test_parent_name
             if input_file.parent != test_dir:
                 test_name = f"{test_parent_name}-{input_file.parent.name}"
-            engine_test_command = f"engine-test -c {engine_test_conf.resolve().as_posix()} run {test_name} --api-socket {engine_api_socket} -j"
+            engine_test_command = f"engine-test -c {engine_test_conf.resolve().as_posix()} run {test_name} -s {Constants.DEFAULT_SESSION} --api-socket {engine_api_socket} -j"
             command = f"cat {input_file.resolve().as_posix()} | {engine_test_command}"
 
             output = test(input_file, command)
@@ -509,6 +511,18 @@ def modify_core_wazuh_decoder(file_path: Path, add_hash: bool = True):
         yaml.dump(content, file, default_flow_style=False, sort_keys=False)
 
 
+def reload_session(engine_handler: EngineHandler) -> None:
+    request = api_tester.SessionReload_Request()
+    request.name = Constants.DEFAULT_SESSION
+    print(f"Reloading session...\n{request}")
+    error, response = engine_handler.api_client.send_recv(request)
+    if error:
+        sys.exit(error)
+    parsed_response = ParseDict(response, api_engine.GenericStatus_Response())
+    if parsed_response.status == api_engine.ERROR:
+        sys.exit(parsed_response.error)
+    print("Session reloaded.")
+
 def decoder_health_test(env_path: Path, integration_name: Optional[str] = None, skip: Optional[List[str]] = None):
     print("Validating environment...")
     conf_path = (env_path / "config.env").resolve()
@@ -561,6 +575,7 @@ def decoder_health_test(env_path: Path, integration_name: Optional[str] = None, 
             load_indexer_output_in_policy(engine_handler)
         modify_core_wazuh_decoder(CORE_WAZUH_DECODER_PATH)
         update_wazuh_core_message(CORE_WAZUH_DECODER_PATH, engine_handler)
+        reload_session(engine_handler)
 
         print("\n\nRunning tests...")
         results = run_test(integrations, engine_handler.api_socket_path)
@@ -572,6 +587,8 @@ def decoder_health_test(env_path: Path, integration_name: Optional[str] = None, 
         print("Restart wazuh-core-message decoder changes")
         modify_core_wazuh_decoder(CORE_WAZUH_DECODER_PATH, add_hash=False)
         update_wazuh_core_message(CORE_WAZUH_DECODER_PATH, engine_handler)
+        reload_session(engine_handler)
+
         engine_handler.stop()
         opensearch_management.stop()
         print("Engine stopped.")
@@ -643,6 +660,7 @@ def rule_health_test(env_path: Path, ruleset_name: Optional[str] = None, skip: O
         print("Update wazuh-core-message decoder")
         modify_core_wazuh_decoder(CORE_WAZUH_DECODER_PATH)
         update_wazuh_core_message(CORE_WAZUH_DECODER_PATH, engine_handler)
+        reload_session(engine_handler)
 
         print("\n\nRunning tests...")
         results = run_test(rules, engine_handler.api_socket_path)
@@ -654,6 +672,8 @@ def rule_health_test(env_path: Path, ruleset_name: Optional[str] = None, skip: O
         print("Restart wazuh-core-message decoder changes")
         modify_core_wazuh_decoder(CORE_WAZUH_DECODER_PATH, add_hash=False)
         update_wazuh_core_message(CORE_WAZUH_DECODER_PATH, engine_handler)
+        reload_session(engine_handler)
+
         engine_handler.stop()
         opensearch_management.stop()
         # Restore level log

--- a/src/engine/tools/engine-suite/src/shared/default_settings.py
+++ b/src/engine/tools/engine-suite/src/shared/default_settings.py
@@ -1,8 +1,21 @@
 from enum import Enum
 
 class Constants:
+    """
+    A collection of constants used throughout the Wazuh Engine API integration.
+
+    Attributes:
+        SOCKET_PATH (str): Path to the Unix socket used to communicate with the engine API.
+        DEFAULT_POLICY (str): Default policy path used when none is explicitly provided.
+        DEFAULT_SESSION (str): Default session name.
+        DEFAULT_NS (str): Default namespace under which requests are made.
+        INDEX_PATTERN (str): Default OpenSearch index pattern where Wazuh alerts are stored.
+        DEFAULT_API_TIMEOUT (int): Default timeout (in microseconds) configured on the server
+                                   for API requests.
+    """
     SOCKET_PATH: str = '/run/wazuh-server/engine-api.socket'
     DEFAULT_POLICY: str = 'policy/wazuh/0'
+    DEFAULT_SESSION: str = 'default'
     DEFAULT_NS: str = 'user'
     INDEX_PATTERN: str = 'wazuh-alerts-5.x-0001'
     DEFAULT_API_TIMEOUT: int = 1000000


### PR DESCRIPTION
|Related issue|
|---|
|#29318|


## Description

This PR addresses performance bottlenecks in dynamic E2E testing by implementing session reuse within the health-test suite. Previously, each test case triggered a new invocation of engine-test, resulting in redundant session initializations and significantly slower runs.

Changes Introduced
- Session Initialization: A single session is now created at the beginning of the health-test run.

- Session Reuse: The same session is passed to each engine-test invocation throughout the suite.

- Graceful Cleanup: The session is properly closed after all tests finish, with handling for failures to ensure cleanup still occurs.

- Benchmarking: Preliminary benchmarks show a noticeable reduction in execution time for dynamic E2E tests.


## Impact
By avoiding repeated session creation, this change leads to faster test execution, improving CI throughput and reducing local iteration times for developers.