### PR TITLE
Improve user_groups collector

### DIFF
--- a/src/data_provider/src/extended_sources/groups/include/user_groups_darwin.hpp
+++ b/src/data_provider/src/extended_sources/groups/include/user_groups_darwin.hpp
@@ -27,6 +27,10 @@ class UserGroupsProvider
         UserGroupsProvider();
         nlohmann::json collect(const std::set<uid_t>& uids = {});
 
+        nlohmann::json getUserNamesByGid(const std::set<gid_t>& gids);
+
+        nlohmann::json getGroupNamesByUid(const std::set<uid_t>& uids);
+
     private:
         std::shared_ptr<IGroupWrapperDarwin> m_groupWrapper;
         std::shared_ptr<IPasswdWrapperDarwin> m_passwdWrapper;
@@ -41,5 +45,6 @@ class UserGroupsProvider
 
         void getGroupsForUser(nlohmann::json& results, const UserInfo& user);
         void addGroupsToResults(nlohmann::json& results, uid_t uid, const gid_t* groups, int ngroups);
+        std::vector<gid_t> getGroupIdsForUser(const UserInfo& user);
 
 };

--- a/src/data_provider/src/extended_sources/groups/include/user_groups_linux.hpp
+++ b/src/data_provider/src/extended_sources/groups/include/user_groups_linux.hpp
@@ -11,27 +11,52 @@
 
 #include <set>
 
-#include "json.hpp"
 #include "igroup_wrapper.hpp"
 #include "ipasswd_wrapper.hpp"
 #include "isystem_wrapper.hpp"
+#include "json.hpp"
 
 #define EXPECTED_GROUPS_MAX 64
 
+// @brief Class for collecting user groups information on Linux systems.
+//
+// This class provides methods to collect user groups information from the
+// Linux operating system. It uses the system's group and passwd databases to retrieve
+// user details such as username, UID, GID, and their associated groups. The collected
+// data is returned in JSON format.
 class UserGroupsProvider
 {
     public:
+        /// @brief Constructs a UserGroupsProvider with specific wrappers.
+        /// @param groupWrapper A shared pointer to an IGroupWrapperLinux instance for group operations.
+        /// @param passwdWrapper A shared pointer to an IPasswdWrapperLinux instance for passwd operations.
+        /// @param sysWrapper A shared pointer to an ISystemWrapper instance for system operations.
         explicit UserGroupsProvider(std::shared_ptr<IGroupWrapperLinux> groupWrapper,
                                     std::shared_ptr<IPasswdWrapperLinux> passwdWrapper,
                                     std::shared_ptr<ISystemWrapper> sysWrapper);
+
+        /// @brief Default constructor that initializes the UserGroupsProvider with default wrappers.
+        /// @note This constructor uses default implementations of IGroupWrapperLinux, IPasswdWrapperLinux, and ISystemWrapper.
         UserGroupsProvider();
+
+        /// @brief Collects user groups information.
+        /// @param uids A set of user IDs (UIDs) to filter the results. If empty, all users are collected.
+        /// @return A JSON array containing user groups information, where each entry includes UID, GID, and group details.
         nlohmann::json collect(const std::set<uid_t>& uids = {});
+
+        /// @brief Retrieves group names associated with the specified UIDs.
+        /// @param uids A set of user IDs (UIDs) for which to retrieve group names.
+        /// @return A JSON object where keys are UIDs and values are arrays of group names associated with those UIDs.
+        /// If a UID has no associated groups, the value will be an empty array.
+        /// @note This method is useful for quickly mapping UIDs to their group names without retrieving full group details.
+        nlohmann::json getGroupNamesByUid(const std::set<uid_t>& uids = {});
 
     private:
         std::shared_ptr<IGroupWrapperLinux> m_groupWrapper;
         std::shared_ptr<IPasswdWrapperLinux> m_passwdWrapper;
         std::shared_ptr<ISystemWrapper> m_sysWrapper;
 
+        /// @brief Structure to hold user information.
         struct UserInfo
         {
             const char* name;
@@ -39,6 +64,18 @@ class UserGroupsProvider
             gid_t gid;
         };
 
-        void getGroupsForUser(nlohmann::json& results, const UserInfo& user);
+        /// @brief Retrieves groups for each user and returns a vector of pairs containing UID and their associated groups.
+        /// @param uids A set of user IDs (UIDs) to filter the results. If empty, all users are processed.
+        /// @return A vector of pairs, where each pair contains a UID and a vector of GIDs representing the groups associated with that UID.
+        /// @note This method is used internally to gather user-group associations before formatting the results into JSON.
+        /// @note If a user has no associated groups, the vector of GIDs will be empty.
+        std::vector<std::pair<uid_t, std::vector<gid_t>>> getUserGroups(const std::set<uid_t>& uids);
+
+        /// @brief Adds groups to the results JSON array for a specific user.
+        /// @param results A reference to the JSON array where the group information will be added.
+        /// @param uid The user ID for which the groups are being added.
+        /// @param groups A pointer to an array of group IDs (GIDs) associated with the user.
+        /// @param ngroups The number of groups in the `groups` array.
+        /// @note This method formats the group information into JSON objects and appends them to the results array.
         void addGroupsToResults(nlohmann::json& results, uid_t uid, const gid_t* groups, int ngroups);
 };

--- a/src/data_provider/src/extended_sources/groups/include/user_groups_linux.hpp
+++ b/src/data_provider/src/extended_sources/groups/include/user_groups_linux.hpp
@@ -49,7 +49,16 @@ class UserGroupsProvider
         /// @return A JSON object where keys are UIDs and values are arrays of group names associated with those UIDs.
         /// If a UID has no associated groups, the value will be an empty array.
         /// @note This method is useful for quickly mapping UIDs to their group names without retrieving full group details.
+        /// @note If `uids` is empty, it retrieves group names for all users.
         nlohmann::json getGroupNamesByUid(const std::set<uid_t>& uids = {});
+
+        /// @brief Retrieves usernames associated with the specified GIDs.
+        /// @param gids A set of group IDs (GIDs) for which to retrieve usernames.
+        /// @return A JSON object where keys are GIDs and values are arrays of usernames associated with those GIDs.
+        /// If a GID has no associated usernames, the value will be an empty array.
+        /// @note This method is useful for quickly mapping GIDs to their usernames without retrieving full user details.
+        /// @note If `gids` is empty, it retrieves usernames for all groups.
+        nlohmann::json getUserNamesByGid(const std::set<gid_t>& gids = {});
 
     private:
         std::shared_ptr<IGroupWrapperLinux> m_groupWrapper;

--- a/src/data_provider/src/extended_sources/groups/include/user_groups_windows.hpp
+++ b/src/data_provider/src/extended_sources/groups/include/user_groups_windows.hpp
@@ -22,16 +22,67 @@
 class UserGroupsProvider
 {
     public:
+        /// @brief Constructs a UserGroupsProvider with specific wrappers.
+        /// @param winapiWrapper A shared pointer to an IWindowsApiWrapper instance for Windows API operations.
+        /// @param usersHelper A shared pointer to an IUsersHelper instance for user operations.
+        /// @param groupsHelper A shared pointer to an IGroupsHelper instance for group operations.
         explicit UserGroupsProvider(std::shared_ptr<IWindowsApiWrapper> winapiWrapper,
                                     std::shared_ptr<IUsersHelper> usersHelper,
                                     std::shared_ptr<IGroupsHelper> groupsHelper);
+
+        /// @brief Default constructor that initializes the UserGroupsProvider with default wrappers.
+        /// @note This constructor uses default implementations of IWindowsApiWrapper, IUsersHelper, and IGroupsHelper.
         UserGroupsProvider();
+
+        /// @brief Collects user groups information.
+        /// @param uids A set of user IDs (UIDs) to filter the results. If empty, all users are collected.
+        /// @return A JSON array containing user groups information, where each entry includes UID and GID.
+        /// @note The GID is the group ID of the group that the user belongs to.
+        /// @note If `uids` is empty, it collects information for all local users.
         nlohmann::json collect(const std::set<std::uint32_t>& uids = {});
+
+        /// @brief Retrieves group names associated with the specified UIDs.
+        /// @param uids A set of user IDs (UIDs) for which to retrieve group names.
+        /// @return A JSON object where keys are UIDs and values are arrays of group names associated with those UIDs.
+        /// If a UID has no associated groups, the value will be an empty array.
+        /// @note If `uids` is empty, it retrieves group names for all users.
+        /// @note If `uids` contains a single UID, the result is an array of group names.
+        /// If `uids` contains multiple UIDs, the result is an object where each key is a UID and the value is an array of group names.
+        nlohmann::json getGroupNamesByUid(const std::set<std::uint32_t>& uids = {});
+
+        /// @brief Retrieves usernames associated with the specified GIDs.
+        /// @param gids A set of group IDs (GIDs) for which to retrieve usernames.
+        /// @return A JSON object where keys are GIDs and values are arrays of usernames associated with those GIDs.
+        /// If a GID has no associated usernames, the value will be an empty array.
+        /// @note If `gids` is empty, it retrieves usernames for all groups.
+        /// @note If `gids` contains a single GID, the result is an array of usernames.
+        /// If `gids` contains multiple GIDs, the result is an object where each key is a GID and the value is an array of usernames.
+        nlohmann::json getUserNamesByGid(const std::set<std::uint32_t>& gids = {});
 
     private:
         std::shared_ptr<IWindowsApiWrapper> m_winapiWrapper;
         std::shared_ptr<IUsersHelper> m_usersHelper;
         std::shared_ptr<IGroupsHelper> m_groupsHelper;
 
+        /// @brief Processes local user groups and appends the results to the provided JSON object.
+        /// @param user The user for whom to process groups.
+        /// @param groups A vector of groups to check against.
+        /// @param results The JSON object to which the results will be appended.
         void processLocalUserGroups(const User& user, const std::vector<Group>& groups, nlohmann::json& results);
+
+        /// @brief Retrieves local users, optionally filtered by UIDs.
+        /// @param uids A set of user IDs (UIDs) to filter the results. If empty, all local users are retrieved.
+        /// @return A vector of User objects representing the local users.
+        std::vector<User> getLocalUsers(const std::set<std::uint32_t>& uids = {});
+
+        /// @brief Retrieves local groups.
+        /// @return A vector of Group objects representing the local groups.
+        /// @note This method retrieves all local groups available on the system.
+        std::vector<Group> getLocalGroups();
+
+        /// @brief Retrieves the names of local groups for a specific user.
+        /// @param username The username for which to retrieve group names.
+        /// @return A vector of strings containing the names of local groups that the user belongs to.
+        /// @note This method uses the Windows API to enumerate the groups associated with the specified user.
+        std::vector<std::string> getLocalGroupNamesForUser(const std::string& username);
 };

--- a/src/data_provider/src/extended_sources/groups/src/user_groups_darwin.cpp
+++ b/src/data_provider/src/extended_sources/groups/src/user_groups_darwin.cpp
@@ -69,18 +69,16 @@ nlohmann::json UserGroupsProvider::collect(const std::set<uid_t>& uids)
 void UserGroupsProvider::getGroupsForUser(nlohmann::json& results, const UserInfo& user)
 {
     int ngroups = m_groupWrapper->getgroupcount(user.name, user.gid);
-    gid_t* groups = new gid_t[ngroups];
+    std::vector<gid_t> groups(ngroups);
 
-    if (m_groupWrapper->getgrouplist(user.name, user.gid, groups, &ngroups) < 0)
+    if (m_groupWrapper->getgrouplist(user.name, user.gid, groups.data(), &ngroups) < 0)
     {
         // std::cerr << "Could not get users group list" << std::endl;
     }
     else
     {
-        addGroupsToResults(results, user.uid, groups, ngroups);
+        addGroupsToResults(results, user.uid, groups.data(), ngroups);
     }
-
-    delete[] groups;
 }
 
 void UserGroupsProvider::addGroupsToResults(nlohmann::json& results, uid_t uid, const gid_t* groups, int ngroups)
@@ -163,9 +161,9 @@ nlohmann::json UserGroupsProvider::getGroupNamesByUid(const std::set<uid_t>& uid
         UserInfo user {pwd->pw_name, pwd->pw_uid, pwd->pw_gid};
 
         int ngroups = m_groupWrapper->getgroupcount(user.name, user.gid);
-        gid_t* groups = new gid_t[ngroups];
+        std::vector<gid_t> groups(ngroups);
 
-        if (m_groupWrapper->getgrouplist(user.name, user.gid, groups, &ngroups) >= 0)
+        if (m_groupWrapper->getgrouplist(user.name, user.gid, groups.data(), &ngroups) >= 0)
         {
             nlohmann::json groupNames = nlohmann::json::array();
 
@@ -188,8 +186,6 @@ nlohmann::json UserGroupsProvider::getGroupNamesByUid(const std::set<uid_t>& uid
                 results[std::to_string(uid)] = groupNames;
             }
         }
-
-        delete[] groups;
     }
 
     return results;

--- a/src/data_provider/src/extended_sources/groups/src/user_groups_darwin.cpp
+++ b/src/data_provider/src/extended_sources/groups/src/user_groups_darwin.cpp
@@ -93,3 +93,104 @@ void UserGroupsProvider::addGroupsToResults(nlohmann::json& results, uid_t uid, 
         results.push_back(row);
     }
 }
+
+std::vector<gid_t> UserGroupsProvider::getGroupIdsForUser(const UserInfo& user)
+{
+    int ngroups = m_groupWrapper->getgroupcount(user.name, user.gid);
+    std::vector<gid_t> groups(ngroups);
+
+    if (m_groupWrapper->getgrouplist(user.name, user.gid, groups.data(), &ngroups) < 0)
+    {
+        return {};
+    }
+
+    groups.resize(ngroups);
+    return groups;
+}
+
+nlohmann::json UserGroupsProvider::getUserNamesByGid(const std::set<gid_t>& gids)
+{
+    bool singleGid = (gids.size() == 1);
+    nlohmann::json results = singleGid ? nlohmann::json::array() : nlohmann::json::object();
+    std::map<std::string, bool> usernames;
+
+    m_odWrapper->genEntries("dsRecTypeStandard:Users", nullptr, usernames);
+
+    for (const auto& username : usernames)
+    {
+        struct passwd* pwd = m_passwdWrapper->getpwnam(username.first.c_str());
+
+        if (pwd != nullptr)
+        {
+            UserInfo user {pwd->pw_name, pwd->pw_uid, pwd->pw_gid};
+            auto userGids = getGroupIdsForUser(user);
+
+            for (const auto& gid : userGids)
+            {
+                if (gids.count(gid))
+                {
+                    if (singleGid)
+                    {
+                        results.push_back(user.name);
+                    }
+                    else
+                    {
+                        results[std::to_string(gid)].push_back(user.name);
+                    }
+                }
+            }
+        }
+    }
+
+    return results;
+}
+
+nlohmann::json UserGroupsProvider::getGroupNamesByUid(const std::set<uid_t>& uids)
+{
+    const bool allUsers = uids.empty();
+    const bool singleUid = (!allUsers && uids.size() == 1);
+    nlohmann::json results = singleUid ? nlohmann::json::array() : nlohmann::json::object();
+
+    for (const auto& uid : uids)
+    {
+        struct passwd* pwd = m_passwdWrapper->getpwuid(uid);
+
+        if (pwd == nullptr)
+        {
+            continue;
+        }
+
+        UserInfo user {pwd->pw_name, pwd->pw_uid, pwd->pw_gid};
+
+        int ngroups = m_groupWrapper->getgroupcount(user.name, user.gid);
+        gid_t* groups = new gid_t[ngroups];
+
+        if (m_groupWrapper->getgrouplist(user.name, user.gid, groups, &ngroups) >= 0)
+        {
+            nlohmann::json groupNames = nlohmann::json::array();
+
+            for (int i = 0; i < ngroups; ++i)
+            {
+                struct group* grp = m_groupWrapper->getgrgid(groups[i]);
+
+                if (grp != nullptr)
+                {
+                    groupNames.push_back(grp->gr_name);
+                }
+            }
+
+            if (singleUid)
+            {
+                results = groupNames;
+            }
+            else
+            {
+                results[std::to_string(uid)] = groupNames;
+            }
+        }
+
+        delete[] groups;
+    }
+
+    return results;
+}

--- a/src/data_provider/src/extended_sources/groups/src/user_groups_linux.cpp
+++ b/src/data_provider/src/extended_sources/groups/src/user_groups_linux.cpp
@@ -7,11 +7,11 @@
  * Foundation.
  */
 
-#include <iostream>
 #include "user_groups_linux.hpp"
 #include "group_wrapper.hpp"
 #include "passwd_wrapper.hpp"
 #include "system_wrapper.hpp"
+#include <iostream>
 
 // Reasonable upper bound for getpw_r buffer
 constexpr size_t MAX_GETPW_R_BUF_SIZE = 16 * 1024;
