### PR TITLE
Add comma after group

### DIFF
--- a/ruleset/rules/0393-fortiauth_rules.xml
+++ b/ruleset/rules/0393-fortiauth_rules.xml
@@ -7,7 +7,7 @@
     FortiAuth ID: 44730 - 44739
 -->
 
-<group name="fortiauth">
+<group name="fortiauth,">
 
   <rule id="44730" level="0">
     <decoded_as>fortiauth</decoded_as>


### PR DESCRIPTION
Having rules with different group tags doesn't work when the main group doesn't end with a comma.
Typical typo ...