### PR TITLE
Sanitize syscollector fields

### DIFF
--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -2327,3 +2327,182 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
         t.join();
     }
 }
+
+TEST_F(SyscollectorImpTest, sanitizeJsonValues)
+{
+    const auto spInfoWrapper{std::make_shared<SysInfoWrapper>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                      R"({"board_serial":" Intel Corporation","scan_time":"2020/12/28 21:49:50 ", "cpu_MHz":2904,"cpu_cores":2,"cpu_name":" Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz ", "ram_free":2257872,"ram_total":4972208,"ram_usage":54})")));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                R"({"architecture":" x86_64","scan_time":"2020/12/28 21:49:50 ", "hostname":" UBUNTU ","os_build":"  7601","os_major":"6  ","os_minor":"  1  ","os_name":" Microsoft   Windows  7 ","os_release":"   sp1","os_version":"6.1.7601   "})")));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                      R"({"iface":[{"address":"127.0.0.1 ","scan_time":" 2020/12/28 21:49:50", "mac":" d4:5d:64:51:07:5d ", "gateway":"  192.168.0.1|600","broadcast":"127.255.255.255  ", "name":"  ens1  ", "mtu":1500, "name":"enp4s0", "adapter":" ", "type":"   ethernet", "state":"up   ", "dhcp":"disabled","iface":"Loopback Pseudo-Interface 1","metric":"75","netmask":"255.0.0.0","proto":"IPv4","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0, "IPv4":[{"address":"192.168.153.1","broadcast":"192.168.153.255","dhcp":"unknown","metric":" ","netmask":"255.255.255.0"}], "IPv6":[{"address":"fe80::250:56ff:fec0:8","dhcp":"unknown","metric":" ","netmask":"ffff:ffff:ffff:ffff::"}]}]})")));
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json::parse(
+                                                                   R"([{"inode":0,"local_ip":" 127.0.0.1 ","scan_time":"  2020/12/28 21:49:50  ", "local_port":631,"pid":0,"process_name":"System  Idle Process","protocol":"tcp   ","remote_ip":"   0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0}])")));
+    EXPECT_CALL(*spInfoWrapper, packages(_))
+    .Times(::testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"architecture":" amd64","scan_time":"2020/12/28 21:49:50 ", "group":"  x11  ","name":" xserver-xorg","priority":"optional ","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14","format":"deb","location":" "})"_json));
+
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(R"([{"hotfix":" KB12345678 "}])"_json));
+
+    EXPECT_CALL(*spInfoWrapper, processes(_))
+    .Times(testing::AtLeast(1))
+    .WillOnce(::testing::InvokeArgument<0>
+              (R"({"egroup":" root ","euser":" root","fgroup":"root ","name":" kworker/u256:2-  ","scan_time":"2020/12/28 21:49:50", "nice":0,"nlwp":1,"pgrp":0,"pid":"  431625  ","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0})"_json));
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackData
+    {
+        [&wrapper](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+            delta["data"].erase("checksum");
+            delta["data"].erase("id");
+            wrapper.callbackMock(delta.dump());
+        }
+    };
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            auto delta = nlohmann::json::parse(data);
+
+            if (delta.at("type").get_ref<const std::string&>().compare("dbsync_osinfo") == 0)
+            {
+                delta["data"].erase("checksum");
+            }
+
+            delta["data"].erase("scan_time");
+            wrapperDelta.callbackMock(delta.dump());
+        }
+    };
+
+    const auto expectedResult1
+    {
+        R"({"data":{"board_serial":"Intel Corporation","checksum":"af7b22eef8f5e06c04af4db49c9f8d1d28963918","cpu_MHz":2904,"cpu_cores":2,"cpu_name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","ram_free":2257872,"ram_total":4972208,"ram_usage":54},"operation":"INSERTED","type":"dbsync_hwinfo"})"
+    };
+    const auto expectedResult2
+    {
+        R"({"data":{"architecture":"x86_64","hostname":"UBUNTU","os_build":"7601","os_major":"6","os_minor":"1","os_name":"Microsoft   Windows  7","os_release":"sp1","os_version":"6.1.7601"},"operation":"INSERTED","type":"dbsync_osinfo"})"
+    };
+    const auto expectedResult3
+    {
+        R"({"data":{"adapter":" ","checksum":"165f7160ecd2838479ee4c43c1012b723736d90a","item_id":"25eef9a0a422a9b644fb6b73650453148bc6151c","mac":"d4:5d:64:51:07:5d","mtu":1500,"name":"enp4s0","rx_bytes":0,"rx_dropped":0,"rx_errors":0,"rx_packets":0,"state":"up","tx_bytes":0,"tx_dropped":0,"tx_errors":0,"tx_packets":0,"type":"ethernet"},"operation":"INSERTED","type":"dbsync_network_iface"})"
+    };
+    const auto expectedResult4
+    {
+        R"({"data":{"checksum":"ff63981c231f110a0877ac6acd8862ac09877b5d","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"d633b040008ea38303d778431ee2fd0b4ee5a37a","metric":" ","type":"ipv4"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+    const auto expectedResult5
+    {
+        R"({"data":{"address":"192.168.153.1","broadcast":"192.168.153.255","checksum":"72dfd66759bd8062cdc17607d760a48c906189b3","iface":"enp4s0","item_id":"3d48ddc47fac84c62a19746af66fbfcf78547de9","netmask":"255.255.255.0","proto":0},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult6
+    {
+        R"({"data":{"address":"fe80::250:56ff:fec0:8","checksum":"f606d1a1c551874d8fab33e4e5cfaa0370673ec8","iface":"enp4s0","item_id":"65973316a5dc8615a6d20b2d6c4ce52ecd074496","netmask":"ffff:ffff:ffff:ffff::","proto":1},"operation":"INSERTED","type":"dbsync_network_address"})"
+    };
+    const auto expectedResult7
+    {
+        R"({"data":{"checksum":"b5cee87f8acba50334d2409d474fbac08d8015e0","inode":0,"item_id":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","local_ip":"127.0.0.1","local_port":631,"pid":0,"process_name":"System  Idle Process","protocol":"tcp","remote_ip":"0.0.0.0","remote_port":0,"rx_queue":0,"state":"listening","tx_queue":0},"operation":"INSERTED","type":"dbsync_ports"})"
+    };
+    const auto expectedResult8
+    {
+        R"({"data":{"checksum":"039934723aa69928b52e470c8d27365b0924b615","egroup":"root","euser":"root","fgroup":"root","name":"kworker/u256:2-","nice":0,"nlwp":1,"pgrp":0,"pid":"431625","ppid":2,"priority":20,"processor":1,"resident":0,"rgroup":"root","ruser":"root","session":0,"sgroup":"root","share":0,"size":0,"start_time":9302261,"state":"I","stime":3,"suser":"root","tgid":431625,"tty":0,"utime":0,"vm_size":0},"operation":"INSERTED","type":"dbsync_processes"})"
+    };
+    const auto expectedResult9
+    {
+        R"({"data":{"architecture":"amd64","checksum":"6ec380a9a572e439b68cfe87621b8a5611c0866c","format":"deb","group":"x11","item_id":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","location":" ","name":"xserver-xorg","priority":"optional","size":4111222333,"source":"xorg","version":"1:7.7+19ubuntu14"},"operation":"INSERTED","type":"dbsync_packages"})"
+    };
+    const auto expectedResult10
+    {
+        R"({"component":"syscollector_osinfo","data":{"begin":"Microsoft   Windows  7","end":"Microsoft   Windows  7"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult11
+    {
+        R"({"component":"syscollector_network_iface","data":{"begin":"25eef9a0a422a9b644fb6b73650453148bc6151c","end":"25eef9a0a422a9b644fb6b73650453148bc6151c"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult12
+    {
+        R"({"component":"syscollector_network_protocol","data":{"begin":"9dff246584835755137820c975f034d089e90b6f","end":"d633b040008ea38303d778431ee2fd0b4ee5a37a"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult13
+    {
+        R"({"component":"syscollector_network_address","data":{"begin":"3d48ddc47fac84c62a19746af66fbfcf78547de9","end":"65973316a5dc8615a6d20b2d6c4ce52ecd074496"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult14
+    {
+        R"({"component":"syscollector_ports","data":{"begin":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba","end":"cbf2ac25a6775175f912ebf2abc72f6f51ab48ba"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult15
+    {
+        R"({"component":"syscollector_processes","data":{"begin":"431625","end":"431625"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult16
+    {
+        R"({"component":"syscollector_hwinfo","data":{"begin":"Intel Corporation","end":"Intel Corporation"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult17
+    {
+        R"({"component":"syscollector_packages","data":{"begin":"4846c220a185b0fc251a07843efbfbb0d90ac4a5","end":"4846c220a185b0fc251a07843efbfbb0d90ac4a5"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult18
+    {
+        R"({"data":{"checksum":"56162cd7bb632b4728ec868e8e271b01222ff131","hotfix":"KB12345678"},"operation":"INSERTED","type":"dbsync_hotfixes"})"
+    };
+    const auto expectedResult19
+    {
+        R"({"component":"syscollector_hotfixes","data":{"begin":"KB12345678","end":"KB12345678"},"type":"integrity_check_global"})"
+    };
+    const auto expectedResult20
+    {
+        R"({"data":{"checksum":"ea17673e7422c0ab04c4f1f111a5828be8cd366a","dhcp":"unknown","gateway":"192.168.0.1|600","iface":"enp4s0","item_id":"9dff246584835755137820c975f034d089e90b6f","metric":" ","type":"ipv6"},"operation":"INSERTED","type":"dbsync_network_protocol"})"
+    };
+
+
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult1)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult2)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult3)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult4)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult5)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult6)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult7)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult8)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult9)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult10)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult11)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult12)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult13)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult14)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult15)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult16)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult17)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult18)).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(expectedResult19)).Times(1);
+    EXPECT_CALL(wrapperDelta, callbackMock(expectedResult20)).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackData, &callbackDataDelta]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          callbackDataDelta,
+                                          callbackData,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          5, true, true, true, true, true, true, true, true, true, true);
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+}


