### PR TITLE
Fix failing RTR checks in GitHub Actions

### DIFF
--- a/src/data_provider/src/packages/berkeleyRpmDbHelper.h
+++ b/src/data_provider/src/packages/berkeleyRpmDbHelper.h
@@ -260,6 +260,7 @@ class BerkeleyRpmDBReader final
                     for (size_t i = 0; i < dirindexes.size(); ++i)
                     {
                         int index = dirindexes[i];
+
                         if (index >= 0 && index < static_cast<int>(dirnames.size()))
                         {
                             std::string fullPath = dirnames[index] + basenames[i];


### PR DESCRIPTION
|Related issue|
|---|
|#29804|

## Description

This PR fixes the `data_provider` coding style.

## Logs/Alerts example

```
cd src/
  python build.py --target agent --readytoreview data_provider
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/[3](https://github.com/wazuh/wazuh/actions/runs/15135332427/job/42545691154#step:6:3).11.12/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.12/x6[4](https://github.com/wazuh/wazuh/actions/runs/15135332427/job/42545691154#step:6:4)/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.12/x[6](https://github.com/wazuh/wazuh/actions/runs/15135332427/job/42545691154#step:6:6)4
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.12/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.12/x64/lib
 <data_provider>=============== Running RTR checks  ===============<data_provider> 
 <data_provider>=============== Running cppcheck    ===============<data_provider> 
 [Cppcheck: PASSED] 
 <data_provider>=============== Running AStyle      ===============<data_provider> 
 [Cleanfolder : PASSED] 
 One or more files do not follow the Coding                                  Style convention. 
 Execute astyle                                  --options=ci/input/astyle.config                                  "data_provider/*.h" "data_provider/*.hpp" "data_provider/*.cpp"                                  for further information. 
 [AStyle: FAILED] 
Traceback (most recent call last):
  File "/home/runner/work/wazuh/wazuh/src/build.py", line 1[7](https://github.com/wazuh/wazuh/actions/runs/15135332427/job/42545691154#step:6:7)0, in <module>
    processArgs()
  File "/home/runner/work/wazuh/wazuh/src/build.py", line 130, in processArgs
    run_check.runReadyToReview(moduleName=args.readytoreview,
  File "/home/runner/work/wazuh/wazuh/src/ci/run_check.py", line 3[10](https://github.com/wazuh/wazuh/actions/runs/15135332427/job/42545691154#step:6:10), in runReadyToReview
    runAStyleCheck(moduleName=moduleName)
  File "/home/runner/work/wazuh/wazuh/src/ci/run_check.py", line 140, in runAStyleCheck
    raise ValueError("Code is not complaint with the expected \
ValueError: Code is not complaint with the expected                               guidelines
Error: Process completed with exit code 1.
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
