### PR TITLE
Backport: Adds URL validation for Maltiverse

### DIFF
--- a/integrations/maltiverse.py
+++ b/integrations/maltiverse.py
@@ -60,6 +60,7 @@ import json
 import os
 import socket
 import sys
+import re
 from urllib.parse import urlsplit
 
 try:
@@ -215,6 +216,19 @@ def is_valid_url(url: str) -> bool:
         True if the URL is valid, False otherwise.
     """
     split_url = urlsplit(url)
+
+    valid_schemes = {"http", "https"}
+    if split_url.scheme not in valid_schemes:
+        return False
+
+    netloc_regex = re.compile(r'^[a-zA-Z0-9.-]+(:[0-9]{1,5})?$')
+    if not netloc_regex.match(split_url.netloc):
+        return False
+
+    invalid_chars = set("<>\"'{}|\\^`")
+    if any(char in split_url.path + split_url.query + split_url.fragment for char in invalid_chars):
+        return False
+
     return bool(split_url.scheme and split_url.netloc)
 
 

--- a/integrations/maltiverse.py
+++ b/integrations/maltiverse.py
@@ -215,7 +215,11 @@ def is_valid_url(url: str) -> bool:
     bool
         True if the URL is valid, False otherwise.
     """
-    split_url = urlsplit(url)
+    try:
+        split_url = urlsplit(url)
+    except ValueError:
+        # Return False if urlsplit raises a ValueError for malformed URLs
+        return False
 
     valid_schemes = {"http", "https"}
     if split_url.scheme not in valid_schemes:

--- a/integrations/tests/test_maltiverse.py
+++ b/integrations/tests/test_maltiverse.py
@@ -140,6 +140,23 @@ def test_get_by_sha1():
         mock_get.assert_called_once_with(f'https://api.maltiverse.com/sample/sha1/{example_sample}')
 
 
+@pytest.mark.parametrize('url,expected', [
+    ('http://example.com', True),
+    ('https://example.com:8080', True),
+    ('https://api.maltiverse.com', True),
+    ('http://example.com/<script>', False),
+    ('https://192.168.0.1:invalid', False),
+    ('malformed://example.com', False),
+    ('http://', False),
+    ('https://user:some]password[@host.com', False),
+    ('https://user:some%5Dpassword%5B@host.com', False)
+])
+def test_is_valid_url(url, expected):
+    """Test the `test_is_valid_url` function works as expected."""
+    result = maltiverse.is_valid_url(url)
+    assert result == expected
+
+
 @pytest.mark.parametrize('number_of_arguments', [1, 2, 3])
 def test_main_exit_with_invalid_number_of_arguments(number_of_arguments):
     """Test that the `main` function exits with the expected code for an invalid number of arguments."""


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/29573|


## Description

Improves the Maltiverse's integration URL validation and adds UT to this functionality.