@@ -35,11 +35,55 @@ UserGroupsProvider::UserGroupsProvider()
 nlohmann::json UserGroupsProvider::collect(const std::set<uid_t>& uids)
 {
     nlohmann::json results = nlohmann::json::array();
-    struct passwd pwd;
-    struct passwd* pwdResults
+    auto usersGroups = getUserGroups(uids);
+
+    for (const auto& [uid, groups] : usersGroups)
     {
-        nullptr
-    };
+        addGroupsToResults(results, uid, groups.data(), static_cast<int>(groups.size()));
+    }
+
+    return results;
+}
+
+nlohmann::json UserGroupsProvider::getGroupNamesByUid(const std::set<uid_t>& uids)
+{
+    nlohmann::json result = nlohmann::json::object();
+    auto usersGroups = getUserGroups(uids);
+
+    size_t bufSize = m_sysWrapper->sysconf(_SC_GETGR_R_SIZE_MAX);
+
+    if (bufSize > MAX_GETPW_R_BUF_SIZE)
+    {
+        bufSize = MAX_GETPW_R_BUF_SIZE;
+    }
+
+    for (const auto& [uid, groups] : usersGroups)
+    {
+        nlohmann::json groupNames = nlohmann::json::array();
+
+        for (const auto& gid : groups)
+        {
+            struct group grp;
+            struct group* grpResult = nullptr;
+            auto groupBuf = std::make_unique<char[]>(bufSize);
+
+            if (m_groupWrapper->getgrgid_r(gid, &grp, groupBuf.get(), bufSize, &grpResult) == 0 && grpResult != nullptr)
+            {
+                groupNames.push_back(grpResult->gr_name);
+            }
+        }
+
+        result[std::to_string(uid)] = groupNames;
+    }
+
+    return result;
+}
+
+std::vector<std::pair<uid_t, std::vector<gid_t>>> UserGroupsProvider::getUserGroups(const std::set<uid_t>& uids)
+{
+    std::vector<std::pair<uid_t, std::vector<gid_t>>> userGroups;
+    struct passwd pwd;
+    struct passwd* pwdResults = nullptr;
 
     size_t bufSize = m_sysWrapper->sysconf(_SC_GETPW_R_SIZE_MAX);
 
@@ -50,15 +94,48 @@ nlohmann::json UserGroupsProvider::collect(const std::set<uid_t>& uids)
 
     auto buf = std::make_unique<char[]>(bufSize);
 
+    auto processUser = [&](const struct passwd * pwdInfo)
+    {
+        UserInfo user {pwdInfo->pw_name, pwdInfo->pw_uid, pwdInfo->pw_gid};
+
+        gid_t groupsBuffer[EXPECTED_GROUPS_MAX];
+        gid_t* groups = groupsBuffer;
+        int nGroups = EXPECTED_GROUPS_MAX;
+
+        if (m_groupWrapper->getgrouplist(user.name, user.gid, groups, &nGroups) < 0)
+        {
+            groups = new gid_t[nGroups];
+
+            if (groups == nullptr)
+            {
+                // std::cerr << "Could not allocate memory to get user groups" << std::endl;
+                return;
+            }
+
+            if (m_groupWrapper->getgrouplist(user.name, user.gid, groups, &nGroups) < 0)
+            {
+                // std::cerr << "Could not get user's group list" << std::endl;
+            }
+            else
+            {
+                userGroups.emplace_back(user.uid, std::vector<gid_t>(groups, groups + nGroups));
+            }
+
+            delete[] groups;
+        }
+        else
+        {
+            userGroups.emplace_back(user.uid, std::vector<gid_t>(groups, groups + nGroups));
+        }
+    };
+
     if (!uids.empty())
     {
         for (const auto& uid : uids)
         {
-            if (m_passwdWrapper->getpwuid_r(uid, &pwd, buf.get(), bufSize, &pwdResults) == 0 &&
-                    pwdResults != nullptr)
+            if (m_passwdWrapper->getpwuid_r(uid, &pwd, buf.get(), bufSize, &pwdResults) == 0 && pwdResults != nullptr)
             {
-                UserInfo user{pwdResults->pw_name, pwdResults->pw_uid, pwdResults->pw_gid};
-                getGroupsForUser(results, user);
+                processUser(pwdResults);
             }
         }
     }
@@ -71,65 +148,25 @@ nlohmann::json UserGroupsProvider::collect(const std::set<uid_t>& uids)
         {
             if (processed_uids.insert(pwdResults->pw_uid).second)
             {
-                UserInfo user{pwdResults->pw_name, pwdResults->pw_uid, pwdResults->pw_gid};
-                getGroupsForUser(results, user);
+                processUser(pwdResults);
             }
         }
 
         m_passwdWrapper->endpwent();
     }
 
-    return results;
-}
-
-void UserGroupsProvider::getGroupsForUser(nlohmann::json& results, const UserInfo& user)
-{
-    gid_t groupsBuffer[EXPECTED_GROUPS_MAX];
-    gid_t* groups = groupsBuffer;
-    int nGroups = EXPECTED_GROUPS_MAX;
-
-    if (!m_groupWrapper)
-    {
-        // std::cerr << "UserGroupsProvider: user groups wrapper is not initialized" << std::endl;
-        return;
-    }
-
-    // GLIBC version before 2.3.3 may have a buffer overrun:
-    // http://man7.org/linux/man-pages/man3/getgrouplist.3.html
-    if (m_groupWrapper->getgrouplist(user.name, user.gid, groups, &nGroups) < 0)
-    {
-        groups = new gid_t[nGroups];
-
-        if (groups == nullptr)
-        {
-            // std::cerr << "Could not allocate memory to get user groups" << std::endl;
-            return;
-        }
-
-        if (m_groupWrapper->getgrouplist(user.name, user.gid, groups, &nGroups) < 0)
-        {
-            // std::cerr << "Could not get user's group list" << std::endl;
-        }
-        else
-        {
-            addGroupsToResults(results, user.uid, groups, nGroups);
-        }
-
-        delete[] groups;
-    }
-    else
-    {
-        addGroupsToResults(results, user.uid, groups, nGroups);
-    }
+    return userGroups;
 }
 
 void UserGroupsProvider::addGroupsToResults(nlohmann::json& results, uid_t uid, const gid_t* groups, int nGroups)
 {
     for (int i = 0; i < nGroups; i++)
     {
-        nlohmann::json row;
-        row["uid"] = uid;
-        row["gid"] = groups[i];
-        results.push_back(row);
+        nlohmann::json groupJson;
+
+        groupJson["uid"] = uid;
+        groupJson["gid"] = groups[i];
+
+        results.push_back(groupJson);
     }
 }

--- a/src/data_provider/src/extended_sources/groups/src/user_groups_windows.cpp
+++ b/src/data_provider/src/extended_sources/groups/src/user_groups_windows.cpp
@@ -31,88 +31,180 @@ UserGroupsProvider::UserGroupsProvider()
 {
 }
 
-void UserGroupsProvider::processLocalUserGroups(const User& user, const std::vector<Group>& groups, nlohmann::json& results)
+nlohmann::json UserGroupsProvider::collect(const std::set<std::uint32_t>& uids)
 {
-    DWORD groupInfoLevel = 0;
-    DWORD numGroups = 0;
-    DWORD totalGroups = 0;
-    localgroup_users_info_0_ptr groupInfo;
 
-    DWORD ret = 0;
+    nlohmann::json results;
 
-    std::wstring username = m_usersHelper->stringToWstring(user.username);
+    auto localUsers = getLocalUsers(uids);
+    auto groups = getLocalGroups();
 
-    ret = m_winapiWrapper->NetUserGetLocalGroupsWrapper(nullptr,
-                                                        username.c_str(),
-                                                        groupInfoLevel,
-                                                        1,
-                                                        reinterpret_cast<LPBYTE*>(groupInfo.get_new_ptr()),
-                                                        MAX_PREFERRED_LENGTH,
-                                                        &numGroups,
-                                                        &totalGroups);
-
-    if (ret == ERROR_MORE_DATA)
+    for (const auto& user : localUsers)
     {
-        // std::cerr << "User " << user.username << " group membership exceeds buffer limits, processing " << numGroups
-        //           << " our of " << totalGroups << " groups" << std::endl;
-    }
-    else if (ret != NERR_Success || groupInfo == nullptr)
-    {
-        // std::cerr << " NetUserGetLocalGroups failed for user " << user.username << " with " << ret << std::endl;
-        return;
+        processLocalUserGroups(user, groups, results);
     }
 
-    for (std::size_t i = 0; i < numGroups; i++)
-    {
-        std::string groupname = Utils::EncodingWindowsHelper::wstringToStringUTF8(groupInfo.get()[i].lgrui0_name);
+    return results;
+}
 
-        auto optGroup = std::find_if(groups.begin(), groups.end(),
-                                     [&groupname](const Group & group)
+nlohmann::json UserGroupsProvider::getGroupNamesByUid(const std::set<std::uint32_t>& uids)
+{
+    auto localUsers = getLocalUsers(uids);
+    auto groups = getLocalGroups();
+
+    const bool singleUid = uids.size() == 1;
+    nlohmann::json result = singleUid ? nlohmann::json::array() : nlohmann::json::object();
+
+    for (const auto& user : localUsers)
+    {
+        const auto groupNames = getLocalGroupNamesForUser(user.username);
+
+        if (singleUid)
+        {
+            for (const auto& group : groupNames)
+            {
+                result.push_back(group);
+            }
+        }
+        else
+        {
+            result[std::to_string(user.uid)] = groupNames;
+        }
+    }
+
+    return result;
+}
+
+nlohmann::json UserGroupsProvider::getUserNamesByGid(const std::set<std::uint32_t>& gids)
+{
+    const bool singleGid = gids.size() == 1;
+    auto localUsers = getLocalUsers({});
+    auto groups = getLocalGroups();
+
+    std::unordered_map<uint32_t, std::vector<std::string>> gidToUsers;
+
+    for (const auto& user : localUsers)
+    {
+        const auto userGroupNames = getLocalGroupNamesForUser(user.username);
+
+        for (const auto& groupname : userGroupNames)
+        {
+            auto it = std::find_if(groups.begin(),
+                                   groups.end(),
+                                   [&groupname](const Group & group)
+            {
+                return group.groupname == groupname;
+            });
+
+            if (it != groups.end())
+            {
+                if (gids.empty() || gids.find(it->gid) != gids.end())
+                {
+                    gidToUsers[it->gid].emplace_back(user.username);
+                }
+            }
+        }
+    }
+
+    if (singleGid)
+    {
+        uint32_t onlyGid = *gids.begin();
+
+        if (gidToUsers.find(onlyGid) != gidToUsers.end())
+        {
+            return gidToUsers[onlyGid];
+        }
+    }
+    else
+    {
+        nlohmann::json result = nlohmann::json::object();
+
+        for (const auto& [gid, usernames] : gidToUsers)
+        {
+            result[std::to_string(gid)] = usernames;
+        }
+
+        return result;
+    }
+}
+
+void UserGroupsProvider::processLocalUserGroups(const User& user,
+                                                const std::vector<Group>& groups,
+                                                nlohmann::json& results)
+{
+    const auto groupNames = getLocalGroupNamesForUser(user.username);
+
+    for (const auto& groupname : groupNames)
+    {
+        auto optGroup = std::find_if(
+                            groups.begin(), groups.end(), [&groupname](const Group & group)
         {
             return group.groupname == groupname;
         });
 
         if (optGroup == groups.end())
         {
-            // std::cerr << "Group " << groupname << " not found in local groups" << std::endl;
             continue;
         }
 
-        nlohmann::json row;
-
-        row["uid"] = user.uid;
-        row["gid"] = optGroup->gid;
-
-        results.push_back(std::move(row));
+        results.push_back({{"uid", user.uid}, {"gid", optGroup->gid}});
     }
 }
 
-nlohmann::json UserGroupsProvider::collect(const std::set<std::uint32_t>& uids)
+std::vector<User> UserGroupsProvider::getLocalUsers(const std::set<std::uint32_t>& uids)
 {
-
-    nlohmann::json results;
-
     std::set<std::string> processedSids;
     auto localUsers = m_usersHelper->processLocalAccounts(processedSids);
-    auto groups = m_groupsHelper->processLocalGroups();
 
-    auto filteringUsers = [&](const std::vector<User>& users)
+    std::vector<User> filteredUsers;
+
+    for (const auto& user : localUsers)
     {
-        for (const auto& user : users)
+        if (uids.empty() || uids.find(user.uid) != uids.end())
         {
-            if (uids.empty() || uids.find(user.uid) != uids.end())
+            if (user.username == "LOCAL SERVICE" || user.username == "SYSTEM" || user.username == "NETWORK SERVICE")
             {
-                if (user.username == "LOCAL SERVICE" || user.username == "SYSTEM" || user.username == "NETWORK SERVICE")
-                {
-                    continue;
-                }
-
-                processLocalUserGroups(user, groups, results);
+                continue;
             }
+
+            filteredUsers.push_back(user);
         }
-    };
+    }
 
-    filteringUsers(localUsers);
+    return filteredUsers;
+}
 
-    return results;
+std::vector<Group> UserGroupsProvider::getLocalGroups()
+{
+    return m_groupsHelper->processLocalGroups();
+}
+
+std::vector<std::string> UserGroupsProvider::getLocalGroupNamesForUser(const std::string& username)
+{
+    std::wstring wUsername = m_usersHelper->stringToWstring(username);
+    DWORD groupInfoLevel = 0;
+    DWORD numGroups = 0;
+    DWORD totalGroups = 0;
+    localgroup_users_info_0_ptr groupInfo;
+
+    DWORD ret = m_winapiWrapper->NetUserGetLocalGroupsWrapper(nullptr,
+                                                              wUsername.c_str(),
+                                                              groupInfoLevel,
+                                                              1,
+                                                              reinterpret_cast<LPBYTE*>(groupInfo.get_new_ptr()),
+                                                              MAX_PREFERRED_LENGTH,
+                                                              &numGroups,
+                                                              &totalGroups);
+
+    std::vector<std::string> groupNames;
+
+    if (ret == NERR_Success && groupInfo != nullptr)
+    {
+        for (std::size_t i = 0; i < numGroups; ++i)
+        {
+            groupNames.emplace_back(Utils::EncodingWindowsHelper::wstringToStringUTF8(groupInfo.get()[i].lgrui0_name));
+        }
+    }
+
+    return groupNames;
 }

--- a/src/data_provider/src/extended_sources/groups/tests/test_groups_linux.cpp
+++ b/src/data_provider/src/extended_sources/groups/tests/test_groups_linux.cpp
@@ -17,6 +17,7 @@ class MockGroupWrapper : public IGroupWrapperLinux
     public:
         MOCK_METHOD(int, getgrgid_r, (gid_t gid, struct group* grp, char* buf, size_t buflen, struct group** result), (const, override));
         MOCK_METHOD(int, getgrent_r, (struct group* grp, char* buf, size_t buflen, struct group** result), (const, override));
+        MOCK_METHOD(struct group*, getgrent, (), (const, override));
         MOCK_METHOD(void, setgrent, (), (const, override));
         MOCK_METHOD(void, endgrent, (), (const, override));
         MOCK_METHOD(int, getgrouplist, (const char* user, gid_t group, gid_t* groups, int* ngroups), (const, override));

--- a/src/data_provider/src/extended_sources/groups/tests/test_user_groups_darwin.cpp
+++ b/src/data_provider/src/extended_sources/groups/tests/test_user_groups_darwin.cpp
@@ -140,3 +140,250 @@ TEST(UserGroupsProviderTest, CollectWithoutUID_ReturnsExpectedGroups)
     free(fakePwd->pw_name);
     delete fakePwd;
 }
