### PR TITLE
Update `host.cpu.cores` field type to `short`

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
@@ -50,7 +50,7 @@
             "cpu": {
               "properties": {
                 "cores": {
-                  "type": "byte"
+                  "type": "short"
                 },
                 "name": {
                   "ignore_above": 1024,


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-indexer/issues/943|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

Update the field `host.cpu.cores` from `wazuh-states-inventory-hardware` index changing its type to `short`

