### PR TITLE
Add http support to remove pagination in wdb

### DIFF
--- a/src/shared_modules/router/include/router.h
+++ b/src/shared_modules/router/include/router.h
@@ -97,6 +97,13 @@ extern "C"
      */
     EXPORTED void router_provider_destroy(ROUTER_PROVIDER_HANDLE handle);
 
+    EXPORTED void
+    router_register_api_endpoint(char* socket_path, const char* method, const char* endpoint, void* callback);
+
+    EXPORTED void router_start_api(const char* socket_path);
+
+    EXPORTED void router_stop_api(const char* socket_path);
+
 #ifdef __cplusplus
 }
 #endif
@@ -112,11 +119,14 @@ typedef ROUTER_PROVIDER_HANDLE (*router_provider_create_func)(const char* name, 
 typedef bool (*router_provider_send_func)(ROUTER_PROVIDER_HANDLE handle,
                                           const char* message,
                                           unsigned int message_size);
-typedef bool (*router_provider_send_fb_func)(ROUTER_PROVIDER_HANDLE handle,
-                                          const char* message,
-                                          const char* schema);
-
+typedef bool (*router_provider_send_fb_func)(ROUTER_PROVIDER_HANDLE handle, const char* message, const char* schema);
 
 typedef void (*router_provider_destroy_func)(ROUTER_PROVIDER_HANDLE handle);
+
+typedef void (*router_register_api_endpoint_func)(char* socket_path, const char* endpoint, void* callback, void* data);
+
+typedef void (*router_start_api_func)(const char* socket_path);
+
+typedef void (*router_stop_api_func)(const char* socket_path);
 
 #endif // _ROUTER_H

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -288,11 +288,14 @@ extern "C"
         }
     }
 
+    /**
+     * @brief Struct to hold the server instance and its thread.
+     */
     struct ServerInstance final
     {
-        std::unique_ptr<httplib::Server> server;
-        std::thread serverThread;
-        bool running {false};
+        std::unique_ptr<httplib::Server> server; ///< Server instance
+        std::thread serverThread;                ///< Thread to run the server
+        bool running {false};                    ///< Flag to indicate if the server is running
     };
 
     std::map<std::string, std::shared_ptr<ServerInstance>> G_HTTPINSTANCES;

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -436,6 +436,16 @@ extern "C"
                     logMessage(modules_log_level_t::LOG_ERROR, "Error starting API. Failed to listen on socket");
                     return;
                 }
+
+                if (chmod(path.c_str(), 0660) == 0)
+                {
+                    logMessage(modules_log_level_t::LOG_DEBUG_VERBOSE, "API socket permissions set to 0660");
+                }
+                else
+                {
+                    logMessage(modules_log_level_t::LOG_ERROR,
+                               "Error setting API socket permissions: " + std::string(strerror(errno)));
+                }
             });
         // Spin lock until server is ready
         while (!instance->server->is_running() && instance->running)

--- a/src/shared_modules/utils/socketWrapper.hpp
+++ b/src/shared_modules/utils/socketWrapper.hpp
@@ -28,6 +28,9 @@
 #include <thread>
 #include <unistd.h>
 
+#ifdef INVALID_SOCKET
+#undef INVALID_SOCKET
+#endif
 constexpr auto INVALID_SOCKET {-1};
 constexpr auto SOCKET_ERROR {-1};
 using PacketFieldType = uint32_t;

--- a/src/unit_tests/wazuh_db/CMakeLists.txt
+++ b/src/unit_tests/wazuh_db/CMakeLists.txt
@@ -38,7 +38,13 @@ list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_scan_info_get -Wl,--wrap,wdb_fim_upd
                         -Wl,--wrap,wdb_global_create_backup -Wl,--wrap,wdb_commit2 -Wl,--wrap,wdb_vacuum -Wl,--wrap,wdb_get_db_state \
                         -Wl,--wrap,wdb_update_last_vacuum_data -Wl,--wrap,wdb_get_db_free_pages_percentage \
                         -Wl,--wrap,w_is_file -Wl,--wrap,wdb_close\
