### PR TITLE
Barakat

### DIFF
--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -198,7 +198,7 @@ def generate_token(user_id: str = None, data: dict = None, auth_context: dict = 
     return jwt.encode(payload, generate_keypair()[0], algorithm=JWT_ALGORITHM)
 
 
-@rbac_utils.token_cache(rbac_utils.tokens_cache)
+@rbac_utils.token_cache()
 def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool) -> dict:
     """Check the validity of a token with the current time and the generation time of the token.
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -24,7 +24,7 @@ from wazuh.core.utils import WazuhVersion, plain_dict_to_nested_dict, get_fields
 from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.core.wazuh_socket import WazuhSocket, WazuhSocketJSON, create_wazuh_socket_message
 from wazuh.core.wdb import WazuhDBConnection
-from wazuh.rbac.utils import resources_cache, resource_cache
+from wazuh.rbac.utils import resource_cache
 
 detect_wrong_lines = re.compile(r'(.+ .+ (?:any|\d+\.\d+\.\d+\.\d+) \w+)')
 detect_valid_lines = re.compile(r'^(\d{3,}) (.+) (any|\d+\.\d+\.\d+\.\d+) (\w+)', re.MULTILINE)
@@ -1311,7 +1311,7 @@ def get_groups() -> set:
     return groups
 
 
-@resource_cache(cache=resources_cache)
+@resource_cache()
 def expand_group(group_name: str) -> set:
     """Expand a certain group or all (*) of them.
 

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -24,6 +24,7 @@ from wazuh.core.utils import WazuhVersion, plain_dict_to_nested_dict, get_fields
 from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.core.wazuh_socket import WazuhSocket, WazuhSocketJSON, create_wazuh_socket_message
 from wazuh.core.wdb import WazuhDBConnection
+from wazuh.rbac.utils import resources_cache, resource_cache
 
 detect_wrong_lines = re.compile(r'(.+ .+ (?:any|\d+\.\d+\.\d+\.\d+) \w+)')
 detect_valid_lines = re.compile(r'^(\d{3,}) (.+) (any|\d+\.\d+\.\d+\.\d+) (\w+)', re.MULTILINE)
@@ -1294,7 +1295,7 @@ def get_agents_info() -> set:
     return result
 
 
-@common.context_cached('system_groups')
+@resource_cache(cache=resources_cache)
 def get_groups() -> set:
     """Get all groups in the system.
 
@@ -1310,7 +1311,7 @@ def get_groups() -> set:
     return groups
 
 
-@common.context_cached('system_expanded_groups')
+@resource_cache(cache=resources_cache)
 def expand_group(group_name: str) -> set:
     """Expand a certain group or all (*) of them.
 
@@ -1349,7 +1350,8 @@ def expand_group(group_name: str) -> set:
     finally:
         wdb_conn.close()
 
-    return set(agents_ids) & get_agents_info()
+    system_agents = get_agents_info()
+    return set(agents_ids) & system_agents
 
 
 @lru_cache()

--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1295,7 +1295,7 @@ def get_agents_info() -> set:
     return result
 
 
-@resource_cache(cache=resources_cache)
+@common.context_cached('system_groups')
 def get_groups() -> set:
     """Get all groups in the system.
 

--- a/framework/wazuh/core/common.py
+++ b/framework/wazuh/core/common.py
@@ -136,8 +136,8 @@ _context_cache = dict()
 
 
 # =========================================== Wazuh constants and variables ============================================
-# Clear cache event.
-cache_event = Event()
+# Token cache clear event.
+token_cache_event = Event()
 _WAZUH_UID = None
 _WAZUH_GID = None
 GROUP_NAME = 'wazuh'

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -16,7 +16,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.agent import *
         from wazuh.core.exception import WazuhException
         from api.util import remove_nones_to_dict
-        from wazuh.rbac.utils import resources_cache
+        from wazuh.rbac.utils import RESOURCES_CACHE
 
 # all necessary params
 
@@ -1316,7 +1316,7 @@ def test_expand_group(socket_mock, group, wdb_response, expected_agents):
         Expected agent IDs for the selected group.
     """
     # Clear and set get_agents_info cache
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     test_get_agents_info()
 
     with patch('wazuh.core.wdb.WazuhDBConnection.send', side_effect=wdb_response):

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -16,7 +16,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.agent import *
         from wazuh.core.exception import WazuhException
         from api.util import remove_nones_to_dict
