### PR TITLE
Fixes IPv6 address format reported by WindowsHelper

### DIFF
--- a/src/shared_modules/utils/tests/windowsHelper_test.cpp
+++ b/src/shared_modules/utils/tests/windowsHelper_test.cpp
@@ -238,4 +238,146 @@ TEST_F(WindowsHelperTest, normalizeTimestampWrongRegistryInstallDateValue)
     EXPECT_ANY_THROW(Utils::normalizeTimestamp(RegistryInstallDateValue, RegistryModificationDateValue));
 }
 
+TEST_F(WindowsHelperTest, getIpV6AddressNullInputReturnsEmptyString)
+{
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(nullptr), "");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressAllZerosReturnsDoubleColon)
+{
+    std::array<uint8_t, 16> addr = {0};
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "::");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressLoopbackReturnsDoubleColonOne)
+{
+    // ::1
+    std::array<uint8_t, 16> addr = {0};
+    addr[15] = 1;
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "::1");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressValidAddressReturnsCompressedIPv6)
+{
+    std::array<uint8_t, 16> addr = {0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x47, 0xf9, 0x90, 0xce, 0xdd, 0xf9, 0x71, 0x1a
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "fe80::47f9:90ce:ddf9:711a");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressGlobalUnicastReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x00, 0x00,
+                                    0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "2001:db8:85a3::8a2e:370:7334");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressLinkLocalReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x01, 0xff,
+                                    0xfe, 0x23, 0x45, 0x67, 0x89, 0x0a, 0x00, 0x00
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "fe80::1ff:fe23:4567:890a:0");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressMulticastReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "ff02::1");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressMultipleZeroBlocksCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0xff, 0x00, 0x00, 0x42, 0x83, 0x29
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "2001:db8::ff00:42:8329");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressLeadingZerosInHextetsOmitsLeadingZeros)
+{
+    std::array<uint8_t, 16> addr = {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0xff, 0x00, 0x00, 0x42, 0x83, 0x29
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "2001:db8::ff00:42:8329");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressIPv4MappedReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0xff, 0xff, 0xc0, 0xa8, 0x01, 0x01
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "::ffff:192.168.1.1");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressNoZeroBlocksReturnsFullAddress)
+{
+    std::array<uint8_t, 16> addr = {0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34, 0x56, 0x78,
+                                    0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()),
+              "2001:db8:1234:5678:9abc:def0:1234:5678");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressEndWithZerosCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34, 0x56, 0x78,
+                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "2001:db8:1234:5678::");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressStartWithZerosCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34,
+                                    0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "::1234:5678:9abc:def0:0");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressMiddleZerosCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "2001:db8::1234:5678:0");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressAllOnesReturnsCorrectFormat)
+{
+    std::array<uint8_t, 16> addr = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                                    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()),
+              "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressCompressionAtStartAndEndCompressesCorrectly)
+{
+    std::array<uint8_t, 16> addr = {0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+                                    0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                                   };
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(addr.data()), "0:1:2:3:4::");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressNullPointerReturnsEmptyString)
+{
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(nullptr), "");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressNullBufferWithSizeReturnsEmptyString)
+{
+    uint8_t* nullBuffer = nullptr;
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(nullBuffer), "");
+}
+
+TEST_F(WindowsHelperTest, getIpV6AddressZeroLengthBufferReturnsEmptyString)
+{
+    std::array<uint8_t, 0> emptyAddr;
+    EXPECT_EQ(Utils::NetworkWindowsHelper::getIpV6Address(emptyAddr.data()), "");
+}
+
 #endif

