### PR TITLE
Fixed obtaining the full path in eBPF for the different file systems

### DIFF
--- a/src/syscheckd/src/ebpf/src/modern.bpf.c
+++ b/src/syscheckd/src/ebpf/src/modern.bpf.c
@@ -17,6 +17,7 @@
 #define TASK_COMM_LEN                   32
 #define FMODE_CREATED                   0x4000
 #define O_CREAT                         0100
+#define O_ACCMODE                       00000003
 
 /* These define general path extraction and buffer limits. */
 #define LIMIT_PATH_SIZE(x)              ((x) & (MAX_PATH_LEN - 1))
@@ -75,6 +76,13 @@ struct {
     __uint(max_entries, 1);
 } heaps_map SEC(".maps");
 
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, char[MAX_PATH_LEN]);
+    __uint(max_entries, 1);
+} full_path_map SEC(".maps");
+
 /*
 * Per-CPU array used for storing CWD (current working directory) paths
 * during path reconstruction.
@@ -88,6 +96,62 @@ struct {
 
 // Kernel version check
 extern int LINUX_KERNEL_VERSION __kconfig;
+
+/*
+* Concatenates a directory path and a filename into a full path.
+* The result is stored in out_buf->data.
+* The function returns the length of the concatenated string.
+* The full path pointer is returned via full_path.
+*
+* This function ensures that the concatenated string does not exceed
+* the maximum length of HALF_PERCPU_ARRAY_SIZE.
+* It also handles the case where the directory path does not end with a '/'
+* by appending it.
+*/
+statfunc long concat_strings_bpf(unsigned char **full_path,
+                                 const char *dir_path,
+                                 const char *filename,
+                                 struct buffer *out_buf)
+{
+    long ret;
+    size_t buf_off = 0;
+    size_t max_len = HALF_PERCPU_ARRAY_SIZE; // Set the maximum length to half of the buffer size
+
+    // Read the directory path (dir_path) into the buffer
+    ret = bpf_probe_read_kernel_str(&out_buf->data[buf_off], max_len, (const char *)dir_path);
+    if (ret < 0)
+        return ret;
+    size_t dir_path_len = ret;
+
+    // Verify the length of the directory path
+    if (dir_path_len == 0)
+        return -1;
+
+    // Update the buffer offset
+    buf_off = dir_path_len - 1;
+
+    // Check if the last character of dir_path is a null terminator
+    if (&out_buf->data[buf_off - 1] != '/') {
+        out_buf->data[buf_off] = '/';
+        buf_off++;
+    }
+
+    // Recalculate the maximum length for the filename
+    max_len = HALF_PERCPU_ARRAY_SIZE - buf_off;
+
+    // Read the filename into the buffer
+    ret = bpf_probe_read_kernel_str(&out_buf->data[buf_off], max_len, (const char *)filename);
+    if (ret < 0)
+        return ret;
+    size_t filename_len = ret;
+
+    // Assign pointer to the start of the concatenated string
+    *full_path = &out_buf->data[0];
+
+    // Return the total length of the concatenated string
+    return (dir_path_len - 1) + (filename_len - 1);
+}
+
 
 /*
 * Reconstructs the full absolute path from a struct path and stores it
@@ -279,6 +343,7 @@ statfunc void submit_event(const char *filename,
 SEC("kprobe/vfs_open")
 int kprobe__vfs_open(struct pt_regs *ctx)
 {
+if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     struct path *path = (struct path *)PT_REGS_PARM1(ctx);
     if (!path)
         return 0;
@@ -333,7 +398,7 @@ int kprobe__vfs_open(struct pt_regs *ctx)
 
     /* Report file creation event. */
     submit_event((const char *)full_path, inode, dev);
-
+}
     return 0;
 }
 
@@ -410,6 +475,7 @@ int kprobe__security_inode_setattr(struct pt_regs *ctx)
 SEC("kprobe/vfs_unlink")
 int kprobe__vfs_unlink(struct pt_regs *ctx)
 {
+if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 8, 0)) {
     struct dentry *dentry;
     if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 12, 0)) {
         dentry = (struct dentry *)PT_REGS_PARM2(ctx);
@@ -465,6 +531,122 @@ int kprobe__vfs_unlink(struct pt_regs *ctx)
     get_inode_dev(d_inode, &inode, &dev);
 
     submit_event((const char *)full_path, inode, dev);
+}
+    return 0;
+}
+
+SEC("lsm/file_open")
+int BPF_PROG(file_open, struct file *file)
+{
+if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
+    struct path *path = NULL;
+    bpf_probe_read_kernel(&path, sizeof(path), &file->f_path);
+    if (!path)
+        return 0;
+
+    /* Check if the file is newly created */
+    fmode_t f_mode = 0;
+    bpf_probe_read_kernel(&f_mode, sizeof(f_mode), &file->f_mode);
+    if (!f_mode)
+        return 0;
+
+    /* Also retrieve f_flags to handle creation if FMODE_CREATED fails */
+    __u32 f_flags = 0;
+    bpf_probe_read_kernel(&f_flags, sizeof(f_flags), &file->f_flags);
+    if (!f_flags)
+        return 0;
+
+    /* If not created, skip */
+    if (!(f_mode & FMODE_CREATED) && !(f_flags & O_CREAT) && !(f_flags & O_ACCMODE)) {
+        return 0;
+    }
+
+    /* Retrieve the dentry. */
+    struct dentry *dentry = NULL;
+    bpf_probe_read_kernel(&dentry, sizeof(dentry), &path->dentry);
+    if (!dentry)
+        return 0;
+
+    struct inode *f_inode = NULL;
+    bpf_probe_read_kernel(&f_inode, sizeof(f_inode), &file->f_inode);
+    if (!f_inode)
+        return 0;
+
+    __u32 mode = 0;
+    bpf_probe_read_kernel(&mode, sizeof(mode), &f_inode->i_mode);
+    if (!mode)
+        return 0;
+
+    /* Only report regular files (0100000 is the S_IFREG mask). */
+    if (((mode & 00170000) != 0100000))
+        return 0;
+
+    char *full_path = bpf_map_lookup_elem(&full_path_map, &(u32){0});
+    if (!full_path)
+        return 0;
+
+    int ret = bpf_d_path(&file->f_path, full_path, MAX_PATH_LEN);
+    if (ret < 0)
+        return 0;
+
+    /* Extract inode/device. */
+    __u64 inode = 0, dev = 0;
+    get_inode_dev(f_inode, &inode, &dev);
+
+    submit_event((const char *)full_path, inode, dev);
+}
+    return 0;
+}
+
+
+SEC("lsm/path_unlink")
+int BPF_PROG(path_unlink, struct path *path, struct dentry *dentry)
+{
+if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(6, 8, 0)) {
+    struct inode *d_inode = NULL;
+    bpf_probe_read_kernel(&d_inode, sizeof(d_inode), &dentry->d_inode);
+    if (!d_inode)
+        return 0;
+
+    __u32 mode = 0;
+    bpf_probe_read_kernel(&mode, sizeof(mode), &d_inode->i_mode);
+    if (!mode)
+        return 0;
+
+    /* Only report regular files (0100000 is the S_IFREG mask). */
+    if (((mode & 00170000) != 0100000))
+        return 0;
+
+    char *dir_path = bpf_map_lookup_elem(&full_path_map, &(u32){0});
+    if (!dir_path)
+        return 0;
+
+    int ret = bpf_d_path(path, dir_path, MAX_PATH_LEN);
+    if (ret < 0)
+        return 0;
+
+    /* Get the file name pointer from dentry->d_name.name */
+    const char *file_name_ptr;
+    bpf_probe_read_kernel(&file_name_ptr, sizeof(file_name_ptr), &dentry->d_name.name);
+    if (!file_name_ptr)
+        return 0;
+
+    /* Reconstruct the path. */
+    struct buffer *string_buf = bpf_map_lookup_elem(&heaps_map, &(u32){0});
+    if (!string_buf)
+        return 0;
+
+    u8 *full_path = NULL;
+    ret = concat_strings_bpf(&full_path, dir_path, file_name_ptr, string_buf);
+    if (ret < 0)
+        return 0;
+
+    /* Extract inode/device. */
+    __u64 inode = 0, dev = 0;
+    get_inode_dev(d_inode, &inode, &dev);
+
+    submit_event((const char *)full_path, inode, dev);
+}
     return 0;
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#28838|

## Description

This PR fixes the problem with getting paths for less common FS (like BTRFS, XFS, etc.).

The following hooks have been used:
- `lsm/file_open`
- `lsm/path_unlink`

More details:
- https://github.com/wazuh/wazuh/issues/28838#issuecomment-2855061153

> [!Note]
> This fix is only available for **+6.8** kernel versions, due to the start of support for the `bpf_d_path()` function for the hooks used:
> - https://github.com/torvalds/linux/blob/v6.8/kernel/bpf/bpf_lsm.c#L257-L370

In addition, the `dentry` parameter for the `kprobe/vfs_unlink` call has been fixed (version 5.12).

Generated precompiled:
- [x] amd64
- [x] i386
- [x] arm64
- [x] arm32
- [x] ppc64le

## Logs/Alerts example

<details><summary>BTRFS - 🟢 </summary>

