### PR TITLE
Prevent installation of mismatched debug symbol packages

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/control
+++ b/packages/debs/SPECS/wazuh-agent/debian/control
@@ -21,6 +21,7 @@ Package: wazuh-agent-dbg
 Section: debug
 Priority: optional
 Architecture: any
+Conflicts: wazuh-agent (<< ${binary:Version}), wazuh-agent (>> ${binary:Version})
 Depends: wazuh-agent
 Description: Debug symbols for wazuh-agent.
-  This package contains debug symbols for debugging wazuh-agent.
+  This package contains files necessary for debugging the wazuh-agent with gdb.

--- a/packages/debs/SPECS/wazuh-manager/debian/control
+++ b/packages/debs/SPECS/wazuh-manager/debian/control
@@ -22,6 +22,7 @@ Package: wazuh-manager-dbg
 Section: debug
 Priority: optional
 Architecture: any
+Conflicts: wazuh-manager (<< ${binary:Version}), wazuh-manager (>> ${binary:Version})
 Depends: wazuh-manager
 Description: Debug symbols for wazuh-manager.
-  This package contains debug symbols for debugging wazuh-manager.
+  This package contains files necessary for debugging the wazuh-manager with gdb.

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -45,6 +45,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %endif
 %package wazuh-agent-debuginfo
 Summary: Debug information for package %{name}.
+Requires: wazuh-agent = %{version}-%{release}
 %description wazuh-agent-debuginfo
 This package provides debug information for package %{name}.
 %endif

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -42,6 +42,7 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %debug_package
 %package wazuh-manager-debuginfo
 Summary: Debug information for package %{name}.
+Requires: wazuh-manager = %{version}-%{release}
 %description wazuh-manager-debuginfo
 This package provides debug information for package %{name}.
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28642|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<details>
<summary>Deb</summary>


<details>
<summary>Agent</summary>

<details>
<summary>Install wazuh-agent 4.11.1</summary>

