### PR TITLE
Skip empty or null results in agent summary

### DIFF
--- a/src/shared_modules/router/src/wazuh-db/endpointPostV1AgentsSummary.hpp
+++ b/src/shared_modules/router/src/wazuh-db/endpointPostV1AgentsSummary.hpp
@@ -53,7 +53,8 @@ public:
     {
         // Queries for connections
         constexpr std::string_view queryConnection = "SELECT id, connection_status AS status FROM agent WHERE id > 0;";
-        constexpr std::string_view queryOs = "SELECT id, os_platform AS platform FROM agent WHERE id > 0;";
+        constexpr std::string_view queryOs = "SELECT id, os_platform AS platform FROM agent WHERE id > 0 AND "
+                                             "os_platform IS NOT NULL AND os_platform <> '';";
         constexpr std::string_view queryGroup =
             "SELECT b.id_agent, g.name AS group_name FROM belongs b JOIN 'group' g "
             "ON b.id_group=g.id WHERE b.id_agent > 0 AND g.name IS NOT NULL AND g.name <> '';";
@@ -64,7 +65,7 @@ public:
 
         constexpr std::string_view queryOsNoFilter =
             "SELECT COUNT(*) as quantity, os_platform AS platform FROM agent WHERE id > 0 "
-            "GROUP BY platform ORDER BY quantity DESC limit 5;";
+            "AND os_platform IS NOT NULL AND os_platform <> '' GROUP BY platform ORDER BY quantity DESC limit 5;";
 
         constexpr std::string_view queryGroupsNoFilter =
             "SELECT COUNT(*) as q, g.name AS group_name FROM belongs b JOIN 'group' g ON b.id_group=g.id WHERE "


### PR DESCRIPTION
|Related issue|
|---|
|Closes #30288|

## Description

This PR addresses an issue where agents with null or empty `os_platform` values were being included in the OS platform summary statistics, which could lead to inaccurate reporting and potential data inconsistencies.

### Changes Made

#### Core Implementation (`endpointPostV1AgentsSummary.hpp`)
- **Modified `queryOs`**: Added `AND os_platform IS NOT NULL AND os_platform <> ''` filter to exclude agents with null/empty OS platform when processing filtered agent requests
- **Modified `queryOsNoFilter`**: Added `AND os_platform IS NOT NULL AND os_platform <> ''` filter to exclude agents with null/empty OS platform when processing unfiltered summary requests

#### Test Updates (`endpointPostV1AgentsSummary_test.cpp`)
- **Updated existing tests**: Modified expected query strings in `NoFilterHappyCase` and `FilteredHappyCase` to reflect the new filters
- **Added `NoFilter_ShouldIgnoreNullAndEmptyOsPlatform`**: Test case validating that unfiltered OS summary queries properly exclude null/empty platforms
- **Added `Filtered_ShouldIgnoreNullAndEmptyOsPlatform`**: Test case validating that filtered OS summary queries properly exclude null/empty platforms

This ensures that:
- `os_platform IS NOT NULL`: Excludes records where the field is NULL
- `os_platform <> ''`: Excludes records where the field is an empty string
