### PR TITLE
Ruleset correction in ossec.conf

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10552,6 +10552,9 @@ paths:
                           - etc/lists/audit-keys
                           - etc/lists/amazon/aws-eventnames
                           - etc/lists/security-eventchannel
+                          - etc/lists/malicious-ioc/malware-hashes
+                          - etc/lists/malicious-ioc/malicious-ip
+                          - etc/lists/malicious-ioc/malicious-domains
                       auth:
                         disabled: no
                         port: "1515"

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -227,9 +227,6 @@
     <rule_dir>ruleset/rules</rule_dir>
     <rule_exclude>0215-policy_rules.xml</rule_exclude>
     <list>etc/lists/audit-keys</list>
-    <list>etc/lists/malicious-ioc/malware-hashes</list>
-    <list>etc/lists/malicious-ioc/malicious-ip</list>
-    <list>etc/lists/malicious-ioc/malicious-domains</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -227,9 +227,6 @@
     <rule_dir>ruleset/rules</rule_dir>
     <rule_exclude>0215-policy_rules.xml</rule_exclude>
     <list>etc/lists/audit-keys</list>
-    <list>etc/lists/malicious-ioc/malware-hashes</list>
-    <list>etc/lists/malicious-ioc/malicious-ip</list>
-    <list>etc/lists/malicious-ioc/malicious-domains</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -232,9 +232,6 @@
     <rule_dir>ruleset/rules</rule_dir>
     <rule_exclude>0215-policy_rules.xml</rule_exclude>
     <list>etc/lists/audit-keys</list>
-    <list>etc/lists/malicious-ioc/malware-hashes</list>
-    <list>etc/lists/malicious-ioc/malicious-ip</list>
-    <list>etc/lists/malicious-ioc/malicious-domains</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -30,7 +30,7 @@ data_path = 'core/tests/data/rules'
 ruleset_conf = {
     'decoder_dir': ['ruleset/decoders', 'etc/decoders'],
     'rule_dir': ['ruleset/rules', 'etc/rules'], 'rule_exclude': ['0215-policy_rules.xml'],
-    'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel']
+    'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel', 'etc/lists/malicious-ioc/malware-hashes', 'etc/lists/malicious-ioc/malicious-ip', 'etc/lists/malicious-ioc/malicious-domains']
 }
 
 

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -39,7 +39,7 @@ other_rule_ossec_conf = {
         'decoder_dir': ['ruleset/decoders', 'etc/decoders'],
         'rule_dir': [core_data_path],
         'rule_exclude': ['0010-rules_config.xml'],
-        'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel']
+        'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel', 'etc/lists/malicious-ioc/malware-hashes', 'etc/lists/malicious-ioc/malicious-ip', 'etc/lists/malicious-ioc/malicious-domains']
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#29937|

## Description

The test configuration template (all_disabled_ossec.conf) was missing the necessary entries to properly load the indicators of compromise (IOC) lists used by custom rules with if_sid. This caused SIDs 99905 and 99906 to not be found in analysisd, and the test_valid_signature_id integration test to fail with the message "Signature ID '…' was not found."

With these changes, analysisd will be able to load the referenced rules before evaluating if_sid, and the test will pass successfully.