### PR DESCRIPTION
|Related issue|
|---|
| #29617 |

## Description

This PR sanitizes syscollector events by removing undesired white spaces from JSON values.

![image](https://github.com/user-attachments/assets/f3c749f2-dc4d-44ce-b56e-08efed2e717d)

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X

### Test Windows 11 agent

#### Before the fix

<details><summary>dbsync_hwinfo event</summary>

```json
{
    "timestamp": "2025-05-21T19:09:23.691+0000",
    "agent":
    {
        "id": "001",
        "name": "vm-win11",
        "ip": "192.168.56.115"
    },
    "manager":
    {
        "name": "vm-ubuntu2204-server"
    },
    "id": "1747854563.3057905",
    "full_log": "{\"data\":{\"board_serial\":\"0\",\"checksum\":\"875ea0ac7e36b1cad7e47b8fc13d8f86fa558b10\",\"cpu_cores\":4,\"cpu_mhz\":3800.0,\"cpu_name\":\"AMD Ryzen 7 5800X 8-Core Processor             \",\"ram_free\":4120392,\"ram_total\":6274756,\"ram_usage\":34,\"scan_time\":\"2025/05/21 19:09:23\"},\"operation\":\"MODIFIED\",\"type\":\"dbsync_hwinfo\"}",
    "decoder":
    {
        "name": "syscollector"
    },
    "data":
    {
        "type": "dbsync_hwinfo",
        "hardware":
        {
            "serial": "0",
            "cpu_name": "AMD Ryzen 7 5800X 8-Core Processor             ",
            "cpu_cores": "4",
            "cpu_mhz": "3800",
            "ram_total": "6274756",
            "ram_free": "4120392",
            "ram_usage": "34"
        },
        "operation_type": "MODIFIED"
    },
    "location": "syscollector"
}
```

</details> 

<details><summary>sys_hwinfo table (manager)</summary>

```console
root@vm-ubuntu2204-server:/home/vagrant# sqlite3 /var/ossec/queue/db/001.db 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.        
sqlite> select * from sys_hwinfo;
0|2025/05/21 19:09:23|0|AMD Ryzen 7 5800X 8-Core Processor             |4|3800.0|6274756|4120392|34|875ea0ac7e36b1cad7e47b8fc13d8f86fa558b10
```

</details> 

#### Fixed

<details><summary>dbsync_hwinfo event</summary>

```json
{
    "timestamp": "2025-05-22T20:18:45.228+0000",
    "agent":
    {
        "id": "002",
        "name": "vm-win11",
        "ip": "192.168.56.115"
    },
    "manager":
    {
        "name": "vm-ubuntu2204-server"
    },
    "id": "1747945125.397438",
    "full_log": "{\"data\":{\"board_serial\":\"0\",\"checksum\":\"051606a0be99493fef2265e9325a358a915eb7ab\",\"cpu_cores\":4,\"cpu_mhz\":3800.0,\"cpu_name\":\"AMD Ryzen 7 5800X 8-Core Processor\",\"ram_free\":4024104,\"ram_total\":6274756,\"ram_usage\":35,\"scan_time\":\"2025/05/22 20:18:45\"},\"operation\":\"MODIFIED\",\"type\":\"dbsync_hwinfo\"}",
    "decoder":
    {
        "name": "syscollector"
    },
    "data":
    {
        "type": "dbsync_hwinfo",
        "hardware":
        {
            "serial": "0",
            "cpu_name": "AMD Ryzen 7 5800X 8-Core Processor",
            "cpu_cores": "4",
            "cpu_mhz": "3800",
            "ram_total": "6274756",
            "ram_free": "4024104",
            "ram_usage": "35"
        },
        "operation_type": "MODIFIED"
    },
    "location": "syscollector"
}
```

</details> 

<details><summary>sys_hwinfo table (manager)</summary>

```console
root@vm-ubuntu2204-server:/home/vagrant# sqlite3 /var/ossec/queue/db/002.db 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite> select * from sys_hwinfo;
0|2025/05/22 20:22:48|0|AMD Ryzen 7 5800X 8-Core Processor|4|3800.0|6274756|4022032|35|b6212d723b7cc5aa8260e9f9eb1e700eeff97446
sqlite> 
```

</details> 