### PR TITLE
Fix `test_valid_signature_id` in Analysisd integration tests

### DIFF
--- a/tests/integration/test_analysisd/test_signature_id/data/configuration_templates/configuration_signature_id_values.yaml
+++ b/tests/integration/test_analysisd/test_signature_id/data/configuration_templates/configuration_signature_id_values.yaml
@@ -30,3 +30,13 @@
       elements:
         - disabled:
             value: 'yes'
+
+    # Add malicious-ioc CDB lists
+    - section: ruleset
+      elements:
+        - list:
+            value: etc/lists/malicious-ioc/malware-hashes
+        - list:
+            value: etc/lists/malicious-ioc/malicious-ip
+        - list:
+            value: etc/lists/malicious-ioc/malicious-domains


### PR DESCRIPTION
|Related issue|
|---|
|#29937|

This PR addresses a failure in the `analysisd` Tier 0 and Tier 1 tests.  
The issue is resolved by explicitly adding the `CDBList` of the failed rules to the test load configuration.

### Notes
While this fix restores test stability, a deeper investigation is needed to understand why including these rules is necessary in this particular test.