-        from wazuh.core.common import reset_context_cache
+        from wazuh.rbac.utils import resources_cache
 
 # all necessary params
 
@@ -1268,7 +1268,6 @@ def test_send_restart_command(wq_mock, wq_send_msg, agents_list, versions_list):
 
 def test_get_agents_info():
     """Test that get_agents_info() returns expected agent IDs"""
-    reset_context_cache()
     with open(os.path.join(test_data_path, 'client.keys')) as f:
         client_keys = ''.join(f.readlines())
 
@@ -1317,7 +1316,7 @@ def test_expand_group(socket_mock, group, wdb_response, expected_agents):
         Expected agent IDs for the selected group.
     """
     # Clear and set get_agents_info cache
-    reset_context_cache()
+    resources_cache.clear()
     test_get_agents_info()
 
     with patch('wazuh.core.wdb.WazuhDBConnection.send', side_effect=wdb_response):

--- a/framework/wazuh/core/tests/test_cdb_list.py
+++ b/framework/wazuh/core/tests/test_cdb_list.py
@@ -14,7 +14,8 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core import common
         from wazuh.core.cdb_list import check_path, get_list_from_file, iterate_lists, \
             split_key_value_with_quotes, validate_cdb_list, create_list_file, delete_list, get_filenames_paths
-        from wazuh.core.exception import WazuhError, WazuhException, WazuhInternalError
+        from wazuh.core.exception import WazuhError
+        from wazuh.rbac.utils import resources_cache
 
 
 # Variables
@@ -91,7 +92,7 @@ def test_iterate_lists(only_names, path):
     """
     required_fields = ['relative_dirname', 'filename'] if only_names else ['relative_dirname', 'filename', 'items']
 
-    common.reset_context_cache()
+    resources_cache.clear()
     result = iterate_lists(absolute_path=path, only_names=only_names)
     assert isinstance(result, list)
     assert len(result) != 0

--- a/framework/wazuh/core/tests/test_cdb_list.py
+++ b/framework/wazuh/core/tests/test_cdb_list.py
@@ -15,7 +15,7 @@ with patch('wazuh.core.common.wazuh_uid'):
         from wazuh.core.cdb_list import check_path, get_list_from_file, iterate_lists, \
             split_key_value_with_quotes, validate_cdb_list, create_list_file, delete_list, get_filenames_paths
         from wazuh.core.exception import WazuhError
-        from wazuh.rbac.utils import resources_cache
+        from wazuh.rbac.utils import RESOURCES_CACHE
 
 
 # Variables
@@ -92,7 +92,7 @@ def test_iterate_lists(only_names, path):
     """
     required_fields = ['relative_dirname', 'filename'] if only_names else ['relative_dirname', 'filename', 'items']
 
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     result = iterate_lists(absolute_path=path, only_names=only_names)
     assert isinstance(result, list)
     assert len(result) != 0

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -1929,30 +1929,6 @@ def test_to_relative_path():
     assert utils.to_relative_path(path, prefix='etc') == os.path.basename(path)
 
 
-@patch('wazuh.core.utils.common.RULES_PATH', new=test_files_path)
-@patch('wazuh.core.utils.common.USER_RULES_PATH', new=test_files_path)
-def test_expand_rules():
-    rules = utils.expand_rules()
-    assert rules == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
-                                                                     f'*{utils.common.RULES_EXTENSION}'))))
-
-
-@patch('wazuh.core.utils.common.DECODERS_PATH', new=test_files_path)
-@patch('wazuh.core.utils.common.USER_DECODERS_PATH', new=test_files_path)
-def test_expand_decoders():
-    decoders = utils.expand_decoders()
-    assert decoders == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
-                                                                        f'*{utils.common.DECODERS_EXTENSION}'))))
-
-
-@patch('wazuh.core.utils.common.LISTS_PATH', new=test_files_path)
-@patch('wazuh.core.utils.common.USER_LISTS_PATH', new=test_files_path)
-def test_expand_lists():
-    lists = utils.expand_lists()
-    assert lists == set(filter(lambda x: len(x.split('.')) == 1, map(os.path.basename, glob.glob(os.path.join(
-        test_files_path, f'*{utils.common.LISTS_EXTENSION}')))))
-
-
 def test_full_copy():
     """Test `full_copy` function.
 

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -2016,63 +2016,6 @@ class WazuhDBQueryGroupBy(WazuhDBQuery):
         self.select = self.select & self.filter_fields['fields']
 
 
