### PR TITLE
Add setting 'auto_expand_replicas' to inventory index templates

### DIFF
--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-files.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-fim-registries.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hardware.json
@@ -6,10 +6,20 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
-          "host.serial_number"
+          "agent.host.architecture",
+          "agent.host.ip",
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "agent.host.ip",
+          "host.serial_number",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hotfixes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-hotfixes.json
@@ -6,10 +6,19 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
-          "package.hotfix.name"
+          "agent.host.architecture",
+          "agent.host.ip",
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "package.hotfix.name",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-interfaces.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-interfaces.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-networks.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-networks.json
@@ -6,11 +6,19 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "agent.host.ip",
+          "interface.name",
           "network.ip",
-          "network.name"
+          "network.name",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node"
         ],
         "refresh_interval": "5s"
       }

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-packages.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-ports.json
@@ -6,13 +6,27 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
+          "agent.host.architecture",
+          "agent.host.ip",
           "agent.id",
+          "agent.name",
+          "agent.version",
+          "host.network.egress.queue",
+          "host.network.ingress.queue",
+          "file.inode",
+          "interface.state",
+          "network.transport",
           "process.name",
+          "process.pid",
           "source.ip",
-          "destination.ip"
+          "destination.ip",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-processes.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-protocols.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-protocols.json
@@ -6,12 +6,20 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
-          "agent.id",
+          "agent.host.architecture",
           "agent.host.ip",
-          "interface.name"
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "network.type",
+          "interface.name",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ],
         "refresh_interval": "5s"
       }

--- a/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
+++ b/src/wazuh_modules/inventory_harvester/indexer/template/wazuh-states-inventory-system.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-indexer/issues/938|

## Description

This PR adds the index setting `auto_expand_replicas` to the inventory index templates. This setting allows a cluster to add a replica index **if possible**.

It also improves the list of default query fields for the indices.

## Configuration options

<!--
When proceed, this section should include new configuration parameters.
-->

## Logs/Alerts example

<!--
Paste here related logs and alerts
-->

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors