### PR TITLE
Execute StartWazuhSvc after InstallFinalize to avoid upgrade errors

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -123,7 +123,7 @@
         <!-- Explicitely stopping and deleting the OSSEC service to install new Wazuh service -->
         <CustomAction Id="StopOssecService" Directory="APPLICATIONFOLDER" ExeCommand="NET STOP OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
         <CustomAction Id="DeleteOssecService" Directory="APPLICATIONFOLDER" ExeCommand="SC DELETE OssecSvc" Execute="deferred" Impersonate="no" Return="ignore" />
-        <CustomAction Id="StartWazuhSvc" BinaryKey="InstallerScripts" VBScriptCall="StartWazuhSvc" Return="check" Execute="deferred" Impersonate="no"/>
+        <CustomAction Id="StartWazuhSvc" BinaryKey="InstallerScripts" VBScriptCall="StartWazuhSvc" Return="check" Execute="immediate" Impersonate="no"/>
 
         <!-- Close the Wazuh agent GUI -->
         <CustomAction Id="CloseGUI" BinaryKey="InstallerScripts" VBScriptCall="KillGUITask" Return="check" Execute="deferred" Impersonate="no"/>
@@ -185,7 +185,7 @@
             <Custom Action="SetWazuhPermissions" After="SetCustomActionDataForSetWazuhPermissions">(WIX_UPGRADE_DETECTED) OR (PATCH)</Custom>
 
             <!-- Start services if necessary -->
-            <Custom Action="StartWazuhSvc" After="InstallServices">((WIX_UPGRADE_DETECTED) OR (PATCH)) AND ((OSSECRUNNING = "Running") OR (WAZUHRUNNING = "Running"))</Custom>
+            <Custom Action="StartWazuhSvc" After="InstallFinalize">((WIX_UPGRADE_DETECTED) OR (PATCH)) AND ((OSSECRUNNING = "Running") OR (WAZUHRUNNING = "Running"))</Custom>
 
             <!-- Stop the service as soon as possible on uninstall, and only on uninstall, in order to unlock the files and folders that must be deleted. -->
 			<Custom Action="SetRemoveAllDataValue" Before="InstallFinalize">(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>


### PR DESCRIPTION
|Related issue|
|---|
|#29170|



## Description

This PR is to avoid a possible race condition that occurs during the upgrade of the Windows agent, using the MSI package. This occurs because we are trying to start the service before completely finishing the installation of the upgrade itself.
We do this by means of a custom action defined in the .vbs script:
Testing I have been able to verify that the error stops appearing if we move this custom action to after installFinalize.
The only drawback is that the custom action must be executed in immediate mode instead of deferred, but as it is not necessary to have privileges, nor is it a custom action that makes changes to the installation, it just starts the service, no problem.


I have tried to check in several ways that this is the reason why the race condition occurs, but it is only possible to check it by testing different packages with the fix and without the fix, seeing that one gives the error and another one does not.
Some attempts have been to try to [open the handle to all the files involved in the Wazuh installation folder](https://github.com/wazuh/wazuh/compare/4.13.0...testing-4.11.2-msi?expand=1), but I have encountered no problems doing so.
It seems to be directly related to the integrity check of the dlls, in the function `enable_dll_verification`.
What the function does is to register the `dll_notification` callback, which will be called every time a library is loaded or unloaded for the first time in each module. And this seems to be interfering with the installation process.

## Testing

To reproduce the error, this script has been used:
```
$attempt = 1

while ($true) {
    Write-Host "`n===== Attempt #$attempt =====`n"

    $srcclient = "C:\Program Files (x86)\ossec-agent\client.keys.save"
    $dstclient = "C:\Program Files (x86)\ossec-agent\client.keys"
    $srclocal = "C:\Program Files (x86)\ossec-agent\local_internal_options.conf.save"
    $dstlocal = "C:\Program Files (x86)\ossec-agent\local_internal_options.conf"
    $srcconf = "C:\Program Files (x86)\ossec-agent\ossec.conf.save"
    $dstconf = "C:\Program Files (x86)\ossec-agent\ossec.conf"

    Write-Host "Installing Wazuh Agent 4.10.2..."
    Start-Process -FilePath ".\wazuh-agent-4.10.2-1.msi" -ArgumentList "/q /l*v C:\Users\vagrant\Desktop\install.log WAZUH_MANAGER=192.168.0.5" -Wait

    if (Test-Path $srcclient) {
        Write-Host "Restoring client.keys from backup..."
        if (Test-Path $dstclient) {
            Remove-Item -Path $dstclient -Force
        }
        Rename-Item -Path $srcclient -NewName $dstclient
    }
    if (Test-Path $srclocal) {
        Write-Host "Restoring local_internal_options from backup..."
        if (Test-Path $dstlocal) {
            Remove-Item -Path $dstlocal -Force
        }
        Rename-Item -Path $srclocal -NewName $dstlocal
    }
    if (Test-Path $srcconf) {
        Write-Host "Restoring ossec.conf from backup..."
        if (Test-Path $dstconf) {
            Remove-Item -Path $dstconf -Force
        }
        Rename-Item -Path $srcconf -NewName $dstconf
    }
    Start-Sleep -Seconds 3
    Write-Host "Starting Wazuh service..."
    Start-Service -Name wazuh
    Start-Sleep -Seconds 8
    $service = Get-Service -Name wazuh
    Write-Host "Checking Wazuh service status after installing 4.10.2..."
    Write-Host "Status: $($service.Status)"
    if ($service.Status -ne 'Running') {
        Write-Host "Wazuh service is not running. Exiting."
        break
    }

    Write-Host "Upgrading to Wazuh Agent 4.12.0..."
    Start-Process -FilePath ".\wazuh-agent-4.12.0-1.msi" -ArgumentList "/q /l*v C:\Users\vagrant\Desktop\install.log"  -Wait
    Start-Sleep -Seconds 8
    $service = Get-Service -Name wazuh
    Write-Host "Checking Wazuh service status after upgrading to 4.12.0..."
    Write-Host "Status: $($service.Status)"
    if ($service.Status -ne 'Running') {
        Write-Host "Wazuh service is not running. Exiting."
        break
    }

    Write-Host "Uninstalling Wazuh Agent 4.12.0..."
    Start-Process -FilePath "msiexec.exe" -ArgumentList "/x wazuh-agent-4.12.0-1.msi /qn" -Wait

    Write-Host "`n=== Loop completed successfully. Restarting process... ===`n"
    $attempt++
}
```

This script, first install a 4.10.1 package, and check that the service is in the Running state. Then reload all .save files, to maintain configuration, connection to the manager and debug mode logs.
Then upgrade with the desired package, and recheck the status. If it is not in Running, the script ends with error. If everything is correct, uninstall the agent, and start again.

Using this script with **official packages 4.10.1, and 4.12.0**, in a windows server 2025 up with virtual box, with 4 cpu and 8192 of RAM, the error is detected **80-90% of the times in the first 3 executions** of the loop, although rarely it is necessary to wait until the sixth or seventh round of the loop.

Using the package with the fix, I have even seen **over 100 turns of the loop without the error**. 