-@common.context_cached('system_rules')
-def expand_rules() -> set:
-    """Return all ruleset rule files in the system.
-
-    Returns
-    -------
-    set
-        Rule files.
-    """
-    folders = [common.RULES_PATH, common.USER_RULES_PATH]
-    rules = set()
-    for folder in folders:
-        for _, _, files in walk(folder):
-            for f in filter(lambda x: x.endswith(common.RULES_EXTENSION), files):
-                rules.add(f)
-
-    return rules
-
-
-@common.context_cached('system_decoders')
-def expand_decoders() -> set:
-    """Return all ruleset decoder files in the system.
-
-    Returns
-    -------
-    set
-        Decoder files.
-    """
-    folders = [common.DECODERS_PATH, common.USER_DECODERS_PATH]
-    decoders = set()
-    for folder in folders:
-        for _, _, files in walk(folder):
-            for f in filter(lambda x: x.endswith(common.DECODERS_EXTENSION), files):
-                decoders.add(f)
-
-    return decoders
-
-
-@common.context_cached('system_lists')
-def expand_lists() -> set:
-    """Return all cdb list files in the system.
-
-    Returns
-    -------
-    set
-        CDB list files.
-    """
-    folders = [common.LISTS_PATH, common.USER_LISTS_PATH]
-    lists = set()
-    for folder in folders:
-        for _, _, files in walk(folder):
-            for f in filter(lambda x: x.endswith(common.LISTS_EXTENSION), files):
-                # List files do not have an extension at the moment
-                if '.' not in f:
-                    lists.add(f)
-
-    return lists
 
 
 def add_dynamic_detail(detail: str, value: str, attribs: dict, details: dict):

--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -11,7 +11,7 @@ from wazuh.core.agent import get_agents_info, get_groups, expand_group
 from wazuh.core.common import rbac, broadcast, cluster_nodes
 from wazuh.core.exception import WazuhPermissionError
 from wazuh.core.results import AffectedItemsWazuhResult
-from wazuh.core.utils import expand_rules, expand_lists, expand_decoders
+from wazuh.rbac.utils import expand_rules, expand_lists, expand_decoders
 from wazuh.rbac.orm import RolesManager, PoliciesManager, AuthenticationManager, RulesManager
 
 integer_resources = ['user:id', 'role:id', 'rule:id', 'policy:id']

--- a/framework/wazuh/rbac/orm.py
+++ b/framework/wazuh/rbac/orm.py
@@ -29,7 +29,7 @@ from api.configuration import security_conf
 from api.constants import SECURITY_PATH
 from wazuh.core.common import wazuh_uid, wazuh_gid, DEFAULT_RBAC_RESOURCES
 from wazuh.core.utils import get_utc_now, safe_move
-from wazuh.rbac.utils import clear_cache
+from wazuh.rbac.utils import clear_tokens_cache
 
 logger = logging.getLogger("wazuh-api")
 
@@ -694,7 +694,7 @@ class TokenManager(RBACManager):
                 self.session.add(RunAsTokenBlacklist())
                 self.session.commit()
 
-            clear_cache()
+            clear_tokens_cache()
             return True
         except IntegrityError:
             self.session.rollback()

--- a/framework/wazuh/rbac/tests/data/utils/test_decoders.xml
+++ b/framework/wazuh/rbac/tests/data/utils/test_decoders.xml
@@ -1,0 +1,7 @@
+<!-- NEW Local Decoders -->
+
+<!-- Modify it at your will. -->
+
+<decoder name="local_decoder_example" type="ossec">
+    <program_name>NEW DECODER</program_name>
+</decoder>

