### PR TITLE
Improve IP schema validator and add unit test

### DIFF
--- a/src/engine/source/builder/test/src/component/definitions.hpp
+++ b/src/engine/source/builder/test/src/component/definitions.hpp
@@ -22,7 +22,8 @@ auto constexpr WAZUH_LOGPAR_TYPES_JSON = R"({
     "name": "name",
     "fields": {
         "wazuh.message": "text",
-        "event.code": "text"
+        "event.code": "text",
+        "source.ip": "ip"
     }
 }
 )";
@@ -149,6 +150,19 @@ auto constexpr DECODER_STAGE_NORMALIZE_WRONG_MAPPING = R"x({
         "map": [
           {
             "event.code": 2
+          }
+        ]
+      }
+    ]
+    })x";
+
+auto constexpr DECODER_STAGE_NORMALIZE_WRONG_IP_MAPPING = R"x({
+    "name": "decoder/test/0",
+    "normalize": [
+      {
+        "map": [
+          {
+            "source.ip": "127.0.0.1/17"
           }
         ]
       }
@@ -333,8 +347,10 @@ public:
 
         ON_CALL(*m_spMocks->m_spSchemf, hasField(DotPath("wazuh.message"))).WillByDefault(testing::Return(true));
         ON_CALL(*m_spMocks->m_spSchemf, hasField(DotPath("event.code"))).WillByDefault(testing::Return(true));
+        ON_CALL(*m_spMocks->m_spSchemf, hasField(DotPath("source.ip"))).WillByDefault(testing::Return(true));
         ON_CALL(*m_spMocks->m_spSchemf, isArray(DotPath("wazuh.message"))).WillByDefault(testing::Return(false));
         ON_CALL(*m_spMocks->m_spSchemf, isArray(DotPath("event.code"))).WillByDefault(testing::Return(false));
+        ON_CALL(*m_spMocks->m_spSchemf, isArray(DotPath("source.ip"))).WillByDefault(testing::Return(false));
 
         builderDeps.logpar =
             std::make_shared<hlp::logpar::Logpar>(json::Json {WAZUH_LOGPAR_TYPES_JSON}, m_spMocks->m_spSchemf);

--- a/src/engine/source/builder/test/src/component/validator_test.cpp
+++ b/src/engine/source/builder/test/src/component/validator_test.cpp
@@ -284,6 +284,19 @@ INSTANTIATE_TEST_SUITE_P(
                           return "In stage 'normalize' builder for block 'map' failed with error: Failed to build "
                                  "operation 'event.code: map(2)': event.code is of type text";
                       })),
+        ValidateA(json::Json {DECODER_STAGE_NORMALIZE_WRONG_IP_MAPPING},
+                  FAILURE_ASSET(
+                      [](const std::shared_ptr<MockSchema>& schema,
+                         const std::shared_ptr<MockDefinitionsBuilder>& defBuild,
+                         const std::shared_ptr<defs::mocks::MockDefinitions>& def)
+                      {
+                          EXPECT_CALL(*schema, validate(testing::_, testing::_))
+                              .WillOnce(testing::Return(base::Error {"source.ip value validation failed: Invalid IP"}));
+                          EXPECT_CALL(*defBuild, build(testing::_)).WillRepeatedly(testing::Return(def));
+                          return "In stage 'normalize' builder for block 'map' failed with error: Failed to build "
+                                 "operation 'source.ip: map(\"127.0.0.1/17\")': source.ip value validation "
+                                 "failed: Invalid IP";
+                      })),
         ValidateA(json::Json {DECODER_STAGE_NORMALIZE_WRONG_PARSE_WITHOUT_SEPARATOR},
                   FAILURE_ASSET(
                       [](const std::shared_ptr<MockSchema>& schema,

--- a/src/engine/source/schemf/src/valueValidators.hpp
+++ b/src/engine/source/schemf/src/valueValidators.hpp
@@ -142,7 +142,7 @@ inline ValueValidator getIpValidator()
         auto val = value.getString().value();
         auto res = ipParser(val);
 
-        if (!res.success())
+        if (!res.success() || !res.remaining().empty())
         {
             return base::Error {"Invalid IP"};
         }


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors