### PR TITLE
Adds agents summary endpoint

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -1620,6 +1620,39 @@ async def get_agent_fields(pretty: bool = False, wait_for_complete: bool = False
     return json_response(data, pretty=pretty)
 
 
+async def get_agents_summary(agents_list: str = None, pretty: bool = False,
+                                   wait_for_complete: bool = False) -> ConnexionResponse:
+    """Get agents summary.
+
+    Parameters
+    ----------
+    agent_list : str
+        Agents list.
+    pretty : bool
+        Show results in human-readable format.
+    wait_for_complete : bool
+        Disable timeout response.
+
+    Returns
+    -------
+    ConnexionResponse
+        API response.
+    """
+    f_kwargs = {'agent_list': agents_list}
+
+    dapi = DistributedAPI(f=agent.get_agents_summary,
+                          f_kwargs=remove_nones_to_dict(f_kwargs),
+                          request_type='local_master',
+                          is_async=True,
+                          wait_for_complete=wait_for_complete,
+                          logger=logger,
+                          rbac_permissions=request.context['token_info']['rbac_policies']
+                          )
+    data = raise_if_exc(await dapi.distribute_function())
+
+    return json_response(data, pretty=pretty)
+
+
 async def get_agent_summary_status(pretty: bool = False, wait_for_complete: bool = False) -> ConnexionResponse:
     """Get agents status summary.
 

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -19,11 +19,11 @@ with patch('wazuh.common.wazuh_uid'):
             delete_multiple_agent_single_group,
             delete_single_agent_multiple_groups,
             delete_single_agent_single_group, get_agent_config,
-            get_agent_fields, get_agent_key, get_agent_no_group,
-            get_agent_outdated, get_agent_summary_os, get_agent_uninstall_permission, get_agent_summary_status,
-            get_agent_upgrade, get_agents, get_agents_in_group, get_daemon_stats,
-            get_component_stats, get_group_config, get_group_file, get_group_files,
-            get_list_group, get_sync_agent, insert_agent, post_group,
+            get_agent_fields, get_agent_key, get_agent_no_group, get_agent_outdated,
+            get_agents_summary, get_agent_summary_os, get_agent_summary_status,
+            get_agent_uninstall_permission, get_agent_upgrade, get_agents, get_agents_in_group,
+            get_daemon_stats, get_component_stats, get_group_config, get_group_file,
+            get_group_files, get_list_group, get_sync_agent, insert_agent, post_group,
             post_new_agent, put_agent_single_group, put_group_config,
             put_multiple_agent_single_group, put_upgrade_agents,
             put_upgrade_custom_agents, reconnect_agents, restart_agent,
@@ -1130,6 +1130,30 @@ async def test_get_agent_fields(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
                                       f_kwargs=mock_remove.return_value,
                                       request_type='local_master',
                                       is_async=False,
+                                      wait_for_complete=False,
+                                      logger=ANY,
+                                      rbac_permissions=mock_request.context['token_info']['rbac_policies']
+                                      )
+    mock_exc.assert_called_once_with(mock_dfunc.return_value)
+    mock_remove.assert_called_once_with(f_kwargs)
+    assert isinstance(result, ConnexionResponse)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mock_request", ["agent_controller"], indirect=True)
+@patch('api.configuration.api_conf')
+@patch('api.controllers.agent_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
+@patch('api.controllers.agent_controller.remove_nones_to_dict')
+@patch('api.controllers.agent_controller.DistributedAPI.__init__', return_value=None)
+@patch('api.controllers.agent_controller.raise_if_exc', return_value=CustomAffectedItems())
+async def test_get_agents_summary(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_exp, mock_request):
+    """Verify 'get_agent_summary_status' endpoint is working as expected."""
+    result = await get_agents_summary()
+    f_kwargs = {'agent_list': None}
+    mock_dapi.assert_called_once_with(f=agent.get_agents_summary,
+                                      f_kwargs=mock_remove.return_value,
+                                      request_type='local_master',
+                                      is_async=True,
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1557,6 +1557,29 @@ components:
       - disconnected
       description: "Agent status. It is calculated based on the last keepalive and the Wazuh version"
 
+    AgentsSummary:
+      type: object
+      properties:
+        status:
+          type: object
+          properties:
+            active:
+              type: integer
+              format: int32
+            disconnected:
+              type: integer
+              format: int32
+            never_connected:
+              type: integer
+              format: int32
+            pending:
+              type: integer
+              format: int32
+        os:
+          type: object
+        groups:
+          type: object
+
     AgentsSummaryStatus:
       type: object
       properties:
@@ -8964,6 +8987,56 @@ paths:
                   total_failed_items: 0
                   failed_items: []
                 message: 'All selected agents information was returned'
+                error: 0
+        '400':
+          $ref: '#/components/responses/ResponseError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDeniedResponse'
+        '405':
+          $ref: '#/components/responses/InvalidHTTPMethodResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsResponse'
+  
+  /agents/summary:
+    get:
+      tags:
+        - Agents
+      summary: "Summarize agents information"
+      description: "Return a summary of the available agents OS, status and groups"
+      operationId: api.controllers.agent_controller.get_agents_summary
+      x-rbac-actions:
+        - $ref: '#/x-rbac-catalog/actions/agent:read'
+      parameters:
+        - $ref: '#/components/parameters/pretty'
+        - $ref: '#/components/parameters/wait_for_complete'
+        - $ref: '#/components/parameters/agents_list'
+      responses:
+        '200':
+          description: "Available agents summary"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/AgentsSummary'
+              example:
+                data:
+                  status:
+                    active: 8
+                    disconnected: 0
+                    never_connected: 1
+                    pending: 2
+                  os:
+                    debian: 8
+                    ubuntu: 3
+                  groups:
+                    default: 11
+                    test: 5
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -4784,6 +4784,36 @@ stages:
           total_failed_items: 0
 
 ---
+test_name: GET /agents/summary
+
+stages:
+
+  - name: Get the agents status summary
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+      method: GET
+      headers:
+        Authorization: "Bearer {test_login_token}"
+    response:
+      status_code: 200
+      json:
+        error: 0
+        data:
+          status:
+            active: 8
+            disconnected: 2
+            never_connected: 2
+            pending: 0
+          os:
+            ubuntu: 10
+          groups:
+            default: 10
+            group2: 8
+            group1: 7
+            group3: 4
+
+---
 test_name: GET /agents/summary/status
 
 stages:

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -600,6 +600,32 @@ stages:
          total_failed_items: 0
 
 ---
+test_name: GET /agents/summary
+
+stages:
+
+ - name: Get the agents summary (Partially allowed, user agnostic)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+     status_code: 200
+     json:
+       error: 0
+       data:
+         status:
+           active: 4
+           disconnected: 1
+           never_connected: 1
+           pending: 0
+         os:
+          ubuntu: 6
+         groups: !anything
+
+---
 test_name: GET /agents/summary/status
 
 stages:

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -607,6 +607,32 @@ stages:
          total_failed_items: 0
 
 ---
+test_name: GET /agents/summary
+
+stages:
+
+ - name: Get the agents summary (Partially allowed, user agnostic)
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+     status_code: 200
+     json:
+       error: 0
+       data:
+         status:
+           active: 4
+           disconnected: 1
+           never_connected: 1
+           pending: 0
+         os:
+          ubuntu: 6
+         groups: !anything
+
+---
 test_name: GET /agents/summary/status
 
 stages:

--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -512,6 +512,32 @@ stages:
     response:
       <<: *empty_response
 
+
+---
+test_name: GET /agents/summary
+
+stages:
+
+ - name: Try to get the agents summary
+   request:
+     verify: False
+     url: "{protocol:s}://{host:s}:{port:d}/agents/summary"
+     method: GET
+     headers:
+       Authorization: "Bearer {test_login_token}"
+   response:
+      status_code: 200
+      json:
+        error: !anyint
+        data:
+          status:
+            active: 0
+            disconnected: 0
+            never_connected: 0
+            pending: 0
+          os: !anything
+          groups: !anything
+
 ---
 test_name: GET /agents/summary/os
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -19,6 +19,7 @@ from wazuh.core.results import WazuhResult, AffectedItemsWazuhResult
 from wazuh.core.utils import chmod_r, chown_r, get_hash, mkdir_with_mode, md5, process_array, clear_temporary_caches, \
     full_copy
 from wazuh.core.wazuh_queue import WazuhQueue
+from wazuh.core.wdb_http import get_wdb_http_client
 from wazuh.rbac.decorators import expose_resources, async_list_handler
 
 cluster_enabled = not read_cluster_config(from_import=True)['disabled']
@@ -94,6 +95,26 @@ def get_distinct_agents(agent_list: list = None, offset: int = 0, limit: int = c
         result.total_affected_items = data['totalItems']
 
     return result
+
+
+@expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)
+async def get_agents_summary(agent_list: list[str] = None) -> WazuhResult:
+    """Count the number of agents by status, OS and group.
+
+    Parameters
+    ----------
+    agent_list : list[str]
+       Agents IDs list.
+
+    Returns
+    -------
+    WazuhResult
+        Result object.
+    """
+    async with get_wdb_http_client() as wdb_client:
+        agents_summary = await wdb_client.get_agents_summary(agent_list)
+
+    return WazuhResult({'data': agents_summary.to_dict()})
 
 
 @expose_resources(actions=["agent:read"], resources=["agent:id:{agent_list}"], post_proc_func=None)

--- a/framework/wazuh/core/tests/test_wdb_http.py
+++ b/framework/wazuh/core/tests/test_wdb_http.py
@@ -143,7 +143,7 @@ class TestWazuhDBHTTPClient:
     
     async def test_get_agents_summary(self, client_mock: AsyncMock, module_instance: WazuhDBHTTPClient):
         """Check that the `get_agents_summary` method works as expected."""
-        agent_ids = [1, 2, 3]
+        agent_ids = []
         expected_result = AgentsSummary(
             agents_by_groups={
                 'default': 30,
@@ -154,7 +154,9 @@ class TestWazuhDBHTTPClient:
             },
             agents_by_status={
                 'active': 10,
-                'disconnected': 20
+                'disconnected': 20,
+                'never_connected': 0,
+                'pending': 0
             },
         )
         response = MagicMock()
@@ -175,9 +177,7 @@ class TestWazuhDBHTTPClient:
         client_mock.post.return_value = response
 
         result = await module_instance.get_agents_summary(agent_ids)
-        assert result.groups == expected_result.groups
-        assert result.os == expected_result.os
-        assert result.status == expected_result.status
+        assert result.to_dict() == expected_result.to_dict()
 
         client_mock.assert_has_calls([
             call.post(

--- a/framework/wazuh/core/wdb_http.py
+++ b/framework/wazuh/core/wdb_http.py
@@ -21,20 +21,48 @@ class AgentIDGroups:
 class AgentStatus:
     """Agent status."""
 
-    def __init__(self, active: int, disconnected: int, never_connected: int, pending: int):
+    def __init__(self, active: int = 0, disconnected: int = 0, never_connected: int = 0, pending: int = 0):
         self.active = active
         self.disconnected = disconnected
         self.never_connected = never_connected
         self.pending = pending
-
+    
+    def to_dict(self) -> dict:
+        """Transform the class into a dictionary.
+        
+        Returns
+        -------
+        dict
+            Dictionary containing the information.
+        """
+        return {
+            'active': self.active,
+            'disconnected': self.disconnected,
+            'never_connected': self.never_connected,
+            'pending': self.pending
+        }
 
 class AgentsSummary:
     """Agents summary."""
 
-    def __init__(self, agents_by_status: AgentStatus, agents_by_os: Any, agents_by_groups: Any):
-        self.status = agents_by_status
+    def __init__(self, agents_by_status: dict = {}, agents_by_os: dict = {}, agents_by_groups: dict = {}):
+        self.status = AgentStatus(**agents_by_status)
         self.os = agents_by_os
         self.groups = agents_by_groups
+    
+    def to_dict(self) -> dict:
+        """Transform the class into a dictionary.
+        
+        Returns
+        -------
+        dict
+            Dictionary containing the information.
+        """
+        return {
+            'status': self.status.to_dict(),
+            'os': self.os,
+            'groups': self.groups
+        }
 
 
 class WazuhDBHTTPClient:

--- a/framework/wazuh/tests/data/security/rbac_catalog.yml
+++ b/framework/wazuh/tests/data/security/rbac_catalog.yml
@@ -101,6 +101,7 @@ get_rbac_actions:
           - GET /agents/no_group
           - GET /agents/outdated
           - GET /agents/stats/distinct
+          - GET /agents/summary
           - GET /agents/summary/os
           - GET /agents/summary/status
           - GET /groups/{group_id}/agents


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/29563 |

## Description

Adds the endpoint `GET /agents/summary` to fetch agents OS, groups and status summary using a single request. 

## Tests

<details><summary>GET /agents/summary</summary>

```console
gasti@gasti:~/work/wazuh/api/test/integration$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55000/agents/summary | jq
{
  "data": {
    "status": {
      "active": 8,
      "disconnected": 2,
      "never_connected": 2,
      "pending": 0
    },
    "os": {
      "ubuntu": 10
    },
    "groups": {
      "default": 10,
      "group2": 8,
      "group1": 7,
      "group3": 4
    }
  },
  "error": 0
}
```

</details>

<details><summary>GET /agents/summary?agents_list=001</summary>

```console
gasti@gasti:~/work/wazuh/api/test/integration$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55000/agents/summary?agents_list=001 | jq
{
  "data": {
    "status": {
      "active": 1,
      "disconnected": 0,
      "never_connected": 0,
      "pending": 0
    },
    "os": {
      "ubuntu": 1
    },
    "groups": {
      "default": 1,
      "group1": 1,
      "group2": 1
    }
  },
  "error": 0
}
```

</details>
