### PR TITLE
macOS 13 SCA - Correct Check 2.3.3.2  to Prevent False Positive

### DIFF
--- a/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
+++ b/ruleset/sca/darwin/22/cis_apple_macOS_13.x.yml
@@ -302,7 +302,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl list | grep -c com.apple.screensharing" -> r:^0$'
+      - 'not c:launchctl list -> r:com.apple.screensharing$'
 
   # 2.3.3.3 Ensure File Sharing Is Disabled. (Automated)
   - id: 30012

--- a/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
+++ b/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
@@ -301,7 +301,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl list | grep -c com.apple.screensharing" -> r:^0$'
+      - 'not c:launchctl list -> r:com.apple.screensharing$'
 
   # 2.3.3.3 Ensure File Sharing Is Disabled. (Automated)
   - id: 34013

--- a/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
+++ b/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
@@ -308,7 +308,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6", "CC7.1", "CC8.1"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl list | grep -c com.apple.screensharing" -> r:^0$'
+      - 'not c:launchctl list -> r:com.apple.screensharing$'
 
   # 2.3.3.3 Ensure File Sharing Is Disabled. (Automated)
   - id: 35012


### PR DESCRIPTION
# Description 

<html>
<body>
<!--StartFragment--><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; margin-top: 0px !important; color: rgb(240, 246, 252); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Wazuh version | Component | Install type | Install method | Platform
-- | -- | -- | -- | --
4.11.2 | SCA | Agent | Packages | MacOS Ventura 13.6.1

