### PR TITLE
Implement wazuh-db HTTP client

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -404,7 +404,7 @@ async def delete_single_agent_multiple_groups(agent_id: str, groups_list: str = 
     dapi = DistributedAPI(f=agent.remove_agent_from_groups,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
-                          is_async=False,
+                          is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request.context['token_info']['rbac_policies']
@@ -479,7 +479,7 @@ async def delete_single_agent_single_group(agent_id: str, group_id: str, pretty:
     dapi = DistributedAPI(f=agent.remove_agent_from_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
-                          is_async=False,
+                          is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request.context['token_info']['rbac_policies']
@@ -518,7 +518,7 @@ async def put_agent_single_group(agent_id: str, group_id: str, force_single_grou
     dapi = DistributedAPI(f=agent.assign_agents_to_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
-                          is_async=False,
+                          is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request.context['token_info']['rbac_policies']
@@ -951,7 +951,7 @@ async def delete_multiple_agent_single_group(group_id: str, agents_list: str = N
     dapi = DistributedAPI(f=agent.remove_agents_from_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
-                          is_async=False,
+                          is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request.context['token_info']['rbac_policies']
@@ -991,7 +991,7 @@ async def put_multiple_agent_single_group(group_id: str, agents_list: str = None
     dapi = DistributedAPI(f=agent.assign_agents_to_group,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='local_master',
-                          is_async=False,
+                          is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request.context['token_info']['rbac_policies']

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -284,7 +284,7 @@ async def test_delete_single_agent_multiple_groups(mock_exc, mock_dapi, mock_rem
     mock_dapi.assert_called_once_with(f=agent.remove_agent_from_groups,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
-                                      is_async=False,
+                                      is_async=True,
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']
@@ -336,7 +336,7 @@ async def test_delete_single_agent_single_group(mock_exc, mock_dapi, mock_remove
     mock_dapi.assert_called_once_with(f=agent.remove_agent_from_group,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
-                                      is_async=False,
+                                      is_async=True,
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']
@@ -363,7 +363,7 @@ async def test_put_agent_single_group(mock_exc, mock_dapi, mock_remove, mock_dfu
     mock_dapi.assert_called_once_with(f=agent.assign_agents_to_group,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
-                                      is_async=False,
+                                      is_async=True,
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']
@@ -682,7 +682,7 @@ async def test_delete_multiple_agent_single_group(mock_exc, mock_dapi, mock_remo
     mock_dapi.assert_called_once_with(f=agent.remove_agents_from_group,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
-                                      is_async=False,
+                                      is_async=True,
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']
@@ -712,7 +712,7 @@ async def test_put_multiple_agent_single_group(mock_exc, mock_dapi, mock_remove,
     mock_dapi.assert_called_once_with(f=agent.assign_agents_to_group,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
-                                      is_async=False,
+                                      is_async=True,
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']

--- a/framework/scripts/agent_groups.py
+++ b/framework/scripts/agent_groups.py
@@ -167,7 +167,8 @@ async def unset_group(agent_id: str, group_id: str = None, quiet: bool = False):
         ans = get_stdin(f"Do you want to delete all groups of agent '{agent_id}'? [y/N]: ")
     if ans.lower() == 'y':
         result = await cluster_utils.forward_function(func=agent.remove_agent_from_groups,
-                                                      f_kwargs={'agent_list': [agent_id], 'group_list': [group_id]})
+                                                      f_kwargs={'agent_list': [agent_id], 'group_list': [group_id]},
+                                                      is_async=True)
         cluster_utils.raise_if_exc(result)
 
         if result.total_affected_items != 0:
@@ -226,9 +227,14 @@ async def set_group(agent_id: str, group_id: str, quiet: bool = False, replace: 
     ans = 'y' if quiet else get_stdin(f"Do you want to add the group '{group_id}' to the agent '{agent_id}'? [y/N]: ")
 
     if ans.lower() == 'y':
-        result = await cluster_utils.forward_function(func=agent.assign_agents_to_group,
-                                                      f_kwargs={'group_list': [group_id], 'agent_list': [agent_id],
-                                                                'replace': replace})
+        result = await cluster_utils.forward_function(
+            func=agent.assign_agents_to_group,
+            f_kwargs={
+                'group_list': [group_id],
+                'agent_list': [agent_id],
+                'replace': replace},
+            is_async=True
+        )
         cluster_utils.raise_if_exc(result)
 
         if result.total_affected_items != 0:

--- a/framework/scripts/tests/test_agent_groups.py
+++ b/framework/scripts/tests/test_agent_groups.py
@@ -169,7 +169,7 @@ async def test_unset_group(print_mock):
             self.total_affected_items = 0 if AffectedItems.called else len(affected_items)
             AffectedItems.called = True
 
-    async def forward_function(func, f_kwargs):
+    async def forward_function(func, f_kwargs, is_async):
         return AffectedItems(affected_items=[{'filename': 'a', 'hash': 'aa'}, {'filename': 'b', 'hash': 'bb'}],
                              failed_items={'a': 'b'})
 
@@ -179,7 +179,7 @@ async def test_unset_group(print_mock):
             group_id = 'testing'
             await agent_groups.unset_group(agent_id=agent_id, group_id=group_id)
             forward_mock.assert_called_once_with(func=agent.remove_agent_from_groups,
-                                        f_kwargs={'agent_list': [agent_id], 'group_list': [group_id]})
+                                        f_kwargs={'agent_list': [agent_id], 'group_list': [group_id]}, is_async=True)
             get_stdin_mock.assert_has_calls([call("Do you want to delete the group 'testing' of agent '99'? [y/N]: ")])
             print_mock.assert_has_calls([call("Agent '99' removed from testing.")])
             print_mock.reset_mock()
@@ -243,14 +243,15 @@ async def test_set_group(print_mock):
             self.total_affected_items = 0 if AffectedItems.called else len(affected_items)
             AffectedItems.called = True
 
-    async def forward_function(func, f_kwargs):
+    async def forward_function(func, f_kwargs, is_async):
         return AffectedItems(affected_items=[{'testing': ['agent0', 'agent1']}], failed_items={'a': 'b'})
 
     with patch('scripts.agent_groups.cluster_utils.forward_function', side_effect=forward_function) as forward_mock:
         with patch('scripts.agent_groups.get_stdin', return_value='y') as get_stdin_mock:
             await agent_groups.set_group(agent_id=1, group_id='testing')
             forward_mock.assert_called_once_with(func=agent.assign_agents_to_group,
-                                   f_kwargs={'group_list': ['testing'], 'agent_list': ['001'], 'replace': False})
+                                   f_kwargs={'group_list': ['testing'], 'agent_list': ['001'], 'replace': False},
+                                   is_async=True)
             get_stdin_mock.assert_has_calls(
                 [call("Do you want to add the group 'testing' to the agent '001'? [y/N]: ")])
             print_mock.assert_has_calls([call("Group 'testing' added to agent '001'.")])

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -961,7 +961,7 @@ class Agent:
             raise WazuhError(1737)
 
         # Update group
-        await Agent.set_agent_group_relationship(agent_id, group_id, override=replace)
+        Agent.set_agent_group_relationship(agent_id, group_id, override=replace)
 
         return f"Agent {agent_id} assigned to {group_id}"
 
@@ -1130,7 +1130,7 @@ class Agent:
                 set_default = True
 
         # Update group file
-        await Agent.set_agent_group_relationship(agent_id, group_id, remove=True)
+        Agent.set_agent_group_relationship(agent_id, group_id, remove=True)
 
         return f"Agent '{agent_id}' removed from '{group_id}'." + (" Agent reassigned to group default."
                                                                    if set_default else "")

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -24,7 +24,9 @@ from wazuh.core.utils import WazuhVersion, plain_dict_to_nested_dict, get_fields
 from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.core.wazuh_socket import WazuhSocket, WazuhSocketJSON, create_wazuh_socket_message
 from wazuh.core.wdb import WazuhDBConnection
+from wazuh.core.wdb_http import get_wdb_http_client
 from wazuh.rbac.utils import resource_cache
+
 
 detect_wrong_lines = re.compile(r'(.+ .+ (?:any|\d+\.\d+\.\d+\.\d+) \w+)')
 detect_valid_lines = re.compile(r'^(\d{3,}) (.+) (any|\d+\.\d+\.\d+\.\d+) (\w+)', re.MULTILINE)
@@ -909,7 +911,7 @@ class Agent:
         return data
 
     @staticmethod
-    def add_group_to_agent(group_id: str, agent_id: str, replace: bool = False, replace_list: list = None) -> str:
+    async def add_group_to_agent(group_id: str, agent_id: str, replace: bool = False, replace_list: list = None) -> str:
         """Add an existing group to an agent.
 
         Parameters
@@ -942,7 +944,7 @@ class Agent:
 
         # Get agent's group
         try:
-            agent_groups = set(Agent.get_agent_groups(agent_id))
+            agent_groups = set(await Agent.get_agent_groups(agent_id))
         except Exception as e:
             raise WazuhInternalError(2007, extra_message=str(e))
 
@@ -959,7 +961,7 @@ class Agent:
             raise WazuhError(1737)
 
         # Update group
-        Agent.set_agent_group_relationship(agent_id, group_id, override=replace)
+        await Agent.set_agent_group_relationship(agent_id, group_id, override=replace)
 
         return f"Agent {agent_id} assigned to {group_id}"
 
@@ -1029,7 +1031,7 @@ class Agent:
             return False
 
     @staticmethod
-    def get_agent_groups(agent_id: str) -> list:
+    async def get_agent_groups(agent_id: str) -> list[str]:
         """Return all agent's groups.
 
         Parameters
@@ -1039,15 +1041,11 @@ class Agent:
 
         Returns
         -------
-        list
+        list[str]
             List of group IDs.
         """
-        wdb = WazuhDBConnection()
-        try:
-            _, payload = wdb.send(f'global select-group-belong {agent_id}', raw=True)
-            return json.loads(payload)
-        finally:
-            wdb.close()
+        async with get_wdb_http_client() as wdb_client:
+            return await wdb_client.get_agent_groups(agent_id)
 
     @staticmethod
     def set_agent_group_relationship(agent_id: str, group_id: str, remove: bool = False, override: bool = False):
@@ -1080,7 +1078,7 @@ class Agent:
             wdb.close()
 
     @staticmethod
-    def unset_single_group_agent(agent_id: str, group_id: str, force: bool = False) -> str:
+    async def unset_single_group_agent(agent_id: str, group_id: str, force: bool = False) -> str:
         """Unset the agent group. If agent has multigroups, it will preserve all previous groups except the last one.
 
         Parameters
@@ -1119,7 +1117,7 @@ class Agent:
                 raise WazuhResourceNotFound(1710)
 
         # Get agent's group
-        group_list = set(Agent.get_agent_groups(agent_id))
+        group_list = set(await Agent.get_agent_groups(agent_id))
         set_default = False
 
         # Check agent belongs to group group_id
@@ -1132,7 +1130,7 @@ class Agent:
                 set_default = True
 
         # Update group file
-        Agent.set_agent_group_relationship(agent_id, group_id, remove=True)
+        await Agent.set_agent_group_relationship(agent_id, group_id, remove=True)
 
         return f"Agent '{agent_id}' removed from '{group_id}'." + (" Agent reassigned to group default."
                                                                    if set_default else "")

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1605,7 +1605,7 @@ class SyncWazuhdb(SyncTask):
         Returns
         -------
         dict | None
-            Agents synchronization information or nothing if there was an error.
+            Agents synchronization information or None if there was an error.
         """
         start_time = time.perf_counter()
         try:
@@ -1636,7 +1636,6 @@ class SyncWazuhdb(SyncTask):
         bool
             True if data was correctly sent to the master/worker node, None otherwise.
         """
-        self.logger.debug(chunks)
         if chunks:
             # Send list of chunks as a JSON string
             data = json.dumps({'set_data_command': self.set_data_command,
@@ -1737,7 +1736,7 @@ async def send_data_to_wdb(data, timeout, info_type='agent-info'):
             if info_type == 'agent-info':
                 agents_sync = data['chunks']
                 async with get_wdb_http_client() as wdb_client:
-                    _ = await wdb_client.set_agents_sync(agents_sync)
+                    await wdb_client.set_agents_sync(agents_sync)
 
                 result['updated_chunks'] += len(agents_sync)
             elif info_type == 'agent-groups':

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -28,6 +28,7 @@ from wazuh.core import common, exception
 from wazuh.core import utils
 from wazuh.core.cluster import cluster, utils as cluster_utils
 from wazuh.core.wdb import AsyncWazuhDBConnection, WazuhDBConnection
+from wazuh.core.wdb_http import get_wdb_http_client
 
 IGNORED_WDB_EXCEPTIONS = ['Cannot execute Global database query; FOREIGN KEY constraint failed']
 
@@ -597,8 +598,7 @@ class Handler(asyncio.Protocol):
             Dict containing number of updated chunks, error messages (if any) and time spent.
         """
         try:
-            result = await cluster.run_in_pool(self.loop, self.server.task_pool, send_data_to_wdb, data,
-                                               timeout, info_type=info_type)
+            result = await send_data_to_wdb(data, timeout, info_type=info_type)
         except Exception as e:
             print(f'error processing {info_type} chunks in process pool: {str(e)}'.encode())
             with contextlib.suppress(Exception):
@@ -1599,6 +1599,28 @@ class SyncWazuhdb(SyncTask):
         self.logger.debug(f"Obtained {len(chunks)} chunks of data in {(time.perf_counter() - start_time):.3f}s.")
         return chunks
 
+    async def retrieve_agents_information(self) -> dict | None:
+        """Collect the agents required information from the local node's database.
+        
+        Returns
+        -------
+        dict | None
+            Agents synchronization information or nothing if there was an error.
+        """
+        start_time = time.perf_counter()
+        try:
+            async with get_wdb_http_client() as wdb_client:
+                agents_sync = await wdb_client.get_agents_sync()
+        except exception.WazuhException as e:
+            self.logger.error(f"Could not obtain data from wazuh-db: {e}")
+            return
+        
+        now = time.perf_counter()
+        self.logger.debug(f"Obtained agents synchronization information in {(now - start_time):.3f}s.")
+
+        return agents_sync
+
+
     async def sync(self, start_time: float, chunks: List):
         """Start sending information to master/worker node.
 
@@ -1614,6 +1636,7 @@ class SyncWazuhdb(SyncTask):
         bool
             True if data was correctly sent to the master/worker node, None otherwise.
         """
+        self.logger.debug(chunks)
         if chunks:
             # Send list of chunks as a JSON string
             data = json.dumps({'set_data_command': self.set_data_command,
@@ -1689,7 +1712,7 @@ def error_receiving_agent_information(logger, response, info_type):
     return b'ok', b'Thanks'
 
 
-def send_data_to_wdb(data, timeout, info_type='agent-info'):
+async def send_data_to_wdb(data, timeout, info_type='agent-info'):
     """Send chunks of data to Wazuh-db socket.
 
     Parameters
@@ -1707,36 +1730,45 @@ def send_data_to_wdb(data, timeout, info_type='agent-info'):
         Dict containing number of updated chunks, error messages (if any) and time spent.
     """
     result = {'updated_chunks': 0, 'error_messages': {'chunks': [], 'others': []}, 'time_spent': 0}
-    wdb_conn = WazuhDBConnection()
     before = time.perf_counter()
 
     try:
         with utils.Timeout(timeout):
-            for i, chunk in enumerate(data['chunks']):
-                try:
-                    if info_type == 'agent-info':
-                        wdb_conn.send(f"{data['set_data_command']} {chunk}", raw=True)
-                    elif info_type == 'agent-groups':
+            if info_type == 'agent-info':
+                agents_sync = data['chunks']
+                async with get_wdb_http_client() as wdb_client:
+                    _ = await wdb_client.set_agents_sync(agents_sync)
+
+                result['updated_chunks'] += len(agents_sync)
+            elif info_type == 'agent-groups':
+                wdb_conn = WazuhDBConnection()
+
+                for i, chunk in enumerate(data['chunks']):
+                    try:
                         data['payload']['data'] = json.loads(chunk)[0]['data']
                         wdb_conn.send(
                             f"{data['set_data_command']} {json.dumps(data['payload'], separators=(',', ':'))}",
                             raw=True
                         )
-                    result['updated_chunks'] += 1
-                except TimeoutError as e:
-                    raise e
-                except Exception as e:
-                    error = str(e)
-                    if any(ignored_exception in error for ignored_exception in IGNORED_WDB_EXCEPTIONS):
-                        continue
-                    result['error_messages']['chunks'].append((i, error))
+                        result['updated_chunks'] += 1
+                    except TimeoutError as e:
+                        wdb_conn.close()
+                        raise e
+                    except Exception as e:
+                        error = str(e)
+
+                        if any(ignored_exception in error for ignored_exception in IGNORED_WDB_EXCEPTIONS):
+                            continue
+
+                        result['error_messages']['chunks'].append((i, error))
+                
+                wdb_conn.close()
     except TimeoutError:
         result['error_messages']['others'].append(f'Timeout while processing {info_type} chunks.')
     except Exception as e:
         result['error_messages']['others'].append(f'Error while processing {info_type} chunks: {e}')
 
     result['time_spent'] = time.perf_counter() - before
-    wdb_conn.close()
     return result
 
 

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -497,7 +497,7 @@ def process_spawn_sleep(child):
 
 
 async def forward_function(func: callable, f_kwargs: dict = None, request_type: str = 'local_master',
-                           nodes: list = None, broadcasting: bool = False):
+                           nodes: list = None, broadcasting: bool = False, is_async: bool = False):
     """Distribute function to master node.
 
     Parameters
@@ -512,6 +512,9 @@ async def forward_function(func: callable, f_kwargs: dict = None, request_type: 
         System cluster nodes.
     broadcasting : bool
         Whether the function will be broadcasted or not.
+    is_async : bool
+        Whether the function is asynchronous.
+
     Returns
     -------
     Return either a dict or `WazuhResult` instance in case the execution did not fail. Return an exception otherwise.
@@ -522,7 +525,7 @@ async def forward_function(func: callable, f_kwargs: dict = None, request_type: 
 
     from wazuh.core.cluster.dapi.dapi import DistributedAPI
     dapi = DistributedAPI(f=func, f_kwargs=f_kwargs, request_type=request_type,
-                          is_async=False, wait_for_complete=True, logger=logger, nodes=nodes,
+                          is_async=is_async, wait_for_complete=True, logger=logger, nodes=nodes,
                           broadcasting=broadcasting)
     pool = concurrent.futures.ThreadPoolExecutor()
     return pool.submit(run, dapi.distribute_function()).result()

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -576,12 +576,14 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         self.agent_info_sync_status['date_start'] = start_time
 
                         agents_sync = await agent_info.retrieve_agents_information()
-                        sync_sum = len(agents_sync['syncreq']) + \
-                            len(agents_sync['syncreq_keepalive']) + \
-                            len(agents_sync['syncreq_status'])
+                        sync_sum = len(agents_sync.get('syncreq', [])) + \
+                            len(agents_sync.get('syncreq_keepalive', [])) + \
+                            len(agents_sync.get('syncreq_status', []))
 
                         if sync_sum > 0:
                             await agent_info.sync(start_time=start_time, chunks=agents_sync)
+                        else:
+                            logger.info('No synchronization required, skipping.')
             except Exception as e:
                 logger.error(f"Error synchronizing agent info: {e}")
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -219,6 +219,7 @@ UPGRADE_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'upgrade')
 REMOTED_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'remote')
 TASKS_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'tasks', 'task')
 WDB_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'db', 'wdb')
+WDB_HTTP_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'wdb-http')
 WMODULES_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'wmodules')
 QUEUE_SOCKET = os.path.join(WAZUH_PATH, 'queue', 'sockets', 'queue')
 

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -433,6 +433,12 @@ class WazuhException(Exception):
                'remediation': 'Restart the Wazuh service to restore the RBAC database to default'},
         2009: {'message': 'Pagination error. Response from wazuh-db was over the maximum socket buffer size'},
         2010: {'message': 'The requested read operation did not complete fully'},
+        2011: {'message': 'Could not connect to the wazuh-db unix socket'},
+        2012: {'message': 'Invalid wazuh-db HTTP request'},
+        2013: {'message': 'Error sending HTTP request'},
+        2014: {'message': 'The wazuh-db client connection timeout has been exceeded'},
+        2015: {'message': 'Invalid request URL scheme'},
+        2016: {'message': 'Invalid unix socket path'},
 
         # External services
         2100: {'message': 'Error in CTI service request'},

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -968,7 +968,7 @@ def test_agent_get_agents_overview_sort(socket_mock, send_mock, sort, first_id):
     ('002', 'test_group', True, ['default']),
 ])
 @patch('wazuh.core.agent.Agent.get_agent_groups', new_callable=AsyncMock)
-@patch('wazuh.core.agent.Agent.set_agent_group_relationship', new_callable=AsyncMock)
+@patch('wazuh.core.agent.Agent.set_agent_group_relationship')
 async def test_agent_add_group_to_agent(set_agent_group_mock, agent_groups_mock, agent_id, group_id, replace, replace_list):
     """Test if add_group_to_agent() works as expected and uses the correct parameters.
 
@@ -1133,7 +1133,7 @@ def test_agent_set_agent_group_relationship_ko(socket_connect_mock):
     ('002', 'test_group', False, ['test_group'], True),
     ('002', 'test_group', False, ['test_group', 'another_test'], False)
 ])
-@patch('wazuh.core.agent.Agent.set_agent_group_relationship', new_callable=AsyncMock)
+@patch('wazuh.core.agent.Agent.set_agent_group_relationship')
 @patch('wazuh.core.agent.Agent.group_exists', return_value=True)
 @patch('wazuh.core.agent.Agent.get_basic_information')
 async def test_agent_unset_single_group_agent(agent_info_mock, group_exists_mock, set_agent_group_mock, agent_id, group_id,

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -7,7 +7,7 @@ import os
 import sqlite3
 import sys
 from copy import copy
-from unittest.mock import patch, mock_open, call
+from unittest.mock import AsyncMock, patch, mock_open, call
 
 import pytest
 
@@ -967,9 +967,9 @@ def test_agent_get_agents_overview_sort(socket_mock, send_mock, sort, first_id):
     ('002', 'test_group', False, None),
     ('002', 'test_group', True, ['default']),
 ])
-@patch('wazuh.core.agent.Agent.get_agent_groups', return_value=['default'])
-@patch('wazuh.core.agent.Agent.set_agent_group_relationship')
-def test_agent_add_group_to_agent(set_agent_group_mock, agent_groups_mock, agent_id, group_id, replace, replace_list):
+@patch('wazuh.core.agent.Agent.get_agent_groups', new_callable=AsyncMock)
+@patch('wazuh.core.agent.Agent.set_agent_group_relationship', new_callable=AsyncMock)
+async def test_agent_add_group_to_agent(set_agent_group_mock, agent_groups_mock, agent_id, group_id, replace, replace_list):
     """Test if add_group_to_agent() works as expected and uses the correct parameters.
 
     Parameters
@@ -983,35 +983,36 @@ def test_agent_add_group_to_agent(set_agent_group_mock, agent_groups_mock, agent
     replace_list : list
         List of Group names that can be replaced.
     """
+    agent_groups_mock.return_value = ['default']
     # Run the method with different options
-    result = Agent.add_group_to_agent(group_id, agent_id, replace, replace_list)
+    result = await Agent.add_group_to_agent(group_id, agent_id, replace, replace_list)
     assert result == f'Agent {agent_id} assigned to {group_id}', 'Result is not the expected one'
     set_agent_group_mock.assert_called_once_with(agent_id, group_id, override=replace)
 
 
 @patch('wazuh.core.agent.Agent.get_agent_groups', return_value=['default'])
-def test_agent_add_group_to_agent_ko(agent_groups_mock):
+async def test_agent_add_group_to_agent_ko(agent_groups_mock):
     """Test if add_group_to_agent() raises expected exceptions"""
     max_groups_number = 128
 
     # Error getting agent groups
     with patch('wazuh.core.agent.Agent.get_agent_groups', side_effect=WazuhError(2003)):
         with pytest.raises(WazuhInternalError, match='.* 2007 .*'):
-            Agent.add_group_to_agent('test_group', '002')
+            await Agent.add_group_to_agent('test_group', '002')
 
     # Group cannot be replaced because it is not in replace_list (not enough permissions in rbac)
     with pytest.raises(WazuhError, match='.* 1752 .*'):
-        Agent.add_group_to_agent('test_group', '002', replace=True, replace_list=['other'])
+        await Agent.add_group_to_agent('test_group', '002', replace=True, replace_list=['other'])
 
     # The group already belongs to the agent
     with pytest.raises(WazuhError, match='.* 1751 .*'):
-        Agent.add_group_to_agent('default', '002')
+        await Agent.add_group_to_agent('default', '002')
 
     with patch('wazuh.core.agent.Agent.get_agent_groups',
                return_value=[f'group_{i}' for i in range(max_groups_number)]):
         # Multigroup limit exceeded.
         with pytest.raises(WazuhError, match='.* 1737 .*'):
-            Agent.add_group_to_agent('test_group', '002')
+            await Agent.add_group_to_agent('test_group', '002')
 
 
 @pytest.mark.parametrize("agent_id, seconds, expected_result", [
@@ -1071,16 +1072,18 @@ def test_agent_group_exists_ko():
         Agent.group_exists('default**')
 
 
-@patch('wazuh.core.agent.WazuhDBConnection.send', return_value=('ok', '["payload"]'))
-@patch('socket.socket.connect')
-def test_agent_get_agent_groups(socket_connect_mock, send_mock):
+@patch('wazuh.core.wdb_http.WazuhDBHTTPClient')
+async def test_agent_get_agent_groups(wdb_http_client_mock: AsyncMock):
     """Test if get_agent_groups() asks for agent's groups correctly."""
     agent_id = '001'
-    agent_groups = Agent.get_agent_groups(agent_id)
+    agent_groups = ['default', 'test1', 'test3']
+    wdb_http_client_mock.return_value.close = AsyncMock()
+    get_agent_groups_mock = AsyncMock(return_value=agent_groups)
+    wdb_http_client_mock.return_value.get_agent_groups = get_agent_groups_mock
+    agent_groups = await Agent.get_agent_groups(agent_id)
 
-    wdb_command = 'global select-group-belong :agent_id:'
-    send_mock.assert_called_once_with(wdb_command.replace(':agent_id:', agent_id), raw=True)
-    assert agent_groups == ['payload']
+    assert agent_groups == agent_groups
+    get_agent_groups_mock.assert_called_once_with(agent_id)
 
 
 @pytest.mark.parametrize('remove, override, expected_mode', [
@@ -1130,10 +1133,10 @@ def test_agent_set_agent_group_relationship_ko(socket_connect_mock):
     ('002', 'test_group', False, ['test_group'], True),
     ('002', 'test_group', False, ['test_group', 'another_test'], False)
 ])
-@patch('wazuh.core.agent.Agent.set_agent_group_relationship')
+@patch('wazuh.core.agent.Agent.set_agent_group_relationship', new_callable=AsyncMock)
 @patch('wazuh.core.agent.Agent.group_exists', return_value=True)
 @patch('wazuh.core.agent.Agent.get_basic_information')
-def test_agent_unset_single_group_agent(agent_info_mock, group_exists_mock, set_agent_group_mock, agent_id, group_id,
+async def test_agent_unset_single_group_agent(agent_info_mock, group_exists_mock, set_agent_group_mock, agent_id, group_id,
                                         force, previous_groups, set_default):
     """Test if unset_single_group_agent() returns expected message and removes group from agent.
 
@@ -1151,7 +1154,7 @@ def test_agent_unset_single_group_agent(agent_info_mock, group_exists_mock, set_
         The agent belongs to 'default' group.
     """
     with patch('wazuh.core.agent.Agent.get_agent_groups', return_value=previous_groups):
-        result = Agent.unset_single_group_agent(agent_id, group_id, force)
+        result = await Agent.unset_single_group_agent(agent_id, group_id, force)
 
     not force and agent_info_mock.assert_called_once()
 
@@ -1162,29 +1165,29 @@ def test_agent_unset_single_group_agent(agent_info_mock, group_exists_mock, set_
 
 @patch('wazuh.core.agent.Agent.get_basic_information')
 @patch('socket.socket.connect')
-def test_agent_unset_single_group_agent_ko(socket_mock, agent_information_mock):
+async def test_agent_unset_single_group_agent_ko(socket_mock, agent_information_mock):
     """Test if unset_single_group_agent() raises expected exceptions."""
     # Master cannot be added to a conf group
     with pytest.raises(WazuhError, match='.* 1703 .*'):
-        Agent.unset_single_group_agent('000', 'test_group')
+        await Agent.unset_single_group_agent('000', 'test_group')
     agent_information_mock.assert_called_once()
 
     # Group does not exists
     with patch('wazuh.core.agent.Agent.group_exists', return_value=False):
         with pytest.raises(WazuhResourceNotFound, match='.* 1710 .*'):
-            Agent.unset_single_group_agent('002', 'test_group')
+            await Agent.unset_single_group_agent('002', 'test_group')
 
     # Agent does not belong to group
     with patch('wazuh.core.agent.Agent.get_agent_groups', return_value=['new_group', 'new_group2']):
         # Group_id is not within group_list
         with pytest.raises(WazuhError, match='.* 1734 .*'):
-            Agent.unset_single_group_agent('002', 'test_group', force=True)
+            await Agent.unset_single_group_agent('002', 'test_group', force=True)
 
     # Group ID is 'default' and it is the last only one remaining
     with patch('wazuh.core.agent.Agent.get_agent_groups', return_value=['default']):
         # Agent file does not exists
         with pytest.raises(WazuhError, match='.* 1745 .*'):
-            Agent.unset_single_group_agent('002', 'default', force=True)
+            await Agent.unset_single_group_agent('002', 'default', force=True)
 
 
 @patch('wazuh.core.wazuh_socket.WazuhSocket')

--- a/framework/wazuh/core/tests/test_wdb_http.py
+++ b/framework/wazuh/core/tests/test_wdb_http.py
@@ -1,0 +1,280 @@
+from unittest.mock import AsyncMock, call, MagicMock
+
+import pytest
+from wazuh.core.wdb_http import AgentIDGroups, AgentsSummary, AgentsSync, APPLICATION_JSON, Status, WazuhDBHTTPClient
+from wazuh.core.exception import WazuhError
+
+
+class TestWazuhDBHTTPClient:
+    """Test the functionality of the `WazuhDBHTTPClient` class."""
+
+    @pytest.fixture
+    def client_mock(self) -> AsyncMock:
+        """Provide a mock client instance for testing."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def module_instance(self, client_mock: AsyncMock) -> WazuhDBHTTPClient:
+        """Provide an instance of VulnerabilityModule with a mocked client for testing."""
+        client = WazuhDBHTTPClient()
+        client._client = client_mock
+        return client
+
+    async def test__get(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `_get` method works as expected."""
+        response = MagicMock()
+        response.is_error = False
+        client_mock.get.return_value = response
+
+        await module_instance._get('/agents')
+        client_mock.assert_has_calls([
+            call.get(url='http://localhost/v1/agents', headers={'Accept': APPLICATION_JSON}),
+            call.get().json()
+        ])
+
+    async def test__get_ko(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `_get` handles exceptions successfully."""
+        response = MagicMock()
+        response.is_error = True
+        response.text = 'Service Unavailable: failure'
+        client_mock.get.return_value = response
+
+        expected_error_msg = 'Error 2012 - Invalid wazuh-db HTTP request: Service Unavailable: failure'
+        with pytest.raises(WazuhError, match=expected_error_msg):
+            await module_instance._get('/agents')
+    
+    async def test__post(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `_post` method works as expected."""
+        response = MagicMock()
+        response.is_error = False
+        client_mock.post.return_value = response
+
+        await module_instance._post('/agents', b'')
+        client_mock.assert_has_calls([
+            call.post(
+                url='http://localhost/v1/agents',
+                json=b'',
+                headers={'Accept': APPLICATION_JSON, 'Content-Type': APPLICATION_JSON}
+            ),
+            call.post().json()
+        ])
+
+    async def test__post_ko(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `_post` handles exceptions successfully."""
+        response = MagicMock()
+        response.is_error = True
+        response.text = 'Service Unavailable: failure'
+        client_mock.post.return_value = response
+
+        expected_error_msg = 'Error 2012 - Invalid wazuh-db HTTP request: Service Unavailable: failure'
+        with pytest.raises(WazuhError, match=expected_error_msg):
+            await module_instance._post('/agents', b'')
+
+    async def test_get_agents_ids(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `get_agents_ids` method works as expected."""
+        expected_result = ['001', '002', '003']
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = [1, 2, 3]
+        client_mock.get.return_value = response
+
+        result = await module_instance.get_agents_ids()
+        assert result == expected_result
+        client_mock.assert_has_calls([
+            call.get(url='http://localhost/v1/agents/ids', headers={'Accept': APPLICATION_JSON}),
+            call.get().json()
+        ])
+
+    async def test_get_agent_groups(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `get_agent_groups` method works as expected."""
+        agent_id = '001'
+        expected_result = ['default', 'test']
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = expected_result
+        client_mock.get.return_value = response
+
+        result = await module_instance.get_agent_groups(agent_id)
+        assert result == expected_result
+        client_mock.assert_has_calls([
+            call.get(url=f'http://localhost/v1/agents/{agent_id}/groups', headers={'Accept': APPLICATION_JSON}),
+            call.get().json()
+        ])
+
+    async def test_get_agents_groups(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `get_agents_groups` method works as expected."""
+        expected_result = [
+            AgentIDGroups(id='001', groups=['default']),
+            AgentIDGroups(id='002', groups=['default', 'test']),
+        ]
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = {'data': [
+            {'id': 1, 'groups': ['default']},
+            {'id': 2, 'groups': ['default','test']}
+        ]}
+        client_mock.get.return_value = response
+
+        result = await module_instance.get_agents_groups()
+        for i, item in enumerate(result):
+            assert item.id == expected_result[i].id
+            assert item.groups == expected_result[i].groups
+
+        client_mock.assert_has_calls([
+            call.get(url='http://localhost/v1/agents/ids/groups', headers={'Accept': APPLICATION_JSON}),
+            call.get().json()
+        ])
+
+    async def test_get_group_agents(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `get_group_agents` method works as expected."""
+        group_name = 'test'
+        expected_result = ['002', '005', '011']
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = [2, 5, 11]
+        client_mock.get.return_value = response
+
+        result = await module_instance.get_group_agents(group_name)
+        assert result == expected_result
+        client_mock.assert_has_calls([
+            call.get(url=f'http://localhost/v1/agents/ids/groups/{group_name}', headers={'Accept': APPLICATION_JSON}),
+            call.get().json()
+        ])
+    
+    async def test_get_agents_summary(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `get_agents_summary` method works as expected."""
+        agent_ids = [1, 2, 3]
+        expected_result = AgentsSummary(
+            agents_by_groups={
+                'default': 30,
+                'test': 30
+            },
+            agents_by_os={
+                'amzn': 30,
+            },
+            agents_by_status={
+                'active': 10,
+                'disconnected': 20
+            },
+        )
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = {
+            'agents_by_groups': {
+                'default': 30,
+                'test': 30
+            },
+            'agents_by_os': {
+                'amzn': 30
+            },
+            'agents_by_status': {
+                'active': 10,
+                'disconnected': 20
+            },
+        }
+        client_mock.post.return_value = response
+
+        result = await module_instance.get_agents_summary(agent_ids)
+        assert result.groups == expected_result.groups
+        assert result.os == expected_result.os
+        assert result.status == expected_result.status
+
+        client_mock.assert_has_calls([
+            call.post(
+                url='http://localhost/v1/agents/summary',
+                json=agent_ids,
+                headers={'Accept': APPLICATION_JSON, 'Content-Type': APPLICATION_JSON}
+            ),
+            call.post().json()
+        ])
+
+    async def test_get_agents_sync(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `get_agents_sync` method works as expected."""
+        expected_result = AgentsSync(
+            syncreq=[
+                {
+                    'id': '010',
+                    'name': 'b922117b0323',
+                    'ip': '172.18.0.9',
+                    'node_name': 'node01',
+                    'last_keepalive': 1745892111,
+                    'connection_status': 'active',
+                    'disconnection_time': 0,
+                    'group_config_status': 'synced',
+                    'status_code': 0,
+                    'labels': []
+                }
+            ],
+            syncreq_keepalive=[],
+            syncreq_status=[],
+        )
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = {
+            'syncreq': [
+                {
+                    'id': 10,
+                    'name': 'b922117b0323',
+                    'ip': '172.18.0.9',
+                    'node_name': 'node01',
+                    'last_keepalive': 1745892111,
+                    'connection_status': 'active',
+                    'disconnection_time': 0,
+                    'group_config_status': 'synced',
+                    'status_code': 0,
+                    'labels': []
+                }
+            ],
+            'syncreq_keepalive': [],
+            'syncreq_status': []
+        }
+        client_mock.get.return_value = response
+
+        result = await module_instance.get_agents_sync()
+        assert result.syncreq[0]['id'] == expected_result.syncreq[0]['id']
+
+        client_mock.assert_has_calls([
+            call.get(
+                url='http://localhost/v1/agents/sync',
+                headers={'Accept': APPLICATION_JSON}
+            ),
+            call.get().json()
+        ])
+    
+    async def test_set_agents_sync(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
+        """Check that the `set_agents_sync` method works as expected."""
+        agents_sync = AgentsSync(
+            syncreq=[
+                {
+                    'id': '010',
+                    'name': 'b922117b0323',
+                    'ip': '172.18.0.9',
+                    'node_name': 'node01',
+                    'last_keepalive': 1745892111,
+                    'connection_status': 'active',
+                    'disconnection_time': 0,
+                    'group_config_status': 'synced',
+                    'status_code': 0,
+                    'labels': []
+                }
+            ],
+            syncreq_keepalive=[],
+            syncreq_status=[],
+        )
+        expected_result = Status(status='success')
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = {'status': 'success'}
+        client_mock.post.return_value = response
+
+        result = await module_instance.set_agents_sync(agents_sync)
+        assert result.status == expected_result.status
+
+        client_mock.assert_has_calls([
+            call.post(
+                url='http://localhost/v1/agents/sync',
+                json=agents_sync,
+                headers={'Accept': APPLICATION_JSON, 'Content-Type': APPLICATION_JSON}
+            ),
+            call.post().json()
+        ])

--- a/framework/wazuh/core/tests/test_wdb_http.py
+++ b/framework/wazuh/core/tests/test_wdb_http.py
@@ -72,10 +72,10 @@ class TestWazuhDBHTTPClient:
 
     async def test_get_agents_ids(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
         """Check that the `get_agents_ids` method works as expected."""
-        expected_result = ['001', '002', '003']
+        expected_result = [1, 2, 3]
         response = MagicMock()
         response.is_error = False
-        response.json.return_value = [1, 2, 3]
+        response.json.return_value = expected_result
         client_mock.get.return_value = response
 
         result = await module_instance.get_agents_ids()
@@ -87,7 +87,7 @@ class TestWazuhDBHTTPClient:
 
     async def test_get_agent_groups(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
         """Check that the `get_agent_groups` method works as expected."""
-        agent_id = '001'
+        agent_id = 1
         expected_result = ['default', 'test']
         response = MagicMock()
         response.is_error = False
@@ -104,8 +104,8 @@ class TestWazuhDBHTTPClient:
     async def test_get_agents_groups(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
         """Check that the `get_agents_groups` method works as expected."""
         expected_result = [
-            AgentIDGroups(id='001', groups=['default']),
-            AgentIDGroups(id='002', groups=['default', 'test']),
+            AgentIDGroups(id=1, groups=['default']),
+            AgentIDGroups(id=2, groups=['default', 'test']),
         ]
         response = MagicMock()
         response.is_error = False
@@ -128,10 +128,10 @@ class TestWazuhDBHTTPClient:
     async def test_get_group_agents(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
         """Check that the `get_group_agents` method works as expected."""
         group_name = 'test'
-        expected_result = ['002', '005', '011']
+        expected_result = [2, 5, 11]
         response = MagicMock()
         response.is_error = False
-        response.json.return_value = [2, 5, 11]
+        response.json.return_value = expected_result
         client_mock.get.return_value = response
 
         result = await module_instance.get_group_agents(group_name)
@@ -193,7 +193,7 @@ class TestWazuhDBHTTPClient:
         expected_result = AgentsSync(
             syncreq=[
                 {
-                    'id': '010',
+                    'id': 10,
                     'name': 'b922117b0323',
                     'ip': '172.18.0.9',
                     'node_name': 'node01',

--- a/framework/wazuh/core/tests/test_wdb_http.py
+++ b/framework/wazuh/core/tests/test_wdb_http.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, call, MagicMock
 
 import pytest
-from wazuh.core.wdb_http import AgentIDGroups, AgentsSummary, AgentsSync, APPLICATION_JSON, Status, WazuhDBHTTPClient
+from wazuh.core.wdb_http import AgentIDGroups, AgentsSummary, APPLICATION_JSON, Status, WazuhDBHTTPClient
 from wazuh.core.exception import WazuhError
 
 
@@ -190,27 +190,7 @@ class TestWazuhDBHTTPClient:
 
     async def test_get_agents_sync(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
         """Check that the `get_agents_sync` method works as expected."""
-        expected_result = AgentsSync(
-            syncreq=[
-                {
-                    'id': 10,
-                    'name': 'b922117b0323',
-                    'ip': '172.18.0.9',
-                    'node_name': 'node01',
-                    'last_keepalive': 1745892111,
-                    'connection_status': 'active',
-                    'disconnection_time': 0,
-                    'group_config_status': 'synced',
-                    'status_code': 0,
-                    'labels': []
-                }
-            ],
-            syncreq_keepalive=[],
-            syncreq_status=[],
-        )
-        response = MagicMock()
-        response.is_error = False
-        response.json.return_value = {
+        expected_result = {
             'syncreq': [
                 {
                     'id': 10,
@@ -226,12 +206,15 @@ class TestWazuhDBHTTPClient:
                 }
             ],
             'syncreq_keepalive': [],
-            'syncreq_status': []
+            'syncreq_status': [],
         }
+        response = MagicMock()
+        response.is_error = False
+        response.json.return_value = expected_result
         client_mock.get.return_value = response
 
         result = await module_instance.get_agents_sync()
-        assert result.syncreq[0]['id'] == expected_result.syncreq[0]['id']
+        assert result == expected_result
 
         client_mock.assert_has_calls([
             call.get(
@@ -243,8 +226,8 @@ class TestWazuhDBHTTPClient:
     
     async def test_set_agents_sync(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
         """Check that the `set_agents_sync` method works as expected."""
-        agents_sync = AgentsSync(
-            syncreq=[
+        agents_sync = {
+            'syncreq': [
                 {
                     'id': '010',
                     'name': 'b922117b0323',
@@ -258,9 +241,9 @@ class TestWazuhDBHTTPClient:
                     'labels': []
                 }
             ],
-            syncreq_keepalive=[],
-            syncreq_status=[],
-        )
+            'syncreq_keepalive': [],
+            'syncreq_status': [],
+        }
         expected_result = Status(status='success')
         response = MagicMock()
         response.is_error = False

--- a/framework/wazuh/core/wdb_http.py
+++ b/framework/wazuh/core/wdb_http.py
@@ -1,0 +1,275 @@
+import json
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+from wazuh.core.exception import WazuhError, WazuhInternalError
+from wazuh.core import common
+from wazuh.core.agent import Agent
+
+from httpx import AsyncClient, AsyncHTTPTransport, ConnectError, Timeout, TimeoutException, UnsupportedProtocol, \
+    RequestError
+
+APPLICATION_JSON = 'application/json'
+
+
+class AgentIDGroups:
+    """Pair of agent ID and its groups."""
+
+    def __init__(self, id: str, groups: list[str] = None):
+        self.id = id
+        self.groups = groups
+
+
+class AgentStatus:
+    """Agent status."""
+
+    def __init__(self, active: int, disconnected: int, never_connected: int, pending: int):
+        self.active = active
+        self.disconnected = disconnected
+        self.never_connected = never_connected
+        self.pending = pending
+
+
+class AgentsSummary:
+    """Agents summary."""
+
+    def __init__(self, agents_by_status: AgentStatus, agents_by_os: Any, agents_by_groups: Any):
+        self.status = agents_by_status
+        self.os = agents_by_os
+        self.groups = agents_by_groups
+
+
+class AgentsSync:
+    """Agents synchronization information."""
+
+    def __init__(self, syncreq: list[Agent], syncreq_keepalive: list[Agent], syncreq_status: list[Agent]):
+        self.syncreq = syncreq
+        self.syncreq_keepalive = syncreq_keepalive
+        self.syncreq_status = syncreq_status
+
+
+class Status:
+    """Agents synchronization set response status."""
+
+    def __init__(self, status: str):
+        self.status = status
+
+
+def parse_agent_ids(ids: list[int]) -> list[str]:
+    return [str(id).zfill(3) for id in ids]
+
+
+class WazuhDBHTTPClient:
+    """Represents a client to the wdb HTTP unix socket."""
+
+    API_URL = 'http://localhost/v1'
+
+    def __init__(self, retries: int = 5, timeout: float = 10):
+        """Class constructor.
+
+        Parameters
+        ----------
+        retries : int
+            Number of connection retries.
+        timeout : float
+            Maximum number of seconds to wait
+        """
+        self.socket_path = f'{common.WDB_HTTP_SOCKET}.sock'
+
+        try:
+            transport = AsyncHTTPTransport(uds=self.socket_path, retries=retries)
+            self._client = AsyncClient(transport=transport, timeout=Timeout(timeout))
+
+        except (OSError, TimeoutException) as e:
+            raise WazuhInternalError(2011, e)
+
+    async def close(self) -> None:
+        """Close the wazuh-db HTTP client."""
+        await self._client.aclose()
+
+    async def _get(self, endpoint: str) -> Any:
+        """Send a GET request to the specified endpoint.
+        
+        Parameters
+        ----------
+        endpoint : str
+            Endpoint name.
+        
+        Returns
+        -------
+        Any
+            JSON response.
+        """
+        try:
+            response = await self._client.get(url=f'{self.API_URL}{endpoint}', headers={'Accept': APPLICATION_JSON})
+            if response.is_error:
+                raise WazuhError(2012, extra_message=response.text)
+
+        except RequestError as exc:
+            raise WazuhError(2013, extra_message=str(exc))
+
+        return response.json()
+    
+    async def _post(self, endpoint: str, data: Any) -> Any:
+        """Send a POST request to the specified endpoint.
+
+        Parameters
+        ----------
+        endpoint : str
+            Endpoint name.
+        data : Any
+            JSON body.
+
+        Returns
+        -------
+        Any
+            JSON response.
+        """
+        try:
+            response = await self._client.post(
+                url=f'{self.API_URL}{endpoint}',
+                json=data,
+                headers={
+                    'Accept': APPLICATION_JSON,
+                    'Content-Type': APPLICATION_JSON,
+                },
+            )
+
+            if response.is_error:
+                raise WazuhError(2012, extra_message=response.text)
+
+        except RequestError as exc:
+            raise WazuhError(2013, extra_message=str(exc))
+
+        return response.json()
+
+    async def get_agents_ids(self) -> list[str]:
+        """Get system agents IDs.
+        
+        Returns
+        -------
+        list[str]
+            Agent IDs.
+        """
+        ids = await self._get('/agents/ids')
+        return parse_agent_ids(ids)
+    
+    async def get_agent_groups(self, agent_id: str) -> list[str]:
+        """Get agent groups.
+        
+        Parameters
+        ----------
+        agent_id : str
+            Agent ID.
+        
+        Returns
+        -------
+        list[str]
+            Group names.
+        """
+        return await self._get(f'/agents/{agent_id}/groups')
+    
+    async def get_agents_groups(self) -> list[AgentIDGroups]:
+        """Get system agents groups.
+        
+        Returns
+        -------
+        list[str]
+            Group names.
+        """
+        data = await self._get('/agents/ids/groups')
+        return [AgentIDGroups(id=str(d['id']).zfill(3), groups=d['groups']) for d in data['data']]
+
+    async def get_group_agents(self, group_name: str) -> list[str]:
+        """Get group agents.
+        
+        Parameters
+        ----------
+        group_name : str
+            Group name.
+        
+        Returns
+        -------
+        list[str]
+            Agent IDs.
+        """
+        data = await self._get(f'/agents/ids/groups/{group_name}')
+        return parse_agent_ids(data)
+    
+    async def get_agents_summary(self, agent_ids: list[str] = []) -> AgentsSummary:
+        """Get agents information summary.
+        
+        Parameters
+        ----------
+        agent_ids : list[str]
+            Agent ID list. By default, the summary of all agents is returned.
+        
+        Returns
+        -------
+        AgentsSummary
+            Agents information summary.
+        """
+        ids = [int(agent_id) for agent_id in agent_ids]
+        data = await self._post('/agents/summary', ids)
+        return AgentsSummary(**data)
+    
+    async def get_agents_sync(self) -> AgentsSync:
+        """Get agents synchronization information.
+        
+        Returns
+        -------
+        AgentsSync
+            Agenst synchronization information.
+        """
+        data = await self._get('/agents/sync')
+        agents_sync = AgentsSync(**data)
+
+        for agent in agents_sync.syncreq:
+            agent['id'] = str(agent['id']).zfill(3)
+        
+        for agent in agents_sync.syncreq_keepalive:
+            agent['id'] = str(agent['id']).zfill(3)
+        
+        for agent in agents_sync.syncreq_status:
+            agent['id'] = str(agent['id']).zfill(3)
+        
+        return agents_sync
+
+    async def set_agents_sync(self, agents_sync: AgentsSync) -> Status:
+        """Set agents synchronization information.
+
+        Parameters
+        ----------
+        agents_sync : AgentsSync
+            Agenst synchronization information.
+        
+        Returns
+        -------
+        Status
+            Operation status.
+        """
+        data = await self._post('/agents/sync', agents_sync)
+        return Status(**data)
+
+
+@asynccontextmanager
+async def get_wdb_http_client() -> AsyncIterator[WazuhDBHTTPClient]:
+    """Create and return the engine client.
+
+    Returns
+    -------
+    AsyncIterator[WazuhDBHTTP]
+        Wazuh DB HTTP client iterator.
+    """
+    client = WazuhDBHTTPClient()
+
+    try:
+        yield client
+    except TimeoutException:
+        raise WazuhInternalError(2014)
+    except UnsupportedProtocol:
+        raise WazuhInternalError(2015)
+    except ConnectError:
+        raise WazuhInternalError(2016)
+    finally:
+        await client.close()

--- a/framework/wazuh/core/wdb_http.py
+++ b/framework/wazuh/core/wdb_http.py
@@ -37,15 +37,6 @@ class AgentsSummary:
         self.groups = agents_by_groups
 
 
-class AgentsSync:
-    """Agents synchronization information."""
-
-    def __init__(self, syncreq: list, syncreq_keepalive: list, syncreq_status: list):
-        self.syncreq = syncreq
-        self.syncreq_keepalive = syncreq_keepalive
-        self.syncreq_status = syncreq_status
-
-
 class Status:
     """Agents synchronization set response status."""
 
@@ -205,23 +196,22 @@ class WazuhDBHTTPClient:
         data = await self._post('/agents/summary', ids)
         return AgentsSummary(**data)
     
-    async def get_agents_sync(self) -> AgentsSync:
+    async def get_agents_sync(self) -> dict:
         """Get agents synchronization information.
         
         Returns
         -------
-        AgentsSync
+        dict
             Agenst synchronization information.
         """
-        data = await self._get('/agents/sync')
-        return AgentsSync(**data)
+        return await self._get('/agents/sync')
 
-    async def set_agents_sync(self, agents_sync: AgentsSync) -> Status:
+    async def set_agents_sync(self, agents_sync: dict) -> Status:
         """Set agents synchronization information.
 
         Parameters
         ----------
-        agents_sync : AgentsSync
+        agents_sync : dict
             Agenst synchronization information.
         
         Returns

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1533,9 +1533,8 @@ def test_get_agents_big_env(mock_conn, mock_send, mock_get_agents, insert_agents
     (['dmz', 'webserver', 'database'], '005', 'dmz')
 ])
 @patch('wazuh.core.agent.Agent.get_agent_groups', new_callable=AsyncMock)
-@patch('wazuh.core.agent.Agent.set_agent_group_relationship', new_callable=AsyncMock)
-@patch('wazuh.core.agent.Agent')
-async def test_unset_single_group_agent(agent_patch, set_agent_group_patch, get_groups_patch, agent_groups,
+@patch('wazuh.core.agent.Agent.set_agent_group_relationship')
+async def test_unset_single_group_agent(set_agent_group_patch, get_groups_patch, agent_groups,
                                    agent_id, group_id):
     """Test successfully unsetting a group from an agent.
 

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -11,7 +11,7 @@ import pytest
 from grp import getgrnam
 from json import dumps
 from pwd import getpwnam
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, patch, call
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..'))
 
@@ -728,7 +728,7 @@ def test_agent_delete_groups_other_exceptions(mock_get_groups, group_list, expec
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('wazuh.core.agent.Agent.group_exists', return_value=True)
 @patch('socket.socket.connect')
-def test_assign_agents_to_group(socket_mock, group_exists_mock, send_mock, add_group_mock, group_list, agent_list,
+async def test_assign_agents_to_group(socket_mock, group_exists_mock, send_mock, add_group_mock, group_list, agent_list,
                                 num_failed):
     """Test `assign_agents_to_group` function from agent module. Does not check its raised exceptions.
 
@@ -741,7 +741,7 @@ def test_assign_agents_to_group(socket_mock, group_exists_mock, send_mock, add_g
     num_failed : int
         Number of expected failed_items
     """
-    result = assign_agents_to_group(group_list, agent_list)
+    result = await assign_agents_to_group(group_list, agent_list)
     # Check typing
     assert isinstance(result, AffectedItemsWazuhResult), 'The returned object is not an "AffectedItemsWazuhResult".'
     assert isinstance(result.affected_items, list)
@@ -764,7 +764,7 @@ def test_assign_agents_to_group(socket_mock, group_exists_mock, send_mock, add_g
 @patch('wazuh.agent.Agent.add_group_to_agent')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
 @patch('socket.socket.connect')
-def test_agent_assign_agents_to_group_exceptions(socket_mock, send_mock, mock_add_group, mock_group_exists, group_list,
+async def test_agent_assign_agents_to_group_exceptions(socket_mock, send_mock, mock_add_group, mock_group_exists, group_list,
                                                  agent_list, expected_error, catch_exception):
     """Test `assign_agents_to_group` function from agent module raises the expected exceptions when using invalid groups.
 
@@ -790,7 +790,7 @@ def test_agent_assign_agents_to_group_exceptions(socket_mock, send_mock, mock_ad
     mock_group_exists.side_effect = group_exists
     mock_add_group.side_effect = add_group_to_agent
     try:
-        result = assign_agents_to_group(group_list, agent_list)
+        result = await assign_agents_to_group(group_list, agent_list)
         assert not catch_exception
         assert isinstance(result, AffectedItemsWazuhResult), 'The returned object is not an "AffectedItemsWazuhResult".'
         assert isinstance(result.failed_items, dict)
@@ -811,7 +811,7 @@ def test_agent_assign_agents_to_group_exceptions(socket_mock, send_mock, mock_ad
 @patch('wazuh.core.agent.Agent.unset_single_group_agent')
 @patch('wazuh.agent.get_groups')
 @patch('wazuh.agent.get_agents_info')
-def test_agent_remove_agent_from_group(mock_get_agents, mock_get_groups, mock_unset, group_id, agent_id):
+async def test_agent_remove_agent_from_group(mock_get_agents, mock_get_groups, mock_unset, group_id, agent_id):
     """Test `remove_agent_from_group` function from agent module. Does not check its raised exceptions.
 
     Parameters
@@ -826,7 +826,7 @@ def test_agent_remove_agent_from_group(mock_get_agents, mock_get_groups, mock_un
     mock_unset.return_value = expected_msg
     mock_get_groups.return_value = {group_id}
 
-    result = remove_agent_from_group(group_list=[group_id], agent_list=[agent_id])
+    result = await remove_agent_from_group(group_list=[group_id], agent_list=[agent_id])
     mock_unset.assert_called_once_with(agent_id=agent_id, group_id=group_id, force=True)
     assert isinstance(result, WazuhResult), 'The returned object is not an "WazuhResult" instance.'
     assert result.dikt['message'] == expected_msg
@@ -839,7 +839,7 @@ def test_agent_remove_agent_from_group(mock_get_agents, mock_get_groups, mock_un
 ])
 @patch('wazuh.agent.get_agents_info', return_value=short_agent_list)
 @patch('wazuh.agent.get_groups', side_effect={'default'})
-def test_agent_remove_agent_from_group_exceptions(group_mock, agents_info_mock, group_id, agent_id, expected_error):
+async def test_agent_remove_agent_from_group_exceptions(group_mock, agents_info_mock, group_id, agent_id, expected_error):
     """Test `remove_agent_from_group` function from agent module raises the expected exceptions if an invalid 'agent_id'
     or 'group_id' are specified.
 
@@ -853,7 +853,7 @@ def test_agent_remove_agent_from_group_exceptions(group_mock, agents_info_mock, 
         The WazuhError object expected to be raised by remove_agent_from_group with the given parameters.
     """
     try:
-        remove_agent_from_group(group_list=[group_id], agent_list=[agent_id])
+        await remove_agent_from_group(group_list=[group_id], agent_list=[agent_id])
         pytest.fail('An exception should be raised for the given configuration.')
     except (WazuhError, WazuhResourceNotFound) as error:
         assert error == expected_error
@@ -865,7 +865,7 @@ def test_agent_remove_agent_from_group_exceptions(group_mock, agents_info_mock, 
 @patch('wazuh.core.agent.Agent.unset_single_group_agent')
 @patch('wazuh.agent.get_agents_info', return_value=short_agent_list)
 @patch('wazuh.agent.get_groups', return_value={'group-1'})
-def test_agent_remove_agent_from_groups(mock_get_groups, mock_get_agents, mock_unset, group_list, agent_list):
+async def test_agent_remove_agent_from_groups(mock_get_groups, mock_get_agents, mock_unset, group_list, agent_list):
     """Test `remove_agent_from_groups` function from agent module.
 
     Parameters
@@ -877,7 +877,7 @@ def test_agent_remove_agent_from_groups(mock_get_groups, mock_get_agents, mock_u
     """
     expected_msg = f"Agent '{group_list[0]}' removed from '{group_list[0]}'"
     mock_unset.return_value = expected_msg
-    result = remove_agent_from_groups(agent_list=agent_list, group_list=group_list)
+    result = await remove_agent_from_groups(agent_list=agent_list, group_list=group_list)
     # Check typing
     assert isinstance(result, AffectedItemsWazuhResult), 'The returned object is not an "AffectedItemsWazuhResult".'
     assert isinstance(result.affected_items, list)
@@ -896,7 +896,7 @@ def test_agent_remove_agent_from_groups(mock_get_groups, mock_get_agents, mock_u
 @patch('wazuh.core.agent.Agent.unset_single_group_agent')
 @patch('wazuh.agent.get_agents_info', return_value=short_agent_list)
 @patch('wazuh.agent.get_groups', return_value={'group-1'})
-def test_agent_remove_agent_from_groups_exceptions(mock_get_groups, mock_get_agents, mock_unset, group_list, agent_list,
+async def test_agent_remove_agent_from_groups_exceptions(mock_get_groups, mock_get_agents, mock_unset, group_list, agent_list,
                                                    expected_error, catch_exception):
     """Test `remove_agent_from_groups` function from agent module raises the expected errors when using invalid group
     or agent lists.
@@ -916,7 +916,7 @@ def test_agent_remove_agent_from_groups_exceptions(mock_get_groups, mock_get_age
     expected_msg = f"Agent '{group_list[0]}' removed from '{group_list[0]}'"
     mock_unset.return_value = expected_msg
     try:
-        result = remove_agent_from_groups(group_list=group_list, agent_list=agent_list)
+        result = await remove_agent_from_groups(group_list=group_list, agent_list=agent_list)
         assert not catch_exception, \
             'An "WazuhError" exception was expected but was not raised.'
         # Check Typing
@@ -947,7 +947,7 @@ def test_agent_remove_agent_from_groups_exceptions(mock_get_groups, mock_get_age
 @patch('wazuh.core.agent.Agent.unset_single_group_agent')
 @patch('wazuh.agent.get_agents_info', return_value=short_agent_list)
 @patch('wazuh.agent.get_groups', return_value={'group-1'})
-def test_agent_remove_agents_from_group(mock_get_groups, mock_get_agents, mock_unset, group_list, agent_list):
+async def test_agent_remove_agents_from_group(mock_get_groups, mock_get_agents, mock_unset, group_list, agent_list):
     """Test `remove_agents_from_group` function from agent module.
 
     Parameters
@@ -959,7 +959,7 @@ def test_agent_remove_agents_from_group(mock_get_groups, mock_get_agents, mock_u
     """
     expected_msg = f"Agent '{group_list[0]}' removed from '{group_list[0]}'"
     mock_unset.return_value = expected_msg
-    result = remove_agents_from_group(agent_list=agent_list, group_list=group_list)
+    result = await remove_agents_from_group(agent_list=agent_list, group_list=group_list)
     # Check typing
     assert isinstance(result, AffectedItemsWazuhResult), 'The returned object is not an "AffectedItemsWazuhResult".'
     assert isinstance(result.affected_items, list)
@@ -977,7 +977,7 @@ def test_agent_remove_agents_from_group(mock_get_groups, mock_get_agents, mock_u
 ])
 @patch('wazuh.agent.get_agents_info', return_value=short_agent_list)
 @patch('wazuh.agent.get_groups', return_value={'group-1'})
-def test_agent_remove_agents_from_group_exceptions(group_mock, agents_info_mock, group_list, agent_list,
+async def test_agent_remove_agents_from_group_exceptions(group_mock, agents_info_mock, group_list, agent_list,
                                                    expected_error, catch_exception):
     """Test `remove_agents_from_group` function from agent module raises the expected exceptions when using invalid
     parameters.
@@ -995,7 +995,7 @@ def test_agent_remove_agents_from_group_exceptions(group_mock, agents_info_mock,
         `AffectedItemsWazuhResult` containing the exceptions in its 'failed_items'.
     """
     try:
-        result = remove_agents_from_group(group_list=group_list, agent_list=agent_list)
+        result = await remove_agents_from_group(group_list=group_list, agent_list=agent_list)
         # Ensure no exception was expected
         assert not catch_exception
         assert isinstance(result, AffectedItemsWazuhResult), 'The returned object is not an "AffectedItemsWazuhResult".'
@@ -1532,10 +1532,10 @@ def test_get_agents_big_env(mock_conn, mock_send, mock_get_agents, insert_agents
     (['dmz', 'webserver'], '005', 'dmz'),
     (['dmz', 'webserver', 'database'], '005', 'dmz')
 ])
-@patch('wazuh.core.agent.Agent.get_agent_groups')
-@patch('wazuh.core.agent.Agent.set_agent_group_file')
+@patch('wazuh.core.agent.Agent.get_agent_groups', new_callable=AsyncMock)
+@patch('wazuh.core.agent.Agent.set_agent_group_relationship', new_callable=AsyncMock)
 @patch('wazuh.core.agent.Agent')
-def test_unset_single_group_agent(agent_patch, set_agent_group_patch, get_groups_patch, agent_groups,
+async def test_unset_single_group_agent(agent_patch, set_agent_group_patch, get_groups_patch, agent_groups,
                                    agent_id, group_id):
     """Test successfully unsetting a group from an agent.
 
@@ -1550,7 +1550,7 @@ def test_unset_single_group_agent(agent_patch, set_agent_group_patch, get_groups
     """
     get_groups_patch.return_value = agent_groups
 
-    ret_msg = Agent.unset_single_group_agent(agent_id, group_id, force=True)
+    ret_msg = await Agent.unset_single_group_agent(agent_id, group_id, force=True)
 
     # Response message is different depending on the remaining group. If the only group is removed, 'default'
     # will be reassigned through wdb and the message will reflect it
@@ -1566,10 +1566,10 @@ def test_unset_single_group_agent(agent_patch, set_agent_group_patch, get_groups
     ('001', 'not_exists', True, 1734),
     ('001', 'default', True, 1745),
 ])
-@patch('wazuh.core.agent.Agent.get_agent_groups', return_value=['default'])
+@patch('wazuh.core.agent.Agent.get_agent_groups', new_callable=AsyncMock)
 @patch('wazuh.core.agent.Agent.group_exists', return_value=False)
 @patch('wazuh.core.agent.Agent.get_basic_information')
-def test_unset_single_group_agent_ko(agent_basic_mock, group_exists_mock, get_groups_mock, agent_id, group_id,
+async def test_unset_single_group_agent_ko(agent_basic_mock, group_exists_mock, get_groups_mock, agent_id, group_id,
                                       force, expected_exc):
     """Test `remove_single_group_agent` method exceptions.
 
@@ -1584,8 +1584,9 @@ def test_unset_single_group_agent_ko(agent_basic_mock, group_exists_mock, get_gr
     expected_exc: int
         Expected WazuhException code error.
     """
+    get_groups_mock.return_value = ['default']
     with pytest.raises(WazuhException, match=f".* {expected_exc} .*"):
-        Agent.unset_single_group_agent(agent_id, group_id, force=force)
+        await Agent.unset_single_group_agent(agent_id, group_id, force=force)
 
 
 def test_check_uninstall_permission():


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/29414 |

## Description

Adds the client for the wazuh-db HTTP server exposed through a unix socket. 

This allows us to get and send larger chunks of information to wazuh-db without having to paginate every 65kb like we are forced now due to the UDP datagrams size limits. 

## Tests

### Agents endpoints

<details><summary>Create agent</summary>

```console
gasti@gasti:~/work/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -ki https://0.0.0.0:55050/agents -d '{
  "name": "NewHost_2",
  "ip": "10.0.10.11"
}'
{"data": {"id": "001", "key": "MDAxIE5ld0hvc3RfMiAxMC4wLjEwLjExIGVjMmQ5MjVmOTJhZjFjMWIwMTYyYmY5ODdmZGJhOGU2YzY1ZjM1ZjU3NGRlY2RmNWJhZTMxMWE1MWNhZGM3ZDE="}, "error": 0}
```

</details>

<details><summary>Create group</summary>

```console
gasti@gasti:~/work/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X POST -k https://0.0.0.0:55050/groups -d '{
  "group_id": "test"
}'
{"message": "Group 'test' created.", "error": 0}
```

</details>

<details><summary>Assign agent to group</summary>

```console
gasti@gasti:~/work/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X PUT -k 'https://0.0.0.0:55050/agents/group?agents_list=001&group_id=test'
{"data": {"affected_items": ["001"], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "All selected agents were assigned to test", "error": 0}
```

</details>

<details><summary>Get agents in group</summary>

```console
gasti@gasti:~/work/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55050/groups/test/agents | jq
{
  "data": {
    "affected_items": [
      {
        "node_name": "unknown",
        "group": [
          "test"
        ],
        "dateAdd": "2025-05-07T14:07:00+00:00",
        "id": "001",
        "status": "never_connected",
        "ip": "10.0.10.11",
        "registerIP": "10.0.10.11",
        "status_code": 0,
        "name": "NewHost_2",
        "group_config_status": "not synced"
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "All selected agents information was returned",
  "error": 0
}
```

</details>

<details><summary>Remove agent from group</summary>

```console
gasti@gasti:~/work/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X DELETE -k 'https://0.0.0.0:55050/agents/group?agents_list=001&group_id=test'
{"data": {"affected_items": ["001"], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "All selected agents were removed from group test", "error": 0}
```

</details>

<details><summary>Get agents in group</summary>

```console
gasti@gasti:~/work/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55050/groups/test/agents | jq
{
  "data": {
    "affected_items": [],
    "total_affected_items": 0,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "No agent information was returned",
  "error": 0
}
```

</details>

### Agent-info sync data

<details><summary>Worker logs</summary>

```console
root@wazuh-worker1:/# tail -n 100 /var/ossec/logs/cluster.log | grep Agent-info
2025/05/07 18:39:00 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Permission to synchronize granted.
2025/05/07 18:39:00 INFO: [Worker wazuh-worker1] [Agent-info sync] Starting.
2025/05/07 18:39:00 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Obtained agents synchronization information in 0.019s.
2025/05/07 18:39:00 INFO: [Worker wazuh-worker1] [Agent-info sync] No synchronization required, skipping.
2025/05/07 18:39:10 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Permission to synchronize granted.
2025/05/07 18:39:10 INFO: [Worker wazuh-worker1] [Agent-info sync] Starting.
2025/05/07 18:39:10 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Obtained agents synchronization information in 0.018s.
2025/05/07 18:39:10 INFO: [Worker wazuh-worker1] [Agent-info sync] No synchronization required, skipping.
2025/05/07 18:39:20 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Permission to synchronize granted.
2025/05/07 18:39:20 INFO: [Worker wazuh-worker1] [Agent-info sync] Starting.
2025/05/07 18:39:20 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Obtained agents synchronization information in 0.018s.
2025/05/07 18:39:20 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Sending chunks.
2025/05/07 18:39:20 INFO: [Worker wazuh-worker1] [Agent-info sync] Finished in 0.046s. Updated 1 chunks.
2025/05/07 18:39:30 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Permission to synchronize granted.
2025/05/07 18:39:30 INFO: [Worker wazuh-worker1] [Agent-info sync] Starting.
2025/05/07 18:39:30 DEBUG: [Worker wazuh-worker1] [Agent-info sync] Obtained agents synchronization information in 0.021s.
2025/05/07 18:39:30 INFO: [Worker wazuh-worker1] [Agent-info sync] No synchronization required, skipping.
```

</details>

<details><summary>Master logs</summary>

```console
root@wazuh-master:/# tail -n 50 /var/ossec/logs/cluster.log | grep Agent-info
2025/05/07 18:39:20 INFO: [Worker wazuh-worker1] [Agent-info sync] Starting.
2025/05/07 18:39:20 DEBUG: [Worker wazuh-worker1] [Agent-info sync] 1/1 chunks updated in wazuh-db in 0.026s.
2025/05/07 18:39:20 INFO: [Worker wazuh-worker1] [Agent-info sync] Finished in 0.027s. Updated 1 chunks.
```

</details>

<details><summary>Before</summary>

```console
2025/05/06 17:32:08 INFO: [Worker worker2] [Agent-info sync] {'set_data_command': 'global sync-agent-info-set', 'payload': {}, 'chunks': ['[{"id":1,"name":"wazuh-agent1","ip":"172.18.0.7","os_name":"Ubuntu","os_version":"20.04.1 LTS","os_major":"20","os_minor":"04","os_codename":"Focal Fossa","os_platform":"ubuntu","os_uname":"Linux |wazuh-agent1 |6.1.0-31-amd64 |#1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07) |x86_64","os_arch":"x86_64","version":"Wazuh v4.11.2","config_sum":"29e0926e5a77442212e824868a2a61df","merged_sum":"b5c9934cd2f2ed781b01a8d4c1944bb3","manager_host":"wazuh-worker2","node_name":"worker2","last_keepalive":1746552725,"connection_status":"active","disconnection_time":0,"group_config_status":"synced","status_code":0,"labels":[{"id":1,"key":"#\\"_agent_ip\\"","value":"172.18.0.7"},{"id":1,"key":"#\\"_manager_hostname\\"","value":"wazuh-worker2"},{"id":1,"key":"#\\"_node_name\\"","value":"worker2"},{"id":1,"key":"#\\"_wazuh_version\\"","value":"Wazuh v4.11.2"}]},{"id":5,"name":"wazuh-agent5","ip":"172.18.0.11","os_name":"Ubuntu","os_version":"18.04.5 LTS","os_major":"18","os_minor":"04","os_codename":"Bionic Beaver","os_platform":"ubuntu","os_uname":"Linux |wazuh-agent5 |6.1.0-31-amd64 |#1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07) |x86_64","os_arch":"x86_64","version":"Wazuh v3.13.2","config_sum":"6ca315e21ec25eab4bcb2a29218c6ae8","merged_sum":"178efd7414cffcef4ec5769d3bddd410","manager_host":"wazuh-worker2","node_name":"worker2","last_keepalive":1746552720,"connection_status":"active","disconnection_time":0,"group_config_status":"synced","status_code":0,"labels":[{"id":5,"key":"#\\"_agent_ip\\"","value":"172.18.0.11"},{"id":5,"key":"#\\"_manager_hostname\\"","value":"wazuh-worker2"},{"id":5,"key":"#\\"_node_name\\"","value":"worker2"},{"id":5,"key":"#\\"_wazuh_version\\"","value":"Wazuh v3.13.2"}]}]']}
```

</details>

<details><summary>Now</summary>

```console
2025/05/06 17:27:27 INFO: [Worker worker1] [Agent-info sync] {'set_data_command': 'global sync-agent-info-set', 'payload': {}, 'chunks': {'syncreq': [{'id': 1, 'name': 'wazuh-agent1', 'ip': '172.18.0.7', 'os_name': 'Ubuntu', 'os_version': '20.04.1 LTS', 'os_major': '20', 'os_minor': '04', 'os_codename': 'Focal Fossa', 'os_platform': 'ubuntu', 'os_uname': 'Linux |wazuh-agent1 |6.1.0-31-amd64 |#1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07) |x86_64', 'os_arch': 'x86_64', 'version': 'Wazuh v4.11.2', 'merged_sum': 'x', 'manager_host': 'wazuh-worker1', 'node_name': 'worker1', 'last_keepalive': 1746552441, 'connection_status': 'active', 'disconnection_time': 0, 'group_config_status': 'synced', 'status_code': 0, 'labels': [{'id': 1, 'key': '#"_agent_ip"', 'value': '172.18.0.7'}, {'id': 1, 'key': '#"_manager_hostname"', 'value': 'wazuh-worker1'}, {'id': 1, 'key': '#"_node_name"', 'value': 'worker1'}, {'id': 1, 'key': '#"_wazuh_version"', 'value': 'Wazuh v4.11.2'}]}, {'id': 4, 'name': 'wazuh-agent4', 'ip': '172.18.0.10', 'os_name': 'Ubuntu', 'os_version': '20.04.1 LTS', 'os_major': '20', 'os_minor': '04', 'os_codename': 'Focal Fossa', 'os_platform': 'ubuntu', 'os_uname': 'Linux |wazuh-agent4 |6.1.0-31-amd64 |#1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07) |x86_64', 'os_arch': 'x86_64', 'version': 'Wazuh v4.11.2', 'merged_sum': 'x', 'manager_host': 'wazuh-worker1', 'node_name': 'worker1', 'last_keepalive': 1746552443, 'connection_status': 'active', 'disconnection_time': 0, 'group_config_status': 'synced', 'status_code': 0, 'labels': [{'id': 4, 'key': '#"_agent_ip"', 'value': '172.18.0.10'}, {'id': 4, 'key': '#"_manager_hostname"', 'value': 'wazuh-worker1'}, {'id': 4, 'key': '#"_node_name"', 'value': 'worker1'}, {'id': 4, 'key': '#"_wazuh_version"', 'value': 'Wazuh v4.11.2'}]}, {'id': 7, 'name': 'wazuh-agent7', 'ip': '172.18.0.13', 'os_name': 'Ubuntu', 'os_version': '18.04.5 LTS', 'os_major': '18', 'os_minor': '04', 'os_codename': 'Bionic Beaver', 'os_platform': 'ubuntu', 'os_uname': 'Linux |wazuh-agent7 |6.1.0-31-amd64 |#1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07) |x86_64', 'os_arch': 'x86_64', 'version': 'Wazuh v3.13.2', 'merged_sum': 'x', 'manager_host': 'wazuh-worker1', 'node_name': 'worker1', 'last_keepalive': 1746552437, 'connection_status': 'active', 'disconnection_time': 0, 'group_config_status': 'synced', 'status_code': 0, 'labels': [{'id': 7, 'key': '#"_agent_ip"', 'value': '172.18.0.13'}, {'id': 7, 'key': '#"_manager_hostname"', 'value': 'wazuh-worker1'}, {'id': 7, 'key': '#"_node_name"', 'value': 'worker1'}, {'id': 7, 'key': '#"_wazuh_version"', 'value': 'Wazuh v3.13.2'}]}], 'syncreq_keepalive': [], 'syncreq_status': []}}
```

</details>

### Integration tests

<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

```console
(venv) gasti@gasti:~/work/wazuh/api/test/integration$ pytest --nobuild --disable-warnings test_agent_GET_endpoints.tavern.yaml
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh/api/test/integration
configfile: pytest.ini
plugins: asyncio-0.18.1, tavern-1.23.5, html-2.1.1, metadata-3.1.1, cov-4.1.0, anyio-4.8.0, trio-0.8.0
asyncio: mode=auto
collected 95 items                                                                                                                                                                                                                           

test_agent_GET_endpoints.tavern.yaml ...............................................................................................                                                                                                   [100%]

================================================================================================ 95 passed, 96 warnings in 294.49s (0:04:54) =================================================================================================
```

</details>
