### PR TITLE
Added `UUID` to the `/manager/info` endpoint

### DIFF
--- a/api/api/signals.py
+++ b/api/api/signals.py
@@ -5,12 +5,11 @@ import asyncio
 import contextlib
 import logging
 import os
-import uuid
 from functools import wraps
 from typing import Callable
 
 from connexion import ConnexionMiddleware
-from wazuh.core import common
+from wazuh.core.common import get_installation_uid
 from wazuh.core.cluster.utils import running_in_master_node
 from wazuh.core.configuration import update_check_is_enabled
 from wazuh.core.manager import query_update_check_service
@@ -53,22 +52,16 @@ def cancel_signal_handler(func: Callable) -> Callable:
 
 
 @cancel_signal_handler
-async def check_installation_uid() -> None:
-    """Check if the installation UID exists, populate it if not and inject it into the global cti context."""
+async def load_installation_uid() -> None:
+    """Load the installation UID into the global cti context."""
 
     global cti_context
     if os.path.exists(INSTALLATION_UID_PATH):
         logger.info("Getting installation UID...")
-        with open(INSTALLATION_UID_PATH, 'r') as file:
-            installation_uid = file.readline()
     else:
         logger.info("Populating installation UID...")
-        installation_uid = str(uuid.uuid4())
-        with open(INSTALLATION_UID_PATH, 'w') as file:
-            file.write(installation_uid)
-            os.chown(file.name, common.wazuh_uid(), common.wazuh_gid())
-            os.chmod(file.name, 0o660)
-    cti_context[INSTALLATION_UID_KEY] = installation_uid
+    
+    cti_context[INSTALLATION_UID_KEY] = get_installation_uid()
 
 
 @cancel_signal_handler
@@ -89,7 +82,7 @@ async def lifespan_handler(_: ConnexionMiddleware):
     tasks: list[asyncio.Task] = []
 
     if running_in_master_node():
-        tasks.append(asyncio.create_task(check_installation_uid()))
+        tasks.append(asyncio.create_task(load_installation_uid()))
         if update_check_is_enabled():
             tasks.append(asyncio.create_task(get_update_information()))
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3819,6 +3819,8 @@ components:
           type: string
         tz_name:
           type: string
+        uuid:
+          type: string
 
     WazuhManagerConfiguration:
       type: object
@@ -10315,6 +10317,7 @@ paths:
                       openssl_support: yes
                       tz_offset: +0000
                       tz_name: UTC
+                      uuid: c842f85c-c24b-4b39-9508-093ce53482e7
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []
@@ -12022,6 +12025,7 @@ paths:
                       openssl_support: yes
                       tz_offset: +0000
                       tz_name: UTC
+                      uuid: c842f85c-c24b-4b39-9508-093ce53482e7
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -64,6 +64,7 @@ stages:
               tz_name: !anystr
               tz_offset: !anystr
               version: !anystr
+              uuid: !anystr
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -4,7 +4,6 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-import os
 from time import strftime
 
 from wazuh.core import common

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -10,6 +10,7 @@ from time import strftime
 from wazuh.core import common
 from wazuh.core.wdb import WazuhDBConnection
 from wazuh.core.exception import WazuhException, WazuhError, WazuhInternalError
