### PR TITLE
Fix compile_schemas build failure

### DIFF
--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -3,6 +3,13 @@ name: Vulnerability Scanner - Database Generation
 on:
   schedule:
     - cron: '20 0 * * *'
+  pull_request:
+    paths:
+      - ".github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml"
+      - ".github/actions/compile_and_test/action.yml"
+      - ".github/actions/vulnerability_scanner_deps/action.yml"
+      - ".github/actions/vulnerability_scanner/content_generation/action.yml"
+      - ".github/actions/vulnerability_scanner/compile/action.yml"
 
   workflow_dispatch:
     inputs:
@@ -39,9 +46,6 @@ jobs:
       # Checkout to the tag. If it doesn't exist, continue with the branch
       - name: Checkout to ${{ matrix.content_version }}
         run: |
-          # Backup current workflows and actions files before checkout new branch.
-          cp -r .github/{actions,workflows} /tmp
-
           if git show-ref --tags --verify --quiet "refs/tags/v${{ matrix.content_version }}"; then
             git checkout --quiet "tags/v${{ matrix.content_version }}"
           else
@@ -56,9 +60,8 @@ jobs:
           fi
           echo "Git branch: $(git branch | grep "*")"
 
-          # We restore the actions from main
-          # to re-use them independently from the checkout branch
-          cp -r /tmp/{actions,workflows} .github/
+          # Replace all occurrences of 'wazuh_version' with 'content_version' in all .yml files
+          find .github/actions .github/workflows -type f -name "*.yml" -exec sed -i 's/wazuh_version/content_version/g' {} +
 
       # Restore missing template file.
       - name: Restore missing template file


### PR DESCRIPTION
|Related issue|
|---|
|#30304|

## Description

This PR resolves a critical build failure in the Vulnerability Scanner - Database Generation workflow, which was caused by a wrong action execution.

## Changes

- Apply a workaround for version `4.8.0`, changing name of the input
- Avoid use main workflow, and use branch workflow