### PR TITLE
[4.12.1] Agent endpoints optimization

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -114,7 +114,7 @@ def get_agents_summary_status(agent_list: list[str] = None) -> WazuhResult:
 
         with WazuhDBQueryGroupByAgents(filter_fields=['status'], select=['status'], query='id!=000',
                                        min_select_fields=set(), count=True, get_data=True, offset=0, 
-                                       limit=common.MAXIMUM_DATABASE_LIMIT, sort=None, search=None,
+                                       limit=4, sort=None, search=None,
                                        **rbac_filters) as db_query:
             status_data = db_query.run()
 
@@ -124,7 +124,7 @@ def get_agents_summary_status(agent_list: list[str] = None) -> WazuhResult:
         
         with WazuhDBQueryGroupByAgents(filter_fields=['group_config_status'], select=['group_config_status'], 
                                        query='id!=000', min_select_fields=set(), count=True, get_data=True,
-                                       offset=0, limit=common.MAXIMUM_DATABASE_LIMIT, sort=None, search=None,
+                                       offset=0, limit=2, sort=None, search=None,
                                        **rbac_filters) as db_query:
             sync_data = db_query.run()
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1312,7 +1312,7 @@ def get_groups() -> set:
 
 @common.context_cached('system_expanded_groups')
 def expand_group(group_name: str) -> set:
-    """Expand a certain group or all (*) of them.
+    """Expand a certain group.
 
     Parameters
     ----------
@@ -1329,17 +1329,14 @@ def expand_group(group_name: str) -> set:
     try:
         last_id = 0
         while True:
-            if group_name == '*':
-                command = f'global get-all-agents last_id {last_id}'
-            else:
-                command = f'global get-group-agents {group_name} last_id {last_id}'
+            command = f'global get-group-agents {group_name} last_id {last_id}'
 
             status, payload = wdb_conn.send(command, raw=True)
             agents = json.loads(payload)
 
-            for agent in agents:
-                agent_id = str(agent['id'] if isinstance(agent, dict) else agent).zfill(3)
-                agents_ids.append(agent_id)
+            for agent_id in agents:
+                agent_id_str = str(agent_id).zfill(3)
+                agents_ids.append(agent_id_str)
 
             if status == 'ok':
                 break

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1330,14 +1330,14 @@ def expand_group(group_name: str) -> set:
         last_id = 0
         while True:
             if group_name == '*':
-                command = 'global sync-agent-groups-get {"last_id":' f'{last_id}' ', "condition":"all"}'
+                command = f'global get-all-agents last_id {last_id}'
             else:
                 command = f'global get-group-agents {group_name} last_id {last_id}'
 
             status, payload = wdb_conn.send(command, raw=True)
             agents = json.loads(payload)
 
-            for agent in agents[0]['data'] if group_name == '*' else agents:
+            for agent in agents:
                 agent_id = str(agent['id'] if isinstance(agent, dict) else agent).zfill(3)
                 agents_ids.append(agent_id)
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1299,9 +1299,9 @@ def test_get_groups():
 @pytest.mark.parametrize('group, wdb_response, expected_agents', [
     ('default', [('due', '[1,2]'), ('ok', '[3,4]')], {'001', '002', '003', '004'}),
     ('test_group', [('ok', '[1,2,3,999]')], {'001', '002', '003'}),
-    ('*', [('due', '[{"data": [{"id": 1}, {"id": 2}]}]'), ('ok', '[{"data": [{"id": 3}, {"id": 4}]}]')],
+    ('*', [('due', '[{"id": 1}, {"id": 2}]'), ('ok', '[{"id": 3}, {"id": 4}]')],
      {'001', '002', '003', '004'}),
-    ('*', [('ok', '[{"data": [{"id": 1}, {"id": 2}, {"id": 999}]}]')], {'001', '002'})
+    ('*', [('ok', '[{"id": 1}, {"id": 2}, {"id": 999}]')], {'001', '002'})
 ])
 @patch('socket.socket.connect')
 def test_expand_group(socket_mock, group, wdb_response, expected_agents):

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1299,9 +1299,6 @@ def test_get_groups():
 @pytest.mark.parametrize('group, wdb_response, expected_agents', [
     ('default', [('due', '[1,2]'), ('ok', '[3,4]')], {'001', '002', '003', '004'}),
     ('test_group', [('ok', '[1,2,3,999]')], {'001', '002', '003'}),
-    ('*', [('due', '[{"id": 1}, {"id": 2}]'), ('ok', '[{"id": 3}, {"id": 4}]')],
-     {'001', '002', '003', '004'}),
-    ('*', [('ok', '[{"id": 1}, {"id": 2}, {"id": 999}]')], {'001', '002'})
 ])
 @patch('socket.socket.connect')
 def test_expand_group(socket_mock, group, wdb_response, expected_agents):

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -33,13 +33,9 @@ def _expand_resource(resource: str) -> set:
     name, attribute, value = resource.split(':')
     resource_type = ':'.join([name, attribute])
 
-    # This is the special case, expand_group can receive * or the name of the group. That's why it' s always called
-    if resource_type == 'agent:group':
-        return expand_group(value)
-
     # We need to transform the wildcard * to the resource of the system
     if value == '*':
-        if resource_type == 'agent:id':
+        if resource_type == 'agent:id' or resource_type == 'agent:group':
             return get_agents_info()
         elif resource_type == 'group:id':
             return get_groups()
@@ -73,8 +69,11 @@ def _expand_resource(resource: str) -> set:
         elif resource_type == '*:*':  # Resourceless
             return {'*'}
         return set()
-    # We return the value casted to set
     else:
+        if resource_type == 'agent:group':
+            return expand_group(value)
+    
+        # We return the value casted to set
         return {value}
 
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -166,19 +166,13 @@ def test_agent_get_agents_summary_status(socket_mock, send_mock):
     summary = get_agents_summary_status(short_agent_list)
     assert isinstance(summary, WazuhResult), 'The returned object is not an "WazuhResult" instance.'
     # Asserts are based on what it should get from the fake database
-    expected_results = {'connection': {'active': 2, 'disconnected': 1, 'never_connected': 1, 'pending': 1, 'total': 5},
-                        'configuration': {'synced': 2, 'not_synced': 3, 'total': 5}}
+    expected_results = {
+        'connection': {'active': 2, 'disconnected': 1, 'never_connected': 1, 'pending': 1, 'total': 5},
+        'configuration': {'synced': 2, 'not_synced': 3, 'total': 5}
+    }
     summary_data = summary['data']
 
-    # For the following test cases, if summary_data has unexpected keys, a KeyError will be raised
-
-    # Check the data dictionary follows the expected keys schema
-    assert all(summary_data[key].keys() == expected_results[key].keys() for key in expected_results.keys()), \
-        'The result obtained has unexpected keys'
-    # Check that the agents count for connection and configuration statuses are the expected ones
-    assert all(all(summary_data[key][status] == expected_results[key][status] for status in
-                   summary_data[key].keys()) for key in expected_results.keys()), \
-        'The agents connection or configuration status counts are not the expected ones'
+    assert summary_data == expected_results
 
 
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
@@ -924,7 +918,7 @@ def test_agent_remove_agent_from_groups_exceptions(mock_get_groups, mock_get_age
     try:
         result = remove_agent_from_groups(group_list=group_list, agent_list=agent_list)
         assert not catch_exception, \
-            f'An "WazuhError" exception was expected but was not raised.'
+            'An "WazuhError" exception was expected but was not raised.'
         # Check Typing
         assert isinstance(result, AffectedItemsWazuhResult), 'The returned object is not an "AffectedItemsWazuhResult".'
         assert isinstance(result.failed_items, dict), \
@@ -934,7 +928,7 @@ def test_agent_remove_agent_from_groups_exceptions(mock_get_groups, mock_get_age
             f'The number of "failed_items" is "{result.total_failed_items}" but was expected to be ' \
             f'"{len(group_list)}".'
         assert result.total_failed_items == len(result.failed_items), \
-            f'"total_failed_items" length does not match with "failed_items".'
+            '"total_failed_items" length does not match with "failed_items".'
         assert set(result.failed_items.keys()).difference({expected_error}) == set(), \
             f'The "failed_items" received does not match.\n' \
             f' - The "failed_items" received is: "{set(result.failed_items.keys())}"\n' \
@@ -942,8 +936,8 @@ def test_agent_remove_agent_from_groups_exceptions(mock_get_groups, mock_get_age
             f' - The difference between them is "{set(result.failed_items.keys()).difference({expected_error})}"\n'
     except (WazuhError, WazuhResourceNotFound) as error:
         assert catch_exception, \
-            f'No exception should be raised at this point. An AffectedItemsWazuhResult object with at least one ' \
-            f'failed item was expected instead.'
+            'No exception should be raised at this point. An AffectedItemsWazuhResult object with at least one ' \
+            'failed item was expected instead.'
         assert error == expected_error
 
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/29362 |

## Description

Introduces optimizations to the way we access agents information by reducing the number of SQL queries necessary.

## Tests

<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest --disable-warnings test_agent_GET_endpoints.tavern.yaml
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 95 items                                                                                                                                                                                                                           

test_agent_GET_endpoints.tavern.yaml ...............................................................................................                                                                                                   [100%]

================================================================================================ 95 passed, 96 warnings in 722.17s (0:12:02) =================================================================================================
```

</details>

<details><summary>test_rbac_black_agent_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest --nobuild --disable-warnings test_rbac_black_agent_endpoints.tavern.yaml
========================================== test session starts ==========================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 42 items                                                                                      

test_rbac_black_agent_endpoints.tavern.yaml ..........................................            [100%]

============================== 42 passed, 43 warnings in 782.31s (0:13:02) ==============================
```

</details>

<details><summary>test_rbac_white_agent_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest --nobuild --disable-warnings test_rbac_white_agent_endpoints.tavern.yaml
========================================== test session starts ==========================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 42 items                                                                                      

test_rbac_white_agent_endpoints.tavern.yaml ..........................................            [100%]

============================== 42 passed, 43 warnings in 819.34s (0:13:39) ==============================
```

</details>

### Agents status summary

<details><summary>All agents never connected</summary>

```console
curl -H "Authorization: Bearer $TOKEN" -s -k https://0.0.0.0:55050/agents/summary/status | jq
{
  "data": {
    "connection": {
      "active": 0,
      "disconnected": 0,
      "never_connected": 50000,
      "pending": 0,
      "total": 50000
    },
    "configuration": {
      "synced": 0,
      "not_synced": 50000,
      "total": 50000
    }
  },
  "error": 0
}
```

</details>

<details><summary>Update agent statuses</summary>

```console
global sql UPDATE agent SET connection_status='active' WHERE id='002';
[]
global sql UPDATE agent SET connection_status='disconnected' WHERE id > '050' AND id < '101';
[]
global sql UPDATE agent SET connection_status='active' WHERE id > '100' AND id < '40000';
[]
global sql UPDATE agent SET connection_status='pending' WHERE id > '40000';
[]
global sql UPDATE agent SET group_config_status='synced' WHERE id > '25000';
[]
```

</details>


<details><summary>Get status summary</summary>

```console
(venv) gasti@gasti:~/work/wazuh$ curl -H "Authorization: Bearer $TOKEN" -s -k https://0.0.0.0:55050/agents/summary/status | jq
{
  "data": {
    "connection": {
      "active": 39900,
      "disconnected": 50,
      "never_connected": 50,
      "pending": 10000,
      "total": 50000
    },
    "configuration": {
      "synced": 25000,
      "not_synced": 25000,
      "total": 50000
    }
  },
  "error": 0
}
```

</details>

<details><summary>Before</summary>

```console
2025/04/24 15:43:02 wazuh-db[28844] main.c:339 at run_dealer(): DEBUG: New client connected (40).
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) from (select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)  )
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) from agent where (id != '000' collate nocase)   order by id asc
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 0
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 1000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 1500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 2000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 2500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 3000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 3500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 4000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 4500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 5000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 5500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 6000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 6500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 7000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 7500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 8000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 8500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 9000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 9500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 10000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 10500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 11000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 11500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 12000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 12500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 13000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 13500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 14000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 14500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 15000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 15500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 16000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 16500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 17000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 17500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 18000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 18500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 19000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 19500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 20000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 20500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 21000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 21500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 22000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 22500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 23000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 23500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 24000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 24500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 25000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 25500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 26000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 26500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 27000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 27500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 28000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 28500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 29000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 29500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 30000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 30500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 31000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 31500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 32000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 32500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 33000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 33500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 34000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 34500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 35000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 35500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 36000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 36500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 37000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 37500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 38000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 38500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 39000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 39500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 40000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 40500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 41000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 41500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 42000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 42500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 43000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 43500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 44000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 44500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 45000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 45500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 46000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 46500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 47000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 47500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 48000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 48500
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 49000
2025/04/24 15:43:02 wazuh-db[28844] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select id as 'id',connection_status as 'status',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   order by id asc limit 500 offset 49500
2025/04/24 15:43:02 wazuh-db[28844] main.c:401 at run_worker(): DEBUG: Client 40 disconnected.
```

</details>

<details><summary>After</summary>

```console
2025/04/24 15:40:20 wazuh-db[3390] main.c:339 at run_dealer(): DEBUG: New client connected (20).
2025/04/24 15:40:20 wazuh-db[3390] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) from (select connection_status as 'status' from agent where (id != '000' collate nocase)  )
2025/04/24 15:40:20 wazuh-db[3390] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) from agent where (id != '000' collate nocase)    order by id asc  
2025/04/24 15:40:20 wazuh-db[3390] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) as 'count',connection_status as 'status' from agent where (id != '000' collate nocase)   group by connection_status order by id asc limit 4 offset 0
2025/04/24 15:40:20 wazuh-db[3390] main.c:401 at run_worker(): DEBUG: Client 20 disconnected.
2025/04/24 15:40:20 wazuh-db[3390] main.c:339 at run_dealer(): DEBUG: New client connected (41).
2025/04/24 15:40:20 wazuh-db[3390] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) from (select group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)  )
2025/04/24 15:40:20 wazuh-db[3390] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) from agent where (id != '000' collate nocase)    order by id asc  
2025/04/24 15:40:20 wazuh-db[3390] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sql select count(*) as 'count',group_config_status as 'group_config_status' from agent where (id != '000' collate nocase)   group by group_config_status order by id asc limit 2 offset 0
2025/04/24 15:40:20 wazuh-db[3390] main.c:401 at run_worker(): DEBUG: Client 41 disconnected.
```

</details>


### RBAC group expansion

<details><summary>Before</summary>

```console
2025/04/23 20:24:56 wazuh-db[117264] main.c:339 at run_dealer(): DEBUG: New client connected (40).
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":0, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":2754, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":5462, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":8170, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":10843, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":13443, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":16043, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":18643, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":21243, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":23843, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":26443, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":29043, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":31643, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":34243, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":36843, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":39443, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":42043, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":44643, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":47243, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: sync-agent-groups-get {"last_id":49843, "condition":"all"}
2025/04/23 20:24:56 wazuh-db[117264] main.c:401 at run_worker(): DEBUG: Client 40 disconnected.
```

</details>

<details><summary>After</summary>

```console
2025/04/23 20:26:21 wazuh-db[119189] main.c:339 at run_dealer(): DEBUG: New client connected (40).
2025/04/23 20:26:21 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 0
2025/04/23 20:26:21 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 5510
2025/04/23 20:26:21 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 10856
2025/04/23 20:26:21 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 15857
2025/04/23 20:26:21 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 20858
2025/04/23 20:26:21 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 25859
2025/04/23 20:26:21 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 30860
2025/04/23 20:26:22 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 35861
2025/04/23 20:26:22 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 40862
2025/04/23 20:26:22 wazuh-db[119189] wdb_parser.c:859 at wdb_parse(): DEBUG: Global query: get-all-agents last_id 45863
2025/04/23 20:26:22 wazuh-db[119189] main.c:401 at run_worker(): DEBUG: Client 40 disconnected.
```

</details>