+
+TEST(UserGroupsProviderTest, GetUserNamesByGidSingleGidReturnsCorrectUsernames)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockODWrapper = std::make_shared<MockODUtilsWrapper>();
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockODWrapper);
+
+    const char* username = "testuser";
+    uid_t uid = 1000;
+    gid_t primaryGid = 2000;
+    gid_t extraGid = 3000;
+    std::set<gid_t> targetGids = {extraGid};
+
+    std::map<std::string, bool> fakeUsers = {{username, true}};
+    passwd* fakePwd = createFakePasswd(username, uid, primaryGid);
+
+    EXPECT_CALL(*mockODWrapper, genEntries("dsRecTypeStandard:Users", nullptr, _))
+    .WillOnce(Invoke([&fakeUsers](const std::string&, const void*, std::map<std::string, bool>& out)
+    {
+        out = fakeUsers;
+    }));
+
+    EXPECT_CALL(*mockPasswd, getpwnam(::testing::StrEq(username)))
+    .WillOnce(Return(fakePwd));
+
+    EXPECT_CALL(*mockGroup, getgroupcount(::testing::StrEq(username), primaryGid))
+    .WillOnce(Return(2));
+
+    EXPECT_CALL(*mockGroup, getgrouplist(::testing::StrEq(username), primaryGid, _, _))
+    .WillOnce(Invoke([ = ](const char*, gid_t, gid_t * groups, int*)
+    {
+        groups[0] = primaryGid;
+        groups[1] = extraGid;
+        return 0;
+    }));
+
+    nlohmann::json result = provider.getUserNamesByGid(targetGids);
+
+    ASSERT_TRUE(result.is_array());
+    ASSERT_EQ(result.size(), static_cast<decltype(result.size())>(1));
+    EXPECT_EQ(result[0], username);
+
+    free(fakePwd->pw_name);
+    delete fakePwd;
+}
+
+TEST(UserGroupsProviderTest, GetUserNamesByGidMultipleGidsReturnsGroupedUsernames)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockODWrapper = std::make_shared<MockODUtilsWrapper>();
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockODWrapper);
+
+    const char* username = "testuser";
+    uid_t uid = 1000;
+    gid_t gid1 = 2000;
+    gid_t gid2 = 3000;
+    std::set<gid_t> gids = {gid1, gid2};
+
+    std::map<std::string, bool> fakeUsers = {{username, true}};
+    passwd* fakePwd = createFakePasswd(username, uid, gid1);
+
+    EXPECT_CALL(*mockODWrapper, genEntries("dsRecTypeStandard:Users", nullptr, _))
+    .WillOnce(Invoke([&fakeUsers](const std::string&, const void*, std::map<std::string, bool>& out)
+    {
+        out = fakeUsers;
+    }));
+
+    EXPECT_CALL(*mockPasswd, getpwnam(::testing::StrEq(username)))
+    .WillOnce(Return(fakePwd));
+
+    EXPECT_CALL(*mockGroup, getgroupcount(::testing::StrEq(username), gid1))
+    .WillOnce(Return(2));
+
+    EXPECT_CALL(*mockGroup, getgrouplist(::testing::StrEq(username), gid1, testing::NotNull(), _))
+    .WillOnce(Invoke([ = ](const char*, gid_t, gid_t * groups, int* ngroups)
+    {
+        if (*ngroups >= 2)
+        {
+            groups[0] = gid1;
+            groups[1] = gid2;
+            *ngroups = 2;
+            return 0;
+        }
+
+        return -1;
+    }));
+
+    auto result = provider.getUserNamesByGid(gids);
+
+    ASSERT_TRUE(result.is_object());
+    EXPECT_TRUE(result.contains(std::to_string(gid1)));
+    EXPECT_TRUE(result.contains(std::to_string(gid2)));
+    EXPECT_THAT(result[std::to_string(gid1)], ::testing::Contains(username));
+    EXPECT_THAT(result[std::to_string(gid2)], ::testing::Contains(username));
+
+    free(fakePwd->pw_name);
+    delete fakePwd;
+}
+
+TEST(UserGroupsProviderTest, GetUserNamesByGid_NoMatch_ReturnsEmpty)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockODWrapper = std::make_shared<MockODUtilsWrapper>();
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockODWrapper);
+
+    std::map<std::string, bool> emptyUsers;
+    EXPECT_CALL(*mockODWrapper, genEntries("dsRecTypeStandard:Users", nullptr, _))
+    .WillOnce(Invoke([&emptyUsers](const std::string&, const void*, std::map<std::string, bool>& out)
+    {
+        out = emptyUsers;
+    }));
+
+    auto result = provider.getUserNamesByGid({1234});
+    ASSERT_TRUE(result.empty());
+}
+
+TEST(UserGroupsProviderTest, GetGroupNamesByUidSingleUidReturnsGroupNames)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockODWrapper = std::make_shared<MockODUtilsWrapper>();
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockODWrapper);
+
+    const char* username = "testuser";
+    uid_t uid = 1001;
+    gid_t primaryGid = 2001;
+    gid_t extraGid = 3001;
+    std::set<uid_t> targetUids = {uid};
+
+    passwd* fakePwd = createFakePasswd(username, uid, primaryGid);
+
+    EXPECT_CALL(*mockPasswd, getpwuid(uid))
+    .WillOnce(Return(fakePwd));
+
+    EXPECT_CALL(*mockGroup, getgroupcount(::testing::StrEq(username), primaryGid))
+    .WillOnce(Return(2));
+
+    EXPECT_CALL(*mockGroup, getgrouplist(::testing::StrEq(username), primaryGid, _, _))
+    .WillOnce(Invoke([ = ](const char*, gid_t, gid_t * groups, int*)
+    {
+        groups[0] = primaryGid;
+        groups[1] = extraGid;
+        return 0;
+    }));
+
+    struct group* fakeGroup1 = new group();
+    fakeGroup1->gr_name = strdup("staff");
+
+    struct group* fakeGroup2 = new group();
+    fakeGroup2->gr_name = strdup("dev");
+
+    EXPECT_CALL(*mockGroup, getgrgid(primaryGid)).WillOnce(Return(fakeGroup1));
+    EXPECT_CALL(*mockGroup, getgrgid(extraGid)).WillOnce(Return(fakeGroup2));
+
+    nlohmann::json result = provider.getGroupNamesByUid(targetUids);
+
+    ASSERT_TRUE(result.is_array());
+    ASSERT_EQ(result.size(), static_cast<decltype(result.size())>(2));
+    EXPECT_THAT(result, ::testing::UnorderedElementsAre("staff", "dev"));
+
+    free(fakePwd->pw_name);
+    delete fakePwd;
+    free(fakeGroup1->gr_name);
+    free(fakeGroup1);
+    free(fakeGroup2->gr_name);
+    delete fakeGroup2;
+}
+
+TEST(UserGroupsProviderTest, GetGroupNamesByUidMultipleUidsReturnsGroupedNames)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockODWrapper = std::make_shared<MockODUtilsWrapper>();
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockODWrapper);
+
+    const char* user1 = "user1";
+    const char* user2 = "user2";
+    uid_t uid1 = 5001;
+    uid_t uid2 = 5002;
+    gid_t gid1 = 3001;
+    gid_t gid2 = 3002;
+
+    auto* pwd1 = createFakePasswd(user1, uid1, gid1);
+    auto* pwd2 = createFakePasswd(user2, uid2, gid2);
+
+    EXPECT_CALL(*mockPasswd, getpwuid(uid1)).WillOnce(Return(pwd1));
+    EXPECT_CALL(*mockPasswd, getpwuid(uid2)).WillOnce(Return(pwd2));
+
+    EXPECT_CALL(*mockGroup, getgroupcount(::testing::StrEq(user1), gid1)).WillOnce(Return(1));
+    EXPECT_CALL(*mockGroup, getgroupcount(::testing::StrEq(user2), gid2)).WillOnce(Return(1));
+
+    EXPECT_CALL(*mockGroup, getgrouplist(::testing::StrEq(user1), gid1, _, _))
+    .WillOnce(Invoke([ = ](const char*, gid_t, gid_t * groups, int*)
+    {
+        groups[0] = gid1;
+        return 0;
+    }));
+
+    EXPECT_CALL(*mockGroup, getgrouplist(::testing::StrEq(user2), gid2, _, _))
+    .WillOnce(Invoke([ = ](const char*, gid_t, gid_t * groups, int*)
+    {
+        groups[0] = gid2;
+        return 0;
+    }));
+
+    struct group* grp1 = new group();
+    grp1->gr_name = strdup("staff");
+
+    struct group* grp2 = new group();
+    grp2->gr_name = strdup("admin");
+
+    EXPECT_CALL(*mockGroup, getgrgid(gid1)).WillOnce(Return(grp1));
+    EXPECT_CALL(*mockGroup, getgrgid(gid2)).WillOnce(Return(grp2));
+
+    std::set<uid_t> uids = {uid1, uid2};
+    auto result = provider.getGroupNamesByUid(uids);
+
+    ASSERT_TRUE(result.is_object());
+    EXPECT_EQ(result[std::to_string(uid1)][0], "staff");
+    EXPECT_EQ(result[std::to_string(uid2)][0], "admin");
+
+    free(pwd1->pw_name);
+    delete pwd1;
+    free(pwd2->pw_name);
+    delete pwd2;
+    free(grp1->gr_name);
+    delete grp1;
+    free(grp2->gr_name);
+    delete grp2;
+}
+
+TEST(UserGroupsProviderTest, GetGroupNamesByUidInvalidUIDReturnsEmpty)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockODWrapper = std::make_shared<MockODUtilsWrapper>();
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockODWrapper);
+
+    uid_t invalidUid = 9999;
+    EXPECT_CALL(*mockPasswd, getpwuid(invalidUid)).WillOnce(Return(nullptr));
+
+    auto result = provider.getGroupNamesByUid({invalidUid});
+    ASSERT_TRUE(result.empty());
+}

--- a/src/data_provider/src/extended_sources/users/tests/test_users_linux.cpp
+++ b/src/data_provider/src/extended_sources/users/tests/test_users_linux.cpp
@@ -31,6 +31,7 @@ class MockPasswdWrapper : public IPasswdWrapperLinux
         MOCK_METHOD(int, getpwent_r,
                     (struct passwd*, char*, size_t, struct passwd**), (override));
         MOCK_METHOD(void, endpwent, (), (override));
