### PR TITLE
Update check_files and SPECS to deal with Oracle Linux 10 SCA

### DIFF
--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -514,6 +514,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/ruleset/sca/cis_nginx_1.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_oracle_database_19c.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_oracle_linux_9.yml*,root,wazuh,640,file,-rw-r-----,,
+/var/ossec/ruleset/sca/cis_oracle_linux_10.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_postgre-sql-13.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_rhel5_linux.yml*,root,wazuh,640,file,-rw-r-----,,
 /var/ossec/ruleset/sca/cis_rhel6_linux.yml*,root,wazuh,640,file,-rw-r-----,,

--- a/.github/actions/check_files/rpm5_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm5_linux_agent_amd64.csv
@@ -55,6 +55,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-4.*-*.el5-tmp/amzn/2023/sca.files,root,wazuh,640,file,-rw-r-----,33,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/ol/9/sca.files,root,wazuh,640,file,-rw-r-----,27,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/ol/9/cis_oracle_linux_9.yml,root,wazuh,640,file,-rw-r-----,334520,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/ol/10/sca.files,root,wazuh,640,file,-rw-r-----,30,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/ol/10/cis_oracle_linux_10.yml,root,wazuh,640,file,-rw-r-----,334599,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/12/sca.files,root,wazuh,640,file,-rw-r-----,28,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1

--- a/.github/actions/check_files/rpm5_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm5_linux_agent_i386.csv
@@ -55,6 +55,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-4.*-*.el5-tmp/amzn/2023/sca.files,root,wazuh,640,file,-rw-r-----,33,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/ol/9/sca.files,root,wazuh,640,file,-rw-r-----,27,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/ol/9/cis_oracle_linux_9.yml,root,wazuh,640,file,-rw-r-----,334520,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/ol/10/sca.files,root,wazuh,640,file,-rw-r-----,30,0.1
+/var/ossec/tmp/sca-4.*-*.el5-tmp/ol/10/cis_oracle_linux_10.yml,root,wazuh,640,file,-rw-r-----,334599,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/12/sca.files,root,wazuh,640,file,-rw-r-----,28,0.1
 /var/ossec/tmp/sca-4.*-*.el5-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -54,6 +54,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-4.*-*-tmp/amzn/2023/sca.files,root,wazuh,640,file,-rw-r-----,33,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/ol/9/sca.files,root,wazuh,640,file,-rw-r-----,27,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/ol/9/cis_oracle_linux_9.yml,root,wazuh,640,file,-rw-r-----,334520,0.1
+/var/ossec/tmp/sca-4.*-*-tmp/ol/10/sca.files,root,wazuh,640,file,-rw-r-----,30,0.1
+/var/ossec/tmp/sca-4.*-*-tmp/ol/10/cis_oracle_linux_10.yml,root,wazuh,640,file,-rw-r-----,334599,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/sles/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/sles/12/sca.files,root,wazuh,640,file,-rw-r-----,28,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -54,6 +54,8 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/tmp/sca-4.*-*-tmp/amzn/2023/sca.files,root,wazuh,640,file,-rw-r-----,33,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/ol/9/sca.files,root,wazuh,640,file,-rw-r-----,27,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/ol/9/cis_oracle_linux_9.yml,root,wazuh,640,file,-rw-r-----,334520,0.1
+/var/ossec/tmp/sca-4.*-*-tmp/ol/10/sca.files,root,wazuh,640,file,-rw-r-----,30,0.1
+/var/ossec/tmp/sca-4.*-*-tmp/ol/10/cis_oracle_linux_10.yml,root,wazuh,640,file,-rw-r-----,334599,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/sles/sca.files,root,wazuh,640,file,-rw-r-----,29,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/sles/12/sca.files,root,wazuh,640,file,-rw-r-----,28,0.1
 /var/ossec/tmp/sca-4.*-*-tmp/sles/12/cis_sles12_linux.yml,root,wazuh,640,file,-rw-r-----,62673,0.1

--- a/packages/debs/SPECS/wazuh-manager/debian/rules
+++ b/packages/debs/SPECS/wazuh-manager/debian/rules
@@ -140,6 +140,7 @@ override_dh_install:
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/11
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/debian/12
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ol/9
+	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ol/10
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/5
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/6
 	mkdir -p ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/7
@@ -203,6 +204,7 @@ override_dh_install:
 	cp etc/templates/config/centos/10/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/centos/10
 
 	cp etc/templates/config/ol/9/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ol/9
+	cp etc/templates/config/ol/10/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/ol/10
 
 	cp etc/templates/config/rhel/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel
 	cp etc/templates/config/rhel/5/sca.files ${TARGET_DIR}$(INSTALLATION_SCRIPTS_DIR)/sca/rhel/5

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -120,7 +120,7 @@ rm -f ${RPM_BUILD_ROOT}%{_localstatedir}/ruleset/sca/*
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/{generic}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/amzn/{1,2,2023}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/{10,8,7,6,5}
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/{9}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/{9,10}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/{9,8,7,6,5}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/{11,12,15}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/suse/{11,12}
@@ -144,6 +144,7 @@ cp etc/templates/config/centos/6/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 cp etc/templates/config/centos/5/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
 
 cp etc/templates/config/ol/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
+cp etc/templates/config/ol/10/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10
 
 cp etc/templates/config/rhel/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 cp etc/templates/config/rhel/10/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/10
@@ -722,6 +723,8 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/10/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -124,7 +124,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/am
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/{8,7,6,5}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/darwin/{15,16,17,18,19,20,21,22,23,24}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/{7,8,9,10,11,12}
-mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/{9}
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/{9,10}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ubuntu/{12,14,16,18,20,22,24}/04
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/{10,9,8,7,6,5}
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/sles/{11,12,15}
@@ -151,6 +151,7 @@ cp etc/templates/config/centos/6/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tm
 cp etc/templates/config/centos/5/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/centos/5
 
 cp etc/templates/config/ol/9/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
+cp etc/templates/config/ol/10/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10
 
 cp etc/templates/config/rhel/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 cp etc/templates/config/rhel/10/sca.files ${RPM_BUILD_ROOT}%{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/10
@@ -852,6 +853,8 @@ rm -fr %{buildroot}
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/debian/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/9/*
+%dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10
+%attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/ol/10/*
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel
 %attr(640, root, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/sca.files
 %dir %attr(750, wazuh, wazuh) %config(missingok) %{_localstatedir}/tmp/sca-%{version}-%{release}-tmp/rhel/5


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-packages/issues/3179|

## Description

This PR adds the needed changes to deal with the new Oracle Linux 10 SCA file:
- Changes in SPECS files to add the new file in the packages
- Changes in the check_files to properly check the files are present.

## Tests

- [Package - Build rpm wazuh-manager on amd64 - checksum OL10_SCA](https://github.com/wazuh/wazuh/actions/runs/14660022124) 🟢
- [Package - Build deb wazuh-manager on amd64 - checksum OL10_SCA](https://github.com/wazuh/wazuh/actions/runs/14660023941) 🟢
- Agent :yellow_circle: (It is currently not possible to run it due to an internal problem.)