### PR TITLE
Refactor Inventory Harvester inventory fields

### DIFF
--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/result.json
@@ -18,9 +18,7 @@
                         "free": 1048576,
                         "total": 2097152,
                         "used": 1048576
-                    }
-                },
-                "observer": {
+                    },
                     "serial_number": "ABC123XYZ789"
                 },
                 "wazuh": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/result.json
@@ -15,12 +15,10 @@
                         "speed": 2497
                     },
                     "memory": {
-                         "free": 1048576,
+                        "free": 1048576,
                         "total": 2097152,
                         "used": 1048576
-                    }
-                },
-                "observer": {
+                    },
                     "serial_number": "A320"
                 },
                 "wazuh": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/pre_existing_data.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/pre_existing_data.json
@@ -19,12 +19,10 @@
                         "speed": 3800
                     },
                     "memory": {
-                        "free": 1048576,
-                        "total": 2097152,
-                        "used": 1048576
-                    }
-                },
-                "observer": {
+                        "free": 1234,
+                        "total": 33554432,
+                        "used": 16777216
+                    },
                     "serial_number": "ABC123XYZ789"
                 },
                 "wazuh": {
@@ -49,9 +47,7 @@
                         "free": 1048576,
                         "total": 2097152,
                         "used": 1048576
-                    }
-                },
-                "observer": {
+                    },
                     "serial_number": "AAA111BBB222"
                 },
                 "wazuh": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/result.json
@@ -15,12 +15,10 @@
                         "speed": 3800
                     },
                     "memory": {
-                         "free": 1048576,
+                        "free": 1048576,
                         "total": 2097152,
                         "used": 1048576
-                    }
-                },
-                "observer": {
+                    },
                     "serial_number": "AAA111BBB222"
                 },
                 "wazuh": {
@@ -42,12 +40,10 @@
                         "speed": 3800
                     },
                     "memory": {
-                         "free": 1048576,
+                        "free": 1048576,
                         "total": 2097152,
                         "used": 1048576
-                    }
-                },
-                "observer": {
+                    },
                     "serial_number": "ABC123XYZ789"
                 },
                 "wazuh": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/000_insert_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/000_insert_delta/result.json
@@ -25,15 +25,11 @@
                         }
                     }
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "mtu": 1500,
-                            "name": "eth0",
-                            "state": "up",
-                            "type": "ethernet"
-                        }
-                    }
+                "interface": {
+                    "mtu": 1500,
+                    "name": "eth0",
+                    "state": "up",
+                    "type": "ethernet"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/001_insert_modify_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/001_insert_modify_delta/result.json
@@ -25,15 +25,11 @@
                         }
                     }
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "mtu": 1500,
-                            "name": "eth0",
-                            "state": "up",
-                            "type": "ethernet"
-                        }
-                    }
+                "interface": {
+                    "mtu": 1500,
+                    "name": "eth0",
+                    "state": "up",
+                    "type": "ethernet"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/003_insert_rsync/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/003_insert_rsync/result.json
@@ -25,15 +25,11 @@
                         }
                     }
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "mtu": 1500,
-                            "name": "eth0",
-                            "state": "up",
-                            "type": "ethernet"
-                        }
-                    }
+                "interface": {
+                    "mtu": 1500,
+                    "name": "eth0",
+                    "state": "up",
+                    "type": "ethernet"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/006_integrity_check_global/pre_existing_data.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/006_integrity_check_global/pre_existing_data.json
@@ -29,15 +29,11 @@
                         }
                     }
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "mtu": 1500,
-                            "name": "eth1",
-                            "state": "up",
-                            "type": "ethernet"
-                        }
-                    }
+                "interface": {
+                    "mtu": 1500,
+                    "name": "eth1",
+                    "state": "up",
+                    "type": "ethernet"
                 },
                 "wazuh": {
                     "schema": {
@@ -68,15 +64,11 @@
                         }
                     }
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "mtu": 1500,
-                            "name": "eth0",
-                            "state": "up",
-                            "type": "ethernet"
-                        }
-                    }
+                "interface": {
+                    "mtu": 1500,
+                    "name": "eth0",
+                    "state": "up",
+                    "type": "ethernet"
                 },
                 "wazuh": {
                     "schema": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/006_integrity_check_global/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/netifaces/006_integrity_check_global/result.json
@@ -25,15 +25,11 @@
                         }
                     }
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "mtu": 1500,
-                            "name": "eth0",
-                            "state": "up",
-                            "type": "ethernet"
-                        }
-                    }
+                "interface": {
+                    "mtu": 1500,
+                    "name": "eth0",
+                    "state": "up",
+                    "type": "ethernet"
                 },
                 "wazuh": {
                     "schema": {
@@ -64,15 +60,11 @@
                         }
                     }
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "mtu": 1500,
-                            "name": "eth0",
-                            "state": "up",
-                            "type": "ethernet"
-                        }
-                    }
+                "interface": {
+                    "mtu": 1500,
+                    "name": "eth0",
+                    "state": "up",
+                    "type": "ethernet"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/000_insert_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/000_insert_delta/result.json
@@ -11,9 +11,11 @@
                 "network": {
                     "broadcast": "0.0.0.0",
                     "ip": "10.0.0.1",
-                    "name": "eth0",
                     "netmask": "1.1.1.1",
-                    "protocol": "IPv4"
+                    "type": "IPv4"
+                },
+                "interface": {
+                    "name": "eth0"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/002_insert_rsync/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/002_insert_rsync/result.json
@@ -11,9 +11,11 @@
                 "network": {
                     "broadcast": "0.0.0.0",
                     "ip": "10.0.0.1",
-                    "name": "eth0",
                     "netmask": "1.1.1.1",
-                    "protocol": "IPv4"
+                    "type": "IPv4"
+                },
+                "interface": {
+                    "name": "eth0"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/005_integrity_check_global/pre_existing_data.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/005_integrity_check_global/pre_existing_data.json
@@ -14,9 +14,11 @@
                 "network": {
                     "broadcast": "0.0.0.0",
                     "ip": "10.0.0.1",
-                    "name": "eth0",
                     "netmask": "1.2.3.4",
-                    "protocol": "IPv4"
+                    "type": "IPv4"
+                },
+                "interface": {
+                    "name": "eth0"
                 },
                 "wazuh": {
                     "schema": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/005_integrity_check_global/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/network_address/005_integrity_check_global/result.json
@@ -14,9 +14,11 @@
                 "network": {
                     "broadcast": "0.0.0.0",
                     "ip": "10.0.0.1",
-                    "name": "eth0",
                     "netmask": "1.1.1.1",
-                    "protocol": "IPv4"
+                    "type": "IPv4"
+                },
+                "interface": {
+                    "name": "eth0"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/000_insert_rsync/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/000_insert_rsync/result.json
@@ -14,12 +14,8 @@
                     "metric": 101,
                     "type": "ipv4"
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "name": "eth1"
-                        }
-                    }
+                "interface": {
+                    "name": "eth1"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/002_insert_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/002_insert_delta/result.json
@@ -14,12 +14,8 @@
                     "metric": 101,
                     "type": "ipv4"
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "name": "eth1"
-                        }
-                    }
+                "interface": {
+                    "name": "eth1"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/005_integrity_check_global/pre_existing_data.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/005_integrity_check_global/pre_existing_data.json
@@ -1,7 +1,7 @@
 [
     {
         "index_name": "wazuh-states-inventory-protocols-cluster01",
-        "ids":{
+        "ids": {
             "001": "001_35c9b5749116035dea24e0c8797c8e01358081a0",
             "002": "002_35c9b5749116035dea24e0c8797c8e01358081a1"
         },
@@ -18,12 +18,8 @@
                     "metric": 101,
                     "type": "ipv4"
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "name": "eth1"
-                        }
-                    }
+                "interface": {
+                    "name": "eth1"
                 },
                 "wazuh": {
                     "schema": {
@@ -43,12 +39,8 @@
                     "metric": 100,
                     "type": "ipv4"
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "name": "eth0"
-                        }
-                    }
+                "interface": {
+                    "name": "eth0"
                 },
                 "wazuh": {
                     "schema": {

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/005_integrity_check_global/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/protocols/005_integrity_check_global/result.json
@@ -14,12 +14,8 @@
                     "metric": 100,
                     "type": "ipv4"
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "name": "eth0"
-                        }
-                    }
+                "interface": {
+                    "name": "eth0"
                 },
                 "wazuh": {
                     "schema": {
@@ -39,12 +35,8 @@
                     "metric": 100,
                     "type": "ipv4"
                 },
-                "observer": {
-                    "ingress": {
-                        "interface": {
-                            "name": "eth0"
-                        }
-                    }
+                "interface": {
+                    "name": "eth0"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
@@ -79,7 +79,7 @@ public:
         element.data.host.memory.used = (usedMem > 0) ? usedMem : 0;
 
         // Ex: AA320
-        element.data.observer.serial_number = boardId;
+        element.data.host.serial_number = boardId;
 
         auto& instancePolicyManager = PolicyHarvesterManager::instance();
         element.data.wazuh.cluster.name = instancePolicyManager.getClusterName();

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netElement.hpp
@@ -70,7 +70,7 @@ public:
         }
 
         // Ex: eth0
-        element.data.network.name = data->netAddressName();
+        element.data.interface.name = data->netAddressName();
 
         // 255.255.255.0
         if (auto networkNetmask = data->netmask(); networkNetmask.compare(" ") != 0)
@@ -81,11 +81,11 @@ public:
         // Ex: IPv4
         if (!data->protocol())
         {
-            element.data.network.protocol = "IPv4";
+            element.data.network.type = "IPv4";
         }
         else
         {
-            element.data.network.protocol = "IPv6";
+            element.data.network.type = "IPv6";
         }
 
         auto& instancePolicyManager = PolicyHarvesterManager::instance();

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netIfaceElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/netIfaceElement.hpp
@@ -70,11 +70,11 @@ public:
         element.data.host.network.egress.errors = data->netIfaceTxErrors();
         element.data.host.network.egress.packets = data->netIfaceTxPackets();
 
-        element.data.observer.ingress.interface.alias = data->netIfaceAdapter();
-        element.data.observer.ingress.interface.name = data->netIfaceName();
-        element.data.observer.ingress.interface.mtu = data->netIfaceMtu();
-        element.data.observer.ingress.interface.state = data->netIfaceState();
-        element.data.observer.ingress.interface.type = data->netIfaceType();
+        element.data.interface.alias = data->netIfaceAdapter();
+        element.data.interface.name = data->netIfaceName();
+        element.data.interface.mtu = data->netIfaceMtu();
+        element.data.interface.state = data->netIfaceState();
+        element.data.interface.type = data->netIfaceType();
 
         auto& instancePolicyManager = PolicyHarvesterManager::instance();
         element.data.wazuh.cluster.name = instancePolicyManager.getClusterName();

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/networkProtocolElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/networkProtocolElement.hpp
@@ -72,7 +72,7 @@ public:
         element.data.network.metric = data->netProtoMetric();
         element.data.network.type = data->netProtoType();
 
-        element.data.observer.ingress.interface.name = data->netProtoIface();
+        element.data.interface.name = data->netProtoIface();
 
         auto& instancePolicyManager = PolicyHarvesterManager::instance();
         element.data.wazuh.cluster.name = instancePolicyManager.getClusterName();

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryHardwareHarvester.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryHardwareHarvester.hpp
@@ -19,20 +19,12 @@
 
 struct InventoryHardwareHarvester final
 {
-    struct Observer final
-    {
-        std::string_view serial_number;
-
-        REFLECTABLE(MAKE_FIELD("serial_number", &Observer::serial_number));
-    } observer;
-
     Agent agent;
     Hardware host;
     Wazuh wazuh;
 
     REFLECTABLE(MAKE_FIELD("host", &InventoryHardwareHarvester::host),
                 MAKE_FIELD("agent", &InventoryHardwareHarvester::agent),
-                MAKE_FIELD("observer", &InventoryHardwareHarvester::observer),
                 MAKE_FIELD("wazuh", &InventoryHardwareHarvester::wazuh));
 };
 

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryNetIfaceHarvester.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryNetIfaceHarvester.hpp
@@ -36,28 +36,14 @@ struct InventoryNetIfaceHarvester final
         REFLECTABLE(MAKE_FIELD("mac", &NetIfaceHost::mac), MAKE_FIELD("network", &NetIfaceHost::network));
     };
 
-    struct NetIfaceObserver final
-    {
-        struct NetIfaceIngress final
-        {
-            NetIface interface;
-
-            REFLECTABLE(MAKE_FIELD("interface", &NetIfaceIngress::interface));
-        };
-
-        NetIfaceIngress ingress;
-
-        REFLECTABLE(MAKE_FIELD("ingress", &NetIfaceObserver::ingress));
-    };
-
     Agent agent;
     NetIfaceHost host;
-    NetIfaceObserver observer;
+    NetIface interface;
     Wazuh wazuh;
 
     REFLECTABLE(MAKE_FIELD("agent", &InventoryNetIfaceHarvester::agent),
                 MAKE_FIELD("host", &InventoryNetIfaceHarvester::host),
-                MAKE_FIELD("observer", &InventoryNetIfaceHarvester::observer),
+                MAKE_FIELD("interface", &InventoryNetIfaceHarvester::interface),
                 MAKE_FIELD("wazuh", &InventoryNetIfaceHarvester::wazuh));
 };
 

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryNetworkHarvester.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryNetworkHarvester.hpp
@@ -19,12 +19,21 @@
 
 struct InventoryNetworkHarvester final
 {
+    struct Interface final
+    {
+        std::string_view name;
+
+        REFLECTABLE(MAKE_FIELD("name", &Interface::name));
+    };
+
+    Interface interface;
 
     Agent agent;
     NetworkAddress network;
     Wazuh wazuh;
 
     REFLECTABLE(MAKE_FIELD("network", &InventoryNetworkHarvester::network),
+                MAKE_FIELD("interface", &InventoryNetworkHarvester::interface),
                 MAKE_FIELD("agent", &InventoryNetworkHarvester::agent),
                 MAKE_FIELD("wazuh", &InventoryNetworkHarvester::wazuh));
 };

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryNetworkProtocolHarvester.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/inventoryNetworkProtocolHarvester.hpp
@@ -19,13 +19,21 @@
 
 struct InventoryNetworkProtocolHarvester final
 {
+    struct Interface final
+    {
+        std::string_view name;
+
+        REFLECTABLE(MAKE_FIELD("name", &Interface::name));
+    };
+
+    Interface interface;
+
     Agent agent;
     Network network;
-    Observer observer;
     Wazuh wazuh;
 
     REFLECTABLE(MAKE_FIELD("network", &InventoryNetworkProtocolHarvester::network),
-                MAKE_FIELD("observer", &InventoryNetworkProtocolHarvester::observer),
+                MAKE_FIELD("interface", &InventoryNetworkProtocolHarvester::interface),
                 MAKE_FIELD("agent", &InventoryNetworkProtocolHarvester::agent),
                 MAKE_FIELD("wazuh", &InventoryNetworkProtocolHarvester::wazuh));
 };

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/hardware.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/hardware.hpp
@@ -36,7 +36,11 @@ struct Hardware final
                     MAKE_FIELD("used", &Memory::used));
     } memory;
 
-    REFLECTABLE(MAKE_FIELD("cpu", &Hardware::cpu), MAKE_FIELD("memory", &Hardware::memory));
+    std::string_view serial_number;
+
+    REFLECTABLE(MAKE_FIELD("cpu", &Hardware::cpu),
+                MAKE_FIELD("memory", &Hardware::memory),
+                MAKE_FIELD("serial_number", &Hardware::serial_number));
 };
 
 #endif // _HW_WCS_MODEL_HPP

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/networkAddress.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/networkAddress.hpp
@@ -21,13 +21,12 @@ struct NetworkAddress final
     std::string_view ip;
     std::string_view name;
     std::string_view netmask;
-    std::string_view protocol;
+    std::string_view type;
 
     REFLECTABLE(MAKE_FIELD("broadcast", &NetworkAddress::broadcast),
                 MAKE_FIELD("ip", &NetworkAddress::ip),
-                MAKE_FIELD("name", &NetworkAddress::name),
                 MAKE_FIELD("netmask", &NetworkAddress::netmask),
-                MAKE_FIELD("protocol", &NetworkAddress::protocol));
+                MAKE_FIELD("type", &NetworkAddress::type));
 };
 
 #endif // _NET_WCS_MODEL_HPP

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/networkProtocol.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/networkProtocol.hpp
@@ -28,25 +28,4 @@ struct Network final
                 MAKE_FIELD("type", &Network::type));
 };
 
