### PR TITLE
Backport: Improve SCA and Syscheck decoders

### DIFF
--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -18,7 +18,7 @@
 void fillData(Eventinfo *lf, const char *key, const char *value)
 {
 
-    if (!key)
+    if (!key || !value)
         return;
 
     if (strcmp(key, "srcip") == 0){

--- a/src/analysisd/decoders/security_configuration_assessment.c
+++ b/src/analysisd/decoders/security_configuration_assessment.c
@@ -186,7 +186,7 @@ int DecodeSCA(Eventinfo *lf, int *socket)
     /* TODO - Check if the event is a final event */
     type = cJSON_GetObjectItem(json_event, "type");
 
-    if(type) {
+    if(type && cJSON_IsString(type)) {
 
         if (strcmp(type->valuestring,"check") == 0){
             char *msg_unformatted = cJSON_PrintUnformatted(json_event);
@@ -1707,15 +1707,15 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
         fillData(lf, "sca.scan_id", value);
     }
 
-    if(name) {
+    if(name && cJSON_IsString(name)) {
         fillData(lf, "sca.policy", name->valuestring);
     }
 
-    if(description) {
+    if(description && cJSON_IsString(description)) {
         fillData(lf, "sca.description", description->valuestring);
     }
 
-    if(policy_id) {
+    if(policy_id && cJSON_IsString(policy_id)) {
         fillData(lf, "sca.policy_id", policy_id->valuestring);
     }
 
@@ -1794,7 +1794,7 @@ static void FillScanInfo(Eventinfo *lf,cJSON *scan_id,cJSON *name,cJSON *descrip
         fillData(lf, "sca.score", value);
     }
 
-    if(file){
+    if(file && cJSON_IsString(file)) {
         fillData(lf, "sca.file", file->valuestring);
     }
 }

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -793,6 +793,9 @@ int fim_alert (char *f_name, sk_sum_t *oldsum, sk_sum_t *newsum, Eventinfo *lf, 
     free(lf->full_log);
     os_strdup(localsdb->comment, lf->full_log);
     lf->log = lf->full_log;
+    // Force clean event
+    lf->program_name = NULL;
+    lf->dec_timestamp = NULL;
 
     return (0);
 }

--- a/src/analysisd/decoders/winevtchannel.c
+++ b/src/analysisd/decoders/winevtchannel.c
@@ -107,6 +107,10 @@ int DecodeWinevt(Eventinfo *lf){
     os_calloc(OS_MAXSTR, sizeof(char), msg_from_prov);
     os_calloc(OS_MAXSTR, sizeof(char), join_data);
 
+    // force a clean event
+    lf->program_name = NULL;
+    lf->dec_timestamp = NULL;
+
     const char *jsonErrPtr;
 
     if (received_event = cJSON_ParseWithOpts(lf->log, &jsonErrPtr, 0), !received_event) {
@@ -141,6 +145,7 @@ int DecodeWinevt(Eventinfo *lf){
             } else {
                 mwarn("Could not read XML string: '%s'", event);
             }
+            OS_ClearXML(&xml);
         } else {
             node = OS_GetElementsbyNode(&xml, NULL);
 
@@ -245,7 +250,7 @@ int DecodeWinevt(Eventinfo *lf){
                                     } else if(child_attr[p]->content && strcmp(child_attr[p]->content, "(NULL)") != 0
                                             && strcmp(child_attr[p]->content, "-") != 0){
                                         filtered_string = replace_win_format(child_attr[p]->content, 0);
-                                        mdebug2("Unexpected attribute at EventData (%s).", child_attr[p]->attributes[j]);
+                                        mdebug2("Unexpected attribute at EventData (%s).", child_attr[p]->attributes[l]);
                                         *child_attr[p]->values[l] = tolower(*child_attr[p]->values[l]);
                                         cJSON_AddStringToObject(json_eventdata_in, child_attr[p]->values[l], filtered_string);
                                         os_free(filtered_string);

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -1657,8 +1657,14 @@ char *decode_win_permissions(char *raw_perm) {
     int perm_size = MAX_WIN_PERM_SIZE;
     char *decoded_it = decoded_perm;
     char *perm_it = raw_perm;
+    char *perm_end = perm_it + strlen(raw_perm);
 
     while (perm_it = strchr(perm_it, '|'), perm_it) {
+        // Minimum size for the next permission
+        if (perm_end - perm_it < 3) {
+            goto error;
+        }
+
         // Get the account/group name
         base_it = ++perm_it;
         if (perm_it = strchr(perm_it, ','), !perm_it) {
@@ -1743,7 +1749,7 @@ char *decode_win_permissions(char *raw_perm) {
         }
     }
 
-    if (decoded_it && size > 1) {
+    if (decoded_it && decoded_it - 2 >= decoded_perm && size > 1) {
         *(decoded_it - 2) = '\0';
         // Adjusts the final size
         os_realloc(decoded_perm, written * sizeof(char), decoded_perm);
@@ -1751,8 +1757,8 @@ char *decode_win_permissions(char *raw_perm) {
 
     return decoded_perm;
 error:
-    free(decoded_perm);
-    free(account_name);
+    os_free(decoded_perm);
+    os_free(account_name);
     mdebug1("The file permissions could not be decoded: '%s'.", raw_perm);
     return NULL;
 }


### PR DESCRIPTION
|Related issue|
|---|
|#2384|

This PR is a backport that improves handling of syscheck and SCA messages