### PR TITLE
Fix/2042 check network drives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ src/win32/route-null.cmd
 src/win32/netsh-win-2016.cmd
 src/win32/route-null-2012.cmd
 src/win32/netsh.cmd
+src/win32/VERSION.json
 src/libwazuhshared.*
 src/libwazuhext.*
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -887,8 +887,8 @@ endif
 winagent: external win32/libwinpthread-1.dll win32/libwinpthreadpatched.a ${WAZUH_LIB_OUTPUT_PATH}${LIBGCC_S_NAME} ${WAZUH_LIB_OUTPUT_PATH}${LIBSTDCPP_NAME} win32/version-dll.o win32/version-app.o
 	${MAKE} ${WAZUHEXT_LIB} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lws2_32 -lcrypt32"
 	${MAKE} ${WINDOWS_LIBS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1"
-	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
-	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust"
+	${MAKE} ${WINDOWS_BINS} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust -lmpr"
+	${MAKE} ${WINDOWS_ACTIVE_RESPONSES} CFLAGS="-DCLIENT -D_POSIX_C_SOURCE -DWIN32 -DPSAPI_VERSION=1" LIBS="-lwsock32 -lwevtapi -lshlwapi -lcomctl32 -ladvapi32 -lkernel32 -lpsapi -lgdi32 -liphlpapi -lws2_32 -lcrypt32 -lwintrust -lmpr"
 	cd win32/ && ./unix2dos.pl ossec.conf > default-ossec.conf
 	cd win32/ && ./unix2dos.pl help.txt > help_win.txt
 	cd win32/ && ./unix2dos.pl ../../etc/internal_options.conf > internal_options.conf
@@ -2719,13 +2719,13 @@ win32/agent-auth.exe: win32/auth_resource.o win32/version-app.o win32/win_servic
 	${OSSEC_CCBIN} -DARGV0=\"agent-auth\" -DOSSECHIDS ${OSSEC_LDFLAGS} $^ ${OSSEC_LIBS} -lshlwapi -lwsock32 -lsecur32 -lws2_32 -flto -o $@
 
 win32/restart-wazuh.exe: win32/restart_wazuh_resource.o win32/version-app.o active-response/active_responses.o active-response/restart-wazuh.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
-	${OSSEC_CCBIN} -DARGV0=\"restart-wazuh\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -o $@
+	${OSSEC_CCBIN} -DARGV0=\"restart-wazuh\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -lmpr -o $@
 
 win32/route-null.exe: win32/route_null_resource.o win32/version-app.o active-response/active_responses.o active-response/route-null.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
-	${OSSEC_CCBIN} -DARGV0=\"route-null\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -o $@
+	${OSSEC_CCBIN} -DARGV0=\"route-null\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -lmpr -o $@
 
 win32/netsh.exe: win32/netsh_resource.o win32/version-app.o active-response/active_responses.o active-response/netsh.o shared/cryptography.o shared/dll_load_notify.o shared/debug_op_proc.o shared/time_op.o shared/file_op_proc.o ${WAZUH_LIB} ${WAZUHEXT_LIB}
-	${OSSEC_CCBIN} -DARGV0=\"netsh\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -o $@
+	${OSSEC_CCBIN} -DARGV0=\"netsh\" ${AR_LDFLAGS} $^ -lwintrust -lpsapi -lcrypt32 -lshlwapi -lmpr -o $@
 
 
 ####################

--- a/src/active-response/firewalls/pf.c
+++ b/src/active-response/firewalls/pf.c
@@ -103,7 +103,7 @@ int main (int argc, char **argv) {
         char *exec_cmd4[4] = { pfctl_path, "-f", PFCTL_RULES, NULL };
 
         // Checking if we have pf config file
-        if (access(PFCTL_RULES, F_OK) == 0) {
+        if (waccess(PFCTL_RULES, F_OK) == 0) {
             if (action == ADD_COMMAND) {
                 const char *arg1[7] = { pfctl_path, "-t", PFCTL_TABLE, "-T", "add", srcip, NULL };
                 memcpy(exec_cmd1, arg1, sizeof(exec_cmd1));
@@ -116,7 +116,7 @@ int main (int argc, char **argv) {
             }
 
             // Checking if pf is running
-            if (access(DEVPF, F_OK) < 0) {
+            if (waccess(DEVPF, F_OK) < 0) {
                 memset(log_msg, '\0', OS_MAXSTR);
                 snprintf(log_msg, OS_MAXSTR - 1, "The file '%s' is not accessible", DEVPF);
                 write_debug_file(argv[0], log_msg);

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -576,7 +576,7 @@ int print_agents(int print_status, int active_only, int inactive_only, int csv_o
             printf("\nList of agentless devices:\n");
         }
 
-        dirp = opendir(AGENTLESS_ENTRYDIR);
+        dirp = wopendir(AGENTLESS_ENTRYDIR);
         if (dirp) {
             while ((dp = readdir(dirp)) != NULL) {
                 if (strncmp(dp->d_name, ".", 1) == 0) {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -152,7 +152,7 @@ void run_notify()
             merror(MEM_ERROR, errno, strerror(errno));
             return;
         }
-    } else if(stat(SHAREDCFG_FILE, &stat_fd) == -1 && ENOENT == errno) {
+    } else if(w_stat(SHAREDCFG_FILE, &stat_fd) == -1 && ENOENT == errno) {
         clear_merged_hash_cache();
     }
 

--- a/src/client-agent/rotate_log.c
+++ b/src/client-agent/rotate_log.c
@@ -70,7 +70,7 @@ void * w_rotate_log_thread(__attribute__((unused)) void * arg) {
         }
 
         if (size_rotate > 0) {
-            if (stat(path, &buf) == 0) {
+            if (w_stat(path, &buf) == 0) {
                 size = buf.st_size;
                 /* If log file reachs maximum size, rotate ossec.log */
                 if ( (unsigned long) size >= size_rotate) {
@@ -78,7 +78,7 @@ void * w_rotate_log_thread(__attribute__((unused)) void * arg) {
                 }
             }
 
-            if (stat(path_json, &buf) == 0) {
+            if (w_stat(path_json, &buf) == 0) {
                 size = buf.st_size;
                 /* If log file reachs maximum size, rotate ossec.json */
                 if ( (unsigned long) size >= size_rotate) {

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -319,6 +319,18 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                     os_strdup(newfile, node[i]->content);
                 }
             }
+            if (is_network_path(node[i]->content)) {
+                merror("Network drives not allowed.");
+
+                logf[pl].file = NULL;
+                logf[pl].ffile = NULL;
+                logf[pl].command = NULL;
+                logf[pl].alias = NULL;
+                logf[pl].logformat = NULL;
+                logf[pl].fp = NULL;
+                labels_free(logf[pl].labels);
+                return 0;
+            }
 #endif
             os_strdup(node[i]->content, logf[pl].file);
         } else if (strcasecmp(node[i]->element, xml_localfile_logformat) == 0) {

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -320,8 +320,6 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
                 }
             }
             if (is_network_path(node[i]->content)) {
-                merror("Network drives not allowed.");
-
                 logf[pl].file = NULL;
                 logf[pl].ffile = NULL;
                 logf[pl].command = NULL;

--- a/src/config/rules-config.c
+++ b/src/config/rules-config.c
@@ -287,7 +287,7 @@ int Read_Rules(XML_NODE node, void *configp, void * list)
         }
 
         f_name[PATH_MAX + 1] = '\0';
-        dfd = opendir(path);
+        dfd = wopendir(path);
 
         if (dfd != NULL) {
 
@@ -340,7 +340,7 @@ int Read_Rules(XML_NODE node, void *configp, void * list)
         }
 
         f_name[PATH_MAX + 1] = '\0';
-        dfd = opendir(path);
+        dfd = wopendir(path);
 
         if (dfd != NULL) {
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -2051,7 +2051,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 if (NULL != (ix = strchr(statcmd, ' '))) {
                     *ix = '\0';
                 }
-                if (stat(statcmd, &statbuf) != 0) {
+                if (w_stat(statcmd, &statbuf) != 0) {
                     mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                     return (OS_INVALID);
                 }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1703,6 +1703,9 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         else if (strcmp(node[i]->element, xml_directories) == 0) {
             char dirs[OS_MAXSTR];
 #ifdef WIN32
+            if (is_network_path(node[i]->content)) {
+                continue;
+            }
             fim_adjust_path(&(node[i]->content));
 #endif
             strncpy(dirs, node[i]->content, sizeof(dirs) - 1);

--- a/src/config/wmodules-office365.c
+++ b/src/config/wmodules-office365.c
@@ -179,7 +179,7 @@ int wm_office365_read(__attribute__((unused)) const OS_XML *xml, xml_node **node
                     merror("It is not allowed to set 'client_secret' and 'client_secret_path' at module '%s'.", WM_OFFICE365_CONTEXT.name);
                     return OS_INVALID;
                 }
-                if(access(office365_auth->client_secret_path, F_OK) != 0 ) {
+                if(waccess(office365_auth->client_secret_path, F_OK) != 0 ) {
                     merror("Invalid content for tag '%s' at module '%s': The path cannot be opened.", XML_CLIENT_SECRET_PATH, WM_OFFICE365_CONTEXT.name);
                     return OS_INVALID;
                 }

--- a/src/config/wmodules-osquery-monitor.c
+++ b/src/config/wmodules-osquery-monitor.c
@@ -68,17 +68,26 @@ int wm_osquery_monitor_read(xml_node **nodes, wmodule *module)
         }
         else if(!strcmp(nodes[i]->element, XML_BINPATH))
         {
+            if (is_network_path(nodes[i]->content)) {
+                continue;
+            }
             free(osquery_monitor->bin_path);
             osquery_monitor->bin_path = strdup(nodes[i]->content);
         }
         else if(!strcmp(nodes[i]->element, XML_LOGPATH))
         {
+            if (is_network_path(nodes[i]->content)) {
+                continue;
+            }
             free(osquery_monitor->log_path);
             osquery_monitor->log_path = strdup(nodes[i]->content);
             mdebug2("Logpath read: %s", osquery_monitor->log_path);
         }
         else if(!strcmp(nodes[i]->element, XML_CONFIGPATH))
         {
+            if (is_network_path(nodes[i]->content)) {
+                continue;
+            }
             free(osquery_monitor->config_path);
             osquery_monitor->config_path = strdup(nodes[i]->content);
             mdebug2("configPath read: %s", osquery_monitor->config_path);

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -110,7 +110,7 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
     sprintf(ruleset_path, "%s/", SECURITY_CONFIGURATION_ASSESSMENT_DIR);
     #endif
 
-    DIR *ruleset_dir = opendir(ruleset_path);
+    DIR *ruleset_dir = wopendir(ruleset_path);
     const int open_dir_errno = errno;
     if (ruleset_dir) {
         struct dirent *dir_entry;

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -19,7 +19,7 @@
 #define FIM_WARN_DELETE                         "(6901): Could not delete from filesystem '%s'"
 #define FIM_WARN_DELETE_HASH_TABLE              "(6902): Could not delete from hash table '%s'"
 #define FIM_WARN_SYMLINKS_UNSUPPORTED           "(6903) Links are not supported: '%s'"
-#define FIM_WARN_STAT_BROKEN_LINK               "(6904): Error in stat() function: %s. This may be caused by a broken symbolic link (%s)."
+#define FIM_WARN_STAT_BROKEN_LINK               "(6904): Error in w_stat() function: %s. This may be caused by a broken symbolic link (%s)."
 #define FIM_WARN_ALLOW_PREFILTER                "(6905): Ignoring prefilter option '%s'. Enable <%s> to use it."
 #define FIM_WARN_REALTIME_OVERFLOW              "(6906): Real time process: no data. Probably buffer overflow."
 #define FIM_WARN_REALTIME_OPENFAIL              "(6907): '%s' does not exist. Monitoring discarded."

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -393,6 +393,54 @@ int w_ref_parent_folder(const char * path);
  */
 char ** wreaddir(const char * name);
 
+/**
+ * @brief Wrapper over access() that rejects UNC or mapped-drive paths.
+ *
+ * @param path  Null-terminated path to test.
+ * @param mode  Standard access() mode flags (R_OK, W_OK, …).
+ * @return 0 on success, −1 on failure (sets errno and GetLastError()).
+ */
+int waccess(const char *path, int mode);
+
+#ifdef WIN32
+/**
+ * @brief Wrapper over CreateFile that blocks network paths.
+ *
+ * @param lpFileName             UTF-8 file name.
+ * @param dwDesiredAccess        Desired access flags.
+ * @param dwShareMode            Share mode flags.
+ * @param lpSecurityAttributes   Optional security descriptor.
+ * @param dwCreationDisposition  Creation action.
+ * @param dwFlagsAndAttributes   File attributes / flags.
+ * @param hTemplateFile          Template file handle (may be NULL).
+ * @return A valid HANDLE or INVALID_HANDLE_VALUE on error.
+ */
+HANDLE wCreateFile(LPCSTR  lpFileName,
+    DWORD   dwDesiredAccess,
+    DWORD   dwShareMode,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+    DWORD   dwCreationDisposition,
+    DWORD   dwFlagsAndAttributes,
+    HANDLE  hTemplateFile);
+#endif
+/**
+ * @brief Wrapper over opendir() that refuses network directories.
+ *
+ * @param name Directory path.
+ * @return Pointer to DIR or NULL on error (sets errno).
+ */
+DIR * wopendir(const char *name);
+
+/**
+ * @brief Wrapper over stat() that blocks network paths.
+ *
+ * @param pathname Path to inspect.
+ * @param statbuf  Output structure to fill.
+ * @return 0 on success, −1 on error (sets errno).
+ */
+int wstat(const char *restrict pathname,
+           struct stat *restrict statbuf);
+
 
 /**
  * @brief Open file normally in Linux, allow read/write/delete in Windows.

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -550,6 +550,17 @@ FILE * w_fopen_r(const char *file, const char * mode, BY_HANDLE_FILE_INFORMATION
  */
 char **expand_win32_wildcards(const char *path);
 
+/**
+ * @brief Checks if a given path is located on network storage.
+ *
+ * This function detects both UNC paths (e.g. "\\\\server\\share\\...") and
+ * paths on drives mapped to remote locations (e.g. "Z:\\folder\\file.txt").
+ *
+ * @param path A null-terminated string containing the file path to check.
+ * @return true if the path points to a network location, false otherwise.
+ */
+bool is_network_path(const char *path);
+
 #endif // Windows
 
 /**

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <sys/stat.h>
 #include <cJSON.h>
+#include <dirent.h>
 
 #ifdef WIN32
 #include <winsock2.h>
@@ -40,6 +41,14 @@ extern int isVista;
 #define PATH_SEP '/'
 typedef ino_t wino_t;
 #endif
+
+#define REJECT_NETWORK_PATH(retval)                  \
+    do {                                             \
+        errno = EACCES;                              \
+        SetLastError(ERROR_NETWORK_ACCESS_DENIED);   \
+        merror("Testing network drives, rejected."); \
+        return (retval);                             \
+    } while (0)
 
 typedef struct File {
     char *name;
@@ -393,6 +402,7 @@ int w_ref_parent_folder(const char * path);
  */
 char ** wreaddir(const char * name);
 
+
 /**
  * @brief Wrapper over access() that rejects UNC or mapped-drive paths.
  *
@@ -401,6 +411,7 @@ char ** wreaddir(const char * name);
  * @return 0 on success, −1 on failure (sets errno and GetLastError()).
  */
 int waccess(const char *path, int mode);
+
 
 #ifdef WIN32
 /**
@@ -423,6 +434,8 @@ HANDLE wCreateFile(LPCSTR  lpFileName,
     DWORD   dwFlagsAndAttributes,
     HANDLE  hTemplateFile);
 #endif
+
+
 /**
  * @brief Wrapper over opendir() that refuses network directories.
  *
@@ -431,15 +444,16 @@ HANDLE wCreateFile(LPCSTR  lpFileName,
  */
 DIR * wopendir(const char *name);
 
+
 /**
- * @brief Wrapper over stat() that blocks network paths.
+ * @brief Wrapper over w_stat() that blocks network paths.
  *
  * @param pathname Path to inspect.
  * @param statbuf  Output structure to fill.
  * @return 0 on success, −1 on error (sets errno).
  */
-int wstat(const char *restrict pathname,
-           struct stat *restrict statbuf);
+int w_stat(const char * pathname,
+           struct stat * statbuf);
 
 
 /**

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -46,7 +46,6 @@ typedef ino_t wino_t;
     do {                                             \
         errno = EACCES;                              \
         SetLastError(ERROR_NETWORK_ACCESS_DENIED);   \
-        merror("Testing network drives, rejected."); \
         return (retval);                             \
     } while (0)
 

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -158,7 +158,7 @@ typedef int gid_t;
 typedef int socklen_t;
 #define sleep(x) Sleep((x) * 1000)
 #define srandom(x) srand(x)
-#define lstat(x,y) stat(x,y)
+#define lstat(x,y) w_stat(x,y)
 void WinSetError();
 typedef uint32_t u_int32_t;
 typedef uint16_t u_int16_t;

--- a/src/logcollector/journal_log.c
+++ b/src/logcollector/journal_log.c
@@ -184,7 +184,7 @@ STATIC INLINE char * find_library_path(const char * library_name) {
  */
 STATIC INLINE bool is_owned_by_root(const char * library_path) {
     struct stat file_stat;
-    if (stat(library_path, &file_stat) != 0) {
+    if (w_stat(library_path, &file_stat) != 0) {
         return false;
     }
 

--- a/src/logcollector/lccom.c
+++ b/src/logcollector/lccom.c
@@ -340,7 +340,7 @@ bool isJsonUpdated(void) {
     bool isJsonUpdated = false;
 
     /*should be reset index to the first page when some files are added or removed*/
-    if (stat(LOGCOLLECTOR_STATE, &outstat) == 0) {
+    if (w_stat(LOGCOLLECTOR_STATE, &outstat) == 0) {
         tm_stat = localtime(&outstat.st_mtime);
         /* Get localized date string. */
         strftime(date_string, sizeof(date_string), "%c", tm_stat);

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -877,7 +877,7 @@ void LogCollectorStart()
                     if (j >= 0) {
 #ifndef WIN32
                         struct stat stat_fd;
-                        if (stat(current->file, &stat_fd) == -1 && ENOENT == errno) {
+                        if (w_stat(current->file, &stat_fd) == -1 && ENOENT == errno) {
 #else
                         if (!PathFileExists(current->file)) {
 #endif
@@ -2663,7 +2663,7 @@ STATIC void w_load_files_status(cJSON * global_json) {
 
         struct stat stat_fd;
 
-        if (stat(path_str, &stat_fd) == -1) {
+        if (w_stat(path_str, &stat_fd) == -1) {
             continue;
         }
 

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -691,7 +691,7 @@ void LogCollectorStart()
 #else
                     HANDLE h1;
 
-                    h1 = CreateFile(current->file, GENERIC_READ,
+                    h1 = wCreateFile(current->file, GENERIC_READ,
                                     FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
                                     NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                     if (h1 == INVALID_HANDLE_VALUE) {
@@ -815,7 +815,7 @@ void LogCollectorStart()
                         int file_exists = 1;
                         HANDLE h1;
 
-                        h1 = CreateFile(current->file, GENERIC_READ,
+                        h1 = wCreateFile(current->file, GENERIC_READ,
                                         FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
                                         NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
                         if (h1 == INVALID_HANDLE_VALUE) {
@@ -1542,7 +1542,7 @@ int check_pattern_expand(int do_seek) {
                                 exists. Deleted files can still appear due to caching */
                             HANDLE h1;
 
-                            h1 = CreateFile(full_path, GENERIC_READ,
+                            h1 = wCreateFile(full_path, GENERIC_READ,
                                             FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
                                             NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
@@ -2436,7 +2436,7 @@ static void check_pattern_expand_excluded() {
                 *wildcard = '\0';
                 wildcard++;
 
-                if (dir = opendir(global_path), !dir) {
+                if (dir = wopendir(global_path), !dir) {
                     merror("Couldn't open directory '%s' due to: %s", global_path, win_strerror(WSAGetLastError()));
                     os_free(global_path);
                     continue;
@@ -2455,7 +2455,7 @@ static void check_pattern_expand_excluded() {
                     /* Skip file if it is a directory */
                     DIR *is_dir = NULL;
 
-                    if (is_dir = opendir(full_path), is_dir) {
+                    if (is_dir = wopendir(full_path), is_dir) {
                         mdebug2("File %s is a directory. Skipping it.", full_path);
                         closedir(is_dir);
                         continue;

--- a/src/logcollector/macos_log.c
+++ b/src/logcollector/macos_log.c
@@ -340,18 +340,18 @@ STATIC wfd_t * w_macos_log_exec(char ** log_cmd_array, u_int32_t flags) {
 }
 
 /**
- * @brief Checks whether the `log` command can be executed or not by using the access() function
+ * @brief Checks whether the `log` command can be executed or not by using the waccess() function
  * @warning if macOS Sierra is beeing used, also `script` command will be checked.
  * @return true when `log` command can be executed, false otherwise.
  */
 STATIC INLINE bool w_macos_is_log_executable(void) {
 
-    if (w_is_macos_sierra() && access(SCRIPT_CMD_STR, X_OK) != 0) {
+    if (w_is_macos_sierra() && waccess(SCRIPT_CMD_STR, X_OK) != 0) {
         merror(ACCESS_ERROR, SCRIPT_CMD_STR, strerror(errno), errno);
         return false;
     }
 
-    const int retval = access(LOG_CMD_STR, X_OK);
+    const int retval = waccess(LOG_CMD_STR, X_OK);
     if (retval == 0) {
         return true;
     }

--- a/src/monitord/monitor_actions.c
+++ b/src/monitord/monitor_actions.c
@@ -170,7 +170,7 @@ void monitor_logs(bool check_logs_size, char path[PATH_MAX], char path_json[PATH
         w_rotate_log(mond.compress, mond.keep_log_days, 1, 0, mond.daily_rotations);
 
     } else if (check_logs_size == TRUE && mond.rotate_log && mond.size_rotate > 0){
-        if (stat(path, &buf) == 0) {
+        if (w_stat(path, &buf) == 0) {
             size = buf.st_size;
             /* If log file reachs maximum size, rotate ossec.log */
             if ( (unsigned long) size >= mond.size_rotate) {
@@ -178,7 +178,7 @@ void monitor_logs(bool check_logs_size, char path[PATH_MAX], char path_json[PATH
             }
         }
 
-        if (stat(path_json, &buf) == 0) {
+        if (w_stat(path_json, &buf) == 0) {
             size = buf.st_size;
             /* If log file reachs maximum size, rotate ossec.json */
             if ( (unsigned long) size >= mond.size_rotate) {

--- a/src/monitord/rotate_log.c
+++ b/src/monitord/rotate_log.c
@@ -196,7 +196,7 @@ void remove_old_logs(const char *base_dir, int keep_log_days) {
     DIR *dir;
     struct dirent *dirent = NULL;
 
-    if (dir = opendir(base_dir), !dir) {
+    if (dir = wopendir(base_dir), !dir) {
         merror("Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
         return;
     }
@@ -225,7 +225,7 @@ void remove_old_logs_y(const char * base_dir, int year, time_t threshold) {
     DIR *dir;
     struct dirent *dirent = NULL;
 
-    if (dir = opendir(base_dir), !dir) {
+    if (dir = wopendir(base_dir), !dir) {
         merror("Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
         return;
     }
@@ -274,7 +274,7 @@ void remove_old_logs_m(const char * base_dir, int year, int month, time_t thresh
     tm.tm_min = 0;
     tm.tm_sec = 0;
 
-    if (dir = opendir(base_dir), !dir) {
+    if (dir = wopendir(base_dir), !dir) {
         merror("Couldn't open directory '%s' to delete old logs: %s", base_dir, strerror(errno));
         return;
     }

--- a/src/os_auth/auth.c
+++ b/src/os_auth/auth.c
@@ -406,7 +406,7 @@ w_err_t w_auth_validate_groups(const char *groups, char *response) {
         }
 
         snprintf(dir, PATH_MAX + 1, SHAREDCFG_DIR "/%s", group);
-        dp = opendir(dir);
+        dp = wopendir(dir);
         if (!dp) {
             merror("Invalid group: %.255s",group);
             if (response) {

--- a/src/os_crypto/signature/signature.c
+++ b/src/os_crypto/signature/signature.c
@@ -274,7 +274,7 @@ int wpk_verify_cert(X509 * cert, const char ** ca_store) {
 
         int r;
 
-        if (stat(ca_store[i], &statbuf) < 0) {
+        if (w_stat(ca_store[i], &statbuf) < 0) {
             merror(FSTAT_ERROR, ca_store[i], errno, strerror(errno));
             continue;
         }

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -191,7 +191,7 @@ size_t wcom_restart(char ** output) {
 #ifndef WIN32
         char *exec_cmd[3] = {NULL};
 
-        if (access("active-response/bin/restart.sh", F_OK) == 0) {
+        if (waccess("active-response/bin/restart.sh", F_OK) == 0) {
             exec_cmd[0] = "active-response/bin/restart.sh";
 #ifdef CLIENT
             exec_cmd[1] = "agent";

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -706,7 +706,7 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
         }
 
         // Merge ar.conf always
-        if (stat(DEFAULTAR, &attrib) == 0) {
+        if (w_stat(DEFAULTAR, &attrib) == 0) {
             if (create_merged) {
                 if (merged_ok = MergeAppendFile(finalfp, DEFAULTAR, -1), merged_ok == 0) {
                     fclose(finalfp);
@@ -771,7 +771,7 @@ STATIC void c_group(const char *group, OSHash **_f_time, os_md5 *_merged_sum, ch
     if (OS_MD5_File(merged, md5sum, OS_TEXT) == 0) {
         snprintf((*_merged_sum), sizeof((*_merged_sum)), "%s", md5sum);
 
-        if (stat(merged, &attrib) != 0) {
+        if (w_stat(merged, &attrib) != 0) {
             merror("Unable to get entry attributes '%s'", merged);
         } else {
             ftime_add(_f_time, SHAREDCFG_FILENAME, attrib.st_mtime);
@@ -1188,7 +1188,7 @@ STATIC int validate_shared_files(const char *src_path, FILE *finalfp, OSHash **_
             }
         }
 
-        if (stat(file, &attrib) != 0) {
+        if (w_stat(file, &attrib) != 0) {
             merror("Unable to get entry attributes '%s'", file);
             continue;
         }

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -808,7 +808,7 @@ STATIC void c_multi_group(char *multi_group, OSHash **_f_time, os_md5 *_merged_s
 
             snprintf(dir, PATH_MAX + 1, "%s/%s", SHAREDCFG_DIR, group);
 
-            dp = opendir(SHAREDCFG_DIR);
+            dp = wopendir(SHAREDCFG_DIR);
 
             if (!dp) {
                 mdebug2("Opening directory: '%s': %s", SHAREDCFG_DIR, strerror(errno));
@@ -823,7 +823,7 @@ STATIC void c_multi_group(char *multi_group, OSHash **_f_time, os_md5 *_merged_s
     }
 
     /* Open the multi-group files and generate merged */
-    dp = opendir(MULTIGROUPS_DIR);
+    dp = wopendir(MULTIGROUPS_DIR);
 
     if (!dp) {
         mdebug2("Opening directory: '%s': %s", MULTIGROUPS_DIR, strerror(errno));
@@ -874,7 +874,7 @@ STATIC void process_groups() {
     struct dirent *entry = NULL;
     char path[PATH_MAX + 1];
 
-    dp = opendir(SHAREDCFG_DIR);
+    dp = wopendir(SHAREDCFG_DIR);
 
     if (!dp) {
         mdebug1("Opening directory: '%s': %s", SHAREDCFG_DIR, strerror(errno));
@@ -1299,7 +1299,7 @@ STATIC void copy_directory(const char *src_path, const char *dst_path, char *gro
         }
 
         /* Is a file */
-        if (dir = opendir(source_path), !dir) {
+        if (dir = wopendir(source_path), !dir) {
             ignored = 0;
 
             char agent_conf_chunck_message[PATH_MAX + 1]= {0};

--- a/src/remoted/shared_download.c
+++ b/src/remoted/shared_download.c
@@ -434,7 +434,7 @@ void w_create_group(char *group){
     }
     else{
         /* Check if group exists */
-        DIR *group_dir = opendir(group_path);
+        DIR *group_dir = wopendir(group_path);
 
         if (!group_dir) {
             /* Create the group */

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -101,7 +101,7 @@ static int read_dev_dir(const char *dir_name)
     }
 
     /* Open directory */
-    dp = opendir(dir_name);
+    dp = wopendir(dir_name);
     if (!dp) {
         return (-1);
     }

--- a/src/rootcheck/check_rc_pids.c
+++ b/src/rootcheck/check_rc_pids.c
@@ -47,15 +47,15 @@ static int proc_opendir(int pid)
     if (noproc) {
         return (0);
     }
-    
-    dp  = opendir("/proc");
+
+    dp  = wopendir("/proc");
     if (!dp) {
         return 0;
     }
     closedir(dp);
-    
+
     snprintf(dir, OS_SIZE_1024, "/proc/%d", pid);
-    dp  = opendir(dir);
+    dp  = wopendir(dir);
     if (!dp) {
         return 0;
     }

--- a/src/rootcheck/check_rc_readproc.c
+++ b/src/rootcheck/check_rc_readproc.c
@@ -52,7 +52,7 @@ int read_proc_dir(const char *dir_name, const char *pid, int position)
     }
 
     /* Open the directory */
-    dp = opendir(dir_name);
+    dp = wopendir(dir_name);
     if (!dp) {
         return (0);
     }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -260,10 +260,10 @@ static int read_sys_dir(const char *dir_name, int do_read)
 #endif
 
     /* Open the directory */
-    dp = opendir(dir_name);
+    dp = wopendir(dir_name);
     if (!dp) {
         if ((strcmp(dir_name, "") == 0) &&
-                (dp = opendir("/"))) {
+                (dp = wopendir("/"))) {
             /* ok */
         } else {
             return (-1);

--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -38,7 +38,7 @@ int rk_check_dir(const char *dir, const char *file, char *pattern)
 
     f_name[PATH_MAX + 1] = '\0';
 
-    dp = opendir(dir);
+    dp = wopendir(dir);
     if (!dp) {
         return (0);
     }
@@ -423,7 +423,7 @@ int isfile_ondir(const char *file, const char *dir)
 {
     DIR *dp = NULL;
     struct dirent *entry = NULL;
-    dp = opendir(dir);
+    dp = wopendir(dir);
 
     if (!dp) {
         return (0);
@@ -455,7 +455,7 @@ int is_file(char *file_name)
         return ret;
     }
 
-    dp = opendir(file_name);
+    dp = wopendir(file_name);
     if (dp) {
         closedir(dp);
         ret = 1;
@@ -468,7 +468,7 @@ int is_file(char *file_name)
     /* Trying other calls */
     if ((stat(file_name, &statbuf) < 0) &&
 #ifndef WIN32
-            (access(file_name, F_OK) < 0) &&
+            (waccess(file_name, F_OK) < 0) &&
 #endif
             ((fp = wfopen(file_name, "r")) == NULL)) {
         return ret;

--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -466,7 +466,7 @@ int is_file(char *file_name)
     }
 
     /* Trying other calls */
-    if ((stat(file_name, &statbuf) < 0) &&
+    if ((w_stat(file_name, &statbuf) < 0) &&
 #ifndef WIN32
             (waccess(file_name, F_OK) < 0) &&
 #endif

--- a/src/rootcheck/win-common.c
+++ b/src/rootcheck/win-common.c
@@ -33,7 +33,7 @@ int os_check_ads(const char *full_path)
     DWORD dwRead, shs, dw1, dw2;
 
     /* Open file */
-    file_h = CreateFile(full_path,
+    file_h = wCreateFile(full_path,
                         GENERIC_READ,
                         FILE_SHARE_READ,
                         NULL,

--- a/src/shared/audit_op.c
+++ b/src/shared/audit_op.c
@@ -269,7 +269,7 @@ int audit_manage_rules(int action, const char *path, int permissions, const char
     // Check path
     type = AUDIT_DIR;
 
-    if (stat(path, &buf) != 0) {
+    if (w_stat(path, &buf) != 0) {
         mdebug2(FIM_STAT_FAILED, path, errno, strerror(errno));
         retval = -1;
         goto end;

--- a/src/shared/exec_op.c
+++ b/src/shared/exec_op.c
@@ -18,6 +18,10 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
     FILE * fp_out = NULL;
 
 #ifdef WIN32
+    if (is_network_path(path)) {
+        REJECT_NETWORK_PATH(NULL);
+    }
+
     int fd;
     LPTSTR lpCommandLine = NULL;
     HANDLE hPipeIn[2] = { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE };

--- a/src/shared/exec_op.c
+++ b/src/shared/exec_op.c
@@ -223,7 +223,7 @@ wfd_t * wpopenv(const char * path, char * const * argv, int flags) {
     case 0:
         // Child code
 
-        if (flags & W_CHECK_WRITE && !access(path, W_OK)) {
+        if (flags & W_CHECK_WRITE && !waccess(path, W_OK)) {
             merror("At wpopenv(): file '%s' has write permissions.", path);
             _exit(127);
         }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2764,7 +2764,7 @@ FILE * wfopen(const char * pathname, const char * mode) {
     FILE * fp;
     int i;
 
-    if (pathname && strchr("\\/", pathname[0]) && strchr("\\/?\"<>|", pathname[1])) {
+    if (is_network_path(pathname)) {
         errno = EINVAL;
         return NULL;
     }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -3229,6 +3229,32 @@ float DirSize(const char *path) {
     return folder_size;
 }
 
+// Checks if a given path is located on network storage.
+
+bool is_network_path(const char *path) {
+    if (!path || !*path) {
+        return false;
+    }
+
+    // Case 1: UNC path (\\server\share\...)
+    if (PathIsUNCA(path)) {
+        return true;
+    }
+
+    // Case 2: Absolute path on mapped network drive
+    if (strlen(path) >= 2 && path[1] == ':') {
+        char root[] = "X:\\";
+        root[0] = path[0];
+
+        UINT type = GetDriveTypeA(root);
+        if (type == DRIVE_REMOTE) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 #endif
 
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -408,7 +408,7 @@ int waccess(const char *path, int mode) {
 }
 
 #ifdef WIN32
-HANDLE wCreateFile(LPCSTR  lpFileName,
+HANDLE wCreateFile(LPCSTR   lpFileName,
                     DWORD   dwDesiredAccess,
                     DWORD   dwShareMode,
                     LPSECURITY_ATTRIBUTES lpSecurityAttributes,
@@ -420,12 +420,12 @@ HANDLE wCreateFile(LPCSTR  lpFileName,
         REJECT_NETWORK_PATH(INVALID_HANDLE_VALUE);
     }
     return CreateFile(lpFileName,
-                       dwDesiredAccess,
-                       dwShareMode,
-                       lpSecurityAttributes,
-                       dwCreationDisposition,
-                       dwFlagsAndAttributes,
-                       hTemplateFile);
+                      dwDesiredAccess,
+                      dwShareMode,
+                      lpSecurityAttributes,
+                      dwCreationDisposition,
+                      dwFlagsAndAttributes,
+                      hTemplateFile);
 }
 #endif
 
@@ -3288,6 +3288,7 @@ bool is_network_path(const char *path) {
 
     // Case 1: UNC path (\\server\share\...)
     if (PathIsUNCA(path)) {
+        merror("UNC path detected: %s", path);
         return true;
     }
 
@@ -3304,8 +3305,6 @@ bool is_network_path(const char *path) {
         if (result == NO_ERROR || result == ERROR_CONNECTION_UNAVAIL) {
             merror("Mapped drive detected: %s -> %s (code: %lu)", root, remoteName, result);
             return true;
-        } else {
-            merror("WNetGetConnectionA failed for %s with error code: %lu", root, result);
         }
     }
 

--- a/src/shared/json-queue.c
+++ b/src/shared/json-queue.c
@@ -73,7 +73,7 @@ cJSON * jqueue_next(file_queue * queue) {
 
         // Check file stats, or sleep and retry if the file is missing.
 
-        if (stat(queue->file_name, &buf) < 0 && (errno != ENOENT || (sleep(1), stat(queue->file_name, &buf) < 0))) {
+        if (w_stat(queue->file_name, &buf) < 0 && (errno != ENOENT || (sleep(1), w_stat(queue->file_name, &buf) < 0))) {
             mwarn(FSTAT_ERROR, queue->file_name, errno, strerror(errno));
             fclose(queue->fp);
             queue->fp = NULL;

--- a/src/shared/syscheck_op.c
+++ b/src/shared/syscheck_op.c
@@ -652,7 +652,7 @@ char *get_file_user(const char *path, char **sid) {
     char *result;
 
     // Get the handle of the file object.
-    hFile = CreateFile(TEXT(path),
+    hFile = wCreateFile(TEXT(path),
                        GENERIC_READ,
                        FILE_SHARE_READ | FILE_SHARE_WRITE,
                        NULL,
@@ -676,10 +676,10 @@ char *get_file_user(const char *path, char **sid) {
         switch (dwErrorCode) {
         case ERROR_ACCESS_DENIED:     // 5
         case ERROR_SHARING_VIOLATION: // 32
-            mdebug1("At get_user(%s): CreateFile(): %s (%lu)", path, messageBuffer, dwErrorCode);
+            mdebug1("At get_user(%s): wCreateFile(): %s (%lu)", path, messageBuffer, dwErrorCode);
             break;
         default:
-            mwarn("At get_user(%s): CreateFile(): %s (%lu)", path, messageBuffer, dwErrorCode);
+            mwarn("At get_user(%s): wCreateFile(): %s (%lu)", path, messageBuffer, dwErrorCode);
         }
 
         LocalFree(messageBuffer);

--- a/src/shared/wait_op.c
+++ b/src/shared/wait_op.c
@@ -92,7 +92,7 @@ void os_wait_primitive(bool (*fn_ptr)()) {
 
 void loop_check(struct stat *file_status, bool (*fn_ptr)()) {
     while (1) {
-        if (stat(WAIT_FILE, file_status) == -1 || (fn_ptr && fn_ptr())) {
+        if (w_stat(WAIT_FILE, file_status) == -1 || (fn_ptr && fn_ptr())) {
             break;
         }
         /* Sleep LOCK_LOOP seconds and check if lock is gone */
@@ -105,7 +105,7 @@ void os_wait_primitive(bool (*fn_ptr)()) {
     static atomic_int_t just_unlocked = ATOMIC_INT_INITIALIZER(0);
 
     /* If the wait file is not present, keep going */
-    if (stat(WAIT_FILE, &file_status) == -1) {
+    if (w_stat(WAIT_FILE, &file_status) == -1) {
         atomic_int_set(&just_unlocked, 1);
         return;
     }

--- a/src/shared_modules/utils/filesystemHelper.h
+++ b/src/shared_modules/utils/filesystemHelper.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <array>
 #include "stringHelper.h"
+#include "file_op.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -34,18 +35,18 @@ namespace Utils
     static bool existsDir(const std::string& path)
     {
         struct stat info {};
-        return !stat(path.c_str(), &info) && (info.st_mode & S_IFDIR);
+        return !w_stat(path.c_str(), &info) && (info.st_mode & S_IFDIR);
     }
     static bool existsRegular(const std::string& path)
     {
         struct stat info {};
-        return !stat(path.c_str(), &info) && (info.st_mode & S_IFREG);
+        return !w_stat(path.c_str(), &info) && (info.st_mode & S_IFREG);
     }
 #ifndef WIN32
     static bool existsSocket(const std::string& path)
     {
         struct stat info {};
-        return !stat(path.c_str(), &info) && ((info.st_mode & S_IFMT) == S_IFSOCK);
+        return !w_stat(path.c_str(), &info) && ((info.st_mode & S_IFMT) == S_IFSOCK);
     }
 #endif
     struct DirSmartDeleter

--- a/src/shared_modules/utils/filesystemHelper.h
+++ b/src/shared_modules/utils/filesystemHelper.h
@@ -59,7 +59,7 @@ namespace Utils
     static std::vector<std::string> enumerateDir(const std::string& path)
     {
         std::vector<std::string> ret;
-        std::unique_ptr<DIR, DirSmartDeleter> spDir{opendir(path.c_str())};
+        std::unique_ptr<DIR, DirSmartDeleter> spDir{wopendir(path.c_str())};
 
         if (spDir)
         {

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -786,7 +786,7 @@ int fim_directory(const char *dir,
     }
 
     // Open the directory given
-    dp = opendir(dir);
+    dp = wopendir(dir);
 
     if (!dp) {
         mwarn(FIM_PATH_NOT_OPEN, dir, strerror(errno));

--- a/src/syscheckd/src/run_realtime.c
+++ b/src/syscheckd/src/run_realtime.c
@@ -673,7 +673,7 @@ int realtime_adddir(const char *dir, directory_t *configuration) {
 
     os_calloc(1, sizeof(win32rtfim), rtlocald);
 
-    rtlocald->h = CreateFile(dir, FILE_LIST_DIRECTORY, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+    rtlocald->h = wCreateFile(dir, FILE_LIST_DIRECTORY, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
                              OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL);
 
     if (rtlocald->h == INVALID_HANDLE_VALUE || rtlocald->h == NULL) {

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -24,6 +24,7 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
 #include "../wrappers/externals/zlib/zlib_wrappers.h"
+#include "../wrappers/windows/fileapi_wrappers.h"
 
 /* setups/teardowns */
 static int setup_group(void **state) {
@@ -1200,6 +1201,24 @@ void test_is_network_path_local(void **state) {
     assert_int_equal(ret, 0);
 }
 
+void test_wfopen_local_path(void **state) {
+    errno = 0;
+    char *path = "C:\\file.txt";
+    expect_CreateFile_call(path, INVALID_HANDLE_VALUE);
+    SetLastError(0);
+    FILE *fp = wfopen(path, "r");
+    assert_int_equal(fp, NULL);
+    assert_int_equal(errno, 0);
+}
+
+void test_wfopen_network_path(void **state) {
+    errno = 0;
+    char *path = "Z:\\file.txt";
+    FILE *fp = wfopen(path, "r");
+    assert_int_equal(fp, NULL);
+    assert_int_equal(errno, EINVAL);
+}
+
 #endif
 
 int main(void) {
@@ -1263,6 +1282,8 @@ int main(void) {
         cmocka_unit_test(test_is_network_path_unc),
         cmocka_unit_test(test_is_network_path_network),
         cmocka_unit_test(test_is_network_path_local),
+        cmocka_unit_test(test_wfopen_local_path),
+        cmocka_unit_test(test_wfopen_network_path),
 
 #endif
     };

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -1172,6 +1172,34 @@ void test_expand_win32_wildcards_file_with_next_glob(void **state) {
     }
 }
 
+void test_is_network_path_null(void **state) {
+    char *path = NULL;
+    int ret = is_network_path(path);
+    assert_int_equal(ret, 0);
+
+    path = "";
+    ret = is_network_path(path);
+    assert_int_equal(ret, 0);
+}
+
+void test_is_network_path_unc(void **state) {
+    char *path = "\\\\server\\share";
+    int ret = is_network_path(path);
+    assert_int_equal(ret, 1);
+}
+
+void test_is_network_path_network(void **state) {
+    char *path = "Z:\\file.txt";
+    int ret = is_network_path(path);
+    assert_int_equal(ret, 1);
+}
+
+void test_is_network_path_local(void **state) {
+    char *path = "C:\\file.txt";
+    int ret = is_network_path(path);
+    assert_int_equal(ret, 0);
+}
+
 #endif
 
 int main(void) {
@@ -1230,7 +1258,11 @@ int main(void) {
         cmocka_unit_test_teardown(test_expand_win32_wildcards_back_link, teardown_win32_wildcards),
         cmocka_unit_test_teardown(test_expand_win32_wildcards_directories, teardown_win32_wildcards),
         cmocka_unit_test_teardown(test_expand_win32_wildcards_directories_reparse_point, teardown_win32_wildcards),
-        cmocka_unit_test_teardown(test_expand_win32_wildcards_file_with_next_glob, teardown_win32_wildcards)
+        cmocka_unit_test_teardown(test_expand_win32_wildcards_file_with_next_glob, teardown_win32_wildcards),
+        cmocka_unit_test(test_is_network_path_null),
+        cmocka_unit_test(test_is_network_path_unc),
+        cmocka_unit_test(test_is_network_path_network),
+        cmocka_unit_test(test_is_network_path_local),
 
 #endif
     };

--- a/src/unit_tests/shared/test_syscheck_op.c
+++ b/src/unit_tests/shared/test_syscheck_op.c
@@ -3660,7 +3660,7 @@ static void test_get_file_user_CreateFile_error_access_denied(void **state) {
 
     expect_FormatMessage_call("An error message");
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At get_user(C:\\a\\path): CreateFile(): An error message (5)");
+    expect_string(__wrap__mdebug1, formatted_msg, "At get_user(C:\\a\\path): wCreateFile(): An error message (5)");
 
     expect_CloseHandle_call(INVALID_HANDLE_VALUE, 1);
 
@@ -3678,7 +3678,7 @@ static void test_get_file_user_CreateFile_error_sharing_violation(void **state) 
 
     expect_FormatMessage_call("An error message");
 
-    expect_string(__wrap__mdebug1, formatted_msg, "At get_user(C:\\a\\path): CreateFile(): An error message (32)");
+    expect_string(__wrap__mdebug1, formatted_msg, "At get_user(C:\\a\\path): wCreateFile(): An error message (32)");
 
     expect_CloseHandle_call(INVALID_HANDLE_VALUE, 1);
 
@@ -3696,7 +3696,7 @@ static void test_get_file_user_CreateFile_error_generic(void **state) {
 
     expect_FormatMessage_call("An error message");
 
-    expect_string(__wrap__mwarn, formatted_msg, "At get_user(C:\\a\\path): CreateFile(): An error message (127)");
+    expect_string(__wrap__mwarn, formatted_msg, "At get_user(C:\\a\\path): wCreateFile(): An error message (127)");
 
     expect_CloseHandle_call(INVALID_HANDLE_VALUE, 1);
 

--- a/src/unit_tests/wrappers/macos/posix/dirent_wrappers.c
+++ b/src/unit_tests/wrappers/macos/posix/dirent_wrappers.c
@@ -31,9 +31,9 @@ DIR * wrap_opendir(const char *filename) {
             errno = ESRCH;
         }
 
-        return ret; 
+        return ret;
     } else {
-        return opendir(filename);
+        return wopendir(filename);
     }
 }
 

--- a/src/unit_tests/wrappers/windows/fileapi_wrappers.c
+++ b/src/unit_tests/wrappers/windows/fileapi_wrappers.c
@@ -135,3 +135,29 @@ BOOL wrap_FindNextFile(HANDLE hFindFile, LPWIN32_FIND_DATA lpFindFileData) {
     }
     return mock_type(BOOL);
 }
+
+UINT wrap_GetDriveTypeA(LPCSTR lpRootPathName) {
+    if (lpRootPathName == NULL) {
+        // If this parameter is NULL, the function uses the root of the current directory.
+        return DRIVE_FIXED;
+    }
+
+    if (strlen(lpRootPathName) == 3 && lpRootPathName[1] == ':' && lpRootPathName[2] == '\\') {
+        switch (lpRootPathName[0]) {
+            case 'A':
+                return DRIVE_REMOVABLE;
+            case 'C':
+                return DRIVE_FIXED;
+            case 'D':
+                return DRIVE_CDROM;
+            case 'R':
+                return DRIVE_RAMDISK;
+            case 'Z':
+                return DRIVE_REMOTE;
+            default:
+                return DRIVE_UNKNOWN;
+        }
+    }
+
+    return DRIVE_NO_ROOT_DIR;
+}

--- a/src/unit_tests/wrappers/windows/fileapi_wrappers.h
+++ b/src/unit_tests/wrappers/windows/fileapi_wrappers.h
@@ -27,6 +27,8 @@
 #define FindFirstFile wrap_FindFirstFile
 #undef FindNextFile
 #define FindNextFile wrap_FindNextFile
+#undef GetDriveTypeA
+#define GetDriveTypeA wrap_GetDriveTypeA
 
 HANDLE wrap_CreateFile(LPCSTR lpFileName,
                        DWORD dwDesiredAccess,
@@ -66,5 +68,7 @@ BOOL wrap_GetFileTime(HANDLE     hFile,
 HANDLE wrap_FindFirstFile(LPCSTR lpFileName,  LPWIN32_FIND_DATAA lpFindFileData);
 
 BOOL wrap_FindNextFile(HANDLE hFindFile, LPWIN32_FIND_DATAA lpFindFileData);
+
+UINT wrap_GetDriveTypeA(LPCSTR lpRootPathName);
 
 #endif

--- a/src/util/clear_stats.c
+++ b/src/util/clear_stats.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
         DIR *daily;
         struct dirent *entry = NULL;
 
-        daily = opendir(daily_dir);
+        daily = wopendir(daily_dir);
         if (!daily) {
             merror_exit("Unable to open: '%s'", daily_dir);
         }
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
             struct dirent *entry = NULL;
 
             snprintf(dir_path, PATH_MAX, "%s/%d", daily_dir, i);
-            daily = opendir(dir_path);
+            daily = wopendir(dir_path);
             if (!daily) {
                 merror_exit("Unable to open: '%s' (no stats)", dir_path);
             }

--- a/src/util/verify-agent-conf.c
+++ b/src/util/verify-agent-conf.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
         } // while
     }//if
     else{
-        gdir = opendir(ar);
+        gdir = wopendir(ar);
         if (!gdir) {
             merror("Opening directory: '%s'", ar);
             return 1;
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
                 break;
             }
 
-            subdir = opendir(path);
+            subdir = wopendir(path);
 
             if (!subdir) {
                 if (errno != ENOTDIR) {

--- a/src/wazuh_db/helpers/wdb_global_helpers.c
+++ b/src/wazuh_db/helpers/wdb_global_helpers.c
@@ -731,7 +731,7 @@ int wdb_update_groups(const char *dirname, int *sock) {
                 continue;
             }
 
-            dp = opendir(group_path);
+            dp = wopendir(group_path);
 
             /* Group doesn't exists anymore, delete it */
             if (!dp) {
@@ -749,7 +749,7 @@ int wdb_update_groups(const char *dirname, int *sock) {
     DIR *dp = NULL;
     struct dirent *dirent = NULL;
 
-    if (!(dp = opendir(dirname))) {
+    if (!(dp = wopendir(dirname))) {
         merror("Couldn't open directory '%s': %s.", dirname, strerror(errno));
         if (!sock) {
             wdbc_close(&aux_sock);

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -517,7 +517,7 @@ void * run_up(__attribute__((unused)) void * args) {
     os_calloc(PATH_MAX + 1, sizeof(char), db_folder);
     snprintf(db_folder, PATH_MAX, "%s", WDB2_DIR);
 
-    fd = opendir(db_folder);
+    fd = wopendir(db_folder);
 
     if (!fd) {
         mdebug1("Opening directory: '%s': %s", db_folder, strerror(errno));

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -2154,7 +2154,7 @@ time_t wdb_global_get_most_recent_backup(char **most_recent_backup_name) {
         struct stat backup_info = {0};
 
         snprintf(tmp_path, OS_SIZE_512, "%s/%s", WDB_BACKUP_FOLDER, entry->d_name);
-        if(!stat(tmp_path, &backup_info)) {
+        if(!w_stat(tmp_path, &backup_info)) {
             if(backup_info.st_mtime >= most_recent_backup_time) {
                 most_recent_backup_time = backup_info.st_mtime;
                 tmp_backup_name = entry->d_name;
@@ -2192,7 +2192,7 @@ time_t wdb_global_get_oldest_backup(char **oldest_backup_name) {
         struct stat backup_info = {0};
 
         snprintf(tmp_path, OS_SIZE_512, "%s/%s", WDB_BACKUP_FOLDER, entry->d_name);
-        if(!stat(tmp_path, &backup_info)) {
+        if(!w_stat(tmp_path, &backup_info)) {
             if((current_time - backup_info.st_mtime) >= aux_time_var) {
                 aux_time_var = current_time - backup_info.st_mtime;
                 oldest_backup_time = backup_info.st_mtime;

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -2013,7 +2013,7 @@ int wdb_global_create_backup(wdb_t* wdb, char* output, const char* tag) {
 }
 
 int wdb_global_remove_old_backups() {
-    DIR* dp = opendir(WDB_BACKUP_FOLDER);
+    DIR* dp = wopendir(WDB_BACKUP_FOLDER);
 
     if(!dp) {
         mdebug1("Unable to open backup directory '%s'", WDB_BACKUP_FOLDER);
@@ -2053,7 +2053,7 @@ cJSON* wdb_global_get_backups() {
     cJSON* j_backups = NULL;
     struct dirent *entry = NULL;
 
-    DIR* dp = opendir(WDB_BACKUP_FOLDER);
+    DIR* dp = wopendir(WDB_BACKUP_FOLDER);
 
     if(!dp) {
         mdebug1("Unable to open backup directory '%s'", WDB_BACKUP_FOLDER);
@@ -2135,7 +2135,7 @@ end:
 }
 
 time_t wdb_global_get_most_recent_backup(char **most_recent_backup_name) {
-    DIR* dp = opendir(WDB_BACKUP_FOLDER);
+    DIR* dp = wopendir(WDB_BACKUP_FOLDER);
 
     if(!dp) {
         mdebug1("Unable to open backup directory '%s'", WDB_BACKUP_FOLDER);
@@ -2171,7 +2171,7 @@ time_t wdb_global_get_most_recent_backup(char **most_recent_backup_name) {
 }
 
 time_t wdb_global_get_oldest_backup(char **oldest_backup_name) {
-    DIR* dp = opendir(WDB_BACKUP_FOLDER);
+    DIR* dp = wopendir(WDB_BACKUP_FOLDER);
 
     if(!dp) {
         mdebug1("Unable to open backup directory '%s'", WDB_BACKUP_FOLDER);

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -385,7 +385,7 @@ void wm_clean_dangling_wdb_dbs() {
     struct dirent * dirent = NULL;
     DIR * dir;
 
-    if (!(dir = opendir(WDB2_DIR))) {
+    if (!(dir = wopendir(WDB2_DIR))) {
         mterror(WM_DATABASE_LOGTAG, "Couldn't open directory '%s': %s.", WDB2_DIR, strerror(errno));
         return;
     }
@@ -421,7 +421,7 @@ void wm_clean_dangling_wdb_dbs() {
 }
 
 void wm_sync_legacy_groups_files() {
-    DIR *dir = opendir(GROUPS_DIR);
+    DIR *dir = wopendir(GROUPS_DIR);
 
     if (!dir) {
         mtdebug1(WM_DATABASE_LOGTAG, "Couldn't open directory '%s': %s.", GROUPS_DIR, strerror(errno));
@@ -525,7 +525,7 @@ int wm_sync_shared_group(const char *fname) {
 
     snprintf(path, PATH_MAX, "%s/%s", SHAREDCFG_DIR, fname);
 
-    dp = opendir(path);
+    dp = wopendir(path);
     if (!dp) {
         /* The group was deleted */
         wdb_remove_group_db(fname, &wdb_wmdb_sock);

--- a/src/wazuh_modules/wm_database.c
+++ b/src/wazuh_modules/wm_database.c
@@ -253,7 +253,7 @@ void wm_check_agents() {
     static ino_t inode = 0;
     struct stat buffer;
 
-    if (stat(KEYS_FILE, &buffer) < 0) {
+    if (w_stat(KEYS_FILE, &buffer) < 0) {
         mterror(WM_DATABASE_LOGTAG, "Couldn't get client.keys stat: %s.", strerror(errno));
     } else {
         if (buffer.st_mtime != timestamp || buffer.st_ino != inode) {

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -231,7 +231,7 @@ int wm_osquery_check_logfile(const char * path, FILE * fp) {
         return -1;
     }
 
-    if (stat(path, &buf) < 0) {
+    if (w_stat(path, &buf) < 0) {
         return -1;
     }
 

--- a/src/wazuh_modules/wm_osquery_monitor.c
+++ b/src/wazuh_modules/wm_osquery_monitor.c
@@ -239,7 +239,7 @@ int wm_osquery_check_logfile(const char * path, FILE * fp) {
     HANDLE hFile;
     BY_HANDLE_FILE_INFORMATION fileInfo;
 
-    if (hFile = CreateFile(path, GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL), hFile == INVALID_HANDLE_VALUE) {
+    if (hFile = wCreateFile(path, GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL), hFile == INVALID_HANDLE_VALUE) {
         return -1;
     }
 
@@ -307,7 +307,7 @@ void *Execute_Osquery(wm_osquery_monitor_t *osquery)
 
         // Check that the configuration file is valid
 
-        if (access(osquery->config_path, R_OK) < 0) {
+        if (waccess(osquery->config_path, R_OK) < 0) {
             mwarn("The configuration file '%s' is not accessible: %s (%d)", osquery->config_path, strerror(errno), errno);
             sleep(600);
             continue;
@@ -576,7 +576,7 @@ int wm_osquery_packs(wm_osquery_monitor_t *osquery)
         if (strcmp(osquery->packs[i]->name, "*")) {
             // Check if the file exists
 
-            if (access(osquery->packs[i]->path, R_OK) < 0) {
+            if (waccess(osquery->packs[i]->path, R_OK) < 0) {
                 mwarn("Possible invalid configuration: Pack file '%s' is not accessible: %s (%d)", osquery->packs[i]->path, strerror(errno), errno);
             }
         } else if (!strchr(osquery->packs[i]->path, '*')) {

--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -2059,7 +2059,7 @@ static int wm_sca_check_dir_existence(const char * const dir, char **reason)
     }
     #endif
 
-    DIR *dp = opendir(realpath_buffer);
+    DIR *dp = wopendir(realpath_buffer);
     const int open_dir_errno = errno;
     if (dp) {
         mdebug2("DIR_EXISTS(%s) -> RETURN_FOUND", dir);
@@ -2108,7 +2108,7 @@ static int wm_sca_check_dir(const char * const dir,
     }
     #endif
 
-    DIR *dp = opendir(realpath_buffer);
+    DIR *dp = wopendir(realpath_buffer);
     if (!dp) {
         const int open_dir_errno = errno;
         if (*reason == NULL) {

--- a/src/win32/setup-iis.c
+++ b/src/win32/setup-iis.c
@@ -32,7 +32,7 @@ int direxist(char *dir)
     DIR *dp;
 
     /* Open dir */
-    dp = opendir(dir);
+    dp = wopendir(dir);
     if (dp == NULL) {
         return (0);
     }

--- a/src/win32/setup-shared.c
+++ b/src/win32/setup-shared.c
@@ -71,7 +71,7 @@ int direxist(char *dir)
     DIR *dp;
 
     /* Open dir */
-    dp = opendir(dir);
+    dp = wopendir(dir);
     if (dp == NULL) {
         return (0);
     }


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/internal-devel-requests/issues/2042#issuecomment-2910268112|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

In progress...

## Configuration options
- logcollecor:
```
  <localfile>
    <location>Z:/test.log</location>
    <log_format>syslog</log_format>
  </localfile>

  <localfile>
    <location>\\192.168.0.5\shared\test.log</location>
    <log_format>syslog</log_format>
  </localfile>
```
- syscheck:
```
    <directories>Z:\scheduled</directories>
    <directories>\\192.168.0.5\shared\scheduled</directories>

    <directories realtime="yes">Z:\realtime</directories>
    <directories realtime="yes">\\192.168.0.5\shared\realtime</directories>

    <directories whodata="yes">Z:\whodata</directories>
    <directories whodata="yes">\\192.168.0.5\shared\whodata</directories>
```
- osquery:
```
  <wodle name="osquery">
    <disabled>no</disabled>
    <run_daemon>yes</run_daemon>
    <bin_path>\\192.168.0.5\shared\osqueryd.exe</bin_path>
    <log_path>\\192.168.0.5\shared\test.log</log_path>
    <config_path>\\192.168.0.5\shared\test.conf</config_path>
    <add_labels>no</add_labels>
  </wodle>
```

## Logs/Alerts example

In progress...

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors