### PR TITLE
Global queries - Add new memory value

### DIFF
--- a/src/shared_modules/utils/reflectiveJson.hpp
+++ b/src/shared_modules/utils/reflectiveJson.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 constexpr auto DEFAULT_INT_VALUE = INT64_MIN;
+constexpr auto DEFAULT_DOUBLE_VALUE = -1.0;
 constexpr auto CHAR_SIZE {256};
 constexpr auto BUFFER_SIZE {32};
 
@@ -153,7 +154,7 @@ constexpr bool IS_REFLECTABLE_MEMBER =
     std::is_same_v<std::decay_t<T>, std::int64_t>;
 
 template<typename C, typename T>
-constexpr auto makeFieldChecked(const char* keyLiteral, const char* keyLiteralField, T C::*member)
+constexpr auto makeFieldChecked(const char* keyLiteral, const char* keyLiteralField, T C::* member)
 {
     static_assert(IS_REFLECTABLE_MEMBER<T>, "Invalid member type for reflection");
     return std::make_tuple(std::string_view {keyLiteral}, std::string_view {keyLiteralField}, member);
@@ -362,8 +363,8 @@ std::enable_if_t<IsReflectable<T>::value, void> serializeToJSON(const T& obj, st
                          json.push_back('"');
                      }
                      else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(data)>> ||
-                                         std::is_same_v<double, std::decay_t<decltype(data)>>)&&!std::
-                                            is_same_v<bool, std::decay_t<decltype(data)>>)
+                                         std::is_same_v<double, std::decay_t<decltype(data)>>) &&
+                                        !std::is_same_v<bool, std::decay_t<decltype(data)>>)
                      {
 
                          auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), data);
@@ -410,8 +411,8 @@ std::enable_if_t<IsReflectable<T>::value, void> serializeToJSON(const T& obj, st
                                  json.push_back('\"');
                              }
                              else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(value)>> ||
-                                                 std::is_same_v<double, std::decay_t<decltype(value)>>)&&!std::
-                                                    is_same_v<bool, std::decay_t<decltype(value)>>)
+                                                 std::is_same_v<double, std::decay_t<decltype(value)>>) &&
+                                                !std::is_same_v<bool, std::decay_t<decltype(value)>>)
                              {
                                  auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), value);
                                  if (ec == std::errc())
@@ -459,8 +460,8 @@ std::enable_if_t<IsReflectable<T>::value, void> serializeToJSON(const T& obj, st
                                  json.push_back('\"');
                              }
                              else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(v)>> ||
-                                                 std::is_same_v<double, std::decay_t<decltype(v)>>)&&!std::
-                                                    is_same_v<bool, std::decay_t<decltype(v)>>)
+                                                 std::is_same_v<double, std::decay_t<decltype(v)>>) &&
+                                                !std::is_same_v<bool, std::decay_t<decltype(v)>>)
                              {
                                  auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), v);
                                  if (ec == std::errc())
@@ -565,12 +566,12 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                          json.push_back('"');
                      }
                      else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(data)>> ||
-                                         std::is_same_v<double, std::decay_t<decltype(data)>>)&&!std::
-                                            is_same_v<bool, std::decay_t<decltype(data)>>)
+                                         std::is_same_v<double, std::decay_t<decltype(data)>>) &&
+                                        !std::is_same_v<bool, std::decay_t<decltype(data)>>)
                      {
 
-                         auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), data);
-                         if (ec == std::errc())
+                         int len = std::snprintf(buffer, sizeof(buffer), "%g", data);
+                         if (len > 0 && len < static_cast<int>(sizeof(buffer)))
                          {
                              json.append(buffer);
                          }
@@ -578,7 +579,6 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                          {
                              json.append("0");
                          }
-
                          std::fill(buffer, buffer + sizeof(buffer), '\0');
                      }
                      else if constexpr (std::is_same_v<bool, std::decay_t<decltype(data)>>)
@@ -614,8 +614,8 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                                  json.push_back('\"');
                              }
                              else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(value)>> ||
-                                                 std::is_same_v<double, std::decay_t<decltype(value)>>)&&!std::
-                                                    is_same_v<bool, std::decay_t<decltype(value)>>)
+                                                 std::is_same_v<double, std::decay_t<decltype(value)>>) &&
+                                                !std::is_same_v<bool, std::decay_t<decltype(value)>>)
                              {
                                  auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), value);
                                  if (ec == std::errc())
@@ -656,8 +656,8 @@ std::enable_if_t<IsReflectable<T>::value, std::string> serializeToJSON(const T& 
                                          json.push_back('\"');
                                      }
                                      else if constexpr ((std::is_arithmetic_v<std::decay_t<decltype(value)>> ||
-                                                         std::is_same_v<double, std::decay_t<decltype(value)>>)&&!std::
-                                                            is_same_v<bool, std::decay_t<decltype(value)>>)
+                                                         std::is_same_v<double, std::decay_t<decltype(value)>>) &&
+                                                        !std::is_same_v<bool, std::decay_t<decltype(value)>>)
                                      {
                                          auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), v);
                                          if (ec == std::errc())

--- a/src/shared_modules/utils/reflectiveJson.hpp
+++ b/src/shared_modules/utils/reflectiveJson.hpp
@@ -367,8 +367,8 @@ std::enable_if_t<IsReflectable<T>::value, void> serializeToJSON(const T& obj, st
                                         !std::is_same_v<bool, std::decay_t<decltype(data)>>)
                      {
 
-                         auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), data);
-                         if (ec == std::errc())
+                         int len = std::snprintf(buffer, sizeof(buffer), "%g", data);
+                         if (len > 0 && len < static_cast<int>(sizeof(buffer)))
                          {
                              json.append(buffer);
                          }

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/inputs/1_delta.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/inputs/1_delta.json
@@ -14,7 +14,7 @@
     "cpu_name": "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
     "ram_free": 1024,
     "ram_total": 2048,
-    "ram_usage": 1024
+    "ram_usage": 50
   },
   "operation": "INSERTED"
 }

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/result.json
@@ -17,7 +17,8 @@
                     "memory": {
                         "free": 1048576,
                         "total": 2097152,
-                        "used": 1048576
+                        "used": 1048576,
+                        "used_percentage": 0.5
                     },
                     "serial_number": "ABC123XYZ789"
                 },

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/000_insert_delta/result.json
@@ -18,7 +18,7 @@
                         "free": 1048576,
                         "total": 2097152,
                         "used": 1048576,
-                        "used_percentage": 0.5
+                        "usage": 0.5
                     },
                     "serial_number": "ABC123XYZ789"
                 },

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/inputs/1_rsync.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/inputs/1_rsync.json
@@ -16,7 +16,7 @@
             "cpu_name": "Intel(R) Core(TM) i9-10500H CPU @ 2.50GHz",
             "ram_free": 1024,
             "ram_total": 2048,
-            "ram_usage": 1024,
+            "ram_usage": 50,
             "scan_time": "2025/03/21 02:04:08"
         },
         "index": "f825a912fb60c89e421a526ba6bcef010cee7315",

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/result.json
@@ -18,7 +18,7 @@
                         "free": 1048576,
                         "total": 2097152,
                         "used": 1048576,
-                        "used_percentage": 0.5
+                        "usage": 0.5
                     },
                     "serial_number": "A320"
                 },

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/002_insert_rsync/result.json
@@ -17,7 +17,8 @@
                     "memory": {
                         "free": 1048576,
                         "total": 2097152,
-                        "used": 1048576
+                        "used": 1048576,
+                        "used_percentage": 0.5
                     },
                     "serial_number": "A320"
                 },

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/inputs/1_delta.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/inputs/1_delta.json
@@ -14,7 +14,7 @@
     "cpu_name": "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
     "ram_free": 1024,
     "ram_total": 2048,
-    "ram_usage": 1024
+    "ram_usage": 50
   },
   "operation": "INSERTED"
 }

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/pre_existing_data.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/pre_existing_data.json
@@ -21,7 +21,8 @@
                     "memory": {
                         "free": 1234,
                         "total": 33554432,
-                        "used": 16777216
+                        "used": 16777216,
+                        "used_percentage": 0.5
                     },
                     "serial_number": "ABC123XYZ789"
                 },
@@ -46,7 +47,8 @@
                     "memory": {
                         "free": 1048576,
                         "total": 2097152,
-                        "used": 1048576
+                        "used": 1048576,
+                        "used_percentage": 0.5
                     },
                     "serial_number": "AAA111BBB222"
                 },

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/pre_existing_data.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/pre_existing_data.json
@@ -22,7 +22,7 @@
                         "free": 1234,
                         "total": 33554432,
                         "used": 16777216,
-                        "used_percentage": 0.5
+                        "usage": 0.5
                     },
                     "serial_number": "ABC123XYZ789"
                 },
@@ -48,7 +48,7 @@
                         "free": 1048576,
                         "total": 2097152,
                         "used": 1048576,
-                        "used_percentage": 0.5
+                        "usage": 0.5
                     },
                     "serial_number": "AAA111BBB222"
                 },

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/result.json
@@ -17,7 +17,8 @@
                     "memory": {
                         "free": 1048576,
                         "total": 2097152,
-                        "used": 1048576
+                        "used": 1048576,
+                        "used_percentage": 0.5
                     },
                     "serial_number": "AAA111BBB222"
                 },
