### PR TITLE
Fix use of npos in substr

### DIFF
--- a/src/wazuh_modules/inventory_harvester/testtool/main.cpp
+++ b/src/wazuh_modules/inventory_harvester/testtool/main.cpp
@@ -88,6 +88,10 @@ int main(const int argc, const char* argv[])
             {
                 pos++;
             }
+            else
+            {
+                pos = 0;
+            }
             std::string_view fileName = file.substr(pos, file.size() - pos);
             char formattedStr[MAX_LEN] = {0};
             vsnprintf(formattedStr, MAX_LEN, message.c_str(), args);


### PR DESCRIPTION
|Related issue|
|---|
|#29608|

## Description
This prevent this case but it will never happen since the file always contains "/" 

```console
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::substr: __pos (which is 18446744073709551615) > this->size() (which is 13)
[1]    13953 IOT instruction (core dumped)  ./a.out
```
