### PR TITLE
Add missing <unordered_set> include to modern package data retriever

### DIFF
--- a/src/data_provider/src/packages/modernPackageDataRetriever.hpp
+++ b/src/data_provider/src/packages/modernPackageDataRetriever.hpp
@@ -16,6 +16,7 @@
 #include "sharedDefs.h"
 #include <functional>
 #include <map>
+#include <unordered_set>
 
 #if defined(HAS_STDFILESYSTEM) && HAS_STDFILESYSTEM==true
 #include "packages/packagesNPM.hpp"


### PR DESCRIPTION
|Related issue|
|---|
| #29333 |

## Description

Missing header file `<unordered_set>` is added to [modernPackageDataRetriever.hpp](https://github.com/wazuh/wazuh/blob/7d00a9bb0ec3a670ac7803febb49509c2e856dc7/src/data_provider/src/packages/modernPackageDataRetriever.hpp), which caused an error when compiling Wazuh agent for macOS intel64.  

## Logs/Alerts example

```log
In file included from /Users/***/wazuh/src/data_provider/src/sysInfoMac.cpp:31:
/Users/***/wazuh/src/data_provider/src/packages/modernPackageDataRetriever.hpp:27:128: error: no template named 'unordered_set' in namespace 'std'; did you mean 'unordered_map'?
        void getPackages(const std::set<std::string>& /*paths*/, std::function<void(nlohmann::json&)> /*callback*/, const std::unordered_set<std::string>& /*excludePaths*/ = {});
                                                                                                                          ~~~~~^~~~~~~~~~~~~
                                                                                                                               unordered_map
/Library/Developer/CommandLineTools/usr/include/c++/v1/unordered_map:747:28: note: 'unordered_map' declared here
class _LIBCPP_TEMPLATE_VIS unordered_map
                           ^
In file included from /Users/***/wazuh/src/data_provider/src/sysInfoMac.cpp:31:
/Users/***/wazuh/src/data_provider/src/packages/modernPackageDataRetriever.hpp:27:128: error: too few template arguments for class template 'unordered_map'
        void getPackages(const std::set<std::string>& /*paths*/, std::function<void(nlohmann::json&)> /*callback*/, const std::unordered_set<std::string>& /*excludePaths*/ = {});
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
- [Packages - Build Wazuh agent macOS packages - intel64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/14596443052) :green_circle: 
- [Packages - Build Wazuh agent Linux amd - legacy packages - rpm - x86_64](https://github.com/wazuh/wazuh-agent-packages/actions/runs/14598101738) :green_circle: 
