### PR TITLE
Exclude null/empty groups from agents summary

### DIFF
--- a/src/shared_modules/router/src/wazuh-db/endpointPostV1AgentsSummary.hpp
+++ b/src/shared_modules/router/src/wazuh-db/endpointPostV1AgentsSummary.hpp
@@ -54,8 +54,9 @@ public:
         // Queries for connections
         constexpr std::string_view queryConnection = "SELECT id, connection_status AS status FROM agent WHERE id > 0;";
         constexpr std::string_view queryOs = "SELECT id, os_platform AS platform FROM agent WHERE id > 0;";
-        constexpr std::string_view queryGroup = "SELECT b.id_agent, g.name AS group_name FROM belongs b JOIN 'group' g "
-                                                "ON b.id_group=g.id WHERE b.id_agent > 0;";
+        constexpr std::string_view queryGroup =
+            "SELECT b.id_agent, g.name AS group_name FROM belongs b JOIN 'group' g "
+            "ON b.id_group=g.id WHERE b.id_agent > 0 AND g.name IS NOT NULL AND g.name <> '';";
 
         constexpr std::string_view queryConnectionNoFilter =
             "SELECT COUNT(*) as quantity, connection_status AS status FROM agent "
@@ -67,7 +68,7 @@ public:
 
         constexpr std::string_view queryGroupsNoFilter =
             "SELECT COUNT(*) as q, g.name AS group_name FROM belongs b JOIN 'group' g ON b.id_group=g.id WHERE "
-            "b.id_agent > 0  GROUP BY b.id_group ORDER BY q DESC LIMIT 5;";
+            "b.id_agent > 0 AND g.name IS NOT NULL AND g.name <> '' GROUP BY b.id_group ORDER BY q DESC LIMIT 5;";
 
         Response response;
 

--- a/src/shared_modules/router/tests/unit/endpointPostV1AgentsSummary_test.cpp
+++ b/src/shared_modules/router/tests/unit/endpointPostV1AgentsSummary_test.cpp
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+using ::testing::HasSubstr;
 using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::Sequence;
@@ -98,10 +99,80 @@ TEST_F(EndpointPostV1AgentsSummaryTest, NoFilterHappyCase)
               "BY status ASC limit 5;");
     EXPECT_EQ((*queries)[1],
               "SELECT COUNT(*) as q, g.name AS group_name FROM belongs b JOIN 'group' g ON b.id_group=g.id WHERE "
-              "b.id_agent > 0  GROUP BY b.id_group ORDER BY q DESC LIMIT 5;");
+              "b.id_agent > 0 AND g.name IS NOT NULL AND g.name <> '' GROUP BY b.id_group ORDER BY q DESC LIMIT 5;");
     EXPECT_EQ((*queries)[2],
               "SELECT COUNT(*) as quantity, os_platform AS platform FROM agent WHERE id > 0 GROUP BY platform ORDER BY "
               "quantity DESC limit 5;");
