### PR TITLE
Add Python dependency vulnerability checks for non-default branches

### DIFF
--- a/.github/workflows/5_codeanalysis_python-vulns.yml
+++ b/.github/workflows/5_codeanalysis_python-vulns.yml
@@ -1,7 +1,8 @@
 name: 'Python dependency vuln checks'
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
 jobs:
   pick-branches:
     name: Get branches to analyze
@@ -48,7 +49,7 @@ jobs:
           ref: ${{ matrix.ref }}
           fetch-depth: 0
 
-      - name: Run Trivy vulnerability scanner in repo mode
+      - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.30.0
         with:
           scan-type: 'fs'

--- a/.github/workflows/5_codeanalysis_python-vulns.yml
+++ b/.github/workflows/5_codeanalysis_python-vulns.yml
@@ -1,4 +1,4 @@
-name: 'Python dependency vuln checks'
+name: 'Python vulnerability checks'
 on:
   workflow_dispatch:
   schedule:
@@ -14,8 +14,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git fetch --all --prune
-
       - name: Generate dynamic matrix
         id: set-matrix
         run: |
@@ -30,7 +28,6 @@ jobs:
 
           echo "matrix=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
           echo Picked branches: $JSON_ARRAY
-
 
   checking-py-vulns:
     needs: pick-branches

--- a/.github/workflows/5_codeanalysis_python-vulns.yml
+++ b/.github/workflows/5_codeanalysis_python-vulns.yml
@@ -1,0 +1,64 @@
+name: 'Python dependency vuln checks'
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  pick-branches:
+    name: Get branches to analyze
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: git fetch --all --prune
+
+      - name: Generate dynamic matrix
+        id: set-matrix
+        run: |
+            VERSIONED_BRANCHES_REGEX="^(main|[0-9]{1,3}\.[0-9]{1,2}(\.[0-9]{1,2})?)$"
+
+            # Filtrar ramas remotas válidas
+            BRANCHES=$(git branch -r | grep -Eo "origin/$VERSIONED_BRANCHES_REGEX" | sed 's|origin/||')
+
+            # Construir array JSON de objetos {ref, sha}
+            JSON_ARRAY=$(printf '%s\n' "$BRANCHES" | while read -r ref; do
+              sha=$(git rev-parse "origin/$ref")
+              jq -n --arg ref "$ref" --arg sha "$sha" '{ref: $ref, sha: $sha}'
+            done | jq -s '{include: .}')
+
+            echo "matrix=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+
+  checking-py-vulns:
+    needs: pick-branches
+    name: Checking Python vulnerabilies
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.ref }}
+          fetch-depth: 0
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'fs'
+          scanners: 'vuln'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          ref: refs/heads/${{ matrix.ref }}
+          sha: ${{ matrix.sha }}
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/5_codeanalysis_python-vulns.yml
+++ b/.github/workflows/5_codeanalysis_python-vulns.yml
@@ -18,25 +18,25 @@ jobs:
       - name: Generate dynamic matrix
         id: set-matrix
         run: |
-            VERSIONED_BRANCHES_REGEX="^(main|[0-9]{1,3}\.[0-9]{1,2}(\.[0-9]{1,2})?)$"
+          VERSIONED_BRANCHES_REGEX="^main$|^[0-9]{1,3}\.[0-9]{2}\.[0-9]{1,2}$"
 
-            # Filtrar ramas remotas válidas
-            BRANCHES=$(git branch -r | grep -Eo "origin/$VERSIONED_BRANCHES_REGEX" | sed 's|origin/||')
+          BRANCHES=$(git branch -r | awk '{print $1}' | sed 's|origin/||' | grep -E "$VERSIONED_BRANCHES_REGEX")
 
-            # Construir array JSON de objetos {ref, sha}
-            JSON_ARRAY=$(printf '%s\n' "$BRANCHES" | while read -r ref; do
-              sha=$(git rev-parse "origin/$ref")
-              jq -n --arg ref "$ref" --arg sha "$sha" '{ref: $ref, sha: $sha}'
-            done | jq -s '{include: .}')
+          JSON_ARRAY=$(printf '%s\n' "$BRANCHES" | while read -r ref; do
+            sha=$(git rev-parse "origin/$ref")
+            jq -c -n --arg ref "$ref" --arg sha "$sha" '{ref: $ref, sha: $sha}'
+          done | jq -c -s '{include: .}')
 
-            echo "matrix=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+          echo "matrix=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+          echo Picked branches: $JSON_ARRAY
+
 
   checking-py-vulns:
     needs: pick-branches
     name: Checking Python vulnerabilies
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.pick-branches.outputs.matrix) }}
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
|Related issue|
|---|
|#29315|

## Description

This issue aims to add Python deps vuln check on non-default branches that are currently active development branches in the following format: MAJOR.MINOR.PATCH and main.

This job is scheduled to be run once a week and manually. Results will be pushed into https://github.com/wazuh/wazuh/security

https://github.com/wazuh/wazuh/actions/runs/14628017495

![image](https://github.com/user-attachments/assets/207a1c19-7b10-431a-9936-7d79369ab102)
![image](https://github.com/user-attachments/assets/d156b073-29b0-4b65-bbf9-27f99e114ec6)
