### PR TITLE
Standardize Service Timeouts (Agent & Manager)

### DIFF
--- a/src/init/templates/wazuh-agent.service
+++ b/src/init/templates/wazuh-agent.service
@@ -5,6 +5,7 @@ After=network.target network-online.target
 
 [Service]
 Type=forking
+TimeoutSec=45
 
 ExecStart=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control start
 ExecStop=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control stop

--- a/src/init/templates/wazuh-manager.service
+++ b/src/init/templates/wazuh-manager.service
@@ -6,6 +6,7 @@ After=network.target network-online.target
 [Service]
 Type=forking
 LimitNOFILE=65536
+TimeoutSec=45
 
 ExecStart=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control start
 ExecStop=/usr/bin/env WAZUH_HOME_TMP/bin/wazuh-control stop

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -31,7 +31,7 @@ LOCK_PID="${LOCK}/pid"
 # to 10 attempts (or 10 seconds) to execute.
 MAX_ITERATION="60"
 
-MAX_KILL_TRIES=600
+MAX_KILL_TRIES=300
 
 checkpid()
 {

--- a/src/init/wazuh-local.sh
+++ b/src/init/wazuh-local.sh
@@ -40,7 +40,7 @@ LOCK_PID="${LOCK}/pid"
 # to 10 attempts (or 10 seconds) to execute.
 MAX_ITERATION="60"
 
-MAX_KILL_TRIES=600
+MAX_KILL_TRIES=300
 
 checkpid() {
     for i in ${DAEMONS}; do

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -44,7 +44,7 @@ LOCK_PID="${LOCK}/pid"
 # to 10 attempts (or 10 seconds) to execute.
 MAX_ITERATION="60"
 
-MAX_KILL_TRIES=600
+MAX_KILL_TRIES=300
 
 
 checkpid()


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/27760|

## Description
This pull request resolves inconsistencies in default service timeouts across different Linux distributions. The default timeout for both the wazuh agent and manager services has been set to 45 seconds. Additionally, the wazuh-control script has been updated to forcefully terminate the service if it fails to stop within approximately 30 seconds.

## Tests

<details>
<summary>Wazuh agent</summary>

```bash
sudo journalctl -u wazuh-agent|grep "couldn't be terminated. It will be killed" -n28
434602-Apr 30 16:51:08 ip-172-31-1-218.ec2.internal systemd[1]: Started wazuh-agent.service - Wazuh agent.
434603-Apr 30 16:51:08 ip-172-31-1-218.ec2.internal systemd[1]: Stopping wazuh-agent.service - Wazuh agent...
434604-Apr 30 16:51:08 ip-172-31-1-218.ec2.internal env[6413]: Killing wazuh-modulesd...
434605-Apr 30 16:51:09 ip-172-31-1-218.ec2.internal env[6413]: Killing wazuh-logcollector...
434606-Apr 30 16:51:09 ip-172-31-1-218.ec2.internal env[6413]: Killing wazuh-syscheckd...
434607:Apr 30 16:51:40 ip-172-31-1-218.ec2.internal env[6413]: Process wazuh-syscheckd couldn't be terminated. It will be killed.
434608-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal env[6413]: Killing wazuh-agentd...
434609-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal env[6413]: Killing wazuh-execd...
434610-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal env[6413]: Wazuh v4.13.0 Stopped
434611-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal systemd[1]: wazuh-agent.service: Deactivated successfully.
434612-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal systemd[1]: Stopped wazuh-agent.service - Wazuh agent.
434613-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal systemd[1]: wazuh-agent.service: Consumed 17.909s CPU time, 225.4M memory peak.
434614-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal systemd[1]: Starting wazuh-agent.service - Wazuh agent...
434615-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal env[7392]: Starting Wazuh v4.13.0...
434616-Apr 30 16:51:40 ip-172-31-1-218.ec2.internal env[7392]: Started wazuh-execd...
434617-Apr 30 16:51:41 ip-172-31-1-218.ec2.internal env[7392]: Started wazuh-agentd...
434618-Apr 30 16:51:42 ip-172-31-1-218.ec2.internal env[7392]: Started wazuh-syscheckd...
434619-Apr 30 16:51:43 ip-172-31-1-218.ec2.internal env[7392]: Started wazuh-logcollector...
434620-Apr 30 16:51:45 ip-172-31-1-218.ec2.internal env[7392]: Started wazuh-modulesd...
434621-Apr 30 16:51:47 ip-172-31-1-218.ec2.internal env[7392]: Completed.
```
</details>

**Note:** This test confirms that the script forces the wazuh-syscheckd service to stop after 32 seconds.

To test it, I used the following script provided by @vikman90:

<details>
<summary>Script for testing</summary>

```bash
while true; do 
    systemctl start wazuh-agent
    while ! systemctl is-active wazuh-agent; do 
        echo Waiting
        sleep 1
    done
    systemctl stop wazuh-agent
    systemctl status wazuh-agent
    echo -e "\n\nRepeating\n\n"
done > test.log
```
</summary>
</details>

- I also tried to check this behavior on the manager, but all modules closed as expected, so the force stop condition was never triggered.
