### PR TITLE
Add ruleset reload for the API endpoints

### DIFF
--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -6,6 +6,7 @@ from os import remove
 from os.path import join, split, exists, isfile, dirname as path_dirname
 
 from wazuh.core import common
+from wazuh.core.analysis import send_reload_ruleset_msg
 from wazuh.core.cdb_list import iterate_lists, get_list_from_file, REQUIRED_FIELDS, SORT_FIELDS, delete_list, \
     get_filenames_paths, validate_cdb_list, LIST_FIELDS
 from wazuh.core.exception import WazuhError
@@ -149,6 +150,12 @@ def upload_list_file(filename: str = None, content: str = None, overwrite: bool 
             delete_file_with_backup(backup_file, full_path, delete_list_file)
 
         upload_file(content, to_relative_path(full_path), check_xml_formula_values=False)
+
+        # After uploading the file, reload rulesets
+        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
+        if socket_response['error'] == 1:
+            raise WazuhError(1811, extra_message=socket_response['data'])
+
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         # Remove back up file if no exceptions were raised.
@@ -182,6 +189,12 @@ def delete_list_file(filename: list) -> AffectedItemsWazuhResult:
 
     try:
         delete_list(to_relative_path(full_path))
+
+        # After deleting the file, reload rulesets
+        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
+        if socket_response['error'] == 1:
+            raise WazuhError(1811, extra_message=socket_response['data'])
+
         result.affected_items.append(to_relative_path(full_path))
     except WazuhError as e:
         result.add_failed_item(id_=to_relative_path(full_path), error=e)

--- a/framework/wazuh/core/analysis.py
+++ b/framework/wazuh/core/analysis.py
@@ -1,0 +1,28 @@
+from json import dumps, loads
+from wazuh.core.common import ANALYSISD_SOCKET
+from wazuh.core.wazuh_socket import create_wazuh_socket_message, WazuhSocket
+
+RELOAD_RULESET_COMMAND = "reload-ruleset"
+
+def send_reload_ruleset_msg(origin: dict[str, str]) -> dict:
+    """Send the reload ruleset command to Analysisd socket.
+
+    Parameters
+    ----------
+    origin: dict[str, str]
+        Origin of the message
+
+    Returns
+    -------
+    dict
+        Response from the socket
+    """
+    msg = create_wazuh_socket_message(origin=origin, command=RELOAD_RULESET_COMMAND)
+
+    socket = WazuhSocket(ANALYSISD_SOCKET)
+    socket.send(dumps(msg).encode())
+
+    data = loads(socket.receive().decode())
+    socket.close()
+
+    return data

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -179,6 +179,7 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the rules'
                },
+        1212: {'message': 'Error sending Rules file update to Wazuh-Analysisd'},
 
         # Stats: 1300 - 1399
         1307: {'message': 'Invalid parameters',
@@ -260,6 +261,7 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the decoders'
                },
+        1508: {'message': 'Error sending decoders files update to Wazuh-Analysisd'},
 
         # Syscheck/AR: 1600 - 1699
         1603: 'Invalid status. Valid statuses are: all, solved and outstanding',
@@ -386,6 +388,7 @@ class WazuhException(Exception):
                },
         1810: {'message': 'Upgrade module\'s reserved exception IDs (1810-1899). '
                           'The error message will be the output of upgrade module'},