@@ -42,7 +43,8 @@
                     "memory": {
                         "free": 1048576,
                         "total": 2097152,
-                        "used": 1048576
+                        "used": 1048576,
+                        "used_percentage": 0.5
                     },
                     "serial_number": "ABC123XYZ789"
                 },

--- a/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/result.json
+++ b/src/wazuh_modules/inventory_harvester/qa/test_data/inventory/hardware/005_integrity_check_global/result.json
@@ -18,7 +18,7 @@
                         "free": 1048576,
                         "total": 2097152,
                         "used": 1048576,
-                        "used_percentage": 0.5
+                        "usage": 0.5
                     },
                     "serial_number": "AAA111BBB222"
                 },
@@ -44,7 +44,7 @@
                         "free": 1048576,
                         "total": 2097152,
                         "used": 1048576,
-                        "used_percentage": 0.5
+                        "usage": 0.5
                     },
                     "serial_number": "ABC123XYZ789"
                 },

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
@@ -78,6 +78,9 @@ public:
         auto usedMem = data->totalMem() - data->freeMem();
         element.data.host.memory.used = (usedMem > 0) ? usedMem : 0;
 
+        // Ex: The percentage of used memory
+        element.data.host.memory.used_percentage = data->usedMem();
+
         // Ex: AA320
         element.data.host.serial_number = boardId;
 

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/elements/hwElement.hpp
@@ -79,7 +79,7 @@ public:
         element.data.host.memory.used = (usedMem > 0) ? usedMem : 0;
 
         // Ex: The percentage of used memory
-        element.data.host.memory.used_percentage = data->usedMem();
+        element.data.host.memory.usage = data->usedMem();
 
         // Ex: AA320
         element.data.host.serial_number = boardId;

--- a/src/wazuh_modules/inventory_harvester/src/systemInventory/systemContext.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/systemInventory/systemContext.hpp
@@ -192,6 +192,26 @@ public:
         return 0;
     }
 
+    double usedMem()
+    {
+        if (m_type == VariantType::Delta)
+        {
+            if (m_delta->data_as_dbsync_hwinfo() && m_delta->data_as_dbsync_hwinfo()->ram_usage())
+            {
+                return m_delta->data_as_dbsync_hwinfo()->ram_usage() * 0.01;
+            }
+        }
+        else if (m_type == VariantType::SyncMsg)
+        {
+            if (m_syncMsg->data_as_state() && m_syncMsg->data_as_state()->attributes_as_syscollector_hwinfo() &&
+                m_syncMsg->data_as_state()->attributes_as_syscollector_hwinfo()->ram_usage())
+            {
+                return m_syncMsg->data_as_state()->attributes_as_syscollector_hwinfo()->ram_usage() * 0.01;
+            }
+        }
+        return 0.0;
+    }
+
     std::string_view cpuName()
     {
         if (m_type == VariantType::Delta)

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/hardware.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/hardware.hpp
@@ -30,12 +30,12 @@ struct Hardware final
         int64_t free = DEFAULT_INT_VALUE;
         int64_t total = DEFAULT_INT_VALUE;
         int64_t used = DEFAULT_INT_VALUE;
-        double used_percentage = DEFAULT_DOUBLE_VALUE;
+        double usage = DEFAULT_DOUBLE_VALUE;
 
         REFLECTABLE(MAKE_FIELD("free", &Memory::free),
                     MAKE_FIELD("total", &Memory::total),
                     MAKE_FIELD("used", &Memory::used),
-                    MAKE_FIELD("used_percentage", &Memory::used_percentage));
+                    MAKE_FIELD("usage", &Memory::usage));
     } memory;
 
     std::string_view serial_number;

--- a/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/hardware.hpp
+++ b/src/wazuh_modules/inventory_harvester/src/wcsModel/wcsClasses/hardware.hpp
@@ -30,10 +30,12 @@ struct Hardware final
         int64_t free = DEFAULT_INT_VALUE;
         int64_t total = DEFAULT_INT_VALUE;
         int64_t used = DEFAULT_INT_VALUE;
+        double used_percentage = DEFAULT_DOUBLE_VALUE;
 
         REFLECTABLE(MAKE_FIELD("free", &Memory::free),
                     MAKE_FIELD("total", &Memory::total),
-                    MAKE_FIELD("used", &Memory::used));
+                    MAKE_FIELD("used", &Memory::used),
+                    MAKE_FIELD("used_percentage", &Memory::used_percentage));
     } memory;
 
     std::string_view serial_number;

--- a/src/wazuh_modules/inventory_harvester/tests/mocks/MockSystemContext.hpp
+++ b/src/wazuh_modules/inventory_harvester/tests/mocks/MockSystemContext.hpp
@@ -12,7 +12,6 @@
 #ifndef _MOCK_SYSTEM_CONTEXT_HPP
 #define _MOCK_SYSTEM_CONTEXT_HPP
 