+        MOCK_METHOD(struct passwd*, getpwent, (), (override));
         MOCK_METHOD(int, getpwuid_r,
                     (uid_t, struct passwd*, char*, size_t, struct passwd**), (override));
         MOCK_METHOD(int, getpwnam_r,

--- a/src/data_provider/src/extended_sources/wrappers/unix/linux/group_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/linux/group_wrapper.hpp
@@ -43,6 +43,13 @@ class GroupWrapperLinux : public IGroupWrapperLinux
             return ::getgrent_r(resultbuf, buffer, buflen, result);
         }
 
+        /// @brief Retrieves the next group entry from the group database.
+        /// @return A pointer to the next group structure, or nullptr if there are no more entries.
+        struct group* getgrent() const override
+        {
+            return ::getgrent();
+        }
+
         /// @brief Rewind the group-file stream.
         void setgrent() const override
         {

--- a/src/data_provider/src/extended_sources/wrappers/unix/linux/igroup_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/linux/igroup_wrapper.hpp
@@ -37,6 +37,10 @@ class IGroupWrapperLinux
         /// @param result A pointer to a group structure pointer that will point to the result.
         virtual int getgrent_r(struct group* resultbuf, char* buffer, size_t buflen, struct group** result) const = 0;
 
+        /// @brief Retrieves the next group entry from the group database.
+        /// @return A pointer to the next group structure, or nullptr if there are no more entries
+        virtual struct group* getgrent() const = 0;
+
         /// @brief Rewind the group-file stream.
         virtual void setgrent() const = 0;
 

--- a/src/data_provider/src/extended_sources/wrappers/unix/linux/ipasswd_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/linux/ipasswd_wrapper.hpp
@@ -43,6 +43,10 @@ class IPasswdWrapperLinux
         /// @brief Closes the passwd database.
         virtual void endpwent() = 0;
 
+        /// @brief Retrieves the next entry from the passwd database.
+        /// @return A pointer to the next passwd structure, or nullptr if there are no more entries.
+        virtual struct passwd* getpwent() = 0;
+
         /// @brief Retrieves the passwd entry for the given user ID.
         /// @param uid User ID to search.
         /// @param pwd Pointer to a passwd structure to fill.

--- a/src/data_provider/src/extended_sources/wrappers/unix/linux/passwd_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/linux/passwd_wrapper.hpp
@@ -55,6 +55,13 @@ class PasswdWrapperLinux : public IPasswdWrapperLinux
             ::endpwent();
         }
 
+        /// @brief Retrieves the next entry from the passwd database.
+        /// @return A pointer to the next passwd structure, or nullptr if there are no more entries.
+        struct passwd* getpwent() override
+        {
+            return ::getpwent();
+        }
+
         /// @brief Retrieves the passwd entry for the given user ID.
         /// @param uid User ID to search.
         /// @param pwd Pointer to a passwd structure to fill.


### PR DESCRIPTION
|Related issue|
|---|
|#30105|

## Description

This PR improves the `user_groups` collector developed in #29587 by adding two methods to the `UserGroupsProvider` class:

1. `getUsernameByGid(gid)`: returns a list of user names belonging to a group.

2. `getGroupNameByUid(uid)`: returns a list of group names to which a user belongs.

## Output example

### Linux

<details><summary>Test getGroupNamesByUid()</summary>

```json
{
    "0": [
        "root"
    ],
    "1": [
        "daemon"
    ],
    "10": [
        "uucp"
    ],
    "100": [
        "nogroup"
    ],
    "1000": [
        "vagrant"
    ],
    "101": [
        "systemd-network"
    ],
    "102": [
        "systemd-resolve"
    ],
    "103": [
        "messagebus"
    ],
    "104": [
        "systemd-timesync"
    ],
    "105": [
        "daemon"
    ],
    "106": [
        "nogroup"
    ],
    "107": [
        "syslog",
        "adm"
    ],
    "108": [
        "uuidd"
    ],
    "109": [
        "tcpdump"
    ],
    "110": [
        "tss"
    ],
    "111": [
        "landscape"
    ],
    "112": [
        "fwupd-refresh"
    ],
    "113": [
        "plugdev"
    ],
    "114": [
        "avahi"
    ],
    "115": [
        "saned",
        "scanner"
    ],
    "116": [
        "wazuh"
    ],
    "13": [
        "proxy"
    ],
    "2": [
        "bin"
    ],
    "3": [
        "sys"
    ],
    "33": [
        "www-data"
    ],
    "34": [
        "backup"
    ],
    "38": [
        "list"
    ],
    "39": [
        "irc"
    ],
    "4": [
        "nogroup"
    ],
    "41": [
        "gnats"
    ],
    "5": [
        "games"
    ],
    "6": [
        "man"
    ],
    "65534": [
        "nogroup"
    ],
    "7": [
        "lp"
    ],
    "8": [
        "mail"
    ],
    "9": [
        "news"
    ],
    "998": [
        "daemon"
    ],
    "999": [
        "users"
    ]
}
```
</details> 

<details><summary>Test getUserNamesByGid()</summary>

```json
{
    "0": [
        "root"
    ],
    "1": [
        "daemon",
        "pollinate",
        "vboxadd"
    ],
    "10": [
        "uucp"
    ],
    "100": [
        "lxd"
    ],
    "1000": [
        "vagrant"
    ],
    "102": [
        "systemd-network"
    ],
    "103": [
        "systemd-resolve"
    ],
    "104": [
        "messagebus"
    ],
    "105": [
        "systemd-timesync"
    ],
    "113": [
        "syslog"
    ],
    "114": [
        "uuidd"
    ],
    "115": [
        "tcpdump"
    ],
    "116": [
        "tss"
    ],
    "117": [
        "landscape"
    ],
    "118": [
        "fwupd-refresh"
    ],
    "12": [
        "man"
    ],
    "122": [
        "saned"
    ],
    "123": [
        "avahi"
    ],
    "124": [
        "saned"
    ],
    "125": [
        "wazuh"
    ],
    "13": [
        "proxy"
    ],
    "2": [
        "bin"
    ],
    "3": [
        "sys"
    ],
    "33": [
        "www-data"
    ],
    "34": [
        "backup"
    ],
    "38": [
        "list"
    ],
    "39": [
        "irc"
    ],
    "4": [
        "syslog"
    ],
    "41": [
        "gnats"
    ],
    "46": [
        "usbmux"
    ],
    "60": [
        "games"
    ],
    "65534": [
        "_apt",
        "nobody",
        "sshd",
        "sync"
    ],
    "7": [
        "lp"
    ],
    "8": [
        "mail"
    ],
    "9": [
        "news"
    ]
}
```

</details>

### macOS

<details><summary>Test getGroupNamesByUid()</summary>