-struct Observer final
-{
-    struct _Ingress final
-    {
-        struct _Interface final
-        {
-            std::string_view name;
-
-            REFLECTABLE(MAKE_FIELD("name", &_Interface::name));
-        };
-
-        _Interface interface;
-
-        REFLECTABLE(MAKE_FIELD("interface", &_Ingress::interface));
-    };
-
-    _Ingress ingress;
-
-    REFLECTABLE(MAKE_FIELD("ingress", &Observer::ingress));
-};
-
 #endif // _NETWORK_PROTOCOL_WCS_MODEL_HPP

--- a/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
@@ -327,7 +327,7 @@ TEST_F(SystemInventoryUpsertElement, emptyBoardId_Hw)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_unknown","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50}},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"observer":{"serial_number":"unknown"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_unknown","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50},"serial_number":"unknown"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentID_Hw)
@@ -351,7 +351,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentID_Hw)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_boardInfo","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50}},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"observer":{"serial_number":"boardInfo"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_boardInfo","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50},"serial_number":"boardInfo"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 /*
@@ -401,7 +401,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentID_NetworkProtocol)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netProtoItemId","operation":"INSERTED","data":{"network":{"dhcp":true,"gateway":"netProtoGateway","metric":150,"type":"netProtoType"},"observer":{"ingress":{"interface":{"name":"netProtoIface"}}},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netProtoItemId","operation":"INSERTED","data":{"network":{"dhcp":true,"gateway":"netProtoGateway","metric":150,"type":"netProtoType"},"interface":{"name":"netProtoIface"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyGateway_NetworkProtocol)
@@ -426,7 +426,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyGateway_NetworkProtocol)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netProtoItemId","operation":"INSERTED","data":{"network":{"dhcp":true,"metric":150,"type":"netProtoType"},"observer":{"ingress":{"interface":{"name":"netProtoIface"}}},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netProtoItemId","operation":"INSERTED","data":{"network":{"dhcp":true,"metric":150,"type":"netProtoType"},"interface":{"name":"netProtoIface"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentIDMultipleGateway_NetworkProtocol)
@@ -451,7 +451,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentIDMultipleGateway_NetworkProtocol
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netProtoItemId","operation":"INSERTED","data":{"network":{"dhcp":true,"metric":150,"type":"netProtoType"},"observer":{"ingress":{"interface":{"name":"netProtoIface"}}},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netProtoItemId","operation":"INSERTED","data":{"network":{"dhcp":true,"metric":150,"type":"netProtoType"},"interface":{"name":"netProtoIface"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 /*
@@ -513,7 +513,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentID_NetIface)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netIfaceItemId","operation":"INSERTED","data":{"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"host":{"mac":"netIfaceMac","network":{"ingress":{"bytes":1,"drops":2,"errors":3,"packets":4},"egress":{"bytes":5,"drops":6,"errors":7,"packets":8}}},"observer":{"ingress":{"interface":{"alias":"netIfaceAdapter","mtu":9,"name":"netIfaceName","state":"netIfaceState","type":"netIfaceType"}}},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netIfaceItemId","operation":"INSERTED","data":{"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"host":{"mac":"netIfaceMac","network":{"ingress":{"bytes":1,"drops":2,"errors":3,"packets":4},"egress":{"bytes":5,"drops":6,"errors":7,"packets":8}}},"interface":{"alias":"netIfaceAdapter","mtu":9,"name":"netIfaceName","state":"netIfaceState","type":"netIfaceType"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 /*
@@ -564,7 +564,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentID_NetworkAddress)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"broadcast":"192.168.0.255","ip":"192.168.0.1","name":"eth0","netmask":"255.255.255.0","protocol":"IPv4"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"broadcast":"192.168.0.255","ip":"192.168.0.1","netmask":"255.255.255.0","type":"IPv4"},"interface":{"name":"eth0"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyBroadcast_NetworkAddress)
@@ -589,7 +589,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyBroadcast_NetworkAddress)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"ip":"192.168.0.1","name":"eth0","netmask":"255.255.255.0","protocol":"IPv4"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"ip":"192.168.0.1","netmask":"255.255.255.0","type":"IPv4"},"interface":{"name":"eth0"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyNetmask_NetworkAddress)
@@ -614,7 +614,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyNetmask_NetworkAddress)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"broadcast":"192.168.0.255","ip":"192.168.0.1","name":"eth0","protocol":"IPv4"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"broadcast":"192.168.0.255","ip":"192.168.0.1","type":"IPv4"},"interface":{"name":"eth0"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyAddress_NetworkAddress)
@@ -639,5 +639,5 @@ TEST_F(SystemInventoryUpsertElement, validAgentIDEmptyAddress_NetworkAddress)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"broadcast":"192.168.0.255","name":"eth0","netmask":"255.255.255.0","protocol":"IPv4"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_netAddressItemId","operation":"INSERTED","data":{"network":{"broadcast":"192.168.0.255","netmask":"255.255.255.0","type":"IPv4"},"interface":{"name":"eth0"},"agent":{"id":"001","name":"agentName","host":{"ip":"192.168.0.1"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #29892 |

# Description

This PR aims to align the Inventory Harvester with the latest changes introduced in the inventory templates `(wazuh-states-inventory-hardware, interfaces, networks, and protocols)`, following PR #29874. Specifically, it removes deprecated fields like observer, updates internal data structures, and adjusts serialization and test logic accordingly to match the revised schema.

### Testing

```console
================================================================ 70 passed in 1139.51s (0:18:59) ================================================================
```

> [!NOTE]
> For testing make sure that index mapping matches wit #29874 


![hwNew](https://github.com/user-attachments/assets/6add7581-e520-4332-9122-df13a449f168)

![interfaceNew](https://github.com/user-attachments/assets/9b4f957c-8357-441c-9dbb-5d38ee8397f4)

![networkNew](https://github.com/user-attachments/assets/876a1e4a-be62-46f2-b0be-a76accf0ebc6)

![protocolNew](https://github.com/user-attachments/assets/69894902-02ee-4567-ac9a-b24faa055d1d)
