### PR TITLE
New defects detected by Coverity in 4.12.1

### DIFF
--- a/src/data_provider/src/packages/berkeleyRpmDbHelper.h
+++ b/src/data_provider/src/packages/berkeleyRpmDbHelper.h
@@ -257,12 +257,13 @@ class BerkeleyRpmDBReader final
 
                 if (isPython && !dirindexes.empty() && !dirnames.empty() && !basenames.empty())
                 {
-                    for (size_t i = 0; i < basenames.size(); ++i)
+                    for (size_t i = 0; i < dirindexes.size(); ++i)
                     {
-                        if (dirindexes[i] < static_cast<int>(dirnames.size()))
+                        int index = dirindexes[i];
+                        if (index >= 0 && index < static_cast<int>(dirnames.size()))
                         {
-                            std::string fullPath = dirnames[dirindexes[i]] + basenames[i];
-                            pythonFiles.push_back(fullPath);
+                            std::string fullPath = dirnames[index] + basenames[i];
+                            pythonFiles.push_back(std::move(fullPath));
                         }
                     }
                 }

--- a/src/data_provider/src/packages/modernPackageDataRetriever.hpp
+++ b/src/data_provider/src/packages/modernPackageDataRetriever.hpp
@@ -38,7 +38,7 @@ template <bool>
 class ModernFactoryPackagesCreator final
 {
     public:
-        static void getPackages(const std::map<std::string, std::set<std::string>>& /*paths*/, std::function<void(nlohmann::json&)> /*callback*/)
+        static void getPackages(const std::map<std::string, std::set<std::string>>& /*paths*/, std::function<void(nlohmann::json&)> /*callback*/, const std::unordered_set<std::string>& /*excludePaths*/ = {})
         {
         }
 };
@@ -51,8 +51,9 @@ class ModernFactoryPackagesCreator<true> final
     public:
         static void getPackages(const std::map<std::string, std::set<std::string>>& paths, std::function<void(nlohmann::json&)> callback, const std::unordered_set<std::string>& excludePaths = {})
         {
-            PYPI().getPackages(paths.at("PYPI"), callback, excludePaths);
-            NPM().getPackages(paths.at("NPM"), callback);
+            auto cbCopy {callback};
+            PYPI().getPackages(paths.at("PYPI"), std::move(callback), excludePaths);
+            NPM().getPackages(paths.at("NPM"), std::move(cbCopy));
         }
 };
 

--- a/src/data_provider/src/packages/packageLinuxParserDeb.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserDeb.cpp
@@ -79,7 +79,7 @@ void getDpkgPythonPackages(std::unordered_set<std::string>& pythonPackages)
 
                             if (std::filesystem::is_regular_file(baseInfoPath))
                             {
-                                pythonPackages.insert(baseInfoPath);
+                                pythonPackages.insert(std::move(baseInfoPath));
                             }
                             else
                             {
@@ -87,7 +87,7 @@ void getDpkgPythonPackages(std::unordered_set<std::string>& pythonPackages)
 
                                 if (std::filesystem::exists(fullPath))
                                 {
-                                    pythonPackages.insert(fullPath);
+                                    pythonPackages.insert(std::move(fullPath));
                                 }
                             }
                         }

--- a/src/data_provider/src/packages/packageLinuxParserRpm.cpp
+++ b/src/data_provider/src/packages/packageLinuxParserRpm.cpp
@@ -140,7 +140,7 @@ void getRpmPythonPackages(std::unordered_set<std::string>& pythonPackages)
 
                         if (std::filesystem::is_regular_file(baseInfoPath))
                         {
-                            pythonPackages.insert(baseInfoPath);
+                            pythonPackages.insert(std::move(baseInfoPath));
                         }
                         else
                         {
@@ -148,7 +148,7 @@ void getRpmPythonPackages(std::unordered_set<std::string>& pythonPackages)
 
                             if (std::filesystem::exists(fullPath))
                             {
-                                pythonPackages.insert(fullPath);
+                                pythonPackages.insert(std::move(fullPath));
                             }
                         }
                     }


### PR DESCRIPTION
|Related issue|
|---|
| #29566 |

## Description

This PR solves the defects reported by Coverity scan in v4.12.1, which originated from #28688. 

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Coverity