```console
uid: 0["wheel","daemon","kmem","sys","tty","operator","procview","procmod","everyone","staff","certusers","localaccounts","admin","com.apple.sharepoint.group.1","access_bpf","_appstore","_lpadmin","_lpoperator","_developer","_analyticsusers","com.apple.access_ftp","com.apple.access_screensharing","com.apple.access_ssh","com.apple.access_remote_ae"]
uid: 1["daemon","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 4["tty","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 13["_taskgated","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 24["_networkd","everyone","localaccounts","_analyticsusers","com.apple.sharepoint.group.1","_lpoperator"]
uid: 25["_installassistant","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 26["_lp","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 27["_postfix","everyone","certusers","_keytabusers","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 31["_scsd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 32["_ces","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 33["_appstore","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 54["_mcxalr","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 55["_appleevents","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 56["_geod","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 59["_devdocs","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 60["_sandbox","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 65["_mdnsresponder","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 67["_ard","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 70["_www","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 71["_eppc","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 72["_cvs","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 73["_svn","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 74["_mysql","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 75["_sshd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 76["_qtss","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 77["mail","everyone","certusers","localaccounts","com.apple.sharepoint.group.1","_keytabusers","_lpoperator"]
uid: 78["_mailman","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 79["_appserverusr","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 82["_clamav","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 83["_amavisd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 84["_jabber","everyone","certusers","_keytabusers","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 87["_appowner","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 88["_windowserver","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 89["_spotlight","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 91["_tokend","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 92["_securityagent","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 93["_calendar","everyone","certusers","_keytabusers","localaccounts","_postgres","com.apple.sharepoint.group.1","_lpoperator"]
uid: 94["_teamsserver","mail","everyone","localaccounts","_www","_calendar","_odchpass","_postgres","_webauthserver","com.apple.sharepoint.group.1","_keytabusers","_lpoperator"]
uid: 95["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 96["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 97["_atsserver","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 98["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 99["_unknown","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 101["wazuh","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 200["_softwareupdate","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 202["_coreaudiod","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 203["_screensaver","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 205["_locationd","everyone","localaccounts","_detachedsig","com.apple.sharepoint.group.1","_lpoperator"]
uid: 208["_trustevaluationagent","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 210["_timezone","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 211["_lda","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 212["_cvms","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 213["_usbmuxd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 214["mail","everyone","certusers","localaccounts","com.apple.sharepoint.group.1","_keytabusers","_lpoperator"]
uid: 215["everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 216["_postgres","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 217["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 218["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 219["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 220["_devicemgr","everyone","localaccounts","_www","_teamsserver","_postgres","_webauthserver","com.apple.sharepoint.group.1","_lpoperator"]
uid: 221["_webauthserver","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 222["_netbios","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 224["_warmd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 227["_dovenull","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 228["_netstatistics","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 229["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 230["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 231["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 232["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 233["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 234["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 235["_assetcache","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 236["_coremediaiod","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 239["_launchservicesd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 240["_iconservices","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 241["_distnote","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 242["_nsurlsessiond","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 244["_displaypolicyd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 245["_astris","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 246["nobody","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 247["_gamecontrollerd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 248["_mbsetupuser","everyone","localaccounts","_analyticsusers","com.apple.sharepoint.group.1","_lpoperator"]
uid: 249["_ondemand","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 251["_xserverdocs","everyone","localaccounts","_postgres","com.apple.sharepoint.group.1","_lpoperator"]
uid: 252["_wwwproxy","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 253["_mobileasset","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 254["_findmydevice","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 257["_datadetectors","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 258["_captiveagent","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 259["_ctkd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 260["_applepay","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 261["_hidd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 262["_cmiodalassistants","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 263["_analyticsd","everyone","localaccounts","_analyticsusers","com.apple.sharepoint.group.1","_lpoperator"]
uid: 265["_fpsd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 266["_timed","everyone","localaccounts","_analyticsusers","_sntpd","com.apple.sharepoint.group.1","_lpoperator"]
uid: 268["_nearbyd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 269["_reportmemoryexception","everyone","localaccounts","_analyticsusers","com.apple.sharepoint.group.1","_lpoperator"]
uid: 270["_driverkit","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 271["_diskimagesiod","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 272["_logd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 273["_appinstalld","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 274["_installcoordinationd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 275["_demod","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 277["_rmd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 278["_accessoryupdater","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 279["_knowledgegraphd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 280["_coreml","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 281["_sntpd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 282["_trustd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 283["_mmaintenanced","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 284["_darwindaemon","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 285["_notification_proxy","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 288["_avphidbridge","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 289["_biome","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 291["_backgroundassets","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 293["_mobilegestalthelper","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 294["_audiomxd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 295["_terminusd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 296["_neuralengine","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 441["_oahd","everyone","localaccounts","com.apple.sharepoint.group.1","_lpoperator"]
uid: 501["staff","access_bpf","everyone","localaccounts","_appserverusr","admin","_appserveradm","_lpadmin","com.apple.sharepoint.group.1","_appstore","_lpoperator","_developer","_analyticsusers","com.apple.access_ftp","com.apple.access_screensharing","com.apple.access_ssh","com.apple.access_remote_ae"]
```
</details>

<details><summary>Test getUserNamesByGid()</summary>

