### PR TITLE
Use launchctl to restart agent after upgrade on macOS

### DIFF
--- a/packages/macos/package_files/postinstall.sh
+++ b/packages/macos/package_files/postinstall.sh
@@ -177,5 +177,5 @@ fi
 
 if [ -n "${upgrade}" ] && [ -n "${restart}" ]; then
     echo "Restarting Wazuh..."
-    ${DIR}/bin/wazuh-control restart
+    launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
 fi


### PR DESCRIPTION
## Description

This PR improves the agent upgrade process on macOS by replacing the existing call to `wazuh-control restart` with `launchctl bootstrap`. This change ensures proper integration with the macOS service manager, resolving issues observed when attempting to stop the agent after an upgrade.

## Proposed Changes

Replace `wazuh-control restart` with `launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist` during upgrade.

### Results and Evidence

<details><summary>Set up</summary>

#### Clean up

```
/Library/Ossec/bin/wazuh-control stop
/bin/rm -r /Library/Ossec
/bin/launchctl remove com.wazuh.agent
/bin/rm -f /Library/LaunchDaemons/com.wazuh.agent.plist
/bin/rm -rf /Library/StartupItems/WAZUH
/usr/bin/dscl . -delete "/Users/wazuh"
/usr/bin/dscl . -delete "/Groups/wazuh"
/usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent
```

#### Install

```
echo "WAZUH_MANAGER='192.168.1.3'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-4.11.2-1.arm64.pkg -target /
launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
```

#### Check

```
/Library/Ossec/bin/wazuh-control status
```

> Running

#### Upgrade

```
installer -pkg wazuh-agent_4.13.0-1_intel64_f4146d4c.pkg -target /
```

#### Check

```
/Library/Ossec/bin/wazuh-control status
```

> Running

</details>

#### Remove daemon

```
launchctl bootout system /Library/LaunchDaemons/com.wazuh.agent.plist
```

#### Check agent status

```
/Library/Ossec/bin/wazuh-control status
```

> Not running

### Artifacts Affected

* macOS installer package for the Wazuh agent.

### Configuration Changes

* No changes to runtime configuration or user-facing options.

### Documentation Updates

* Pending: Suggest updating the Wazuh documentation to recommend using `launchctl bootout` instead of `launchctl unload`.

### Tests Introduced

Manual upgrade tests on macOS 14 (Sonoma) and macOS 15 (Sequoia):

* Upgrade an already running agent.
* Confirm agent remains running after the upgrade.
* Confirm the agent can be properly stopped using `launchctl bootout`.

## Review Checklist

* [ ] Code changes reviewed
* [ ] Relevant evidence provided
* [ ] Tests cover the new functionality
* [ ] Configuration changes documented
* [ ] Developer documentation reflects the changes
* [ ] Meets requirements and/or definition of done
* [ ] No unresolved dependencies with other issues