+from wazuh.core.common import get_installation_uid
 
 """
 Wazuh HIDS Python package
@@ -52,7 +53,7 @@ class Wazuh:
         self.openssl_support = 'N/A'
         self.tz_offset = None
         self.tz_name = None
-        self.uuid = None
+        self.uuid = get_installation_uid()
 
         self._initialize()
 
@@ -94,14 +95,6 @@ class Wazuh:
         except Exception:
             self.tz_offset = None
             self.tz_name = None
-
-        # UUID info
-        uuid_file = os.path.join(self.path, 'api/configuration/security/installation_uid')
-        try:
-            with open(uuid_file, 'r') as f:
-                self.uuid = f.read().strip()
-        except FileNotFoundError:
-            self.uuid = None
 
         return self.to_dict()
 

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -96,11 +96,11 @@ class Wazuh:
             self.tz_name = None
 
         # UUID info
+        uuid_file = os.path.join(self.path, 'api/configuration/security/installation_uid')
         try:
-            uuid_file = os.path.join(self.path, 'api/configuration/security/installation_uid')
             with open(uuid_file, 'r') as f:
                 self.uuid = f.read().strip()
-        except Exception:
+        except FileNotFoundError:
             self.uuid = None
 
         return self.to_dict()

--- a/framework/wazuh/__init__.py
+++ b/framework/wazuh/__init__.py
@@ -4,6 +4,7 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import os
 from time import strftime
 
 from wazuh.core import common
@@ -51,6 +52,7 @@ class Wazuh:
         self.openssl_support = 'N/A'
         self.tz_offset = None
         self.tz_name = None
+        self.uuid = None
 
         self._initialize()
 
@@ -69,7 +71,8 @@ class Wazuh:
                 'max_agents': self.max_agents,
                 'openssl_support': self.openssl_support,
                 'tz_offset': self.tz_offset,
-                'tz_name': self.tz_name
+                'tz_name': self.tz_name,
+                'uuid' : self.uuid                
                 }
 
     def _initialize(self):
@@ -91,6 +94,14 @@ class Wazuh:
         except Exception:
             self.tz_offset = None
             self.tz_name = None
+
+        # UUID info
+        try:
+            uuid_file = os.path.join(self.path, 'api/configuration/security/installation_uid')
+            with open(uuid_file, 'r') as f:
+                self.uuid = f.read().strip()
+        except Exception:
+            self.uuid = None
 
         return self.to_dict()
 

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1659,8 +1659,12 @@ def test_asyncio_exception_handler(format_tb, mock_loop, mock_logging):
     mock_logging.assert_called_once_with(output)
 
 
+@patch('wazuh.core.common.os.chmod')
+@patch('wazuh.core.common.os.chown')
+@patch('wazuh.core.common.wazuh_gid', return_value=0)
+@patch('wazuh.core.common.wazuh_uid', return_value=0)
 @patch('wazuh.core.common.INSTALLATION_UID_PATH', os.path.join('/tmp', 'installation_uid'))
-def test_wazuh_json_encoder_default():
+def test_wazuh_json_encoder_default(mock_chmod, mock_chown, mock_gid, mock_uid):
     """Test if a special JSON encoder is defined for Wazuh."""
 
     wazuh_encoder = cluster_common.WazuhJSONEncoder()
@@ -1719,8 +1723,12 @@ def test_wazuh_json_encoder_default():
             wazuh_encoder.default({"key": "value"})
 
 
+@patch('wazuh.core.common.os.chmod')
+@patch('wazuh.core.common.os.chown')
+@patch('wazuh.core.common.wazuh_gid', return_value=0)
+@patch('wazuh.core.common.wazuh_uid', return_value=0)
 @patch('wazuh.core.common.INSTALLATION_UID_PATH', os.path.join('/tmp', 'installation_uid'))
-def test_as_wazuh_object_ok():
+def test_as_wazuh_object_ok(mock_chmod, mock_chown, mock_gid, mock_uid):
     """Test the different outputs taking into account the input values."""
 
     # Test the first condition and nested if
@@ -1763,8 +1771,12 @@ def test_as_wazuh_object_ok():
            {"__wazuh_datetime_bad__": "2021-10-14"}
 
 
+@patch('wazuh.core.common.os.chmod')
+@patch('wazuh.core.common.os.chown')
+@patch('wazuh.core.common.wazuh_gid', return_value=0)
+@patch('wazuh.core.common.wazuh_uid', return_value=0)
 @patch('wazuh.core.common.INSTALLATION_UID_PATH', os.path.join('/tmp', 'installation_uid'))
-def test_as_wazuh_object_ko():
+def test_as_wazuh_object_ko(mock_chmod, mock_chown, mock_gid, mock_uid):
     """Test if the exceptions are correctly raised."""
 
     with pytest.raises(exception.WazuhInternalError, match=r'.* 1000 .*'):

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -1659,6 +1659,7 @@ def test_asyncio_exception_handler(format_tb, mock_loop, mock_logging):
     mock_logging.assert_called_once_with(output)
 
 
+@patch('wazuh.core.common.INSTALLATION_UID_PATH', os.path.join('/tmp', 'installation_uid'))
 def test_wazuh_json_encoder_default():
     """Test if a special JSON encoder is defined for Wazuh."""
 
@@ -1718,6 +1719,7 @@ def test_wazuh_json_encoder_default():
             wazuh_encoder.default({"key": "value"})
 
 
+@patch('wazuh.core.common.INSTALLATION_UID_PATH', os.path.join('/tmp', 'installation_uid'))
 def test_as_wazuh_object_ok():
     """Test the different outputs taking into account the input values."""
 
@@ -1761,6 +1763,7 @@ def test_as_wazuh_object_ok():
            {"__wazuh_datetime_bad__": "2021-10-14"}
 
 
+@patch('wazuh.core.common.INSTALLATION_UID_PATH', os.path.join('/tmp', 'installation_uid'))
 def test_as_wazuh_object_ko():
     """Test if the exceptions are correctly raised."""
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import uuid
 from contextvars import ContextVar
 from copy import deepcopy
 from functools import lru_cache, wraps
@@ -125,18 +126,24 @@ def get_context_cache() -> dict:
     return _context_cache
 
 
-def get_installation_uid() -> str | None:
-    """Retrieve the installation UID from file if it exists.
+def get_installation_uid() -> str:
+    """Get the installation UID, creating it if it does not exist.
     Returns
     -------
-    str or None
-        The installation UID, or None if the file is not found.
+    str
+        A string containing the installation UID.
     """
