### PR TITLE
Fix hidden port detection and improve netstat availability handling

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -173,6 +173,15 @@ int check_path_type(const char *dir) __attribute__((nonnull));
  * @return 0 if it is a link, -1 otherwise.
  */
 int IsLink(const char * file) __attribute__((nonnull));
+
+/**
+ * Check if a program is available in the system PATH.
+ *
+ * @param program The name of the program to check.
+ * @return true if the program is available, false otherwise.
+ */
+bool is_program_available(const char *program);
+
 #endif
 
 

--- a/src/rootcheck/check_rc_ports.c
+++ b/src/rootcheck/check_rc_ports.c
@@ -150,6 +150,13 @@ void check_rc_ports()
 
     int i = 0;
 
+    if (!is_program_available("netstat")) {
+        minfo("netstat not available. Skipping port check.");
+        notify_rk(ALERT_SYSTEM_ERR, "netstat not available. "
+                 "Skipping port check.");
+        return;
+    }
+
     while (i <= 65535) {
         total_ports_tcp[i] = 0;
         total_ports_udp[i] = 0;

--- a/src/rootcheck/check_rc_ports.c
+++ b/src/rootcheck/check_rc_ports.c
@@ -45,7 +45,7 @@ static int run_netstat(int proto, int port)
 
     if (ret == 0) {
         return (1);
-    } else if (ret == 1) {
+    } else if (WEXITSTATUS(ret) == 1) {
         return (0);
     }
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1156,6 +1156,42 @@ void goDaemon()
     nowDaemon();
 }
 
+// Check if a program is available in the system PATH.
+
+bool is_program_available(const char *program) {
+    if (!program || !*program) {
+        return false;
+    }
+
+    const char *path_env = getenv("PATH");
+    if (!path_env) {
+        return false;
+    }
+
+    char *path = strdup(path_env);
+    if (!path) {
+        return false;
+    }
+
+    bool found = false;
+    char *saveptr = NULL;
+    char *dir = strtok_r(path, ":", &saveptr);
+
+    while (dir) {
+        char fullpath[512];
+        snprintf(fullpath, sizeof(fullpath), "%s/%s", dir, program);
+        if (access(fullpath, X_OK) == 0) {
+            found = true;
+            break;
+        }
+
+        dir = strtok_r(NULL, ":", &saveptr);
+    }
+
+    free(path);
+    return found;
+}
+
 #else /* WIN32 */
 
 int checkVista()

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
                             -Wl,--wrap,gzopen,--wrap,gzread,--wrap,gzclose,--wrap,fgetc \
                             -Wl,--wrap,gzeof,--wrap,gzerror,--wrap,gzwrite,--wrap,fgetpos \
                             -Wl,--wrap,realpath,--wrap,getenv,--wrap,atexit ${DEBUG_OP_WRAPPERS} \
-                            -Wl,--wrap,merror,--wrap,fseek")
+                            -Wl,--wrap,merror,--wrap,fseek,--wrap,access")
     list(APPEND shared_tests_flags "${FILE_OP_BASE_FLAGS}")
 else()
     list(APPEND shared_tests_flags "-Wl,--wrap,get_windows_file_time_epoch,--wrap,mdebug2 \


### PR DESCRIPTION
## Description

Rootcheck includes a feature to detect hidden ports, which may indicate the presence of a rootkit. The detection mechanism attempts to connect to each TCP port, and if the connection fails with `EADDRINUSE`, it checks whether the port is listed by `netstat`. If a port is in use but not reported by `netstat`, it triggers a "hidden port" alert.

Previously, the code relied on the exit status of the following command:

```sh
netstat -an -p <port> | grep "[^0-9]<port> " > /dev/null
```

This was expected to return exit code `1` when:

* The port is not reported by `netstat`.
* `netstat` is not available.

However, the C code did not extract the actual exit code correctly. Instead of checking `WEXITSTATUS(status)`, it compared the raw exit status (e.g., `256` instead of `1`), which caused false negatives. In addition, we were not checking if `netstat` was available at all before attempting the scan.

## Proposed Changes

1. Fix the exit code evaluation using `WEXITSTATUS()` to correctly detect hidden ports.
2. Add a runtime check to skip the port scan if `netstat` is not installed, to avoid false positives and reduce noise in environments where `netstat` is not available.

### Results and Evidence

#### Normal scan

```
2025/05/08 17:20:23 rootcheck: INFO: Starting rootcheck scan.
2025/05/08 17:20:28 rootcheck: INFO: Ending rootcheck scan.
```

(No alerts generated.)

#### `netstat` not installed

```
2025/05/08 17:20:42 rootcheck: INFO: Starting rootcheck scan.
2025/05/08 17:20:42 wazuh-syscheckd: INFO: netstat not available. Skipping port check.
2025/05/08 17:20:47 rootcheck: INFO: Ending rootcheck scan.
```

(No alerts generated.)

#### Hidden port detected (via Reptile rootkit)

```
** Alert 1746702006.9864: - ossec,rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,
2025 May 08 13:00:06 (centos6) any->rootcheck
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
Port '25'(tcp) hidden. Kernel-level rootkit or trojaned version of netstat.
title: Port '25'(tcp) hidden.
```

> [!NOTE]
> You can find instructions to install and run Reptile at https://github.com/wazuh/wazuh/issues/29488.

> [!IMPORTANT]
> This feature works with or without IPv6 enabled. However, Rootcheck only scans for hidden IPv4 ports.

#### Tested OSs

- [x] CentOS 6: Reptile

### Artifacts Affected

* wazuh-syscheckd (Rootcheck module)

This change does not apply on Windows, as this feature is not implemented on it.

### Configuration Changes

None.

### Documentation Updates

Not applicable.

### Tests Introduced

- Unit tests for `is_program_available()`.

Integration testing would require introducing a rootkit in the environment, which is not feasible or advisable for automated test environments.

## Review Checklist

* [x] Code changes reviewed
* [x] Relevant evidence provided
* [ ] Tests cover the new functionality
* [ ] Configuration changes documented
* [ ] Developer documentation reflects the changes
* [x] Meets requirements and/or definition of done
* [x] No unresolved dependencies with other issues
