### PR TITLE
Add new check audit version for FIM whodata

### DIFF
--- a/packages/debs/SPECS/wazuh-agent/debian/postrm
+++ b/packages/debs/SPECS/wazuh-agent/debian/postrm
@@ -32,6 +32,14 @@ case "$1" in
             rm -rf ${DIR}/etc/shared
         fi
 
+        # Delete audisp wazuh plugin if exists
+        if [ -e /etc/audit/plugins.d/af_wazuh.conf ]; then
+            rm -f -- /etc/audit/plugins.d/af_wazuh.conf
+        fi
+        if [ -e /etc/audisp/plugins.d/af_wazuh.conf ]; then
+            rm -f -- /etc/audisp/plugins.d/af_wazuh.conf
+        fi
+
         # Delete old .save
         find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
 

--- a/packages/debs/SPECS/wazuh-manager/debian/postrm
+++ b/packages/debs/SPECS/wazuh-manager/debian/postrm
@@ -42,6 +42,14 @@ case "$1" in
             rm -rf ${DIR}/etc/decoders
         fi
 
+        # Delete audisp wazuh plugin if exists
+        if [ -e /etc/audit/plugins.d/af_wazuh.conf ]; then
+            rm -f -- /etc/audit/plugins.d/af_wazuh.conf
+        fi
+        if [ -e /etc/audisp/plugins.d/af_wazuh.conf ]; then
+            rm -f -- /etc/audisp/plugins.d/af_wazuh.conf
+        fi
+
         # Delete old .save
         find ${DIR}/etc/ -type f  -name "*save" -exec rm -f {} \;
         find ${DIR}/api/ -type f  -name "*save" -exec rm -f {} \;

--- a/packages/rpms/SPECS/wazuh-agent.spec
+++ b/packages/rpms/SPECS/wazuh-agent.spec
@@ -542,6 +542,14 @@ if [ $1 = 0 ]; then
     rm -f /etc/init.d/wazuh-agent
   fi
 
+  # Delete audisp wazuh plugin if exists
+  if [ -e /etc/audit/plugins.d/af_wazuh.conf ]; then
+    rm -f -- /etc/audit/plugins.d/af_wazuh.conf
+  fi
+  if [ -e /etc/audisp/plugins.d/af_wazuh.conf ]; then
+    rm -f -- /etc/audisp/plugins.d/af_wazuh.conf
+  fi
+
   # Remove SCA files
   rm -f %{_localstatedir}/ruleset/sca/*
 

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -583,6 +583,15 @@ if [ $1 = 0 ];then
   rm -rf %{_localstatedir}/logs/
   rm -rf %{_localstatedir}/ruleset/
   rm -rf %{_localstatedir}/tmp
+
+
+  # Delete audisp wazuh plugin if exists
+  if [ -e /etc/audit/plugins.d/af_wazuh.conf ]; then
+    rm -f -- /etc/audit/plugins.d/af_wazuh.conf
+  fi
+  if [ -e /etc/audisp/plugins.d/af_wazuh.conf ]; then
+    rm -f -- /etc/audisp/plugins.d/af_wazuh.conf
+  fi
 fi
 
 # posttrans code is the last thing executed in a install/upgrade

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -506,6 +506,14 @@ void *audit_parse_thread();
 void audit_set_db_consistency(void);
 
 /**
+ * @brief Function that gets the Audit version using auditctl command
+ *
+ * @param [out] out_code The variable where to store the version code
+ * @return 0 on success, -1 on error
+ */
+int get_audit_version_code(unsigned *out_code);
+
+/**
  * @brief Check if the Audit daemon is installed and running
  *
  * @return The PID of Auditd

--- a/src/syscheckd/src/whodata/syscheck_audit.h
+++ b/src/syscheckd/src/whodata/syscheck_audit.h
@@ -16,7 +16,7 @@
 #include "audit_op.h"
 
 #define WHODATA_PERMS (AUDIT_PERM_WRITE | AUDIT_PERM_ATTR)
-
+#define VERCODE(M,m,p)  ((((unsigned)(M) & 0xFF) << 16) | (((unsigned)(m) & 0xFF) << 8) | ((unsigned)(p) & 0xFF))
 #define AUDIT_HEALTHCHECK_KEY "wazuh_hc"
 #define AUDIT_KEY "wazuh_fim"
 

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1205,7 +1205,7 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "    System Version: macOS 10.12 (16A323)\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     // sw_vers -productVersion
@@ -1222,7 +1222,7 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "10.2\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     // sw_vers -buildVersion
@@ -1233,7 +1233,7 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "10\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     // uname -r
@@ -1244,11 +1244,11 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "macos\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -1362,7 +1362,7 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, NULL);
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     // sw_vers -productVersion
@@ -1379,7 +1379,7 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "10.2\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     // sw_vers -buildVersion
@@ -1390,7 +1390,7 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "10\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     // uname -r
@@ -1401,11 +1401,11 @@ void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "macos\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -1511,7 +1511,7 @@ void test_get_unix_version_fail_os_release_uname_sunos(void **state)
     will_return(__wrap_fclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -1619,7 +1619,7 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one(void **st
     will_return(__wrap_fclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -1725,7 +1725,7 @@ void test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two(void **st
     will_return(__wrap_fclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -1826,11 +1826,11 @@ void test_get_unix_version_fail_os_release_uname_hp_ux(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "B.3.5");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -1932,11 +1932,11 @@ void test_get_unix_version_fail_os_release_uname_bsd(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "10.3.5");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -2038,10 +2038,10 @@ void test_get_unix_version_zscaler(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "10-R");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();
@@ -2147,11 +2147,11 @@ void test_get_unix_version_fail_os_release_uname_aix(void **state)
     expect_value(__wrap_fgets, __stream, 1);
     will_return(__wrap_fgets, "7.1\n");
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
 
-    expect_value(__wrap_pclose, stream, 1);
+    expect_value(__wrap_pclose, __stream, 1);
     will_return(__wrap_pclose, 1);
 
     ret = get_unix_version();

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -57,7 +57,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
     add_executable(test_syscheck_audit test_syscheck_audit.c)
     target_compile_options(test_syscheck_audit PRIVATE "-Wall")
 
-    set(SYSCHECK_AUDIT_FLAGS "-Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock \
+    set(SYSCHECK_AUDIT_FLAGS "-Wl,--wrap,pthread_cond_wait -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,lstat -Wl,--wrap,stat \
                               -Wl,--wrap,openproc -Wl,--wrap,readproc -Wl,--wrap,freeproc -Wl,--wrap,popen \
                               -Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,audit_add_rule -Wl,--wrap,audit_restart  \
                               -Wl,--wrap,pthread_mutex_unlock -Wl,--wrap,closeproc  -Wl,--wrap,recv -Wl,--wrap,IsDir \
@@ -66,7 +66,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
                               -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                               -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap,symlink -Wl,--wrap,SendMSG \
-                              -Wl,--wrap,audit_get_rule_list -Wl,--wrap,fim_audit_reload_rules \
+                              -Wl,--wrap,audit_get_rule_list -Wl,--wrap,fim_audit_reload_rules -Wl,--wrap,link \
                               -Wl,--wrap,search_audit_rule -Wl,--wrap,abspath -Wl,--wrap,atomic_int_get \
                               -Wl,--wrap,atomic_int_set -Wl,--wrap,atomic_int_dec -Wl,--wrap,atomic_int_inc \
                               -Wl,--wrap,pthread_rwlock_wrlock -Wl,--wrap,pthread_rwlock_unlock \

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.c
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.c
@@ -230,14 +230,20 @@ FILE *__wrap_popen(const char *command, const char *type) {
 }
 
 void expect_popen(const char *command, const char *type, FILE *ret) {
-  expect_string(__wrap_popen, command, command);
-  expect_string(__wrap_popen, type, type);
-  will_return(__wrap_popen, ret);
+    expect_string(__wrap_popen, command, command);
+    expect_string(__wrap_popen, type, type);
+    will_return(__wrap_popen, ret);
 }
 
-int __wrap_pclose(FILE *stream) {
-    check_expected(stream);
+extern int __real_pclose(FILE *__stream);
+int __wrap_pclose(FILE *__stream) {
+    check_expected(__stream);
     return mock();
+}
+
+void expect_pclose(FILE *__stream, int ret) {
+    expect_value(__wrap_pclose, __stream, __stream);
+    will_return(__wrap_pclose, ret);
 }
 
 int __wrap_fputc(char character, FILE *stream) {

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.h
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.h
@@ -58,6 +58,8 @@ int __wrap__fseeki64(FILE *stream, long offset, int whence);
 FILE *__wrap_popen(const char *command, const char *type);
 void expect_popen(const char *command, const char *type, FILE *ret);
 
+void expect_fscanf(FILE *__stream, const char *formatted_msg, int ret);
+
 int __wrap_pclose(FILE *stream);
 
 int __wrap_fputc(char character, FILE *stream);

--- a/src/unit_tests/wrappers/posix/unistd_wrappers.c
+++ b/src/unit_tests/wrappers/posix/unistd_wrappers.c
@@ -89,6 +89,12 @@ int __wrap_symlink(const char *path1, const char *path2) {
     return mock();
 }
 
+int __wrap_link(const char *path1, const char *path2) {
+    check_expected(path1);
+    check_expected(path2);
+    return mock();
+}
+
 int __wrap_access (const char *__name, int __type) {
     check_expected(__name);
     check_expected(__type);

--- a/src/unit_tests/wrappers/posix/unistd_wrappers.h
+++ b/src/unit_tests/wrappers/posix/unistd_wrappers.h
@@ -47,6 +47,8 @@ int __wrap_readlink(void **state);
 
 int __wrap_symlink(const char *path1, const char *path2);
 
+int __wrap_link(const char *path1, const char *path2);
+
 int __wrap_access (const char *__name, int __type);
 #ifdef WIN32
 int __wrap__access (const char *__name, int __type);


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28984#top|


# Description
Hi team,

in this PR we are adding a check of the Auditd version installed in the system, to configure the plugin correctly according to the version.
We were encountering some problems due to the latest changes made in version 4 of audit in relation to the plugin, because among others, they have tightened the security of the plugin preventing the configuration file to be a symlink. Therefore we are now creating the file directly in the audit directory.

Finally, after investigacions, our conditionals for fix the audit version issue, are this:
- Older than 3.1.1 no changes needed: `AUDISP_CONFIGURATION_0`
- Between 3.1.1 and 4.0.2 (with an exception in 3.1.5 (Due to newest releases for some OSs, included some fixes)), include the changes for audispd af_unix plugin to a standalone program, so a fix to the warnings is included: `AUDISP_CONFIGURATION_1`
- Audit version 3.1.5 and starting at 4.0.3, include the changes to propagate event format to the audisp-af_unix plugin: `AUDISP_CONFIGURATION_2`

Code related:
```
        if (get_audit_version_code(&vcode) != 0) {
            mdebug2("Could not get audit version code. Using default configuration.");
            strcpy(audisp_config, AUDISP_CONFIGURATION_2);
        } else {
            mdebug2("Audit version detected: %u.%u.%u", (vcode >> 16) & 0xFF, (vcode >> 8) & 0xFF, vcode & 0xFF);
            if (vcode < VERCODE(3, 1, 1)) {
                // Before audit version 3.1.1 old code worked with builtin_af_unix
                strcpy(audisp_config, AUDISP_CONFIGURATION_0);
            } else if (vcode < VERCODE(3, 1, 5)) {
                // Audit version 3.1.1 include the changes for audispd af_unix plugin to a standalone program
                strcpy(audisp_config, AUDISP_CONFIGURATION_1);
            } else if (vcode < VERCODE(4, 0, 0)) {
                // Audit version 3.1.5 include the changes to propagate event format to the audisp-af_unix plugin
                strcpy(audisp_config, AUDISP_CONFIGURATION_2);
            } else if (vcode < VERCODE(4, 0, 3)) {
                // From audit version 4.0.0 to 4.0.2 format changes are not included
                strcpy(audisp_config, AUDISP_CONFIGURATION_1);
            } else {
                // From audit version 4.0.3 format changes are included
                strcpy(audisp_config, AUDISP_CONFIGURATION_2);
            }
        }
    }
```


## Configuration options
```
  <directories whodata="yes">/test</directories>
  <whodata>
     <provider>audit</provider>
  </whodata> 
```

## Testing

General testing has been carried out on different operating systems:
- First checking that audit and audispd-plugins are installed:
```
root@debian13:/home/vagrant# apt install auditd audispd-plugins
auditd is already the newest version (1:4.0.5-1).
audispd-plugins is already the newest version (1:4.0.5-1).
Summary:
  Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 187
```
- Check `-a never,task` rule, what prevents setting new rules.
- Check that auditd can be manual restarted (remove `RefuseManualStop=yes`):
```
[root@centos9stream vagrant]# nano /usr/lib/systemd/system/auditd.service
[root@centos9stream vagrant]# systemctl daemon-reload
```
- We install Wazuh with the PR branch: `fix/whodata-audit-4`
- Configured:
```
<directories whodata="yes">/test</directories>
```
- Restart Wazuh and check debug syscheck logs:

```
2025/09/05 10:08:12 wazuh-syscheckd[23052] syscheck_audit.c:191 at set_auditd_config(): DEBUG: Audit version detected: 3.1.5
2025/09/05 10:08:12 wazuh-syscheckd[23052] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2025/09/05 10:08:12 wazuh-syscheckd[23052] syscheck_audit.c:429 at audit_init(): INFO: (6046): Internal audit queue size set to '16384'.
2025/09/05 10:08:12 wazuh-syscheckd[23052] audit_healthcheck.c:41 at audit_health_check(): DEBUG: (6279): Whodata health-check: Starting.
2025/09/05 10:08:12 wazuh-syscheckd[23052] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2025/09/05 10:08:12 wazuh-syscheckd[23052] audit_healthcheck.c:102 at audit_healthcheck_thread(): DEBUG: (6255): Whodata health-check: Reading thread active.
2025/09/05 10:08:12 wazuh-syscheckd[23052] audit_parse.c:326 at filterkey_audit_events(): DEBUG: (6251): Match audit_key: 'wazuh_hc'
2025/09/05 10:08:12 wazuh-syscheckd[23052] audit_parse.c:979 at audit_parse(): DEBUG: (6254): Whodata health-check: Unrecognized event (206)
2025/09/05 10:08:12 wazuh-syscheckd[23052] audit_parse.c:326 at filterkey_audit_events(): DEBUG: (6251): Match audit_key: 'wazuh_hc'
2025/09/05 10:08:12 wazuh-syscheckd[23052] audit_parse.c:968 at audit_parse(): DEBUG: (6252): Whodata health-check: Detected file creation event (56)
2025/09/05 10:08:13 wazuh-syscheckd[23052] audit_healthcheck.c:73 at audit_health_check(): DEBUG: (6261): Whodata health-check: Success.
2025/09/05 10:08:13 wazuh-syscheckd[23052] audit_healthcheck.c:106 at audit_healthcheck_thread(): DEBUG: (6256): Whodata health-check: Reading thread finished.
2025/09/05 10:08:13 wazuh-syscheckd[23052] audit_rule_handling.c:127 at fim_rules_initial_load(): DEBUG: (6270): Added audit rule for monitoring directory: '/test'
2025/09/05 10:10:38 wazuh-syscheckd[23052] run_check.c:125 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"data":{"attributes":{"checksum":"08aba5a13ca2d39567af85702a453b351a17616d","gid":"0","group_name":"root","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":"70509150","mtime":1757067038,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"mode":"whodata","path":"/test/hola","timestamp":1757067038,"type":"added","version":"2.0","audit":{"user_id":"0","user_name":"root","process_name":"/usr/bin/touch","process_id":25565,"cwd":"/home/vagrant","group_id":"0","group_name":"root","audit_uid":"1000","audit_name":"vagrant","effective_uid":"0","effective_name":"root","parent_name":"/usr/bin/bash","parent_cwd":"/home/vagrant","ppid":6205}},"type":"event"}
```

- Check auditctl logs:
```
Sep 05 10:07:58 centos9stream systemd[1]: Stopping Security Auditing Service...
Sep 05 10:07:58 centos9stream sedispatch[20250]: sedispatch is exiting on stop request
Sep 05 10:07:58 centos9stream auditd[20248]: plugin /usr/sbin/sedispatch terminated unexpectedly
Sep 05 10:07:58 centos9stream auditd[20248]: plugin /usr/sbin/sedispatch was restarted
Sep 05 10:07:58 centos9stream sedispatch[22658]: sedispatch is exiting on stdin EOF
Sep 05 10:07:58 centos9stream auditd[20248]: The audit daemon is exiting.
Sep 05 10:07:58 centos9stream systemd[1]: auditd.service: Deactivated successfully.
Sep 05 10:07:58 centos9stream systemd[1]: Stopped Security Auditing Service.
Sep 05 10:07:58 centos9stream systemd[1]: Starting Security Auditing Service...
Sep 05 10:07:58 centos9stream auditd[22661]: audit dispatcher initialized with q_depth=2000 and 2 active plugins
Sep 05 10:07:58 centos9stream auditd[22661]: Init complete, auditd 3.1.5 listening for events (startup state enable)
Sep 05 10:07:58 centos9stream audisp-af_unix[22664]: audisp-af_unix plugin is listening for events
Sep 05 10:07:58 centos9stream augenrules[22667]: /sbin/augenrules: No change
Sep 05 10:07:58 centos9stream augenrules[22682]: No rules
Sep 05 10:07:58 centos9stream augenrules[22682]: enabled 1
Sep 05 10:07:58 centos9stream augenrules[22682]: failure 1
Sep 05 10:07:58 centos9stream augenrules[22682]: pid 22661
Sep 05 10:07:58 centos9stream augenrules[22682]: rate_limit 0
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_limit 8192
Sep 05 10:07:58 centos9stream augenrules[22682]: lost 0
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog 4
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_wait_time 60000
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_wait_time_actual 0
Sep 05 10:07:58 centos9stream augenrules[22682]: enabled 1
Sep 05 10:07:58 centos9stream augenrules[22682]: failure 1
Sep 05 10:07:58 centos9stream augenrules[22682]: pid 22661
Sep 05 10:07:58 centos9stream augenrules[22682]: rate_limit 0
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_limit 8192
Sep 05 10:07:58 centos9stream augenrules[22682]: lost 0
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog 4
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_wait_time 60000
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_wait_time_actual 0
Sep 05 10:07:58 centos9stream augenrules[22682]: enabled 1
Sep 05 10:07:58 centos9stream augenrules[22682]: failure 1
Sep 05 10:07:58 centos9stream augenrules[22682]: pid 22661
Sep 05 10:07:58 centos9stream augenrules[22682]: rate_limit 0
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_limit 8192
Sep 05 10:07:58 centos9stream augenrules[22682]: lost 0
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog 4
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_wait_time 60000
Sep 05 10:07:58 centos9stream augenrules[22682]: backlog_wait_time_actual 0
Sep 05 10:07:58 centos9stream systemd[1]: Started Security Auditing Service.
Sep 05 10:08:12 centos9stream audisp-af_unix[22664]: Client connected
```

## Extra testing
# Tested systems

Distro / Release | 3.1.2 | 3.1.3 | 3.1.5 | 4.0.0 | 4.0.1 | 4.0.2 | 4.0.3 | 4.0.5 | 4.1.1 | 4.1.3 (current main)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Ubuntu 24.04 LTS (Noble) | ✅ | ➖ | ➖ | ➖ | ➖ | ✔️ | ✔️ | ➖ | ✔️ | ➖
Debian 13 (Trixie) | ➖ | ➖ | ➖ | ➖ | ➖ | ✅ | ➖ | ❌ | ➖ | ✔️
Fedora (40/41/42) | ➖ | ➖ | ➖ | ✅ | ✅ | ✅ | ✅ | ➖ | ✔️ | ➖
Fedora (39) | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖
CentOS Stream 9 | ➖ | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ | ✔️ | ➖ | ✔️
Rocky Linux 9.6 | ➖ | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ | ➖ | ✔️ | ➖


✅ -> Official Audit package in the OS repo tested
❌ -> Official Audit package in the OS repo dont work
➖ -> No official Audit package found for this version in this OS
✔️ -> Local compiled Audit version tested

- Extended explanation: https://github.com/wazuh/wazuh/issues/28984#issuecomment-3253201417

## ITs FIM tier 2 🟢 
- https://github.com/wazuh/wazuh/actions/runs/17446602239/job/49542510375