-    try:
+    if os.path.exists(INSTALLATION_UID_PATH):
         with open(INSTALLATION_UID_PATH, 'r') as f:
-            return f.read().strip()
-    except FileNotFoundError:
-        return None
+            installation_uid = f.read().strip()
+    else:
+        installation_uid = str(uuid.uuid4())
+        with open(INSTALLATION_UID_PATH, 'w') as f:
+            f.write(installation_uid)
+            os.chown(f.name, wazuh_uid(), wazuh_gid())
+            os.chmod(f.name, 0o660)
+
+    return installation_uid
 
 
 # ================================================= Context variables ==================================================

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -125,6 +125,20 @@ def get_context_cache() -> dict:
     return _context_cache
 
 
+def get_installation_uid() -> str | None:
+    """Retrieve the installation UID from file if it exists.
+    Returns
+    -------
+    str or None
+        The installation UID, or None if the file is not found.
+    """
+    try:
+        with open(INSTALLATION_UID_PATH, 'r') as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+
+
 # ================================================= Context variables ==================================================
 rbac: ContextVar[Dict] = ContextVar('rbac', default={'rbac_mode': 'black'})
 current_user: ContextVar[str] = ContextVar('current_user', default='')
@@ -231,3 +245,7 @@ LISTS_PATH = os.path.join(RULESET_PATH, 'lists')
 USER_LISTS_PATH = os.path.join(WAZUH_PATH, 'etc', 'lists')
 USER_RULES_PATH = os.path.join(WAZUH_PATH, 'etc', 'rules')
 USER_DECODERS_PATH = os.path.join(WAZUH_PATH, 'etc', 'decoders')
+
+# ========================================== INSTALLATION UID PATH ====================================================
+SECURITY_PATH = os.path.join(WAZUH_PATH, 'api', 'configuration', 'security')
+INSTALLATION_UID_PATH = os.path.join(SECURITY_PATH, 'installation_uid')

--- a/framework/wazuh/core/tests/test_common.py
+++ b/framework/wazuh/core/tests/test_common.py
@@ -3,15 +3,16 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
+import uuid
 from contextvars import ContextVar
 from grp import getgrnam
 from pwd import getpwnam
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
 
 import pytest
 
 from wazuh.core.common import find_wazuh_path, wazuh_uid, wazuh_gid, context_cached, reset_context_cache, \
