### PR TITLE
Add syn parser for key_value

### DIFF
--- a/src/engine/source/hlp/src/parsers/kvmap.cpp
+++ b/src/engine/source/hlp/src/parsers/kvmap.cpp
@@ -15,92 +15,6 @@ namespace
 using namespace hlp;
 using namespace hlp::parser;
 
-void processKeyValue(
-    json::Json& doc, std::string_view key, std::string_view value, char quote, char esc, char sep, char delim)
-{
-    bool isQuoted = false;
-    bool hasEscape = false;
-
-    // Check for escapes before cutting quotes
-    for (size_t i = 0; i + 1 < value.size(); ++i)
-    {
-        if (value[i] == esc
-            && (value[i + 1] == quote || value[i + 1] == sep || value[i + 1] == delim || value[i + 1] == esc))
-        {
-            hasEscape = true;
-            break;
-        }
-    }
-
-    // Check if it is enclosed in real (not escaped) quotes
-    auto quoted = (value.size() >= 2 && value.front() == quote && value.back() == quote
-                   && (value.size() < 2 || value[value.size() - 2] != esc));
-
-    if (quoted)
-    {
-        value = value.substr(1, value.size() - 2);
-        isQuoted = true;
-    }
-
-    // The same applies to the key
-    if (key.size() >= 2 && key.front() == quote && key.back() == quote)
-    {
-        key = key.substr(1, key.size() - 2);
-    }
-
-    updateDoc(doc, fmt::format("/{}", key), value, hasEscape, std::string(1, esc), isQuoted);
-}
-
-size_t findNext(std::string_view input, size_t start, char ch, char quote, char esc)
-{
-    bool inQuotes = false;
-
-    auto isEscaped = [quote, esc, input](size_t i)
-    {
-        return i > 0 && input[i - 1] == esc && esc != quote;
-    };
-
-    auto isDoubleQuoteEscape = [quote, esc, input](size_t i)
-    {
-        return quote == esc && i + 1 < input.size() && input[i] == quote && input[i + 1] == quote;
-    };
-
-    auto isQuoteChar = [input, quote](size_t i)
-    {
-        return input[i] == quote;
-    };
-
-    for (size_t i = start; i < input.size(); ++i)
-    {
-        if (isQuoteChar(i))
-        {
-            if (isDoubleQuoteEscape(i))
-            {
-                ++i;
-                continue;
-            }
-
-            if (quote == esc || !isEscaped(i))
-            {
-                inQuotes = !inQuotes;
-                continue;
-            }
-        }
-
-        if (input[i] == ch && !inQuotes)
-        {
-            if (isEscaped(i))
-            {
-                continue;
-            }
-
-            return i;
-        }
-    }
-
-    return std::string_view::npos;
-}
-
 Mapper getMapper(const json::Json& doc, std::string_view targetField)
 {
     return [doc, targetField](json::Json& event)
@@ -114,59 +28,96 @@ SemParser getSemParser(const std::string& targetField, char delim, char sep, cha
     return [=](std::string_view input)
     {
         json::Json doc {};
-        size_t pos = 0;
-        size_t len = input.size();
+        size_t start = 0;
 
-        while (pos < len)
+        // Search for target respecting quotes and escapes
+        auto findNext = [&](std::string_view text, size_t pos, char target) -> size_t
         {
-            size_t sepPos = findNext(input, pos, sep, quote, esc);
-            size_t delimBeforeSep = findNext(input, pos, delim, quote, esc);
-
-            // Validate that there is no delimiter before a separator
-            if (delimBeforeSep != std::string_view::npos
-                && (sepPos == std::string_view::npos || delimBeforeSep < sepPos))
+            bool inQuotes = false;
+            for (size_t i = pos; i < text.size(); ++i)
             {
-                break;
+                bool isQuote = text[i] == quote;
+                bool isEscaped = (i > 0 && text[i - 1] == esc && esc != quote);
+                bool isDoubleQuoteEscape =
+                    (quote == esc && i + 1 < text.size() && text[i] == quote && text[i + 1] == quote);
+
+                if (isQuote && !isEscaped)
+                {
+                    if (isDoubleQuoteEscape)
+                    {
+                        ++i;
+                    }
+                    else
+                    {
+                        inQuotes = !inQuotes;
+                    }
+                }
+                else if (text[i] == target && !inQuotes && !isEscaped)
+                {
+                    return i;
+                }
+            }
+            return std::string_view::npos;
+        };
+
+        // Process and normalize key/value before inserting into JSON
+        auto processKeyValue = [&](std::string_view rawKey, std::string_view rawValue)
+        {
+            // Strip outer quotes if they exist
+            bool escapedEndQuote =
+                rawValue.size() >= 2 && rawValue.back() == quote && rawValue[rawValue.size() - 2] == esc;
+            bool quoted =
+                (rawValue.size() >= 2 && rawValue.front() == quote && rawValue.back() == quote && !escapedEndQuote);
+            if (quoted)
+            {
+                rawValue.remove_prefix(1), rawValue.remove_suffix(1);
             }
 
+            if (rawKey.size() >= 2 && rawKey.front() == quote && rawKey.back() == quote)
+            {
+                rawKey.remove_prefix(1), rawKey.remove_suffix(1);
+            }
+
+            // Detect internal escapes
+            bool hasEscape = false;
+            for (size_t i = 0; i + 1 < rawValue.size(); ++i)
+            {
+                char c = rawValue[i], n = rawValue[i + 1];
+                if (c == esc && (n == quote || n == sep || n == delim || n == esc))
+                {
+                    hasEscape = true;
+                    break;
+                }
+            }
+
+            updateDoc(doc, fmt::format("/{}", rawKey), rawValue, hasEscape, std::string(1, esc), quoted);
+        };
+
+        while (start < input.size())
+        {
+            // key–value separation is sought
+            size_t sepPos = findNext(input, start, sep);
             if (sepPos == std::string_view::npos)
-            {
-                pos = (pos == 0) ? pos : pos - 1;
                 break;
-            }
 
-            // Validate non-empty key
-            auto key = input.substr(pos, sepPos - pos);
-            if (key.empty())
-            {
-                break;
-            }
+            std::string_view key = input.substr(start, sepPos - start);
+            size_t valStart = sepPos + 1;
 
-            pos = sepPos + 1;
+            // The end of the value is sought
+            size_t delimPos = findNext(input, valStart, delim);
+            std::string_view value = (delimPos == std::string_view::npos) ? input.substr(valStart)
+                                                                          : input.substr(valStart, delimPos - valStart);
 
-            // Search delimiter to find value
-            auto delimPos = findNext(input, pos, delim, quote, esc);
-            std::string_view rawVal;
+            processKeyValue(key, value);
+
             if (delimPos == std::string_view::npos)
             {
-                rawVal = input.substr(pos);
-                pos = len;
+                break;
             }
-            else
-            {
-                rawVal = input.substr(pos, delimPos - pos);
-                pos = delimPos + 1;
-            }
-
-            processKeyValue(doc, key, rawVal, quote, esc, sep, delim);
+            start = delimPos + 1;
         }
 
-        if (targetField.empty())
-        {
-            return noMapper();
-        }
-
-        return getMapper(doc, targetField);
+        return targetField.empty() ? noMapper() : getMapper(doc, targetField);
     };
 }
 
@@ -175,58 +126,84 @@ syntax::Parser getSynParser(char delim, char sep, char quote, char esc)
     return [=](std::string_view input) -> syntax::Result
     {
         if (input.empty())
-        {
             return abs::makeFailure<syntax::ResultT>(input, {});
-        }
 
         size_t pos = 0;
         size_t lastValidPos = 0;
         bool parsedAny = false;
+        std::string_view key, value;
+        bool inQuotes = false;
 
-        while (pos < input.size())
+        // Search for target respecting quotes and escapes
+        auto findNext = [&](std::string_view text, size_t start, char target) -> size_t
         {
-            auto sepPos = findNext(input, pos, sep, quote, esc);
-            auto delimBeforeSep = findNext(input, pos, delim, quote, esc);
-
-            // Validate that there is no delimiter before a separator
-            if (delimBeforeSep != std::string_view::npos
-                && (sepPos == std::string_view::npos || delimBeforeSep < sepPos))
+            for (size_t i = start; i < text.size(); ++i)
             {
-                break;
+                bool isEscaped = (i > 0 && text[i - 1] == esc && esc != quote);
+                bool isQuote = (text[i] == quote) && !isEscaped;
+                bool isDoubleQuoteEscape =
+                    (quote == esc && i + 1 < text.size() && text[i] == quote && text[i + 1] == quote);
+
+                if (isQuote)
+                {
+                    if (isDoubleQuoteEscape)
+                    {
+                        ++i;
+                    }
+                    else
+                    {
+                        inQuotes = !inQuotes;
+                    }
+                }
+                else if (text[i] == target && !inQuotes && !isEscaped)
+                {
+                    return i;
+                }
+            }
+            return std::string_view::npos;
+        };
+
+        // Validates a key=value pair using findNext
+        auto validateKeyValue =
+            [&](std::string_view text, size_t& pos, std::string_view& key, std::string_view& value) -> bool
+        {
+            size_t sepPos = findNext(text, pos, sep);
+            size_t delimPos = findNext(text, pos, delim);
+            if (delimPos != std::string_view::npos && (sepPos == std::string_view::npos || delimPos < sepPos))
+            {
+                return false;
             }
 
-            if (sepPos == std::string_view::npos)
+            if (sepPos == std::string_view::npos || sepPos == pos)
             {
-                pos == 0 ? pos : pos - 1;
-                break;
+                return false;
             }
 
-            // Validate non-empty key
-            auto key = input.substr(pos, sepPos - pos);
-            if (key.empty())
-            {
-                break;
-            }
-
+            key = text.substr(pos, sepPos - pos);
             pos = sepPos + 1;
 
-            // Search delimiter to find value
-            auto delimPos = findNext(input, pos, delim, quote, esc);
             if (delimPos == std::string_view::npos)
             {
-                input.substr(pos);
-                lastValidPos = input.size();
-                pos = input.size();
-                parsedAny = true;
-                break;
+                // If the quotes were not closed, it fails
+                if (inQuotes)
+                {
+                    return false;
+                }
+                value = text.substr(pos);
+                pos = text.size();
             }
             else
             {
-                input.substr(pos, delimPos - pos);
-                lastValidPos = delimPos;
+                value = text.substr(pos, delimPos - pos);
                 pos = delimPos + 1;
             }
 
+            return true;
+        };
+
+        while (pos < input.size() && validateKeyValue(input, pos, key, value))
+        {
+            lastValidPos = pos;
             parsedAny = true;
         }
 
@@ -252,11 +229,12 @@ Parser getKVParser(const Params& params)
                                              "character and escape character"));
     }
 
