### PR TITLE
Updated repository_bumper.sh to change VIProductVersion

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -199,7 +199,7 @@ update_file_sources() {
     # Update wazuh-installer.nsi
     if [[ -n "$new_version" ]]; then
         sed -i -E "s|(^!define VERSION\s+\")[0-9]+\.[0-9]+\.[0-9]+(\")|\1${new_version}\2|" "$DIR_SRC/win32/wazuh-installer.nsi"
-        sed -i -E "s|(^VIProductVersion\s+\")[0-9]+\.[0-9]+\.[0-9]+(\.\"\$)|\1${new_version}\2|" "$DIR_SRC/win32/wazuh-installer.nsi"
+        sed -i -E "s|(^VIProductVersion\s+\")[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(\")|\1${new_version}.0\2|" "$DIR_SRC/win32/wazuh-installer.nsi"
         log_action "Modified $DIR_SRC/win32/wazuh-installer.nsi with new version: $new_version"
     fi
     if [[ -n "$new_stage" ]]; then


### PR DESCRIPTION
|Related issue|
|---|
|#29657|

This PR update `repository_bumper.sh` to change `VIProductVersion` in `wazuh-installer.nsi`.