### PR TITLE
Add collector for the account policy data

### DIFF
--- a/src/data_provider/src/extended_sources/users/include/users_darwin.hpp
+++ b/src/data_provider/src/extended_sources/users/include/users_darwin.hpp
@@ -60,6 +60,11 @@ class UsersProvider
         /// @return JSON array of users matching the UIDs.
         nlohmann::json collectUsers(const std::set<uid_t>& uids);
 
+        /// @brief Collects account policy data for a specific user UID.
+        /// @param uid The numeric user ID (UID) for which to retrieve account policy data.
+        /// @return A JSON object containing account policy information for the given UID.
+        nlohmann::json collectAccountPolicyData(const uid_t uid);
+
         /// @brief Passwd utility wrapper.
         std::shared_ptr<IPasswdWrapperDarwin> m_passwdWrapper;
 

--- a/src/data_provider/src/extended_sources/users/src/users_darwin.cpp
+++ b/src/data_provider/src/extended_sources/users/src/users_darwin.cpp
@@ -87,6 +87,8 @@ nlohmann::json UsersProvider::collectUsers(const std::set<uid_t>& uids)
             nlohmann::json user = genUserJson(pwd);
             user["is_hidden"] = int(userNames[user["username"]]);
 
+            user.update(collectAccountPolicyData(user["uid"]));
+
             users.push_back(user);
         }
 
@@ -118,8 +120,18 @@ nlohmann::json UsersProvider::collectUsers(const std::set<uid_t>& uids)
 
         user["is_hidden"] = static_cast<int>(isHidden);
 
+        user.update(collectAccountPolicyData(user["uid"]));
+
         users.push_back(user);
     }
 
     return users;
+}
+
+nlohmann::json UsersProvider::collectAccountPolicyData(const uid_t uid)
+{
+    nlohmann::json accountData;
+    m_odWrapper->genAccountPolicyData(std::to_string(uid), accountData);
+
+    return accountData;
 }

--- a/src/data_provider/src/extended_sources/users/tests/test_users_darwin.cpp
+++ b/src/data_provider/src/extended_sources/users/tests/test_users_darwin.cpp
@@ -41,9 +41,13 @@ class MockODUtilsWrapper : public IODUtilsWrapper
                      const std::string* record,
                      StringBoolMap& names),
                     (override));
+        MOCK_METHOD(void, genAccountPolicyData,
+                    (const std::string& uid,
+                     nlohmann::json& policyData),
+                    (override));
 };
 
-TEST(UsersProviderTest, CollectWithConstraints_SingleUser)
+TEST(UsersProviderTest, CollectWithConstraintsSingleUser)
 {
     auto mockPasswd = std::make_shared<MockPasswdWrapper>();
     auto mockUUID = std::make_shared<MockUUIDWrapper>();
@@ -72,6 +76,17 @@ TEST(UsersProviderTest, CollectWithConstraints_SingleUser)
     {
         names["testuser"] = false;
     });
+    EXPECT_CALL(*mockOD, genAccountPolicyData(testing::_, testing::_))
+    .WillOnce([](const std::string&, nlohmann::json & policyData)
+    {
+        policyData =
+        {
+            {"creation_time", 1735576566.727},
+            {"failed_login_count", 0},
+            {"failed_login_timestamp", 0},
+            {"password_last_set_time", 1735576569.186}
+        };
+    });
 
     UsersProvider provider(mockPasswd, mockUUID, mockOD);
 
@@ -81,4 +96,65 @@ TEST(UsersProviderTest, CollectWithConstraints_SingleUser)
     EXPECT_EQ(result[0]["username"], "testuser");
     EXPECT_EQ(result[0]["uuid"], "abcdef00-1234-5678-90ab-cdefabcdef12");
     EXPECT_EQ(result[0]["is_hidden"], 0);
+    EXPECT_EQ(result[0]["creation_time"], 1735576566.727);
+    EXPECT_EQ(result[0]["failed_login_count"], 0);
+    EXPECT_EQ(result[0]["failed_login_timestamp"], 0);
+    EXPECT_EQ(result[0]["password_last_set_time"], 1735576569.186);
+}
+
+TEST(UsersProviderTest, CollectInvokesCollectAccountPolicyData)
+{
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockUUID = std::make_shared<MockUUIDWrapper>();
+    auto mockOD = std::make_shared<MockODUtilsWrapper>();
+
+    static struct passwd fakePasswd
+    {
+        .pw_name = (char*)"testuser",
+        .pw_uid = 101,
+        .pw_gid = 20,
+        .pw_gecos = (char*)"Test User",
+        .pw_dir = (char*)"/Users/testuser",
+        .pw_shell = (char*)"/bin/bash"
+    };
+
+    EXPECT_CALL(*mockOD, genEntries(testing::_, testing::_, testing::_)).WillOnce([](const std::string&, const std::string*, std::map<std::string, bool>& names)
+    {
+        names["testuser"] = false;
+    });
+
+    EXPECT_CALL(*mockPasswd, getpwnam(testing::_)).WillOnce(testing::Return(&fakePasswd));
+    EXPECT_CALL(*mockUUID, uidToUUID(101, testing::_)).WillOnce([](uid_t, uuid_t& uuid)
+    {
+        std::fill(std::begin(uuid), std::end(uuid), 0xAB);
+    });
+    EXPECT_CALL(*mockUUID, uuidToString(testing::_, testing::_)).WillOnce([](const uuid_t&, uuid_string_t& str)
+    {
+        strcpy(str, "abcdef00-1234-5678-90ab-cdefabcdef12");
+    });
+    EXPECT_CALL(*mockOD, genAccountPolicyData(testing::_, testing::_))
+    .WillOnce([](const std::string&, nlohmann::json & policyData)
+    {
+        policyData =
+        {
+            {"creation_time", 1735576566.727},
+            {"failed_login_count", 0},
+            {"failed_login_timestamp", 0},
+            {"password_last_set_time", 1735576569.186}
+        };
+    });
+
+    UsersProvider provider(mockPasswd, mockUUID, mockOD);
+
+    auto result = provider.collect();
+
+    ASSERT_EQ(result.size(), static_cast<size_t>(1));
+    const auto& user = result[0];
+    EXPECT_EQ(user["username"], "testuser");
+    EXPECT_EQ(user["uuid"], "abcdef00-1234-5678-90ab-cdefabcdef12");
+    EXPECT_EQ(user["is_hidden"], 0);
+    EXPECT_EQ(user["creation_time"], 1735576566.727);
+    EXPECT_EQ(user["failed_login_count"], 0);
+    EXPECT_EQ(user["failed_login_timestamp"], 0);
+    EXPECT_EQ(user["password_last_set_time"], 1735576569.186);
 }

--- a/src/data_provider/src/extended_sources/wrappers/unix/darwin/iopen_directory_utils_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/darwin/iopen_directory_utils_wrapper.hpp
@@ -31,4 +31,23 @@ class IODUtilsWrapper
         virtual void genEntries(const std::string& recordType,
                                 const std::string* record,
                                 std::map<std::string, bool>& names) = 0;
+
+        /// @brief Retrieves account policy data for a given user UID.
+        ///
+        /// Queries the local OpenDirectory node for the `accountPolicyData` attribute of the user
+        /// corresponding to the provided UID. Parses the returned property list (plist) data
+        /// and extracts relevant account policy fields.
+        ///
+        /// The following fields are extracted and populated in the output JSON object:
+        /// - "creation_time": When the account was first created (double)
+        /// - "failed_login_count": Number of failed login attempts (int)
+        /// - "failed_login_timestamp": Time of last failed login attempt (double)
+        /// - "password_last_set_time": Time when the password was last changed (double)
+        ///
+        /// If the user does not have `accountPolicyData`, or the attribute is missing or malformed,
+        /// the output JSON will still contain those fields with `null` values.
+        ///
+        /// @param uid The UID of the user to query.
+        /// @param policyData Output JSON object to be populated with account policy data.
+        virtual void genAccountPolicyData(const std::string& uid, nlohmann::json& policyData) = 0;
 };

--- a/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.hpp
@@ -12,6 +12,8 @@
 #include <map>
 #include <string>
 
+#include "json.hpp"
+
 namespace od
 {
     /// @brief Queries local OpenDirectory records.
@@ -26,5 +28,24 @@ namespace od
     void genEntries(const std::string& record_type,
                     const std::string* record,
                     std::map<std::string, bool>& names);
+
+    /// @brief Retrieves account policy data for a given user UID.
+    ///
+    /// Queries the local OpenDirectory node for the `accountPolicyData` attribute of the user
+    /// corresponding to the provided UID. Parses the returned property list (plist) data
+    /// and extracts relevant account policy fields.
+    ///
+    /// The following fields are extracted and populated in the output JSON object:
+    /// - "creation_time": When the account was first created (double)
+    /// - "failed_login_count": Number of failed login attempts (int)
+    /// - "failed_login_timestamp": Time of last failed login attempt (double)
+    /// - "password_last_set_time": Time when the password was last changed (double)
+    ///
+    /// If the user does not have `accountPolicyData`, or the attribute is missing or malformed,
+    /// the output JSON will still contain those fields with `null` values.
+    ///
+    /// @param uid The UID of the user to query.
+    /// @param policyData Output JSON object to be populated with account policy data.
+    void genAccountPolicyData(const std::string& uid, nlohmann::json& policyData);
 
 } // namespace od

--- a/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm
+++ b/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm
@@ -10,6 +10,7 @@
 #import <OpenDirectory/OpenDirectory.h>
 #import <Foundation/Foundation.h>
 #include "od_wrapper.hpp"
+#include "json.hpp"
 
 namespace od
 {
@@ -65,6 +66,143 @@ namespace od
                 std::string name([[re recordName] UTF8String]);
                 names[name] = isHidden;
             }
+        }
+    }
+
+    void genAccountPolicyData(const std::string& uid, nlohmann::json& policyData)
+    {
+        ODSession* s = [ODSession defaultSession];
+        NSError* err = nullptr;
+
+        policyData =
+        {
+            {"creation_time", nullptr},
+            {"failed_login_count", nullptr},
+            {"failed_login_timestamp", nullptr},
+            {"password_last_set_time", nullptr}
+        };
+
+        ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
+
+        if (err != nullptr)
+        {
+            return;
+        }
+
+        ODQuery* q =
+            [ODQuery queryWithNode:root
+                     forRecordTypes:kODRecordTypeUsers
+                     attribute:kODAttributeTypeUniqueID
+                     matchType:kODMatchEqualTo
+                     queryValues:[NSString stringWithFormat:@"%s", uid.c_str()]
+                     returnAttributes:@"dsAttrTypeNative:accountPolicyData"
+                     maximumResults:0
+                     error:&err];
+
+        if (err != nullptr)
+        {
+            return;
+        }
+
+        NSArray* od_results = [q resultsAllowingPartial:NO error:&err];
+
+        if (err != nullptr)
+        {
+            // std::cout << "Error with OpenDirectory results: "
+            //  << std::string([[err localizedDescription] UTF8String])
+            //  << std::endl;
+            return;
+        }
+
+        for (ODRecord * re in od_results)
+        {
+
+            NSError* attrErr = nullptr;
+            NSArray* userPolicyDataValues =
+                [re valuesForAttribute:@"dsAttrTypeNative:accountPolicyData"
+                    error:&attrErr];
+
+            if (attrErr != nullptr || ![userPolicyDataValues count])
+            {
+                // std::cout << "No accountPolicyData found for UID: "
+                // << uid.c_str() << std::endl;
+                return;
+            }
+
+            NSData* plistData = userPolicyDataValues[0];
+            NSPropertyListFormat format;
+            NSError* plistError = nil;
+
+            id plistDict = [NSPropertyListSerialization propertyListWithData:plistData
+                                                        options:NSPropertyListMutableContainersAndLeaves
+                                                        format:&format
+                                                        error:&plistError];
+
+            if (plistError != nil || ![plistDict isKindOfClass:[NSDictionary class]])
+            {
+                return;
+            }
+
+            NSDictionary* dict = (NSDictionary*)plistDict;
+            nlohmann::json tree;
+
+            for (NSString * key in dict)
+            {
+                id value = [dict objectForKey:key];
+                std::string k = [key UTF8String];
+
+                if ([value isKindOfClass:[NSNumber class]])
+                {
+                    tree[k] = [value doubleValue];
+                }
+                else if ([value isKindOfClass:[NSString class]])
+                {
+                    tree[k] = std::string([value UTF8String]);
+                }
+            }
+
+            auto assign_safe = [&](const char* plistKey, const char* jsonKey, bool isInteger)
+            {
+                if (!tree.contains(plistKey)) return;
+
+                const auto& val = tree[plistKey];
+
+                try
+                {
+                    if (val.is_number())
+                    {
+                        if (isInteger)
+                        {
+                            policyData[jsonKey] = static_cast<int64_t>(val.get<double>());
+                        }
+                        else
+                        {
+                            policyData[jsonKey] = val.get<double>();
+                        }
+                    }
+                    else if (val.is_string())
+                    {
+                        if (isInteger)
+                        {
+                            policyData[jsonKey] = std::stoll(val.get<std::string>());
+                        }
+                        else
+                        {
+                            policyData[jsonKey] = std::stod(val.get<std::string>());
+                        }
+                    }
+                }
+                catch (...)
+                {
+                    // Keep value in null if it fails
+                }
+            };
+
+            // Assign values if present and valid
+            assign_safe("creationTime", "creation_time", false);
+            assign_safe("failedLoginCount", "failed_login_count", true);
+            assign_safe("failedLoginTimestamp", "failed_login_timestamp", false);
+            assign_safe("passwordLastSetTime", "password_last_set_time", false);
         }
     }
 

--- a/src/data_provider/src/extended_sources/wrappers/unix/darwin/open_directory_utils_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/darwin/open_directory_utils_wrapper.hpp
@@ -34,4 +34,26 @@ class ODUtilsWrapper : public IODUtilsWrapper
         {
             od::genEntries(recordType, record, names);
         }
+
+        /// @brief Retrieves account policy data for a given user UID.
+        ///
+        /// Queries the local OpenDirectory node for the `accountPolicyData` attribute of the user
+        /// corresponding to the provided UID. Parses the returned property list (plist) data
+        /// and extracts relevant account policy fields.
+        ///
+        /// The following fields are extracted and populated in the output JSON object:
+        /// - "creation_time": When the account was first created (double)
+        /// - "failed_login_count": Number of failed login attempts (int)
+        /// - "failed_login_timestamp": Time of last failed login attempt (double)
+        /// - "password_last_set_time": Time when the password was last changed (double)
+        ///
+        /// If the user does not have `accountPolicyData`, or the attribute is missing or malformed,
+        /// the output JSON will still contain those fields with `null` values.
+        ///
+        /// @param uid The UID of the user to query.
+        /// @param policyData Output JSON object to be populated with account policy data.
+        void genAccountPolicyData(const std::string& uid, nlohmann::json& policyData) override
+        {
+            od::genAccountPolicyData(uid, policyData);
+        }
 };


### PR DESCRIPTION
|Related issue|
|---|
|Closes #29627|


## Description

Add support for retrieving account policy data from the system through the users table using the new os_data submodule in data_provider. This information will enrich the system inventory with real-time user session context, including which users are currently logged in, from where and since when.

- [x]  Implement the data extractors from macOS.
- [x]  Implement logic in extended_sources to retrieve OS account policy data.
- [x]  Add unit tests to validate field extraction and transformation.

## Proposed Changes

Since the account policy data is intended to be included in the users table, the collectUsers method in `users_darwin` was modified to also retrieve account policy data. This ensures that each user entry includes both standard user information and the associated account policy details, returning a comprehensive JSON object with all collected data

## Example output

### macOS

<details><summary>Original output</summary>

```json
[
  {
    "creation_time": "",
    "failed_login_count": "0",
    "failed_login_timestamp": "0.0",
    "password_last_set_time": "1735576360.12905",
    "uid": "248"
  },
  {
    "creation_time": "",
    "failed_login_count": "",
    "failed_login_timestamp": "",
    "password_last_set_time": "",
    "uid": "4294967294"
  },
  {
    "creation_time": "1735576566.72748",
    "failed_login_count": "0",
    "failed_login_timestamp": "0.0",
    "password_last_set_time": "1735576569.18672",
    "uid": "501"
  },
  {
    "creation_time": "1744313155.6957",
    "failed_login_count": "",
    "failed_login_timestamp": "",
    "password_last_set_time": "",
    "uid": "101"
  }
]
``` 

