### PR TITLE
Backport crash fix in wazuh-modulesd to 4.10.2

### DIFF
--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -437,9 +437,9 @@ ProcessInfo portProcessInfo(const std::string& procPath, const std::deque<int64_
     auto findInode = [](const std::string & filePath) -> int64_t
     {
         constexpr size_t MAX_LENGTH {256};
-        char buffer[MAX_LENGTH];
+        char buffer[MAX_LENGTH] = "";
 
-        if (-1 == readlink(filePath.c_str(), buffer, MAX_LENGTH))
+        if (-1 == readlink(filePath.c_str(), buffer, MAX_LENGTH - 1))
         {
             throw std::system_error(errno, std::system_category(), "readlink");
         }

--- a/src/shared_modules/utils/hashHelper.h
+++ b/src/shared_modules/utils/hashHelper.h
@@ -107,6 +107,14 @@ namespace Utils
             }
             static void initializeContext(const HashType hashType, std::unique_ptr<EVP_MD_CTX, EvpContextDeleter>& spCtx)
             {
+                static auto cryptoInitialized { false };
+
+                if (!cryptoInitialized)
+                {
+                    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT, nullptr);
+                    cryptoInitialized = true;
+                }
+
                 auto ret{0};
 
                 switch (hashType)

--- a/src/wazuh_modules/wm_syscollector.h
+++ b/src/wazuh_modules/wm_syscollector.h
@@ -31,6 +31,7 @@ typedef struct wm_sys_flags_t {
     unsigned int portsinfo:1;               // Opened ports inventory
     unsigned int allports:1;                // Scan only listening ports or all
     unsigned int procinfo:1;                // Running processes inventory
+    unsigned int running:1;                 // The module is running
 } wm_sys_flags_t;
 
 typedef struct wm_sys_state_t {


### PR DESCRIPTION
|Related issue|Original issue|Original PR|Original target|
|---|---|---|---|
|#29575|#26488|#26647|4.12.0|

## Description

This pull request backports a set of fixes from version 4.12.0 that resolve a segmentation fault and shutdown-related issues in `wazuh-modulesd`. These issues occur when the daemon is stopped immediately after startup or receives multiple termination signals in quick succession.

## Proposed Changes

The following changes are included in this backport:

1. **OpenSSL initialization and cleanup**: Manually initialize OpenSSL to avoid using the automatic cleanup routine, which could cause a segmentation fault during shutdown if threads are still active.
2. **Syscollector shutdown guard**: Introduce a flag to prevent double shutdown of Syscollector in the case of receiving multiple signals.
3. **Buffer initialization in DataProvider**: Ensure buffers are zero-initialized to prevent potential overruns.

### Results and Evidence

* `wazuh-modulesd` can now be stopped immediately after starting without crashing.
* Running the daemon under Valgrind shows no memory leaks introduced by these changes.
* Memory leaks unrelated to this fix (in Vulnerability Detector and Syscollector shutdown) are acknowledged but not addressed here.

<details><summary>Valgrind report</summary>

```
==57793== Memcheck, a memory error detector
==57793== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==57793== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==57793== Command: wazuh-modulesd -f
==57793== 
2024/10/31 11:02:08 wazuh-modulesd:router: INFO: Loaded router module.
2024/10/31 11:02:08 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
2024/10/31 11:02:08 wazuh-modulesd: INFO: Started (pid: 57793).
2024/10/31 11:02:08 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2024/10/31 11:02:08 wazuh-modulesd:task-manager: INFO: (8200): Module Task Manager started.
2024/10/31 11:02:08 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2024/10/31 11:02:09 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2024/10/31 11:02:09 sca: INFO: Module started.
2024/10/31 11:02:09 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2024/10/31 11:02:10 sca: INFO: Starting Security Configuration Assessment scan.
2024/10/31 11:02:10 2024/10/31 11:02:11 wazuh-modulesd:database: INFO: Module started.
wazuh-modulesd:router: INFO: Starting router module.
2024/10/31 11:02:11 2024/10/31 11:02:11 wazuh-modulesd:download: INFO: Module started.
2024/10/31 11:02:11 sca: INFO: Skipping policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml': 'Check Ubuntu version.'
2024/10/31 11:02:10 wazuh-modulesd:content_manager: INFO: Starting content_manager module.
wazuh-modulesd:vulnerability-scanner: 2024/10/31 11:02:11 wazuh-modulesd:control: INFO: Starting control thread.
2024/10/31 11:02:12 sca: 2024/10/31 11:02:13 wazuh-modulesd:syscollector: INFO: Module started.
INFO: Starting vulnerability_scanner module.
INFO: 2024/10/31 11:02:13 wazuh-modulesd:syscollector: 2024/10/31 11:02:15 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
Security Configuration Assessment scan finished. Duration: 2 seconds.
INFO: Starting evaluation.==57793== Warning: unimplemented fcntl command: 1036

==57793== Warning: unimplemented fcntl command: 1036
2024/10/31 11:02:31 wazuh-modulesd:vulnerability-scanner: INFO: Vulnerability scanner module is disabled.
2024/10/31 11:02:34 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2024/10/31 11:02:36 wazuh-modulesd:syscollector: INFO: Module finished.
2024/10/31 11:02:36 wazuh-modulesd:vulnerability-scanner: INFO: Stopping vulnerability_scanner module.
2024/10/31 11:02:36 wazuh-modulesd:router: INFO: Stopping router module.
2024/10/31 11:02:37 wazuh-modulesd:content_manager: INFO: Stopping content_manager module.
==57793== 
==57793== HEAP SUMMARY:
==57793==     in use at exit: 342,925 bytes in 340 blocks
==57793==   total heap usage: 613,486 allocs, 613,146 frees, 172,995,143 bytes allocated
==57793== 
==57793== 48 bytes in 1 blocks are definitely lost in loss record 161 of 284
==57793==    at 0x484D953: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==57793==    by 0x142776: Read_Global (global-config.c:526)
==57793==    by 0x13A738: read_main_elements (config.c:85)
==57793==    by 0x13C016: ReadConfig (config.c:372)
==57793==    by 0x173CE9: wm_vulnerability_detection_subnode_read (wmodules-vulnerability-detection.c:106)
==57793==    by 0x174101: Read_Vulnerability_Detection (wmodules-vulnerability-detection.c:170)
==57793==    by 0x13B2B7: read_main_elements (config.c:196)
==57793==    by 0x13C016: ReadConfig (config.c:372)
==57793==    by 0x117CD9: wm_config (wmodules.c:77)
==57793==    by 0x1150E2: wm_setup (main.c:134)
==57793==    by 0x114E33: main (main.c:82)
==57793== 
==57793== 64 bytes in 1 blocks are definitely lost in loss record 179 of 284
==57793==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==57793==    by 0x400E150: malloc (rtld-malloc.h:56)
==57793==    by 0x400E150: resize_scopes (dl-open.c:295)
==57793==    by 0x400E150: dl_open_worker_begin (dl-open.c:728)
==57793==    by 0x400151B: _dl_catch_exception (dl-catch.c:237)
==57793==    by 0x400CD1F: dl_open_worker (dl-open.c:803)
==57793==    by 0x400151B: _dl_catch_exception (dl-catch.c:237)
==57793==    by 0x400D163: _dl_open (dl-open.c:905)
==57793==    by 0x593C193: dlopen_doit (dlopen.c:56)
==57793==    by 0x400151B: _dl_catch_exception (dl-catch.c:237)
==57793==    by 0x4001668: _dl_catch_error (dl-catch.c:256)
==57793==    by 0x593BC72: _dlerror_run (dlerror.c:138)
==57793==    by 0x593C24E: dlopen_implementation (dlopen.c:71)
==57793==    by 0x593C24E: dlopen@@GLIBC_2.34 (dlopen.c:81)
==57793==    by 0x1D76C6: so_check_module_loaded (sym_load.c:69)
==57793==    by 0x1A4757: wm_sys_main (wm_syscollector.c:183)
==57793==    by 0x5940A93: start_thread (pthread_create.c:447)
==57793==    by 0x59CDA33: clone (clone.S:100)
==57793== 
==57793== 74 bytes in 1 blocks are definitely lost in loss record 194 of 284
==57793==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==57793==    by 0x595834E: strdup (strdup.c:42)
==57793==    by 0x140945: Read_Global (global-config.c:210)
==57793==    by 0x13A738: read_main_elements (config.c:85)
==57793==    by 0x13C016: ReadConfig (config.c:372)
==57793==    by 0x173CE9: wm_vulnerability_detection_subnode_read (wmodules-vulnerability-detection.c:106)
==57793==    by 0x174101: Read_Vulnerability_Detection (wmodules-vulnerability-detection.c:170)
==57793==    by 0x13B2B7: read_main_elements (config.c:196)
==57793==    by 0x13C016: ReadConfig (config.c:372)
==57793==    by 0x117CD9: wm_config (wmodules.c:77)
==57793==    by 0x1150E2: wm_setup (main.c:134)
==57793==    by 0x114E33: main (main.c:82)
==57793== 
==57793== 208 bytes in 2 blocks are definitely lost in loss record 251 of 284
==57793==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==57793==    by 0x4002C36: malloc (rtld-malloc.h:56)
==57793==    by 0x4002C36: _dl_map_object_deps (dl-deps.c:422)
==57793==    by 0x400D944: dl_open_worker_begin (dl-open.c:638)
==57793==    by 0x400151B: _dl_catch_exception (dl-catch.c:237)
==57793==    by 0x400CD1F: dl_open_worker (dl-open.c:803)
==57793==    by 0x400151B: _dl_catch_exception (dl-catch.c:237)
==57793==    by 0x400D163: _dl_open (dl-open.c:905)
==57793==    by 0x593C193: dlopen_doit (dlopen.c:56)
==57793==    by 0x400151B: _dl_catch_exception (dl-catch.c:237)
==57793==    by 0x4001668: _dl_catch_error (dl-catch.c:256)
==57793==    by 0x593BC72: _dlerror_run (dlerror.c:138)
==57793==    by 0x593C24E: dlopen_implementation (dlopen.c:71)
==57793==    by 0x593C24E: dlopen@@GLIBC_2.34 (dlopen.c:81)
==57793==    by 0x1D762D: so_get_module_handle (sym_load.c:53)
==57793==    by 0x1A46C9: wm_sys_main (wm_syscollector.c:176)
==57793==    by 0x5940A93: start_thread (pthread_create.c:447)
==57793==    by 0x59CDA33: clone (clone.S:100)
==57793== 
==57793== LEAK SUMMARY:
==57793==    definitely lost: 394 bytes in 5 blocks
==57793==    indirectly lost: 0 bytes in 0 blocks
==57793==      possibly lost: 6,784 bytes in 19 blocks
==57793==    still reachable: 335,747 bytes in 316 blocks
==57793==         suppressed: 0 bytes in 0 blocks
==57793== Reachable blocks (those to which a pointer was found) are not shown.
==57793== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==57793== 
==57793== For lists of detected and suppressed errors, rerun with: -s
==57793== ERROR SUMMARY: 12 errors from 12 contexts (suppressed: 0 from 0)
```

</details>

### Artifacts Affected

* `wazuh-modulesd` (agent and manager)

### Configuration Changes

None.

### Documentation Updates

Not required.

### Tests Introduced

No new tests were added.

Manual testing and analysis using GDB and Valgrind were performed to validate the fixes.

## Review Checklist

* [ ] Code changes reviewed
* [ ] Relevant evidence provided
* [ ] Tests cover the new functionality
* [ ] Configuration changes documented
* [ ] Developer documentation reflects the changes
* [ ] Meets requirements and/or definition of done
* [ ] No unresolved dependencies with other issues