Check 31012 (MacOS "disable screen sharing") was reported [here](https://github.com/wazuh/external-devel-requests/issues/5722) to not perform the proper check. The instructions for mitigating this particular item-id ("disable screen sharing") was followed, and yet the check continues to fail.


### Current rule:
```
    condition: all
    rules:
      - 'c:sh -c "launchctl list | grep -c com.apple.screensharing" -> r:^0$'

```

## Observation
- The current rule produces false positive because it matches every instances of `com.apple.screensharing` including `com.apple.screensharing.agent` and `com.apple.screensharing.menuextra` which are not indicators of screensharing Enabled. 
- The CIS document specifically provided ` /usr/bin/sudo /bin/launchctl list | /usr/bin/grep -E
"com.apple.screensharing$"
`, with the $ at the end which means that it expected ONLY com.apple.screensharing to be searched for without any extra characters or extension.

wrong check
```console
# launchctl list | grep -E "com.apple.screensharing"
-       0       com.apple.screensharing.agent
-       0       com.apple.screensharing.menuextra
```

### Proposed rule
```console
# launchctl list | grep -E "com.apple.screensharing$"
sh-3.2# No output
```


To correct the current rule and follow the documentation strictly, the correct rule is:

```
    condition: all
    rules:
      - 'not c:launchctl list -> r:com.apple.screensharing$' 

```

This works as expected and in line with the documentation, thereby eliminating the false positive.

## Test Output

<details>
<summary>Screensharing is Disabled - Passed as Expected</summary>

```console
2025/06/20 00:00:45 sca[6738] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(-     0       com.apple.nowplayingtouchui) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(-  0       com.apple.AskPermissionUI) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(-     0       com.apple.AskPermissionUI) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(1757       0       com.apple.SoftwareUpdateNotificationManager) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(1757  0       com.apple.SoftwareUpdateNotificationManager) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(-  0       com.apple.wifiFirmwareLoader) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(-     0       com.apple.wifiFirmwareLoader) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(82 0       com.apple.fseventsd) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(82    0       com.apple.fseventsd) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(-  0       com.apple.Kerberos.digest-service
2025/06/20 00:00:45 sca[6738] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(-     0       com.apple.Kerberos.digest-service
2025/06/20 00:00:45 sca[6738] wm_sca.c:1762 at wm_sca_read_command(): DEBUG: Result for (r:com.apple.screensharing$)(launchctl list) -> 0
2025/06/20 00:00:45 sca[6738] wm_sca.c:1280 at wm_sca_do_scan(): DEBUG: Result for rule 'not c:launchctl list -> r:com.apple.screensharing$': 1
2025/06/20 00:00:45 sca[6738] wm_sca.c:1303 at wm_sca_do_scan(): DEBUG: Result for check id: 30011 'Ensure Screen Sharing Is Disabled.' -> 1
2025/06/20 00:00:45 sca[6738] wm_sca.c:502 at wm_sca_read_files(): DEBUG: Calculating hash for scanned results.
2025/06/20 00:00:45 sca[6738] wm_sca.c:2965 at wm_sca_hash_integrity(): DEBUG: Concatenating check results:
2025/06/20 00:00:45 sca[6738] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 30011; Result: 'passed'
2025/06/20 00:00:48 sca[6738] wm_sca.c:2598 at wm_sca_send_summary(): DEBUG: Sending summary event for file: 'cis_macOS_13.0_Ventura.yml'
2025/06/20 00:00:48 sca[6738] wm_sca.c:271 at wm_sca_send_alert(): DEBUG: Sending event: {"type":"summary","scan_id":1904189392,"name":"CIS_Apple_macOS_13.0_Ventura_Benchmark_v1.1.0","policy_id":"cis_macOS_13.0_Ventura.yml","file":"cis_macOS_13.0_Ventura.yml","description":"This document provides prescriptive guidance for establishing a secure configuration posture for MacOS 13 Ventura systems.","references":"https://www.cisecurity.org/cis-benchmarks/","passed":1,"failed":0,"invalid":0,"total_checks":1,"score":100,"start_time":1750402845,"end_time":1750402845,"hash":"284d1e8c4918248233df17642bbb940c001e1fa856c18aab86ba6dbe7813eb13","hash_file":"02d34f4905d19759b3f5de346b4de99f2cc58975c8461dd11248cc20b2677353","first_scan":1}
```

</details>

<details>
<summary>Screensharing is Enabled - Failed as Expected</summary>

```console
2025/06/19 23:59:26 sca[6686] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(232   0       com.apple.awdd) -> 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(148        0       com.apple.contextstored) -> 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(148   0       com.apple.contextstored) -> 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(216        0       com.apple.mDNSResponderHelper.reloaded) -> 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(216   0       com.apple.mDNSResponderHelper.reloaded) -> 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:2041 at wm_sca_pattern_matches(): DEBUG: Testing minterm (r:com.apple.screensharing$)(-  0       com.apple.screensharing) -> 1
2025/06/19 23:59:26 sca[6686] wm_sca.c:2044 at wm_sca_pattern_matches(): DEBUG: Pattern test result: (r:com.apple.screensharing$)(-     0       com.apple.screensharing) -> 1
2025/06/19 23:59:26 sca[6686] wm_sca.c:1762 at wm_sca_read_command(): DEBUG: Result for (r:com.apple.screensharing$)(launchctl list) -> 1
2025/06/19 23:59:26 sca[6686] wm_sca.c:1191 at wm_sca_do_scan(): DEBUG: Command output matched.
2025/06/19 23:59:26 sca[6686] wm_sca.c:1280 at wm_sca_do_scan(): DEBUG: Result for rule 'not c:launchctl list -> r:com.apple.screensharing$': 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:1287 at wm_sca_do_scan(): DEBUG: Breaking from rule aggregator 'all' with found = 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:1303 at wm_sca_do_scan(): DEBUG: Result for check id: 30011 'Ensure Screen Sharing Is Disabled.' -> 0
2025/06/19 23:59:26 sca[6686] wm_sca.c:502 at wm_sca_read_files(): DEBUG: Calculating hash for scanned results.
2025/06/19 23:59:26 sca[6686] wm_sca.c:2965 at wm_sca_hash_integrity(): DEBUG: Concatenating check results:
2025/06/19 23:59:26 sca[6686] wm_sca.c:2968 at wm_sca_hash_integrity(): DEBUG: ID: 30011; Result: 'failed'

```