### PR TITLE
Backport fix WPK packages for DEB when upgrading from 4.3.11 or older

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -56,7 +56,7 @@ elif [[ "$OS" == "Linux" ]]; then
         fi
     elif find ./var/upgrade/ -mindepth 1 -maxdepth 1 -type f -name "*.deb" | read; then
         if command -v dpkg >/dev/null 2>&1; then
-            dpkg -i ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
+            dpkg -i --force-confdef ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. DEB package found but dpkg command not found." >> ./logs/upgrade.log
             echo -ne "2" > ./var/upgrade/upgrade_result


### PR DESCRIPTION
|Related issue|Original issue|Original PR|
|---|---|---|
|#29576|#28809|#28928|

## Description

When upgrading Wazuh agents remotely from version 4.3.11 (or earlier) to 4.9.0 (or later) on Debian and Ubuntu systems, the process gets blocked due to an internal `dpkg` prompt. This issue arises because, starting from version 4.9.0, the remote upgrade (WPK) mechanism internally uses DEB packages, and a critical file change occurs between versions 4.3.11 and 4.4.0. Since the WPK installer cannot interact with `dpkg` prompts, the upgrade remains stuck.

## Proposed Changes

The proposed solution ensures that the WPK package instructs `dpkg` to use the default action when encountering prompts. This change prevents the upgrade process from stalling.

A test was conducted by generating a 4.10.1 package incorporating this updated logic, and the results confirmed a successful upgrade.

## Results and Evidence

### Test Procedure

1. Install version 4.2.7 on the agent:
   ```sh
   WAZUH_MANAGER=manager apt-get install wazuh-agent=4.2.7-1
   ```
2. Update the WPK root CA:
   ```sh
   curl -o /var/ossec/etc/wpk_root_2022.pem https://raw.githubusercontent.com/wazuh/wazuh/00718e3720d127c44d73d7c9b093d90a918790a0/etc/wpk_root.pem
   sed -i 's| <ca_store>etc/wpk_root.pem| <ca_store>etc/wpk_root_2022.pem|1' /var/ossec/etc/ossec.conf
   chown $(ls -l /var/ossec/etc/wpk_root.pem | awk '{print $3":"$4}') /var/ossec/etc/wpk_root_2022.pem
   service wazuh-agent restart
   ```
3. Place the patched WPK [wazuh-agent_4.10.1-1_amd64.deb.wpk.gz](https://github.com/user-attachments/files/20159884/wazuh-agent_4.10.1-1_amd64.deb.wpk.gz) in `/var/ossec/tmp` on the manager:
   ```sh
   cd /var/ossec/tmp
   curl -O -H "Authorization: token $GITHUB_TOKEN" https://github.com/user-attachments/files/20159884/wazuh-agent_4.10.1-1_amd64.deb.wpk.gz
   gzip -d wazuh-agent_4.10.1-1_amd64.deb.wpk.gz
   ```
> [!IMPORTANT]
> You need your `$GITHUB_TOKEN` to download the file using this method.
4. Upgrade the agent from the manager:
   ```sh
   /var/ossec/bin/agent_upgrade -a 003 -f /var/ossec/tmp/wazuh-agent_4.10.1-1_amd64.deb.wpk
   ```
5. Verify the upgrade result:
   ```
   Upgrading...

   Upgraded agents:
           Agent 003 upgraded: Wazuh v4.2.7 -> Wazuh v4.10.1
   ```
6. Confirm the agent log reflects the upgrade:
   > 2025/05/12 12:59:08 wazuh-agentd: INFO: Version detected -> Linux |noble |6.8.0-53-generic |`#55`-Ubuntu SMP PREEMPT_DYNAMIC Fri Jan 17 15:37:52 UTC 2025 |x86_64 [Ubuntu|ubuntu: 24.04.2 LTS (Noble Numbat)] - Wazuh v4.10.1

## Artifacts Affected

- WPK installer (DEB version)

## Configuration Changes

None.

## Documentation Updates

None.

## Tests Introduced

None.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues





