### PR TITLE
 Fix `test_valid_signature_id` in Analysisd integration tests

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -10552,6 +10552,9 @@ paths:
                           - etc/lists/audit-keys
                           - etc/lists/amazon/aws-eventnames
                           - etc/lists/security-eventchannel
+                          - etc/lists/malicious-ioc/malware-hashes
+                          - etc/lists/malicious-ioc/malicious-ip
+                          - etc/lists/malicious-ioc/malicious-domains
                       auth:
                         disabled: no
                         port: "1515"

--- a/framework/wazuh/core/tests/test_rule.py
+++ b/framework/wazuh/core/tests/test_rule.py
@@ -30,7 +30,7 @@ data_path = 'core/tests/data/rules'
 ruleset_conf = {
     'decoder_dir': ['ruleset/decoders', 'etc/decoders'],
     'rule_dir': ['ruleset/rules', 'etc/rules'], 'rule_exclude': ['0215-policy_rules.xml'],
-    'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel']
+    'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel', 'etc/lists/malicious-ioc/malware-hashes', 'etc/lists/malicious-ioc/malicious-ip', 'etc/lists/malicious-ioc/malicious-domains']
 }
 
 

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -39,7 +39,7 @@ other_rule_ossec_conf = {
         'decoder_dir': ['ruleset/decoders', 'etc/decoders'],
         'rule_dir': [core_data_path],
         'rule_exclude': ['0010-rules_config.xml'],
-        'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel']
+        'list': ['etc/lists/audit-keys', 'etc/lists/amazon/aws-eventnames', 'etc/lists/security-eventchannel', 'etc/lists/malicious-ioc/malware-hashes', 'etc/lists/malicious-ioc/malicious-ip', 'etc/lists/malicious-ioc/malicious-domains']
     }
 }
 


### PR DESCRIPTION
|Related issue|
|---|
|#29937|

This PR addresses a failure in the `analysisd` Tier 0 and Tier 1 tests.  
The issue is resolved by explicitly adding the `CDBList` of the failed rules to the test load configuration.

### Notes
While this fix restores test stability, a deeper investigation is needed to understand why including these rules is necessary in this particular test.