--- a/framework/wazuh/rbac/tests/data/utils/test_lists
+++ b/framework/wazuh/rbac/tests/data/utils/test_lists
@@ -1,0 +1,5 @@
+test-wazuh-w:write
+test-wazuh-r:read
+test-wazuh-a:attribute
+test-wazuh-x:execute
+test-wazuh-c:command

--- a/framework/wazuh/rbac/tests/data/utils/test_rules.xml
+++ b/framework/wazuh/rbac/tests/data/utils/test_rules.xml
@@ -1,0 +1,17 @@
+<!-- Local rules -->
+
+<!-- Modify it at your will. -->
+
+<!-- Example -->
+<group name="local,">
+
+  <!--
+   NEW RULE 
+   -->
+   <rule id="100001111" level="5">
+     <if_sid>5716</if_sid>
+     <srcip>1.1.1.1</srcip>
+     <description>sshd: authentication failed from IP 1.1.1.1.</description>
+     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+   </rule>
+</group>

--- a/framework/wazuh/rbac/tests/test_utils.py
+++ b/framework/wazuh/rbac/tests/test_utils.py
@@ -1,0 +1,37 @@
+
+import glob
+import os
+from unittest.mock import patch
+
+from wazuh.core.utils import common
+from wazuh.rbac.utils import resources_cache, expand_decoders, expand_lists, expand_rules
+
+test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+test_files_path = os.path.join(test_data_path, 'utils')
+
+
+@patch('wazuh.core.utils.common.RULES_PATH', new=test_files_path)
+@patch('wazuh.core.utils.common.USER_RULES_PATH', new=test_files_path)
+def test_expand_rules():
+    resources_cache.clear()
+    rules = expand_rules()
+    assert rules == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
+                                                                     f'*{common.RULES_EXTENSION}'))))
+
+
+@patch('wazuh.core.utils.common.DECODERS_PATH', new=test_files_path)
+@patch('wazuh.core.utils.common.USER_DECODERS_PATH', new=test_files_path)
+def test_expand_decoders():
+    resources_cache.clear()
+    decoders = expand_decoders()
+    assert decoders == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
+                                                                        f'*{common.DECODERS_EXTENSION}'))))
+
+
+@patch('wazuh.core.utils.common.LISTS_PATH', new=test_files_path)
+@patch('wazuh.core.utils.common.USER_LISTS_PATH', new=test_files_path)
+def test_expand_lists():
+    resources_cache.clear()
+    lists = expand_lists()
+    assert lists == set(filter(lambda x: len(x.split('.')) == 1, map(os.path.basename, glob.glob(os.path.join(
+        test_files_path, f'*{common.LISTS_EXTENSION}')))))

--- a/framework/wazuh/rbac/tests/test_utils.py
+++ b/framework/wazuh/rbac/tests/test_utils.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import patch
 
 from wazuh.core.utils import common
-from wazuh.rbac.utils import resources_cache, expand_decoders, expand_lists, expand_rules
+from wazuh.rbac.utils import RESOURCES_CACHE, expand_decoders, expand_lists, expand_rules
 
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 test_files_path = os.path.join(test_data_path, 'utils')
@@ -13,7 +13,7 @@ test_files_path = os.path.join(test_data_path, 'utils')
 @patch('wazuh.core.utils.common.RULES_PATH', new=test_files_path)
 @patch('wazuh.core.utils.common.USER_RULES_PATH', new=test_files_path)
 def test_expand_rules():
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     rules = expand_rules()
     assert rules == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
                                                                      f'*{common.RULES_EXTENSION}'))))
@@ -22,7 +22,7 @@ def test_expand_rules():
 @patch('wazuh.core.utils.common.DECODERS_PATH', new=test_files_path)
 @patch('wazuh.core.utils.common.USER_DECODERS_PATH', new=test_files_path)
 def test_expand_decoders():
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     decoders = expand_decoders()
     assert decoders == set(map(os.path.basename, glob.glob(os.path.join(test_files_path,
                                                                         f'*{common.DECODERS_EXTENSION}'))))
@@ -31,7 +31,7 @@ def test_expand_decoders():
 @patch('wazuh.core.utils.common.LISTS_PATH', new=test_files_path)
 @patch('wazuh.core.utils.common.USER_LISTS_PATH', new=test_files_path)
 def test_expand_lists():
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     lists = expand_lists()
     assert lists == set(filter(lambda x: len(x.split('.')) == 1, map(os.path.basename, glob.glob(os.path.join(
         test_files_path, f'*{common.LISTS_EXTENSION}')))))

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -2,20 +2,23 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-from functools import wraps
-
 from cachetools import TTLCache, cached
-from wazuh.core.common import cache_event
+from cachetools.keys import hashkey
+from functools import partial, wraps
+from os import walk
+
+from wazuh.core import common
 
 from api.configuration import security_conf
 
 # Tokens cache
-tokens_cache = TTLCache(maxsize=4500, ttl=security_conf['auth_token_exp_timeout'])
+tokens_cache = TTLCache(maxsize=4500, ttl=security_conf["auth_token_exp_timeout"])
+resources_cache = TTLCache(maxsize=100, ttl=10)
 
 
-def clear_cache():
+def clear_tokens_cache():
     """This function clear the authorization tokens cache."""
-    cache_event.set()
+    common.token_cache_event.set()
 
 
 def token_cache(cache: TTLCache):
@@ -30,22 +33,84 @@ def token_cache(cache: TTLCache):
     -------
     Requested function
     """
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            origin_node_type = kwargs.pop('origin_node_type')
+            origin_node_type = kwargs.pop("origin_node_type")
 
-            if cache_event.is_set():
+            if common.token_cache_event.is_set():
                 cache.clear()
-                cache_event.clear()
+                common.token_cache_event.clear()
 
             @cached(cache=cache)
             def f(*_args, **_kwargs):
                 return func(*_args, **_kwargs)
 
-            if origin_node_type == 'master':
+            if origin_node_type == "master":
                 return f(*args, **kwargs)
 
             return func(*args, **kwargs)
+
         return wrapper
+
     return decorator
+
+
+@cached(cache=resources_cache, key=partial(hashkey, 'expand_rules'))
+def expand_rules() -> set:
+    """Return all ruleset rule files in the system.
+
+    Returns
+    -------
+    set
+        Rule files.
+    """
+    folders = [common.RULES_PATH, common.USER_RULES_PATH]
+    rules = set()
+    for folder in folders:
+        for _, _, files in walk(folder):
+            for f in filter(lambda x: x.endswith(common.RULES_EXTENSION), files):
+                rules.add(f)
+
+    return rules
+
+
+@cached(cache=resources_cache, key=partial(hashkey, 'expand_decoders'))
+def expand_decoders() -> set:
+    """Return all ruleset decoder files in the system.
+
+    Returns
+    -------
+    set
+        Decoder files.
+    """
+    folders = [common.DECODERS_PATH, common.USER_DECODERS_PATH]
+    decoders = set()
+    for folder in folders:
+        for _, _, files in walk(folder):
+            for f in filter(lambda x: x.endswith(common.DECODERS_EXTENSION), files):
+                decoders.add(f)
+
+    return decoders
+
+
+@cached(cache=resources_cache, key=partial(hashkey, 'expand_lists'))
+def expand_lists() -> set:
+    """Return all cdb list files in the system.
+
+    Returns
+    -------
+    set
+        CDB list files.
+    """
+    folders = [common.LISTS_PATH, common.USER_LISTS_PATH]
+    lists = set()
+    for folder in folders:
+        for _, _, files in walk(folder):
+            for f in filter(lambda x: x.endswith(common.LISTS_EXTENSION), files):
+                # List files do not have an extension at the moment
+                if "." not in f:
+                    lists.add(f)
+
+    return lists

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -57,7 +57,7 @@ def token_cache(cache: TTLCache):
 
 
 def resource_cache(cache: TTLCache):
-    """Apply cache depending on the function type.
+    """Apply cache depending on the decorated function name.
 
     Parameters
     ----------
@@ -125,7 +125,7 @@ def expand_decoders() -> set:
 
 @resource_cache(cache=resources_cache)
 def expand_lists() -> set:
-    """Return all cdb list files in the system.
+    """Return all CDB list files in the system.
 
     Returns
     -------

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -11,7 +11,7 @@ from wazuh.core import common
 
 from api.configuration import security_conf
 
-tokens_cache = TTLCache(maxsize=4500, ttl=security_conf["auth_token_exp_timeout"])
+tokens_cache = TTLCache(maxsize=4500, ttl=security_conf['auth_token_exp_timeout'])
 resources_cache = TTLCache(maxsize=100, ttl=10)
 
 
@@ -36,7 +36,7 @@ def token_cache(cache: TTLCache):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            origin_node_type = kwargs.pop("origin_node_type")
+            origin_node_type = kwargs.pop('origin_node_type')
 
             if common.token_cache_event.is_set():
                 cache.clear()
@@ -46,7 +46,7 @@ def token_cache(cache: TTLCache):
             def f(*_args, **_kwargs):
                 return func(*_args, **_kwargs)
 
-            if origin_node_type == "master":
+            if origin_node_type == 'master':
                 return f(*args, **kwargs)
 
             return func(*args, **kwargs)
@@ -138,7 +138,7 @@ def expand_lists() -> set:
         for _, _, files in walk(folder):
             for f in filter(lambda x: x.endswith(common.LISTS_EXTENSION), files):
                 # List files do not have an extension at the moment
-                if "." not in f:
+                if '.' not in f:
                     lists.add(f)
 
     return lists

--- a/framework/wazuh/rbac/utils.py
+++ b/framework/wazuh/rbac/utils.py
@@ -11,8 +11,8 @@ from wazuh.core import common
 
 from api.configuration import security_conf
 
-tokens_cache = TTLCache(maxsize=4500, ttl=security_conf['auth_token_exp_timeout'])
-resources_cache = TTLCache(maxsize=100, ttl=10)
+TOKENS_CACHE = TTLCache(maxsize=4500, ttl=security_conf['auth_token_exp_timeout'])
+RESOURCES_CACHE = TTLCache(maxsize=100, ttl=10)
 
 
 def clear_tokens_cache():
@@ -20,7 +20,7 @@ def clear_tokens_cache():
     common.token_cache_event.set()
 
 
-def token_cache(cache: TTLCache):
+def token_cache(cache: TTLCache = TOKENS_CACHE):
     """Apply cache depending on whether the request comes from the master node or from a worker node.
 
     Parameters
