### PR TITLE
Use new curl certificates for RPM5 i386 Dockerfile

### DIFF
--- a/packages/rpms/i386/legacy/Dockerfile
+++ b/packages/rpms/i386/legacy/Dockerfile
@@ -43,6 +43,8 @@ RUN curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.12.4.tar.gz && \
     linux32 ./bootstrap && linux32 make -j2 && linux32 make install && \
     cd / && rm -rf cmake-*
 
+RUN rm -f /etc/pki/tls/certs/ca-bundle.crt && curl -k -o /etc/pki/tls/certs/ca-bundle.crt https://curl.se/ca/cacert.pem
+
 RUN ln -fs $(which gcc) $(which cc)
 
 # Add the scripts to build the RPM package


### PR DESCRIPTION
|Related Issue|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/347|

## Description
Hi team, 

This PR updates the certificates used in our `ppkg_rpm_legacy_builder_i386` Docker image to avoid problems with curl due to obsolete certificates.

## Tests:
:green_circle: [Packages - Build Wazuh agent Linux amd - legacy packages - rpm - i386 #216](https://github.com/wazuh/wazuh-agent-packages/actions/runs/15588939608/job/43902592013)