-                        -Wl,--wrap,wdb_pool_leave ${DEBUG_OP_WRAPPERS}")
+                        -Wl,--wrap,wdb_pool_leave -Wl,--wrap,wdb_global_get_group_all_agents\
+                        -Wl,--wrap,wdb_global_select_group_belong_agent_id\
+                        -Wl,--wrap,wdb_global_get_group_all_agents\
+                        -Wl,--wrap,wdb_global_sync_agent_groups_get_all\
+                        -Wl,--wrap,wdb_global_get_summary\
+                        -Wl,--wrap,wdb_global_sync_agent_info_get_np\
+                        -Wl,--wrap,wdb_global_sync_agent_info_set_np ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND wdb_tests_names "test_wdb_global_parser")
 list(APPEND wdb_tests_flags "-Wl,--wrap,wdb_open_global -Wl,--wrap,wdb_leave -Wl,--wrap,wdb_exec -Wl,--wrap,sqlite3_errmsg \

--- a/src/unit_tests/wazuh_db/test_wdb_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_parser.c
@@ -2603,6 +2603,217 @@ void test_wdb_parse_delete_db_file (void **state) {
     os_free(query);
 }
 
+static void test_wdb_parse_global_get_group_agents_api_success(void **state) {
+    (void) state;
+    wdb_t dummy_wdb = { 0 };
+    const char *json_input = "{\"name\": \"groupA\"}";
+    cJSON *mock_response = cJSON_CreateString("ok");
+
+    expect_any(__wrap_wdb_global_get_group_all_agents, wdb);
+    expect_string(__wrap_wdb_global_get_group_all_agents, group_name, "groupA");
+    will_return(__wrap_wdb_global_get_group_all_agents, mock_response);
+
+    cJSON *result = wdb_parse_global_get_group_agents_api(&dummy_wdb, json_input);
+    assert_non_null(result);
+    assert_string_equal(result->valuestring, "ok");
+
+    cJSON_Delete(result);
+}
+
+static void test_wdb_parse_global_get_group_agents_api_invalid_json(void **state) {
+    (void) state;
+    wdb_t dummy_wdb = { 0 };
+    const char *bad_json = "{name: groupA";
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON syntax when parsing get_group_agents.");
+
+    cJSON *result = wdb_parse_global_get_group_agents_api(&dummy_wdb, bad_json);
+    assert_null(result);
+}
+
+static void test_wdb_parse_global_get_group_agents_api_missing_name(void **state) {
+    (void) state;
+    wdb_t dummy_wdb = { 0 };
+    const char *json_input = "{\"wrong_key\": \"value\"}";
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON syntax when parsing get_group_agents.");
+
+    cJSON *result = wdb_parse_global_get_group_agents_api(&dummy_wdb, json_input);
+    assert_null(result);
+}
+
+static void test_sync_agent_groups_get_api_success(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"condition\":\"sync_status\",\"set_synced\":true,\"get_global_hash\":false,\"agent_registration_delta\":5}";
+    cJSON *expected = cJSON_CreateString("ok");
+
+    expect_any(__wrap_wdb_global_sync_agent_groups_get_all, wdb);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, condition, WDB_GROUP_SYNC_STATUS);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, set_synced, true);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, get_hash, false);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, agent_registration_delta, 5);
+    will_return(__wrap_wdb_global_sync_agent_groups_get_all, expected);
+
+    cJSON *res = wdb_parse_global_sync_agent_groups_get_api(&dummy, input);
+    assert_non_null(res);
+    assert_string_equal(res->valuestring, "ok");
+    cJSON_Delete(res);
+}
+
+static void test_sync_agent_groups_get_api_invalid_json(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{malformed";
+    expect_string(__wrap__mdebug1, formatted_msg, "Global DB Invalid JSON syntax when parsing /sync-agent-groups-get");
+
+    cJSON *res = wdb_parse_global_sync_agent_groups_get_api(&dummy, input);
+    assert_null(res);
+}
+
+static void test_sync_agent_groups_get_api_invalid_fields(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"condition\": 123, \"set_synced\": \"yes\"}";
+    expect_string(__wrap__mdebug1, formatted_msg, "Invalid alternative fields data in /sync-agent-groups-get.");
+
+    cJSON *res = wdb_parse_global_sync_agent_groups_get_api(&dummy, input);
+    assert_null(res);
+}
+
+static void test_sync_agent_groups_get_api_backend_error(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"condition\":\"sync_status\"}";
+
+    expect_string(__wrap__merror, formatted_msg, "Could not obtain a response from wdb_global_sync_agent_groups_get_all");
+
+    expect_any(__wrap_wdb_global_sync_agent_groups_get_all, wdb);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, condition, WDB_GROUP_SYNC_STATUS);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, set_synced, false);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, get_hash, false);
+    expect_value(__wrap_wdb_global_sync_agent_groups_get_all, agent_registration_delta, 0);
+    will_return(__wrap_wdb_global_sync_agent_groups_get_all, NULL);
+
+    cJSON *res = wdb_parse_global_sync_agent_groups_get_api(&dummy, input);
+    assert_null(res);
+}
+
+static void test_select_group_belong_api_success(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"agent_id\":\"42\"}";
+    cJSON *expected = cJSON_CreateString("groupX");
+
+    expect_any(__wrap_wdb_global_select_group_belong_agent_id, wdb);
+    expect_value(__wrap_wdb_global_select_group_belong_agent_id, agent_id, 42);
+    will_return(__wrap_wdb_global_select_group_belong_agent_id, expected);
+
+    cJSON *res = wdb_parse_global_select_group_belong_api(&dummy, input);
+    assert_non_null(res);
+    assert_string_equal(res->valuestring, "groupX");
+    cJSON_Delete(res);
+}
+
+static void test_select_group_belong_api_invalid_json(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{agent_id:\"unquoted\"";
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON syntax when parsing wdb_parse_global_select_group_belong_api.");
+
+    cJSON *res = wdb_parse_global_select_group_belong_api(&dummy, input);
+    assert_null(res);
+}
+
+static void test_select_group_belong_api_missing_id(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"bad_field\":\"value\"}";
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON syntax when parsing wdb_parse_global_select_group_belong_api.");
+
+    cJSON *res = wdb_parse_global_select_group_belong_api(&dummy, input);
+    assert_null(res);
+}
+
+static void test_get_summary_api_success(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"test\":true}";
+    cJSON *expected = cJSON_CreateString("summary");
+
+    expect_any(__wrap_wdb_global_get_summary, wdb);
+    expect_any(__wrap_wdb_global_get_summary, parameters_json);
+    will_return(__wrap_wdb_global_get_summary, expected);
+
+    cJSON *res = wdb_parse_global_get_summary_api(&dummy, input);
+    assert_non_null(res);
+    assert_string_equal(res->valuestring, "summary");
+    cJSON_Delete(res);
+}
+
+static void test_get_summary_api_invalid_json(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{not_valid}";
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON syntax when parsing wdb_parse_global_get_summary_api {not_valid}.");
+
+    cJSON *res = wdb_parse_global_get_summary_api(&dummy, input);
+    assert_null(res);
+}
+
+static void test_get_summary_api_backend_error(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"valid\":true}";
+
+    expect_any(__wrap_wdb_global_get_summary, wdb);
+    expect_any(__wrap_wdb_global_get_summary, parameters_json);
+    will_return(__wrap_wdb_global_get_summary, NULL);
+
+    cJSON *res = wdb_parse_global_get_summary_api(&dummy, input);
+    assert_null(res);
+}
+
+static void test_sync_agent_info_get_api_success(void **state) {
+    wdb_t dummy = {0};
+    cJSON *expected = cJSON_CreateString("info");
+
+    expect_any(__wrap_wdb_global_sync_agent_info_get_np, wdb);
+    will_return(__wrap_wdb_global_sync_agent_info_get_np, expected);
+
+    cJSON *res = wdb_parse_global_sync_agent_info_get_api(&dummy);
+    assert_non_null(res);
+    assert_string_equal(res->valuestring, "info");
+    cJSON_Delete(res);
+}
+
+static void test_sync_agent_info_set_api_success(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"set\":true}";
+
+    expect_any(__wrap_wdb_global_sync_agent_info_set_np, wdb);
+    expect_any(__wrap_wdb_global_sync_agent_info_set_np, parameters_json);
+    will_return(__wrap_wdb_global_sync_agent_info_set_np, OS_SUCCESS);
+
+    int res = wdb_parse_global_sync_agent_info_set_api(&dummy, input);
+    assert_int_equal(res, OS_SUCCESS);
+}
+
+static void test_sync_agent_info_set_api_invalid_json(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"unterminated\":true";
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid JSON syntax when parsing wdb_parse_global_sync_agent_info_set_api {\"unterminated\":true.");
+
+    int ret = wdb_parse_global_sync_agent_info_set_api(&dummy, input);
+    assert_int_equal(ret, OS_INVALID);
+}
+
+static void test_sync_agent_info_set_api_backend_error(void **state) {
+    wdb_t dummy = {0};
+    const char *input = "{\"valid\":true}";
+
+    expect_any(__wrap_wdb_global_sync_agent_info_set_np, wdb);
+    expect_any(__wrap_wdb_global_sync_agent_info_set_np, parameters_json);
+    will_return(__wrap_wdb_global_sync_agent_info_set_np, OS_INVALID);
+
+    expect_string(__wrap__merror, formatted_msg, "Error in wdb_global_sync_agent_info_set_np.");
+
+    int ret = wdb_parse_global_sync_agent_info_set_api(&dummy, input);
+    assert_int_equal(ret, OS_INVALID);
+}
+
 int main()
 {
     const struct CMUnitTest tests[] = {
@@ -2743,7 +2954,29 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_agent_get_fragmentation_free_pages_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_fragmentation_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_delete_db_file, test_setup, test_teardown),
-
+        /* wdb_parse_global_get_group_agents_api */
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_group_agents_api_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_group_agents_api_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_get_group_agents_api_missing_name, test_setup, test_teardown),
+        /* wdb_parse_global_sync_agent_groups_get_api */
+        cmocka_unit_test_setup_teardown(test_sync_agent_groups_get_api_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_sync_agent_groups_get_api_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_sync_agent_groups_get_api_invalid_fields, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_sync_agent_groups_get_api_backend_error, test_setup, test_teardown),
+        /* wdb_parse_global_select_group_belong_api */
+        cmocka_unit_test_setup_teardown(test_select_group_belong_api_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_select_group_belong_api_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_select_group_belong_api_missing_id, test_setup, test_teardown),
+        /* wdb_parse_global_get_summary_api */
+        cmocka_unit_test_setup_teardown(test_get_summary_api_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_summary_api_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_get_summary_api_backend_error, test_setup, test_teardown),
+        /* wdb_parse_global_sync_agent_info_get_api */
+        cmocka_unit_test_setup_teardown(test_sync_agent_info_get_api_success, test_setup, test_teardown),
+        /* wwdb_parse_global_sync_agent_info_set_api */
+        cmocka_unit_test_setup_teardown(test_sync_agent_info_set_api_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_sync_agent_info_set_api_invalid_json, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_sync_agent_info_set_api_backend_error, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -375,3 +375,41 @@ cJSON* __wrap_wdb_global_get_distinct_agent_groups(   __attribute__((unused)) wd
 int __wrap_wdb_global_recalculate_all_agent_groups_hash(__attribute__((unused)) wdb_t *wdb) {
     return mock();
 }
+
+cJSON* __wrap_wdb_global_get_group_all_agents(wdb_t* wdb, const char* group_name) {
+    check_expected_ptr(wdb);
+    check_expected_ptr(group_name);
+    return mock_ptr_type(cJSON*);
+}
+
+cJSON *__wrap_wdb_global_sync_agent_groups_get_all(wdb_t *wdb, wdb_groups_sync_condition_t condition, bool set_synced, bool get_hash, int agent_registration_delta) {
+    check_expected_ptr(wdb);
+    check_expected(condition);
+    check_expected(set_synced);
+    check_expected(get_hash);
+    check_expected(agent_registration_delta);
+    return mock_ptr_type(cJSON *);
+}
+
+cJSON *__wrap_wdb_global_select_group_belong_agent_id(wdb_t *wdb, int agent_id) {
+    check_expected_ptr(wdb);
+    check_expected(agent_id);
+    return mock_ptr_type(cJSON *);
+}
+
+cJSON *__wrap_wdb_global_get_summary(wdb_t *wdb, cJSON *parameters_json) {
+    check_expected_ptr(wdb);
+    check_expected_ptr(parameters_json);
+    return mock_ptr_type(cJSON *);
+}
+
+cJSON *__wrap_wdb_global_sync_agent_info_get_np(wdb_t *wdb) {
+    check_expected_ptr(wdb);
+    return mock_ptr_type(cJSON *);
+}
+
+int __wrap_wdb_global_sync_agent_info_set_np(wdb_t *wdb, cJSON *parameters_json) {
+    check_expected_ptr(wdb);
+    check_expected_ptr(parameters_json);
+    return mock_type(int);
+}

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -114,4 +114,16 @@ cJSON* __wrap_wdb_global_get_distinct_agent_groups(   __attribute__((unused)) wd
 
 int __wrap_wdb_global_recalculate_all_agent_groups_hash(__attribute__((unused)) wdb_t *wdb);
 
+cJSON* __wrap_wdb_global_get_group_all_agents(wdb_t* wdb, const char* group_name);
+
+cJSON *__wrap_wdb_global_sync_agent_groups_get_all(wdb_t *wdb, wdb_groups_sync_condition_t condition, bool set_synced, bool get_hash, int agent_registration_delta);
+
+cJSON *__wrap_wdb_global_select_group_belong_agent_id(wdb_t *wdb, int agent_id);
+
+cJSON *__wrap_wdb_global_get_summary(wdb_t *wdb, cJSON *parameters_json);
+
+cJSON *__wrap_wdb_global_sync_agent_info_get_api(wdb_t *wdb);
+
+int __wrap_wdb_global_sync_agent_info_set_np(wdb_t *wdb, cJSON *parameters_json);
+
 #endif

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.c
@@ -100,6 +100,10 @@ cJSON * __wrap_wdb_exec_stmt(__attribute__((unused)) sqlite3_stmt *stmt) {
     return mock_ptr_type(cJSON *);
 }
 
+cJSON * __wrap_wdb_exec_stmt_single_column(__attribute__((unused)) sqlite3_stmt *stmt) {
+    return mock_ptr_type(cJSON *);
+}
+
 cJSON * __wrap_wdb_exec_stmt_sized(__attribute__((unused)) sqlite3_stmt *stmt,
                                    size_t max_size,
                                    int* status,

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_wrappers.h
@@ -47,6 +47,8 @@ int __wrap_wdb_syscheck_save2(wdb_t *wdb, const char *payload);
 
 cJSON * __wrap_wdb_exec_stmt(sqlite3_stmt *stmt);
 
+cJSON * __wrap_wdb_exec_stmt_single_column(sqlite3_stmt *stmt);
+
 cJSON * __wrap_wdb_exec_stmt_sized(sqlite3_stmt *stmt, size_t max_size, int* status, bool column_mode);
 
 int __wrap_wdbc_parse_result(char *result, char **payload);

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -236,6 +236,8 @@ int main(int argc, char ** argv)
     router_register_api_endpoint("wdb-http.sock", "GET", "/v1/agents/ids/groups", (void*)&wdb_parse_api);
     router_register_api_endpoint("wdb-http.sock", "GET", "/v1/agents/:agent_id/groups", (void*)&wdb_parse_api);
     router_register_api_endpoint("wdb-http.sock", "POST", "/v1/agents/summary", (void*)&wdb_parse_api);
+    router_register_api_endpoint("wdb-http.sock", "GET", "/v1/agents/sync", (void*)&wdb_parse_api);
+    router_register_api_endpoint("wdb-http.sock", "POST", "/v1/agents/sync", (void*)&wdb_parse_api);
 
     router_start_api("wdb-http.sock");
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -231,7 +231,12 @@ int main(int argc, char ** argv)
 
     os_calloc(wconfig.worker_pool_size, sizeof(pthread_t), worker_pool);
 
-    router_register_api_endpoint("wdb-http.sock", "GET", "/get-all-agents-ids", (void*)&wdb_parse_api);
+    router_register_api_endpoint("wdb-http.sock", "GET", "/v1/agents/ids", (void*)&wdb_parse_api);
+    router_register_api_endpoint("wdb-http.sock", "GET", "/v1/agents/ids/groups/:name", (void*)&wdb_parse_api);
+    router_register_api_endpoint("wdb-http.sock", "GET", "/v1/agents/ids/groups", (void*)&wdb_parse_api);
+    router_register_api_endpoint("wdb-http.sock", "GET", "/v1/agents/:agent_id/groups", (void*)&wdb_parse_api);
+    router_register_api_endpoint("wdb-http.sock", "POST", "/v1/agents/summary", (void*)&wdb_parse_api);
+
     router_start_api("wdb-http.sock");
 
     for (i = 0; i < wconfig.worker_pool_size; i++) {

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -1280,6 +1280,29 @@ cJSON* wdb_exec_stmt(sqlite3_stmt* stmt) {
     return result;
 }
 
+cJSON* wdb_exec_stmt_single_column(sqlite3_stmt* stmt) {
+    cJSON * result;
+    cJSON * row;
+
+    if (!stmt) {
+        mdebug1("Invalid SQL statement.");
+        return NULL;
+    }
+
+    int status = SQLITE_ERROR;
+    result = cJSON_CreateArray();
+    while ((row = wdb_exec_row_stmt(stmt, &status, STMT_SINGLE_COLUMN))) {
+        cJSON_AddItemToArray(result, row);
+    }
+
+    if (status != SQLITE_DONE) {
+        cJSON_Delete(result);
+        result = NULL;
+    }
+
+    return result;
+}
+
 cJSON* wdb_exec_row_stmt_single_column(sqlite3_stmt* stmt, int* status) {
     cJSON* result = NULL;
     int _status = SQLITE_ERROR;

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -188,6 +188,8 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET] = "SELECT id FROM agent WHERE id > ? AND group_sync_status = 'syncreq' AND date_add < ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET] = "SELECT id FROM agent WHERE id > ? AND date_add < ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET_API] = "SELECT id FROM agent WHERE group_sync_status = 'syncreq' AND date_add < ? AND id > 0;",
+    [WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET_API] = "SELECT id FROM agent WHERE date_add < ? AND id > 0;",
     [WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND] = "SELECT 1 FROM agent WHERE group_sync_status = 'syncreq';",
     [WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET] = "SELECT count(id_group) groups_number from belongs WHERE id_agent = ?;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_SET] = "UPDATE agent SET group_sync_status = ? WHERE id = ?;",
@@ -274,6 +276,9 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_SYSCOLLECTOR_OSINFO_CLEAR] = "DELETE FROM sys_osinfo;",
     [WDB_STMT_SYS_HOTFIXES_GET] = "SELECT HOTFIX FROM SYS_HOTFIXES;",
     [WDB_STMT_SYS_PROGRAMS_GET] = "SELECT DISTINCT NAME, VERSION, ARCHITECTURE, VENDOR, FORMAT, SOURCE, CPE, MSU_NAME, ITEM_ID, DESCRIPTION, LOCATION, SIZE, INSTALL_TIME FROM SYS_PROGRAMS;",
+    [WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS] = "SELECT COUNT(*) as quantity, connection_status AS status FROM agent WHERE id > 0 GROUP BY status ORDER BY status ASC limit 5;",
+    [WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS_BY_OS] = "SELECT COUNT(*) as quantity, os_platform AS platform FROM agent WHERE id > 0 GROUP BY platform ORDER BY quantity DESC limit 5;",
+    [WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS_BY_GROUP] = "SELECT COUNT(*) as q, g.name AS group_name FROM belongs b JOIN 'group' g ON b.id_group=g.id WHERE b.id_agent > 0  GROUP BY b.id_group ORDER BY q DESC LIMIT 5;",
 };
 
 /**

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -279,6 +279,10 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS] = "SELECT COUNT(*) as quantity, connection_status AS status FROM agent WHERE id > 0 GROUP BY status ORDER BY status ASC limit 5;",
     [WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS_BY_OS] = "SELECT COUNT(*) as quantity, os_platform AS platform FROM agent WHERE id > 0 GROUP BY platform ORDER BY quantity DESC limit 5;",
     [WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS_BY_GROUP] = "SELECT COUNT(*) as q, g.name AS group_name FROM belongs b JOIN 'group' g ON b.id_group=g.id WHERE b.id_agent > 0  GROUP BY b.id_group ORDER BY q DESC LIMIT 5;",
+    [WDB_STMT_GLOBAL_SYNC_REQ_GET_API] = "SELECT id, name, ip, os_name, os_version, os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, merged_sum, manager_host, node_name, last_keepalive, connection_status, disconnection_time, group_config_status, status_code FROM agent WHERE id > 0 AND sync_status = 'syncreq';",
+    [WDB_STMT_GLOBAL_SYNC_REQ_KEEPALIVE_GET_API] = "SELECT id FROM agent WHERE id > 0 AND sync_status = 'syncreq_keepalive';",
+    [WDB_STMT_GLOBAL_SYNC_REQ_STATUS_GET_API] = "SELECT id, connection_status, disconnection_time, status_code FROM agent WHERE id > 0 AND sync_status = 'syncreq_status';",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE_API] = "UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW') WHERE id = ?;",
 };
 
 /**

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -2690,7 +2690,7 @@ int wdb_set_synchronous_normal(wdb_t * wdb);
  * @return cJSON* Returns a cJSON object with the elements that were not synced.
  *        NULL on error.
  */
-cJSON* wdb_global_sync_agent_info_get_api(wdb_t *wdb);
+cJSON* wdb_global_sync_agent_info_get_np(wdb_t *wdb);
 
 /**
  * @brief Get the elements of the agent table that were not synced.
@@ -2710,7 +2710,7 @@ cJSON* wdb_parse_global_sync_agent_info_get_api(wdb_t* wdb);
  * @param agent_info A JSON object with the agent information.
  * @return Returns 0 on success or -1 if an error occurs while setting the agent information.
  */
-int wdb_global_sync_agent_info_set_api(wdb_t *wdb, const cJSON *parameters);
+int wdb_global_sync_agent_info_set_np(wdb_t *wdb, const cJSON *parameters);
 
 /**
  * @brief Set the elements of the agent table that were not synced.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -975,6 +975,14 @@ int wdb_exec_stmt_send(sqlite3_stmt* stmt, int peer);
 cJSON* wdb_exec_stmt(sqlite3_stmt* stmt);
 
 /**
+ * @brief Function to execute a SQL statement and save the result in a JSON array.
+ *
+ * @param [in] stmt The SQL statement to be executed.
+ * @return JSON array with the statement execution results. NULL On error.
+ */
+cJSON* wdb_exec_stmt_single_column(sqlite3_stmt* stmt);
+
+/**
  * @brief Function to execute a SQL query and save the result in a JSON array.
  *
  * @param [in] db The SQL database to be queried.
@@ -1000,6 +1008,7 @@ wdb_t * wdb_pool_find_prev(wdb_t * wdb);
 int wdb_stmt_cache(wdb_t * wdb, int index);
 
 int wdb_parse(char * input, char * output, int peer);
+int wdb_parse_api(const char * endpoint, const char * input, char ** output);
 
 int wdb_parse_syscheck(wdb_t * wdb, wdb_component_t component, char * input, char * output);
 int wdb_parse_syscollector(wdb_t * wdb, const char * query, char * input, char * output);
@@ -2250,6 +2259,8 @@ cJSON* wdb_global_get_agent_info(wdb_t *wdb, int id);
  * @retval NULL on error.
  */
 cJSON* wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* status);
+
+cJSON* wdb_global_get_all_agent_ids(wdb_t *wdb);
 
 /**
  * @brief Gets every agent ID with context.

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -337,6 +337,10 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS,
     WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS_BY_OS,
     WDB_STMT_GLOBAL_AGENT_SUMMARY_CONNECTIONS_BY_GROUP,
+    WDB_STMT_GLOBAL_SYNC_REQ_GET_API,
+    WDB_STMT_GLOBAL_SYNC_REQ_KEEPALIVE_GET_API,
+    WDB_STMT_GLOBAL_SYNC_REQ_STATUS_GET_API,
+    WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE_API,
     WDB_STMT_SIZE // This must be the last constant
 } wdb_stmt;
 
@@ -1013,7 +1017,7 @@ wdb_t * wdb_pool_find_prev(wdb_t * wdb);
 int wdb_stmt_cache(wdb_t * wdb, int index);
 
 int wdb_parse(char * input, char * output, int peer);
-int wdb_parse_api(const char * endpoint, const char * input, char ** output);
+int wdb_parse_api(const char * endpoint, const char * method, const char * input, char ** output);
 
 int wdb_parse_syscheck(wdb_t * wdb, wdb_component_t component, char * input, char * output);
 int wdb_parse_syscollector(wdb_t * wdb, const char * query, char * input, char * output);
@@ -2676,5 +2680,45 @@ void wdbcom_dispatch(char* request, char* output);
  * @return Returns 0 on success or -1 if an error occurs while setting the synchronous mode.
  */
 int wdb_set_synchronous_normal(wdb_t * wdb);
+
+/**
+ * @brief Get the elements of the agent table that were not synced.
+ * This function is likely to be called from the worker and this data is sent across the cluster to
+ * the master.
+ *
+ * @param wdb The database structure.
+ * @return cJSON* Returns a cJSON object with the elements that were not synced.
+ *        NULL on error.
+ */
+cJSON* wdb_global_sync_agent_info_get_api(wdb_t *wdb);
+
+/**
+ * @brief Get the elements of the agent table that were not synced.
+ * This function is likely to be called from the worker and this data is sent across the cluster to
+ * the master.
+ *
+ * @param wdb The database structure.
+ * @return cJSON* Returns a cJSON object with the elements that were not synced.
+ */
+cJSON* wdb_parse_global_sync_agent_info_get_api(wdb_t* wdb);
+
+/**
+ * @brief Set the elements of the agent table that were not synced.
+ * This function is called from the master with data obtained from the worker.
+ *
+ * @param wdb The database structure.
+ * @param agent_info A JSON object with the agent information.
+ * @return Returns 0 on success or -1 if an error occurs while setting the agent information.
+ */
+int wdb_global_sync_agent_info_set_api(wdb_t *wdb, const cJSON *parameters);
+
+/**
+ * @brief Set the elements of the agent table that were not synced.
+ *
+ * @param wdb The database structure.
+ * @param input A JSON object with the agent information.
+ * @return Returns 0 on success or -1 if an error occurs while setting the agent information.
+ */
+int wdb_parse_global_sync_agent_info_set_api(wdb_t *wdb, const char *input);
 
 #endif

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -1839,6 +1839,25 @@ cJSON* wdb_global_get_all_agents(wdb_t *wdb, int last_agent_id, wdbc_result* sta
     return result;
 }
 
+cJSON* wdb_global_get_all_agent_ids(wdb_t *wdb) {
+    //Prepare SQL query
+    if (!wdb->transaction && wdb_begin2(wdb) < 0) {
+        mdebug1("Cannot begin transaction");
+        return NULL;
+    }
+    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_GET_AGENTS) < 0) {
+        mdebug1("Cannot cache statement");
+        return NULL;
+    }
+    sqlite3_stmt* stmt = wdb->stmt[WDB_STMT_GLOBAL_GET_AGENTS];
+    if (sqlite3_bind_int(stmt, 1, 0) != SQLITE_OK) {
+        merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+        return NULL;
+    }
+
+    return wdb_exec_stmt_single_column(stmt);
+}
+
 int wdb_global_agent_exists(wdb_t *wdb, int agent_id) {
     //Prepare SQL query
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -2276,7 +2276,6 @@ cJSON* wdb_global_get_distinct_agent_groups(wdb_t *wdb, char *group_hash, wdbc_r
 
 
 cJSON* wdb_global_sync_agent_groups_get_all(wdb_t *wdb, wdb_groups_sync_condition_t condition, bool set_synced, bool get_hash, int agent_registration_delta) {
-    int last_agent_id = 0;
 
     wdb_stmt sync_statement_index = WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET_API;
     switch (condition) {
@@ -2341,7 +2340,7 @@ cJSON* wdb_global_sync_agent_groups_get_all(wdb_t *wdb, wdb_groups_sync_conditio
             if (set_synced) {
                 //Set groups sync status as synced
                 if (OS_SUCCESS != wdb_global_set_agent_groups_sync_status(wdb, id, "synced")) {
-                    merror("Cannot set group_sync_status for agent %d", last_agent_id);
+                    merror("Cannot set group_sync_status for agent %d", id);
                 }
             }
         }

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -2527,7 +2527,7 @@ cJSON* wdb_global_get_summary(wdb_t *wdb, cJSON* agent_array) {
     return result;
 }
 
-cJSON* wdb_global_sync_agent_info_get_api(wdb_t *wdb) {
+cJSON* wdb_global_sync_agent_info_get_np(wdb_t *wdb) {
     sqlite3_stmt* agent_stmt = NULL;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
@@ -2656,7 +2656,7 @@ static int wdb_global_sync_agent_keepalive_info_set(wdb_t *wdb, int id) {
     return wdb_exec_stmt_silent(stmt);
 }
 
-int wdb_global_sync_agent_info_set_api(wdb_t *wdb, const cJSON *parameters) {
+int wdb_global_sync_agent_info_set_np(wdb_t *wdb, const cJSON *parameters) {
     cJSON * j_syncreq = cJSON_GetObjectItem(parameters, "syncreq");
     if (j_syncreq == NULL) {
         mdebug1("Parameter 'syncreq' not found");

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -228,7 +228,7 @@ int wdb_parse_api(const char* endpoint, __attribute__((unused)) const char* inpu
     timersub(&end, &begin, &diff);
     w_inc_global_open_time(diff);
 
-    cJSON* result = NULL;;
+    cJSON* result = NULL;
     if (strcmp(endpoint, "/v1/agents/ids") == 0) {
         result = wdb_global_get_all_agent_ids(wdb);
     } else if (strcmp(endpoint, "/v1/agents/ids/groups/:name") == 0) {

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -229,10 +229,21 @@ int wdb_parse_api(const char* endpoint, __attribute__((unused)) const char* inpu
     w_inc_global_open_time(diff);
 
     cJSON* result = NULL;;
-    if (strcmp(endpoint, "/get-all-agents-ids") == 0)
-    {
+    if (strcmp(endpoint, "/v1/agents/ids") == 0) {
         result = wdb_global_get_all_agent_ids(wdb);
+    } else if (strcmp(endpoint, "/v1/agents/ids/groups/:name") == 0) {
+        result = wdb_parse_global_get_group_agents_api(wdb, input);
+    } else if (strcmp(endpoint, "/v1/agents/ids/groups") == 0) {
+        // This call is used to get the list of groups for each agent.
+        result = wdb_parse_global_sync_agent_groups_get_api(wdb, R"({"condition":"all"})");
+    } else if (strcmp(endpoint, "/v1/agents/:agent_id/groups") == 0) {
+        result = wdb_parse_global_select_group_belong_api(wdb, input);
+    } else if (strcmp(endpoint, "/v1/agents/summary") == 0) {
+        // This call is used to get the summary of all agents. The method is post because
+        // we can receive a big list of agents and we need to use the body to send it.
+        result = wdb_parse_global_get_summary_api(wdb, input);
     }
+    wdb_pool_leave(wdb);
 
     if (!result) {
         mdebug1("Error calling endpoint from global.db.");
@@ -243,7 +254,6 @@ int wdb_parse_api(const char* endpoint, __attribute__((unused)) const char* inpu
     *output = cJSON_PrintUnformatted(result);
     cJSON_Delete(result);
 
-    wdb_pool_leave(wdb);
     return OS_SUCCESS;
 }
 
@@ -6767,4 +6777,120 @@ int wdb_parse_task_delete_old(wdb_t* wdb, const cJSON *parameters, char* output)
     cJSON_Delete(response);
 
     return result;
+}
+
+cJSON* wdb_parse_global_get_group_agents_api(wdb_t* wdb, const char* input) {
+    char *group_name = NULL;
+
+    cJSON *parameters_json = NULL;
+    // Detect parameters
+    if (parameters_json = cJSON_ParseWithOpts(input, 0, TRUE), !parameters_json) {
+        merror("Invalid JSON syntax when parsing get_group_agents.");
+        return NULL;
+    }
+
+    cJSON *group_json = cJSON_GetObjectItem(parameters_json, "name");
+    if (!group_json || (group_json->type != cJSON_String)) {
+        merror("Invalid JSON syntax when parsing get_group_agents.");
+        return NULL;
+    }
+    group_name = group_json->valuestring;
+
+    cJSON* ret = wdb_global_get_group_all_agents(wdb, group_name);
+
+    cJSON_Delete(parameters_json);
+
+    return ret;
+}
+
+cJSON* wdb_parse_global_sync_agent_groups_get_api(wdb_t* wdb, const char* input) {
+    cJSON *ret = NULL;
+    cJSON *args = cJSON_ParseWithOpts(input, 0, TRUE);
+    if (args) {
+        cJSON *j_sync_condition = cJSON_GetObjectItem(args, "condition");
+        cJSON *j_set_synced = cJSON_GetObjectItem(args, "set_synced");
+        cJSON *j_get_hash = cJSON_GetObjectItem(args, "get_global_hash");
+        cJSON *j_agent_registration_delta = cJSON_GetObjectItem(args, "agent_registration_delta");
+
+        // Checking data types of alternative parameters in case they would have been sent in the input JSON.
+        if ((j_sync_condition && !cJSON_IsString(j_sync_condition)) ||
+            (j_set_synced && !cJSON_IsBool(j_set_synced)) ||
+            (j_get_hash && !cJSON_IsBool(j_get_hash)) ||
+            (j_agent_registration_delta && (!cJSON_IsNumber(j_agent_registration_delta) || j_agent_registration_delta->valueint < 0))) {
+            mdebug1("Invalid alternative fields data in /sync-agent-groups-get.");
+            ret = NULL;
+        } else {
+            wdb_groups_sync_condition_t condition = WDB_GROUP_NO_CONDITION;
+            bool set_synced = false;
+            bool get_hash = false;
+            int agent_registration_delta = 0;
+
+            if (j_sync_condition && 0 == strcmp(j_sync_condition->valuestring, "sync_status")) {
+                condition = WDB_GROUP_SYNC_STATUS;
+            } else if (j_sync_condition && 0 == strcmp(j_sync_condition->valuestring, "all")) {
+                condition = WDB_GROUP_ALL;
+            } else if (j_sync_condition) {
+                condition = WDB_GROUP_INVALID_CONDITION;
+            }
+            if (cJSON_IsTrue(j_set_synced)) {
+                set_synced = true;
+            }
+            if (cJSON_IsTrue(j_get_hash)) {
+                get_hash = true;
+            }
+            if (j_agent_registration_delta) {
+                agent_registration_delta = j_agent_registration_delta->valueint;
+            }
+
+            ret = wdb_global_sync_agent_groups_get_all(wdb, condition, set_synced, get_hash, agent_registration_delta);
+            if (!ret) {
+                merror("Could not obtain a response from wdb_global_sync_agent_groups_get_all");
+            }
+        }
+        cJSON_Delete(args);
+    } else {
+        mdebug1("Global DB Invalid JSON syntax when parsing /sync-agent-groups-get");
+        return NULL;
+    }
+
+    return ret;
+}
+
+cJSON * wdb_parse_global_select_group_belong_api(wdb_t *wdb, const char *input) {
+    int agent_id;
+
+    cJSON *parameters_json = NULL;
+    // Detect parameters
+    if (parameters_json = cJSON_ParseWithOpts(input, 0, TRUE), !parameters_json) {
+        merror("Invalid JSON syntax when parsing wdb_parse_global_select_group_belong_api.");
+        return NULL;
+    }
+
+    cJSON *agent_id_param = cJSON_GetObjectItem(parameters_json, "agent_id");
+    if (!agent_id_param || (agent_id_param->type != cJSON_String)) {
+        merror("Invalid JSON syntax when parsing wdb_parse_global_select_group_belong_api.");
+        return NULL;
+    }
+    agent_id = atoi(agent_id_param->valuestring);
+
+    cJSON* ret = wdb_global_select_group_belong_agent_id(wdb, agent_id);
+
+    cJSON_Delete(parameters_json);
+
+    return ret;
+}
+
+cJSON* wdb_parse_global_get_summary_api(wdb_t *wdb, const char *input) {
+    cJSON *parameters_json = NULL;
+    // Detect parameters
+    if (parameters_json = cJSON_ParseWithOpts(input, 0, TRUE), !parameters_json) {
+        merror("Invalid JSON syntax when parsing wdb_parse_global_get_summary_api %s.", input);
+        return NULL;
+    }
+
+    cJSON* ret = wdb_global_get_summary(wdb, parameters_json);
+
+    cJSON_Delete(parameters_json);
+
+    return ret;
 }

--- a/src/wazuh_db/wdb_parser.c
+++ b/src/wazuh_db/wdb_parser.c
@@ -6915,7 +6915,8 @@ cJSON* wdb_parse_global_get_summary_api(wdb_t *wdb, const char *input) {
 }
 
 cJSON* wdb_parse_global_sync_agent_info_get_api(wdb_t* wdb) {
-    return wdb_global_sync_agent_info_get_api(wdb);
+    cJSON* ret = wdb_global_sync_agent_info_get_np(wdb);
+    return ret;
 }
 
 int wdb_parse_global_sync_agent_info_set_api(wdb_t *wdb, const char *input) {
@@ -6926,10 +6927,10 @@ int wdb_parse_global_sync_agent_info_set_api(wdb_t *wdb, const char *input) {
         return OS_INVALID;
     }
 
-    int ret = wdb_global_sync_agent_info_set_api(wdb, parameters_json);
+    int ret = wdb_global_sync_agent_info_set_np(wdb, parameters_json);
 
     if (ret != OS_SUCCESS) {
-        merror("Error in wdb_global_sync_agent_info_set_api.");
+        merror("Error in wdb_global_sync_agent_info_set_np.");
         return OS_INVALID;
     }
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #29396|

## Summary

This pull request introduces HTTP protocol support to the Wazuh Database (WDB), enabling the removal of pagination in API responses. This enhancement allows clients to retrieve complete datasets in a single request, improving efficiency and simplifying data handling.

## Changes

- Implemented HTTP protocol support in WDB.
- Modified API responses to eliminate pagination, providing full data sets in single responses.

## Motivation

Previously, WDB responses were paginated, requiring multiple requests to access complete data sets. This enhancement simplifies data retrieval by allowing clients to obtain all relevant data in a single request, reducing complexity and potential overhead.

