### PR TITLE
Add platform mapping for Rocky Linux and AlmaLinux in the agent upgrade module

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -211,6 +211,23 @@ void test_wm_agent_upgrade_validate_system_rocky_ok(void **state)
     os_free(package_type);
 }
 
+void test_wm_agent_upgrade_validate_system_almalinux_ok(void **state)
+{
+    (void) state;
+    char *platform = "almalinux";
+    char *os_major = "9";
+    char *os_minor = "5";
+    char *arch = "x64";
+    char *package_type = NULL;
+
+    int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch, &package_type);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+    assert_non_null(package_type);
+    assert_string_equal(package_type, "rpm");
+    os_free(package_type);
+}
+
 void test_wm_agent_upgrade_validate_system_darwin_x64_ok(void **state)
 {
     (void) state;
@@ -1771,6 +1788,7 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_rhel_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_ubuntu_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_rocky_ok),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_almalinux_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_darwin_x64_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_darwin_arm_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_solaris),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_validate.c
@@ -194,6 +194,23 @@ void test_wm_agent_upgrade_validate_system_ubuntu_ok(void **state)
     os_free(package_type);
 }
 
+void test_wm_agent_upgrade_validate_system_rocky_ok(void **state)
+{
+    (void) state;
+    char *platform = "rocky";
+    char *os_major = "9";
+    char *os_minor = "3";
+    char *arch = "x64";
+    char *package_type = NULL;
+
+    int ret = wm_agent_upgrade_validate_system(platform, os_major, os_minor, arch, &package_type);
+
+    assert_int_equal(ret, WM_UPGRADE_SUCCESS);
+    assert_non_null(package_type);
+    assert_string_equal(package_type, "rpm");
+    os_free(package_type);
+}
+
 void test_wm_agent_upgrade_validate_system_darwin_x64_ok(void **state)
 {
     (void) state;
@@ -1753,6 +1770,7 @@ int main(void) {
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_windows_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_rhel_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_ubuntu_ok),
+        cmocka_unit_test(test_wm_agent_upgrade_validate_system_rocky_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_darwin_x64_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_darwin_arm_ok),
         cmocka_unit_test(test_wm_agent_upgrade_validate_system_invalid_platform_solaris),

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -52,6 +52,7 @@ static const char* rpm_platforms[] = {
     "sles",
     "suse",
     "rocky",
+    "almalinux",
 };
 
 int wm_agent_upgrade_validate_id(int agent_id) {

--- a/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
+++ b/src/wazuh_modules/agent_upgrade/manager/wm_agent_upgrade_validate.c
@@ -50,7 +50,8 @@ static const char* rpm_platforms[] = {
     "opensuse-tumbleweed",
     "rhel",
     "sles",
-    "suse"
+    "suse",
+    "rocky",
 };
 
 int wm_agent_upgrade_validate_id(int agent_id) {


### PR DESCRIPTION
## Description

This pull request adds support for Rocky Linux and AlmaLinux in the agent upgrade module by including it in the internal platform mapping. This change allows the Wazuh manager to properly infer the package type (`rpm`) for these agents during remote upgrades.

## Proposed Changes

- Added `"rocky"` and `"almalinux"` to the platform mapping logic in the agent upgrade module.
- Ensured that agents running Rocky Linux and AlmaLinux are recognized as RPM-based, enabling seamless remote upgrades.

### Results and Evidence

After the change, remote upgrades on agents running Rocky Linux succeed without requiring the user to specify the `package_type` parameter.

#### Example for Rocky Linux

<details><summary>Agent info</summary>

```json
{
    "data": {
        "affected_items": [
            {
                "os": {
                    "arch": "x86_64",
                    "codename": "Blue Onyx",
                    "major": "9",
                    "minor": "3",
                    "name": "Rocky Linux",
                    "platform": "rocky",
                    "uname": "Linux |a338973110e1 |5.15.167.4-microsoft-standard-WSL2 |#1 SMP Tue Nov 5 00:21:55 UTC 2024 |x86_64",
                    "version": "9.3"
                },
                "ip": "172.17.0.2",
                "node_name": "node01",
                "status": "disconnected",
                "disconnection_time": "2025-04-25T08:16:34+00:00",
                "name": "a338973110e1",
                "dateAdd": "2025-04-25T06:32:50+00:00",
                "status_code": 5,
                "version": "Wazuh v4.11.2",
                "mergedSum": "57d13abb385626b61d343d06d9a185f9",
                "lastKeepAlive": "2025-04-25T08:14:07+00:00",
                "registerIP": "any",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00",
                "id": "002",
                "group_config_status": "synced",
                "group": [
                    "default"
                ],
                "manager": "Rocket"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

```bash
PUT "https://localhost:55000/agents/upgrade?agents_list=002&upgrade_version=4.11.2"
GET "https://localhost:55000/agents/upgrade_result?agents_list=002"
```

The agent is successfully upgraded using the default upgrade flow:

```json
{
    "data": {
        "affected_items": [
            {
                "message": "Success",
                "agent": "002",
                "task_id": 5,
                "node": "node01",
                "module": "upgrade_module",
                "command": "upgrade",
                "status": "Updated",
                "create_time": "2025-04-25T09:59:17Z",
                "update_time": "2025-04-25T10:00:05Z"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All upgrade tasks were returned",
    "error": 0
}
```

#### Example for AlmaLinux

<details><summary>Agent info</summary>

```json
{
    "data": {
        "affected_items": [
            {
                "os": {
                    "arch": "x86_64",
                    "codename": "Teal Serval",
                    "major": "9",
                    "minor": "5",
                    "name": "AlmaLinux",
                    "platform": "almalinux",
                    "uname": "Linux |6e4577451b14 |5.15.167.4-microsoft-standard-WSL2 |#1 SMP Tue Nov 5 00:21:55 UTC 2024 |x86_64",
                    "version": "9.5"
                },
                "ip": "172.17.0.2",
                "node_name": "node01",
                "status": "active",
                "name": "6e4577451b14",
                "dateAdd": "2025-04-25T08:41:03+00:00",
                "status_code": 0,
                "version": "Wazuh v4.11.2",
                "mergedSum": "57d13abb385626b61d343d06d9a185f9",
                "lastKeepAlive": "2025-04-25T08:51:08+00:00",
                "registerIP": "any",
                "configSum": "ab73af41699f13fdd81903b5f23d8d00",
                "id": "003",
                "group_config_status": "synced",
                "group": [
                    "default"
                ],
                "manager": "Rocket"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All selected agents information was returned",
    "error": 0
}
```

</details>

```bash
PUT "https://localhost:55000/agents/upgrade?agents_list=003&upgrade_version=4.11.2"
GET "https://localhost:55000/agents/upgrade_result?agents_list=003"
```

The agent is successfully upgraded using the default upgrade flow:

```json
{
    "data": {
        "affected_items": [
            {
                "message": "Success",
                "agent": "003",
                "task_id": 7,
                "node": "node01",
                "module": "upgrade_module",
                "command": "upgrade",
                "status": "Updated",
                "create_time": "2025-04-25T10:43:32Z",
                "update_time": "2025-04-25T10:44:16Z"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "All upgrade tasks were returned",
    "error": 0
}
```

### Artifacts Affected

- `wazuh-modulesd` (manager side)

### Configuration Changes

- None

### Documentation Updates

- None required

### Tests Introduced

- Added a unit test to verify platform inference for `"rocky"` and its correct mapping to RPM packages.

## Review Checklist

- [ ] Code changes reviewed  
- [ ] Relevant evidence provided  
- [ ] Tests cover the new functionality  
- [ ] Configuration changes documented  
- [ ] Developer documentation reflects the changes  
- [ ] Meets requirements and/or definition of done  
- [ ] No unresolved dependencies with other issues