@@ -56,7 +56,7 @@ def token_cache(cache: TTLCache):
     return decorator
 
 
-def resource_cache(cache: TTLCache):
+def resource_cache(cache: TTLCache = RESOURCES_CACHE):
     """Apply cache depending on the decorated function name.
 
     Parameters
@@ -85,7 +85,7 @@ def resource_cache(cache: TTLCache):
     return decorator
 
 
-@resource_cache(cache=resources_cache)
+@resource_cache()
 def expand_rules() -> set:
     """Return all ruleset rule files in the system.
 
@@ -104,7 +104,7 @@ def expand_rules() -> set:
     return rules
 
 
-@resource_cache(cache=resources_cache)
+@resource_cache()
 def expand_decoders() -> set:
     """Return all ruleset decoder files in the system.
 
@@ -123,7 +123,7 @@ def expand_decoders() -> set:
     return decoders
 
 
-@resource_cache(cache=resources_cache)
+@resource_cache()
 def expand_lists() -> set:
     """Return all CDB list files in the system.
 

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -25,7 +25,7 @@ with patch('wazuh.core.common.getgrnam'):
             delete_list_file
         from wazuh.core import common
         from wazuh.core.results import AffectedItemsWazuhResult
-        from wazuh.rbac.utils import resources_cache
+        from wazuh.rbac.utils import RESOURCES_CACHE
 
 
 RELATIVE_PATH = os.path.join("framework", "wazuh", "tests", "data", "test_cdb_list")
