### PR TITLE
Fix: fim reports false files inode changed

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -831,9 +831,9 @@ bool SQLiteDBEngine::bindJsonData(const std::shared_ptr<SQLite::IStatement> stmt
         }
         else if (ColumnType::Integer == type)
         {
-            int32_t value
+            int64_t value
             {
-                jsData.is_number() ? jsData.get<int32_t>() : jsData.is_string()
+                jsData.is_number() ? jsData.get<int64_t>() : jsData.is_string()
                 && jsData.get_ref<const std::string&>().size()
                 ? std::stoi(jsData.get_ref<const std::string&>())
                 : 0
@@ -1000,7 +1000,7 @@ void SQLiteDBEngine::getTableData(std::shared_ptr<SQLite::IStatement>const stmt,
     }
     else if (ColumnType::Integer == type)
     {
-        row[fieldName] = std::make_tuple(type, std::string(), stmt->column(index)->value(int32_t{}), 0, 0, 0);
+        row[fieldName] = std::make_tuple(type, std::string(), stmt->column(index)->value(int64_t{}), 0, 0, 0);
     }
     else if (ColumnType::Text == type)
     {

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.h
@@ -84,7 +84,7 @@ using TableColumns =
     std::vector<ColumnData>;
 
 using TableField =
-    std::tuple<int32_t, std::string, int32_t, int64_t, uint64_t, double_t>;
+    std::tuple<int32_t, std::string, int64_t, int64_t, uint64_t, double_t>;
 
 using Row = std::map<std::string, TableField>;
 

--- a/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
+++ b/src/shared_modules/dbsync/tests/dbengine/dbengine_test.cpp
@@ -608,7 +608,7 @@ TEST_F(DBEngineTest, GetRowsToBeDeletedByStatusField)
     .WillOnce(Return(SQLITE_DONE));
 
     auto mockColumn_9 { std::make_unique<MockColumn>() };
-    EXPECT_CALL(*mockColumn_9, value(An<const int32_t&>()))
+    EXPECT_CALL(*mockColumn_9, value(An<const int64_t&>()))
     .WillOnce(Return(1));
 
     EXPECT_CALL(*mockStatement_3, column(0))


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/20128|

## Description
This PR changes the data type used for binding integer values in the SQLiteDBEngine::bindJsonData function for the Integer column type from int32_t to int64_t. This ensures that the full range of possible inode and size values (which are effectively treated as int64_t by SQLite) can be stored without overflow. This aligns the application's behavior with SQLite's data type handling.


| Version               | Input Value  | Output Value   | Explanation                                                          |
|-----------------------|--------------|----------------|----------------------------------------------------------------------|
| `int32_t`             | `2266849930` | `-2028117366`  | Overflow occurs because 2266849930 exceeds the `int32_t` max value (2,147,483,647). |
| ✅ `int64_t` (Fixed)   | `2266849930` | `2266849930`   | Correctly handles large numbers using `int64_t` without overflow.      |

<details>
<summary> Fix also a similar bug with file size </summary>

![image](https://github.com/user-attachments/assets/5c0a87b4-9e73-432e-a663-9083f03aa410)

```bash
** Alert 1747166312.3524760: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 13 19:58:32 (3f938c2658c2) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/root/test/my_dummy_file.bin' modified
Mode: scheduled
Changed attributes: size
Size changed from '-2028117366' to '2266849930'

Attributes:
 - Size: 2266849930
 - Permissions: rw-r--r--
 - Date: Mon May 12 13:58:09 2025
 - Inode: 11283946
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```
</details>

<!--
Paste here related logs and alerts
-->

## Tests
Prove that alerts with hardcoded inode values, as reported in the original issue, exhibit the negative value overflow.

<details>
<summary>Alert is triggered  when the inode value is hardcoded </summary>

```bash
** Alert 1746643791.44965170: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 07 18:49:51 (centos-wazuh) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/etc/profile.d/gawk.sh' modified
Mode: scheduled
Changed attributes: inode
Old inode was: '-2028117366', now it is '2266849930'

Attributes:
 - Size: 757
 - Permissions: rw-r--r--
 - Date: Thu Dec 14 17:53:45 2017
 - Inode: 2266849930
 - User: root (0)
 - Group: root (0)
 - MD5: bfc054c0862d0fad98ca641b951c7061
 - SHA1: e69dfc5c1b719471f65c11b88325b80ae7e373e7
 - SHA256: 70621a3b586d3d523b020e76977633b444a70013ba50e1ea901a3a07a676f15f
```
</details>


Demonstrate that, after this change, the inode value is correctly handled, and the overflow no longer occurs.

![image](https://github.com/user-attachments/assets/c3b6e736-d97d-433b-a740-53dc0dbc442c)

In the case of file size, we can verify the fix by running the following commands:

```bash
truncate -s 2266849930 /root/test/my_dummy_file.bin
touch /root/test/my_dummy_file.bin
```

This action resulted in the following alert on the manager:


```bash
** Alert 1747325308.146432333: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 15 16:08:28 (3f938c2658c2) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/root/test/my_dummy_file.bin' added
Mode: scheduled

Attributes:
 - Size: 2266849930
 - Permissions: rw-r--r--
 - Date: Thu May 15 16:08:25 2025
 - Inode: 11278449
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

** Alert 1747325478.146433044: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 15 16:11:18 (3f938c2658c2) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/root/test/my_dummy_file.bin' modified
Mode: scheduled
Changed attributes: mtime
Old modification time was: '1747325305', now it is '1747325474'

Attributes:
 - Size: 2266849930
 - Permissions: rw-r--r--
 - Date: Thu May 15 16:11:14 2025
 - Inode: 11278449
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

```

I also checked that the value is saved correctly in the database.

![image](https://github.com/user-attachments/assets/a90f40f5-b4ef-457c-9cf1-b77418f29eae)
