### PR TITLE
Backport: Fix overflow when reading email alerts without email_to attribute

### DIFF
--- a/src/config/email-alerts-config.c
+++ b/src/config/email-alerts-config.c
@@ -16,8 +16,8 @@
 int Read_EmailAlerts(XML_NODE node, __attribute__((unused)) void *configp, void *mailp)
 {
     int i = 0;
-    unsigned int granto_size = 0;
-    unsigned int granto_email_counter = 0;
+    int granto_size = 0;
+    int granto_email_counter = 0;
 
     /* XML definitions */
     const char *xml_email_to = "email_to";
@@ -239,12 +239,11 @@ int Read_EmailAlerts(XML_NODE node, __attribute__((unused)) void *configp, void 
 
     /* We must have at least one entry set */
     if ((Mail->gran_location[granto_size] == NULL &&
-            Mail->gran_level[granto_size] == 0 &&
-            Mail->gran_group[granto_size] == NULL &&
-            Mail->gran_id[granto_size] == NULL &&
-            Mail->gran_format[granto_size] == FULL_FORMAT) ||
-            Mail->gran_to == NULL ||
-            Mail->gran_to[granto_size] == NULL) {
+        Mail->gran_level[granto_size] == 0 &&
+        Mail->gran_group[granto_size] == NULL &&
+        Mail->gran_id[granto_size] == NULL &&
+        Mail->gran_format[granto_size] == FULL_FORMAT) ||
+        (Mail->to == NULL && (Mail->gran_to == NULL || Mail->gran_to[granto_size] == NULL))) {
         merror(XML_INV_GRAN_MAIL);
         return (OS_INVALID);
     }


### PR DESCRIPTION
|Related issue|
|---|
|#29572|

This PR is a backport that fixes overflow when reading email alerts without email_to attribute. The variables were defined as unsigned integers and a subtraction was performed to the value zero, not supported by that type of data when no recipient for the email was indicated in the configuration. In addition, the problem of redefining email_to if it was previously defined in the global configuration is solved.