### PR TITLE
Fix ppc64 rpm packages generation

### DIFF
--- a/packages/generate_package.sh
+++ b/packages/generate_package.sh
@@ -70,11 +70,7 @@ build_pkg() {
         fi
     else
         CONTAINER_NAME="pkg_${SYSTEM}_${TARGET}_builder_${ARCHITECTURE}"
-        if [ "${ARCHITECTURE}" = "ppc64le" ]; then
-            DOCKERFILE_PATH="${CURRENT_PATH}/${SYSTEM}s/${ARCHITECTURE}"
-        else
-            DOCKERFILE_PATH="${CURRENT_PATH}/${SYSTEM}s/${ARCHITECTURE}/${TARGET}"
-        fi
+        DOCKERFILE_PATH="${CURRENT_PATH}/${SYSTEM}s/${ARCHITECTURE}/${TARGET}"
     fi
 
     # Copy the necessary files

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -40,15 +40,14 @@ log analysis, file integrity monitoring, intrusions detection and policy and com
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
 # Build debuginfo package
-%if %{_arch} != ppc64le
+%ifnarch ppc64le
 %package -n wazuh-agent-debuginfo
-%endif
 Requires: wazuh-agent = %{_version}-%{_release}
 Summary: Debug information for package %{name}.
 %description -n wazuh-agent-debuginfo
 This package provides debug information for package %{name}.
 %endif
-
+%endif
 
 %prep
 %setup -q
@@ -61,14 +60,14 @@ pushd src
 make clean
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
-    make deps TARGET=agent
+    make -j%{_threads} deps TARGET=agent
     make -j%{_threads} TARGET=agent USE_SELINUX=yes DEBUG=%{_debugenabled}
 %else
     %ifnarch amd64
       MSGPACK="USE_MSGPACK_OPT=no"
     %endif
     deps_version=`cat Makefile | grep "DEPS_VERSION =" | cut -d " " -f 3`
-    make deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
+    make -j%{_threads} deps RESOURCES_URL=http://packages.wazuh.com/deps/${deps_version} TARGET=agent
     make -j%{_threads} TARGET=agent USE_AUDIT=no USE_SELINUX=yes USE_EXEC_ENVIRON=no DEBUG=%{_debugenabled} ${MSGPACK}
 
 %endif
@@ -785,7 +784,9 @@ rm -fr %{buildroot}
 %attr(750, root, wazuh) %{_localstatedir}/wodles/gcloud/*
 
 %if 0%{?el} >= 6 || 0%{?rhel} >= 6
+%ifnarch ppc64le
 %files -n wazuh-agent-debuginfo -f debugfiles.list
+%endif
 %endif
 
 %changelog


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/29535|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Hi team,

this PR fixes the package building process for `RPM ppc64le` packages, which were having problem skipping the debug symbols package generation.

## Tests
* :green_circle: WF build: [Packages - Build Wazuh agent Linux ppc - rpm](https://github.com/wazuh/wazuh-agent-packages/actions/runs/14999676744)

Debug packages for non-ppc64le systems are working with no problems:

* 4.12.0 Package installation:
```console
[root@ae51c0a07704 /]# curl -sO https://packages.wazuh.com/4.x/yum/wazuh-agent-4.12.0-1.x86_64.rpm
[root@ae51c0a07704 /]# rpm -ivh wazuh-agent-4.12.0-1.x86_64.rpm 
warning: wazuh-agent-4.12.0-1.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 29111145: NOKEY
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-4.12.0-1             ################################# [100%]
```

Newer debug symbols package version is tried to be installed, but it's refused:
```console
[root@ae51c0a07704 /]# rpm -ivh /wazuh/packages/output/wazuh-agent-debuginfo_4.13.0-0_x86_64_a0d2a80.rpm 
error: Failed dependencies:
        wazuh-agent = 4.13.0-0 is needed by wazuh-agent-debuginfo-4.13.0-0.x86_64
```

After updating to the expected version, symbols are properly installed:
```console
[root@ae51c0a07704 /]# rpm -Uvh /wazuh/packages/output/wazuh-agent_4.13.0-0_x86_64_a0d2a80.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-4.13.0-0             ################################# [ 50%]
Cleaning up / removing...
   2:wazuh-agent-4.12.0-1             ################################# [100%]
[root@ae51c0a07704 /]# rpm -ivh /wazuh/packages/output/wazuh-agent-debuginfo_4.13.0-0_x86_64_a0d2a80.rpm 
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:wazuh-agent-debuginfo-4.13.0-0   ################################# [100%]
[root@ae51c0a07704 /]# 
```