- Added:
```
** Alert 1746671276.30626: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:27:56 (fedora) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/test/test.txt' added
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 07:00:50 2025
 - Inode: 117631
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48732
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746671308.31580: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:28:28 (fedora) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/home/vagrant/test/test.txt' added
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 07:01:25 2025
 - Inode: 900022
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48741
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

- Modified:
```
** Alert 1746671313.32547: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:28:33 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/test/test.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746687650', now it is '1746687690'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 07:01:30 2025
 - Inode: 117631
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48743
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746671315.33599: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:28:35 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/home/vagrant/test/test.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746687685', now it is '1746687692'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 07:01:32 2025
 - Inode: 900022
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48744
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

- Deleted:
```
** Alert 1746671321.34664: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:28:41 (fedora) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/test/test.txt' deleted
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 07:01:30 2025
 - Inode: 117631
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48745
 - (Audit) Process name: rm
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746671327.35607: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:28:47 (fedora) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/home/vagrant/test/test.txt' deleted
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 07:01:32 2025
 - Inode: 900022
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48746
 - (Audit) Process name: rm
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

</details>

<details><summary>OverlayFS - 🟢</summary>

- Added: 
```
** Alert 1746669085.14146: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:51:25 (fedora) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/lower/test1.txt' added
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:21:16 2025
 - Inode: 117513
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47448
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669144.17101: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:52:24 (fedora) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/upper/test1.txt' added
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:22:21 2025
 - Inode: 117514
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47453
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669151.18057: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:52:31 (fedora) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/work/test1.txt' added
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:22:28 2025
 - Inode: 117515
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47454
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669157.19012: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:52:37 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/mnt/overlayfs/test1.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746684856', now it is '1746685355'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:22:35 2025
 - Inode: 117511
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47455
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

- Modified:
```
** Alert 1746669088.15102: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:51:28 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/lower/test1.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746685276', now it is '1746685279'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:21:19 2025
 - Inode: 117513
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47449
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669210.20074: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:53:30 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/upper/test1.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746685341', now it is '1746685412'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:23:32 2025
 - Inode: 117514
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47457
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669212.21128: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:53:32 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/work/test1.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746685348', now it is '1746685414'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:23:34 2025
 - Inode: 117515
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47458
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669215.22181: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:53:35 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/mnt/overlayfs/test1.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746685355', now it is '1746685417'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:23:37 2025
 - Inode: 117511
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47459
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

- Deleted: (`rm: cannot remove '/mnt/overlayfs/test1.txt': Stale file handle`) 
```
** Alert 1746669100.16156: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:51:40 (fedora) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/lower/test1.txt' deleted
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:21:19 2025
 - Inode: 117513
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47451
 - (Audit) Process name: rm
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669305.24199: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:55:05 (fedora) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/upper/test1.txt' deleted
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:23:32 2025
 - Inode: 117514
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47467
 - (Audit) Process name: rm
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant

** Alert 1746669310.25144: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 01:55:10 (fedora) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/work/test1.txt' deleted
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:23:34 2025
 - Inode: 117515
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 47468
 - (Audit) Process name: rm
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

</details>

<details><summary>XFS - 🟢</summary>

- Added:
```
** Alert 1746670281.27677: - ossec,syscheck,syscheck_entry_added,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:11:21 (fedora) any->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
File '/mnt/xfs/test.txt' added
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:42:52 2025
 - Inode: 131
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48672
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

- Modified:
```
** Alert 1746670282.28631: - ossec,syscheck,syscheck_entry_modified,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:11:22 (fedora) any->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
File '/mnt/xfs/test.txt' modified
Mode: whodata
Changed attributes: mtime
Old modification time was: '1746686572', now it is '1746686574'

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:42:54 2025
 - Inode: 131
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48673
 - (Audit) Process name: touch
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

- Deleted:
```
** Alert 1746670291.29683: - ossec,syscheck,syscheck_entry_deleted,syscheck_file,pci_dss_11.5,gpg13_4.11,gdpr_II_5.1.f,hipaa_164.312.c.1,hipaa_164.312.c.2,nist_800_53_SI.7,tsc_PI1.4,tsc_PI1.5,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
2025 May 08 02:11:31 (fedora) any->syscheck
Rule: 553 (level 7) -> 'File deleted.'
File '/mnt/xfs/test.txt' deleted
Mode: whodata

Attributes:
 - Size: 0
 - Permissions: rw-r--r--
 - Date: Thu May  8 06:42:54 2025
 - Inode: 131
 - User: root (0)
 - Group: root (0)
 - MD5: d41d8cd98f00b204e9800998ecf8427e
 - SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
 - SHA256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 - (Audit) User name: root
 - (Audit) Group name: root
 - (Audit) Process id: 48674
 - (Audit) Process name: rm
 - (Audit) Process cwd: /root/home/vagrant
 - (Audit) Parent process name: bash
 - (Audit) Parent process id: 4908
 - (Audit) Parent process cwd: /root/home/vagrant
```

</details>

## Tests

- :arrow_up: 
- https://github.com/wazuh/wazuh/issues/29556