-    get_context_cache
+    get_context_cache, get_installation_uid
 
 
 @pytest.mark.parametrize('fake_path, expected', [
@@ -103,3 +104,28 @@ async def test_origin_module_context_var_api(mock_check_wazuh_status, mock_creat
         await d.distribute_function()
 
     assert mock_create_socket_msg.call_args[1]['origin']['module'] == 'API'
+
+
+@patch('wazuh.core.common.os.chmod')
+@patch('wazuh.core.common.os.chown')
+def test_get_installation_uid_creates_file(chown_mock, chmod_mock, tmp_path):
+    """Test get_installation_uid creates the UID file if it doesn't exist."""
+
+    test_path = tmp_path / 'installation_uid'
+    with patch('wazuh.core.common.INSTALLATION_UID_PATH', str(test_path)):
+        uid = get_installation_uid()
+
+        uuid.UUID(uid)  # should not raise
+        with open(test_path, 'r') as f:
+            assert f.read().strip() == uid
+
+        chown_mock.assert_called_once()
+        chmod_mock.assert_called_once()
+
+
+@patch('wazuh.core.common.os.path.exists', return_value=True)
+@patch('builtins.open', new_callable=mock_open, read_data='test-uuid')
+def test_get_installation_uid_reads_existing(mock_file, mock_exists):
+    """Test get_installation_uid reads the UID if the file exists."""
+    result = get_installation_uid()
+    assert result == 'test-uuid'

--- a/framework/wazuh/core/tests/test_common.py
+++ b/framework/wazuh/core/tests/test_common.py
@@ -106,9 +106,11 @@ async def test_origin_module_context_var_api(mock_check_wazuh_status, mock_creat
     assert mock_create_socket_msg.call_args[1]['origin']['module'] == 'API'
 
 
+@patch('wazuh.core.common.wazuh_uid', return_value=0)
+@patch('wazuh.core.common.wazuh_gid', return_value=0)
 @patch('wazuh.core.common.os.chmod')
 @patch('wazuh.core.common.os.chown')
-def test_get_installation_uid_creates_file(chown_mock, chmod_mock, tmp_path):
+def test_get_installation_uid_creates_file(chown_mock, chmod_mock, mock_gid, mock_uid, tmp_path):
     """Test get_installation_uid creates the UID file if it doesn't exist."""
 
     test_path = tmp_path / 'installation_uid'

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -8,7 +8,7 @@ import operator
 import os
 import socket
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open
 
 import pytest
 
@@ -319,8 +319,13 @@ def test_read_ossec_con_ko():
     assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
     assert result.render()['data']['failed_items'][0]['error']['code'] == 1102
 
-@patch('builtins.open')
-def test_get_basic_info(mock_open):
+
+@patch('wazuh.core.common.os.chown')  # <- evita el fallo
+@patch('wazuh.core.common.os.path.exists', return_value=True)
+@patch('builtins.open', new_callable=mock_open, read_data='test-uuid')
+@patch('wazuh.core.common.wazuh_gid', return_value=0)
+@patch('wazuh.core.common.wazuh_uid', return_value=0)
+def test_get_basic_info(mock_uid, mock_gid, mock_open_file, mock_exists, mock_chown):
     """Tests get_basic_info() function works as expected"""
     result = get_basic_info()
 


### PR DESCRIPTION
|Related issue|
|---|
| #29446  |

## Description

This PR closes #29446 by adding the server `UUID` to the `/manager/info` endpoint.

<details>

<summary>Status</summary>

```console
root@wazuh-master:/# /var/ossec/bin/wazuh-control status
wazuh-clusterd is running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...
```

</details>

<details>

<summary>manager/info</summary>

```console
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/manager/info?pretty=true" -H "Authorization: Bearer $TOKEN""
{
   "data": {
      "affected_items": [
         {
            "path": "/var/ossec",
            "version": "v4.12.1",
            "type": "server",
            "max_agents": "unlimited",
            "openssl_support": "yes",
            "tz_offset": "+0000",
            "tz_name": "UTC",
            "uuid": "4d03ffbc-2237-4c01-968e-ffffdcff2818"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "Basic information was successfully read in specified node",
   "error": 0
}
```

</details>

<details>

<summary>cluster/{node_id}/info</summary>


```console
root@wazuh-master:/# curl -k -X GET "https://localhost:55000/cluster/master-node/info?pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         {
            "path": "/var/ossec",
            "version": "v4.12.1",
            "type": "server",
            "max_agents": "unlimited",
            "openssl_support": "yes",
            "tz_offset": "+0000",
            "tz_name": "UTC",
            "uuid": "4d03ffbc-2237-4c01-968e-ffffdcff2818"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "Basic information was successfully read in specified node",
   "error": 0
}
```

</details>


## Tests

<details>

<summary>test_manager_endpoints.tavern.yaml</summary>

```console
(api-it) wazuh@javier:~/Git/wazuh/api/test/integration$ pytest -vv test_manager_endpoints.tavern.yaml
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0 -- /home/wazuh/Git/wazuh/api-it/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-6.5.0-35-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'anyio': '4.1.0', 'cov': '4.1.0', 'metadata': '3.1.1', 'trio': '0.8.0', 'html': '2.1.1', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 35 items                                                                                                                                                                                                

test_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                              [  2%]
test_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                                [  5%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[alerts] PASSED                                                                                                                     [  8%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[auth] PASSED                                                                                                                       [ 11%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cis-cat] PASSED                                                                                                                    [ 14%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[cluster] PASSED                                                                                                                    [ 17%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[command] PASSED                                                                                                                    [ 20%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[global] PASSED                                                                                                                     [ 22%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[localfile] PASSED                                                                                                                  [ 25%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[osquery] PASSED                                                                                                                    [ 28%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[remote] PASSED                                                                                                                     [ 31%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[rootcheck] PASSED                                                                                                                  [ 34%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[ruleset] PASSED                                                                                                                    [ 37%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[sca] PASSED                                                                                                                        [ 40%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscheck] PASSED                                                                                                                   [ 42%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[syscollector] PASSED                                                                                                               [ 45%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[vulnerability-detection] PASSED                                                                                                    [ 48%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration?{section}[indexer] PASSED                                                                                                                    [ 51%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                                       [ 54%]
test_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                                                                       [ 57%]
test_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                               [ 60%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                                        [ 62%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                                        [ 65%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                                     [ 68%]
test_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                                       [ 71%]
test_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                                [ 74%]
test_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                                        [ 77%]
test_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                                          [ 80%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/validation (OK) PASSED                                                                                                                       [ 82%]
test_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                           [ 85%]
test_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                                                                       [ 88%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update_check disabled PASSED                                                                                                            [ 91%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update_check enabled PASSED                                                                                                             [ 94%]
test_manager_endpoints.tavern.yaml::GET /manager/version/check with update_check service error PASSED                                                                                                       [ 97%]
test_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                             [100%]

================================================================================================ warnings summary =================================================================================================
../../../api-it/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/wazuh/Git/wazuh/api-it/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_manager_endpoints.tavern.yaml: 35 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================== 35 passed, 36 warnings in 769.72s (0:12:49) ===================================================================================
```

</details>

<details>

<summary>test_rbac_black_manager_endpoints.tavern.yaml</summary>

```console
(api-it) wazuh@javier:~/Git/wazuh/api/test/integration$ pytest -vv test_rbac_black_manager_endpoints.tavern.yaml        
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0 -- /home/wazuh/Git/wazuh/api-it/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-6.5.0-35-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'anyio': '4.1.0', 'cov': '4.1.0', 'metadata': '3.1.1', 'trio': '0.8.0', 'html': '2.1.1', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 16 items                                                                                                                                                                                                

test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                            [  6%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                                                                                                                 [ 12%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                [ 18%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                     [ 25%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                     [ 31%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                             [ 37%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                                                            [ 43%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                    [ 50%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                          [ 56%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                             [ 62%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                            [ 68%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                             [ 75%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                   [ 81%]
test_rbac_black_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                               [ 87%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                                                            [ 93%]
test_rbac_black_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                  [100%]

================================================================================================ warnings summary =================================================================================================
../../../api-it/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/wazuh/Git/wazuh/api-it/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_black_manager_endpoints.tavern.yaml: 16 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================== 16 passed, 17 warnings in 543.35s (0:09:03) ===================================================================================
```

</details>

<details>

<summary>test_rbac_white_manager_endpoints.tavern.yaml</summary>

```console
(api-it) wazuh@javier:~/Git/wazuh/api/test/integration$ pytest -vv test_rbac_white_manager_endpoints.tavern.yaml
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0 -- /home/wazuh/Git/wazuh/api-it/bin/python3.10
cachedir: .pytest_cache
metadata: {'Python': '3.10.13', 'Platform': 'Linux-6.5.0-35-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.5.0'}, 'Plugins': {'anyio': '4.1.0', 'cov': '4.1.0', 'metadata': '3.1.1', 'trio': '0.8.0', 'html': '2.1.1', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/Git/wazuh/api/test/integration
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 16 items                                                                                                                                                                                                

test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration PASSED                                                                                                                            [  6%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/validation PASSED                                                                                                                 [ 12%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/configuration/{component}/{configuration} PASSED                                                                                                [ 18%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/info PASSED                                                                                                                                     [ 25%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs PASSED                                                                                                                                     [ 31%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/logs/summary PASSED                                                                                                                             [ 37%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/daemons/stats PASSED                                                                                                                            [ 43%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats PASSED                                                                                                                                    [ 50%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/analysisd PASSED                                                                                                                          [ 56%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/hourly PASSED                                                                                                                             [ 62%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/remoted PASSED                                                                                                                            [ 68%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/stats/weekly PASSED                                                                                                                             [ 75%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/status PASSED                                                                                                                                   [ 81%]
test_rbac_white_manager_endpoints.tavern.yaml::GET /manager/api/config PASSED                                                                                                                               [ 87%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/configuration PASSED                                                                                                                            [ 93%]
test_rbac_white_manager_endpoints.tavern.yaml::PUT /manager/restart PASSED                                                                                                                                  [100%]

================================================================================================ warnings summary =================================================================================================
../../../api-it/lib/python3.10/site-packages/_pytest/nodes.py:642
  /home/wazuh/Git/wazuh/api-it/lib/python3.10/site-packages/_pytest/nodes.py:642: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to YamlFile is deprecated. Please use the (path: pathlib.Path) argument instead.
  See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
    return super().from_parent(parent=parent, fspath=fspath, path=path, **kw)

test_rbac_white_manager_endpoints.tavern.yaml: 16 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================== 16 passed, 17 warnings in 547.41s (0:09:07) ===================================================================================
```

</details>

<details>

<summary>unit_test framework</summary>

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest framework/
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/wazuh/Git/wazuh/framework
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 2417 items                                                                                                                                                                                              

framework/scripts/tests/test_agent_groups.py ..............                                                                                                                                                 [  0%]
framework/scripts/tests/test_agent_upgrade.py ................                                                                                                                                              [  1%]
framework/scripts/tests/test_cluster_control.py ......                                                                                                                                                      [  1%]
framework/scripts/tests/test_rbac_control.py .........                                                                                                                                                      [  1%]
framework/scripts/tests/test_wazuh_clusterd.py ........                                                                                                                                                     [  2%]
framework/scripts/tests/test_wazuh_logtest.py ......................                                                                                                                                        [  3%]
framework/wazuh/core/cluster/dapi/tests/test_dapi.py ................................                                                                                                                       [  4%]
framework/wazuh/core/cluster/hap_helper/tests/test_hap_helper.py .......................................................                                                                                    [  6%]
framework/wazuh/core/cluster/hap_helper/tests/test_proxy.py ........................................................................................................                                        [ 11%]
framework/wazuh/core/cluster/hap_helper/tests/test_wazuh.py ..........                                                                                                                                      [ 11%]
framework/wazuh/core/cluster/tests/test_client.py ................                                                                                                                                          [ 12%]
framework/wazuh/core/cluster/tests/test_cluster.py .....................................                                                                                                                    [ 13%]
framework/wazuh/core/cluster/tests/test_common.py ......................................................................................                                                                    [ 17%]
framework/wazuh/core/cluster/tests/test_control.py ......                                                                                                                                                   [ 17%]
framework/wazuh/core/cluster/tests/test_local_client.py ..............                                                                                                                                      [ 17%]
framework/wazuh/core/cluster/tests/test_local_server.py ........................                                                                                                                            [ 18%]
framework/wazuh/core/cluster/tests/test_master.py ................................................                                                                                                          [ 20%]
framework/wazuh/core/cluster/tests/test_server.py .............................                                                                                                                             [ 22%]
framework/wazuh/core/cluster/tests/test_utils.py .............................                                                                                                                              [ 23%]
framework/wazuh/core/cluster/tests/test_worker.py ..................................                                                                                                                        [ 24%]
framework/wazuh/core/tests/test_active_response.py ....................                                                                                                                                     [ 25%]
framework/wazuh/core/tests/test_agent.py .....................................................................................................................................................              [ 31%]
framework/wazuh/core/tests/test_cdb_list.py ......................................                                                                                                                          [ 33%]
framework/wazuh/core/tests/test_common.py .........                                                                                                                                                         [ 33%]
framework/wazuh/core/tests/test_configuration.py ...........................................................................................                                                                [ 37%]
framework/wazuh/core/tests/test_decoder.py ................                                                                                                                                                 [ 38%]
framework/wazuh/core/tests/test_exception.py ..........                                                                                                                                                     [ 38%]
framework/wazuh/core/tests/test_input_validator.py ...                                                                                                                                                      [ 38%]
framework/wazuh/core/tests/test_logtest.py ...                                                                                                                                                              [ 38%]
framework/wazuh/core/tests/test_manager.py ...............................                                                                                                                                  [ 40%]
framework/wazuh/core/tests/test_mitre.py .............                                                                                                                                                      [ 40%]
framework/wazuh/core/tests/test_pyDaemonModule.py .....                                                                                                                                                     [ 40%]
framework/wazuh/core/tests/test_results.py ........................................                                                                                                                         [ 42%]
framework/wazuh/core/tests/test_rootcheck.py .............                                                                                                                                                  [ 43%]
framework/wazuh/core/tests/test_rule.py .......................                                                                                                                                             [ 43%]
framework/wazuh/core/tests/test_sca.py .............................                                                                                                                                        [ 45%]
framework/wazuh/core/tests/test_security.py .............                                                                                                                                                   [ 45%]
framework/wazuh/core/tests/test_stats.py ........................................                                                                                                                           [ 47%]
framework/wazuh/core/tests/test_syscheck.py .......                                                                                                                                                         [ 47%]
framework/wazuh/core/tests/test_syscollector.py ...                                                                                                                                                         [ 47%]
framework/wazuh/core/tests/test_task.py ........                                                                                                                                                            [ 48%]
framework/wazuh/core/tests/test_utils.py .................................................................................................................................................................. [ 54%]
....................................................................................................................................                                                                        [ 60%]
framework/wazuh/core/tests/test_wazuh_queue.py .......................                                                                                                                                      [ 61%]
framework/wazuh/core/tests/test_wazuh_socket.py ....................                                                                                                                                        [ 62%]
framework/wazuh/core/tests/test_wdb.py ...............................                                                                                                                                      [ 63%]
framework/wazuh/core/tests/test_wlogging.py ............                                                                                                                                                    [ 63%]
framework/wazuh/rbac/tests/test_auth_context.py ..                                                                                                                                                          [ 63%]
framework/wazuh/rbac/tests/test_decorators.py .............................................................................................................                                                 [ 68%]
framework/wazuh/rbac/tests/test_default_configuration.py .......................................................                                                                                            [ 70%]
framework/wazuh/rbac/tests/test_orm.py ..............................................................                                                                                                       [ 73%]
framework/wazuh/rbac/tests/test_preprocessor.py ...........                                                                                                                                                 [ 73%]
framework/wazuh/tests/test_active_response.py ............                                                                                                                                                  [ 74%]
framework/wazuh/tests/test_agent.py ..................................................................................................................................                                      [ 79%]
framework/wazuh/tests/test_cdb_list.py .....................................................                                                                                                                [ 81%]
framework/wazuh/tests/test_ciscat.py .................................                                                                                                                                      [ 83%]
framework/wazuh/tests/test_cluster.py ..........                                                                                                                                                            [ 83%]
framework/wazuh/tests/test_decoder.py ..........................................................                                                                                                            [ 85%]
framework/wazuh/tests/test_event.py ....                                                                                                                                                                    [ 86%]
framework/wazuh/tests/test_logtest.py ......                                                                                                                                                                [ 86%]
framework/wazuh/tests/test_manager.py ....................................                                                                                                                                  [ 87%]
framework/wazuh/tests/test_mitre.py .......                                                                                                                                                                 [ 88%]
framework/wazuh/tests/test_rootcheck.py ..................................................                                                                                                                  [ 90%]
framework/wazuh/tests/test_rule.py ..........................................................................                                                                                               [ 93%]
framework/wazuh/tests/test_sca.py ...........                                                                                                                                                               [ 93%]
framework/wazuh/tests/test_security.py .......................................................................                                                                                              [ 96%]
framework/wazuh/tests/test_stats.py ...............                                                                                                                                                         [ 97%]
framework/wazuh/tests/test_syscheck.py .........................                                                                                                                                            [ 98%]
framework/wazuh/tests/test_syscollector.py ............                                                                                                                                                     [ 98%]
framework/wazuh/tests/test_task.py ............................                                                                                                                                             [100%]

================================================================================================ warnings summary =================================================================================================
venv/lib/python3.10/site-packages/connexion/lifecycle.py:8
  /home/wazuh/Git/wazuh/venv/lib/python3.10/site-packages/connexion/lifecycle.py:8: PendingDeprecationWarning: Please use `import python_multipart` instead.
    from multipart.multipart import parse_options_header

venv/lib/python3.10/site-packages/connexion/json_schema.py:16
venv/lib/python3.10/site-packages/connexion/json_schema.py:16
  /home/wazuh/Git/wazuh/venv/lib/python3.10/site-packages/connexion/json_schema.py:16: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import Draft4Validator, RefResolver

venv/lib/python3.10/site-packages/connexion/json_schema.py:17
  /home/wazuh/Git/wazuh/venv/lib/python3.10/site-packages/connexion/json_schema.py:17: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema.exceptions import RefResolutionError, ValidationError  # noqa

venv/lib/python3.10/site-packages/connexion/validators/form_data.py:4
venv/lib/python3.10/site-packages/connexion/validators/form_data.py:4
  /home/wazuh/Git/wazuh/venv/lib/python3.10/site-packages/connexion/validators/form_data.py:4: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import ValidationError, draft4_format_checker

venv/lib/python3.10/site-packages/connexion/validators/json.py:6
venv/lib/python3.10/site-packages/connexion/validators/json.py:6
  /home/wazuh/Git/wazuh/venv/lib/python3.10/site-packages/connexion/validators/json.py:6: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import Draft4Validator, ValidationError, draft4_format_checker

wazuh/core/tests/test_manager.py::test_query_update_check_service_request
  /home/wazuh/Git/wazuh/framework/wazuh/core/tests/test_manager.py:382: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    await query_update_check_service(installation_uid)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 2417 passed, 9 warnings in 242.15s (0:04:02) ===================================================================================
```

</details>
