### PR TITLE
Fix camel casing in ownCloud ruleset header

### DIFF
--- a/ruleset/rules/0500-owncloud_rules.xml
+++ b/ruleset/rules/0500-owncloud_rules.xml
@@ -1,5 +1,5 @@
 <!--
-  -  OwnCloud ruleset
+  -  ownCloud ruleset
   -  Created by Wazuh, Inc.
   -  Copyright (C) 2015, Wazuh Inc.
   -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.


### PR DESCRIPTION
Fixed camel casing in ownCloud ruleset header.

|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/28376|


## Description

A user reported a typo in the ruleset header for the ownCloud rules file `0500-owncloud_rules.xml`.

> The product name had never used camel casing `OwnCloud` and had only started with one single lowercase letter `ownCloud` since ever.

This PR aims to fix the issue.

