### PR TITLE
Fix worker-master race condition.

### DIFF
--- a/src/shared_modules/router/src/wazuh-db/endpointPostV1AgentsSync.hpp
+++ b/src/shared_modules/router/src/wazuh-db/endpointPostV1AgentsSync.hpp
@@ -103,9 +103,10 @@ public:
         {
             if (jsonBody.contains("syncreq_keepalive"))
             {
-                DBStatement stmt(
-                    db,
-                    "UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW'), sync_status = 'synced' WHERE id = ?;");
+                DBStatement stmt(db,
+                                 "UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW'),sync_status = 'synced',"
+                                 "connection_status = 'active',disconnection_time = 0,"
+                                 "status_code = 0 WHERE id = ?;");
 
                 for (const auto& agent : jsonBody.at("syncreq_keepalive"))
                 {

--- a/src/shared_modules/router/tests/unit/endpointPostV1AgentsSync_test.cpp
+++ b/src/shared_modules/router/tests/unit/endpointPostV1AgentsSync_test.cpp
@@ -96,7 +96,11 @@ TEST_F(EndpointPostV1AgentsSyncTest, SyncReqTwoAgents)
     TEndpointPostV1AgentsSync<MockSQLiteConnection, TrampolineSQLiteStatement>::call(db, req, res);
 
     ASSERT_EQ(qdump->size(), 1);
-    EXPECT_TRUE((*qdump)[0].find("UPDATE agent SET config_sum") != std::string::npos);
+    EXPECT_EQ((*qdump)[0],
+              "UPDATE agent SET config_sum = ?, ip = ?, manager_host = ?, merged_sum = ?, name = ?, node_name = ?, "
+              "os_arch = ?, os_build = ?, os_codename = ?, os_major = ?, os_minor = ?, os_name = ?, os_platform = ?, "
+              "os_uname = ?, os_version = ?, version = ?, last_keepalive = ?, connection_status = ?, "
+              "disconnection_time = ?, group_config_status = ?, status_code= ?, sync_status = 'synced' WHERE id = ?;");
 }
 
 TEST_F(EndpointPostV1AgentsSyncTest, KeepAliveThreeAgents)
@@ -113,7 +117,9 @@ TEST_F(EndpointPostV1AgentsSyncTest, KeepAliveThreeAgents)
     TEndpointPostV1AgentsSync<MockSQLiteConnection, TrampolineSQLiteStatement>::call(db, req, res);
 
     ASSERT_EQ(qdump->size(), 1);
-    EXPECT_TRUE((*qdump)[0].find("last_keepalive") != std::string::npos);
+    EXPECT_EQ((*qdump)[0],
+              "UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW'),sync_status = 'synced',connection_status = "
+              "'active',disconnection_time = 0,status_code = 0 WHERE id = ?;");
 }
 
 TEST_F(EndpointPostV1AgentsSyncTest, StatusSingleAgent)
@@ -132,5 +138,7 @@ TEST_F(EndpointPostV1AgentsSyncTest, StatusSingleAgent)
     TEndpointPostV1AgentsSync<MockSQLiteConnection, TrampolineSQLiteStatement>::call(db, req, res);
 
     ASSERT_EQ(qdump->size(), 1);
-    EXPECT_TRUE((*qdump)[0].find("connection_status") != std::string::npos);
+    EXPECT_EQ((*qdump)[0],
+              "UPDATE agent SET connection_status = ?, sync_status = 'synced', disconnection_time = ?, status_code = ? "
+              "WHERE id = ?;");
 }


### PR DESCRIPTION
#### Root cause (recap)
| Step | Event | Effect on `wazuh-db` (master) |
|------|-------|--------------------------------|
| 1 | Agent connects to **worker-2** | status ➜ **active** |
| 2 | Agent disconnects from **worker-2** and immediately connects to **worker-1** | — |
| 3 | **worker-1** syncs first | status ➜ **active** |
| 4 | **worker-2** syncs afterwards | status ➜ **disconnected** (stale) |

Because we accept the **last** sync packet as authoritative, an “older” *disconnect* can overwrite a newer *connect* when they arrive out of order.  [oai_citation:0‡GitHub](https://github.com/wazuh/wazuh/issues/29601?utm_source=chatgpt.com)


## Description
These changes cause the value to be adjusted to the actual data in the subsequent update.