```bash
root@fa47911f61f9:/# WAZUH_MANAGER=1.1.1.1 apt install wazuh-agent=4.11.1-1
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  distro-info-data libpython3-stdlib lsb-release python3 python3-minimal python3.10
  python3.10-minimal
Suggested packages:
  python3-doc python3-tk python3-venv python3.10-venv python3.10-doc binutils binfmt-support
The following NEW packages will be installed:
  distro-info-data libpython3-stdlib lsb-release python3 python3-minimal python3.10
  python3.10-minimal wazuh-agent
0 upgraded, 8 newly installed, 0 to remove and 14 not upgraded.
Need to get 13.9 MB of archives.
After this operation, 46.7 MB of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-agent amd64 4.11.1-1 [11.1 MB]
Get:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 python3.10-minimal amd64 3.10.12-1~22.04.9 [2263 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 python3-minimal amd64 3.10.6-1~22.04.1 [24.3 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 python3.10 amd64 3.10.12-1~22.04.9 [508 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libpython3-stdlib amd64 3.10.6-1~22.04.1 [6812 B]
Get:6 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 python3 amd64 3.10.6-1~22.04.1 [22.8 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 distro-info-data all 0.52ubuntu0.8 [5302 B]
Get:8 http://archive.ubuntu.com/ubuntu jammy/main amd64 lsb-release all 11.1.0ubuntu4 [10.8 kB]
Fetched 13.9 MB in 5s (2595 kB/s)     
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package python3.10-minimal.
(Reading database ... 7918 files and directories currently installed.)
Preparing to unpack .../python3.10-minimal_3.10.12-1~22.04.9_amd64.deb ...
Unpacking python3.10-minimal (3.10.12-1~22.04.9) ...
Setting up python3.10-minimal (3.10.12-1~22.04.9) ...
Selecting previously unselected package python3-minimal.
(Reading database ... 7929 files and directories currently installed.)
Preparing to unpack .../python3-minimal_3.10.6-1~22.04.1_amd64.deb ...
Unpacking python3-minimal (3.10.6-1~22.04.1) ...
Selecting previously unselected package python3.10.
Preparing to unpack .../python3.10_3.10.12-1~22.04.9_amd64.deb ...
Unpacking python3.10 (3.10.12-1~22.04.9) ...
Selecting previously unselected package libpython3-stdlib:amd64.
Preparing to unpack .../libpython3-stdlib_3.10.6-1~22.04.1_amd64.deb ...
Unpacking libpython3-stdlib:amd64 (3.10.6-1~22.04.1) ...
Setting up python3-minimal (3.10.6-1~22.04.1) ...
Selecting previously unselected package python3.
(Reading database ... 7974 files and directories currently installed.)
Preparing to unpack .../python3_3.10.6-1~22.04.1_amd64.deb ...
Unpacking python3 (3.10.6-1~22.04.1) ...
Selecting previously unselected package distro-info-data.
Preparing to unpack .../distro-info-data_0.52ubuntu0.8_all.deb ...
Unpacking distro-info-data (0.52ubuntu0.8) ...
Selecting previously unselected package lsb-release.
Preparing to unpack .../lsb-release_11.1.0ubuntu4_all.deb ...
Unpacking lsb-release (11.1.0ubuntu4) ...
Selecting previously unselected package wazuh-agent.
Preparing to unpack .../wazuh-agent_4.11.1-1_amd64.deb ...
Unpacking wazuh-agent (4.11.1-1) ...
Setting up python3.10 (3.10.12-1~22.04.9) ...
Setting up distro-info-data (0.52ubuntu0.8) ...
Setting up libpython3-stdlib:amd64 (3.10.6-1~22.04.1) ...
Setting up python3 (3.10.6-1~22.04.1) ...
running python rtupdate hooks for python3.10...
running python post-rtupdate hooks for python3.10...
Setting up lsb-release (11.1.0ubuntu4) ...
Setting up wazuh-agent (4.11.1-1) ...


root@fa47911f61f9:/#  /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.11.1"
WAZUH_REVISION="41112"
WAZUH_TYPE="agent"
```
</details>

<details>
<summary>Install wazuh-agent-dbg 4.12.1 </summary>

```bash

root@fa47911f61f9:~# apt install ./wazuh-agent-dbg_4.12.1-0_amd64_77297cb.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent-dbg' instead of './wazuh-agent-dbg_4.12.1-0_amd64_77297cb.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 wazuh-agent-dbg : Conflicts: wazuh-agent (< 4.12.1-0) but 4.11.1-1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

</details>

<details>
<summary>Uprade wazuh-agent 4.12.1 </summary>

```bash

root@fa47911f61f9:~# apt install ./wazuh-agent_4.12.1-0_amd64_77297cb.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of './wazuh-agent_4.12.1-0_amd64_77297cb.deb'
The following packages will be upgraded:
  wazuh-agent
