### PR TITLE
Remove multi-fields from inventory index templates

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
@@ -105,11 +105,6 @@
               "type": "keyword"
             },
             "path": {
-              "fields": {
-                "text": {
-                  "type": "text"
-                }
-              },
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
@@ -110,11 +110,6 @@
         "process": {
           "properties": {
             "name": {
-              "fields": {
-                "text": {
-                  "type": "text"
-                }
-              },
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
@@ -75,19 +75,9 @@
               "type": "long"
             },
             "command_line": {
-              "fields": {
-                "text": {
-                  "type": "text"
-                }
-              },
               "type": "keyword"
             },
             "name": {
-              "fields": {
-                "text": {
-                  "type": "text"
-                }
-              },
               "ignore_above": 1024,
               "type": "keyword"
             },


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-indexer/issues/827 |

## Description

This PR removes multi-fields from Inventory index templates.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors