### PR TITLE
Add actions permissions to the packages generation workflow main

### DIFF
--- a/.github/workflows/4_builderpackage_manager-multiples-2.yml
+++ b/.github/workflows/4_builderpackage_manager-multiples-2.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   Generate-Packages:
+    permissions:
+      actions: write
     runs-on: ubuntu-24.04
     steps:
       - name: Build DEB Manager


### PR DESCRIPTION
## Description

Explicitly defines the permissions to be used by the workflow.

Commit taken from https://github.com/wazuh/wazuh/pull/30245.