### PR TITLE
Fix support for parquet version 2 in AWS Wodle

### DIFF
--- a/wodles/aws/subscribers/s3_log_handler.py
+++ b/wodles/aws/subscribers/s3_log_handler.py
@@ -291,7 +291,7 @@ class AWSSLSubscriberBucket(wazuh_integration.WazuhIntegration, AWSS3LogHandler)
         pfile = pq.ParquetFile(raw_parquet)
         for i in pfile.iter_batches():
             for j in i.to_pylist():
-                events.append(json.dumps(j))
+                events.append(json.dumps(j, default=str))
         aws_tools.debug(f'Found {len(events)} events in file {log_path}', 2)
         return events
 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/29888 |


## Description
Ensure that Security Lake is compatible with both v1.0 and v2.0 paquet version.