-    if (params.options[0].size() != 1 || params.options[1].size() != 1 || params.options[2].size() != 1
-        || params.options[3].size() != 1)
+    for (const auto& opt : params.options)
     {
-        throw std::runtime_error(fmt::format("KV parser: separator, delimiter, quote and escape must be single "
-                                             "characters"));
+        if (opt.size() != 1)
+        {
+            throw std::runtime_error("KV parser: separator, delimiter, quote and escape must be single characters");
+        }
     }
 
     const char sep = params.options[0][0];   // separator between key and value
@@ -264,13 +242,12 @@ Parser getKVParser(const Params& params)
     const char quote = params.options[2][0]; // quote character
     const char esc = params.options[3][0];   // escape character
 
-    // Check if the arguments of the parser are valid
     if (sep == delim)
     {
-        throw std::runtime_error(fmt::format("KV parser: separator and delimiter must be different"));
+        throw std::runtime_error("KV parser: separator and delimiter must be different");
     }
 
-    const auto targetField = params.targetField.empty() ? "" : params.targetField;
+    const auto targetField = params.targetField;
 
     const auto synP = getSynParser(delim, sep, quote, esc);
     const auto semP = getSemParser(targetField, delim, sep, quote, esc);

--- a/src/engine/source/hlp/src/parsers/parse_field.cpp
+++ b/src/engine/source/hlp/src/parsers/parse_field.cpp
@@ -86,6 +86,19 @@ void unescape(bool is_escaped, std::string& vs, std::string_view escape)
     }
 }
 
+// TODO: evaluate which is the most suitable site for this functionality
+std::string convertDotToSlash(std::string_view key)
+{
+    auto pos = key.find('.');
+    if (pos == std::string_view::npos)
+    {
+        return std::string {key};
+    }
+    std::string s {key};
+    std::replace(s.begin() + pos, s.end(), '.', '/');
+    return s;
+}
+
 void updateDoc(json::Json& doc,
                std::string_view key,
                std::string_view value,
@@ -102,7 +115,7 @@ void updateDoc(json::Json& doc,
     // If the value is a string, unescape it if necessary and add it to the JSON document
     auto vs = std::string {value.data(), value.size()};
     unescape(is_escaped, vs, escape);
-    doc.setString(vs, key);
+    doc.setString(vs, convertDotToSlash(key));
 }
 
 } // namespace hlp

--- a/src/engine/source/hlp/test/src/unit/dsv_csv_test.cpp
+++ b/src/engine/source/hlp/test/src/unit/dsv_csv_test.cpp
@@ -230,7 +230,14 @@ INSTANTIATE_TEST_SUITE_P(
                j(fmt::format(R"({{"{}":{{"f1":"v1","f2":"v2","f3":"v3"}}}})", TARGET.substr(1))),
                14,
                getCSVParser,
-               {NAME, TARGET, {""}, {"f1", "f2", "f3"}})));
+               {NAME, TARGET, {""}, {"f1", "f2", "f3"}}),
+        ParseT(SUCCESS,
+               R"("v1","v2","v3")",
+               j(fmt::format(R"({{"{}":{{"f1":{{"key":"v1"}},"f2":{{"key":"v2"}},"f3":{{"key":{{"subkey":"v3"}}}}}}}})",
+                             TARGET.substr(1))),
+               14,
+               getCSVParser,
+               {NAME, TARGET, {""}, {"f1.key", "f2/key", "f3.key/subkey"}})));
 
 /************************************
  *  DSV Parser
@@ -474,4 +481,12 @@ INSTANTIATE_TEST_SUITE_P(
                              TARGET.substr(1))),
                strlen(R"("\"value1\""|value2|value3|valueN)"),
                getDSVParser,
-               {NAME, TARGET, {""}, {"|", "\"", "\\", "out1", "out2", "out3", "outN"}})));
+               {NAME, TARGET, {""}, {"|", "\"", "\\", "out1", "out2", "out3", "outN"}}),
+        ParseT(SUCCESS,
+               R"("\"v1\""|v2|v3)",
+               j(fmt::format(
+                   R"({{"{}":{{"f1":{{"key":"\"v1\""}},"f2":{{"key":"v2"}},"f3":{{"key":{{"subkey":"v3"}}}}}}}})",
+                   TARGET.substr(1))),
+               strlen(R"("\"v1\""|v2|v3)"),
+               getDSVParser,
+               {NAME, TARGET, {""}, {"|", "\"", "\\", "f1.key", "f2/key", "f3.key/subkey"}})));

--- a/src/engine/source/hlp/test/src/unit/kvmap_test.cpp
+++ b/src/engine/source/hlp/test/src/unit/kvmap_test.cpp
@@ -59,14 +59,14 @@ INSTANTIATE_TEST_SUITE_P(
         ParseT(SUCCESS,
                R"(key1=Value1 Key2)",
                j(fmt::format(R"({{"{}":{{"key1":"Value1"}}}})", TARGET.substr(1))),
-               11,
+               12,
                getKVParser,
                {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
 
         ParseT(SUCCESS,
                R"(key1=Value1 =Value2)",
                j(fmt::format(R"({{"{}":{{"key1":"Value1"}}}})", TARGET.substr(1))),
-               11,
+               12,
                getKVParser,
                {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
 
@@ -94,7 +94,7 @@ INSTANTIATE_TEST_SUITE_P(
         ParseT(SUCCESS,
                R"(keyX:"valueX;";)",
                j(fmt::format(R"({{"{}":{{"keyX":"valueX;"}}}})", TARGET.substr(1))),
-               14,
+               15,
                getKVParser,
                {NAME, TARGET, {}, {":", ";", "\"", "\\"}}),
 
@@ -107,6 +107,8 @@ INSTANTIATE_TEST_SUITE_P(
 
         ParseT(FAILURE, R"(: ;)", {}, 0, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
 
+        ParseT(FAILURE, R"(key:'hi!)", {}, 4, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
+
         ParseT(FAILURE, R"(: valueX;)", {}, 0, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
 
         ParseT(FAILURE, R"(: valueX)", {}, 0, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
@@ -116,28 +118,28 @@ INSTANTIATE_TEST_SUITE_P(
         ParseT(SUCCESS,
                R"(key1:value1,:value2)",
                j(fmt::format(R"({{"{}":{{"key1":"value1"}}}})", TARGET.substr(1))),
-               11,
+               12,
                getKVParser,
                {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
 
         ParseT(SUCCESS,
                R"(key1:value1,key2:value2,:value3)",
                j(fmt::format(R"({{"{}":{{"key1":"value1","key2":"value2"}}}})", TARGET.substr(1))),
-               23,
+               24,
                getKVParser,
                {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
 
         ParseT(SUCCESS,
                R"(key1:value1,key2:value2,value3)",
                j(fmt::format(R"({{"{}":{{"key1":"value1","key2":"value2"}}}})", TARGET.substr(1))),
-               23,
+               24,
                getKVParser,
                {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
 
         ParseT(SUCCESS,
                R"(key1:value1,key2:value2,:)",
                j(fmt::format(R"({{"{}":{{"key1":"value1","key2":"value2"}}}})", TARGET.substr(1))),
-               23,
+               24,
                getKVParser,
                {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
 
@@ -238,7 +240,7 @@ INSTANTIATE_TEST_SUITE_P(
         ParseT(SUCCESS,
                R"(L=New York City, O=Acme U.S.A., INC., CN=update.acme.com)",
                j(fmt::format(R"({{"{}": {{"L":"New York City"," O":"Acme U.S.A."}}}})", TARGET.substr(1))),
-               30,
+               31,
                getKVParser,
                {NAME, TARGET, {}, {"=", ",", "'", "\\"}}),
 

--- a/src/engine/source/hlp/test/src/unit/kvmap_test.cpp
+++ b/src/engine/source/hlp/test/src/unit/kvmap_test.cpp
@@ -56,9 +56,19 @@ INSTANTIATE_TEST_SUITE_P(
                getKVParser,
                {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
 
-        ParseT(FAILURE, R"(key1=Value1 Key2)", {}, 11, getKVParser, {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
+        ParseT(SUCCESS,
+               R"(key1=Value1 Key2)",
+               j(fmt::format(R"({{"{}":{{"key1":"Value1"}}}})", TARGET.substr(1))),
+               11,
+               getKVParser,
+               {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
 
-        ParseT(FAILURE, R"(key1=Value1 =Value2)", {}, 12, getKVParser, {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
+        ParseT(SUCCESS,
+               R"(key1=Value1 =Value2)",
+               j(fmt::format(R"({{"{}":{{"key1":"Value1"}}}})", TARGET.substr(1))),
+               11,
+               getKVParser,
+               {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
 
         ParseT(FAILURE, R"(=Value1 =Value2)", {}, 0, getKVParser, {NAME, TARGET, {}, {"=", " ", "'", "\\"}}),
         // should we support multi chars sep or delim?
@@ -81,7 +91,12 @@ INSTANTIATE_TEST_SUITE_P(
                getKVParser,
                {NAME, TARGET, {}, {"|", ",", "'", "\\"}}),
 
-        ParseT(FAILURE, R"(keyX:"valueX;";)", {}, 14, getKVParser, {NAME, TARGET, {}, {":", ";", "\"", "\\"}}),
+        ParseT(SUCCESS,
+               R"(keyX:"valueX;";)",
+               j(fmt::format(R"({{"{}":{{"keyX":"valueX;"}}}})", TARGET.substr(1))),
+               14,
+               getKVParser,
+               {NAME, TARGET, {}, {":", ";", "\"", "\\"}}),
 
         ParseT(SUCCESS,
                R"(key1= key2="" key3=)",
@@ -90,31 +105,41 @@ INSTANTIATE_TEST_SUITE_P(
                getKVParser,
                {NAME, TARGET, {}, {"=", " ", "\"", "\\"}}),
 
-        ParseT(FAILURE, R"(: ;)", {}, 1, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
+        ParseT(FAILURE, R"(: ;)", {}, 0, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
 
-        ParseT(FAILURE, R"(: valueX;)", {}, 1, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
+        ParseT(FAILURE, R"(: valueX;)", {}, 0, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
 
-        ParseT(FAILURE, R"(: valueX)", {}, 1, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
+        ParseT(FAILURE, R"(: valueX)", {}, 0, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
 
         ParseT(FAILURE, R"(:valueX)", {}, 0, getKVParser, {NAME, TARGET, {}, {":", " ", "'", "\\"}}),
 
-        ParseT(FAILURE, R"(key1:value1,:value2)", {}, 12, getKVParser, {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
-
-        ParseT(FAILURE,
-               R"(key1:value1,key2:value2,:value3)",
-               {},
-               24,
+        ParseT(SUCCESS,
+               R"(key1:value1,:value2)",
+               j(fmt::format(R"({{"{}":{{"key1":"value1"}}}})", TARGET.substr(1))),
+               11,
                getKVParser,
                {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
 
-        ParseT(FAILURE,
-               R"(key1:value1,key2:value2,value3)",
-               {},
+        ParseT(SUCCESS,
+               R"(key1:value1,key2:value2,:value3)",
+               j(fmt::format(R"({{"{}":{{"key1":"value1","key2":"value2"}}}})", TARGET.substr(1))),
                23,
                getKVParser,
                {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
 
-        ParseT(FAILURE, R"(key1:value1,key2:value2,:)", {}, 24, getKVParser, {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
+        ParseT(SUCCESS,
+               R"(key1:value1,key2:value2,value3)",
+               j(fmt::format(R"({{"{}":{{"key1":"value1","key2":"value2"}}}})", TARGET.substr(1))),
+               23,
+               getKVParser,
+               {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
+
+        ParseT(SUCCESS,
+               R"(key1:value1,key2:value2,:)",
+               j(fmt::format(R"({{"{}":{{"key1":"value1","key2":"value2"}}}})", TARGET.substr(1))),
+               23,
+               getKVParser,
+               {NAME, TARGET, {}, {":", ",", "'", "\\"}}),
 
         ParseT(SUCCESS,
                R"("key1":"value\"1",key2:value2)",
@@ -210,9 +235,17 @@ INSTANTIATE_TEST_SUITE_P(
                getKVParser,
                {NAME, TARGET, {}, {"=", " ", "\"", "'"}}),
 
-        ParseT(FAILURE,
+        ParseT(SUCCESS,
+               R"(L=New York City, O=Acme U.S.A., INC., CN=update.acme.com)",
+               j(fmt::format(R"({{"{}": {{"L":"New York City"," O":"Acme U.S.A."}}}})", TARGET.substr(1))),
+               30,
+               getKVParser,
+               {NAME, TARGET, {}, {"=", ",", "'", "\\"}}),
+
+        ParseT(SUCCESS,
                R"(key1='value=1',key2=value''2,key3='value,3',key4='value=,''4')",
-               {},
-               14,
+               j(fmt::format(R"({{"{}": {{"key1":"value=1","key2":"value'2","key3":"value,3","key4":"value=,'4"}}}})",
+                             TARGET.substr(1))),
+               61,
                getKVParser,
                {NAME, TARGET, {}, {"=", ",", "'", "'"}})));

--- a/src/engine/test/helper_tests/helpers_description/transformation/parse_csv.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/parse_csv.yml
@@ -59,6 +59,22 @@ test:
       out3: value3
     description: Success csv parse
   - arguments:
+      input_field: value1,value2,value3
+      out1: out1.key
+      out2: out2/key
+      out3: out3.key/subkey
+    target_field: any_value
+    should_pass: true
+    expected:
+      out1:
+        key: value1
+      out2:
+        key: value2
+      out3:
+        key:
+          subkey: value3
+    description: Success csv parse with slash and dotpath
+  - arguments:
       input_field: valu1=1 value2=2
       out1: out1
       out2: out2

--- a/src/engine/test/helper_tests/helpers_description/transformation/parse_dsv.yml
+++ b/src/engine/test/helper_tests/helpers_description/transformation/parse_dsv.yml
@@ -64,6 +64,25 @@ test:
       out2: value2
     description: Success dsv parse
   - arguments:
+      input_field: value1|value2|value3
+      delim_char: "|"
+      quote_char: "'"
+      esc_char: "\\"
+      out: out1.key
+      out_2: out2/key
+      out_3: out3.key/subkey
+    target_field: any_value
+    should_pass: true
+    expected:
+      out1:
+        key: value1
+      out2:
+        key: value2
+      out3:
+        key:
+          subkey: value3
+    description: Success dsv parse with slash and dotpath
+  - arguments:
       input_field: "key1:value1"
       delim_char: "|"
       quote_char: "\\"


### PR DESCRIPTION
|Related issue|
|---|
|#29364|

## Description

This PR fixes a bug in the parse_csv function where field names using dot notation (akey.anotherkey) were incorrectly treated as literal strings instead of indicating nested fields, unlike the slash notation (akey/anotherkey), which already worked as expected.

- Updates the parse_csv logic to interpret dots (.) as sublevel indicators, the same way slashes (/) are handled.
- Ensures consistency in field mapping regardless of separator used (akey.anotherkey now maps the same as akey/anotherkey).

```
[🟢] decoder/test/0 -> success
  ↳ [/event/original: <message>] -> Success
  ↳ outmap: parse_csv($message, "akey/anotherkey", "test") -> Success
  ↳ outmap1: parse_csv($message, "akey.anotherkey", "test") -> Success

output:
  '@timestamp': '2025-04-24T21:32:40Z'
  agent:
    groups:
    - group1
    - group2
    host:
      architecture: x86_64
      hostname: wazuh-endpoint-linux
      ip:
      - 192.168.1.2
      os:
        name: Amazon Linux 2
        platform: Linux
    id: 2887e1cf-9bf2-431a-b066-a46860080f56
    name: wazuh-agent-name
    type: endpoint
    version: 5.0.0
  event:
    collector: file
    created: '2024-11-22T02:00:00Z'
    module: logcollector
    original: yes,what
  log:
    file:
      path: /var/log/syslog.log
  message: yes,what
  outmap:
    akey:
      anotherkey: 'yes'
    test: what
  outmap1:
    akey:
      anotherkey: 'yes'
    test: what
  tags:
  - production-server


```