### PR TITLE
Skip Inspector Classic related tests

### DIFF
--- a/tests/integration/test_aws/test_discard_regex.py
+++ b/tests/integration/test_aws/test_discard_regex.py
@@ -421,6 +421,7 @@ configurator.configure_test(configuration_file='configuration_inspector_discard_
 
 
 @pytest.mark.tier(level=0)
+@pytest.mark.skip(reason="The Inspector Classic service was deprecated. A migration to Inspector v2 is required")
 @pytest.mark.parametrize('test_configuration, metadata',
                          zip(configurator.test_configuration_template, configurator.metadata),
                          ids=configurator.cases_ids)

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -563,6 +563,7 @@ configurator.configure_test(configuration_file='inspector_configuration_with_onl
 
 
 @pytest.mark.tier(level=0)
+@pytest.mark.skip(reason="The Inspector Classic service was deprecated. A migration to Inspector v2 is required")
 @pytest.mark.parametrize('test_configuration, metadata',
                          zip(configurator.test_configuration_template, configurator.metadata),
                          ids=configurator.cases_ids)
@@ -870,7 +871,7 @@ configurator.configure_test(cases_file='cases_inspector_multiple_calls.yaml')
 @pytest.mark.parametrize('metadata',
                          configurator.metadata,
                          ids=configurator.cases_ids)
-@pytest.mark.xfail
+@pytest.mark.skip(reason="The Inspector Classic service was deprecated. A migration to Inspector v2 is required")
 def test_inspector_multiple_calls(
     metadata, clean_aws_services_db, load_wazuh_basic_configuration, restart_wazuh_function
 ):

--- a/tests/integration/test_aws/test_regions.py
+++ b/tests/integration/test_aws/test_regions.py
@@ -332,6 +332,7 @@ configurator.configure_test(configuration_file='inspector_configuration_regions.
 
 
 @pytest.mark.tier(level=0)
+@pytest.mark.skip(reason="The Inspector Classic service was deprecated. A migration to Inspector v2 is required")
 @pytest.mark.parametrize('test_configuration, metadata',
                          zip(configurator.test_configuration_template, configurator.metadata),
                          ids=configurator.cases_ids)


### PR DESCRIPTION
|Related issue|
|---|
|#30135|


## Description

Mark the AWS Inspector Classic service tests as skippable due to the service's deprecation.

Workflow test after the changes: https://github.com/wazuh/wazuh/actions/runs/15535264257