+        1811: {'message': 'Error sending CDB list files update to Wazuh-Analysisd'},
 
         # Manager:
         1901: {'message': '\'execq\' socket has not been created'

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -11,6 +11,7 @@ import xmltodict
 
 import wazuh.core.configuration as configuration
 from wazuh.core import common
+from wazuh.core.analysis import send_reload_ruleset_msg
 from wazuh.core.decoder import load_decoders_from_file, check_status, REQUIRED_FIELDS, SORT_FIELDS, DECODER_FIELDS, \
     DECODER_FILES_FIELDS, DECODER_FILES_REQUIRED_FIELDS
 from wazuh.core.exception import WazuhInternalError, WazuhError
@@ -374,6 +375,11 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
 
             raise exc
 
+        # After uploading the file, reload rulesets
+        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
+        if socket_response['error'] == 1:
+            raise WazuhError(1501, extra_message=socket_response['data'])
+
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         backup_file and exists(backup_file) and remove(backup_file)
@@ -422,6 +428,12 @@ def delete_decoder_file(filename: Union[str, list], relative_dirname: str = None
                 raise WazuhError(1907) from exc
         else:
             raise WazuhError(1906)
+
+        # After deleting the file, reload rulesets
+        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
+        if socket_response['error'] == 1:
+            raise WazuhError(1508, extra_message=socket_response['data'])
+
     except WazuhError as exc:
         result.add_failed_item(id_=to_relative_path(full_path), error=exc)
     result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -11,6 +11,7 @@ import xmltodict
 
 import wazuh.core.configuration as configuration
 from wazuh.core import common
+from wazuh.core.analysis import send_reload_ruleset_msg
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.utils import read_cluster_config
 from wazuh.core.exception import WazuhError
@@ -500,6 +501,11 @@ def upload_rule_file(filename: str, content: str, relative_dirname: str = None,
 
             raise exc
 
+        # After uploading the file, reload rulesets
+        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
+        if socket_response['error'] == 1:
+            raise WazuhError(1212, extra_message=socket_response['data'])
+
         result.affected_items.append(to_relative_path(full_path))
         result.total_affected_items = len(result.affected_items)
         backup_file and exists(backup_file) and remove(backup_file)
@@ -547,6 +553,11 @@ def delete_rule_file(filename: Union[str, list], relative_dirname: str = None) -
                 raise WazuhError(1907) from exc
         else:
             raise WazuhError(1906)
+
+        # After deleting the file, reload rulesets
+        socket_response = send_reload_ruleset_msg(origin={'module': 'api'})
+        if socket_response['error'] == 1:
+            raise WazuhError(1212, extra_message=socket_response['data'])
     except WazuhError as exc:
         result.add_failed_item(id_=to_relative_path(full_path), error=exc)
     result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -325,7 +325,8 @@ def test_get_list_file(filename, raw, expected_result, total_failed_items):
 @patch('wazuh.cdb_list.delete_list_file')
 @patch('wazuh.cdb_list.remove')
 @patch('wazuh.cdb_list.exists', return_value=True)
-def test_upload_list_file(mock_exists, mock_remove, mock_delete_list_file, mock_upload_file,
+@patch('wazuh.cdb_list.send_reload_ruleset_msg', return_value={'error': 0})
+def test_upload_list_file(mock_reload, mock_exists, mock_remove, mock_delete_list_file, mock_upload_file,
                           mock_delete_file_with_backup, mock_safe_move):
     """Check that functions inside upload_list_file are called with expected params"""
     filename = 'test_file'
@@ -337,6 +338,7 @@ def test_upload_list_file(mock_exists, mock_remove, mock_delete_list_file, mock_
     mock_delete_file_with_backup.assert_called_once_with(os.path.join(common.USER_LISTS_PATH, filename + '.backup'),
                                                          os.path.join(common.USER_LISTS_PATH, filename),
                                                          mock_delete_list_file)
+    mock_reload.assert_called_once()
 
 
 @patch('wazuh.cdb_list.common.USER_LISTS_PATH', return_value='/test/path')
@@ -373,7 +375,8 @@ def test_upload_list_file_ko(mock_remove, mock_lists_path):
 
 
 @patch('wazuh.core.cdb_list.delete_wazuh_file')
-def test_delete_list_file(mock_delete_file):
+@patch('wazuh.cdb_list.send_reload_ruleset_msg', return_value={'error': 0})
+def test_delete_list_file(mock_reload, mock_delete_file):
     """Check that expected result is returned when the file is deleted."""
     try:
         # Create directory for the test
@@ -392,6 +395,7 @@ def test_delete_list_file(mock_delete_file):
             pass
 
     mock_delete_file.assert_called_once_with(test_file)
+    mock_reload.assert_called_once()
 
 
 def test_delete_list_file_ko():

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -351,24 +351,26 @@ def test_upload_file(mock_logtest, mock_safe_move, mock_remove, mock_xml, mock_f
         ret_validation = rule.validate_upload_delete_dir(relative_dirname=relative_dirname)
         with patch('wazuh.rule.validate_upload_delete_dir', return_value=ret_validation):
             with patch('wazuh.rule.exists', return_value=overwrite):
-                result = rule.upload_rule_file(filename=file, relative_dirname=relative_dirname,
-                                                content=content, overwrite=overwrite)
+                with patch('wazuh.rule.send_reload_ruleset_msg', return_value={'error': 0}) as mock_reload:
+                    result = rule.upload_rule_file(filename=file, relative_dirname=relative_dirname,
+                                                    content=content, overwrite=overwrite)
 
-                # Assert data match what was expected, type of the result and correct
-                # parameters in delete() method.
-                assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
-                assert result.affected_items[0] == rule_path, 'Expected item not found'
-                mock_xml.assert_called_once_with(content, rule_path)
-                if overwrite:
-                    full_path = os.path.join(wazuh.common.WAZUH_PATH, rule_path)
-                    backup_file = full_path+'.backup'
-                    mock_full_copy.assert_called_once_with(full_path, backup_file), \
-                    'full_copy function not called with expected parameters'
-                    mock_delete.assert_called_once_with(filename= file,
-                                                        relative_dirname=os.path.dirname(rule_path)), \
-                        'delete_rule_file method not called with expected parameter'
-                    mock_remove.assert_called_once()
-                    mock_safe_move.assert_called_once()
+                    # Assert data match what was expected, type of the result and correct
+                    # parameters in delete() method.
+                    assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+                    assert result.affected_items[0] == rule_path, 'Expected item not found'
+                    mock_xml.assert_called_once_with(content, rule_path)
+                    if overwrite:
+                        full_path = os.path.join(wazuh.common.WAZUH_PATH, rule_path)
+                        backup_file = full_path+'.backup'
+                        mock_full_copy.assert_called_once_with(full_path, backup_file), \
+                        'full_copy function not called with expected parameters'
+                        mock_delete.assert_called_once_with(filename= file,
+                                                            relative_dirname=os.path.dirname(rule_path)), \
+                            'delete_rule_file method not called with expected parameter'
+                        mock_remove.assert_called_once()
+                        mock_safe_move.assert_called_once()
+                        mock_reload.assert_called_once()
 
 
 @patch('wazuh.rule.delete_rule_file', side_effect=WazuhError(1019))
@@ -435,9 +437,11 @@ def test_delete_rule_file(file, relative_dirname):
     with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
         with patch('wazuh.rule.exists', return_value=True):
             with patch('wazuh.rule.remove'):
-                # Assert returned type is AffectedItemsWazuhResult when everything is correct
-                assert(isinstance(rule.delete_rule_file(filename=file, relative_dirname=relative_dirname), 
-                                AffectedItemsWazuhResult))
+                with patch('wazuh.rule.send_reload_ruleset_msg', return_value={'error': 0}) as mock_reload:
+                    # Assert returned type is AffectedItemsWazuhResult when everything is correct
+                    assert(isinstance(rule.delete_rule_file(filename=file, relative_dirname=relative_dirname),
+                                    AffectedItemsWazuhResult))
+                    mock_reload.assert_called_once()
 
 def test_delete_rule_file_ko():
     """Delete rule file invalid test cases"""


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/29901|

## Description

Modifies the API endpoints related to the ruleset so that they use the `/var/ossec/queue/sockets/analysis` socket to reload the ruleset.