### PR TITLE
Correct SCA 1.4.2 for Ubuntu 24.04.

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
@@ -1082,7 +1082,7 @@ checks:
        - soc_2: ["CC5.2", "CC6.1"]
      condition: all
      rules:
-      - 'c:stat /boot/grub/grub.cfg -> r:Access: \(0400/-r--------\) && r:Uid:\s+\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s+\t*\(\s*\t*0/\s*\t*root\)'
+      - 'c:stat /boot/grub/grub.cfg -> r:Access: \(0600/-rw-------\) && r:Uid:\s+\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s+\t*\(\s*\t*0/\s*\t*root\)'
 
   # 1.5.1 Ensure address space layout randomization is enabled. (Automated)
    - id: 35542


### PR DESCRIPTION
|Related issue|
|---|
| #30116 |

## Description

Correct audit check for Ubuntu 24.04 (1.4.2).

Perhaps a better approach would be to check that the code is either 600 or 400 as the SCA check for Ubuntu 22.04 does:

```
'c:stat -Lc "%n %a %u %U %g %G" /boot/grub/grub.cfg -> r:0 root 0 root && r:600|400'
```
