### PR TITLE
Remove 4.12.2 references from 4.13.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,25 @@ All notable changes to this project will be documented in this file.
 - Fixed false positive in configuration uploading. ([#28962](https://github.com/wazuh/wazuh/pull/28962))
 - Fixed sorting by version in agent list endpoint. ([#29166](https://github.com/wazuh/wazuh/pull/29166))
 
+### Ruleset
+
+#### Added
+
+- Added SCA content for Oracle Linux 10. ([#29139](https://github.com/wazuh/wazuh/pull/29139))
+- Added rule to minimize event flooding from Windows events on the Wazuh manager. ([#28790](https://github.com/wazuh/wazuh/pull/28790))
+
+#### Changed
+
+- Fixed multiple checks in RHEL 9, RHEL 10, Rocky Linux 8 and Rocky Linux 9 SCA policies. ([#29040](https://github.com/wazuh/wazuh/pull/29040))
+- Fixed diff causing false negatives in rootcheck. ([#28982](https://github.com/wazuh/wazuh/pull/28982))
+- Fixed multiple RHEL 8 and CentOS 7 SCA checks generating incorrect results. ([#28711](https://github.com/wazuh/wazuh/pull/28711))
+
 ### Other
 
 #### Changed
 - Upgraded Python embedded interpreter to 3.10.16. ([#28646](https://github.com/wazuh/wazuh/pull/28646))
 - Upgraded h11 to 0.16.0 and httpcore to 1.0.9. ([#29735](https://github.com/wazuh/wazuh/pull/29735))
 - Removed unused Python Azure dependencies. ([#28564](https://github.com/wazuh/wazuh/pull/28564))
-
-
-## [v4.12.2]
 
 
 ## [v4.12.1]
@@ -73,6 +83,13 @@ All notable changes to this project will be documented in this file.
 
 #### Added
 - Added the server uuid to the /manager/info endpoint. ([#29524](https://github.com/wazuh/wazuh/pull/29524))
+
+### Ruleset
+
+#### Added
+
+- Added SCA content for CentOS Stream 9. ([#29269](https://github.com/wazuh/wazuh/pull/29269))
+- Added IOCs and rules for Wazuh 4.x ruleset improvement. ([#29653](https://github.com/wazuh/wazuh/pull/29653))
 
 ### Other
 
@@ -139,14 +156,22 @@ All notable changes to this project will be documented in this file.
 
 #### Added
 
+- Created SCA content for Distribution Independent Linux. ([#27749](https://github.com/wazuh/wazuh/pull/27749))
+- Created SCA policy for Ubuntu 24.04 LTS. ([#27253](https://github.com/wazuh/wazuh/pull/27253))
+- Added SCA content for CentOS Stream 10. ([#24495](https://github.com/wazuh/wazuh/issues/24495))
 - Added SCA content for Windows Server 2025. ([#26732](https://github.com/wazuh/wazuh/issues/26732))
-- Added SCA content for Fedora 41. ([#26736](https://github.com/wazuh/wazuh/issues/26736))
-- Create SCA policy for Distribution Independent Linux. ([#26837](https://github.com/wazuh/wazuh/issues/26837))
-- Create SCA policy for Ubuntu 24.04 LTS. ([#23194](https://github.com/wazuh/wazuh/issues/23194))
+- Added SCA content for RHEL 10. ([#27752](https://github.com/wazuh/wazuh/pull/27752))
+- Added SCA content for AlmaLinux 10. ([#27998](https://github.com/wazuh/wazuh/pull/27998))
 
 #### Changed
 
-- SCA rule Improvement for MacOS 15 SCA. ([#26982](https://github.com/wazuh/wazuh/issues/26982))
+- Improved SCA rule for macOS 15. ([#27751](https://github.com/wazuh/wazuh/pull/27751))
+- Updated SCA Policy for Ubuntu 22.04 LTS to CIS Benchmark v2.0.0. ([#28466](https://github.com/wazuh/wazuh/pull/28466))
+- Fixed incorrect registry key in Windows Server 2022 SCA policy. ([#27911](https://github.com/wazuh/wazuh/pull/27911))
+- Fixed duplicated SCA check IDs for Windows Server 2025. ([#29204](https://github.com/wazuh/wazuh/pull/29204))
+- Fixed Ubuntu SCA checks to ensure nftables and iptables do not co-exist ([#27913](https://github.com/wazuh/wazuh/pull/27913))
+- Fixed errors in multiple checks in Rocky Linux 9 SCA checks ([#28468](https://github.com/wazuh/wazuh/pull/28468))
+- Fixed Ubuntu 24.04 SCA parsing error. ([#28379](https://github.com/wazuh/wazuh/pull/28379))
 
 ### Other
 

--- a/packages/aix/SPECS/wazuh-agent-aix.spec
+++ b/packages/aix/SPECS/wazuh-agent-aix.spec
@@ -283,8 +283,6 @@ rm -fr %{buildroot}
 %changelog
 * Wed Jun 04 2025 support <info@wazuh.com> - 4.13.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-13-0.html
-* Wed May 21 2025 support <info@wazuh.com> - 4.12.2
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-12-2.html
 * Wed May 14 2025 support <info@wazuh.com> - 4.12.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-12-1.html
 * Wed May 07 2025 support <info@wazuh.com> - 4.12.0

--- a/packages/debs/SPECS/wazuh-agent/debian/changelog
+++ b/packages/debs/SPECS/wazuh-agent/debian/changelog
@@ -4,12 +4,6 @@ wazuh-agent (4.13.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 04 Jun 2025 00:00:00 +0000
 
-wazuh-agent (4.12.2-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-12-2.html
-
- -- Wazuh, Inc <info@wazuh.com>  Wed, 21 May 2025 00:00:00 +0000
-
 wazuh-agent (4.12.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-12-1.html

--- a/packages/debs/SPECS/wazuh-manager/debian/changelog
+++ b/packages/debs/SPECS/wazuh-manager/debian/changelog
@@ -4,12 +4,6 @@ wazuh-manager (4.13.0-RELEASE) stable; urgency=low
 
  -- Wazuh, Inc <info@wazuh.com>  Wed, 04 Jun 2025 00:00:00 +0000
 
-wazuh-manager (4.12.2-RELEASE) stable; urgency=low
-
-  * More info: https://documentation.wazuh.com/current/release-notes/release-4-12-2.html
-
- -- Wazuh, Inc <info@wazuh.com>  Wed, 21 May 2025 00:00:00 +0000
-
 wazuh-manager (4.12.1-RELEASE) stable; urgency=low
 
   * More info: https://documentation.wazuh.com/current/release-notes/release-4-12-1.html

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -792,8 +792,6 @@ rm -fr %{buildroot}
 %changelog
 * Wed Jun 04 2025 support <info@wazuh.com> - 4.13.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-13-0.html
-* Wed May 21 2025 support <info@wazuh.com> - 4.12.2
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-12-2.html
 * Wed May 14 2025 support <info@wazuh.com> - 4.12.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-12-1.html
 * Wed May 07 2025 support <info@wazuh.com> - 4.12.0

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -950,8 +950,6 @@ rm -fr %{buildroot}
 %changelog
 * Wed Jun 04 2025 support <info@wazuh.com> - 4.13.0
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-13-0.html
-* Wed May 21 2025 support <info@wazuh.com> - 4.12.2
-- More info: https://documentation.wazuh.com/current/release-notes/release-4-12-2.html
 * Wed May 14 2025 support <info@wazuh.com> - 4.12.1
 - More info: https://documentation.wazuh.com/current/release-notes/release-4-12-1.html
 * Wed May 07 2025 support <info@wazuh.com> - 4.12.0

--- a/src/win32/wazuh-installer.nsi
+++ b/src/win32/wazuh-installer.nsi
@@ -36,7 +36,7 @@ Name "${NAME} Windows Agent v${VERSION}"
 BrandingText "Copyright (C) 2015, Wazuh Inc."
 OutFile "${OutFile}"
 
-VIProductVersion "4.12.2.0"
+VIProductVersion "4.13.0.0"
 VIAddVersionKey ProductName "${NAME}"
 VIAddVersionKey CompanyName "Wazuh Inc."
 VIAddVersionKey LegalCopyright "2023 - Wazuh Inc."


### PR DESCRIPTION
|Related issue|
|---|
|#29943|

This PR removes references to 4.12.2 and updates the changelog for 4.13.0 and previous versions.