### PR TITLE
Remove group inference mechanism from remoted

### DIFF
--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -161,7 +161,6 @@ cJSON *getRemoteInternalConfig(void) {
     cJSON_AddNumberToObject(remoted,"disk_storage",disk_storage);
     cJSON_AddNumberToObject(remoted,"rlimit_nofile",nofile);
     cJSON_AddNumberToObject(remoted,"merge_shared",logr.nocmerged);
-    cJSON_AddNumberToObject(remoted,"guess_agent_group",guess_agent_group);
     cJSON_AddNumberToObject(remoted,"receive_chunk",receive_chunk);
     cJSON_AddNumberToObject(remoted,"send_chunk",send_chunk);
     cJSON_AddNumberToObject(remoted,"buffer_relax",buffer_relax);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -433,7 +433,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
 
                 w_mutex_unlock(&files_mutex);
             } else {
-                merror("Error getting group for agent '%s'", key->id);
+                mdebug2("No group for agent '%s'", key->id);
             }
 
             w_mutex_unlock(&lastmsg_mutex);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -110,22 +110,6 @@ STATIC void process_deleted_multi_groups(bool initial_scan);
 STATIC void ftime_add(OSHash **_f_time, const char *name, const time_t m_time);
 
 /**
- * @brief Find a group structure from a file name and md5
- * @param md5 MD5 of the file
- * @param group_name Array to store the group name if exists
- * @return Group structure if exists, NULL otherwise
- */
-STATIC group_t* find_group_from_sum(const char * md5, char group_name[OS_SIZE_65536]);
-
-/**
- * @brief Find a multigroup structure from a file name and md5
- * @param md5 MD5 of the file
- * @param multigroup_name Array to store the multigroup name if exists
- * @return Multigroup structure if exists, NULL otherwise
- */
-STATIC group_t* find_multi_group_from_sum(const char * md5, char multigroup_name[OS_SIZE_65536]);
-
-/**
  * @brief Compare and check if the file time has changed
  * @param old_time File time table of previous scan
  * @param new_time File time table of new scan
@@ -145,20 +129,11 @@ STATIC bool group_changed(const char *multi_group);
 /**
  * @brief Get agent group
  * @param agent_id. Agent id to assign a group
- * @param msg. Message from agent to process and validate current configuration files
  * @param group. Name of the found group, it will include the name of the group or 'default' group or NULL if it fails.
  * @param wdb_sock Wazuh-DB socket.
  * @return OS_SUCCESS if it found or assigned a group, OS_INVALID otherwise
  */
-STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **group, int *wdb_sock);
-
-/**
- * @brief Redirect the request to the master node to assign a group
- * @param agent_id. Agent id to assign a group
- * @param md5. MD5 sum used if guessing is enabled
- * @return JSON* with group name if successful, NULL otherwise
- */
-STATIC cJSON *assign_group_to_agent_worker(const char *agent_id, const char *md5);
+STATIC int lookfor_agent_group(const char *agent_id, char **group, int *wdb_sock);
 
 /**
  * @brief Send a shared file to an agent
@@ -440,7 +415,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
 
             os_strdup(msg, data->message);
 
-            if (OS_SUCCESS == lookfor_agent_group(key->id, data->message, &data->group, wdb_sock)) {
+            if (OS_SUCCESS == lookfor_agent_group(key->id, &data->group, wdb_sock)) {
                 group_t *aux = NULL;
 
                 w_mutex_lock(&files_mutex);
@@ -535,77 +510,6 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
     }
 
     os_free(clean);
-}
-
-/* Assign a group to an agent without group */
-cJSON *assign_group_to_agent(const char *agent_id, const char *md5) {
-    cJSON *result = NULL;
-    char* group = NULL;
-
-    os_calloc(OS_SIZE_65536 + 1, sizeof(char), group);
-
-    mdebug2("Agent '%s' with file '%s' MD5 '%s'", agent_id, SHAREDCFG_FILENAME, md5);
-
-    w_mutex_lock(&files_mutex);
-
-    if (!guess_agent_group || (!find_group_from_sum(md5, group) && !find_multi_group_from_sum(md5, group))) {
-        // If the group could not be guessed, set to "default"
-        // or if the user requested not to guess the group, through the internal
-        // option 'guess_agent_group', set to "default"
-        strncpy(group, "default", OS_SIZE_65536);
-    }
-
-    w_mutex_unlock(&files_mutex);
-
-    wdb_set_agent_groups_csv(atoi(agent_id),
-                            group,
-                            WDB_GROUP_MODE_EMPTY_ONLY,
-                            w_is_single_node(NULL) ? "synced" : "syncreq",
-                            NULL);
-
-    mdebug2("Group assigned: '%s'", group);
-
-    result = cJSON_CreateObject();
-    cJSON_AddStringToObject(result, "group", group);
-
-    os_free(group);
-    return result;
-}
-
-STATIC cJSON *assign_group_to_agent_worker(const char *agent_id, const char *md5) {
-    char response[OS_MAXSTR] = "";
-    char *request = NULL;
-    cJSON *payload_json = NULL;
-    cJSON *response_json = NULL;
-    cJSON *data_json = NULL;
-
-    cJSON *message_json = cJSON_CreateObject();
-    cJSON *parameters_json = cJSON_CreateObject();
-
-    cJSON_AddStringToObject(parameters_json, "agent", agent_id);
-    cJSON_AddStringToObject(parameters_json, "md5", md5);
-
-    cJSON_AddStringToObject(message_json, "command", "assigngroup");
-    cJSON_AddItemToObject(message_json, "parameters", parameters_json);
-
-    payload_json = w_create_sendsync_payload("remoted", message_json);
-
-    request = cJSON_PrintUnformatted(payload_json);
-
-    mdebug2("Sending message to master node: '%s'", request);
-
-    if (w_send_clustered_message("sendsync", request, response) == 0) {
-        response_json = cJSON_Parse(response);
-        data_json = cJSON_Duplicate(cJSON_GetObjectItem(response_json, "data"), 1);
-    }
-
-    mdebug2("Message received from master node: '%s'", response);
-
-    os_free(request);
-    cJSON_Delete(payload_json);
-    cJSON_Delete(response_json);
-
-    return data_json;
 }
 
 /* Generate merged file for groups */
@@ -1352,48 +1256,6 @@ STATIC void ftime_add(OSHash **_f_time, const char *name, const time_t m_time) {
     }
 }
 
-STATIC group_t* find_group_from_sum(const char * md5, char group_name[OS_SIZE_65536]) {
-    group_t *group;
-    OSHashNode *my_node;
-    unsigned int i;
-
-    my_node = OSHash_Begin(groups, &i);
-
-    while (my_node) {
-        group = my_node->data;
-
-        if (!strcmp(group->merged_sum, md5)) {
-            snprintf(group_name, OS_SIZE_65536, "%s", group->name);
-            return group;
-        }
-
-        my_node = OSHash_Next(groups, &i, my_node);
-    }
-
-    return NULL;
-}
-
-STATIC group_t* find_multi_group_from_sum(const char * md5, char multigroup_name[OS_SIZE_65536]) {
-    group_t *multigroup;
-    OSHashNode *my_node;
-    unsigned int i;
-
-    my_node = OSHash_Begin(multi_groups, &i);
-
-    while (my_node) {
-        multigroup = my_node->data;
-
-        if (!strcmp(multigroup->merged_sum, md5)) {
-            snprintf(multigroup_name, OS_SIZE_65536, "%s", multigroup->name);
-            return multigroup;
-        }
-
-        my_node = OSHash_Next(multi_groups, &i, my_node);
-    }
-
-    return NULL;
-}
-
 STATIC bool ftime_changed(OSHash *old_time, OSHash *new_time) {
     unsigned int size_old, size_new = 0;
 
@@ -1485,12 +1347,9 @@ STATIC void send_wrong_version_response(const char *agent_id, char *msg, agent_s
 }
 
 /* look for agent group */
-STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, int *wdb_sock)
+STATIC int lookfor_agent_group(const char *agent_id, char **r_group, int *wdb_sock)
 {
     char* group = NULL;
-    char *end;
-    char *fmsg;
-    char *message;
 
     group = wdb_get_agent_group(atoi(agent_id), wdb_sock);
     if (group) {
@@ -1499,76 +1358,6 @@ STATIC int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, 
         return OS_SUCCESS;
     }
 
-    os_strdup(msg, message);
-    fmsg = message;
-
-    // Skip agent-info and label data
-    if (message = strchr(message, '\n'), !message) {
-        merror("Invalid message from agent ID '%s' (strchr \\n)", agent_id);
-        os_free(fmsg);
-        return OS_INVALID;
-    }
-
-    for (message++; (*message == '\"' || *message == '!' || *message == '#') && (end = strchr(message, '\n')); message = end + 1);
-
-    /* Parse message */
-    while (*message != '\0') {
-        char *md5;
-        char *file;
-
-        md5 = message;
-        file = message;
-
-        message = strchr(message, '\n');
-        if (!message) {
-            merror("Invalid message from agent ID '%s' (strchr \\n)", agent_id);
-            break;
-        }
-
-        *message = '\0';
-        message++;
-
-        // Skip labeled data
-        if (*md5 == '\"' || *md5 == '!' || *md5 == '#') {
-            continue;
-        }
-
-        file = strchr(file, ' ');
-        if (!file) {
-            merror("Invalid message from agent ID '%s' (strchr ' ')", agent_id);
-            break;
-        }
-
-        *file = '\0';
-        file++;
-
-        /* New agents only have merged.mg */
-        if (strcmp(file, SHAREDCFG_FILENAME) == 0) {
-            cJSON *group_json = NULL;
-            cJSON *value = NULL;
-
-            if (!logr.worker_node) {
-                group_json = assign_group_to_agent(agent_id, md5);
-            } else {
-                group_json = assign_group_to_agent_worker(agent_id, md5);
-            }
-
-            value = cJSON_GetObjectItem(group_json, "group");
-            if (cJSON_IsString(value) && value->valuestring != NULL) {
-                os_strdup(value->valuestring, *r_group);
-            } else {
-                merror("Agent '%s' invalid or empty group assigned.", agent_id);
-                cJSON_Delete(group_json);
-                break;
-            }
-
-            cJSON_Delete(group_json);
-            os_free(fmsg);
-            return OS_SUCCESS;
-        }
-    }
-
-    os_free(fmsg);
     return OS_INVALID;
 }
 

