### PR TITLE
Prevent installation of mismatched debug symbol packages

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/control
+++ b/packages/debs/SPECS/wazuh-agent/debian/control
@@ -21,6 +21,7 @@ Package: wazuh-agent-dbg
 Section: debug
 Priority: optional
 Architecture: any
+Conflicts: wazuh-agent (<< ${binary:Version}), wazuh-agent (>> ${binary:Version})
 Depends: wazuh-agent
 Description: Debug symbols for wazuh-agent.
-  This package contains debug symbols for debugging wazuh-agent.
+  This package contains files necessary for debugging the wazuh-agent with gdb.

--- a/packages/debs/SPECS/wazuh-manager/debian/control
+++ b/packages/debs/SPECS/wazuh-manager/debian/control
@@ -22,6 +22,7 @@ Package: wazuh-manager-dbg
 Section: debug
 Priority: optional
 Architecture: any
+Conflicts: wazuh-manager (<< ${binary:Version}), wazuh-manager (>> ${binary:Version})
 Depends: wazuh-manager
 Description: Debug symbols for wazuh-manager.
-  This package contains debug symbols for debugging wazuh-manager.
+  This package contains files necessary for debugging the wazuh-manager with gdb.

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -41,11 +41,11 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
 # Build debuginfo package
 %if %{_arch} != ppc64le
-%debug_package
+%package -n wazuh-agent-debuginfo
 %endif
-%package wazuh-agent-debuginfo
+Requires: wazuh-agent = %{_version}-%{_release}
 Summary: Debug information for package %{name}.
-%description wazuh-agent-debuginfo
+%description -n wazuh-agent-debuginfo
 This package provides debug information for package %{name}.
 %endif
 
@@ -780,6 +780,10 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
+
+%if 0%{?el} >= 6 || 0%{?rhel} >= 6
+%files -n wazuh-agent-debuginfo -f debugfiles.list
+%endif
 
 %changelog
 * Wed Jun 04 2025 support <info@wazuh.com> - 4.13.0

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -39,10 +39,10 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 %global _build_id_links none
 
 # Build debuginfo package
-%debug_package
-%package wazuh-manager-debuginfo
+%package -n wazuh-manager-debuginfo
+Requires: wazuh-manager = %{_version}-%{_release}
 Summary: Debug information for package %{name}.
-%description wazuh-manager-debuginfo
+%description -n wazuh-manager-debuginfo
 This package provides debug information for package %{name}.
 
 