-#include "gmock/gmock-function-mocker.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/src/wazuh_modules/inventory_harvester/tests/mocks/MockSystemContext.hpp
+++ b/src/wazuh_modules/inventory_harvester/tests/mocks/MockSystemContext.hpp
@@ -12,6 +12,7 @@
 #ifndef _MOCK_SYSTEM_CONTEXT_HPP
 #define _MOCK_SYSTEM_CONTEXT_HPP
 
+#include "gmock/gmock-function-mocker.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -115,6 +116,7 @@ public:
     MOCK_METHOD(int64_t, cpuFrequency, (), (const));
     MOCK_METHOD(int64_t, freeMem, (), (const));
     MOCK_METHOD(int64_t, totalMem, (), (const));
+    MOCK_METHOD(double, usedMem, (), (const));
     MOCK_METHOD(std::string_view, netProtoIface, (), (const));
     MOCK_METHOD(std::string_view, netProtoType, (), (const));
     MOCK_METHOD(std::string_view, netProtoGateway, (), (const));

--- a/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
@@ -322,12 +322,13 @@ TEST_F(SystemInventoryUpsertElement, emptyBoardId_Hw)
     EXPECT_CALL(*context, cpuFrequency()).WillOnce(testing::Return(2497));
     EXPECT_CALL(*context, freeMem()).WillRepeatedly(testing::Return(50));
     EXPECT_CALL(*context, totalMem()).WillRepeatedly(testing::Return(100));
+    EXPECT_CALL(*context, usedMem()).WillRepeatedly(testing::Return(0.5));
 
     EXPECT_NO_THROW(upsertElement->handleRequest(context));
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_unknown","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50},"serial_number":"unknown"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_unknown","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50,"used_percentage":0.5},"serial_number":"unknown"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentID_Hw)
@@ -346,12 +347,13 @@ TEST_F(SystemInventoryUpsertElement, validAgentID_Hw)
     EXPECT_CALL(*context, cpuFrequency()).WillOnce(testing::Return(2497));
     EXPECT_CALL(*context, freeMem()).WillRepeatedly(testing::Return(50));
     EXPECT_CALL(*context, totalMem()).WillRepeatedly(testing::Return(100));
+    EXPECT_CALL(*context, usedMem()).WillRepeatedly(testing::Return(0.5));
 
     EXPECT_NO_THROW(upsertElement->handleRequest(context));
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_boardInfo","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50},"serial_number":"boardInfo"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_boardInfo","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50,"used_percentage":0.5},"serial_number":"boardInfo"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 /*

--- a/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
+++ b/src/wazuh_modules/inventory_harvester/tests/unit/systemInventoryUpsertElement_test.cpp
@@ -328,7 +328,7 @@ TEST_F(SystemInventoryUpsertElement, emptyBoardId_Hw)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_unknown","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50,"used_percentage":0.5},"serial_number":"unknown"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_unknown","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50,"usage":0.5},"serial_number":"unknown"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 TEST_F(SystemInventoryUpsertElement, validAgentID_Hw)
@@ -353,7 +353,7 @@ TEST_F(SystemInventoryUpsertElement, validAgentID_Hw)
 
     EXPECT_EQ(
         context->m_serializedElement,
-        R"({"id":"001_boardInfo","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50,"used_percentage":0.5},"serial_number":"boardInfo"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
+        R"({"id":"001_boardInfo","operation":"INSERTED","data":{"host":{"cpu":{"cores":2,"name":"cpuName","speed":2497},"memory":{"free":50,"total":100,"used":50,"usage":0.5},"serial_number":"boardInfo"},"agent":{"id":"001","name":"agentName","host":{"ip":"agentIp"},"version":"agentVersion"},"wazuh":{"cluster":{"name":"clusterName"},"schema":{"version":"1.0"}}}})");
 }
 
 /*


### PR DESCRIPTION
|Related issue|
|---|
|Closes wazuh/wazuh#30146 |

# Objective

This PR add a new data visualization related to IT Hygiene:

- `host.memory.usage` is multiplied by `0.01` to normalize their values to percentage.

Also, in order to compile this `double` element, some changes related to `reflectiveJson` were made, to avoid use no standard 17 functions. We apply clang format too.

## Testing

> [!NOTE]
> Test behavior doesn't change due the cosmetic rename field

![usagePercentTwo](https://github.com/user-attachments/assets/be0c4046-1719-4080-bd0b-5f5c3174256a)


![usagePercent](https://github.com/user-attachments/assets/a2a2dc98-e670-4c2b-b9cf-253b2f5434d8)
