### PR TITLE
Race condition solved in the event queue

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1229,7 +1229,7 @@ void * ad_input_main(void * args) {
             w_rwlock_rdlock(&g_hotreload_ruleset_mutex);
 
             if (msg[0] == SYSCHECK_MQ) {
-                if (!queue_full(decode_queue_syscheck_input)) {
+                if (!queue_full_ex(decode_queue_syscheck_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(decode_queue_syscheck_input, copy);
@@ -1251,7 +1251,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else if (msg[0] == ROOTCHECK_MQ) {
-                if (!queue_full(decode_queue_rootcheck_input)) {
+                if (!queue_full_ex(decode_queue_rootcheck_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(decode_queue_rootcheck_input, copy);
@@ -1272,7 +1272,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else if (msg[0] == SCA_MQ) {
-                if (!queue_full(decode_queue_sca_input)) {
+                if (!queue_full_ex(decode_queue_sca_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(decode_queue_sca_input, copy);
@@ -1293,7 +1293,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else if (msg[0] == SYSCOLLECTOR_MQ) {
-                if (!queue_full(decode_queue_syscollector_input)) {
+                if (!queue_full_ex(decode_queue_syscollector_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(decode_queue_syscollector_input, copy);
@@ -1314,7 +1314,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else if (msg[0] == HOSTINFO_MQ) {
-                if (!queue_full(decode_queue_hostinfo_input)) {
+                if (!queue_full_ex(decode_queue_hostinfo_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(decode_queue_hostinfo_input, copy);
@@ -1335,7 +1335,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else if (msg[0] == WIN_EVT_MQ) {
-                if (!queue_full(decode_queue_winevt_input)) {
+                if (!queue_full_ex(decode_queue_winevt_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(decode_queue_winevt_input, copy);
@@ -1356,7 +1356,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else if (msg[0] == DBSYNC_MQ) {
-                if (!queue_full(dispatch_dbsync_input)) {
+                if (!queue_full_ex(dispatch_dbsync_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(dispatch_dbsync_input, copy);
@@ -1377,7 +1377,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else if (msg[0] == UPGRADE_MQ) {
-                if (!queue_full(upgrade_module_input)) {
+                if (!queue_full_ex(upgrade_module_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(upgrade_module_input, copy);
@@ -1398,7 +1398,7 @@ void * ad_input_main(void * args) {
                     }
                 }
             } else {
-                if (!queue_full(decode_queue_event_input)) {
+                if (!queue_full_ex(decode_queue_event_input)) {
                     os_strdup(buffer, copy);
 
                     result = queue_push_ex(decode_queue_event_input, copy);

--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -57,6 +57,15 @@ void queue_free(w_queue_t * queue);
 int queue_full(const w_queue_t * queue);
 
 /**
+ * @brief Same as queue_full but with mutual exclusion
+ * for multithreaded applications
+ *
+ * @param queue
+ * @return 1 if true, 0 if false
+ * */
+int queue_full_ex(const w_queue_t * queue);
+
+/**
  * @brief Evaluates whether the queue is empty or not
  * 
  * @param queue

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -37,6 +37,16 @@ int queue_full(const w_queue_t * queue) {
     return (queue->begin + 1) % queue->size == queue->end;
 }
 
+int queue_full_ex(const w_queue_t * queue) {
+    int is_full;
+
+    w_mutex_lock(&queue->mutex);
+    is_full = queue_full(queue);
+    w_mutex_unlock(&queue->mutex);
+
+    return is_full;
+}
+
 int queue_empty(const w_queue_t * queue) {
     return queue->begin == queue->end;
 }

--- a/src/unit_tests/shared/test_queue_op.c
+++ b/src/unit_tests/shared/test_queue_op.c
@@ -89,6 +89,18 @@ void test_queue_full(void **state){
     assert_int_equal(queue_full(queue), 1);
 }
 
+void test_queue_full_ex(void **state) {
+    w_queue_t *queue = *state;
+    expect_value_count(__wrap_pthread_mutex_lock, mutex,  &queue->mutex, QUEUE_SIZE);
+    expect_value_count(__wrap_pthread_mutex_unlock, mutex, &queue->mutex, QUEUE_SIZE);
+
+    for (int i=0; i < QUEUE_SIZE - 1; i++){
+        assert_int_equal(queue_full_ex(queue), 0);
+        queue->begin++;
+    }
+    assert_int_equal(queue_full_ex(queue), 1);
+}
+
 void test_queue_empty(void **state){
     w_queue_t *queue = *state;
     assert_int_equal(queue_empty(queue), 1);
@@ -288,6 +300,7 @@ void test_queue_pop_ex_timedwait_no_timeout(void **state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_queue_full, setup_queue, teardown_queue),
+        cmocka_unit_test_setup_teardown(test_queue_full_ex, setup_queue, teardown_queue),
         cmocka_unit_test_setup_teardown(test_queue_empty, setup_queue, teardown_queue),
         cmocka_unit_test_setup_teardown(test_queue_push, setup_queue, teardown_queue),
         cmocka_unit_test_setup_teardown(test_queue_push_ex, setup_queue, teardown_queue),


### PR DESCRIPTION
|Related issue|
|---|
|#29546|

## Description

This PR addresses a data race condition detected by ThreadSanitizer when checking if there is space in the event queue used by decoder threads in analysisd.

The root cause of the issue was a concurrent read-write access to internal queue variables (begin, end, size) without proper synchronization. The queue_full() function was being called in ad_input_main() without holding the queue mutex, while queue_pop() (which modifies the same internal state) was being called in w_decode_event_thread() under a mutex lock.

##  Changes introduced

- Added a new function queue_full_ex() which wraps queue_full() in a critical section (mutex-protected).

- Replaced direct calls to queue_full() in ad_input_main() with the thread-safe queue_full_ex() version.

- Added unit test to ensure the correctness of queue_is_full_safe() and its synchronization behavior.
