### PR TITLE
Wazuh-Analysisd - Fix internal decoder rc startup

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -60,7 +60,7 @@ STATIC bool w_get_attr_regex_type(xml_node * node, w_exp_type_t * type);
 int getDecoderfromlist(const char *name, OSStore **decoder_store) {
 
     if (*decoder_store) {
-        return (OSStore_GetPosition(*decoder_store, name));
+        return (OSStore_GetPosition_ex(*decoder_store, name));
     }
 
     return (0);
@@ -77,7 +77,7 @@ STATIC int addDecoder2list(const char *name, OSStore **decoder_store) {
     }
 
     /* Store data */
-    if (!OSStore_Put(*decoder_store, name, NULL)) {
+    if (!OSStore_Put_ex(*decoder_store, name, NULL)) {
         merror(LIST_ADD_ERROR);
         return (0);
     }

--- a/src/headers/store_op.h
+++ b/src/headers/store_op.h
@@ -31,6 +31,8 @@ typedef struct _OSStore {
     int currently_size;
     int max_size;
 
+    pthread_rwlock_t wr_mutex; ///< RW for list (not the data inside the nodes)
+
     void (*free_data_function)(void *data);
 } OSStore;
 
@@ -38,10 +40,12 @@ OSStore *OSStore_Create(void);
 OSStore *OSStore_Free(OSStore *list) __attribute__((nonnull));
 
 int OSStore_Put(OSStore *list, const char *key, void *data) __attribute__((nonnull(1, 2)));
+int OSStore_Put_ex(OSStore *list, const char *key, void *data) __attribute__((nonnull(1, 2)));
 int OSStore_Check(OSStore *list, const char *key) __attribute__((nonnull));
 int OSStore_NCheck(OSStore *list, const char *key) __attribute__((nonnull));
 int OSStore_NCaseCheck(OSStore *list, const char *key) __attribute__((nonnull));
 int OSStore_GetPosition(OSStore *list, const char *key) __attribute__((nonnull));
+int OSStore_GetPosition_ex(OSStore *list, const char *key) __attribute__((nonnull));
 void *OSStore_Get(OSStore *list, const char *key) __attribute__((nonnull));
 OSStoreNode *OSStore_GetFirstNode(OSStore *list) __attribute__((nonnull));
 int OSStore_Sort(OSStore *list, void *(sort_data_function)(void *d1, void *d2)) __attribute__((nonnull));

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -136,7 +136,7 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,FreeDecoderInfo")
 
 LIST(APPEND analysisd_names "test_decode-xml")
 LIST(APPEND analysisd_flags "-Wl,--wrap,_os_analysisd_add_logmsg -Wl,--wrap,OSStore_Create \
-                             -Wl,--wrap,OSStore_Put ${DEBUG_OP_WRAPPERS}")
+                             -Wl,--wrap,OSStore_Put_ex ${DEBUG_OP_WRAPPERS}")
 
 LIST(APPEND analysisd_names "test_lists_list")
 LIST(APPEND analysisd_flags "-Wl,--wrap,OSMatch_FreePattern")

--- a/src/unit_tests/analysisd/test_decode-xml.c
+++ b/src/unit_tests/analysisd/test_decode-xml.c
@@ -52,7 +52,7 @@ OSStore * __wrap_OSStore_Create() {
     return mock_type(OSStore *);
 }
 
-int __wrap_OSStore_Put(OSStore *list, const char *key, void *data) {
+int __wrap_OSStore_Put_ex(OSStore *list, const char *key, void *data) {
     return mock_type(int);
 }
 
@@ -239,7 +239,7 @@ void test_addDecoder2list_empty_list_deco_ok(void ** state)
     int retval;
 
     will_return(__wrap_OSStore_Create, (OSStore *) 1);
-    will_return(__wrap_OSStore_Put, 1);
+    will_return(__wrap_OSStore_Put_ex, 1);
 
     retval = addDecoder2list(name, &decoder_store);
 
@@ -254,7 +254,7 @@ void test_addDecoder2list_fail_push(void ** state)
     int retval;
     os_calloc(1, sizeof(OSStore), decoder_store);
 
-    will_return(__wrap_OSStore_Put, 0);
+    will_return(__wrap_OSStore_Put_ex, 0);
     expect_string(__wrap__merror, formatted_msg, "(1291): Error adding nodes to list.");
 
     retval = addDecoder2list(name, &decoder_store);
@@ -271,7 +271,7 @@ void test_addDecoder2list_push_ok(void ** state)
     int retval;
     os_calloc(1, sizeof(OSStore), decoder_store);
 
-    will_return(__wrap_OSStore_Put, 1);
+    will_return(__wrap_OSStore_Put_ex, 1);
 
     retval = addDecoder2list(name, &decoder_store);
 


### PR DESCRIPTION
Closes #29542

This PR fixes the RC over the list of decoder when fim decoder is initizialized, addding a mutex to protect de internal list.

Also added a `OSStore_Put_ex` function to improve future hotreload ruleset feature