### PR TITLE
Split crl message process in wazuh-remoted

### DIFF
--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -137,7 +137,7 @@ void HandleSecure()
     const int protocol = logr.proto[logr.position];
     int n_events = 0;
 
-    w_linked_queue_t * control_msg_queue = NULL; ///< Pointer to the control message queue
+    w_linked_queue_t * control_msg_queue = linked_queue_init(); ///< Pointer to the control message queue
 
     struct sockaddr_storage peer_info;
     memset(&peer_info, 0, sizeof(struct sockaddr_storage));
@@ -218,16 +218,7 @@ void HandleSecure()
     }
 
     // Create upsert control message thread
-    {
-        //int control_pool = getDefine_Int("remoted", "control_msg_pool", 1, 16);
-        int control_pool = 4;
-        // Inizialize queue
-        control_msg_queue = linked_queue_init();
-        while (control_pool > 0) {
-            w_create_thread(save_control_thread, (void *) control_msg_queue);
-            control_pool--;
-        }
-    }
+    w_create_thread(save_control_thread, (void *) control_msg_queue);
 
     // Create message handler thread pool
     {

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -810,6 +810,8 @@ STATIC void HandleSecureMessage(const message_t *message, w_linked_queue_t * con
                 memcpy(ctrl_msg_data->message, tmp_msg, ctrl_msg_data->length);
 
                 linked_queue_push_ex(control_msg_queue, ctrl_msg_data);
+
+                rem_inc_ctrl_msg_queue_usage();
                 mdebug2("Control message pushed to queue.");
             }
 
@@ -1031,6 +1033,7 @@ void * save_control_thread(void * control_msg_queue)
     while (FOREVER()) {
         if ((ctrl_msg_data = (w_ctrl_msg_data_t *)linked_queue_pop_ex(queue))) {
 
+            rem_dec_ctrl_msg_queue_usage();
             // Process the control message
             save_controlmsg(ctrl_msg_data->key, ctrl_msg_data->message, ctrl_msg_data->length, &wdb_sock);
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -1028,7 +1028,7 @@ void * save_control_thread(void * control_msg_queue)
     w_ctrl_msg_data_t * ctrl_msg_data = NULL;
     int wdb_sock = -1;
 
-    while (1) {
+    while (FOREVER()) {
         if ((ctrl_msg_data = (w_ctrl_msg_data_t *)linked_queue_pop_ex(queue))) {
 
             // Process the control message

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -63,13 +63,13 @@ STATIC void handle_new_tcp_connection(wnotify_t * notify, struct sockaddr_storag
 void router_message_forward(char* msg, const char* agent_id, const char* agent_ip, const char* agent_name);
 
 // Message handler thread
-static void * rem_handler_main(__attribute__((unused)) void * args);
+static void * rem_handler_main(void * args);
 
 // Key reloader thread
 void * rem_keyupdate_main(__attribute__((unused)) void * args);
 
 /* Handle each message received */
-STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock);
+STATIC void HandleSecureMessage(const message_t *message, w_linked_queue_t * control_msg_queue);
 
 // Close and remove socket from keystore
 int _close_sock(keystore * keys, int sock);
@@ -110,11 +110,34 @@ char *str_family_address[FAMILY_ADDRESS_SIZE] = {
     "AF_VSOCK", "AF_KCM", "AF_QIPCRTR", "AF_SMC", "AF_XDP", "AF_MCTP"
 };
 
+/**
+ * @brief Structure to hold control message data
+ * 
+ */
+typedef struct {
+    keyentry * key; ///< Pointer to the key entry of agent to which the message belongs
+    char * message; ///< Raw message received
+    size_t length;  ///< Length of the message
+} w_ctrl_msg_data_t;
+
+/**
+ * @brief Thread function to save control messages
+ * 
+ * This function is executed by the control message thread pool. It waits for messages to be pushed into the queue and processes them.
+ * Updates the agent's status in wazuhdb and sends the message to the appropriate handler.
+ * @param queue Pointer to the control message queue, which is used to store messages to be processed.
+ * @return void* Null
+ */
+void * save_control_thread(void * queue);
+
+
 /* Handle secure connections */
 void HandleSecure()
 {
     const int protocol = logr.proto[logr.position];
     int n_events = 0;
+
+    w_linked_queue_t * control_msg_queue = NULL; ///< Pointer to the control message queue
 
     struct sockaddr_storage peer_info;
     memset(&peer_info, 0, sizeof(struct sockaddr_storage));
@@ -194,6 +217,18 @@ void HandleSecure()
         mdebug2("Failed to create router handle for 'rsync'.");
     }
 
+    // Create upsert control message thread
+    {
+        //int control_pool = getDefine_Int("remoted", "control_msg_pool", 1, 16);
+        int control_pool = 4;
+        // Inizialize queue
+        control_msg_queue = linked_queue_init();
+        while (control_pool > 0) {
+            w_create_thread(save_control_thread, (void *) control_msg_queue);
+            control_pool--;
+        }
+    }
+
     // Create message handler thread pool
     {
         int worker_pool = getDefine_Int("remoted", "worker_pool", 1, 16);
@@ -201,7 +236,7 @@ void HandleSecure()
         global_counter = 0;
         rem_initList(FD_LIST_INIT_VALUE);
         while (worker_pool > 0) {
-            w_create_thread(rem_handler_main, NULL);
+            w_create_thread(rem_handler_main, control_msg_queue);
             worker_pool--;
         }
     }
@@ -398,14 +433,14 @@ STATIC void handle_outgoing_data_to_tcp_socket(int sock_client)
 }
 
 // Message handler thread
-void * rem_handler_main(__attribute__((unused)) void * args) {
+void * rem_handler_main(void * args) {
     message_t * message;
-    int wdb_sock = -1;
+    w_linked_queue_t * control_msg_queue = (w_linked_queue_t *) args;
     mdebug1("Message handler thread started.");
 
     while (1) {
         message = rem_msgpop();
-        HandleSecureMessage(message, &wdb_sock);
+        HandleSecureMessage(message, control_msg_queue);
         rem_msgfree(message);
     }
 
@@ -485,7 +520,7 @@ STATIC const char * get_schema(const int type)
     return NULL;
 
 }
-STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
+STATIC void HandleSecureMessage(const message_t *message, w_linked_queue_t * control_msg_queue) {
     int agentid;
     const int protocol = (message->sock == USING_UDP_NO_CLIENT_SOCKET) ? REMOTED_NET_PROTOCOL_UDP : REMOTED_NET_PROTOCOL_TCP;
     char cleartext_msg[OS_MAXSTR + 1];
@@ -769,10 +804,24 @@ STATIC void HandleSecureMessage(const message_t *message, int *wdb_sock) {
             }
 
             // The critical section for readers closes within this function
-            save_controlmsg(key, tmp_msg, msg_length - 3, wdb_sock);
             rem_inc_recv_ctrl(key->id);
 
-            OS_FreeKey(key);
+            // Send the control message to the queue for processing in the control thread
+            {
+                w_ctrl_msg_data_t * ctrl_msg_data;
+                os_calloc(sizeof(w_ctrl_msg_data_t), 1, ctrl_msg_data);
+
+                ctrl_msg_data->key = key;
+                key = NULL;
+
+                ctrl_msg_data->length = msg_length - 3;
+                os_calloc(msg_length, sizeof(char), ctrl_msg_data->message);
+                memcpy(ctrl_msg_data->message, tmp_msg, ctrl_msg_data->length);
+
+                linked_queue_push_ex(control_msg_queue, ctrl_msg_data);
+                mdebug2("Control message pushed to queue.");
+            }
+
         } else {
             key_unlock();
             rem_inc_recv_dequeued();
@@ -978,4 +1027,29 @@ void *current_timestamp(__attribute__((unused)) void *none)
     }
 
     return NULL;
+}
+
+// Save control message thread
+void * save_control_thread(void * control_msg_queue)
+{
+    assert(control_msg_queue != NULL);
+    w_linked_queue_t * queue = (w_linked_queue_t *)control_msg_queue;
+    w_ctrl_msg_data_t * ctrl_msg_data = NULL;
+    int wdb_sock = -1;
+
+    while (1) {
+        if ((ctrl_msg_data = (w_ctrl_msg_data_t *)linked_queue_pop_ex(queue))) {
+
+            // Process the control message
+            save_controlmsg(ctrl_msg_data->key, ctrl_msg_data->message, ctrl_msg_data->length, &wdb_sock);
+
+            // Free the key entry
+            OS_FreeKey(ctrl_msg_data->key);
+            os_free(ctrl_msg_data->message);
+            os_free(ctrl_msg_data);
+        }
+    }
+
+    return NULL;
+
 }

--- a/src/remoted/state.h
+++ b/src/remoted/state.h
@@ -50,6 +50,7 @@ typedef struct _remoted_state_t {
     uint64_t sent_bytes;
     uint32_t tcp_sessions;
     uint32_t keys_reload_count;
+    uint32_t ctrl_msg_queue_usage;
     recv_msgs_t recv_breakdown;
     sent_msgs_t sent_breakdown;
 } remoted_state_t;
@@ -83,6 +84,16 @@ void rem_inc_tcp();
  * @brief Decrement TCP sessions counter
  */
 void rem_dec_tcp();
+
+/**
+ * @brief Increment control message queue usage
+ */
+void rem_inc_ctrl_msg_queue_usage();
+
+/**
+ * @brief Decrement control message queue usage
+ */
+void rem_dec_ctrl_msg_queue_usage();
 
 /**
  * @brief Increment bytes received

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -75,6 +75,14 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
                             -Wl,--wrap,router_provider_send_fb ${HASH_OP_WRAPPERS}")
 
+list(APPEND remoted_names "test_save_ctrlmsg_thread")
+list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \
+                            -Wl,--wrap,fclose -Wl,--wrap,fcntl -Wl,--wrap,fflush -Wl,--wrap,fgetc \
+                            -Wl,--wrap,fgetpos -Wl,--wrap,fgets -Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fread \
+                            -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,getpid -Wl,--wrap,remove \
+                            -Wl,--wrap,FOREVER -Wl,--wrap,linked_queue_push_ex  -Wl,--wrap,linked_queue_pop_ex \
+                            -Wl,--wrap,save_controlmsg")
+
 list(APPEND remoted_names "test_netbuffer")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,_mdebug1 -Wl,--wrap,wnet_order -Wl,--wrap,wnotify_modify \
                             -Wl,--wrap,bqueue_push -Wl,--wrap,bqueue_peek -Wl,--wrap,bqueue_drop -Wl,--wrap,bqueue_clear -Wl,--wrap,sleep \

--- a/src/unit_tests/remoted/test_save_ctrlmsg_thread.c
+++ b/src/unit_tests/remoted/test_save_ctrlmsg_thread.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../../headers/shared.h"
+#include "../../remoted/remoted.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+#include "../wrappers/wazuh/shared/queue_linked_op_wrappers.h"
+
+#include "../wrappers/wazuh/remoted/queue_wrappers.h"
+#include "../wrappers/wazuh/remoted/manager_wrappers.h"
+#include "../../remoted/secure.c"
+
+void * save_control_thread(void * control_msg_queue);
+
+void test_save_control_message_empty(void **state)
+{
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_linked_queue_pop_ex, (w_linked_queue_t *) -1);
+    expect_value(__wrap_linked_queue_pop_ex, queue, 0x1);
+
+
+    will_return(__wrap_FOREVER, 0);
+
+    assert_null(save_control_thread((void *) 0x1));
+}
+
+
+void test_save_control_message_ok(void **state)
+{
+    w_linked_queue_t * queue = linked_queue_init();
+
+    w_ctrl_msg_data_t * ctrl_msg_data;
+    os_calloc(sizeof(w_ctrl_msg_data_t), 1, ctrl_msg_data);
+    os_calloc(sizeof(keyentry), 1, ctrl_msg_data->key);
+
+    ctrl_msg_data->length = strlen("test message") + 1;
+    os_calloc(ctrl_msg_data->length, sizeof(char), ctrl_msg_data->message);
+    memcpy(ctrl_msg_data->message, "test message", ctrl_msg_data->length);
+
+    linked_queue_push(queue, ctrl_msg_data);
+
+    will_return(__wrap_FOREVER, 1);
+    will_return(__wrap_linked_queue_pop_ex, (void *) ctrl_msg_data);
+    expect_value(__wrap_linked_queue_pop_ex, queue, queue);
+
+    expect_value(__wrap_save_controlmsg, key, ctrl_msg_data->key);
+    expect_value(__wrap_save_controlmsg, r_msg, ctrl_msg_data->message);
+    expect_any(__wrap_save_controlmsg, wdb_sock);
+
+    will_return(__wrap_FOREVER, 0);
+
+    assert_null(save_control_thread((void *) queue));
+    linked_queue_free(queue);
+}
+
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_save_control_message_empty),
+        cmocka_unit_test(test_save_control_message_ok),
+        };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Description

This PR  migrate an improvove from 4.13: the control message to a separate thread on wazuh-remoted