### PR TITLE
Add FIPS support to Filebeat RPM package

### DIFF
--- a/.github/workflows/4_builderpackage_filebeat-package.yml
+++ b/.github/workflows/4_builderpackage_filebeat-package.yml
@@ -125,6 +125,13 @@ jobs:
 
           sed -i '/func TestDocker(t \*testing\.T) {/,/^}$/d' dev-tools/packaging/package_test.go
 
+      - name: Add RPM compatibility with FIPS
+        working-directory: filebeat
+        run: |
+          # https://github.com/elastic/beats/pull/27103
+          FIX_COMMIT=0bf2fe7b5625f180d11b20c69593ded5b825356f
+          git cherry-pick -n ${FIX_COMMIT}
+
       - name: Modify FPM call (add revision/version)
         run: |
           # https://fpm.readthedocs.io/en/v1.14.0/cli-reference.html

--- a/.github/workflows/4_builderpackage_filebeat-package.yml
+++ b/.github/workflows/4_builderpackage_filebeat-package.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           # https://github.com/elastic/beats/pull/27103
           FIX_COMMIT=0bf2fe7b5625f180d11b20c69593ded5b825356f
-          git cherry-pick -n ${FIX_COMMIT}
+          git fetch origin ${FIX_COMMIT} && git cherry-pick -n ${FIX_COMMIT}
 
       - name: Modify FPM call (add revision/version)
         run: |

--- a/.github/workflows/4_builderpackage_filebeat-package.yml
+++ b/.github/workflows/4_builderpackage_filebeat-package.yml
@@ -108,6 +108,13 @@ jobs:
           sudo apt update -y
           sudo apt install -y docker-ce
 
+      - name: Add RPM compatibility with FIPS
+        working-directory: filebeat
+        run: |
+          # https://github.com/elastic/beats/pull/27103
+          FIX_COMMIT=0bf2fe7b5625f180d11b20c69593ded5b825356f
+          git fetch origin ${FIX_COMMIT} && git cherry-pick -n ${FIX_COMMIT}
+
       - name: Apply patch for Ubuntu build
         run: |
           sed -i 's/apt-get install -y --no-install-recommends/DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends/' filebeat/Dockerfile
@@ -124,13 +131,6 @@ jobs:
           RUN apt-get update -y && \\\n    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes ca-certificates curl libcap2-bin xz-utils && \\\n    apt-get clean && \\\n    exit_code=$? && \\\n    [ $exit_code -eq 0 ] || exit $exit_code' dev-tools/packaging/templates/docker/Dockerfile.tmpl
 
           sed -i '/func TestDocker(t \*testing\.T) {/,/^}$/d' dev-tools/packaging/package_test.go
-
-      - name: Add RPM compatibility with FIPS
-        working-directory: filebeat
-        run: |
-          # https://github.com/elastic/beats/pull/27103
-          FIX_COMMIT=0bf2fe7b5625f180d11b20c69593ded5b825356f
-          git fetch origin ${FIX_COMMIT} && git cherry-pick -n ${FIX_COMMIT}
 
       - name: Modify FPM call (add revision/version)
         run: |


### PR DESCRIPTION
|Related issue|
|---|
|#29397|


## Description


This issue aims to fix #29397 by picking https://github.com/elastic/beats/pull/27103 changes into our Filebeat package building workflow


## Test

- 4.13.0 workflow execution (baseline for comparison): https://github.com/wazuh/wazuh/actions/runs/14885571073
- Current branch workflow execution:
  - aarch64 https://github.com/wazuh/wazuh/actions/runs/15542235575
  - x86_64: https://github.com/wazuh/wazuh/actions/runs/15542421877


:warning: NOTE: these packages are not signed, so the `--checksig` command will not show the same result as prod packages

```console
bash-5.2# rpm --checksig --verbose  filebeat-7.10.2-0.x86_64_1dae6a132.rpm 
filebeat-7.10.2-0.x86_64_1dae6a132.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
bash-5.2# rpm -i  filebeat-7.10.2-0.x86_64_1dae6a132.rpm 
bash-5.2# rpm -qi filebeat
Name        : filebeat
Version     : 7.10.2
Release     : 0
Architecture: x86_64
Install Date: Mon Jun  9 19:15:01 2025
Group       : default
Size        : 73612990
License     : ASL-2.0
Signature   : (none)
Source RPM  : filebeat-7.10.2-0.src.rpm
Build Date  : Mon Jun  9 19:08:27 2025
Build Host  : b08ea6e0838b
Relocations : / 
Packager    : <@b08ea6e0838b>
Vendor      : Elastic
URL         : https://www.elastic.co/products/beats/filebeat
Summary     : Filebeat sends log files to Logstash or directly to Elasticsearch.
Description :
Filebeat sends log files to Logstash or directly to Elasticsearch.
bash-5.2# cat /etc/os-release 
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
ID_LIKE="fedora"
VERSION_ID="2023"
PLATFORM_ID="platform:al2023"
PRETTY_NAME="Amazon Linux 2023.7.20250512"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
DOCUMENTATION_URL="https://docs.aws.amazon.com/linux/"
SUPPORT_URL="https://aws.amazon.com/premiumsupport/"
BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
VENDOR_NAME="AWS"
VENDOR_URL="https://aws.amazon.com/"
SUPPORT_END="2029-06-30"
```