--- a/src/shared_modules/utils/windowsHelper.h
+++ b/src/shared_modules/utils/windowsHelper.h
@@ -569,56 +569,23 @@ namespace Utils
 
             static std::string getIpV6Address(const uint8_t* addrParam)
             {
-                std::string retVal;
-
-                if (addrParam)
-                {
-                    constexpr auto IPV6_BUFFER_ADDRESS_SIZE { 16 };
-                    std::array<char, IPV6_BUFFER_ADDRESS_SIZE> buffer;
-                    memcpy(buffer.data(), addrParam, IPV6_BUFFER_ADDRESS_SIZE);
-
-                    std::array<char, IPV6_BUFFER_ADDRESS_SIZE> addrComparator;
-                    addrComparator.fill(0);
-
-                    if (std::equal(buffer.begin(), buffer.end(), addrComparator.begin()))
-                    {
-                        retVal = "::";
-                    }
-                    else
-                    {
-                        addrComparator.at(IPV6_BUFFER_ADDRESS_SIZE - 1) = 0x1;
-
-                        if (std::equal(buffer.begin(), buffer.end(), addrComparator.begin()))
-                        {
-                            retVal = "::1";
-                        }
-                        else
-                        {
-                            std::stringstream ss;
-                            bool separator { false };
-                            ss << std::hex << std::setfill('0');
-
-                            for (const auto& value : buffer)
-                            {
-                                ss << std::setw(2) << (static_cast<unsigned>(value) & 0xFF);
-
-                                if (separator)
-                                {
-                                    ss << ":";
-                                }
-
-                                separator = !separator;
-                            }
-
-                            retVal = ss.str();
-                            Utils::replaceAll(retVal, "0000", "");
-                            Utils::replaceAll(retVal, ":::", "::");
-                            retVal = retVal.substr(0, retVal.size() - 1);
-                        }
-                    }
+                if (!addrParam ) {
+                    return "";
                 }
 
-                return retVal;
+                sockaddr_in6 sa6 {};
+                sa6.sin6_family = AF_INET6;
+                memcpy(&sa6.sin6_addr, addrParam, 16);
+
+                char buffer[INET6_ADDRSTRLEN] = {};
+                DWORD bufSize = sizeof(buffer);
+
+                if (WSAAddressToStringA(reinterpret_cast<SOCKADDR*>(&sa6), sizeof(sa6), nullptr, buffer, &bufSize) != 0)
+                {
+                    return "";
+                }
+
+                return std::string(buffer);
             }
 
             static std::string ipv6Netmask(const uint8_t maskLength)


### PR DESCRIPTION
|Related issue|
|---|
|#29457|

## Description

The original function manually formats the IPv6 address by converting each byte to hexadecimal and inserting colons, but it doesn't follow the standard `IPv6` compression rules. Specifically, it fails to properly identify and compress the longest sequence of zero blocks (::), which can lead to invalid or non-canonical representations like `"fe80:::47f9:90ce:ddf9:711a"`. This results in incorrect formatting and potential interoperability issues.

## Proposed Changes

The improved version uses the Windows API function `WSAAddressToStringA`, which properly formats and compresses `IPv6 `addresses according to standard rules (e.g., :: for zero blocks, mixed IPv4 notation when applicable). This approach ensures correctness, avoids manual formatting errors, and produces canonical, human-readable IPv6 strings reliably.

## Results and Evidence

**Before the proposed changes:**

![image](https://github.com/user-attachments/assets/9a6761a1-9957-41b7-bce7-e436052bd466)


<details><summary>WindowsHelperTest</summary>

```
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressNullInputReturnsEmptyString
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressNullInputReturnsEmptyString (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressAllZerosReturnsDoubleColon
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressAllZerosReturnsDoubleColon (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressLoopbackReturnsDoubleColonOne
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressLoopbackReturnsDoubleColonOne (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressValidAddressReturnsCompressedIPv6
/home/nico/wazuh/src/shared_modules/utils/tests/windowsHelper_test.cpp:284: Failure
Expected equality of these values:
  Utils::NetworkWindowsHelper::getIpV6Address(addr.data())
    Which is: "fe80:::47f9:90ce:ddf9:711a"
  "fe80::47f9:90ce:ddf9:711a"
[0;31m[  FAILED  ] [mWindowsHelperTest.getIpV6AddressValidAddressReturnsCompressedIPv6 (4499 ms)
[0;32m[----------] [m22 tests from WindowsHelperTest (58135 ms total)
```

Note: this test was added to check the error case.

</details>

**After the proposed changes:**

<details><summary>Windows 11</summary>

![image](https://github.com/user-attachments/assets/29229d0d-110e-4ccf-8c75-2cfb74653f21)

</details>

<details><summary>WindowsHelperTest</summary>

```
root@nico-VirtualBox:/home/nico/wazuh/src/shared_modules/utils/build# wine ./tests/utils_unit_test.exe 
0064:err:explorer:initialize_display_settings Failed to query current display settings for L"\\\\.\\DISPLAY1".
0064:err:ole:start_rpcss Failed to start RpcSs service
[0;32m[==========] [mRunning 48 tests from 3 test suites.
[0;32m[----------] [mGlobal test environment set-up.
[0;32m[----------] [m37 tests from WindowsHelperTest
[0;32m[ RUN      ] [mWindowsHelperTest.ipv6NetMask_64
[0;32m[       OK ] [mWindowsHelperTest.ipv6NetMask_64 (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.ipv6NetMask_127
[0;32m[       OK ] [mWindowsHelperTest.ipv6NetMask_127 (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.ipv6NetMask_55
[0;32m[       OK ] [mWindowsHelperTest.ipv6NetMask_55 (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.ipv6NetMask_77
[0;32m[       OK ] [mWindowsHelperTest.ipv6NetMask_77 (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.ipv6NetMask_72
[0;32m[       OK ] [mWindowsHelperTest.ipv6NetMask_72 (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.ipv6NetMask_INVALID
[0;32m[       OK ] [mWindowsHelperTest.ipv6NetMask_INVALID (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getSerialNumberFromSMBIOSWithNullData_TEST
[0;32m[       OK ] [mWindowsHelperTest.getSerialNumberFromSMBIOSWithNullData_TEST (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getSerialNumberFromSMBIOSRealData_TEST
[0;32m[       OK ] [mWindowsHelperTest.getSerialNumberFromSMBIOSRealData_TEST (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getSerialNumberFromSMBIOSCorruptedData1_TEST
[0;32m[       OK ] [mWindowsHelperTest.getSerialNumberFromSMBIOSCorruptedData1_TEST (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getSerialNumberFromSMBIOSCorruptedData2_TEST
[0;32m[       OK ] [mWindowsHelperTest.getSerialNumberFromSMBIOSCorruptedData2_TEST (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getSerialNumberFromSMBIOSTablesNoEndDoubleNull_TEST
[0;32m[       OK ] [mWindowsHelperTest.getSerialNumberFromSMBIOSTablesNoEndDoubleNull_TEST (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getSerialNumberFromSMBIOSTables2NoEndDoubleNull_TEST
[0;32m[       OK ] [mWindowsHelperTest.getSerialNumberFromSMBIOSTables2NoEndDoubleNull_TEST (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.normalizeTimestampShortRegistryInstallDateValue
[0;32m[       OK ] [mWindowsHelperTest.normalizeTimestampShortRegistryInstallDateValue (9 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.normalizeTimestampLongRegistryInstallDateValue
[0;32m[       OK ] [mWindowsHelperTest.normalizeTimestampLongRegistryInstallDateValue (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.normalizeTimestampUnknownRegistryInstallDateValue
[0;32m[       OK ] [mWindowsHelperTest.normalizeTimestampUnknownRegistryInstallDateValue (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.normalizeTimestampNotEqual
[0;32m[       OK ] [mWindowsHelperTest.normalizeTimestampNotEqual (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.normalizeTimestampEqual
[0;32m[       OK ] [mWindowsHelperTest.normalizeTimestampEqual (1 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.normalizeTimestampWrongRegistryInstallDateValue
[0;32m[       OK ] [mWindowsHelperTest.normalizeTimestampWrongRegistryInstallDateValue (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressNullInputReturnsEmptyString
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressNullInputReturnsEmptyString (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressAllZerosReturnsDoubleColon
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressAllZerosReturnsDoubleColon (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressLoopbackReturnsDoubleColonOne
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressLoopbackReturnsDoubleColonOne (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressValidAddressReturnsCompressedIPv6
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressValidAddressReturnsCompressedIPv6 (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressGlobalUnicastReturnsCorrectFormat
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressGlobalUnicastReturnsCorrectFormat (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressLinkLocalReturnsCorrectFormat
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressLinkLocalReturnsCorrectFormat (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressMulticastReturnsCorrectFormat
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressMulticastReturnsCorrectFormat (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressMultipleZeroBlocksCompressesCorrectly
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressMultipleZeroBlocksCompressesCorrectly (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressLeadingZerosInHextetsOmitsLeadingZeros
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressLeadingZerosInHextetsOmitsLeadingZeros (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressIPv4MappedReturnsCorrectFormat
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressIPv4MappedReturnsCorrectFormat (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressNoZeroBlocksReturnsFullAddress
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressNoZeroBlocksReturnsFullAddress (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressEndWithZerosCompressesCorrectly
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressEndWithZerosCompressesCorrectly (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressStartWithZerosCompressesCorrectly
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressStartWithZerosCompressesCorrectly (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressMiddleZerosCompressesCorrectly
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressMiddleZerosCompressesCorrectly (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressAllOnesReturnsCorrectFormat
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressAllOnesReturnsCorrectFormat (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressCompressionAtStartAndEndCompressesCorrectly
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressCompressionAtStartAndEndCompressesCorrectly (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressNullPointerReturnsEmptyString
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressNullPointerReturnsEmptyString (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressNullBufferWithSizeReturnsEmptyString
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressNullBufferWithSizeReturnsEmptyString (0 ms)
[0;32m[ RUN      ] [mWindowsHelperTest.getIpV6AddressZeroLengthBufferReturnsEmptyString
[0;32m[       OK ] [mWindowsHelperTest.getIpV6AddressZeroLengthBufferReturnsEmptyString (0 ms)
[0;32m[----------] [m37 tests from WindowsHelperTest (142636 ms total)

[0;32m[----------] [m8 tests from RegistryUtilsTest
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryString
[0;32m[       OK ] [mRegistryUtilsTest.RegistryString (1 ms)
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryStringNoThrow
[0;32m[       OK ] [mRegistryUtilsTest.RegistryStringNoThrow (1 ms)
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryDWORD
[0;32m[       OK ] [mRegistryUtilsTest.RegistryDWORD (0 ms)
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryDWORDNoThrow
[0;32m[       OK ] [mRegistryUtilsTest.RegistryDWORDNoThrow (1 ms)
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryQWORD
[0;32m[       OK ] [mRegistryUtilsTest.RegistryQWORD (10 ms)
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryQWORDNoThrow
[0;32m[       OK ] [mRegistryUtilsTest.RegistryQWORDNoThrow (1 ms)
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryEnumerate
[0;32m[       OK ] [mRegistryUtilsTest.RegistryEnumerate (3 ms)
[0;32m[ RUN      ] [mRegistryUtilsTest.RegistryEnumerateNoThrow
[0;32m[       OK ] [mRegistryUtilsTest.RegistryEnumerateNoThrow (0 ms)
[0;32m[----------] [m8 tests from RegistryUtilsTest (18259 ms total)

[0;32m[----------] [m3 tests from EncodingWindowsHelperTest
[0;32m[ RUN      ] [mEncodingWindowsHelperTest.NoExceptConversion
[0;32m[       OK ] [mEncodingWindowsHelperTest.NoExceptConversion (0 ms)
[0;32m[ RUN      ] [mEncodingWindowsHelperTest.ExceptWithoutConversion
[0;32m[       OK ] [mEncodingWindowsHelperTest.ExceptWithoutConversion (0 ms)
[0;32m[ RUN      ] [mEncodingWindowsHelperTest.ReturnValueEmptyConversion
[0;32m[       OK ] [mEncodingWindowsHelperTest.ReturnValueEmptyConversion (0 ms)
[0;32m[----------] [m3 tests from EncodingWindowsHelperTest (8700 ms total)

[0;32m[----------] [mGlobal test environment tear-down
[0;32m[==========] [m48 tests from 3 test suites ran. (183629 ms total)
[0;32m[  PASSED  ] [m48 tests.
```

</details>

<details><summary>Windows server 2016 Datacenter</summary>

![image](https://github.com/user-attachments/assets/c85e7480-92b1-4b9a-8458-6f63bbd4dd0a)
![image](https://github.com/user-attachments/assets/c049765d-9929-4e04-8142-e94cb5b3955d)


</details>

## Tests Introduced

Tests for “WindowsHelperTest”

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X
- [x] Source installation
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues