### PR TITLE
Fix multiple Rocky Linux SCA checks generating incorrect results

### DIFF
--- a/ruleset/sca/rocky/cis_rocky_linux_9.yml
+++ b/ruleset/sca/rocky/cis_rocky_linux_9.yml
@@ -48,9 +48,9 @@ checks:
       - pci_dss_3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
-    condition: all
+    condition: any
     rules:
-      - "c:modprobe -n -v squashfs -> r:install /bin/false|Module squashfs not found"
+      - "c:modprobe -n -v squashfs -> r:install /bin/false|install /bin/true|Module squashfs not found"
       - "not c:lsmod -> r:squashfs"
       - 'd:/etc/modprobe.d/ -> r:\.*.conf -> r:^blacklist\s+squashfs'
 
@@ -73,9 +73,9 @@ checks:
       - pci_dss_3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
-    condition: all
+    condition: any
     rules:
-      - "c:modprobe -n -v udf -> r:install /bin/false|Module udf not found"
+      - "c:modprobe -n -v udf -> r:install /bin/false|install /bin/true|Module udf not found"
       - "not c:lsmod -> r:udf"
       - 'd:/etc/modprobe.d/ -> r:\.*.conf -> r:^blacklist\s+udf'
 
@@ -758,10 +758,11 @@ checks:
       - mitre_tactics: ["TA0001", "TA0010"]
       - mitre_techniques: ["T1091"]
       - nist_sp_800-53: ["SC-18(4)"]
-    condition: all
+    condition: any
     rules:
-      - "c:modprobe -n -v usb-storage -> r:install /bin/true"
+      - "c:modprobe -n -v usb-storage -> r:install /bin/true|install /bin/false"
       - "not c:lsmod -> r:usb-storage"
+      - 'd:/etc/modprobe.d/ -> r:\.*.conf -> r:^blacklist\s+usb-storage'
 
   ###############################################
   # 1.2 Configure Software Updates
@@ -1931,8 +1932,9 @@ checks:
       - mitre_techniques: ["T1068", "T1210"]
     condition: all
     rules:
-      - "c:modprobe -n -v tipc -> r:install /bin/true"
+      - "c:modprobe -n -v tipc -> r:install /bin/true|install /bin/false"
       - "not c:lsmod -> r:tipc"
+      - 'd:/etc/modprobe.d/ -> r:\.*.conf -> r:^blacklist\s+tipc'
 
   ###############################################
   # 3.2 Network Parameters (Host Only)
@@ -2007,11 +2009,13 @@ checks:
       - pci_dss_3.2.1: ["1.1.4", "1.3.1", "1.4"]
       - pci_dss_4.0: ["1.2.1", "1.4.1"]
       - soc_2: ["CC6.6"]
-    condition: any
+    condition: all
     rules:
-      - "c:rpm -q firewalld -> r:^package firewalld is not installed"
-      - "not c:firewall-cmd --state -> r:^running"
-      - "c:systemctl is-enabled firewalld -> r:^masked"
+      - "c:rpm -q nftables firewalld -> r:^nftables-|^firewalld-"
+      - "c:systemctl is-enabled nftables firewalld -> r:^masked|^disabled|^No such file or directory"
+      - "c:systemctl is-active nftables firewalld -> r:^inactive"
+      - "c:systemctl is-enabled nftables firewalld -> r:^enabled"
+      - "c:systemctl is-active nftables firewalld -> r:^active"
 
   # 3.4.2.1 Ensure firewalld default zone is set. (Automated) - Not Implemented
 
@@ -2084,8 +2088,6 @@ checks:
     condition: all
     rules:
       - "c:rpm -q nftables -> r:^nftables-"
-      - "c:nft list ruleset -> r:policy drop"
-      - "c:nft list ruleset -> r:policy drop"
       - "c:nft list ruleset -> r:policy drop"
 
   ############################################################
@@ -2600,10 +2602,10 @@ checks:
       - pci_dss_3.2.1: ["10.2", "10.3", "7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_4.0: ["1.3.1", "10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2", "7.1"]
       - soc_2: ["CC5.2", "CC6.1"]
-    condition: any
+    condition: all
     rules:
-      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
-      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode && r:0640|0600|0400'
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 06\d0|^\$FileCreateMode 04\d0|^\$FileCreateMode 02\d0|^\$FileCreateMode 00\d0'
+      - 'f:/etc/rsyslog.conf -> r:^\$FileCreateMode 0\d40|^\$FileCreateMode 0\d20|^\$FileCreateMode 0\d00'
 
   # 4.2.1.5 Ensure logging is configured. (Manual) - Not Implemented
 
@@ -3057,7 +3059,7 @@ checks:
       - pci_dss_3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - pci_dss_4.0: ["1.3.1", "7.1"]
       - soc_2: ["CC5.2", "CC6.1"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -> r:^\s*AllowUsers\s+\w*|^\s*AllowGroups\s+\w*|^\s*DenyUsers\s+\w*|^\s*DenyGroups\s+\w*'
       - 'f:/etc/ssh/sshd_config -> r:^\s*AllowUsers\s+\w*|^\s*AllowGroups\s+\w*|^\s*DenyUsers\s+\w*|^\s*DenyGroups\s+\w*'
@@ -3082,7 +3084,7 @@ checks:
       - nist_sp_800-53: ["AU-12", "AU-2", "SI-5"]
       - pci_dss_3.2.1: ["10.2", "10.3"]
       - pci_dss_4.0: ["10.2.1", "10.2.1.1", "10.2.1.2", "10.2.1.3", "10.2.1.4", "10.2.1.5", "10.2.1.6", "10.2.1.7", "10.2.2", "5.3.4", "6.4.1", "6.4.2"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*LogLevel\s+VERBOSE|^\s*LogLevel\s+INFO'
       - "f:/etc/ssh/sshd_config -> r:loglevel"
@@ -3100,10 +3102,10 @@ checks:
       - mitre_tactics: ["TA0001"]
       - mitre_techniques: ["T1021", "T1021.004"]
       - nist_sp_800-53: ["CM-1", "CM-2", "CM-6", "CM-7", "IA-5"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*usepam\s+yes'
-      - 'not f:/etc/ssh/sshd_config -> r:^\sUsePAM\s+no'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:UsePAM\s+no'
 
   # 5.2.7 Ensure SSH root login is disabled. (Automated)
   - id: 31624
@@ -3123,10 +3125,10 @@ checks:
       - nist_sp_800-53: ["AC-6(2)", "AC-6(5)"]
       - pci_dss_3.2.1: ["7.1", "7.1.1", "7.1.2", "7.1.3"]
       - soc_2: ["CC6.1", "CC6.3"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*PermitRootLogin\s*no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\sPermitRootLogin\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\s+yes'
 
   # 5.2.8 Ensure SSH HostbasedAuthentication is disabled. (Automated)
   - id: 31625
@@ -3146,10 +3148,10 @@ checks:
       - pci_dss_3.2.1: ["11.5", "2.2"]
       - pci_dss_4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
       - soc_2: ["CC7.1", "CC8.1"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*HostbasedAuthentication\s*\t*no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\sHostbasedAuthentication\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\s+yes'
 
   # 5.2.9 Ensure SSH PermitEmptyPasswords is disabled. (Automated)
   - id: 31626
@@ -3169,10 +3171,10 @@ checks:
       - nist_sp_800-53: ["CM-1", "CM-2", "CM-6", "CM-7", "IA-5"]
       - pci_dss_4.0: ["2.2.2", "8.3.5", "8.3.6", "8.6.3"]
       - soc_2: ["CC6.1"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*PermitEmptyPasswords\s*no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\sPermitEmptyPasswords\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:PermitEmptyPasswords\s+yes'
 
   # 5.2.10 Ensure SSH PermitUserEnvironment is disabled. (Automated)
   - id: 31627
@@ -3193,10 +3195,10 @@ checks:
       - pci_dss_3.2.1: ["11.5", "2.2"]
       - pci_dss_4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
       - soc_2: ["CC7.1", "CC8.1"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*PermitUserEnvironment\s*no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\sPermitUserEnvironment\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:PermitUserEnvironment\s+yes'
 
   # 5.2.11 Ensure SSH IgnoreRhosts is enabled. (Automated)
   - id: 31628
@@ -3210,10 +3212,10 @@ checks:
       - mitre_tactics: ["TA0001"]
       - mitre_techniques: ["T1078", "T1078.001", "T1078.003"]
       - nist_sp_800-53: ["CM-1", "CM-2", "CM-6", "CM-7", "IA-5"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:\s*ignorerhosts\s*yes'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*ignorerhosts\s+no'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:ignorerhosts\s+no'
 
   # 5.2.12 Ensure SSH X11 forwarding is disabled. (Automated)
   - id: 31629
@@ -3234,10 +3236,10 @@ checks:
       - pci_dss_3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
       - pci_dss_4.0: ["1.2.5", "2.2.4", "6.4.1"]
       - soc_2: ["CC6.3", "CC6.6"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*X11Forwarding\s*no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*x11forwarding\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:x11forwarding\s+yes'
 
   # 5.2.13 Ensure SSH AllowTcpForwarding is disabled. (Automated)
   - id: 31630
@@ -3261,10 +3263,10 @@ checks:
       - pci_dss_3.2.1: ["11.5", "2.2"]
       - pci_dss_4.0: ["1.1.1", "1.2.1", "1.2.6", "1.2.7", "1.5.1", "2.1.1", "2.2.1"]
       - soc_2: ["CC7.1", "CC8.1"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> r:^\s*AllowTcpForwarding\s+no'
-      - 'not f:/etc/ssh/sshd_config -> r:^\s*AllowTcpForwarding\s+yes'
+      - 'not f:/etc/ssh/sshd_config -> !r:^# && r:AllowTcpForwarding\s+yes'
 
   # 5.2.14 Ensure system-wide crypto policy is not over-ridden. (Automated)
   - id: 31631
@@ -3319,7 +3321,7 @@ checks:
       - pci_dss_3.2.1: ["10.1", "10.2.2", "10.2.4", "10.2.5", "10.3"]
       - pci_dss_4.0: ["10.2", "10.2.1", "10.2.1.2", "10.2.1.5", "9.4.5"]
       - soc_2: ["CC5.2", "CC7.2"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> n:^\s*MaxAuthTries\s*\t*(\d+) compare <= 4'
       - 'f:/etc/ssh/sshd_config -> n:^\s*MaxAuthTries\s*\t*(\d+) compare <= 4'
@@ -3378,7 +3380,7 @@ checks:
       - mitre_mitigations: ["M1036"]
       - mitre_tactics: ["TA0006"]
       - mitre_techniques: ["T1110", "T1110.001", "T1110.003", "T1110.004"]
-    condition: all
+    condition: any
     rules:
       - 'c:sshd -T -C user=root -> n:^\s*LoginGraceTime\s*\t*(\d+) compare <= 60 && n:^\s*LoginGraceTime\s*\t*(\d+) compare > 0'
       - 'f:/etc/ssh/sshd_config -> n:^\s*LoginGraceTime\s*\t*(\d+) compare <= 60 && n:^\s*LoginGraceTime\s*\t*(\d+) compare > 0'
@@ -3399,8 +3401,8 @@ checks:
       - nist_sp_800-53: ["CM-1", "CM-2", "CM-6", "CM-7", "IA-5"]
     condition: all
     rules:
-      - 'c:sshd -T -C user=root -> n:^\s*ClientAliveInterval\s*\t*(\d+) compare > 0 && n:^\s*ClientAliveInterval\s*\t*(\d+) compare <= 900'
-      - 'c:sshd -T -C user=root -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare == 0'
+      - 'c:sshd -T -C user=root -> n:^\s*ClientAliveInterval\s*\t*(\d+) compare > 0'
+      - 'c:sshd -T -C user=root -> n:^\s*ClientAliveCountMax\s*\t*(\d+) compare > 0'
 
   ############################################################
   # 5.3 Configure privilege escalation


### PR DESCRIPTION

## Description

A user reported multiple SCA checks with false results on Rocky Linux 9 [here](https://github.com/wazuh/wazuh/issues/29618).

## Observation


Check ID | Change Required
-- | --
31500 | Condition   should be ANY and `install /bin/true`    should be included in the regex
31501 | Condition   should be ANY and `install /bin/true`    and `blacklist` should be included in the regex
31528 | Condition   should be ANY and `install /bin/false`   and `blacklist` should be included in the regex
31578 | Condition   should be ANY and `install /bin/true`    and `blacklist` should be included in the regex
31580 | Logic   needs to be redefined to verify only one of NFT or Firewalld is active while   the other is disabled.
31583 | Duplicate   rule should be removed.
31598 | The   current rule works as intended as the proposed rule introduces a false   positive that was reported in   https://github.com/wazuh/external-devel-requests/issues/5040
31621 | Having   the Condition as ANY is more suitable.
31622 | Having   the Condition as ANY is more suitable.
31623 | Having   the Condition as ANY is more suitable.
31624 | Having   the Condition as ANY is more suitable.
31625 | Having   the Condition as ANY is more suitable.
31626 | Having   the Condition as ANY is more suitable.
31627 | Having   the Condition as ANY is more suitable.
31628 | Having   the Condition as ANY is more suitable.
31629 | Having   the Condition as ANY is more suitable.
31630 | Having   the Condition as ANY is more suitable.
31632 | Having   the Condition as ANY is more suitable.
31633 | Having   the Condition as ANY is more suitable.
31635 | The   current rule works as expected.
31636 | Having   the Condition as ANY is more suitable.
31637 | Having   the Condition as ANY is more suitable.
