### PR TITLE
Update the default number of expected CDB lists

### DIFF
--- a/api/test/integration/test_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_cdb_list_endpoints.tavern.yaml
@@ -48,7 +48,7 @@ stages:
               relative_dirname: !anystr
               filename: !anystr
           failed_items: []
-          total_affected_items: 4 # Number of cdb_lists by default in Wazuh, this number may change anytime, update accordingly
+          total_affected_items: 7 # Number of cdb_lists by default in Wazuh, this number may change anytime, update accordingly
           total_failed_items: 0
       # Save some data for future use in the test
       save:

--- a/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cdb_list_endpoints.tavern.yaml
@@ -22,8 +22,11 @@ stages:
             - items: !anything
               filename: aws-sources
               relative_dirname: etc/lists/amazon
+            - items: !anything
+              filename: malware-hashes
+              relative_dirname: etc/lists/malicious-ioc
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: 5
           total_failed_items: 0
 
   - name: Show an specified filename (Allow)
@@ -85,8 +88,10 @@ stages:
               relative_dirname: etc/lists
             - filename: aws-sources
               relative_dirname: etc/lists/amazon
+            - filename: malware-hashes
+              relative_dirname: etc/lists/malicious-ioc
           failed_items: []
-          total_affected_items: 2
+          total_affected_items: 5
           total_failed_items: 0
 
 ---


### PR DESCRIPTION
|Related issue|
|---|
|#30061|

This PR closes #30061. Updates the default number of expected CDB lists in the related API integration tests.

## Tests

https://jenkins-staging.qa.wazuh.info/job/Test_integration_endpoints/81/