### PR TITLE
Remove @timestamp field from index templates

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
@@ -37,9 +37,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
@@ -42,9 +42,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
@@ -18,9 +18,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hotfixes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hotfixes.json
@@ -18,9 +18,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-interfaces.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-interfaces.json
@@ -21,9 +21,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-networks.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-networks.json
@@ -19,9 +19,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
@@ -38,9 +38,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
@@ -21,9 +21,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
@@ -35,9 +35,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-protocols.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-protocols.json
@@ -20,9 +20,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
@@ -41,9 +41,6 @@
       "date_detection": false,
       "dynamic": "strict",
       "properties": {
-        "@timestamp": {
-          "type": "date"
-        },
         "agent": {
           "properties": {
             "host": {


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-indexer/issues/838 |

## Description

This PR removes the `@timestamp` field from the Inventory index templates.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors