### PR TITLE
Fix file processing in aws

### DIFF
--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -224,10 +224,10 @@ class AWSSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler):
                 if re.match(self.discard_regex, log['full_log']):
                     aws_tools.debug(f'+++ The "{self.discard_regex.pattern}" regex found a match. '
                                     f'The event will be skipped.', 2)
+                    continue
                 else:
                     print(f'WARNING: The "{self.discard_regex.pattern}" regex did not find a match. '
                           f'The event will be processed.')
-                    continue
             elif self.event_should_be_skipped(log):
                 aws_tools.debug(f'+++ The "{self.discard_regex.pattern}" regex found a match '
                                 f'in the "{self.discard_field}" '

--- a/wodles/aws/tests/test_s3_log_handler.py
+++ b/wodles/aws/tests/test_s3_log_handler.py
@@ -210,6 +210,7 @@ def test_process_file_sends_expected_messages(mock_debug):
         log_with_match = {'full_log': 'some log entry matching discard regex'}
         formatted_logs_with_match = [log_with_match]
 
+        processor.send_msg.reset_mock()
         processor.obtain_logs.return_value = formatted_logs_with_match
         processor.process_file(message_body)
         processor.send_msg.assert_called_once()


### PR DESCRIPTION
|Related issue|
|---|
| #29568  |

## Description

This PR closes #29568, where the same changes as in https://github.com/wazuh/wazuh/issues/27693 were implemented to fix the error when processing logs in AWS.

## Test

```console
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/test_s3_log_handler.py
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 23 items                                                                                                                                                                                         

wodles/aws/tests/test_s3_log_handler.py .......................                                                                                                                                      [100%]

============================================================================================ 23 passed in 0.28s ============================================================================================
(venv) wazuh@javier:~/Git/wazuh$ PYTHONPATH=/home/wazuh/Git/wazuh/api:/home/wazuh/Git/wazuh/framework python3 -m pytest wodles/aws/tests/
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.10.13, pytest-7.3.1, pluggy-1.5.0
rootdir: /home/wazuh/Git/wazuh/wodles/aws/tests
configfile: pytest.ini
plugins: anyio-4.1.0, cov-4.1.0, metadata-3.1.1, trio-0.8.0, html-2.1.1, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 685 items                                                                                                                                                                                        

wodles/aws/tests/test_aws_bucket.py ................................................................................................................................................................ [ 23%]
.................................................................................                                                                                                                    [ 35%]
wodles/aws/tests/test_aws_s3.py ......................                                                                                                                                               [ 38%]
wodles/aws/tests/test_aws_service.py ....                                                                                                                                                            [ 38%]
wodles/aws/tests/test_cloudtrail.py ..                                                                                                                                                               [ 39%]
wodles/aws/tests/test_cloudwatchlogs.py .....................................................                                                                                                        [ 47%]
wodles/aws/tests/test_config.py .................................................................................                                                                                    [ 58%]
wodles/aws/tests/test_guardduty.py .................                                                                                                                                                 [ 61%]
wodles/aws/tests/test_inspector.py ......                                                                                                                                                            [ 62%]
wodles/aws/tests/test_load_balancers.py ............                                                                                                                                                 [ 63%]
wodles/aws/tests/test_s3_log_handler.py .......................                                                                                                                                      [ 67%]
wodles/aws/tests/test_server_access.py .................................                                                                                                                             [ 72%]
wodles/aws/tests/test_sqs_message_processor.py ........                                                                                                                                              [ 73%]
wodles/aws/tests/test_sqs_queue.py .......                                                                                                                                                           [ 74%]
wodles/aws/tests/test_tools.py ..................................                                                                                                                                    [ 79%]
wodles/aws/tests/test_umbrella.py ......                                                                                                                                                             [ 80%]
wodles/aws/tests/test_vpcflow.py ...........................                                                                                                                                         [ 84%]
wodles/aws/tests/test_waf.py .......                                                                                                                                                                 [ 85%]
wodles/aws/tests/test_wazuh_integration.py ......................................................................................................                                                    [100%]

=========================================================================================== 685 passed in 3.29s ============================================================================================
```