### PR TITLE
Fix host-deny active response failure on cross-filesystem rename

### DIFF
--- a/src/active-response/host-deny.c
+++ b/src/active-response/host-deny.c
@@ -206,7 +206,7 @@ int main (int argc, char **argv) {
         fclose(host_deny_fp);
         fclose(temp_host_deny_fp);
 
-        if (write_fail || rename(temp_hosts_deny_path, hosts_deny_path) != 0) {
+        if (write_fail || OS_MoveFile(temp_hosts_deny_path, hosts_deny_path) != 0) {
             memset(log_msg, '\0', OS_MAXSTR);
             snprintf(log_msg, OS_MAXSTR -1, "Unable to write file '%s'", hosts_deny_path);
             write_debug_file(argv[0], log_msg);


### PR DESCRIPTION
## Description

This pull request fixes an issue in the `host-deny` active response that prevented it from working correctly when `/etc` and `/var/ossec` were located on different mounted file systems.

```
active-response/bin/host-deny: Unable to write file '/etc/hosts.deny'
```

The problem was caused by the use of `rename()`, which does not support cross-filesystem file moves.

## Proposed Changes

The `rename()` call has been replaced with `OS_MoveFile()`, a wrapper that first attempts to use `rename()` and, if it fails (e.g., due to EXDEV errors across filesystems), performs a manual copy followed by deletion of the original file. This ensures compatibility across different partition setups.

### Results and Evidence

To replicate the issue, `/var/ossec/active-response/bin` was mounted on a `tmpfs`:

```bash
cd /var/ossec 
cp active-response/bin/host-deny bin
mount -t tmpfs -o size=100M tmpfs active-response/bin
cp bin/host-deny active-response/bin
```

**Command: `add`**

```bash
active-response/bin/host-deny <<EOF
{"version":1,"origin":{},"command":"add","parameters":{"alert":{"data":{"srcip":"1.0.0.0"}}}}
{"version":1,"origin":{},"command":"continue","parameters":{}}
EOF
```

**Command: `delete`**

```bash
active-response/bin/host-deny <<EOF
{"version":1,"origin":{},"command":"delete","parameters":{"alert":{"data":{"srcip":"1.0.0.0"}}}}
{"version":1,"origin":{},"command":"continue","parameters":{}}
EOF
```

**Logs for `add`:**

```
2025/04/24 13:28:03 active-response/bin/host-deny: Starting
2025/04/24 13:28:03 active-response/bin/host-deny: {"version":1,"origin":{},"command":"add","parameters":{"alert":{"data":{"srcip":"1.0.0.0"}}}}
2025/04/24 13:28:03 active-response/bin/host-deny: {"version":1,"origin":{"name":"host-deny","module":"active-response"},"command":"check_keys","parameters":{"keys":["1.0.0.0"]}}
2025/04/24 13:28:03 active-response/bin/host-deny: {"version":1,"origin":{},"command":"continue","parameters":{}}
2025/04/24 13:28:03 active-response/bin/host-deny: Ended
```

**Logs for `delete`:**

```
2025/04/24 13:28:56 active-response/bin/host-deny: Starting
2025/04/24 13:28:56 active-response/bin/host-deny: {"version":1,"origin":{},"command":"delete","parameters":{"alert":{"data":{"srcip":"1.0.0.0"}}}}
2025/04/24 13:28:56 active-response/bin/host-deny: Ended
```

**File content after `add`:**

```
/etc/hosts.deny
ALL:1.0.0.0
```

**File content after `delete`:**

```
/etc/hosts.deny
(empty)
```

### Artifacts Affected

- Active Response: `host-deny`

### Configuration Changes

None.

### Documentation Updates

Not applicable.

### Tests Introduced

None. The `host-deny` active response currently has no unit tests.

## Review Checklist

- [x] Code changes reviewed  
- [x] Relevant evidence provided  
- [ ] ~Tests cover the new functionality~
- [ ] ~Configuration changes documented~
- [ ] ~Developer documentation reflects the changes~
- [x] Meets requirements and/or definition of done  
- [x] No unresolved dependencies with other issues