@@ -189,7 +189,7 @@ def test_get_path_lists(iterate_mock):
     `get_path_lists` works different than `get_lists` as it will read every CDB file from the default path (mocked to
     `DATA_PATH`) and will remove from the result any file that is not in the `path` parameter provided.
     """
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     result = get_path_lists(filename=[NAME_FILE_1])
 
     assert isinstance(result, AffectedItemsWazuhResult)
@@ -208,7 +208,7 @@ def test_get_path_lists_limit(iterate_mock, limit):
     limit : int
         Maximum number of items to be returned by `get_path_lists`
     """
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     result = get_path_lists(filename=NAME_FILES, limit=limit, sort_by=['filename'])
 
     assert isinstance(result, AffectedItemsWazuhResult)
@@ -227,7 +227,7 @@ def test_get_path_lists_offset(iterate_mock, offset):
     offset : int
          Indicates the first item to return.
     """
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     result = get_path_lists(filename=NAME_FILES, offset=offset, sort_by=['filename'])
 
     assert isinstance(result, AffectedItemsWazuhResult)
@@ -271,7 +271,7 @@ def test_get_path_lists_search(iterate_mock, search_text, complementary_search, 
     expected_result : list of dict
         The content expected to be returned by `get_lists` when using the specified search parameters.
     """
-    resources_cache.clear()
+    RESOURCES_CACHE.clear()
     result = get_path_lists(filename=paths, search_text=search_text, complementary_search=complementary_search,
                             search_in_fields=search_in_fields, sort_by=['filename'])
     assert isinstance(result, AffectedItemsWazuhResult)

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -25,6 +25,8 @@ with patch('wazuh.core.common.getgrnam'):
             delete_list_file
         from wazuh.core import common
         from wazuh.core.results import AffectedItemsWazuhResult
+        from wazuh.rbac.utils import resources_cache
+
 
 RELATIVE_PATH = os.path.join("framework", "wazuh", "tests", "data", "test_cdb_list")
 NAME_FILE_1 = "test_lists_1"
@@ -187,7 +189,7 @@ def test_get_path_lists(iterate_mock):
     `get_path_lists` works different than `get_lists` as it will read every CDB file from the default path (mocked to
     `DATA_PATH`) and will remove from the result any file that is not in the `path` parameter provided.
     """
-    common.reset_context_cache()
+    resources_cache.clear()
     result = get_path_lists(filename=[NAME_FILE_1])
 
     assert isinstance(result, AffectedItemsWazuhResult)
@@ -206,7 +208,7 @@ def test_get_path_lists_limit(iterate_mock, limit):
     limit : int
         Maximum number of items to be returned by `get_path_lists`
     """
-    common.reset_context_cache()
+    resources_cache.clear()
     result = get_path_lists(filename=NAME_FILES, limit=limit, sort_by=['filename'])
 
     assert isinstance(result, AffectedItemsWazuhResult)
@@ -225,7 +227,7 @@ def test_get_path_lists_offset(iterate_mock, offset):
     offset : int
          Indicates the first item to return.
     """
-    common.reset_context_cache()
+    resources_cache.clear()
     result = get_path_lists(filename=NAME_FILES, offset=offset, sort_by=['filename'])
 
     assert isinstance(result, AffectedItemsWazuhResult)
@@ -269,7 +271,7 @@ def test_get_path_lists_search(iterate_mock, search_text, complementary_search, 
     expected_result : list of dict
         The content expected to be returned by `get_lists` when using the specified search parameters.
     """
-    common.reset_context_cache()
+    resources_cache.clear()
     result = get_path_lists(filename=paths, search_text=search_text, complementary_search=complementary_search,
                             search_in_fields=search_in_fields, sort_by=['filename'])
     assert isinstance(result, AffectedItemsWazuhResult)


### PR DESCRIPTION
|Related issue|
|Ensure GDM is removed or login is configured failure regardless of configuration|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description
Ensure GDM is removed or login is configured fails due to check's condition being all which requires GDM to be removed and its configuration to exist at the same time which doesn't make sense at all to have both
<!--
Add a clear description of how the problem has been solved.
-->

## Configuration options
The condition: all was changed to condition: any in 33047 Ensure GDM is removed or login is configured. 
<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests
33047|Ensure GDM is removed or login is configured.|File: /etc/gdm3/greeter.dconf-defaults|Passed
<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors