### PR TITLE
Assign "default" group to new agents during enrollment

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -43,7 +43,7 @@ void add_insert(const keyentry *entry,const char *group) {
     node->name = strdup(entry->name);
     node->ip = strdup(entry->ip->ip);
     node->raw_key = strdup(entry->raw_key);
-    node->group = group ? strdup(group) : NULL;
+    node->group = strdup(group ? group : "default");
 
     (*insert_tail) = node;
     insert_tail = &node->next;

--- a/tests/integration/test_authd/conftest.py
+++ b/tests/integration/test_authd/conftest.py
@@ -63,7 +63,7 @@ def insert_pre_existent_agents(test_metadata, stop_authd):
             else:
                 registration_time = time_now
 
-            mocking.create_mocked_agent(id=id, name=name, ip=ip, date_add=registration_time,
+            mocking.create_mocked_agent(id=id, name=name, ip=ip, date_add=registration_time, group='default',
                                         connection_status=connection_status, disconnection_time=disconnection_time,
                                         client_key_secret=key)
 

--- a/tests/integration/test_authd/test_cluster/data/test_cases/cases_authd_local.yaml
+++ b/tests/integration/test_authd/test_cluster/data/test_cases/cases_authd_local.yaml
@@ -6,15 +6,19 @@
     -
       input: '{"arguments":{"name":"user1","ip":"any"},"function":"add"}'
       output: '{"error":0,"data":{"id":"001","name":"user1","ip":"any","key":'
+      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user2","ip":"192.0.0.0"},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"user2","ip":"192.0.0.0","key":'
+      expected_group: 'default'
     -
       input: '{"arguments":{"id":"100","name":"user100","ip":"any"},"function":"add"}'
       output: '{"error":0,"data":{"id":"100","name":"user100","ip":"any","key":'
+      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user4","ip":"any","id":"101","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"},"function":"add"}'
       output: '{"error":0,"data":{"id":"101","name":"user4","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"'
+      expected_group: 'default'
     pre_existent_agents:
     -
     groups:
@@ -78,12 +82,15 @@
     -
       input: '{"arguments":{"name":"user1","ip":"any","force":{"enabled":true, "key_mismatch":false, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"004","name":"user1","ip":"any","key":'
+      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user_2","ip":"192.0.0.0","force":{"enabled":true, "key_mismatch":false, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"005","name":"user_2","ip":"192.0.0.0","key":'
+      expected_group: 'default'
     -
       input: '{"arguments":{"id":"003","name":"user_3","ip":"any","force":{"enabled":true, "key_mismatch":false, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"003","name":"user_3","ip":"any","key":'
+      expected_group: 'default'
     pre_existent_agents:
     -
       id: '001'
@@ -111,12 +118,14 @@
     -
       input: '{"arguments":{"name":"user21","ip":"any","groups":"Group1"},"function":"add"}'
       output: '{"error":0,"data":{"id":"001","name":"user21","ip":"any","key":'
+      expected_group: 'Group1'
     -
       input: '{"arguments":{"name":"user_","ip":"any","groups":"Group_"},"function":"add"}'
       output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
     -
       input: '{"arguments":{"name":"user22","ip":"any","groups":"Group1,Group2"},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"user22","ip":"any","key":'
+      expected_group: 'Group1,Group2'
     -
       input: '{"arguments":{"name":"user_","ip":"any","groups":"Group1,Group2,Group3"},"function":"add"}'
       output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
@@ -169,12 +178,14 @@
     -
       input: '{"arguments":{"name":"new_user1","ip":"any","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"new_user1","ip":"any","key":'
+      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user1","ip":"any","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":9008,"message":"Duplicate name"}'
     -
       input: '{"arguments":{"name":"user1","ip":"any","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"003","name":"user1","ip":"any","key":'
+      expected_group: 'default'
     pre_existent_agents:
     -
       id: '001'
@@ -192,6 +203,7 @@
     -
       input: '{"arguments":{"name":"new_user","ip":"10.0.0.1","groups":"Group1","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"new_user","ip":"10.0.0.1","key":'
+      expected_group: 'Group1'
     -
       input: '{"arguments":{"name":"user1","ip":"any","groups":"Group1","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":9008,"message":"Duplicate name"}'
@@ -201,6 +213,7 @@
     -
       input: '{"arguments":{"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"003","name":"user1","ip":"10.10.10.10","key":'
+      expected_group: 'Group1'
     pre_existent_agents:
     -
       id: '001'

--- a/tests/integration/test_authd/test_cluster/test_authd_local.py
+++ b/tests/integration/test_authd/test_cluster/test_authd_local.py
@@ -39,10 +39,13 @@ tags:
 '''
 from pathlib import Path
 
+import json
 import pytest
+import time
 
 from wazuh_testing.constants.paths.sockets import WAZUH_DB_SOCKET_PATH, AUTHD_SOCKET_PATH
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, WAZUH_DB_DAEMON
+from wazuh_testing.utils import database
 from wazuh_testing.utils.configuration import load_configuration_template, get_test_cases_data
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
@@ -136,3 +139,20 @@ def test_authd_local_messages(test_configuration, test_metadata, set_wazuh_confi
         assert response[:len(expected)] == expected, \
             'Failed: Response was: {} instead of: {}' \
             .format(response, expected)
+
+        if 'expected_group' in case:
+            data = json.loads(response)['data']
+            query = "global sql SELECT * FROM `agent` WHERE `id` = {}".format(data['id'])
+
+            for i in range(3):
+                group = database.query_wdb(query)
+
+                if group:
+                    break
+
+                time.sleep(1)
+
+            if not group:
+                assert False, 'The agent was not created in the database'
+
+            assert group[0]['group'] == case['expected_group']

--- a/tests/integration/test_authd/test_common/data/test_cases/cases_authd.yaml
+++ b/tests/integration/test_authd/test_common/data/test_cases/cases_authd.yaml
@@ -6,6 +6,7 @@
     -
       input: "OSSEC A:'user1'"
       output: "OSSEC K:'"
+      expected_group: "default"
     groups:
       -
 
@@ -17,6 +18,7 @@
     -
       input: "OSSEC A:'user2' G:'Group1'"
       output: "OSSEC K:"
+      expected_group: "Group1"
     groups:
       - 'Group1'
       - 'Group2'
@@ -90,6 +92,7 @@
     -
       input: "OSSEC A:'user3' G:'Group1,Group2'"
       output: "OSSEC K:"
+      expected_group: "Group1,Group2"
 
 - name: "Multiple Group - One group is invalid"
   description: "Check Multiple groups enrollment"

--- a/tests/integration/test_authd/test_common/test_authd.py
+++ b/tests/integration/test_authd/test_common/test_authd.py
@@ -52,6 +52,7 @@ from pathlib import Path
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_ENROLLMENT_PORT
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, WAZUH_DB_DAEMON, MODULES_DAEMON
+from wazuh_testing.utils import database
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 
 # Marks
@@ -152,3 +153,20 @@ def test_ossec_auth_messages(test_configuration, test_metadata, set_wazuh_config
                 assert response != '', 'The manager did not respond to the message sent.'
         assert response[:len(expected)] == expected, \
             'Failed test case {}: Response was: {} instead of: {}'.format(set_up_groups['name'], response, expected)
+
+        if 'expected_group' in stage:
+            id = int(response.split("K:'")[1].split()[0])
+            query = "global sql SELECT * FROM `agent` WHERE `id` = {}".format(id)
+
+            for i in range(3):
+                group = database.query_wdb(query)
+
+                if group:
+                    break
+
+                time.sleep(1)
+
+            if not group:
+                assert False, 'The agent was not created in the database'
+
+            assert group[0]['group'] == stage['expected_group']


### PR DESCRIPTION
# Assign "default" group to new agents during enrollment

## Description

This pull request introduces changes to ensure that all newly registered agents are automatically assigned to the `"default"` group unless a different group is explicitly specified during enrollment. This standardization simplifies the agent management lifecycle and eliminates the need for handling edge cases related to agents without assigned groups.

## Proposed Changes

- **wazuh-authd** now assigns the `"default"` group to all agents registered through port `1515`, unless a group is explicitly specified.
- Agents forwarded from a worker to the master are handled similarly, inheriting the `"default"` group if no other is provided.
- **wazuh-modulesd** updates the client.keys synchronization module to ensure that newly added agents from `client.keys` are registered in the `"default"` group.
- REST API behavior remains consistent by ensuring that agents registered without specifying a group are also assigned to `"default"`.

**Cases covered:**
1. Agent enrollment via `wazuh-authd` (port 1515).
2. Agent enrollment on a worker node with forwarding to the master.
3. Agent registration through the REST API.
4. Pre-existing agent in `client.keys` added to the database.

**Case not covered:**
- Previously registered "never-connected" agents without a group. This will be addressed in issue [[#29402](https://github.com/wazuh/wazuh/issues/29402)](https://github.com/wazuh/wazuh/issues/29402).

### Results and Evidence

**Agent enrollment using `agent-auth`:**
```
/var/ossec/bin/agent-auth -m 172.21.187.131 -A rockylinux
```
`agent` table:
```json
{
    "id": 2,
    "name": "rockylinux",
    "register_ip": "any",
    "internal_key": "ea88185dc2927b9dd3ce94e7ab886d5326bc9c4ab14ae8496623ed0154d7af7c",
    "node_name": "unknown",
    "date_add": 1745934245,
    "group": "default",
    "group_hash": "37a8eec1",
    "group_sync_status": "synced",
    "sync_status": "synced",
    "connection_status": "never_connected",
    "disconnection_time": 0,
    "group_config_status": "not synced",
    "status_code": 0
}
```
`belongs` table:
```json
{
    "id_agent": 2,
    "id_group": 1,
    "priority": 0
}
```

**Agent registration via API:**
```bash
POST -H 'Content-Type: application/json' https://localhost:55000/agents -d '{"name": "api-reg", "ip":"any"}'
```
`agent` table:
```json
{
    "id": 3,
    "name": "api-reg",
    "register_ip": "any",
    "internal_key": "e4ce99e1b4e170d652847612295d63d730fd22528f87ba1a38698e715cdfb15e",
    "node_name": "unknown",
    "date_add": 1745934438,
    "group": "default",
    "group_hash": "37a8eec1",
    "group_sync_status": "synced",
    "sync_status": "synced",
    "connection_status": "never_connected",
    "disconnection_time": 0,
    "group_config_status": "not synced",
    "status_code": 0
}
```
`belongs` table:
```json
{
    "id_agent": 3,
    "id_group": 1,
    "priority": 0
}
```

**Pre-existing agent in `client.keys`:**
```bash
echo "001 agent1 any aslkdjad" >> /var/ossec/etc/client.keys
```
`agent` table:
```json
{
    "id": 1,
    "name": "agent1",
    "register_ip": "any",
    "internal_key": "aslkdjad",
    "node_name": "unknown",
    "date_add": 1745926751,
    "group": "default",
    "group_hash": "37a8eec1",
    "group_sync_status": "synced",
    "sync_status": "synced",
    "connection_status": "never_connected",
    "disconnection_time": 0,
    "group_config_status": "not synced",
    "status_code": 0
}
```
`belongs` table:
```json
{
    "id_agent": 1,
    "id_group": 1,
    "priority": 0
}
```

### Artifacts Affected

- `wazuh-authd` (manager)
- `wazuh-modulesd` (manager)

### Configuration Changes

No configuration changes required.

### Documentation Updates

Not applicable.

### Tests Introduced

- Unit test for `wazuh-authd` input validator: ensures `"default"` group assignment when `group` is not provided.
- Integration tests:
  - Agent enrollment via master node (port 1515)
  - Agent enrollment via worker node with forwarding

#### Authd integration tests

```
test_authd.py::test_ossec_auth_messages[AgentName] PASSED                                                        [  7%]
test_authd.py::test_ossec_auth_messages[Single Group - Valid group] PASSED                                       [ 14%]
test_authd.py::test_ossec_auth_messages[Single Group - Invalid group] PASSED                                     [ 21%]
test_authd.py::test_ossec_auth_messages[Single Group - Name too long] PASSED                                     [ 28%]
test_authd.py::test_ossec_auth_messages[Single Group - Invalid Characters] PASSED                                [ 35%]
test_authd.py::test_ossec_auth_messages[Single Group - Empty Group] PASSED                                       [ 42%]
test_authd.py::test_ossec_auth_messages[Multiple Group - Valid groups] PASSED                                    [ 50%]
test_authd.py::test_ossec_auth_messages[Multiple Group - One group is invalid] PASSED                            [ 57%]
test_authd.py::test_ossec_auth_messages[Multiple Group - Name too long] PASSED                                   [ 64%]
test_authd.py::test_ossec_auth_messages[Multiple Group - Invalid Characters] PASSED                              [ 71%]
test_authd.py::test_ossec_auth_messages[Multiple Group - Empty List] PASSED                                      [ 78%]
test_authd.py::test_ossec_auth_messages[Multiple Group - Exceed max multigrup length] PASSED                     [ 85%]
test_authd.py::test_ossec_auth_messages[Multiple Group - Exceed max Multigrup number] PASSED                     [ 92%]
test_authd.py::test_ossec_auth_messages[Multiple Group - Send a message of exactly 16k] PASSED                   [100%]
```

#### Local Authd integration tests

```
test_authd_local.py::test_authd_local_messages[Add agent] PASSED                                                 [ 12%]
test_authd_local.py::test_authd_local_messages[Add duplicate agent without force options in request] PASSED      [ 25%]
test_authd_local.py::test_authd_local_messages[Failed duplicate registration] PASSED                             [ 37%]
test_authd_local.py::test_authd_local_messages[Force registration] PASSED                                        [ 50%]
test_authd_local.py::test_authd_local_messages[Single/Multi Group] PASSED                                        [ 62%]
test_authd_local.py::test_authd_local_messages[Remove agent] PASSED                                              [ 75%]
test_authd_local.py::test_authd_local_messages[Agent with key hash simple] PASSED                                [ 87%]
test_authd_local.py::test_authd_local_messages[Agent with key hash and group] PASSED                             [100%]
```

## Review Checklist

- [ ] Code changes reviewed  
- [ ] Relevant evidence provided  
- [ ] Tests cover the new functionality  
- [ ] Configuration changes documented  
- [ ] Developer documentation reflects the changes  
- [ ] Meets requirements and/or definition of done  
- [ ] No unresolved dependencies with other issues