### PR TITLE
Fix Debian package changelog addition in bumper script

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -317,9 +317,9 @@ update_file_packages() {
 cat <<EOF
 ${INSTALL_TYPE} (${final_version}-RELEASE) stable; urgency=low
 
-* More info: https://documentation.wazuh.com/current/release-notes/release-${final_version//./-}.html
+  * More info: https://documentation.wazuh.com/current/release-notes/release-${final_version//./-}.html
 
--- Wazuh, Inc <info@wazuh.com>  ${formatted_date}
+ -- Wazuh, Inc <info@wazuh.com>  ${formatted_date}
 
 EOF
 )"


### PR DESCRIPTION
|Related issue|
|---|
|#29793|

## Description

Fixed the bumper script to update the Debian package changelog to the expected format.

Example:
```
$ ./repository_bumper.sh --version 4.14.0 --stage beta1 --date 2025-10-14
```

```
$ head -n 11 ../packages/debs/SPECS/wazuh-agent/debian/changelog
wazuh-agent (4.14.0-RELEASE) stable; urgency=low

  * More info: https://documentation.wazuh.com/current/release-notes/release-4-14-0.html

 -- Wazuh, Inc <info@wazuh.com>  Tue, 14 Oct 2025 00:00:00 +0000

wazuh-agent (4.13.0-RELEASE) stable; urgency=low

  * More info: https://documentation.wazuh.com/current/release-notes/release-4-13-0.html

 -- Wazuh, Inc <info@wazuh.com>  Wed, 04 Jun 2025 00:00:00 +0000
```