</details>

<details><summary>usersprovider darwin output</summary>

```json
[
    {
        "creation_time": null,
        "description": "Accessory Update Daemon",
        "directory": "/var/db/accessoryupdater",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 278,
        "gid_signed": 278,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 278,
        "uid_signed": 278,
        "username": "_accessoryupdater",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000116"
    },
    {
        "creation_time": null,
        "description": "AMaViS Daemon",
        "directory": "/var/virusmails",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 83,
        "gid_signed": 83,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 83,
        "uid_signed": 83,
        "username": "_amavisd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000053"
    },
    {
        "creation_time": null,
        "description": "Analytics Daemon",
        "directory": "/var/db/analyticsd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 263,
        "gid_signed": 263,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 263,
        "uid_signed": 263,
        "username": "_analyticsd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000107"
    },
    {
        "creation_time": null,
        "description": "App Install Daemon",
        "directory": "/var/db/appinstalld",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 273,
        "gid_signed": 273,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 273,
        "uid_signed": 273,
        "username": "_appinstalld",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000111"
    },
    {
        "creation_time": null,
        "description": "AppleEvents Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 55,
        "gid_signed": 55,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 55,
        "uid_signed": 55,
        "username": "_appleevents",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000037"
    },
    {
        "creation_time": null,
        "description": "applepay Account",
        "directory": "/var/db/applepay",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 260,
        "gid_signed": 260,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 260,
        "uid_signed": 260,
        "username": "_applepay",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000104"
    },
    {
        "creation_time": null,
        "description": "Application Owner",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 87,
        "gid_signed": 87,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 87,
        "uid_signed": 87,
        "username": "_appowner",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000057"
    },
    {
        "creation_time": null,
        "description": "Application Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 79,
        "gid_signed": 79,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 79,
        "uid_signed": 79,
        "username": "_appserver",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000004F"
    },
    {
        "creation_time": null,
        "description": "Mac App Store Service",
        "directory": "/var/db/appstore",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 33,
        "gid_signed": 33,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 33,
        "uid_signed": 33,
        "username": "_appstore",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000021"
    },
    {
        "creation_time": null,
        "description": "Apple Remote Desktop",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 67,
        "gid_signed": 67,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 67,
        "uid_signed": 67,
        "username": "_ard",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000043"
    },
    {
        "creation_time": null,
        "description": "Asset Cache Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 235,
        "gid_signed": 235,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 235,
        "uid_signed": 235,
        "username": "_assetcache",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000EB"
    },
    {
        "creation_time": null,
        "description": "Astris Services",
        "directory": "/var/db/astris",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 245,
        "gid_signed": 245,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 245,
        "uid_signed": 245,
        "username": "_astris",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F5"
    },
    {
        "creation_time": null,
        "description": "ATS Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 97,
        "gid_signed": 97,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 97,
        "uid_signed": 97,
        "username": "_atsserver",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000061"
    },
    {
        "creation_time": null,
        "description": "Audio and MediaExperience Daemon",
        "directory": "/var/db/audiomxd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 294,
        "gid_signed": 294,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 294,
        "uid_signed": 294,
        "username": "_audiomxd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000126"
    },
    {
        "creation_time": null,
        "description": "Ethernet AVB Device Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 229,
        "uid_signed": 229,
        "username": "_avbdeviced",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E5"
    },
    {
        "creation_time": null,
        "description": "Apple Virtual Platform HID Bridge",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 288,
        "gid_signed": 288,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 288,
        "uid_signed": 288,
        "username": "_avphidbridge",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000120"
    },
    {
        "creation_time": null,
        "description": "Background Assets Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 291,
        "gid_signed": 291,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 291,
        "uid_signed": 291,
        "username": "_backgroundassets",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000123"
    },
    {
        "creation_time": null,
        "description": "Biome",
        "directory": "/var/db/biome",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 289,
        "gid_signed": 289,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 289,
        "uid_signed": 289,
        "username": "_biome",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000121"
    },
    {
        "creation_time": null,
        "description": "Calendar",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 93,
        "gid_signed": 93,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 93,
        "uid_signed": 93,
        "username": "_calendar",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000005D"
    },
    {
        "creation_time": null,
        "description": "captiveagent",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 258,
        "gid_signed": 258,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 258,
        "uid_signed": 258,
        "username": "_captiveagent",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000102"
    },
    {
        "creation_time": null,
        "description": "Certificate Enrollment Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 32,
        "gid_signed": 32,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 32,
        "uid_signed": 32,
        "username": "_ces",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000020"
    },
    {
        "creation_time": null,
        "description": "ClamAV Daemon",
        "directory": "/var/virusmails",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 82,
        "gid_signed": 82,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 82,
        "uid_signed": 82,
        "username": "_clamav",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000052"
    },
    {
        "creation_time": null,
        "description": "CoreMedia IO Assistants User",
        "directory": "/var/db/cmiodalassistants",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 262,
        "gid_signed": 262,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 262,
        "uid_signed": 262,
        "username": "_cmiodalassistants",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000106"
    },
    {
        "creation_time": null,
        "description": "Core Audio Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 202,
        "gid_signed": 202,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 202,
        "uid_signed": 202,
        "username": "_coreaudiod",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000CA"
    },
    {
        "creation_time": null,
        "description": "Core Media IO Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 236,
        "gid_signed": 236,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 236,
        "uid_signed": 236,
        "username": "_coremediaiod",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000EC"
    },
    {
        "creation_time": null,
        "description": "CoreML Services",
        "directory": "/var/db/coreml",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 280,
        "gid_signed": 280,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 280,
        "uid_signed": 280,
        "username": "_coreml",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000118"
    },
    {
        "creation_time": null,
        "description": "ctkd Account",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 259,
        "gid_signed": 259,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 259,
        "uid_signed": 259,
        "username": "_ctkd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000103"
    },
    {
        "creation_time": null,
        "description": "CVMS Root",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 212,
        "gid_signed": 212,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 212,
        "uid_signed": 212,
        "username": "_cvmsroot",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D4"
    },
    {
        "creation_time": null,
        "description": "CVS Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 72,
        "gid_signed": 72,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 72,
        "uid_signed": 72,
        "username": "_cvs",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000048"
    },
    {
        "creation_time": null,
        "description": "Cyrus Administrator",
        "directory": "/var/imap",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 6,
        "gid_signed": 6,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 77,
        "uid_signed": 77,
        "username": "_cyrus",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000004D"
    },
    {
        "creation_time": null,
        "description": "Darwin Daemon",
        "directory": "/var/db/darwindaemon",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 284,
        "gid_signed": 284,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 284,
        "uid_signed": 284,
        "username": "_darwindaemon",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000011C"
    },
    {
        "creation_time": null,
        "description": "DataDetectors",
        "directory": "/var/db/datadetectors",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 257,
        "gid_signed": 257,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 257,
        "uid_signed": 257,
        "username": "_datadetectors",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000101"
    },
    {
        "creation_time": null,
        "description": "Demo Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 275,
        "gid_signed": 275,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 275,
        "uid_signed": 275,
        "username": "_demod",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000113"
    },
    {
        "creation_time": null,
        "description": "Developer Documentation",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 59,
        "gid_signed": 59,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 59,
        "uid_signed": 59,
        "username": "_devdocs",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000003B"
    },
    {
        "creation_time": null,
        "description": "Device Management Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 220,
        "gid_signed": 220,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 220,
        "uid_signed": 220,
        "username": "_devicemgr",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000DC"
    },
    {
        "creation_time": null,
        "description": "DiskImages IO Daemon",
        "directory": "/var/db/diskimagesiod",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 271,
        "gid_signed": 271,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 271,
        "uid_signed": 271,
        "username": "_diskimagesiod",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000010F"
    },
    {
        "creation_time": null,
        "description": "Display Policy Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 244,
        "gid_signed": 244,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 244,
        "uid_signed": 244,
        "username": "_displaypolicyd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F4"
    },
    {
        "creation_time": null,
        "description": "DistNote",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 241,
        "gid_signed": 241,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 241,
        "uid_signed": 241,
        "username": "_distnote",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F1"
    },
    {
        "creation_time": null,
        "description": "Dovecot Administrator",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 6,
        "gid_signed": 6,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 214,
        "uid_signed": 214,
        "username": "_dovecot",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D6"
    },
    {
        "creation_time": null,
        "description": "Dovecot Authentication",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 227,
        "gid_signed": 227,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 227,
        "uid_signed": 227,
        "username": "_dovenull",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E3"
    },
    {
        "creation_time": null,
        "description": "DP Audio",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 215,
        "gid_signed": 215,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 215,
        "uid_signed": 215,
        "username": "_dpaudio",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D7"
    },
    {
        "creation_time": null,
        "description": "DriverKit",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 270,
        "gid_signed": 270,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 270,
        "uid_signed": 270,
        "username": "_driverkit",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000010E"
    },
    {
        "creation_time": null,
        "description": "Apple Events User",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 71,
        "gid_signed": 71,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 71,
        "uid_signed": 71,
        "username": "_eppc",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000047"
    },
    {
        "creation_time": null,
        "description": "Find My Device Daemon",
        "directory": "/var/db/findmydevice",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 254,
        "gid_signed": 254,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 254,
        "uid_signed": 254,
        "username": "_findmydevice",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000FE"
    },
    {
        "creation_time": null,
        "description": "FPS Daemon",
        "directory": "/var/db/fpsd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 265,
        "gid_signed": 265,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 265,
        "uid_signed": 265,
        "username": "_fpsd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000109"
    },
    {
        "creation_time": null,
        "description": "FTP Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 98,
        "uid_signed": 98,
        "username": "_ftp",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000062"
    },
    {
        "creation_time": null,
        "description": "Game Controller Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 247,
        "gid_signed": 247,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 247,
        "uid_signed": 247,
        "username": "_gamecontrollerd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F7"
    },
    {
        "creation_time": null,
        "description": "Geo Services Daemon",
        "directory": "/var/db/geod",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 56,
        "gid_signed": 56,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 56,
        "uid_signed": 56,
        "username": "_geod",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000038"
    },
    {
        "creation_time": null,
        "description": "HID Service User",
        "directory": "/var/db/hidd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 261,
        "gid_signed": 261,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 261,
        "uid_signed": 261,
        "username": "_hidd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000105"
    },
    {
        "creation_time": null,
        "description": "IconServices",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 240,
        "gid_signed": 240,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 240,
        "uid_signed": 240,
        "username": "_iconservices",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F0"
    },
    {
        "creation_time": null,
        "description": "Install Assistant",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 25,
        "gid_signed": 25,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 25,
        "uid_signed": 25,
        "username": "_installassistant",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000019"
    },
    {
        "creation_time": null,
        "description": "Install Coordination Daemon",
        "directory": "/var/db/installcoordinationd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 274,
        "gid_signed": 274,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 274,
        "uid_signed": 274,
        "username": "_installcoordinationd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000112"
    },
    {
        "creation_time": null,
        "description": "Installer",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 96,
        "uid_signed": 96,
        "username": "_installer",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000060"
    },
    {
        "creation_time": null,
        "description": "Jabber XMPP Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 84,
        "gid_signed": 84,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 84,
        "uid_signed": 84,
        "username": "_jabber",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000054"
    },
    {
        "creation_time": null,
        "description": "Kerberos Admin Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 218,
        "uid_signed": 218,
        "username": "_kadmin_admin",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000DA"
    },
    {
        "creation_time": null,
        "description": "Kerberos Change Password Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 219,
        "uid_signed": 219,
        "username": "_kadmin_changepw",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000DB"
    },
    {
        "creation_time": null,
        "description": "Knowledge Graph Daemon",
        "directory": "/var/db/knowledgegraphd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 279,
        "gid_signed": 279,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 279,
        "uid_signed": 279,
        "username": "_knowledgegraphd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000117"
    },
    {
        "creation_time": null,
        "description": "Open Directory Kerberos Anonymous",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 234,
        "uid_signed": 234,
        "username": "_krb_anonymous",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000EA"
    },
    {
        "creation_time": null,
        "description": "Open Directory Kerberos Change Password Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 232,
        "uid_signed": 232,
        "username": "_krb_changepw",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E8"
    },
    {
        "creation_time": null,
        "description": "Open Directory Kerberos Admin Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 231,
        "uid_signed": 231,
        "username": "_krb_kadmin",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E7"
    },
    {
        "creation_time": null,
        "description": "Open Directory Kerberos",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 233,
        "uid_signed": 233,
        "username": "_krb_kerberos",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E9"
    },
    {
        "creation_time": null,
        "description": "Open Directory Kerberos Ticket Granting Ticket",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 230,
        "uid_signed": 230,
        "username": "_krb_krbtgt",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E6"
    },
    {
        "creation_time": null,
        "description": "Kerberos FAST Account",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 246,
        "uid_signed": 246,
        "username": "_krbfast",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F6"
    },
    {
        "creation_time": null,
        "description": "Kerberos Ticket Granting Ticket",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 217,
        "uid_signed": 217,
        "username": "_krbtgt",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D9"
    },
    {
        "creation_time": null,
        "description": "_launchservicesd",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 239,
        "gid_signed": 239,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 239,
        "uid_signed": 239,
        "username": "_launchservicesd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000EF"
    },
    {
        "creation_time": null,
        "description": "Local Delivery Agent",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 211,
        "gid_signed": 211,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 211,
        "uid_signed": 211,
        "username": "_lda",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D3"
    },
    {
        "creation_time": null,
        "description": "Location Daemon",
        "directory": "/var/db/locationd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 205,
        "gid_signed": 205,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 205,
        "uid_signed": 205,
        "username": "_locationd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000CD"
    },
    {
        "creation_time": null,
        "description": "Log Daemon",
        "directory": "/var/db/diagnostics",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 272,
        "gid_signed": 272,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 272,
        "uid_signed": 272,
        "username": "_logd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000110"
    },
    {
        "creation_time": null,
        "description": "Printing Services",
        "directory": "/var/spool/cups",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 26,
        "gid_signed": 26,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 26,
        "uid_signed": 26,
        "username": "_lp",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000001A"
    },
    {
        "creation_time": null,
        "description": "Mailman List Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 78,
        "gid_signed": 78,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 78,
        "uid_signed": 78,
        "username": "_mailman",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000004E"
    },
    {
        "creation_time": null,
        "description": "Setup User",
        "directory": "/var/setup",
        "failed_login_count": 0,
        "failed_login_timestamp": 0.0,
        "gid": 248,
        "gid_signed": 248,
        "is_hidden": 0,
        "password_last_set_time": 1735576360.129046,
        "shell": "/bin/bash",
        "uid": 248,
        "uid_signed": 248,
        "username": "_mbsetupuser",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F8"
    },
    {
        "creation_time": null,
        "description": "MCX AppLaunch",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 54,
        "gid_signed": 54,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 54,
        "uid_signed": 54,
        "username": "_mcxalr",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000036"
    },
    {
        "creation_time": null,
        "description": "mDNSResponder",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 65,
        "gid_signed": 65,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 65,
        "uid_signed": 65,
        "username": "_mdnsresponder",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000041"
    },
    {
        "creation_time": null,
        "description": "mmaintenanced",
        "directory": "/var/db/mmaintenanced",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 283,
        "gid_signed": 283,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 283,
        "uid_signed": 283,
        "username": "_mmaintenanced",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000011B"
    },
    {
        "creation_time": null,
        "description": "MobileAsset User",
        "directory": "/var/ma",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 253,
        "gid_signed": 253,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 253,
        "uid_signed": 253,
        "username": "_mobileasset",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000FD"
    },
    {
        "creation_time": null,
        "description": "MobileGestaltHelper",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 293,
        "gid_signed": 293,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 293,
        "uid_signed": 293,
        "username": "_mobilegestalthelper",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000125"
    },
    {
        "creation_time": null,
        "description": "MySQL Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 74,
        "gid_signed": 74,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 74,
        "uid_signed": 74,
        "username": "_mysql",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000004A"
    },
    {
        "creation_time": null,
        "description": "Proximity and Ranging Daemon",
        "directory": "/var/db/nearbyd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 268,
        "gid_signed": 268,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 268,
        "uid_signed": 268,
        "username": "_nearbyd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000010C"
    },
    {
        "creation_time": null,
        "description": "NetBIOS",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 222,
        "gid_signed": 222,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 222,
        "uid_signed": 222,
        "username": "_netbios",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000DE"
    },
    {
        "creation_time": null,
        "description": "Network Statistics Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 228,
        "gid_signed": 228,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 228,
        "uid_signed": 228,
        "username": "_netstatistics",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E4"
    },
    {
        "creation_time": null,
        "description": "Network Services",
        "directory": "/var/networkd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 24,
        "gid_signed": 24,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 24,
        "uid_signed": 24,
        "username": "_networkd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000018"
    },
    {
        "creation_time": null,
        "description": "AppleNeuralEngine",
        "directory": "/var/db/neuralengine",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 296,
        "gid_signed": 296,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 296,
        "uid_signed": 296,
        "username": "_neuralengine",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000128"
    },
    {
        "creation_time": null,
        "description": "Notification Proxy",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 285,
        "gid_signed": 285,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 285,
        "uid_signed": 285,
        "username": "_notification_proxy",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000011D"
    },
    {
        "creation_time": null,
        "description": "NSURLSession Daemon",
        "directory": "/var/db/nsurlsessiond",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 242,
        "gid_signed": 242,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 242,
        "uid_signed": 242,
        "username": "_nsurlsessiond",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F2"
    },
    {
        "creation_time": null,
        "description": "OAH Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 441,
        "gid_signed": 441,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 441,
        "uid_signed": 441,
        "username": "_oahd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000001B9"
    },
    {
        "creation_time": null,
        "description": "On Demand Resource Daemon",
        "directory": "/var/db/ondemand",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 249,
        "gid_signed": 249,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 249,
        "uid_signed": 249,
        "username": "_ondemand",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000F9"
    },
    {
        "creation_time": null,
        "description": "Postfix Mail Server",
        "directory": "/var/spool/postfix",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 27,
        "gid_signed": 27,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 27,
        "uid_signed": 27,
        "username": "_postfix",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000001B"
    },
    {
        "creation_time": null,
        "description": "PostgreSQL Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 216,
        "gid_signed": 216,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 216,
        "uid_signed": 216,
        "username": "_postgres",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D8"
    },
    {
        "creation_time": null,
        "description": "QuickTime Streaming Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 76,
        "gid_signed": 76,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 76,
        "uid_signed": 76,
        "username": "_qtss",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000004C"
    },
    {
        "creation_time": null,
        "description": "ReportMemoryException",
        "directory": "/var/db/reportmemoryexception",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 269,
        "gid_signed": 269,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 269,
        "uid_signed": 269,
        "username": "_reportmemoryexception",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000010D"
    },
    {
        "creation_time": null,
        "description": "Remote Management Daemon",
        "directory": "/var/db/rmd",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 277,
        "gid_signed": 277,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 277,
        "uid_signed": 277,
        "username": "_rmd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000115"
    },
    {
        "creation_time": null,
        "description": "Seatbelt",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 60,
        "gid_signed": 60,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 60,
        "uid_signed": 60,
        "username": "_sandbox",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000003C"
    },
    {
        "creation_time": null,
        "description": "Screensaver",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 203,
        "gid_signed": 203,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 203,
        "uid_signed": 203,
        "username": "_screensaver",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000CB"
    },
    {
        "creation_time": null,
        "description": "Service Configuration Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 31,
        "gid_signed": 31,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 31,
        "uid_signed": 31,
        "username": "_scsd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000001F"
    },
    {
        "creation_time": null,
        "description": "SecurityAgent",
        "directory": "/var/db/securityagent",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 92,
        "gid_signed": 92,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 92,
        "uid_signed": 92,
        "username": "_securityagent",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000005C"
    },
    {
        "creation_time": null,
        "description": "SNTP Server Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 281,
        "gid_signed": 281,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 281,
        "uid_signed": 281,
        "username": "_sntpd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000119"
    },
    {
        "creation_time": null,
        "description": "Software Update Service",
        "directory": "/var/db/softwareupdate",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 200,
        "gid_signed": 200,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 200,
        "uid_signed": 200,
        "username": "_softwareupdate",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000C8"
    },
    {
        "creation_time": null,
        "description": "Spotlight",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 89,
        "gid_signed": 89,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 89,
        "uid_signed": 89,
        "username": "_spotlight",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000059"
    },
    {
        "creation_time": null,
        "description": "sshd Privilege separation",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 75,
        "gid_signed": 75,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 75,
        "uid_signed": 75,
        "username": "_sshd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000004B"
    },
    {
        "creation_time": null,
        "description": "SVN Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 73,
        "gid_signed": 73,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 73,
        "uid_signed": 73,
        "username": "_svn",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000049"
    },
    {
        "creation_time": null,
        "description": "Task Gate Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 13,
        "gid_signed": 13,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 13,
        "uid_signed": 13,
        "username": "_taskgated",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000000D"
    },
    {
        "creation_time": null,
        "description": "TeamsServer",
        "directory": "/var/teamsserver",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 94,
        "gid_signed": 94,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 94,
        "uid_signed": 94,
        "username": "_teamsserver",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000005E"
    },
    {
        "creation_time": null,
        "description": "Terminus",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 295,
        "gid_signed": 295,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 295,
        "uid_signed": 295,
        "username": "_terminusd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000127"
    },
    {
        "creation_time": null,
        "description": "Time Sync Daemon",
        "directory": "/var/db/timed",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 266,
        "gid_signed": 266,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 266,
        "uid_signed": 266,
        "username": "_timed",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000010A"
    },
    {
        "creation_time": null,
        "description": "AutoTimeZoneDaemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 210,
        "gid_signed": 210,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 210,
        "uid_signed": 210,
        "username": "_timezone",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D2"
    },
    {
        "creation_time": null,
        "description": "Token Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 91,
        "gid_signed": 91,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 91,
        "uid_signed": 91,
        "username": "_tokend",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000005B"
    },
    {
        "creation_time": null,
        "description": "trustd",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 282,
        "gid_signed": 282,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 282,
        "uid_signed": 282,
        "username": "_trustd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000011A"
    },
    {
        "creation_time": null,
        "description": "Trust Evaluation Agent",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 208,
        "gid_signed": 208,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 208,
        "uid_signed": 208,
        "username": "_trustevaluationagent",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D0"
    },
    {
        "creation_time": null,
        "description": "Unknown User",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 99,
        "gid_signed": 99,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 99,
        "uid_signed": 99,
        "username": "_unknown",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000063"
    },
    {
        "creation_time": null,
        "description": "Update Sharing",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 95,
        "uid_signed": 95,
        "username": "_update_sharing",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA0000005F"
    },
    {
        "creation_time": null,
        "description": "iPhone OS Device Helper",
        "directory": "/var/db/lockdown",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 213,
        "gid_signed": 213,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 213,
        "uid_signed": 213,
        "username": "_usbmuxd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000D5"
    },
    {
        "creation_time": null,
        "description": "Unix to Unix Copy Protocol",
        "directory": "/var/spool/uucp",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4,
        "gid_signed": 4,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/sbin/uucico",
        "uid": 4,
        "uid_signed": 4,
        "username": "_uucp",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000004"
    },
    {
        "creation_time": null,
        "description": "Warm Daemon",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 224,
        "gid_signed": 224,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 224,
        "uid_signed": 224,
        "username": "_warmd",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000E0"
    },
    {
        "creation_time": null,
        "description": "Web Auth Server",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 221,
        "gid_signed": 221,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 221,
        "uid_signed": 221,
        "username": "_webauthserver",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000DD"
    },
    {
        "creation_time": null,
        "description": "WindowServer",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 88,
        "gid_signed": 88,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 88,
        "uid_signed": 88,
        "username": "_windowserver",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000058"
    },
    {
        "creation_time": null,
        "description": "World Wide Web Server",
        "directory": "/Library/WebServer",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 70,
        "gid_signed": 70,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 70,
        "uid_signed": 70,
        "username": "_www",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000046"
    },
    {
        "creation_time": null,
        "description": "WWW Proxy",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 252,
        "gid_signed": 252,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 252,
        "uid_signed": 252,
        "username": "_wwwproxy",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000FC"
    },
    {
        "creation_time": null,
        "description": "macOS Server Documents Service",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 251,
        "gid_signed": 251,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 251,
        "uid_signed": 251,
        "username": "_xserverdocs",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA000000FB"
    },
    {
        "creation_time": null,
        "description": "System Services",
        "directory": "/var/root",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 1,
        "gid_signed": 1,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 1,
        "uid_signed": 1,
        "username": "daemon",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000001"
    },
    {
        "creation_time": null,
        "description": "Unprivileged User",
        "directory": "/var/empty",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 4294967294,
        "gid_signed": -2,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 4294967294,
        "uid_signed": -2,
        "username": "nobody",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAAFFFFFFFE"
    },
    {
        "creation_time": null,
        "description": "System Administrator",
        "directory": "/var/root",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 0,
        "gid_signed": 0,
        "is_hidden": 0,
        "password_last_set_time": null,
        "shell": "/bin/sh",
        "uid": 0,
        "uid_signed": 0,
        "username": "root",
        "uuid": "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000000"
    },
    {
        "creation_time": 1735576566.7274818,
        "description": "test",
        "directory": "/Users/test",
        "failed_login_count": 0,
        "failed_login_timestamp": 0.0,
        "gid": 20,
        "gid_signed": 20,
        "is_hidden": 0,
        "password_last_set_time": 1735576569.1867251,
        "shell": "/bin/zsh",
        "uid": 501,
        "uid_signed": 501,
        "username": "test",
        "uuid": "86E5195F-57EA-4ECA-A31C-A0F5278F3B82"
    },
    {
        "creation_time": 1744313155.6956968,
        "description": "wazuh",
        "directory": "/var/wazuh",
        "failed_login_count": null,
        "failed_login_timestamp": null,
        "gid": 101,
        "gid_signed": 101,
        "is_hidden": 1,
        "password_last_set_time": null,
        "shell": "/usr/bin/false",
        "uid": 101,
        "uid_signed": 101,
        "username": "wazuh",
        "uuid": "D914B632-3E00-42A4-8830-5DD700503D37"
    }
]

``` 

</details>

# Checks

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

Review Checklist
  - [x]  Code changes reviewed
  - [x]  Relevant evidence provided
  - [x]  Tests cover the new functionality
  - [x]  Configuration changes documented
  - [x]  Developer documentation reflects the changes
  - [x]  Meets requirements and/or definition of done
  - [x]  No unresolved dependencies with other issues