### PR TITLE
Include kvdb cleanup in engine-integration delete

### DIFF
--- a/src/engine/tools/engine-suite/src/engine_integration/README.md
+++ b/src/engine/tools/engine-suite/src/engine_integration/README.md
@@ -105,10 +105,10 @@ Deletes assets listed in the integration and the integration from the Engine's c
 ```
 $ engine-integration delete -h
 usage: engine-integration delete [-h] [-a API_SOCK] [--dry-run] [-n NAMESPACE]
-                                 integration-name
+                                 integration-path
 
 positional arguments:
-  integration-name      Integration name to be deleted
+  integration-path      Integration path to be deleted
 
 options:
   -h, --help            show this help message and exit

--- a/src/engine/tools/engine-suite/src/engine_integration/cmds/delete.py
+++ b/src/engine/tools/engine-suite/src/engine_integration/cmds/delete.py
@@ -1,4 +1,5 @@
 import yaml
+from pathlib import Path
 import shared.resource_handler as rs
 import shared.executor as exec
 from shared.default_settings import Constants as DefaultSettings
@@ -6,7 +7,6 @@ from api_communication.client import APIClient
 from api_communication.proto import catalog_pb2 as api_catalog
 from api_communication.proto import kvdb_pb2 as api_kvdb
 from api_communication.proto.engine_pb2 import GenericStatus_Response
-
 
 def delete_asset_task(executor: exec.Executor, client: APIClient, asset_name: str, namespace: str) -> None:
     # Backup asset
@@ -51,57 +51,94 @@ def delete_asset_task(executor: exec.Executor, client: APIClient, asset_name: st
     executor.add(exec.RecoverableTask(do, undo, f'Delete asset [{namespace}]: {asset_name}'))
 
 
-def run(args, _: rs.ResourceHandler):
-    api_socket = args['api_sock']
-    namespace = args['namespace']
-    dry_run = args['dry-run']
-    integration_name = args['integration-name']
+def run(args, resource_handler):
+    api_socket    = args['api_sock']
+    namespace     = args['namespace']
+    dry_run       = args['dry-run']
+    integration_path = Path(args['integration-path']).resolve()
 
-    print(f'Removing integration: {integration_name}')
-    print('Importantly, KVDBs will not be removed')
-    client: APIClient
+    # --- Load manifest ---
+    manifest_file = integration_path / 'manifest.yml'
+    manifest = resource_handler.load_file(manifest_file.as_posix())
+    integration_name = manifest['name']
+    print(f"Removing integration: {integration_name}")
+
+    # --- Init API client ---
     try:
         client = APIClient(api_socket)
     except Exception as e:
-        print(f'Error: {e}')
+        print(f"Error connecting to API socket '{api_socket}': {e}")
         return -1
 
     executor = exec.Executor()
 
-    # Get integration from store
-    json_request = dict()
-    json_request['namespaceid'] = namespace
-    json_request['name'] = integration_name
-    json_request['format'] = 'yaml'
+    # --- Fetch remote integration definition ---
+    get_req = {
+        'namespaceid': namespace,
+        'name':        integration_name,
+        'format':      'yaml'
+    }
     error, response = client.jsend(
-        json_request, api_catalog.ResourceGet_Request(), api_catalog.ResourceGet_Response())
+        get_req,
+        api_catalog.ResourceGet_Request(),
+        api_catalog.ResourceGet_Response()
+    )
     if error:
-        print(f'Error: {error}')
+        print(f"Error fetching integration '{integration_name}': {error}")
         return -1
 
     integration = yaml.safe_load(response['content'])
 
-    # Create tasks to remove all assets from the integration
-    for asset_name in [
-        asset_name
-        for key, asset_list in integration.items()
-        if key != "name"
-        for asset_name in asset_list
-    ]:
-        delete_asset_task(executor, client, asset_name, namespace)
+    # --- Prepare asset list ---
+    assets = [
+        asset
+        for key, lst in integration.items()
+        if key != 'name'
+        for asset in lst
+    ]
+    decoders_root = integration_path.parent.parent / 'decoders'
 
-    # Remove the integration
+    # --- Schedule deletion tasks for each asset and its KVDBs ---
+    for asset in assets:
+        delete_asset_task(executor, client, asset, namespace)
+
+        # find matching decoder folder
+        for subdir in decoders_root.iterdir():
+            if not subdir.is_dir():
+                continue
+
+            # check each YAML for a matching "name"
+            for yml in subdir.glob('*.yml'):
+                decoder = resource_handler.load_file(yml.as_posix())
+                if decoder.get('name') != asset:
+                    continue
+
+                # delete all KVDB JSONs in that folder
+                for json_path in subdir.glob('*.json'):
+                    kvdb_name = json_path.stem
+                    err, _ = client.jsend(
+                        {'name': kvdb_name},
+                        api_kvdb.managerDelete_Request(),
+                        GenericStatus_Response()
+                    )
+                    if err:
+                        raise Exception(f"Error deleting KVDB '{kvdb_name}': {err}")
+                    print(f"Deleted KVDB: {kvdb_name}")
+                break  # found & processed this decoder
+            else:
+                continue
+            break  # move to next asset
+
     delete_asset_task(executor, client, integration_name, namespace)
 
-    print(f'Deleting {integration_name} from the catalog')
-    print('\nTasks:')
+    print(f"\nDeleting {integration_name} from the catalog")
+    print("\nTasks:")
     executor.list_tasks()
-    print('\nExecuting tasks...')
+    print("\nExecuting tasks...")
     executor.execute(dry_run)
-    print('\nDone')
+    print("\nDone")
     if dry_run:
-        print(
-            f'If you want to apply the changes, run again without the --dry-run flag')
+        print("If you want to apply the changes, run again without the --dry-run flag")
 
 
 def configure(subparsers):
@@ -110,8 +147,8 @@ def configure(subparsers):
     parser_rm.add_argument('-a', '--api-sock', type=str, default=DefaultSettings.SOCKET_PATH, dest='api_sock',
                            help=f'[default="{DefaultSettings.SOCKET_PATH}"] Engine instance API socket path')
 
-    parser_rm.add_argument('integration-name', type=str,
-                           help=f'Integration name to be deleted')
+    parser_rm.add_argument('integration-path', type=str,
+                           help=f'Integration path to be deleted')
 
     parser_rm.add_argument('--dry-run', dest='dry-run', action='store_true',
                            help=f'default False, When True will print all the steps to apply without affecting the store')


### PR DESCRIPTION
|Related issue|
|---|
|#29893|

## Description

Currently, when running engine-integration delete on an integration, only the decoder and integration resources are removed. Any KVDB entries defined by that integration remain in the catalog. As a result, re-adding the same integration immediately afterward fails with an “already exists” error for the orphaned KVDB names.

## What’s Changed:
- Delete associated KVDB entries

After scheduling each asset deletion, scan the corresponding decoders/<name> folder for .json files and invoke kvdb.managerDelete for each KVDB.

- Refactor delete flow

Pull KVDB–deletion logic into the delete_asset_task / helper so that both integration assets and KVDBs are cleaned up in one atomic task list.

- Add unit/integration tests
