### PR TITLE
Fix Solaris 11 SSL certs error

### DIFF
--- a/packages/solaris/solaris11/generate_wazuh_packages.sh
+++ b/packages/solaris/solaris11/generate_wazuh_packages.sh
@@ -95,6 +95,9 @@ build_environment() {
     cd ..
     rm -rf *cmake-*
     ln -sf /usr/local/bin/cmake /usr/bin/cmake
+
+    export CURL_CA_BUNDLE="/etc/certs/ca-bundle.crt"
+    echo "export CURL_CA_BUNDLE=/etc/certs/ca-bundle.crt" >> /etc/profile
 }
 
 compute_version_revision() {
@@ -137,6 +140,7 @@ compile() {
     export PATH=/usr/local/gcc-5.5.0/bin:/usr/sbin:/usr/bin:/usr/ccs/bin:/opt/csw/bin
     export CPLUS_INCLUDE_PATH=/usr/local/gcc-5.5.0/include/c++/5.5.0
     export LD_LIBRARY_PATH=/usr/local/gcc-5.5.0/lib
+    export CURL_CA_BUNDLE="/etc/certs/ca-bundle.crt"
 
     cd ${current_path}
     VERSION="v$(sed -n 's/.*"version"[ \t]*:[ \t]*"\([^"]*\)".*/\1/p' ${SOURCE}/VERSION.json)"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-agent-packages/issues/346|

## Description

This PR fixes the SSL certificate problem on both _Solaris 11 i386_ and _Solaris 11 SPARC_, both of which had the same error.
The solution has been to download and pass the `curl` certificate bundle to the machine, to be used by default via the `CURL_CA_BUNDLE` environment variable.

## Tests

- :green_circle: Solaris 11 i386 - [Packages - Build Wazuh agent Solaris 11 i386 -](https://github.com/wazuh/wazuh-agent-packages/actions/runs/15614120288)
- :green_circle: Solaris 11 SPARC - [Packages - Build Wazuh agent special package - System solaris11 - checks](https://github.com/wazuh/wazuh-agent-packages/actions/runs/15606661381)
