### PR TITLE
Index inode for files

### DIFF
--- a/src/wazuh_modules/inventory_harvester/qa/test_data/fim/file/000_insert_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/fim/file/000_insert_delta/result.json
@@ -20,7 +20,8 @@
                     "owner": "root",
                     "path": "/home/folderB/AFileInB.txt",
                     "size": 0,
-                    "uid": "0"
+                    "uid": "0",
+                    "inode": "28183416"
                 },
                 "wazuh": {
                     "cluster": {

--- a/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/fileElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/fimInventory/elements/fileElement.hpp
@@ -64,6 +64,7 @@ public:
         element.data.file.uid = data->uid();
         element.data.file.owner = data->userName();
         element.data.file.size = data->size();
+        element.data.file.inode = data->inode() > 0 ? std::to_string(data->inode()) : "";
 
         element.data.file.mtime = data->mtimeISO8601();
 

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/file.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/file.hpp
@@ -21,7 +21,7 @@ struct File final
     std::string_view path;
     std::string_view gid;
     std::string_view group;
-    std::string_view inode;
+    std::string inode;
     std::string mtime;
     std::int64_t size = DEFAULT_INT_VALUE;
     std::string_view uid;

--- a/src/wazuh_modules/inventory_harvester/tests/unit/fimInventoryUpsertElement_test.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/fimInventoryUpsertElement_test.cpp
@@ -125,12 +125,13 @@ TEST_F(FimInventoryUpsertElement, valid_File)
     EXPECT_CALL(*context, userName()).WillRepeatedly(testing::Return("sysadmin"));
     EXPECT_CALL(*context, size()).WillRepeatedly(testing::Return(512));
     EXPECT_CALL(*context, mtimeISO8601()).WillRepeatedly(testing::Return("2025-04-09T12:00:00Z"));
+    EXPECT_CALL(*context, inode()).WillRepeatedly(testing::Return(112233));
 
     EXPECT_NO_THROW(upsertElement->handleRequest(context));
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_HASH_HASH","operation":"INSERTED","data":{"file":{"path":"/etc/hosts","gid":"1000","group":"root","mtime":"2025-04-09T12:00:00Z","size":512,"uid":"1000","owner":"sysadmin","hash":{"md5":"md5-file","sha1":"sha1-file","sha256":"sha256-file"}},"agent":{"id":"001","name":"agent-file","host":{"ip":"192.168.1.20"},"version":"v4.0.0"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_HASH_HASH","operation":"INSERTED","data":{"file":{"path":"/etc/hosts","gid":"1000","group":"root","inode":"112233","mtime":"2025-04-09T12:00:00Z","size":512,"uid":"1000","owner":"sysadmin","hash":{"md5":"md5-file","sha1":"sha1-file","sha256":"sha256-file"}},"agent":{"id":"001","name":"agent-file","host":{"ip":"192.168.1.20"},"version":"v4.0.0"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 /*


### PR DESCRIPTION
|Related issue|
|---|
|Closes #29951|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

<!--
Add a clear description of how the problem has been solved.
-->

This PR adds the `inode` field for files.
It can't be added as `std::string_view` because the origin uses int64 and the indexed value is a string.


## Tests

WIP