### PR TITLE
Fix math lib inclusion on AIX

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2010,7 +2010,7 @@ $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)
 		ar -x libwazuhext/$$lib; \
 		mv *.o libwazuhext/; \
 	done
-	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc -latomic
+	$(OSSEC_SHARED) $(OSSEC_CFLAGS) libwazuhext/*.o -o $@ -static-libgcc -latomic -lm
 else
 ifeq (${uname_S},HP-UX)
 $(WAZUHEXT_LIB): $(EXTERNAL_LIBS)


### PR DESCRIPTION

## Description

This PR solves the compilation problem on AIX, due to the missing math library (`-lm`).

The compilation error was as follows:
```
ld: 0711-317 ERROR: Undefined symbol: ._isnan
ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
collect2: error: ld returned 8 exit status
gmake[1]: *** [Makefile:2010: libwazuhext.so] Error 1
gmake[1]: Leaving directory '/opt/freeware/src/packages/BUILD/wazuh-agent-4.12.1/src'
gmake: *** [Makefile:863: agent] Error 2
```

And to solve it, it was simply necessary to add the `-lm` parameter when compiling the **`libwazuhext`** for AIX.

## Tests

- [x] [Packages - Build Wazuh agent special package - System aix - is stage - checksum - #62](https://github.com/wazuh/wazuh-agent-packages/actions/runs/15390019929)