```console
gid: 278["_accessoryupdater"]
gid: 83["_amavisd"]
gid: 263["_analyticsd"]
gid: 250["_analyticsd","_mbsetupuser","_networkd","_reportmemoryexception","_timed","root","test"]
gid: 273["_appinstalld"]
gid: 55["_appleevents"]
gid: 260["_applepay"]
gid: 87["_appowner"]
gid: 81["test"]
gid: 79["_appserver","test"]
gid: 33["_appstore","root","test"]
gid: 67["_ard"]
gid: 235["_assetcache"]
gid: 245["_astris"]
gid: 97["_atsserver"]
gid: 294["_audiomxd"]
gid: 288["_avphidbridge"]
gid: 291["_backgroundassets"]
gid: 289["_biome"]
gid: 93["_calendar","_teamsserver"]
gid: 258["_captiveagent"]
gid: 32["_ces"]
gid: 82["_clamav"]
gid: 262["_cmiodalassistants"]
gid: 202["_coreaudiod"]
gid: 236["_coremediaiod"]
gid: 280["_coreml"]
gid: 259["_ctkd"]
gid: 212["_cvmsroot"]
gid: 72["_cvs"]
gid: 284["_darwindaemon"]
gid: 257["_datadetectors"]
gid: 275["_demod"]
gid: 207["_locationd"]
gid: 59["_devdocs"]
gid: 204["root","test"]
gid: 220["_devicemgr"]
gid: 271["_diskimagesiod"]
gid: 244["_displaypolicyd"]
gid: 241["_distnote"]
gid: 227["_dovenull"]
gid: 270["_driverkit"]
gid: 71["_eppc"]
gid: 254["_findmydevice"]
gid: 265["_fpsd"]
gid: 247["_gamecontrollerd"]
gid: 56["_geod"]
gid: 201[]
gid: 261["_hidd"]
gid: 240["_iconservices"]
gid: 25["_installassistant"]
gid: 274["_installcoordinationd"]
gid: 96[]
gid: 84["_jabber"]
gid: 30["_calendar","_cyrus","_dovecot","_jabber","_postfix","_teamsserver"]
gid: 279["_knowledgegraphd"]
gid: 239["_launchservicesd"]
gid: 211["_lda"]
gid: 205["_locationd"]
gid: 272["_logd"]
gid: 26["_lp"]
gid: 98["root","test"]
gid: 100["_accessoryupdater","_amavisd","_analyticsd","_appinstalld","_appleevents","_applepay","_appowner","_appserver","_appstore","_ard","_assetcache","_astris","_atsserver","_audiomxd","_avbdeviced","_avphidbridge","_backgroundassets","_biome","_calendar","_captiveagent","_ces","_clamav","_cmiodalassistants","_coreaudiod","_coremediaiod","_coreml","_ctkd","_cvmsroot","_cvs","_cyrus","_darwindaemon","_datadetectors","_demod","_devdocs","_devicemgr","_diskimagesiod","_displaypolicyd","_distnote","_dovecot","_dovenull","_dpaudio","_driverkit","_eppc","_findmydevice","_fpsd","_ftp","_gamecontrollerd","_geod","_hidd","_iconservices","_installassistant","_installcoordinationd","_installer","_jabber","_kadmin_admin","_kadmin_changepw","_knowledgegraphd","_krb_anonymous","_krb_changepw","_krb_kadmin","_krb_kerberos","_krb_krbtgt","_krbfast","_krbtgt","_launchservicesd","_lda","_locationd","_logd","_lp","_mailman","_mbsetupuser","_mcxalr","_mdnsresponder","_mmaintenanced","_mobileasset","_mobilegestalthelper","_mysql","_nearbyd","_netbios","_netstatistics","_networkd","_neuralengine","_notification_proxy","_nsurlsessiond","_oahd","_ondemand","_postfix","_postgres","_qtss","_reportmemoryexception","_rmd","_sandbox","_screensaver","_scsd","_securityagent","_sntpd","_softwareupdate","_spotlight","_sshd","_svn","_taskgated","_teamsserver","_terminusd","_timed","_timezone","_tokend","_trustd","_trustevaluationagent","_unknown","_update_sharing","_usbmuxd","_uucp","_warmd","_webauthserver","_windowserver","_www","_wwwproxy","_xserverdocs","daemon","nobody","root","test","wazuh"]
gid: 78["_mailman"]
gid: 248["_mbsetupuser"]
gid: 54["_mcxalr"]
gid: 65["_mdnsresponder"]
gid: 283["_mmaintenanced"]
gid: 253["_mobileasset"]
gid: 293["_mobilegestalthelper"]
gid: 74["_mysql"]
gid: 268["_nearbyd"]
gid: 222["_netbios"]
gid: 228["_netstatistics"]
gid: 24["_networkd"]
gid: 296["_neuralengine"]
gid: 285["_notification_proxy"]
gid: 242["_nsurlsessiond"]
gid: 441["_oahd"]
gid: 209["_teamsserver"]
gid: 249["_ondemand"]
gid: 28[]
gid: 27["_postfix"]
gid: 216["_calendar","_devicemgr","_postgres","_teamsserver","_xserverdocs"]
gid: 76["_qtss"]
gid: 269["_reportmemoryexception"]
gid: 277["_rmd"]
gid: 60["_sandbox"]
gid: 203["_screensaver"]
gid: 31["_scsd"]
gid: 92["_securityagent"]
gid: 281["_sntpd","_timed"]
gid: 200["_softwareupdate"]
gid: 89["_spotlight"]
gid: 75["_sshd"]
gid: 73["_svn"]
gid: 13["_taskgated"]
gid: 94["_devicemgr","_teamsserver"]
gid: 295["_terminusd"]
gid: 266["_timed"]
gid: 210["_timezone"]
gid: 91["_tokend"]
gid: 282["_trustd"]
gid: 208["_trustevaluationagent"]
gid: 99["_unknown"]
gid: 95[]
gid: 213["_usbmuxd"]
gid: 66[]
gid: 224["_warmd"]
gid: 221["_devicemgr","_teamsserver","_webauthserver"]
gid: 264[]
gid: 88["_windowserver"]
gid: 70["_devicemgr","_teamsserver","_www"]
gid: 252["_wwwproxy"]
gid: 251["_xserverdocs"]
gid: 102["root","test"]
gid: 90[]
gid: 80["root","test"]
gid: 50[]
gid: 7[]
gid: 29["_calendar","_cyrus","_dovecot","_jabber","_postfix","root"]
gid: 396[]
gid: 395["root","test"]
gid: 400["root","test"]
gid: 398["root","test"]
gid: 397[]
gid: 399["root","test"]
gid: 701["_accessoryupdater","_amavisd","_analyticsd","_appinstalld","_appleevents","_applepay","_appowner","_appserver","_appstore","_ard","_assetcache","_astris","_atsserver","_audiomxd","_avbdeviced","_avphidbridge","_backgroundassets","_biome","_calendar","_captiveagent","_ces","_clamav","_cmiodalassistants","_coreaudiod","_coremediaiod","_coreml","_ctkd","_cvmsroot","_cvs","_cyrus","_darwindaemon","_datadetectors","_demod","_devdocs","_devicemgr","_diskimagesiod","_displaypolicyd","_distnote","_dovecot","_dovenull","_dpaudio","_driverkit","_eppc","_findmydevice","_fpsd","_ftp","_gamecontrollerd","_geod","_hidd","_iconservices","_installassistant","_installcoordinationd","_installer","_jabber","_kadmin_admin","_kadmin_changepw","_knowledgegraphd","_krb_anonymous","_krb_changepw","_krb_kadmin","_krb_kerberos","_krb_krbtgt","_krbfast","_krbtgt","_launchservicesd","_lda","_locationd","_logd","_lp","_mailman","_mbsetupuser","_mcxalr","_mdnsresponder","_mmaintenanced","_mobileasset","_mobilegestalthelper","_mysql","_nearbyd","_netbios","_netstatistics","_networkd","_neuralengine","_notification_proxy","_nsurlsessiond","_oahd","_ondemand","_postfix","_postgres","_qtss","_reportmemoryexception","_rmd","_sandbox","_screensaver","_scsd","_securityagent","_sntpd","_softwareupdate","_spotlight","_sshd","_svn","_taskgated","_teamsserver","_terminusd","_timed","_timezone","_tokend","_trustd","_trustevaluationagent","_unknown","_update_sharing","_usbmuxd","_uucp","_warmd","_webauthserver","_windowserver","_www","_wwwproxy","_xserverdocs","daemon","nobody","root","test","wazuh"]
gid: 53[]
gid: 1["daemon","root"]
gid: 68[]
gid: 12["_accessoryupdater","_amavisd","_analyticsd","_appinstalld","_appleevents","_applepay","_appowner","_appserver","_appstore","_ard","_assetcache","_astris","_atsserver","_audiomxd","_avbdeviced","_avphidbridge","_backgroundassets","_biome","_calendar","_captiveagent","_ces","_clamav","_cmiodalassistants","_coreaudiod","_coremediaiod","_coreml","_ctkd","_cvmsroot","_cvs","_cyrus","_darwindaemon","_datadetectors","_demod","_devdocs","_devicemgr","_diskimagesiod","_displaypolicyd","_distnote","_dovecot","_dovenull","_dpaudio","_driverkit","_eppc","_findmydevice","_fpsd","_ftp","_gamecontrollerd","_geod","_hidd","_iconservices","_installassistant","_installcoordinationd","_installer","_jabber","_kadmin_admin","_kadmin_changepw","_knowledgegraphd","_krb_anonymous","_krb_changepw","_krb_kadmin","_krb_kerberos","_krb_krbtgt","_krbfast","_krbtgt","_launchservicesd","_lda","_locationd","_logd","_lp","_mailman","_mbsetupuser","_mcxalr","_mdnsresponder","_mmaintenanced","_mobileasset","_mobilegestalthelper","_mysql","_nearbyd","_netbios","_netstatistics","_networkd","_neuralengine","_notification_proxy","_nsurlsessiond","_oahd","_ondemand","_postfix","_postgres","_qtss","_reportmemoryexception","_rmd","_sandbox","_screensaver","_scsd","_securityagent","_sntpd","_softwareupdate","_spotlight","_sshd","_svn","_taskgated","_teamsserver","_terminusd","_timed","_timezone","_tokend","_trustd","_trustevaluationagent","_unknown","_update_sharing","_usbmuxd","_uucp","_warmd","_webauthserver","_windowserver","_www","_wwwproxy","_xserverdocs","daemon","nobody","root","test","wazuh"]
gid: 16[]
gid: 51[]
gid: 2["root"]
gid: 61["_accessoryupdater","_amavisd","_analyticsd","_appinstalld","_appleevents","_applepay","_appowner","_appserver","_appstore","_ard","_assetcache","_astris","_atsserver","_audiomxd","_avbdeviced","_avphidbridge","_backgroundassets","_biome","_calendar","_captiveagent","_ces","_clamav","_cmiodalassistants","_coreaudiod","_coremediaiod","_coreml","_ctkd","_cvmsroot","_cvs","_cyrus","_darwindaemon","_datadetectors","_demod","_devdocs","_devicemgr","_diskimagesiod","_displaypolicyd","_distnote","_dovecot","_dovenull","_dpaudio","_driverkit","_eppc","_findmydevice","_fpsd","_ftp","_gamecontrollerd","_geod","_hidd","_iconservices","_installassistant","_installcoordinationd","_installer","_jabber","_kadmin_admin","_kadmin_changepw","_knowledgegraphd","_krb_anonymous","_krb_changepw","_krb_kadmin","_krb_kerberos","_krb_krbtgt","_krbfast","_krbtgt","_launchservicesd","_lda","_locationd","_logd","_lp","_mailman","_mbsetupuser","_mcxalr","_mdnsresponder","_mmaintenanced","_mobileasset","_mobilegestalthelper","_mysql","_nearbyd","_netbios","_netstatistics","_networkd","_neuralengine","_notification_proxy","_nsurlsessiond","_oahd","_ondemand","_postfix","_postgres","_qtss","_reportmemoryexception","_rmd","_sandbox","_screensaver","_scsd","_securityagent","_sntpd","_softwareupdate","_spotlight","_sshd","_svn","_taskgated","_teamsserver","_terminusd","_timed","_timezone","_tokend","_trustd","_trustevaluationagent","_unknown","_update_sharing","_usbmuxd","_uucp","_warmd","_webauthserver","_windowserver","_www","_wwwproxy","_xserverdocs","daemon","nobody","root","test","wazuh"]
gid: 6["_cyrus","_dovecot","_teamsserver"]
gid: 62[]
gid: 52[]
gid: 69[]
gid: 4294967294["_avbdeviced","_ftp","_installer","_kadmin_admin","_kadmin_changepw","_krb_anonymous","_krb_changepw","_krb_kadmin","_krb_kerberos","_krb_krbtgt","_krbfast","_krbtgt","_update_sharing","nobody"]
gid: 4294967295[]
gid: 5["root"]
gid: 10[]
gid: 9["root"]
gid: 8["root"]
gid: 20["root","test"]
gid: 3["root"]
gid: 4["_uucp","root"]
gid: 45[]
gid: 101["wazuh"]
gid: 0["root"]
```

</details>

### Windows

<details><summary>Test getGroupNamesByUid()</summary>

```json                                                                                                                                                                                                     
{
    "1000":
    [
        "Administrators",
        "Users"
    ],
    "500":
    [
        "Administrators"
    ],
    "501":
    [
        "Guests"
    ],
    "503":
    [
        "System Managed Accounts Group"
    ],
    "504":
    []
}  

```
</details>

<details><summary>Test getUserNamesByGid()</summary>

```json                                                                                                                                                                             

{
    "544":
    [
        "Administrator",
        "vagrant"
    ],
    "545":
    [
        "vagrant"
    ],
    "546":
    [
        "Guest"
    ],
    "581":
    [
        "DefaultAccount"
    ]
}

```
</details>


## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [x] Windows
  - [x] MAC OS X
