### PR TITLE
Improve IP schema validator and add unit test

### DIFF
--- a/src/engine/source/builder/test/src/component/definitions.hpp
+++ b/src/engine/source/builder/test/src/component/definitions.hpp
@@ -22,7 +22,8 @@ auto constexpr WAZUH_LOGPAR_TYPES_JSON = R"({
     "name": "name",
     "fields": {
         "wazuh.message": "text",
-        "event.code": "text"
+        "event.code": "text",
+        "source.ip": "ip"
     }
 }
 )";
@@ -149,6 +150,19 @@ auto constexpr DECODER_STAGE_NORMALIZE_WRONG_MAPPING = R"x({
         "map": [
           {
             "event.code": 2
+          }
+        ]
+      }
+    ]
+    })x";
+
+auto constexpr DECODER_STAGE_NORMALIZE_WRONG_IP_MAPPING = R"x({
+    "name": "decoder/test/0",
+    "normalize": [
+      {
+        "map": [
+          {
+            "source.ip": "127.0.0.1/17"
           }
         ]
       }
@@ -333,8 +347,10 @@ public:
 
         ON_CALL(*m_spMocks->m_spSchemf, hasField(DotPath("wazuh.message"))).WillByDefault(testing::Return(true));
         ON_CALL(*m_spMocks->m_spSchemf, hasField(DotPath("event.code"))).WillByDefault(testing::Return(true));
+        ON_CALL(*m_spMocks->m_spSchemf, hasField(DotPath("source.ip"))).WillByDefault(testing::Return(true));
         ON_CALL(*m_spMocks->m_spSchemf, isArray(DotPath("wazuh.message"))).WillByDefault(testing::Return(false));
         ON_CALL(*m_spMocks->m_spSchemf, isArray(DotPath("event.code"))).WillByDefault(testing::Return(false));
+        ON_CALL(*m_spMocks->m_spSchemf, isArray(DotPath("source.ip"))).WillByDefault(testing::Return(false));
 
         builderDeps.logpar =
             std::make_shared<hlp::logpar::Logpar>(json::Json {WAZUH_LOGPAR_TYPES_JSON}, m_spMocks->m_spSchemf);

--- a/src/engine/source/builder/test/src/component/validator_test.cpp
+++ b/src/engine/source/builder/test/src/component/validator_test.cpp
@@ -284,6 +284,19 @@ INSTANTIATE_TEST_SUITE_P(
                           return "In stage 'normalize' builder for block 'map' failed with error: Failed to build "
                                  "operation 'event.code: map(2)': event.code is of type text";
                       })),
+        ValidateA(json::Json {DECODER_STAGE_NORMALIZE_WRONG_IP_MAPPING},
+                  FAILURE_ASSET(
+                      [](const std::shared_ptr<MockSchema>& schema,
+                         const std::shared_ptr<MockDefinitionsBuilder>& defBuild,
+                         const std::shared_ptr<defs::mocks::MockDefinitions>& def)
+                      {
+                          EXPECT_CALL(*schema, validate(testing::_, testing::_))
+                              .WillOnce(testing::Return(base::Error {"source.ip value validation failed: Invalid IP"}));
+                          EXPECT_CALL(*defBuild, build(testing::_)).WillRepeatedly(testing::Return(def));
+                          return "In stage 'normalize' builder for block 'map' failed with error: Failed to build "
+                                 "operation 'source.ip: map(\"127.0.0.1/17\")': source.ip value validation "
+                                 "failed: Invalid IP";
+                      })),
         ValidateA(json::Json {DECODER_STAGE_NORMALIZE_WRONG_PARSE_WITHOUT_SEPARATOR},
                   FAILURE_ASSET(
                       [](const std::shared_ptr<MockSchema>& schema,

--- a/src/engine/source/schemf/src/valueValidators.hpp
+++ b/src/engine/source/schemf/src/valueValidators.hpp
@@ -142,7 +142,7 @@ inline ValueValidator getIpValidator()
         auto val = value.getString().value();
         auto res = ipParser(val);
 
-        if (!res.success())
+        if (!res.success() || !res.remaining().empty())
         {
             return base::Error {"Invalid IP"};
         }


### PR DESCRIPTION
|Related issue|
|---|
|#29787|

## Description

Fixed IP address validation in the builder, considering an input valid when the parsing remainder is empty. This indicates that the input corresponds solely to an IP address with no additional elements (e.g., no CIDR suffix), which could previously lead to incorrect validation.

Additionally, validation tests were added to the builder component tests to cover these cases and ensure expected behavior.