### PR TITLE
Add actions permissions to the packages generation workflow

### DIFF
--- a/.github/workflows/4_builderpackage_manager-multiples-2.yml
+++ b/.github/workflows/4_builderpackage_manager-multiples-2.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   Generate-Packages:
+    permissions:
+      actions: write
     runs-on: ubuntu-24.04
     steps:
       - name: Build DEB Manager


### PR DESCRIPTION
## Description

<!--
Add a clear description of how the problem has been solved.
-->

Explicitly defines the permissions to be used by the workflow.

The runs of the different workflows can be found at https://github.com/wazuh/wazuh/actions?query=branch%3Achange%2F2499-enhance-workflows.