### PR TITLE
Enhancement/30040 router content manager failing tests

### DIFF
--- a/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
+++ b/src/shared_modules/content_manager/tests/unit/CtiDownloader_test.cpp
@@ -180,7 +180,10 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadWithRetryGenericServerError)
     const auto& lastQueryTimestamp {records.back().timestamp};
     const auto milliseconds {
         std::chrono::duration_cast<std::chrono::milliseconds>(lastQueryTimestamp - firstQueryTimestamp).count()};
-    EXPECT_GE(milliseconds, TOO_MANY_REQUESTS_RETRY_TIME_MS * 2);
+    auto minExpectedSleepTime = TOO_MANY_REQUESTS_RETRY_TIME_MS * 2;
+    // We accept a small margin of error in the sleep time.
+    minExpectedSleepTime *= 0.9;
+    EXPECT_GE(milliseconds, minExpectedSleepTime);
 }
 
 /**
@@ -218,7 +221,10 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadWithRetryTooManyRequestsError)
     const auto& lastQueryTimestamp {records.back().timestamp};
     const auto milliseconds {
         std::chrono::duration_cast<std::chrono::milliseconds>(lastQueryTimestamp - firstQueryTimestamp).count()};
-    EXPECT_GE(milliseconds, TOO_MANY_REQUESTS_RETRY_TIME_MS);
+    auto minExpectedSleepTime = TOO_MANY_REQUESTS_RETRY_TIME_MS;
+    // We accept a small margin of error in the sleep time.
+    minExpectedSleepTime *= 0.9;
+    EXPECT_GE(milliseconds, minExpectedSleepTime);
 }
 
 /**
@@ -257,7 +263,10 @@ TEST_F(CtiDownloaderTest, BaseParametersDownloadWithRetryDifferentErrors)
     const auto& lastQueryTimestamp {records.back().timestamp};
     const auto milliseconds {
         std::chrono::duration_cast<std::chrono::milliseconds>(lastQueryTimestamp - firstQueryTimestamp).count()};
-    EXPECT_GE(milliseconds, TOO_MANY_REQUESTS_RETRY_TIME_MS * 2 + GENERIC_ERROR_INITIAL_RETRY_TIME_MS);
+    auto minExpectedSleepTime = TOO_MANY_REQUESTS_RETRY_TIME_MS * 2 + GENERIC_ERROR_INITIAL_RETRY_TIME_MS;
+    // We accept a small margin of error in the sleep time.
+    minExpectedSleepTime *= 0.9;
+    EXPECT_GE(milliseconds, minExpectedSleepTime);
 }
 
 /**

--- a/src/shared_modules/router/tests/CMakeLists.txt
+++ b/src/shared_modules/router/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g --coverage -fsanitize=address,leak,undefined")
+
 include_directories(${SRC_FOLDER}/external/googletest/googletest/include/)
 include_directories(${SRC_FOLDER}/external/googletest/googlemock/include/)
 include_directories(${SRC_FOLDER}/shared_modules/router/)


### PR DESCRIPTION
|Related issue|
|---|
|#30040|

## Description

- Backported from 4.13.x the workaround for spurious wake ups in content manager unit tests
- Adding missing sanitizer flags during tests compilation. 