--- a/src/remoted/remcom.c
+++ b/src/remoted/remcom.c
@@ -98,8 +98,6 @@ STATIC size_t remcom_dispatch(char* request, char** output) {
     cJSON *config_json = NULL;
     cJSON *agents_json = NULL;
     cJSON *last_id_json = NULL;
-    cJSON *agent_json = NULL;
-    cJSON *md5_json = NULL;
     const char *json_err;
     int *agents_ids;
     int count;
@@ -162,18 +160,6 @@ STATIC size_t remcom_dispatch(char* request, char** output) {
                     }
                 } else {
                     *output = remcom_output_builder(ERROR_EMPTY_SECTION, error_messages[ERROR_EMPTY_SECTION], NULL);
-                }
-            } else {
-                *output = remcom_output_builder(ERROR_EMPTY_PARAMATERS, error_messages[ERROR_EMPTY_PARAMATERS], NULL);
-            }
-        } else if (strcmp(command_json->valuestring, "assigngroup") == 0) {
-            if (parameters_json = cJSON_GetObjectItem(request_json, "parameters"), cJSON_IsObject(parameters_json)) {
-                agent_json = cJSON_GetObjectItem(parameters_json, "agent");
-                md5_json = cJSON_GetObjectItem(parameters_json, "md5");
-                if (cJSON_IsString(agent_json) && cJSON_IsString(md5_json)) {
-                    *output = remcom_output_builder(ERROR_OK, error_messages[ERROR_OK], assign_group_to_agent(agent_json->valuestring, md5_json->valuestring));
-                } else {
-                    *output = remcom_output_builder(ERROR_EMPTY_AGENT_OR_MD5, error_messages[ERROR_EMPTY_AGENT_OR_MD5], NULL);
                 }
             } else {
                 *output = remcom_output_builder(ERROR_EMPTY_PARAMATERS, error_messages[ERROR_EMPTY_PARAMATERS], NULL);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -99,9 +99,6 @@ void *update_shared_files(void *none);
 /* Save control messages */
 void save_controlmsg(const keyentry * key, char *msg, size_t msg_length, int *wdb_sock);
 
-/* Assign a group to an agent without group */
-cJSON *assign_group_to_agent(const char *agent_id, const char *md5);
-
 // Initialize request module
 void req_init();
 

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -199,7 +199,6 @@ extern int response_timeout;
 extern int INTERVAL;
 extern int disk_storage;
 extern rlim_t nofile;
-extern int guess_agent_group;
 extern unsigned receive_chunk;
 extern unsigned send_chunk;
 extern int buffer_relax;

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -43,7 +43,6 @@ int max_attempts;
 int request_pool;
 int request_timeout;
 int response_timeout;
-int guess_agent_group;
 
 // Initialize request module
 void req_init() {
@@ -54,11 +53,6 @@ void req_init() {
     rto_sec = getDefine_Int("remoted", "request_rto_sec", 0, 60);
     rto_msec = getDefine_Int("remoted", "request_rto_msec", 0, 999);
     max_attempts = getDefine_Int("remoted", "max_attempts", 1, 16);
-    guess_agent_group = getDefine_Int("remoted", "guess_agent_group", 0, 1);
-
-    if (guess_agent_group && logr.worker_node) {
-        mwarn("The internal option guess_agent_group must be configured on the master node.");
-    }
 
     // Create hash table
     if (req_table = OSHash_Create(), !req_table) {

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -4709,7 +4709,7 @@ void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__merror, formatted_msg, "Error getting group for agent '001'");
+    expect_string(__wrap__mdebug2, formatted_msg, "No group for agent '001'");
 
     agent_info_data *agent_data;
     os_calloc(1, sizeof(agent_info_data), agent_data);

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -30,7 +30,7 @@
 #include "../remoted/shared_download.h"
 #include "../../remoted/manager.c"
 
-int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, int* wdb_sock);
+int lookfor_agent_group(const char *agent_id, char **r_group, int* wdb_sock);
 extern OSHash *agent_data_hash;
 
 /* tests */
@@ -172,6 +172,8 @@ static int test_process_deleted_groups_setup(void ** state) {
 
     test_mode = 0;
 
+    multi_groups = OSHash_Create();
+
     os_calloc(1, sizeof(group_t), group1);
     group1->name = strdup("test_default");
 
@@ -217,6 +219,8 @@ static int test_process_deleted_multi_groups_setup(void ** state) {
     group_t *multigroup2 = NULL;
 
     test_mode = 0;
+
+    multi_groups = OSHash_Create();
 
     os_calloc(1, sizeof(group_t), multigroup1);
     multigroup1->name = strdup("test_default2");
@@ -444,6 +448,7 @@ static int test_process_deleted_groups_teardown(void ** state) {
     test_mode = 0;
 
     free_group_c_group(group);
+    OSHash_Free(multi_groups);
 
     test_mode = 1;
 
@@ -546,7 +551,6 @@ void test_lookfor_agent_group_with_group()
 {
     const int agent_id = 1;
     const char agent_id_str[] = "001";
-    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
     char *r_group = NULL;
     char *test_group = strdup("TESTGROUP");
 
@@ -555,208 +559,11 @@ void test_lookfor_agent_group_with_group()
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' group is 'TESTGROUP'");
 
-    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
+    int ret = lookfor_agent_group(agent_id_str, &r_group, NULL);
     assert_int_equal(OS_SUCCESS, ret);
     assert_string_equal(r_group, test_group);
 
     os_free(test_group);
-}
-
-void test_lookfor_agent_group_set_default_group()
-{
-    const int agent_id = 1;
-    const char agent_id_str[] = "001";
-    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
-    char *r_group = NULL;
-
-    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
-    will_return(__wrap_wdb_get_agent_group, NULL);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' with file 'merged.mg' MD5 'c2305e0ac17e7176e924294c69cc7a24'");
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-
-    will_return(__wrap_w_is_single_node, 0);
-
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_value(__wrap_wdb_set_agent_groups_csv, id, agent_id);
-    will_return(__wrap_wdb_set_agent_groups_csv, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "Group assigned: 'default'");
-
-    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
-    assert_int_equal(OS_SUCCESS, ret);
-    assert_string_equal(r_group, "default");
-
-    os_free(r_group);
-}
-
-void test_lookfor_agent_group_set_group_worker()
-{
-    const int agent_id = 1;
-    const char agent_id_str[] = "001";
-    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
-    char *r_group = NULL;
-
-    cJSON *input = cJSON_CreateObject();
-
-    cJSON *parameters = cJSON_CreateObject();
-
-    cJSON_AddStringToObject(parameters, "agent", "001");
-    cJSON_AddStringToObject(parameters, "md5", "c2305e0ac17e7176e924294c69cc7a24");
-
-    cJSON_AddStringToObject(input, "command", "assigngroup");
-    cJSON_AddItemToObject(input, "parameters", parameters);
-
-    cJSON * cluster_request = cJSON_CreateObject();
-
-    cJSON_AddStringToObject(cluster_request, "daemon_name", "remoted");
-    cJSON_AddItemToObject(cluster_request, "message", input);
-
-    char *message = "{\"daemon_name\":\"remoted\","
-                     "\"message\":{\"command\":\"assigngroup\","
-                                  "\"parameters\":{\"agent\":\"001\","
-                                                  "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}";
-
-    char *response = "{\"error\":0,\"data\":{\"group\":\"test1\"}}";
-
-    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
-    will_return(__wrap_wdb_get_agent_group, NULL);
-
-    expect_string(__wrap_w_create_sendsync_payload, daemon_name, "remoted");
-    will_return(__wrap_w_create_sendsync_payload, 1);
-    will_return(__wrap_w_create_sendsync_payload, cluster_request);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "Sending message to master node: '{\"daemon_name\":\"remoted\","
-                                                                                    "\"message\":{\"command\":\"assigngroup\","
-                                                                                                 "\"parameters\":{\"agent\":\"001\","
-                                                                                                                 "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}'");
-
-    expect_string(__wrap_w_send_clustered_message, command, "sendsync");
-    expect_string(__wrap_w_send_clustered_message, payload, message);
-    will_return(__wrap_w_send_clustered_message, response);
-    will_return(__wrap_w_send_clustered_message, 0);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "Message received from master node: '{\"error\":0,\"data\":{\"group\":\"test1\"}}'");
-
-    logr.worker_node = 1;
-    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
-    logr.worker_node = 0;
-
-    assert_int_equal(OS_SUCCESS, ret);
-    assert_string_equal(r_group, "test1");
-
-    os_free(r_group);
-}
-
-void test_lookfor_agent_group_set_group_worker_error()
-{
-    const int agent_id = 1;
-    const char agent_id_str[] = "001";
-    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
-    char *r_group = NULL;
-
-    cJSON *input = cJSON_CreateObject();
-
-    cJSON *parameters = cJSON_CreateObject();
-
-    cJSON_AddStringToObject(parameters, "agent", "001");
-    cJSON_AddStringToObject(parameters, "md5", "c2305e0ac17e7176e924294c69cc7a24");
-
-    cJSON_AddStringToObject(input, "command", "assigngroup");
-    cJSON_AddItemToObject(input, "parameters", parameters);
-
-    cJSON * cluster_request = cJSON_CreateObject();
-
-    cJSON_AddStringToObject(cluster_request, "daemon_name", "remoted");
-    cJSON_AddItemToObject(cluster_request, "message", input);
-
-    char *message = "{\"daemon_name\":\"remoted\","
-                     "\"message\":{\"command\":\"assigngroup\","
-                                  "\"parameters\":{\"agent\":\"001\","
-                                                  "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}";
-
-    char *response = "{\"error\":1,\"data\":{}}";
-
-    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
-    will_return(__wrap_wdb_get_agent_group, NULL);
-
-    expect_string(__wrap_w_create_sendsync_payload, daemon_name, "remoted");
-    will_return(__wrap_w_create_sendsync_payload, 1);
-    will_return(__wrap_w_create_sendsync_payload, cluster_request);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "Sending message to master node: '{\"daemon_name\":\"remoted\","
-                                                                                    "\"message\":{\"command\":\"assigngroup\","
-                                                                                                 "\"parameters\":{\"agent\":\"001\","
-                                                                                                                 "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}'");
-
-    expect_string(__wrap_w_send_clustered_message, command, "sendsync");
-    expect_string(__wrap_w_send_clustered_message, payload, message);
-    will_return(__wrap_w_send_clustered_message, response);
-    will_return(__wrap_w_send_clustered_message, 1);
-
-    expect_string(__wrap__mdebug2, formatted_msg, "Message received from master node: '{\"error\":1,\"data\":{}}'");
-
-    expect_string(__wrap__merror, formatted_msg, "Agent '001' invalid or empty group assigned.");
-
-    logr.worker_node = 1;
-    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
-    logr.worker_node = 0;
-
-    assert_int_equal(OS_INVALID, ret);
-    assert_null(r_group);
-}
-
-void test_lookfor_agent_group_msg_without_enter()
-{
-    const int agent_id = 2;
-    const char agent_id_str[] = "002";
-    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00c2305e0ac17e7176e924294c69cc7a24 merged.mg";
-    char *r_group = NULL;
-
-    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
-    will_return(__wrap_wdb_get_agent_group, NULL);
-
-    expect_string(__wrap__merror, formatted_msg, "Invalid message from agent ID '002' (strchr \\n)");
-
-    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
-    assert_int_equal(OS_INVALID, ret);
-    assert_null(r_group);
-}
-
-void test_lookfor_agent_group_bad_message()
-{
-    const int agent_id = 3;
-    const char agent_id_str[] = "003";
-    char *msg = "Linux |localhost.localdomain\n#c2305e0ac17e7176e924294c69cc7a24 merged.mg\nc2305e0ac17e7176e924294c69cc7a24merged.mg\n#\"_agent_ip\":10.0.2.4";
-    char *r_group = NULL;
-
-    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
-    will_return(__wrap_wdb_get_agent_group, NULL);
-
-     expect_string(__wrap__merror, formatted_msg, "Invalid message from agent ID '003' (strchr ' ')");
-
-    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
-    assert_int_equal(OS_INVALID, ret);
-    assert_null(r_group);
-}
-
-void test_lookfor_agent_group_message_without_second_enter()
-{
-    const int agent_id = 4;
-    const char agent_id_str[] = "004";
-    char *msg = "Linux |localhost.localdomain \n#\"_agent_ip\":10.0.2.4";
-    char *r_group = NULL;
-
-    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
-    will_return(__wrap_wdb_get_agent_group, NULL);
-
-    expect_string(__wrap__merror, formatted_msg, "Invalid message from agent ID '004' (strchr \\n)");
-
-    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
-    assert_int_equal(OS_INVALID, ret);
-    assert_null(r_group);
 }
 
 void test_c_group_no_changes(void **state)
@@ -1995,114 +1802,6 @@ void test_c_multi_group_call_c_group(void **state)
 
     os_free(hash_multigroup);
     os_free(multi_group);
-}
-
-void test_find_group_from_file_found(void **state)
-{
-    char group_name[OS_SIZE_65536] = {0};
-
-    OSHashNode* node = NULL;
-    os_calloc(1, sizeof(OSHashNode), node);
-    node->data = state[0];
-
-    expect_value(__wrap_OSHash_Begin, self, groups);
-    will_return(__wrap_OSHash_Begin, node);
-
-    group_t *group = find_group_from_sum("ABCDEF1234567890", group_name);
-
-    assert_string_equal(group_name, "test_default");
-    assert_non_null(group);
-    assert_string_equal(group->name, "test_default");
-
-    os_free(node);
-}
-
-void test_find_group_from_file_not_found(void **state)
-{
-    char group_name[OS_SIZE_65536] = {0};
-
-    OSHashNode* node1 = NULL;
-    os_calloc(1, sizeof(OSHashNode), node1);
-    node1->data = state[0];
-
-    OSHashNode* node2 = NULL;
-    os_calloc(1, sizeof(OSHashNode), node2);
-    node2->data = state[1];
-
-    expect_value(__wrap_OSHash_Begin, self, groups);
-    will_return(__wrap_OSHash_Begin, node1);
-
-    expect_value(__wrap_OSHash_Next, self, groups);
-    will_return(__wrap_OSHash_Next, node2);
-
-    expect_value(__wrap_OSHash_Next, self, groups);
-    will_return(__wrap_OSHash_Next, NULL);
-
-    group_t *group = find_group_from_sum("2121212121", group_name);
-
-    assert_string_equal(group_name, "\0");
-    assert_null(group);
-
-    os_free(node1);
-    os_free(node2);
-}
-
-void test_find_multi_group_from_file_found(void **state)
-{
-    char multi_group_name[OS_SIZE_65536] = {0};
-
-    OSHashNode* node1 = NULL;
-    os_calloc(1, sizeof(OSHashNode), node1);
-    node1->data = state[0];
-
-    OSHashNode* node2 = NULL;
-    os_calloc(1, sizeof(OSHashNode), node2);
-    node2->data = state[1];
-
-    expect_value(__wrap_OSHash_Begin, self, multi_groups);
-    will_return(__wrap_OSHash_Begin, node1);
-
-    expect_value(__wrap_OSHash_Next, self, multi_groups);
-    will_return(__wrap_OSHash_Next, node2);
-
-    group_t *multi_group = find_multi_group_from_sum("1234567890ABCDFE", multi_group_name);
-
-    assert_string_equal(multi_group_name, "test_test_default2");
-    assert_non_null(multi_group);
-    assert_string_equal(multi_group->name, "test_test_default2");
-
-    os_free(node1);
-    os_free(node2);
-}
-
-void test_find_multi_group_from_file_not_found(void **state)
-{
-    char multi_group_name[OS_SIZE_65536] = {0};
-
-    OSHashNode* node1 = NULL;
-    os_calloc(1, sizeof(OSHashNode), node1);
-    node1->data = state[0];
-
-    OSHashNode* node2 = NULL;
-    os_calloc(1, sizeof(OSHashNode), node2);
-    node2->data = state[1];
-
-    expect_value(__wrap_OSHash_Begin, self, multi_groups);
-    will_return(__wrap_OSHash_Begin, node1);
-
-    expect_value(__wrap_OSHash_Next, self, multi_groups);
-    will_return(__wrap_OSHash_Next, node2);
-
-    expect_value(__wrap_OSHash_Next, self, multi_groups);
-    will_return(__wrap_OSHash_Next, NULL);
-
-    group_t *multi_group = find_multi_group_from_sum("4545454545", multi_group_name);
-
-    assert_string_equal(multi_group_name, "\0");
-    assert_null(multi_group);
-
-    os_free(node1);
-    os_free(node2);
 }
 
 void test_ftime_changed_same_fsum(void **state)
@@ -5226,12 +4925,6 @@ int main(void)
     const struct CMUnitTest tests[] = {
         // Tests lookfor_agent_group
         cmocka_unit_test(test_lookfor_agent_group_with_group),
-        cmocka_unit_test(test_lookfor_agent_group_set_default_group),
-        cmocka_unit_test(test_lookfor_agent_group_set_group_worker),
-        cmocka_unit_test(test_lookfor_agent_group_set_group_worker_error),
-        cmocka_unit_test(test_lookfor_agent_group_msg_without_enter),
-        cmocka_unit_test(test_lookfor_agent_group_bad_message),
-        cmocka_unit_test(test_lookfor_agent_group_message_without_second_enter),
         // Tests c_group
         cmocka_unit_test_setup_teardown(test_c_group_no_changes, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_no_changes_disk, test_c_group_setup, test_c_group_teardown),
@@ -5257,12 +4950,6 @@ int main(void)
         cmocka_unit_test(test_c_multi_group_Ignore_hidden_files),
         cmocka_unit_test(test_c_multi_group_subdir_fail),
         cmocka_unit_test(test_c_multi_group_call_c_group),
-        // Test find_group_from_sum
-        cmocka_unit_test_setup_teardown(test_find_group_from_file_found, test_find_group_setup, test_c_group_teardown),
-        cmocka_unit_test_setup_teardown(test_find_group_from_file_not_found, test_find_group_setup, test_c_group_teardown),
-        // Test find_multi_group_from_sum
-        cmocka_unit_test_setup_teardown(test_find_multi_group_from_file_found, test_find_multi_group_setup, test_c_multi_group_teardown),
-        cmocka_unit_test_setup_teardown(test_find_multi_group_from_file_not_found, test_find_multi_group_setup, test_c_multi_group_teardown),
         // Test ftime_changed
         cmocka_unit_test_setup_teardown(test_ftime_changed_same_fsum, test_ftime_changed_setup, test_ftime_changed_teardown),
         cmocka_unit_test_setup_teardown(test_ftime_changed_different_fsum_sum, test_ftime_changed_setup, test_ftime_changed_teardown),

--- a/src/unit_tests/remoted/test_remcom.c
+++ b/src/unit_tests/remoted/test_remcom.c
@@ -309,52 +309,6 @@ void test_remcom_dispatch_getagentsstats_array_ok(void ** state) {
     assert_int_equal(size, strlen(response));
 }
 
-void test_remcom_dispatch_assigngroup(void ** state) {
-    char* request = "{\"command\":\"assigngroup\", \"parameters\": {\"agent\": \"001\", \"md5\": \"1234567890abcdef\"}}";
-    char *response = NULL;
-
-    cJSON* data_json = cJSON_CreateObject();
-    cJSON_AddStringToObject(data_json, "group", "test1");
-
-    expect_string(__wrap_assign_group_to_agent, agent_id, "001");
-    expect_string(__wrap_assign_group_to_agent, md5, "1234567890abcdef");
-    will_return(__wrap_assign_group_to_agent, data_json);
-
-    size_t size = remcom_dispatch(request, &response);
-
-    *state = response;
-
-    assert_non_null(response);
-    assert_string_equal(response, "{\"error\":0,\"message\":\"ok\",\"data\":{\"group\":\"test1\"}}");
-    assert_int_equal(size, strlen(response));
-}
-
-void test_remcom_dispatch_assigngroup_invalid_parameters(void ** state) {
-    char* request = "{\"command\":\"assigngroup\", \"parameters\": {\"md5\": \"1234567890abcdef\"}}";
-    char *response = NULL;
-
-    size_t size = remcom_dispatch(request, &response);
-
-    *state = response;
-
-    assert_non_null(response);
-    assert_string_equal(response, "{\"error\":12,\"message\":\"Invalid agent or md5 parameter\",\"data\":{}}");
-    assert_int_equal(size, strlen(response));
-}
-
-void test_remcom_dispatch_assigngroup_empty_parameters(void ** state) {
-    char* request = "{\"command\":\"assigngroup\"}}";
-    char *response = NULL;
-
-    size_t size = remcom_dispatch(request, &response);
-
-    *state = response;
-
-    assert_non_null(response);
-    assert_string_equal(response, "{\"error\":5,\"message\":\"Empty parameters\",\"data\":{}}");
-    assert_int_equal(size, strlen(response));
-}
-
 void test_remcom_dispatch_unknown_command(void ** state) {
     char* request = "{\"command\":\"unknown\"}";
     char *response = NULL;
@@ -722,9 +676,6 @@ int main(void) {
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_all_ok, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_array_empty_agents, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_array_ok, test_teardown),
-        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup, test_teardown),
-        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup_invalid_parameters, test_teardown),
-        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup_empty_parameters, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_unknown_command, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_empty_command, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_invalid_json, test_teardown),


### PR DESCRIPTION
## Description

This pull request removes the legacy group inference mechanism from `wazuh-remoted`. This mechanism, which attempted to deduce an agent's group during keep-alive handling based on remote configuration checksums, is no longer necessary. With the current default behavior assigning new agents to the "default" group, this inference adds unnecessary complexity and overhead.

## Proposed Changes

- Remove all logic related to agent group inference during keep-alive handling.
  - `remoted` now assumes all agents have an assigned group, except when cluster synchronization is pending.
- Deprecate the internal option `remoted.guess_agent_group`.
- Update the unit test suite to reflect the removal of this behavior.

### Results and Evidence

#### New agent with default group

```
2025/04/30 16:30:56 wazuh-remoted[89524] manager.c:1356 at lookfor_agent_group(): DEBUG: Agent '024' group is 'default'
2025/04/30 16:30:56 wazuh-remoted[89524] manager.c:1477 at wait_for_msgs(): DEBUG: Sending file 'default/merged.mg' to agent '024'.
2025/04/30 16:30:56 wazuh-remoted[89524] manager.c:1493 at wait_for_msgs(): DEBUG: End sending file 'default/merged.mg' to agent '024'.
2025/04/30 16:30:56 wazuh-remoted[89524] manager.c:307 at save_controlmsg(): DEBUG: Agent 7af976160262 sent HC_SHUTDOWN from '172.21.176.1'
```

#### New agent with no group

```
2025/04/30 16:26:01 wazuh-remoted[84457] manager.c:436 at save_controlmsg(): DEBUG: No group for agent '023'
```

After assigning the agent to the `default` and `test` groups:

```
2025/04/30 16:26:41 wazuh-remoted[84457] manager.c:1356 at lookfor_agent_group(): DEBUG: Agent '023' group is 'default,test'
2025/04/30 16:26:39 wazuh-remoted[84457] manager.c:1477 at wait_for_msgs(): DEBUG: Sending file 'default,test/merged.mg' to agent '023'.
```

### Artifacts Affected

- `wazuh-remoted` (manager component)

### Configuration Changes

- Deprecated internal option: `remoted.guess_agent_group`

### Documentation Updates

- Pending update to mark `remoted.guess_agent_group` as deprecated in the internal configuration documentation.

### Tests Introduced

- Updated existing unit tests to remove dependency on group inference logic.
- Manual regression testing performed and verified (see logs above).

## Review Checklist

- [x] Code changes reviewed  
- [x] Relevant evidence provided  
- [x] Tests cover the new functionality  
- [x] Configuration changes documented  
- [x] Developer documentation reflects the changes  
- [x] Meets requirements and/or definition of done  
- [x] No unresolved dependencies with other issues  