+}
+
+TEST_F(EndpointPostV1AgentsSummaryTest, NoFilter_ShouldIgnoreNullAndEmptyGroups)
+{
+    Sequence s;
+    EXPECT_CALL(*stmt, step())
+        .InSequence(s)
+        // status - Doesn't matter for this test
+        .WillOnce(Return(SQLITE_DONE))
+        // groups - The important part
+        .WillOnce(Return(SQLITE_ROW))  // Group "prod"
+        .WillOnce(Return(SQLITE_ROW))  // Group "dev"
+        .WillOnce(Return(SQLITE_DONE)) // End of groups
+        // os - Doesn't matter for this test
+        .WillOnce(Return(SQLITE_DONE));
+
+    // Define the return values for the groups query
+    EXPECT_CALL(*stmt, valueInt64(0))
+        .WillOnce(Return(10)) // 10 agents in "prod"
+        .WillOnce(Return(5)); // 5 agents in "dev"
+    EXPECT_CALL(*stmt, valueString(1)).WillOnce(Return("prod")).WillOnce(Return("dev"));
+
+    MockSQLiteConnection db;
+    httplib::Request req;
+    httplib::Response res;
+
+    TEndpointPostV1AgentsSummary<MockSQLiteConnection, TrampolineSQLiteStatement>::call(db, req, res);
+
+    // Verify that the query contains the new filter
+    ASSERT_EQ(queries->size(), 3);
+    EXPECT_THAT((*queries)[1], HasSubstr("g.name IS NOT NULL AND g.name <> ''"));
+
+    // Verify that the response body is correct
+    EXPECT_EQ(res.body, R"({"agents_by_groups":{"dev":5,"prod":10}})");
+}
+
+TEST_F(EndpointPostV1AgentsSummaryTest, Filtered_ShouldIgnoreNullAndEmptyGroups)
+{
+    Sequence s;
+    EXPECT_CALL(*stmt, step())
+        .InSequence(s)
+        // connections - Doesn't matter for this test
+        .WillOnce(Return(SQLITE_DONE))
+        // groups - The important part
+        .WillOnce(Return(SQLITE_ROW))  // Agent 1 in "prod"
+        .WillOnce(Return(SQLITE_ROW))  // Agent 2 in "dev"
+        .WillOnce(Return(SQLITE_DONE)) // End of groups
+        // os - Doesn't matter for this test
+        .WillOnce(Return(SQLITE_DONE));
+
+    // Define the return values for the groups query
+    EXPECT_CALL(*stmt, valueInt64(0))
+        .WillOnce(Return(1))  // Agent ID 1
+        .WillOnce(Return(2)); // Agent ID 2
+    EXPECT_CALL(*stmt, valueString(1)).WillOnce(Return("prod")).WillOnce(Return("dev"));
+
+    MockSQLiteConnection db;
+    httplib::Request req;
+    httplib::Response res;
+    // We request agents 1, 2, and 3. Agent 3 would be in a null/empty group and should be filtered out by the query.
+    req.body = "1,2,3";
+
+    TEndpointPostV1AgentsSummary<MockSQLiteConnection, TrampolineSQLiteStatement>::call(db, req, res);
+
+    // Verify that the query contains the new filter
+    ASSERT_EQ(queries->size(), 3);
+    EXPECT_THAT((*queries)[1], HasSubstr("g.name IS NOT NULL AND g.name <> ''"));
+
+    // Verify that the response body is correct, containing only the valid groups for the requested agents
+    EXPECT_EQ(res.body, R"({"agents_by_groups":{"dev":1,"prod":1}})");
 }
 
 TEST_F(EndpointPostV1AgentsSummaryTest, FilteredHappyCase)
@@ -144,6 +215,6 @@ TEST_F(EndpointPostV1AgentsSummaryTest, FilteredHappyCase)
     EXPECT_EQ((*queries)[0], "SELECT id, connection_status AS status FROM agent WHERE id > 0;");
     EXPECT_EQ((*queries)[1],
               "SELECT b.id_agent, g.name AS group_name FROM belongs b JOIN 'group' g ON b.id_group=g.id WHERE "
-              "b.id_agent > 0;");
+              "b.id_agent > 0 AND g.name IS NOT NULL AND g.name <> '';");
     EXPECT_EQ((*queries)[2], "SELECT id, os_platform AS platform FROM agent WHERE id > 0;");
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #30234 |

### Description

This Pull Request enhances the agents summary endpoint (`POST /agents/summary`) to exclude groups that have a null or empty name (`NULL` or `''`), ensuring that only meaningful data is displayed in the API response.

#### Problem Solved

Currently, the agents summary endpoint may include groups in its count that do not have an assigned name in the database. This can lead to the API returning an "empty" group category, which is not useful for users and can cause confusion in frontend visualizations.

#### Description of Changes

To address this, the following modifications have been made:

1.  **Updated SQL Queries:**
    *   The `queryGroupsNoFilter` query has been modified to include the condition `g.name IS NOT NULL AND g.name <> ''`. This ensures that the general group summary only counts agents belonging to groups with valid names.
    *   The same filter has been applied to the `queryGroup` query, which is used when a summary is requested for a specific set of agents.

2.  **Updated Unit Tests:**
    *   Two new test cases (`NoFilter_ShouldIgnoreNullAndEmptyGroups` and `Filtered_ShouldIgnoreNullAndEmptyGroups`) have been added to explicitly verify that null or empty groups are ignored by the queries.
    *   Existing tests (`NoFilterHappyCase` and `FilteredHappyCase`) have been updated so their assertions match the new SQL queries, ensuring the entire test suite continues to pass.