1 upgraded, 0 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/12.0 MB of archives.
After this operation, 4355 kB of additional disk space will be used.
Get:1 /root/wazuh-agent_4.12.1-0_amd64_77297cb.deb wazuh-agent amd64 4.12.1-0 [12.0 MB]
Preconfiguring packages ...      
(Reading database ... 10872 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.12.1-0_amd64_77297cb.deb ...
Unpacking wazuh-agent (4.12.1-0) over (4.11.1-1) ...
Setting up wazuh-agent (4.12.1-0) ...
```

</details>

<details>
<summary>Install wazuh-agent-dbg 4.12.1 </summary>

```bash

root@fa47911f61f9:~# apt install ./wazuh-agent-dbg_4.12.1-0_amd64_77297cb.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent-dbg' instead of './wazuh-agent-dbg_4.12.1-0_amd64_77297cb.deb'
The following NEW packages will be installed:
  wazuh-agent-dbg
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/21.2 MB of archives.
After this operation, 87.7 MB of additional disk space will be used.
Get:1 /root/wazuh-agent-dbg_4.12.1-0_amd64_77297cb.deb wazuh-agent-dbg amd64 4.12.1-0 [21.2 MB]
Selecting previously unselected package wazuh-agent-dbg.
(Reading database ... 10888 files and directories currently installed.)
Preparing to unpack .../wazuh-agent-dbg_4.12.1-0_amd64_77297cb.deb ...
Unpacking wazuh-agent-dbg (4.12.1-0) ...
Setting up wazuh-agent-dbg (4.12.1-0) ...
root@fa47911f61f9:~# 

```
</details>

</details>



<details>
<summary>Manager</summary>

<details>
<summary>Install wazuh-manager 4.11.2</summary>

```bash
root@69cb22d8afad:~# apt install wazuh-manager
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 382 MB of archives.
After this operation, 942 MB of additional disk space will be used.
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-manager amd64 4.11.2-1 [382 MB]
Fetched 382 MB in 2min 19s (2742 kB/s)                                                                                                                                                                     
Selecting previously unselected package wazuh-manager.
(Reading database ... 10410 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.11.2-1_amd64.deb ...
Unpacking wazuh-manager (4.11.2-1) ...
Setting up wazuh-manager (4.11.2-1) ...

root@69cb22d8afad:~#  /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.11.2"
WAZUH_REVISION="41122"
WAZUH_TYPE="server"
```
</details>


<details>
<summary>Install wazuh-manager-dbg 4.12.1</summary>

```bash
root@69cb22d8afad:~# apt install ./wazuh-manager-dbg_4.12.1-0_amd64_77297cb.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager-dbg' instead of './wazuh-manager-dbg_4.12.1-0_amd64_77297cb.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 wazuh-manager-dbg : Depends: wazuh-manager but it is not installable
E: Unable to correct problems, you have held broken packages.


root@69cb22d8afad:~# dpkg -l |grep wazuh-manager
ii  wazuh-manager               4.11.2-1                                amd64        Wazuh manager


```
</details>




<details>
<summary>Uprade wazuh-manager 4.12.1</summary>

```bash
root@69cb22d8afad:~# apt install ./wazuh-manager_4.12.1-0_amd64_77297cb.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.12.1-0_amd64_77297cb.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-manager
1 upgraded, 0 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/374 MB of archives.
After this operation, 296 kB disk space will be freed.
Get:1 /root/wazuh-manager_4.12.1-0_amd64_77297cb.deb wazuh-manager amd64 4.12.1-0 [374 MB]
(Reading database ... 34364 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.12.1-0_amd64_77297cb.deb ...
Unpacking wazuh-manager (4.12.1-0) over (4.11.2-1) ...
Setting up wazuh-manager (4.12.1-0) ...

root@69cb22d8afad:~#  /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.12.1"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="server"


```
</details>



<details>
<summary>Install wazuh-manager-dbg 4.12.1</summary>

```bash

root@69cb22d8afad:~# apt install ./wazuh-manager-dbg_4.12.1-0_amd64_77297cb.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager-dbg' instead of './wazuh-manager-dbg_4.12.1-0_amd64_77297cb.deb'
The following NEW packages will be installed:
  wazuh-manager-dbg
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/33.1 MB of archives.
After this operation, 234 MB of additional disk space will be used.
Get:1 /root/wazuh-manager-dbg_4.12.1-0_amd64_77297cb.deb wazuh-manager-dbg amd64 4.12.1-0 [33.1 MB]
Selecting previously unselected package wazuh-manager-dbg.
(Reading database ... 34414 files and directories currently installed.)
Preparing to unpack .../wazuh-manager-dbg_4.12.1-0_amd64_77297cb.deb ...
Unpacking wazuh-manager-dbg (4.12.1-0) ...
Setting up wazuh-manager-dbg (4.12.1-0) ...
```
</details>

</details>
