### PR TITLE
Set default for server in centralized configuration - Implementation

### DIFF
--- a/framework/wazuh/core/config/models/central_config.py
+++ b/framework/wazuh/core/config/models/central_config.py
@@ -51,7 +51,7 @@ class Config(WazuhConfigBaseModel):
         Configuration for the communications API. Default is an instance of CommsAPIConfig.
     """
 
-    server: ServerConfig
+    server: ServerConfig = ServerConfig()
     indexer: IndexerConfig
     engine: EngineConfig = EngineConfig()
     management_api: ManagementAPIConfig = ManagementAPIConfig()

--- a/framework/wazuh/core/config/models/tests/test_central_config.py
+++ b/framework/wazuh/core/config/models/tests/test_central_config.py
@@ -9,6 +9,7 @@ from wazuh.core.config.models.central_config import (
     EngineConfig,
     IndexerConfig,
     ManagementAPIConfig,
+    ServerConfig,
 )
 
 
@@ -29,18 +30,14 @@ def test_config_sections_ko():
                     'username': 'user_example',
                     'password': 'password_example',
                 },
-                'server': {},
             },
             {
-                'server': {
-                    'update_check': False,
-                    'logging.level': 'info',
-                },
                 'indexer': {
                     'hosts': [{'host': 'localhost', 'port': 9200}],
                     'username': 'user_example',
                     'password': 'password_example',
                 },
+                'server': {},
                 'engine': {},
                 'management_api': {},
                 'communications_api': {},
@@ -53,10 +50,8 @@ def test_config_default_values(init_values, expected):
     with patch.object(ValidateFilePathMixin, '_validate_file_path', return_value=None):
         config = Config(**init_values)
 
-        assert config.server.update_check == expected['server']['update_check']
-        assert config.server.logging.level == expected['server']['logging.level']
-
         assert config.indexer == IndexerConfig(**expected['indexer'])
         assert config.engine == EngineConfig(**expected['engine'])
+        assert config.server == ServerConfig(**expected['server'])
         assert config.management_api == ManagementAPIConfig(**expected['management_api'])
         assert config.communications_api == CommsAPIConfig(**expected['communications_api'])

--- a/framework/wazuh/core/config/tests/test_client.py
+++ b/framework/wazuh/core/config/tests/test_client.py
@@ -14,16 +14,13 @@ from wazuh.core.config.models.central_config import (
 from wazuh.core.config.models.server import ServerConfig
 
 mock_config_data = {
-    'server': {
-        'logging': {'level': 'debug2'},
-        'cti': {},
-    },
     'indexer': {
         'hosts': [{'host': 'localhost', 'port': 9200}],
         'username': 'admin',
         'password': 'password',
         'ssl': {'use_ssl': False, 'key': '', 'certificate': '', 'certificate_authorities': ['']},
     },
+    'server': {},
     'engine': {},
     'management_api': {},
     'communications_api': {},


### PR DESCRIPTION
|Related issue|
|---|
|Closing #29416|

## Description
This issue aims to add the default configuration handler for the Server configuration

### Unit tests
```
root@wazuh-dev:~/repos/wazuh# pytest framework/wazuh/core/config/
=============================================================== test session starts ===============================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-0.13.1
rootdir: /root/repos/wazuh/framework, configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, cov-4.1.0, trio-0.8.0, tornasync-0.6.0, testinfra-5.0.0, html-3.1.1, metadata-2.0.4, anyio-3.7.1
asyncio: mode=auto
collected 105 items                                                                                                                               

framework/wazuh/core/config/models/tests/test_central_config.py ..                                                                          [  1%]
framework/wazuh/core/config/models/tests/test_comms_api.py ............                                                                     [ 13%]
framework/wazuh/core/config/models/tests/test_engine.py ..........                                                                          [ 22%]
framework/wazuh/core/config/models/tests/test_indexer.py .......                                                                            [ 29%]
framework/wazuh/core/config/models/tests/test_logging.py .................                                                                  [ 45%]
framework/wazuh/core/config/models/tests/test_management_api.py ..........................                                                  [ 70%]
framework/wazuh/core/config/models/tests/test_server.py ....                                                                                [ 74%]
framework/wazuh/core/config/models/tests/test_ssl_config.py .................                                                               [ 90%]
framework/wazuh/core/config/tests/test_client.py ..........                                                                                 [100%]

=============================================================== 105 passed in 0.92s ===============================================================
```

### Manual tests 

```console
root@wazuh-dev:~/repos/wazuh/apis/tools/env# cat wazuh-server/wazuh-server.yml 
indexer:
  hosts:
    - host: wazuh-indexer
      port: 9200
  username: admin
  password: admin
  ssl:
    use_ssl: true
    key: /etc/wazuh-server/certs/indexer-key.pem
    certificate: /etc/wazuh-server/certs/indexer.pem
    certificate_authorities:
      - /etc/wazuh-server/certs/root-ca.pem
    verify_certificates: true
communications_api:
  host: 0.0.0.0
  ssl:
    key: /etc/wazuh-server/certs/server-key.pem
    cert: /etc/wazuh-server/certs/server.pem
management_api:
  host: 0.0.0.0
  ssl:
    key: /etc/wazuh-server/certs/server-key.pem
    cert: /etc/wazuh-server/certs/server.pem
root@wazuh-dev:~/repos/wazuh/apis/tools/env# docker compose up -d
[+] Running 5/5
 ✔ Network dev-wazuh_default  Created                                                                                                         0.1s 
 ✔ Container wazuh-indexer    Started                                                                                                         0.9s 
 ✔ Container wazuh-manager    Started                                                                                                         1.5s 
 ✔ Container nginx-lb         Started                                                                                                         2.2s 
 ✔ Container wazuh-agent      Started                                                                                                         2.8s 
root@wazuh-dev:~/repos/wazuh/apis/tools/env# docker compose logs wazuh-manager
wazuh-manager  | Waiting for the indexer to be up...
wazuh-manager  | Creating RBAC admin user...
wazuh-manager  | {"_index":"wazuh-internal-users","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}
wazuh-manager  | 2025/04/30 12:26:54 INFO: [Server] [Main] Starting server (pid: 111)
wazuh-manager  | 2025/04/30 12:26:54 INFO: [Server] [Main] Configuration server is not available, retrying...
wazuh-manager  | 2025/04/30 12:26:54 INFO: [Server] [Config Server] Started server process [111]
wazuh-manager  | 2025/04/30 12:26:54 INFO: [Server] [Config Server] Waiting for application startup.
wazuh-manager  | 2025/04/30 12:26:54 INFO: [Server] [Config Server] Application startup complete.
wazuh-manager  | 2025/04/30 12:26:54 INFO: [Server] [Config Server] Uvicorn running on unix socket /run/wazuh-server/config-server.sock (Press CTRL+C to quit)
wazuh-manager  | 2025/04/30 12:26:55 INFO: [Server] [Main] Starting wazuh-engined
wazuh-manager  | 2025-04-30 12:26:55.215 120:120 info: Logging initialized.
wazuh-manager  | 2025/04/30 12:26:55 INFO: [Server] [Config Server]  - "GET /api/v1/config?sections=indexer,engine HTTP/1.1" 200
wazuh-manager  | 2025-04-30 12:26:55.219 120:120 info: Metrics manager configured successfully
wazuh-manager  | 2025-04-30 12:26:55.219 120:120 info: Metrics initialized.
wazuh-manager  | 2025-04-30 12:26:55.219 120:120 info: Metrics disabled.
wazuh-manager  | 2025-04-30 12:26:55.219 120:120 info: Store initialized.
wazuh-manager  | 2025-04-30 12:26:55.220 120:120 warning: Could not load RBAC model, using default model: File '/var/lib/wazuh-server/engine/store/internal/rbac/model/0' does not exist
wazuh-manager  | 2025-04-30 12:26:55.221 120:120 info: RBAC initialized.
wazuh-manager  | 2025-04-30 12:26:55.424 120:120 info: KVDB initialized.
wazuh-manager  | 2025-04-30 12:26:55.424 120:120 info: Geo initialized.
wazuh-manager  | 2025-04-30 12:26:55.467 120:120 info: Schema initialized.
wazuh-manager  | 2025-04-30 12:26:55.486 120:120 info: Loaded timezone database version: '2024a'
wazuh-manager  | 2025-04-30 12:26:55.486 120:120 info: HLP initialized.
wazuh-manager  | 2025-04-30 12:26:55.665 120:120 info: Indexer Connector initialized.
wazuh-manager  | 2025-04-30 12:26:55.666 120:120 info: Builder initialized.
wazuh-manager  | 2025-04-30 12:26:55.666 120:120 info: Catalog initialized.
wazuh-manager  | 2025-04-30 12:26:55.666 120:120 info: Policy manager initialized.
wazuh-manager  | 2025-04-30 12:26:55.668 120:120 info: No flooding file provided, the queue will not be flooded.
wazuh-manager  | 2025-04-30 12:26:55.678 120:120 info: No flooding file provided, the queue will not be flooded.
wazuh-manager  | 2025-04-30 12:26:55.678 120:120 info: Router: router/router/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/router/0' does not exist
wazuh-manager  | 2025-04-30 12:26:55.679 120:120 info: Router: router/tester/0 table not found in store. Creating new table: File '/var/lib/wazuh-server/engine/store/router/tester/0' does not exist
wazuh-manager  | 2025-04-30 12:26:55.679 120:120 warning: Router: EPS settings could not be loaded from the store due to 'File '/var/lib/wazuh-server/engine/store/router/eps/0' does not exist'. Using default settings
wazuh-manager  | 2025-04-30 12:26:55.679 120:120 info: Router: EPS settings dumped to the store
wazuh-manager  | 2025-04-30 12:26:55.679 120:120 info: Router initialized.
wazuh-manager  | 2025-04-30 12:26:55.679 120:120 info: Starting database file decompression.
wazuh-manager  | 2025/04/30 12:26:57 INFO: [Server] [Main] Started wazuh-engined (pid: 120)
wazuh-manager  | 2025/04/30 12:26:57 INFO: [Server] [Main] Starting wazuh-comms-apid
wazuh-manager  | 2025/04/30 12:26:59 INFO: [Server] [Main] Started wazuh-comms-apid (pid: 176)
wazuh-manager  | 2025/04/30 12:26:59 INFO: [Server] [Main] Starting wazuh-server-management-apid
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Starting API
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Listening on 0.0.0.0:27000
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Starting gunicorn 22.0.0
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Listening at: https://0.0.0.0:27000 (176)
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Using worker: uvicorn.workers.UvicornWorker
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Booting worker with pid: 226
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Started server process [176]
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Waiting for application startup.
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Application startup complete.
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Uvicorn running on unix socket /run/wazuh-server/comms-api.sock (Press CTRL+C to quit)
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Booting worker with pid: 227
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Started server process [227]
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Waiting for application startup.
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Application startup complete.
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Booting worker with pid: 228
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Booting worker with pid: 229
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Started server process [228]
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Waiting for application startup.
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Application startup complete.
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Started server process [229]
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Waiting for application startup.
wazuh-manager  | 2025/04/30 12:27:00 INFO: [Communications API] Application startup complete.
wazuh-manager  | 2025/04/30 12:27:01 INFO: [Server] [Main] Started wazuh-server-management-apid (pid: 177)
wazuh-manager  | 2025/04/30 12:27:01 WARNING: [Server] [Main] The Server doesn't meet the expected daemons state: {'wazuh-server-ma': False, 'wazuh-comms-apid': True, 'wazuh-engined': True}. Sleeping until next checking...
wazuh-manager  | 2025/04/30 12:27:01 INFO: [Management API] Starting API
```