### PR TITLE
API integration tests are failing in 4.11-performance branch - Implementation

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -1468,6 +1468,7 @@ async def insert_agent(pretty: bool = False, wait_for_complete: bool = False) ->
     return json_response(data, pretty=pretty)
 
 
+@deprecate_endpoint()
 async def get_agent_no_group(pretty: bool = False, wait_for_complete: bool = False, offset: int = 0,
                              limit: int = DATABASE_LIMIT, select=None, sort=None, search=None, q=None) -> ConnexionResponse:
     """Get agents without group.

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -8590,6 +8590,7 @@ paths:
     get:
       tags:
         - Agents
+      deprecated: true
       summary: "List agents without group"
       description: "Return a list with all the available agents without an assigned group"
       operationId: api.controllers.agent_controller.get_agent_no_group

--- a/api/test/integration/env/config.txt
+++ b/api/test/integration/env/config.txt
@@ -1,9 +1,9 @@
-| Group   | Agents                                  |
-|---------|-----------------------------------------|
-| default | 001,002,003,004,005,006,007,008,009,010 |
-| group1  | 001,005,007,008,009                     |
-| group2  | 002,005,006,008,010                     |
-| group3  | 003,006,007,008                         |
+| Group   | Agents                                        |
+|---------|-----------------------------------------------|
+| default | 001,002,003,004,005,006,007,008,009,010,11,12 |
+| group1  | 001,005,007,008,009                           |
+| group2  | 002,005,006,008,010                           |
+| group3  | 003,006,007,008                               |
 
 | Agent | Name          | Groups                       | Status          |
 |-------|---------------|------------------------------|-----------------|
@@ -18,5 +18,5 @@
 | 008   | wazuh-agent8  | default,group1,group2,group3 | active          |
 | 009   | wazuh-agent9  | default,group1               | disconnected    |
 | 010   | wazuh-agent10 | default,group2               | disconnected    |
-| 011   | wazuh-agent11 |                              | never_connected |
-| 012   | wazuh-agent12 |                              | never_connected |
+| 011   | wazuh-agent11 | default                      | never_connected |
+| 012   | wazuh-agent12 | default                      | never_connected |

--- a/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
+++ b/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
@@ -13,7 +13,7 @@ https:
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
 logs:
- level: "debug2"
+ level: "info"
  format: "plain"
 
 # Cross-origin resource sharing: https://github.com/aio-libs/aiohttp-cors#usage

--- a/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
+++ b/api/test/integration/env/configurations/base/manager/config/api/configuration/api.yaml
@@ -13,7 +13,7 @@ https:
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
 logs:
- level: "info"
+ level: "debug2"
  format: "plain"
 
 # Cross-origin resource sharing: https://github.com/aio-libs/aiohttp-cors#usage

--- a/api/test/integration/env/configurations/rbac/agent/black_config.txt
+++ b/api/test/integration/env/configurations/rbac/agent/black_config.txt
@@ -1,9 +1,9 @@
-| Group   | Agents                                  |
-|---------|-----------------------------------------|
-| default | 001,002,003,004,005,006,007,008,009,010 |
-| group1  | 001,005,007,008,009                     |
-| group2  | 002,005,006,008,010                     |
-| group3  | 003,006,007,008                         |
+| Group   | Agents                                          |
+|---------|-------------------------------------------------|
+| default | 001,002,003,004,005,006,007,008,009,010,011,012 |
+| group1  | 001,005,007,008,009                             |
+| group2  | 002,005,006,008,010                             |
+| group3  | 003,006,007,008                                 |
 
 | Agent | Name          | Groups                       | Status          |
 |-------|---------------|------------------------------|-----------------|
@@ -18,8 +18,8 @@
 | 008   | wazuh-agent8  | default,group1,group2,group3 | active          |
 | 009   | wazuh-agent9  | default,group1               | disconnected    |
 | 010   | wazuh-agent10 | default,group2               | disconnected    |
-| 011   | wazuh-agent11 |                              | never_connected |
-| 012   | wazuh-agent12 |                              | never_connected |
+| 011   | wazuh-agent11 | default                      | never_connected |
+| 012   | wazuh-agent12 | default                      | never_connected |
 
 | Resource    | List                                                |
 |-------------|-----------------------------------------------------|

--- a/api/test/integration/env/configurations/rbac/agent/white_config.txt
+++ b/api/test/integration/env/configurations/rbac/agent/white_config.txt
@@ -1,9 +1,9 @@
-| Group   | Agents                                  |
-|---------|-----------------------------------------|
-| default | 001,002,003,004,005,006,007,008,009,010 |
-| group1  | 001,005,007,008,009                     |
-| group2  | 002,005,006,008,010                     |
-| group3  | 003,006,007,008                         |
+| Group   | Agents                                          |
+|---------|-------------------------------------------------|
+| default | 001,002,003,004,005,006,007,008,009,010,011,012 |
+| group1  | 001,005,007,008,009                             |
+| group2  | 002,005,006,008,010                             |
+| group3  | 003,006,007,008                                 |
 
 | Agent | Name          | Groups                       | Status          |
 |-------|---------------|------------------------------|-----------------|
@@ -18,8 +18,8 @@
 | 008   | wazuh-agent8  | default,group1,group2,group3 | active          |
 | 009   | wazuh-agent9  | default,group1               | disconnected    |
 | 010   | wazuh-agent10 | default,group2               | disconnected    |
-| 011   | wazuh-agent11 |                              | never_connected |
-| 012   | wazuh-agent12 |                              | never_connected |
+| 011   | wazuh-agent11 | default                      | never_connected |
+| 012   | wazuh-agent12 | default                      | never_connected |
 
 | Resource    | List                                                |
 |-------------|-----------------------------------------------------|

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -1790,7 +1790,6 @@ stages:
             remoted:
               buffer_relax: !anyint
               comp_average_printout: !anyint
-              guess_agent_group: !anyint
               max_attempts: !anyint
               merge_shared: !anyint
               pass_empty_keyfile: !anyint

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -932,8 +932,10 @@ stages:
             - id: '004'
             - id: '006'
             - id: '010'
+            - id: '011'
+            - id: '012'
           failed_items: []
-          total_affected_items: 5
+          total_affected_items: 7
           total_failed_items: 0
 
   - name: Filter agents by query (group - get agents with group~group)
@@ -2560,7 +2562,7 @@ stages:
         data: &get_groups_answer
           affected_items:
             - name: 'default'
-              count: 10
+              count: 12
             - name: 'group1'
               count: 5
             - name: 'group2'
@@ -2711,7 +2713,7 @@ stages:
         data:
           affected_items:
             - name: 'default'
-              count: 10
+              count: 12
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -2771,7 +2773,7 @@ stages:
         data:
           affected_items:
             - name: 'default'
-              count: 10
+              count: 12
           failed_items: []
           total_affected_items: 1
           total_failed_items: 0
@@ -3978,11 +3980,9 @@ stages:
       json: &no_group_response
         error: 0
         data:
-          affected_items:
-            - id: '011'
-            - id: '012'
+          affected_items: []
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: 0
           total_failed_items: 0
 
   - name: Pagination
@@ -3997,10 +3997,9 @@ stages:
       json:
         error: 0
         data:
-          affected_items:
-            - id: '011'
+          affected_items: []
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: 0
           total_failed_items: 0
 
   - name: Try show agents with offset -1
@@ -4032,9 +4031,9 @@ stages:
       params:
         offset: 9999999999999999999
     response:
-      status_code: 400
+      status_code: 200
       json:
-        error: 2003
+        error: 0
 
   - name: Try show agents with limit 0
     request:
@@ -4103,10 +4102,9 @@ stages:
       json:
         error: 0
         data:
-          affected_items:
-            - id: '011'
+          affected_items: []
           failed_items: []
-          total_affected_items: 1
+          total_affected_items: 0
           total_failed_items: 0
 
   - name: Try show agents with empty search

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1275,7 +1275,6 @@ stages:
                 remoted:
                   buffer_relax: !anyint
                   comp_average_printout: !anyint
-                  guess_agent_group: !anyint
                   max_attempts: !anyint
                   merge_shared: !anyint
                   pass_empty_keyfile: !anyint

--- a/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_agent_endpoints.tavern.yaml
@@ -540,10 +540,9 @@ stages:
      json:
        error: 0
        data:
-         affected_items:
-           - id: '011'
+         affected_items: []
          failed_items: []
-         total_affected_items: 1
+         total_affected_items: 0
          total_failed_items: 0
 
 ---

--- a/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_agent_endpoints.tavern.yaml
@@ -547,10 +547,9 @@ stages:
      json:
        error: 0
        data:
-         affected_items:
-           - id: '012'
+         affected_items: []
          failed_items: []
-         total_affected_items: 1
+         total_affected_items: 0
          total_failed_items: 0
 
 ---


### PR DESCRIPTION
|Related issue|
|---|
|#29579|


## Description

This PR aims to fix #29579 failing tests by

- Explicitly defining the default group to those agents that had an empty group 
- Marking `/agents/no_group` endpoint as deprecated. Code still exists, but is meaningless
- Removing expected `guess_agent_group` field on configuration endpoints

## Tests

- [x] https://jenkins-staging.qa.wazuh.info/job/Test_integration_endpoints/70/

:warning: NOTE: known issue https://github.com/wazuh/wazuh/issues/24401