@@ -916,6 +916,8 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/docker/*
 %dir %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
+
+%files -n wazuh-manager-debuginfo -f debugfiles.list
 
 %changelog
 * Wed Jun 04 2025 support <info@wazuh.com> - 4.13.0


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28642|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This resolves potential debug symbol incompatibility by requiring that the Wazuh agent/manager use the same version as the debug package during installation.

## Tests

<details>
<summary> :green_circle:  Deb</summary>


<details>
<summary>Agent</summary>

<details>
<summary>Installed wazuh-agent 4.11.1</summary>

```bash
root@ubuntu22:/home/vagrant# apt install wazuh-agent
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 0 to remove and 219 not upgraded.
Need to get 11.1 MB of archives.
After this operation, 39.7 MB of additional disk space will be used.
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-agent amd64 4.11.2-1 [11.1 MB]
Fetched 11.1 MB in 5s (2,020 kB/s)                  
Preconfiguring packages ...
Selecting previously unselected package wazuh-agent.
(Reading database ... 76324 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.11.2-1_amd64.deb ...
Unpacking wazuh-agent (4.11.2-1) ...
Setting up wazuh-agent (4.11.2-1) ...
Scanning processes...                                                                                                                                                                                       
Scanning linux images...                                                                                                                                                                                    

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

root@ubuntu22:/home/vagrant#  /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.11.1"
WAZUH_REVISION="41112"
WAZUH_TYPE="agent"
```
</details>

<details>
<summary>Tested the fix by attempting to install wazuh-agent-dbg.</summary>

```bash

root@ubuntu22:/home/vagrant# apt install ./wazuh-agent-dbg_4.13.0-0_amd64_f040703.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent-dbg' instead of './wazuh-agent-dbg_4.13.0-0_amd64_f040703.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 wazuh-agent-dbg : Depends: wazuh-agent but it is not installable
E: Unable to correct problems, you have held broken packages.

root@ubuntu22:/home/vagrant# dpkg -l|grep  wazuh-agent
ii  wazuh-agent                 4.11.2-1                                amd64        Wazuh agent

root@ubuntu22:/home/vagrant# dpkg -I ./wazuh-agent-dbg_4.13.0-0_amd64_f040703.deb
 new Debian package, version 2.0.
 size 15766916 bytes: control archive=1417 bytes.
     420 bytes,    13 lines      control              
    2695 bytes,    33 lines      md5sums              
 Package: wazuh-agent-dbg
 Source: wazuh-agent
 Version: 4.13.0-0
 Architecture: amd64
 Maintainer: Wazuh, Inc <info@wazuh.com>
 Installed-Size: 67079
 Depends: wazuh-agent
 Conflicts: wazuh-agent (>> 4.13.0-0), wazuh-agent (<< 4.13.0-0)
 Section: debug
 Priority: optional
 Homepage: https://www.wazuh.com
 Description: Debug symbols for wazuh-agent.
   This package contains files necessary for debugging the wazuh-agent with gdb.

```

</details>

<details>
<summary>Uprade wazuh-agent 4.13.0 </summary>

```bash
root@ubuntu22:/home/vagrant# apt install ./wazuh-agent_4.13.0-0_amd64_f040703.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent' instead of './wazuh-agent_4.13.0-0_amd64_f040703.deb'
The following packages will be upgraded:
  wazuh-agent
1 upgraded, 0 newly installed, 0 to remove and 219 not upgraded.
Need to get 0 B/13.7 MB of archives.
After this operation, 17.0 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent_4.13.0-0_amd64_f040703.deb wazuh-agent amd64 4.13.0-0 [13.7 MB]
Preconfiguring packages ...
(Reading database ... 76751 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_4.13.0-0_amd64_f040703.deb ...
Unpacking wazuh-agent (4.13.0-0) over (4.11.2-1) ...
Setting up wazuh-agent (4.13.0-0) ...

Configuration file '/etc/systemd/system/wazuh-agent.service'
 ==> Deleted (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** wazuh-agent.service (Y/I/N/O/D/Z) [default=N] ? 
Scanning processes...                                                                                                                                                                                       
Scanning linux images...                                                                                                                                                                                    

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.


root@ubuntu22:/home/vagrant# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.13.0"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="agent"

```

</details>

<details>
<summary>Install wazuh-agent-dbg 4.13.1 </summary>

```bash
root@ubuntu22:/home/vagrant# apt install  ./wazuh-agent-dbg_4.13.0-0_amd64_f040703.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-agent-dbg' instead of './wazuh-agent-dbg_4.13.0-0_amd64_f040703.deb'
The following NEW packages will be installed:
  wazuh-agent-dbg
0 upgraded, 1 newly installed, 0 to remove and 219 not upgraded.
Need to get 0 B/15.8 MB of archives.
After this operation, 68.7 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-agent-dbg_4.13.0-0_amd64_f040703.deb wazuh-agent-dbg amd64 4.13.0-0 [15.8 MB]
Selecting previously unselected package wazuh-agent-dbg.
(Reading database ... 76769 files and directories currently installed.)
Preparing to unpack .../wazuh-agent-dbg_4.13.0-0_amd64_f040703.deb ...
Unpacking wazuh-agent-dbg (4.13.0-0) ...
Setting up wazuh-agent-dbg (4.13.0-0) ...
Scanning processes...                                                                                                                                                                                       
Scanning linux images...                                                                                                                                                                                    

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

```
</details>

</details>



<details>
<summary>Manager</summary>

<details>
<summary>Install wazuh-manager 4.11.2</summary>

```bash
root@ubuntu22:/home/vagrant# apt install wazuh-manager
Reading package lists... Done
Building dependency tree... 0%
Building dependency tree... Done
Reading state information... Done
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 219 not upgraded.
Need to get 382 MB of archives.
After this operation, 942 MB of additional disk space will be used.
Get:1 https://packages.wazuh.com/4.x/apt stable/main amd64 wazuh-manager amd64 4.11.2-1 [382 MB]
Fetched 382 MB in 2min 9s (2,970 kB/s)                                                                                                                                                                     
Selecting previously unselected package wazuh-manager.
(Reading database ... 76324 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.11.2-1_amd64.deb ...
Unpacking wazuh-manager (4.11.2-1) ...
Setting up wazuh-manager (4.11.2-1) ...
Scanning processes...                                                                                                                                                                                       
Scanning linux images...                                                                                                                                                                                    

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.


root@ubuntu22:/home/vagrant# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.11.2"
WAZUH_REVISION="41122"
WAZUH_TYPE="server"

```
</details>


<details>
<summary>Install wazuh-manager-dbg 4.13.0</summary>

```bash
root@ubuntu22:/home/vagrant# apt install ./wazuh-manager-dbg_4.13.0-0_amd64_f040703.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager-dbg' instead of './wazuh-manager-dbg_4.13.0-0_amd64_f040703.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 wazuh-manager-dbg : Depends: wazuh-manager but it is not installable
E: Unable to correct problems, you have held broken packages.


root@ubuntu22:/home/vagrant#  dpkg -l |grep wazuh-manager
ii  wazuh-manager                         4.11.2-1                                amd64        Wazuh manager

root@ubuntu22:/home/vagrant# dpkg -I ./wazuh-manager-dbg_4.13.0-0_amd64_f040703.deb
 new Debian package, version 2.0.
 size 23251946 bytes: control archive=2165 bytes.
     434 bytes,    13 lines      control              
    4424 bytes,    55 lines      md5sums              
 Package: wazuh-manager-dbg
 Source: wazuh-manager
 Version: 4.13.0-0
 Architecture: amd64
 Maintainer: Wazuh, Inc <info@wazuh.com>
 Installed-Size: 163885
 Depends: wazuh-manager
 Conflicts: wazuh-manager (>> 4.13.0-0), wazuh-manager (<< 4.13.0-0)
 Section: debug
 Priority: optional
 Homepage: http://www.wazuh.com
 Description: Debug symbols for wazuh-manager.
   This package contains files necessary for debugging the wazuh-manager with gdb.

```
</details>




<details>
<summary>Uprade wazuh-manager 4.13.0</summary>

```bash
root@ubuntu22:/home/vagrant# apt install ./wazuh-manager_4.13.0-0_amd64_f040703.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager' instead of './wazuh-manager_4.13.0-0_amd64_f040703.deb'
Suggested packages:
  expect
The following packages will be upgraded:
  wazuh-manager
1 upgraded, 0 newly installed, 0 to remove and 219 not upgraded.
Need to get 0 B/393 MB of archives.
After this operation, 63.3 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-manager_4.13.0-0_amd64_f040703.deb wazuh-manager amd64 4.13.0-0 [393 MB]
(Reading database ... 100278 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.13.0-0_amd64_f040703.deb ...
Unpacking wazuh-manager (4.13.0-0) over (4.11.2-1) ...
Setting up wazuh-manager (4.13.0-0) ...
Scanning processes...                                                                                                                                                                                       
Scanning linux images...                                                                                                                                                                                    

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

root@ubuntu22:/home/vagrant# /var/ossec/bin/wazuh-control info
WAZUH_VERSION="v4.13.0"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="server"
```
</details>



<details>
<summary>Install wazuh-manager-dbg 4.13.0</summary>

```bash
root@ubuntu22:/home/vagrant# apt install ./wazuh-manager-dbg_4.13.0-0_amd64_f040703.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'wazuh-manager-dbg' instead of './wazuh-manager-dbg_4.13.0-0_amd64_f040703.deb'
The following NEW packages will be installed:
  wazuh-manager-dbg
0 upgraded, 1 newly installed, 0 to remove and 219 not upgraded.
Need to get 0 B/23.3 MB of archives.
After this operation, 168 MB of additional disk space will be used.
Get:1 /home/vagrant/wazuh-manager-dbg_4.13.0-0_amd64_f040703.deb wazuh-manager-dbg amd64 4.13.0-0 [23.3 MB]
Selecting previously unselected package wazuh-manager-dbg.
(Reading database ... 100259 files and directories currently installed.)
Preparing to unpack .../wazuh-manager-dbg_4.13.0-0_amd64_f040703.deb ...
Unpacking wazuh-manager-dbg (4.13.0-0) ...
Setting up wazuh-manager-dbg (4.13.0-0) ...
Scanning processes...                                                                                                                                                                                       
Scanning linux images...                                                                                                                                                                                    

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

```
</details>

</details>

</details>


<details>
<summary> :green_circle:   RPM</summary>

<details>

<summary>Agent</summary>


<details>

<summary>Install agent and test the fix</summary>

```bash
[root@centos8 vagrant]# yum install wazuh-agent
CentOS Linux 8 - AppStream                                           6.6 kB/s | 4.3 kB     00:00    
CentOS Linux 8 - BaseOS                                               18 kB/s | 3.9 kB     00:00    
CentOS Linux 8 - Extras                                              7.2 kB/s | 1.5 kB     00:00    
EL-8 - Wazuh                                                          16 kB/s | 3.5 kB     00:00    
Dependencies resolved.
=====================================================================================================
 Package                    Architecture          Version                 Repository            Size
=====================================================================================================
Installing:
 wazuh-agent                x86_64                4.11.2-1                wazuh                8.9 M

Transaction Summary
=====================================================================================================
Install  1 Package

Total download size: 8.9 M
Installed size: 26 M
Is this ok [y/N]: y
Downloading Packages:
wazuh-agent-4.11.2-1.x86_64.rpm                                      2.3 MB/s | 8.9 MB     00:03    
-----------------------------------------------------------------------------------------------------
Total                                                                2.3 MB/s | 8.9 MB     00:03     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                             1/1 
  Running scriptlet: wazuh-agent-4.11.2-1.x86_64                                                 1/1 
  Installing       : wazuh-agent-4.11.2-1.x86_64                                                 1/1 
  Running scriptlet: wazuh-agent-4.11.2-1.x86_64                                                 1/1 
  Verifying        : wazuh-agent-4.11.2-1.x86_64                                                 1/1 

Installed:
  wazuh-agent-4.11.2-1.x86_64                                                                        

Complete!
[root@centos8 vagrant]# /var/ossec/bin/wazuh-control info 
WAZUH_VERSION="v4.11.2"
WAZUH_REVISION="41122"
WAZUH_TYPE="agent"

# Testing this PR
[root@centos8 vagrant]#  rpm -Uvh wazuh-agent-debuginfo_4.13.0-0_x86_64_f040703.rpm
error: Failed dependencies:
	wazuh-agent = 4.13.0-0 is needed by wazuh-agent-debuginfo-4.13.0-0.x86_64


[root@centos8 vagrant]# rpm -qR wazuh-agent-debuginfo 
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
wazuh-agent = 4.13.0-0

```
</details>

<details>
<summary>Uprade wazuh-agent 4.13.0 and install debuginfo </summary>

```bash
[root@centos8 vagrant]#  rpm -Uvh wazuh-agent_4.13.0-0_x86_64_f040703.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-4.13.0-0             ################################# [ 50%]
Cleaning up / removing...
   2:wazuh-agent-4.11.2-1             ################################# [100%]
[root@centos8 vagrant]#  rpm -Uvh wazuh-agent-debuginfo_4.13.0-0_x86_64_f040703.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-debuginfo-4.13.0-0   ################################# [100%]
```
</details>
</details>



<details>
<summary>Manager</summary>

<details>
<summary>Wazuh-manager 4.11.0</summary>

```bash
bash-5.2# /var/ossec/bin/wazuh-control info   
WAZUH_VERSION="v4.11.0"
WAZUH_REVISION="41103"
WAZUH_TYPE="server"

```
</details>


<details>
<summary>Verify if the issue exists on wazuh-manager-debuginfo 4.13.0 and test the fix</summary>

```bash

bash-5.2# rpm -Uvh  wazuh-manager-debuginfo-4.13.0-0.x86_64.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-manager-debuginfo-4.13.0-0 ################################# [100%]
bash-5.2# rpm -q wazuh-manager-debuginfo
wazuh-manager-debuginfo-4.13.0-0.x86_64

# Remove debuginfo package
bash-5.2# rpm -e wazuh-manager-debuginfo
bash-5.2# rpm -q wazuh-manager-debuginfo
package wazuh-manager-debuginfo is not installed

# Testing this PR
bash-5.2# rpm -Uvh  wazuh-manager-debuginfo_4.13.0-0_x86_64_f040703.rpm
error: Failed dependencies:
	wazuh-manager = 4.13.0-0 is needed by wazuh-manager-debuginfo-4.13.0-0.x86_64

bash-5.2# rpm -qR wazuh-manager-debuginfo_4.13.0-0_x86_64_f040703.rpm
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
wazuh-manager = 4.13.0-0
```
</details>




<details>
<summary>Uprade wazuh-manager 4.13.0 and install debuginfo</summary>

```bash

bash-5.2# rpm -Uvh wazuh-manager_4.13.0-0_x86_64_f040703.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-manager-4.13.0-0           ################################# [ 50%]
warning: /var/ossec/etc/ossec.conf created as /var/ossec/etc/ossec.conf.rpmnew
Cleaning up / removing...
   2:wazuh-manager-4.11.0-1           ################################# [100%]

bash-5.2#  /var/ossec/bin/wazuh-control info  
WAZUH_VERSION="v4.13.0"
WAZUH_REVISION="alpha0"
WAZUH_TYPE="server"

# Install debuginfo

bash-5.2# rpm -Uvh wazuh-manager-debuginfo_4.13.0-0_x86_64_f040703.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-manager-debuginfo-4.13.0-0 ################################# [100%]

bash-5.2#  rpm -q wazuh-manager-debuginfo
wazuh-manager-debuginfo-4.13.0-0.x86_64
```
</details>

</details>
</details>
