### PR TITLE
 Revert default group assignment and restore group inference mechanism

### DIFF
--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -43,7 +43,7 @@ void add_insert(const keyentry *entry,const char *group) {
     node->name = strdup(entry->name);
     node->ip = strdup(entry->ip->ip);
     node->raw_key = strdup(entry->raw_key);
-    node->group = strdup(group ? group : "default");
+    node->group = group ? strdup(group) : NULL;
 
     (*insert_tail) = node;
     insert_tail = &node->next;

--- a/src/remoted/config.c
+++ b/src/remoted/config.c
@@ -161,6 +161,7 @@ cJSON *getRemoteInternalConfig(void) {
     cJSON_AddNumberToObject(remoted,"disk_storage",disk_storage);
     cJSON_AddNumberToObject(remoted,"rlimit_nofile",nofile);
     cJSON_AddNumberToObject(remoted,"merge_shared",logr.nocmerged);
+    cJSON_AddNumberToObject(remoted,"guess_agent_group",guess_agent_group);
     cJSON_AddNumberToObject(remoted,"receive_chunk",receive_chunk);
     cJSON_AddNumberToObject(remoted,"send_chunk",send_chunk);
     cJSON_AddNumberToObject(remoted,"buffer_relax",buffer_relax);

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -439,7 +439,7 @@ void save_controlmsg(const keyentry * key, char *r_msg, size_t msg_length, int *
 
                 w_mutex_unlock(&files_mutex);
             } else {
-                mdebug2("No group for agent '%s'", key->id);
+                merror("Error getting group for agent '%s'", key->id);
             }
 
             w_mutex_unlock(&lastmsg_mutex);

--- a/src/remoted/remcom.c
+++ b/src/remoted/remcom.c
@@ -98,6 +98,8 @@ STATIC size_t remcom_dispatch(char* request, char** output) {
     cJSON *config_json = NULL;
     cJSON *agents_json = NULL;
     cJSON *last_id_json = NULL;
+    cJSON *agent_json = NULL;
+    cJSON *md5_json = NULL;
     const char *json_err;
     int *agents_ids;
     int count;
@@ -160,6 +162,18 @@ STATIC size_t remcom_dispatch(char* request, char** output) {
                     }
                 } else {
                     *output = remcom_output_builder(ERROR_EMPTY_SECTION, error_messages[ERROR_EMPTY_SECTION], NULL);
+                }
+            } else {
+                *output = remcom_output_builder(ERROR_EMPTY_PARAMATERS, error_messages[ERROR_EMPTY_PARAMATERS], NULL);
+            }
+        } else if (strcmp(command_json->valuestring, "assigngroup") == 0) {
+            if (parameters_json = cJSON_GetObjectItem(request_json, "parameters"), cJSON_IsObject(parameters_json)) {
+                agent_json = cJSON_GetObjectItem(parameters_json, "agent");
+                md5_json = cJSON_GetObjectItem(parameters_json, "md5");
+                if (cJSON_IsString(agent_json) && cJSON_IsString(md5_json)) {
+                    *output = remcom_output_builder(ERROR_OK, error_messages[ERROR_OK], assign_group_to_agent(agent_json->valuestring, md5_json->valuestring));
+                } else {
+                    *output = remcom_output_builder(ERROR_EMPTY_AGENT_OR_MD5, error_messages[ERROR_EMPTY_AGENT_OR_MD5], NULL);
                 }
             } else {
                 *output = remcom_output_builder(ERROR_EMPTY_PARAMATERS, error_messages[ERROR_EMPTY_PARAMATERS], NULL);

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -199,6 +199,7 @@ extern int response_timeout;
 extern int INTERVAL;
 extern int disk_storage;
 extern rlim_t nofile;
+extern int guess_agent_group;
 extern unsigned receive_chunk;
 extern unsigned send_chunk;
 extern int buffer_relax;

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -99,6 +99,9 @@ void *update_shared_files(void *none);
 /* Save control messages */
 void save_controlmsg(const keyentry * key, char *msg, size_t msg_length, int *wdb_sock, bool *startup_msg);
 
+/* Assign a group to an agent without group */
+cJSON *assign_group_to_agent(const char *agent_id, const char *md5);
+
 // Initialize request module
 void req_init();
 

--- a/src/remoted/request.c
+++ b/src/remoted/request.c
@@ -43,6 +43,7 @@ int max_attempts;
 int request_pool;
 int request_timeout;
 int response_timeout;
+int guess_agent_group;
 
 // Initialize request module
 void req_init() {
@@ -53,6 +54,11 @@ void req_init() {
     rto_sec = getDefine_Int("remoted", "request_rto_sec", 0, 60);
     rto_msec = getDefine_Int("remoted", "request_rto_msec", 0, 999);
     max_attempts = getDefine_Int("remoted", "max_attempts", 1, 16);
+    guess_agent_group = getDefine_Int("remoted", "guess_agent_group", 0, 1);
+
+    if (guess_agent_group && logr.worker_node) {
+        mwarn("The internal option guess_agent_group must be configured on the master node.");
+    }
 
     // Create hash table
     if (req_table = OSHash_Create(), !req_table) {

--- a/src/unit_tests/os_auth/test_auth.c
+++ b/src/unit_tests/os_auth/test_auth.c
@@ -24,9 +24,6 @@
 #include "../wrappers/wazuh/os_auth/os_auth_wrappers.h"
 #include "../wrappers/wazuh/shared/randombytes_wrappers.h"
 
-extern struct keynode *queue_insert;
-extern struct keynode * volatile *insert_tail;
-
 /* tests */
 
 static void test_w_generate_random_pass_success(void **state) {
@@ -46,72 +43,9 @@ static void test_w_generate_random_pass_success(void **state) {
     os_free(result);
 }
 
-static int auth_setup(void **state) {
-    insert_tail = &queue_insert;
-
-    return 0;
-}
-
-static int auth_teardown(void **state) {
-    struct keynode *cur;
-    struct keynode *next;
-
-    for (cur = queue_insert; cur; cur = next) {
-        next = cur->next;
-        free(cur->id);
-        free(cur->name);
-        free(cur->ip);
-        free(cur->raw_key);
-        free(cur->group);
-        free(cur);
-    }
-
-    return 0;
-}
-
-static void test_w_insert_any_group(void **state) {
-    os_ip ip = { .ip = "127.0.0.1" };
-
-    keyentry entry = {
-        .id = "001",
-        .name = "TestName",
-        .ip = &ip,
-        .raw_key = "TestKey",
-    };
-
-    add_insert(&entry, "TestGroup");
-
-    assert_string_equal(queue_insert->id, "001");
-    assert_string_equal(queue_insert->name, "TestName");
-    assert_string_equal(queue_insert->ip, "127.0.0.1");
-    assert_string_equal(queue_insert->raw_key, "TestKey");
-    assert_string_equal(queue_insert->group, "TestGroup");
-}
-
-static void test_w_insert_null_group(void **state) {
-    os_ip ip = { .ip = "127.0.0.1" };
-
-    keyentry entry = {
-        .id = "001",
-        .name = "TestName",
-        .ip = &ip,
-        .raw_key = "TestKey",
-    };
-
-    add_insert(&entry, NULL);
-
-    assert_string_equal(queue_insert->id, "001");
-    assert_string_equal(queue_insert->name, "TestName");
-    assert_string_equal(queue_insert->ip, "127.0.0.1");
-    assert_string_equal(queue_insert->raw_key, "TestKey");
-    assert_string_equal(queue_insert->group, "default");
-}
-
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_w_generate_random_pass_success),
-        cmocka_unit_test_setup_teardown(test_w_insert_any_group, auth_setup, auth_teardown),
-        cmocka_unit_test_setup_teardown(test_w_insert_null_group, auth_setup, auth_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -30,7 +30,7 @@
 #include "../remoted/shared_download.h"
 #include "../../remoted/manager.c"
 
-int lookfor_agent_group(const char *agent_id, char **r_group, int* wdb_sock);
+int lookfor_agent_group(const char *agent_id, char *msg, char **r_group, int* wdb_sock);
 extern OSHash *agent_data_hash;
 
 /* tests */
@@ -172,8 +172,6 @@ static int test_process_deleted_groups_setup(void ** state) {
 
     test_mode = 0;
 
-    multi_groups = OSHash_Create();
-
     os_calloc(1, sizeof(group_t), group1);
     group1->name = strdup("test_default");
 
@@ -219,8 +217,6 @@ static int test_process_deleted_multi_groups_setup(void ** state) {
     group_t *multigroup2 = NULL;
 
     test_mode = 0;
-
-    multi_groups = OSHash_Create();
 
     os_calloc(1, sizeof(group_t), multigroup1);
     multigroup1->name = strdup("test_default2");
@@ -448,7 +444,6 @@ static int test_process_deleted_groups_teardown(void ** state) {
     test_mode = 0;
 
     free_group_c_group(group);
-    OSHash_Free(multi_groups);
 
     test_mode = 1;
 
@@ -551,6 +546,7 @@ void test_lookfor_agent_group_with_group()
 {
     const int agent_id = 1;
     const char agent_id_str[] = "001";
+    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
     char *r_group = NULL;
     char *test_group = strdup("TESTGROUP");
 
@@ -559,11 +555,208 @@ void test_lookfor_agent_group_with_group()
 
     expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' group is 'TESTGROUP'");
 
-    int ret = lookfor_agent_group(agent_id_str, &r_group, NULL);
+    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
     assert_int_equal(OS_SUCCESS, ret);
     assert_string_equal(r_group, test_group);
 
     os_free(test_group);
+}
+
+void test_lookfor_agent_group_set_default_group()
+{
+    const int agent_id = 1;
+    const char agent_id_str[] = "001";
+    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
+    char *r_group = NULL;
+
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent '001' with file 'merged.mg' MD5 'c2305e0ac17e7176e924294c69cc7a24'");
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    will_return(__wrap_w_is_single_node, 0);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_value(__wrap_wdb_set_agent_groups_csv, id, agent_id);
+    will_return(__wrap_wdb_set_agent_groups_csv, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Group assigned: 'default'");
+
+    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
+    assert_int_equal(OS_SUCCESS, ret);
+    assert_string_equal(r_group, "default");
+
+    os_free(r_group);
+}
+
+void test_lookfor_agent_group_set_group_worker()
+{
+    const int agent_id = 1;
+    const char agent_id_str[] = "001";
+    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
+    char *r_group = NULL;
+
+    cJSON *input = cJSON_CreateObject();
+
+    cJSON *parameters = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(parameters, "agent", "001");
+    cJSON_AddStringToObject(parameters, "md5", "c2305e0ac17e7176e924294c69cc7a24");
+
+    cJSON_AddStringToObject(input, "command", "assigngroup");
+    cJSON_AddItemToObject(input, "parameters", parameters);
+
+    cJSON * cluster_request = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(cluster_request, "daemon_name", "remoted");
+    cJSON_AddItemToObject(cluster_request, "message", input);
+
+    char *message = "{\"daemon_name\":\"remoted\","
+                     "\"message\":{\"command\":\"assigngroup\","
+                                  "\"parameters\":{\"agent\":\"001\","
+                                                  "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}";
+
+    char *response = "{\"error\":0,\"data\":{\"group\":\"test1\"}}";
+
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
+
+    expect_string(__wrap_w_create_sendsync_payload, daemon_name, "remoted");
+    will_return(__wrap_w_create_sendsync_payload, 1);
+    will_return(__wrap_w_create_sendsync_payload, cluster_request);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Sending message to master node: '{\"daemon_name\":\"remoted\","
+                                                                                    "\"message\":{\"command\":\"assigngroup\","
+                                                                                                 "\"parameters\":{\"agent\":\"001\","
+                                                                                                                 "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}'");
+
+    expect_string(__wrap_w_send_clustered_message, command, "sendsync");
+    expect_string(__wrap_w_send_clustered_message, payload, message);
+    will_return(__wrap_w_send_clustered_message, response);
+    will_return(__wrap_w_send_clustered_message, 0);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Message received from master node: '{\"error\":0,\"data\":{\"group\":\"test1\"}}'");
+
+    logr.worker_node = 1;
+    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
+    logr.worker_node = 0;
+
+    assert_int_equal(OS_SUCCESS, ret);
+    assert_string_equal(r_group, "test1");
+
+    os_free(r_group);
+}
+
+void test_lookfor_agent_group_set_group_worker_error()
+{
+    const int agent_id = 1;
+    const char agent_id_str[] = "001";
+    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00\nc2305e0ac17e7176e924294c69cc7a24 merged.mg\n#\"_agent_ip\":10.0.2.4";
+    char *r_group = NULL;
+
+    cJSON *input = cJSON_CreateObject();
+
+    cJSON *parameters = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(parameters, "agent", "001");
+    cJSON_AddStringToObject(parameters, "md5", "c2305e0ac17e7176e924294c69cc7a24");
+
+    cJSON_AddStringToObject(input, "command", "assigngroup");
+    cJSON_AddItemToObject(input, "parameters", parameters);
+
+    cJSON * cluster_request = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(cluster_request, "daemon_name", "remoted");
+    cJSON_AddItemToObject(cluster_request, "message", input);
+
+    char *message = "{\"daemon_name\":\"remoted\","
+                     "\"message\":{\"command\":\"assigngroup\","
+                                  "\"parameters\":{\"agent\":\"001\","
+                                                  "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}";
+
+    char *response = "{\"error\":1,\"data\":{}}";
+
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
+
+    expect_string(__wrap_w_create_sendsync_payload, daemon_name, "remoted");
+    will_return(__wrap_w_create_sendsync_payload, 1);
+    will_return(__wrap_w_create_sendsync_payload, cluster_request);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Sending message to master node: '{\"daemon_name\":\"remoted\","
+                                                                                    "\"message\":{\"command\":\"assigngroup\","
+                                                                                                 "\"parameters\":{\"agent\":\"001\","
+                                                                                                                 "\"md5\":\"c2305e0ac17e7176e924294c69cc7a24\"}}}'");
+
+    expect_string(__wrap_w_send_clustered_message, command, "sendsync");
+    expect_string(__wrap_w_send_clustered_message, payload, message);
+    will_return(__wrap_w_send_clustered_message, response);
+    will_return(__wrap_w_send_clustered_message, 1);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Message received from master node: '{\"error\":1,\"data\":{}}'");
+
+    expect_string(__wrap__merror, formatted_msg, "Agent '001' invalid or empty group assigned.");
+
+    logr.worker_node = 1;
+    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
+    logr.worker_node = 0;
+
+    assert_int_equal(OS_INVALID, ret);
+    assert_null(r_group);
+}
+
+void test_lookfor_agent_group_msg_without_enter()
+{
+    const int agent_id = 2;
+    const char agent_id_str[] = "002";
+    char *msg = "Linux |localhost.localdomain |4.18.0-240.22.1.el8_3.x86_64 |#1 SMP Thu Apr 8 19:01:30 UTC 2021 |x86_64 [CentOS Linux|centos: 8.3] - Wazuh v4.2.0 / ab73af41699f13fdd81903b5f23d8d00c2305e0ac17e7176e924294c69cc7a24 merged.mg";
+    char *r_group = NULL;
+
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid message from agent ID '002' (strchr \\n)");
+
+    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
+    assert_int_equal(OS_INVALID, ret);
+    assert_null(r_group);
+}
+
+void test_lookfor_agent_group_bad_message()
+{
+    const int agent_id = 3;
+    const char agent_id_str[] = "003";
+    char *msg = "Linux |localhost.localdomain\n#c2305e0ac17e7176e924294c69cc7a24 merged.mg\nc2305e0ac17e7176e924294c69cc7a24merged.mg\n#\"_agent_ip\":10.0.2.4";
+    char *r_group = NULL;
+
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
+
+     expect_string(__wrap__merror, formatted_msg, "Invalid message from agent ID '003' (strchr ' ')");
+
+    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
+    assert_int_equal(OS_INVALID, ret);
+    assert_null(r_group);
+}
+
+void test_lookfor_agent_group_message_without_second_enter()
+{
+    const int agent_id = 4;
+    const char agent_id_str[] = "004";
+    char *msg = "Linux |localhost.localdomain \n#\"_agent_ip\":10.0.2.4";
+    char *r_group = NULL;
+
+    expect_value(__wrap_wdb_get_agent_group, id, agent_id);
+    will_return(__wrap_wdb_get_agent_group, NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid message from agent ID '004' (strchr \\n)");
+
+    int ret = lookfor_agent_group(agent_id_str, msg, &r_group, NULL);
+    assert_int_equal(OS_INVALID, ret);
+    assert_null(r_group);
 }
 
 void test_c_group_no_changes(void **state)
@@ -1802,6 +1995,114 @@ void test_c_multi_group_call_c_group(void **state)
 
     os_free(hash_multigroup);
     os_free(multi_group);
+}
+
+void test_find_group_from_file_found(void **state)
+{
+    char group_name[OS_SIZE_65536] = {0};
+
+    OSHashNode* node = NULL;
+    os_calloc(1, sizeof(OSHashNode), node);
+    node->data = state[0];
+
+    expect_value(__wrap_OSHash_Begin, self, groups);
+    will_return(__wrap_OSHash_Begin, node);
+
+    group_t *group = find_group_from_sum("ABCDEF1234567890", group_name);
+
+    assert_string_equal(group_name, "test_default");
+    assert_non_null(group);
+    assert_string_equal(group->name, "test_default");
+
+    os_free(node);
+}
+
+void test_find_group_from_file_not_found(void **state)
+{
+    char group_name[OS_SIZE_65536] = {0};
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = state[0];
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->data = state[1];
+
+    expect_value(__wrap_OSHash_Begin, self, groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Next, self, groups);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    group_t *group = find_group_from_sum("2121212121", group_name);
+
+    assert_string_equal(group_name, "\0");
+    assert_null(group);
+
+    os_free(node1);
+    os_free(node2);
+}
+
+void test_find_multi_group_from_file_found(void **state)
+{
+    char multi_group_name[OS_SIZE_65536] = {0};
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = state[0];
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->data = state[1];
+
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    group_t *multi_group = find_multi_group_from_sum("1234567890ABCDFE", multi_group_name);
+
+    assert_string_equal(multi_group_name, "test_test_default2");
+    assert_non_null(multi_group);
+    assert_string_equal(multi_group->name, "test_test_default2");
+
+    os_free(node1);
+    os_free(node2);
+}
+
+void test_find_multi_group_from_file_not_found(void **state)
+{
+    char multi_group_name[OS_SIZE_65536] = {0};
+
+    OSHashNode* node1 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node1);
+    node1->data = state[0];
+
+    OSHashNode* node2 = NULL;
+    os_calloc(1, sizeof(OSHashNode), node2);
+    node2->data = state[1];
+
+    expect_value(__wrap_OSHash_Begin, self, multi_groups);
+    will_return(__wrap_OSHash_Begin, node1);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, node2);
+
+    expect_value(__wrap_OSHash_Next, self, multi_groups);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    group_t *multi_group = find_multi_group_from_sum("4545454545", multi_group_name);
+
+    assert_string_equal(multi_group_name, "\0");
+    assert_null(multi_group);
+
+    os_free(node1);
+    os_free(node2);
 }
 
 void test_ftime_changed_same_fsum(void **state)
@@ -4925,6 +5226,12 @@ int main(void)
     const struct CMUnitTest tests[] = {
         // Tests lookfor_agent_group
         cmocka_unit_test(test_lookfor_agent_group_with_group),
+        cmocka_unit_test(test_lookfor_agent_group_set_default_group),
+        cmocka_unit_test(test_lookfor_agent_group_set_group_worker),
+        cmocka_unit_test(test_lookfor_agent_group_set_group_worker_error),
+        cmocka_unit_test(test_lookfor_agent_group_msg_without_enter),
+        cmocka_unit_test(test_lookfor_agent_group_bad_message),
+        cmocka_unit_test(test_lookfor_agent_group_message_without_second_enter),
         // Tests c_group
         cmocka_unit_test_setup_teardown(test_c_group_no_changes, test_c_group_setup, test_c_group_teardown),
         cmocka_unit_test_setup_teardown(test_c_group_no_changes_disk, test_c_group_setup, test_c_group_teardown),
@@ -4950,6 +5257,12 @@ int main(void)
         cmocka_unit_test(test_c_multi_group_Ignore_hidden_files),
         cmocka_unit_test(test_c_multi_group_subdir_fail),
         cmocka_unit_test(test_c_multi_group_call_c_group),
+        // Test find_group_from_sum
+        cmocka_unit_test_setup_teardown(test_find_group_from_file_found, test_find_group_setup, test_c_group_teardown),
+        cmocka_unit_test_setup_teardown(test_find_group_from_file_not_found, test_find_group_setup, test_c_group_teardown),
+        // Test find_multi_group_from_sum
+        cmocka_unit_test_setup_teardown(test_find_multi_group_from_file_found, test_find_multi_group_setup, test_c_multi_group_teardown),
+        cmocka_unit_test_setup_teardown(test_find_multi_group_from_file_not_found, test_find_multi_group_setup, test_c_multi_group_teardown),
         // Test ftime_changed
         cmocka_unit_test_setup_teardown(test_ftime_changed_same_fsum, test_ftime_changed_setup, test_ftime_changed_teardown),
         cmocka_unit_test_setup_teardown(test_ftime_changed_different_fsum_sum, test_ftime_changed_setup, test_ftime_changed_teardown),

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -4709,7 +4709,7 @@ void test_save_controlmsg_update_msg_lookfor_agent_group_fail(void **state)
 
     expect_function_call(__wrap_pthread_mutex_unlock);
 
-    expect_string(__wrap__mdebug2, formatted_msg, "No group for agent '001'");
+    expect_string(__wrap__merror, formatted_msg, "Error getting group for agent '001'");
 
     agent_info_data *agent_data;
     os_calloc(1, sizeof(agent_info_data), agent_data);

--- a/src/unit_tests/remoted/test_remcom.c
+++ b/src/unit_tests/remoted/test_remcom.c
@@ -309,6 +309,52 @@ void test_remcom_dispatch_getagentsstats_array_ok(void ** state) {
     assert_int_equal(size, strlen(response));
 }
 
+void test_remcom_dispatch_assigngroup(void ** state) {
+    char* request = "{\"command\":\"assigngroup\", \"parameters\": {\"agent\": \"001\", \"md5\": \"1234567890abcdef\"}}";
+    char *response = NULL;
+
+    cJSON* data_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(data_json, "group", "test1");
+
+    expect_string(__wrap_assign_group_to_agent, agent_id, "001");
+    expect_string(__wrap_assign_group_to_agent, md5, "1234567890abcdef");
+    will_return(__wrap_assign_group_to_agent, data_json);
+
+    size_t size = remcom_dispatch(request, &response);
+
+    *state = response;
+
+    assert_non_null(response);
+    assert_string_equal(response, "{\"error\":0,\"message\":\"ok\",\"data\":{\"group\":\"test1\"}}");
+    assert_int_equal(size, strlen(response));
+}
+
+void test_remcom_dispatch_assigngroup_invalid_parameters(void ** state) {
+    char* request = "{\"command\":\"assigngroup\", \"parameters\": {\"md5\": \"1234567890abcdef\"}}";
+    char *response = NULL;
+
+    size_t size = remcom_dispatch(request, &response);
+
+    *state = response;
+
+    assert_non_null(response);
+    assert_string_equal(response, "{\"error\":12,\"message\":\"Invalid agent or md5 parameter\",\"data\":{}}");
+    assert_int_equal(size, strlen(response));
+}
+
+void test_remcom_dispatch_assigngroup_empty_parameters(void ** state) {
+    char* request = "{\"command\":\"assigngroup\"}}";
+    char *response = NULL;
+
+    size_t size = remcom_dispatch(request, &response);
+
+    *state = response;
+
+    assert_non_null(response);
+    assert_string_equal(response, "{\"error\":5,\"message\":\"Empty parameters\",\"data\":{}}");
+    assert_int_equal(size, strlen(response));
+}
+
 void test_remcom_dispatch_unknown_command(void ** state) {
     char* request = "{\"command\":\"unknown\"}";
     char *response = NULL;
@@ -676,6 +722,9 @@ int main(void) {
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_all_ok, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_array_empty_agents, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_getagentsstats_array_ok, test_teardown),
+        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup, test_teardown),
+        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup_invalid_parameters, test_teardown),
+        cmocka_unit_test_teardown(test_remcom_dispatch_assigngroup_empty_parameters, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_unknown_command, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_empty_command, test_teardown),
         cmocka_unit_test_teardown(test_remcom_dispatch_invalid_json, test_teardown),

--- a/src/wazuh_db/schema_global.sql
+++ b/src/wazuh_db/schema_global.sql
@@ -84,6 +84,4 @@ CREATE TABLE IF NOT EXISTS metadata (
     value TEXT
 );
 
-INSERT INTO `group` (name) VALUES ('default');
-
 INSERT INTO metadata (key, value) VALUES ('db_version', '7');

--- a/src/wazuh_db/schema_global_upgrade_v7.sql
+++ b/src/wazuh_db/schema_global_upgrade_v7.sql
@@ -50,17 +50,6 @@ CREATE INDEX IF NOT EXISTS agent_name ON agent (name);
 CREATE INDEX IF NOT EXISTS agent_ip ON agent (ip);
 CREATE INDEX IF NOT EXISTS agent_group_hash ON agent (group_hash);
 
-INSERT OR IGNORE INTO `group` (name) VALUES ('default');
-
-UPDATE agent SET `group` = 'default' WHERE `group` IS NULL AND id != 0;
-
-WITH default_group AS (
-    SELECT id AS id_group FROM `group` WHERE name = 'default'
-) INSERT INTO belongs (id_agent, id_group, priority)
-SELECT agent.id, dg.id_group, 0 FROM agent CROSS JOIN default_group dg WHERE agent.id != 0 AND NOT EXISTS (
-    SELECT 1 FROM belongs WHERE belongs.id_agent = agent.id
-);
-
 UPDATE metadata SET value = '7' WHERE key = 'db_version';
 
 END;

--- a/tests/integration/test_authd/conftest.py
+++ b/tests/integration/test_authd/conftest.py
@@ -63,7 +63,7 @@ def insert_pre_existent_agents(test_metadata, stop_authd):
             else:
                 registration_time = time_now
 
-            mocking.create_mocked_agent(id=id, name=name, ip=ip, date_add=registration_time, group='default',
+            mocking.create_mocked_agent(id=id, name=name, ip=ip, date_add=registration_time,
                                         connection_status=connection_status, disconnection_time=disconnection_time,
                                         client_key_secret=key)
 

--- a/tests/integration/test_authd/test_cluster/data/test_cases/cases_authd_local.yaml
+++ b/tests/integration/test_authd/test_cluster/data/test_cases/cases_authd_local.yaml
@@ -6,19 +6,15 @@
     -
       input: '{"arguments":{"name":"user1","ip":"any"},"function":"add"}'
       output: '{"error":0,"data":{"id":"001","name":"user1","ip":"any","key":'
-      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user2","ip":"192.0.0.0"},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"user2","ip":"192.0.0.0","key":'
-      expected_group: 'default'
     -
       input: '{"arguments":{"id":"100","name":"user100","ip":"any"},"function":"add"}'
       output: '{"error":0,"data":{"id":"100","name":"user100","ip":"any","key":'
-      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user4","ip":"any","id":"101","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"},"function":"add"}'
       output: '{"error":0,"data":{"id":"101","name":"user4","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"'
-      expected_group: 'default'
     pre_existent_agents:
     -
     groups:
@@ -82,15 +78,12 @@
     -
       input: '{"arguments":{"name":"user1","ip":"any","force":{"enabled":true, "key_mismatch":false, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"004","name":"user1","ip":"any","key":'
-      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user_2","ip":"192.0.0.0","force":{"enabled":true, "key_mismatch":false, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"005","name":"user_2","ip":"192.0.0.0","key":'
-      expected_group: 'default'
     -
       input: '{"arguments":{"id":"003","name":"user_3","ip":"any","force":{"enabled":true, "key_mismatch":false, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"003","name":"user_3","ip":"any","key":'
-      expected_group: 'default'
     pre_existent_agents:
     -
       id: '001'
@@ -118,14 +111,12 @@
     -
       input: '{"arguments":{"name":"user21","ip":"any","groups":"Group1"},"function":"add"}'
       output: '{"error":0,"data":{"id":"001","name":"user21","ip":"any","key":'
-      expected_group: 'Group1'
     -
       input: '{"arguments":{"name":"user_","ip":"any","groups":"Group_"},"function":"add"}'
       output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
     -
       input: '{"arguments":{"name":"user22","ip":"any","groups":"Group1,Group2"},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"user22","ip":"any","key":'
-      expected_group: 'Group1,Group2'
     -
       input: '{"arguments":{"name":"user_","ip":"any","groups":"Group1,Group2,Group3"},"function":"add"}'
       output: '{"error":9014,"message":"Invalid Group(s) Name(s)"}'
@@ -178,14 +169,12 @@
     -
       input: '{"arguments":{"name":"new_user1","ip":"any","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"new_user1","ip":"any","key":'
-      expected_group: 'default'
     -
       input: '{"arguments":{"name":"user1","ip":"any","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":9008,"message":"Duplicate name"}'
     -
       input: '{"arguments":{"name":"user1","ip":"any","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"003","name":"user1","ip":"any","key":'
-      expected_group: 'default'
     pre_existent_agents:
     -
       id: '001'
@@ -203,7 +192,6 @@
     -
       input: '{"arguments":{"name":"new_user","ip":"10.0.0.1","groups":"Group1","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"002","name":"new_user","ip":"10.0.0.1","key":'
-      expected_group: 'Group1'
     -
       input: '{"arguments":{"name":"user1","ip":"any","groups":"Group1","key_hash":"74ccacd341a6087b2d3a31656b07664a9c5bb307","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":9008,"message":"Duplicate name"}'
@@ -213,7 +201,6 @@
     -
       input: '{"arguments":{"name":"user1","ip":"10.10.10.10","groups":"Group1","key_hash":"123ABC","force":{"enabled":true, "key_mismatch":true, "disconnected_time":{"enabled":false, "value":"0"}, "after_registration_time":"0"}},"function":"add"}'
       output: '{"error":0,"data":{"id":"003","name":"user1","ip":"10.10.10.10","key":'
-      expected_group: 'Group1'
     pre_existent_agents:
     -
       id: '001'

--- a/tests/integration/test_authd/test_cluster/test_authd_local.py
+++ b/tests/integration/test_authd/test_cluster/test_authd_local.py
@@ -39,13 +39,10 @@ tags:
 '''
 from pathlib import Path
 
-import json
 import pytest
-import time
 
 from wazuh_testing.constants.paths.sockets import WAZUH_DB_SOCKET_PATH, AUTHD_SOCKET_PATH
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, WAZUH_DB_DAEMON
-from wazuh_testing.utils import database
 from wazuh_testing.utils.configuration import load_configuration_template, get_test_cases_data
 
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
@@ -139,20 +136,3 @@ def test_authd_local_messages(test_configuration, test_metadata, set_wazuh_confi
         assert response[:len(expected)] == expected, \
             'Failed: Response was: {} instead of: {}' \
             .format(response, expected)
-
-        if 'expected_group' in case:
-            data = json.loads(response)['data']
-            query = "global sql SELECT * FROM `agent` WHERE `id` = {}".format(data['id'])
-
-            for i in range(3):
-                group = database.query_wdb(query)
-
-                if group:
-                    break
-
-                time.sleep(1)
-
-            if not group:
-                assert False, 'The agent was not created in the database'
-
-            assert group[0]['group'] == case['expected_group']

--- a/tests/integration/test_authd/test_common/data/test_cases/cases_authd.yaml
+++ b/tests/integration/test_authd/test_common/data/test_cases/cases_authd.yaml
@@ -6,7 +6,6 @@
     -
       input: "OSSEC A:'user1'"
       output: "OSSEC K:'"
-      expected_group: "default"
     groups:
       -
 
@@ -18,7 +17,6 @@
     -
       input: "OSSEC A:'user2' G:'Group1'"
       output: "OSSEC K:"
-      expected_group: "Group1"
     groups:
       - 'Group1'
       - 'Group2'
@@ -92,7 +90,6 @@
     -
       input: "OSSEC A:'user3' G:'Group1,Group2'"
       output: "OSSEC K:"
-      expected_group: "Group1,Group2"
 
 - name: "Multiple Group - One group is invalid"
   description: "Check Multiple groups enrollment"

--- a/tests/integration/test_authd/test_common/test_authd.py
+++ b/tests/integration/test_authd/test_common/test_authd.py
@@ -52,7 +52,6 @@ from pathlib import Path
 from . import CONFIGURATIONS_FOLDER_PATH, TEST_CASES_FOLDER_PATH
 from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_ENROLLMENT_PORT
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, WAZUH_DB_DAEMON, MODULES_DAEMON
-from wazuh_testing.utils import database
 from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
 
 # Marks
@@ -153,20 +152,3 @@ def test_ossec_auth_messages(test_configuration, test_metadata, set_wazuh_config
                 assert response != '', 'The manager did not respond to the message sent.'
         assert response[:len(expected)] == expected, \
             'Failed test case {}: Response was: {} instead of: {}'.format(set_up_groups['name'], response, expected)
-
-        if 'expected_group' in stage:
-            id = int(response.split("K:'")[1].split()[0])
-            query = "global sql SELECT * FROM `agent` WHERE `id` = {}".format(id)
-
-            for i in range(3):
-                group = database.query_wdb(query)
-
-                if group:
-                    break
-
-                time.sleep(1)
-
-            if not group:
-                assert False, 'The agent was not created in the database'
-
-            assert group[0]['group'] == stage['expected_group']


### PR DESCRIPTION
## Description

This pull request reverts recent changes that automatically assigned the "default" group to newly registered agents and removed the group inference logic during keep-alive processing. These changes introduced complex race conditions during cluster synchronization, which proved difficult to resolve cleanly.

By reverting these changes, we restore the previous behavior where agents can be registered without an assigned group, and the manager dynamically infers the group assignment at connection time if necessary.

## Proposed Changes

- Reverted commits introducing automatic "default" group assignment during agent enrollment.
- Reverted the removal of the group inference logic from the manager.
- Resolved merge conflicts in the SQL upgrade script (`version 7`) caused by previous changes.
- Re-enabled the previous behavior where `remoted.guess_agent_group` determines if group inference is used.
- Restored original unit and integration tests related to group assignment and inference.

### Related issues

- https://github.com/wazuh/wazuh/issues/29401
- https://github.com/wazuh/wazuh/issues/29402

### Related PRs

- https://github.com/wazuh/wazuh/pull/29422
- https://github.com/wazuh/wazuh/pull/29432

### Results and Evidence

#### New agent enrollment results in `group = null`

<details><summary>Agent data</summary>

```json
{
   "id": 1,
   "name": "a0e96993900f",
   "register_ip": "any",
   "internal_key": "7d14f261c4951b5c53e79614234a9ed9c4b139356d05423f0686668e552439ce",
   "node_name": "unknown",
   "date_add": 1748248268,
   "group_sync_status": "synced",
   "sync_status": "synced",
   "connection_status": "never_connected",
   "disconnection_time": 0,
   "group_config_status": "not synced",
   "status_code": 0
}
```

</details>

#### Upon agent connection, the group is set to `default` by inference

<details><summary>Agent data</summary>

```json
{
   "id": 1,
   "name": "a0e96993900f",
   "ip": "172.17.0.2",
   "register_ip": "any",
   "internal_key": "7d14f261c4951b5c53e79614234a9ed9c4b139356d05423f0686668e552439ce",
   "os_name": "Ubuntu",
   "os_version": "24.04.2 LTS",
   "os_major": "24",
   "os_minor": "04",
   "os_codename": "Noble Numbat",
   "os_platform": "ubuntu",
   "os_uname": "Linux |a0e96993900f |5.15.167.4-microsoft-standard-WSL2 |#1 SMP Tue Nov 5 00:21:55 UTC 2024 |x86_64",
   "os_arch": "x86_64",
   "version": "Wazuh v4.11.2",
   "merged_sum": "x",
   "manager_host": "Rocket",
   "node_name": "node01",
   "date_add": 1748248268,
   "last_keepalive": 1748248288,
   "group": "default",
   "group_hash": "37a8eec1",
   "group_sync_status": "synced",
   "sync_status": "synced",
   "connection_status": "disconnected",
   "disconnection_time": 1748248289,
   "group_config_status": "not synced",
   "status_code": 3
}
```

</details>

#### When `remoted.guess_agent_group = 0` and the agent reconnects: group remains as `default`

<details><summary>Agent data</summary>

```json
{
   "id": 2,
   "name": "agent2",
   "ip": "172.17.0.2",
   "register_ip": "any",
   "internal_key": "b31ffa22a1f42bb14cdba1b1afceb7b49e185264fd0f3e39b86ce97990402721",
   "os_name": "Ubuntu",
   "os_version": "24.04.2 LTS",
   "os_major": "24",
   "os_minor": "04",
   "os_codename": "Noble Numbat",
   "os_platform": "ubuntu",
   "os_uname": "Linux |a0e96993900f |5.15.167.4-microsoft-standard-WSL2 |#1 SMP Tue Nov 5 00:21:55 UTC 2024 |x86_64",
   "os_arch": "x86_64",
   "version": "Wazuh v4.11.2",
   "config_sum": "ab73af41699f13fdd81903b5f23d8d00",
   "merged_sum": "cb5dc59d195320bb20b6039a519a8c0e",
   "manager_host": "Rocket",
   "node_name": "node01",
   "date_add": 1748249111,
   "last_keepalive": 1748249133,
   "group": "default",
   "group_hash": "37a8eec1",
   "group_sync_status": "synced",
   "sync_status": "synced",
   "connection_status": "active",
   "disconnection_time": 0,
   "group_config_status": "synced",
   "status_code": 0
}
```

</details>

#### When `remoted.guess_agent_group = 1` and the agent reconnects: group is restored to its previous value (if any)

<details><summary>Agent data</summary>

```json
{
   "id": 3,
   "name": "agent3",
   "ip": "172.17.0.2",
   "register_ip": "any",
   "internal_key": "8fca1fb587acc2485a7ab791a2bb2bd915bea0eb23e3fa4da8a6e41407708845",
   "os_name": "Ubuntu",
   "os_version": "24.04.2 LTS",
   "os_major": "24",
   "os_minor": "04",
   "os_codename": "Noble Numbat",
   "os_platform": "ubuntu",
   "os_uname": "Linux |a0e96993900f |5.15.167.4-microsoft-standard-WSL2 |#1 SMP Tue Nov 5 00:21:55 UTC 2024 |x86_64",
   "os_arch": "x86_64",
   "version": "Wazuh v4.11.2",
   "config_sum": "c6d5ee92633625a16df7f54d8a6586dd",
   "merged_sum": "fad72f991d898d95cdef92868abc1d7f",
   "manager_host": "Rocket",
   "node_name": "node01",
   "date_add": 1748249974,
   "last_keepalive": 1748249997,
   "group": "default,dummy",
   "group_hash": "bf7e5fb1",
   "group_sync_status": "synced",
   "sync_status": "synced",
   "connection_status": "active",
   "disconnection_time": 0,
   "group_config_status": "synced",
   "status_code": 0
}
```

</details>


### Artifacts Affected

- `wazuh-authd`
- `wazuh-remoted`
- `wazuh-modulesd` (Agent Sync module)
- `wazuh-db`
- Unit and integration test suites

### Configuration Changes

- `remoted.guess_agent_group` regains its original behavior and relevance.

### Documentation Updates

Pending update to restore documentation of the `remoted.guess_agent_group` option:

- https://github.com/wazuh/wazuh-documentation/issues/8576

### Tests Introduced

- Re-enabled previously existing:
   - Unit tests for agent registration and group handling.
   - Integration tests for agent lifecycle, group inference, and cluster behavior.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
