### PR TITLE
Sanity check VD hotfix value

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -340,10 +340,13 @@ public:
                                 m_type = ScannerType::HotfixInsert;
 
                                 // Insert the new hotfix into the remediation data cache.
-                                const std::string hotfix = delta->data_as_dbsync_hotfixes()->hotfix()->str();
-                                Remediation remediation = {.hotfixes = {hotfix}};
-                                TRemediationDataCache::instance().addRemediationData(agentId().data(),
-                                                                                     std::move(remediation));
+                                if (delta->data_as_dbsync_hotfixes()->hotfix())
+                                {
+                                    const std::string hotfix = delta->data_as_dbsync_hotfixes()->hotfix()->str();
+                                    Remediation remediation = {.hotfixes = {hotfix}};
+                                    TRemediationDataCache::instance().addRemediationData(agentId().data(),
+                                                                                         std::move(remediation));
+                                }
                             }
                             else if (delta->operation()->str().compare("DELETED") == 0)
                             {
@@ -475,12 +478,15 @@ public:
                             // Set the affected component type
                             m_affectedComponentType = AffectedComponentType::Hotfix;
 
-                            // Insert the new hotfix into the remediation data cache.
-                            const std::string hotfix =
-                                syncMsg->data_as_state()->attributes_as_syscollector_hotfixes()->hotfix()->str();
-                            Remediation remediation = {.hotfixes = {hotfix}};
-                            TRemediationDataCache::instance().addRemediationData(agentId().data(),
-                                                                                 std::move(remediation));
+                            if (syncMsg->data_as_state()->attributes_as_syscollector_hotfixes()->hotfix())
+                            {
+                                // Insert the new hotfix into the remediation data cache.
+                                const std::string hotfix =
+                                    syncMsg->data_as_state()->attributes_as_syscollector_hotfixes()->hotfix()->str();
+                                Remediation remediation = {.hotfixes = {hotfix}};
+                                TRemediationDataCache::instance().addRemediationData(agentId().data(),
+                                                                                     std::move(remediation));
+                            }
 
                             // If data comes from Wdb, we build the CPE and update the cache
                             if (!TOsDataCache::instance().getOsData(agentId().data(), m_osData))

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanContext_test.cpp
@@ -137,6 +137,23 @@ namespace NSScanContextTest
             }
         )";
 
+    const std::string DELTA_HOTFIXES_INSERTED_MSG_NO_HOTFIX =
+        R"(
+            {
+                "agent_info": {
+                    "agent_id": "001",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal"
+                },
+                "data_type": "dbsync_hotfixes",
+                "data": {
+                    "checksum":"56162cd7bb632b4728ec868e8e271b01222ff131",
+                    "scan_time":"2024/01/05 10:30:25"
+                },
+                "operation": "INSERTED"
+            }
+        )";
+
     const std::string DELTA_HOTFIXES_DELETED_MSG =
         R"(
             {
@@ -249,6 +266,26 @@ namespace NSScanContextTest
                     "attributes": {
                         "checksum":"56162cd7bb632b4728ec868e8e271b01222ff131",
                         "hotfix":"KB12345678",
+                        "scan_time":"2024/01/05 10:30:25"
+                    },
+                    "index": "e051a99ad3950084b538c6538c0fcad0f1c4c713"
+                }
+            }
+        )";
+
+    const std::string SYNCHRONIZATION_STATE_HOTFIXES_MSG_NO_HOTFIX =
+        R"(
+            {
+                "agent_info": {
+                    "agent_id": "001",
+                    "agent_ip": "192.168.33.20",
+                    "agent_name": "focal"
+                },
+                "data_type": "state",
+                "data": {
+                    "attributes_type": "syscollector_hotfixes",
+                    "attributes": {
+                        "checksum":"56162cd7bb632b4728ec868e8e271b01222ff131",
                         "scan_time":"2024/01/05 10:30:25"
                     },
                     "index": "e051a99ad3950084b538c6538c0fcad0f1c4c713"
@@ -668,6 +705,57 @@ TEST_F(ScanContextTest, TestSyscollectorDeltasHotfixesInserted)
     EXPECT_STREQ(scanContext->osDisplayVersion().data(), osData.displayVersion.c_str());
 }
 
+TEST_F(ScanContextTest, TestSyscollectorDeltasHotfixesInsertedNoHotfix)
+{
+    expectOsData();
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
+    EXPECT_CALL(*spRemediationDataCacheMock, addRemediationData(_, _)).Times(0);
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(syscollector_deltas_SCHEMA));
+    ASSERT_TRUE(parser.Parse(DELTA_HOTFIXES_INSERTED_MSG_NO_HOTFIX.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> msg =
+        SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer));
+
+    std::shared_ptr<scanContext_t> scanContext;
+    EXPECT_NO_THROW(scanContext = std::make_shared<scanContext_t>(msg));
+
+    EXPECT_EQ(scanContext->getType(), ScannerType::HotfixInsert);
+
+    EXPECT_STREQ(scanContext->agentId().data(),
+                 fbStringGetHelper(
+                     SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer))->agent_info()->agent_id()));
+    EXPECT_STREQ(scanContext->agentIp().data(),
+                 fbStringGetHelper(
+                     SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer))->agent_info()->agent_ip()));
+    EXPECT_STREQ(scanContext->agentName().data(),
+                 fbStringGetHelper(
+                     SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer))->agent_info()->agent_name()));
+    EXPECT_STREQ(
+        scanContext->agentVersion().data(),
+        fbStringGetHelper(
+            SyscollectorDeltas::GetDelta(reinterpret_cast<const char*>(buffer))->agent_info()->agent_version()));
+
+    EXPECT_STREQ(scanContext->osHostName().data(), osData.hostName.c_str());
+    EXPECT_STREQ(scanContext->osArchitecture().data(), osData.architecture.c_str());
+    EXPECT_STREQ(scanContext->osName().data(), osData.name.c_str());
+    EXPECT_STREQ(scanContext->osVersion().data(), osData.version.c_str());
+    EXPECT_STREQ(scanContext->osCodeName().data(), osData.codeName.c_str());
+    EXPECT_STREQ(scanContext->osMajorVersion().data(), osData.majorVersion.c_str());
+    EXPECT_STREQ(scanContext->osMinorVersion().data(), osData.minorVersion.c_str());
+    EXPECT_STREQ(scanContext->osPatch().data(), osData.patch.c_str());
+    EXPECT_STREQ(scanContext->osBuild().data(), osData.build.c_str());
+    EXPECT_STREQ(scanContext->osPlatform().data(), osData.platform.c_str());
+    EXPECT_STREQ(scanContext->osKernelSysName().data(), osData.sysName.c_str());
+    EXPECT_STREQ(scanContext->osKernelRelease().data(), osData.kernelRelease.c_str());
+    EXPECT_STREQ(scanContext->osKernelVersion().data(), osData.kernelVersion.c_str());
+    EXPECT_STREQ(scanContext->osRelease().data(), osData.release.c_str());
+    EXPECT_STREQ(scanContext->osDisplayVersion().data(), osData.displayVersion.c_str());
+}
+
 TEST_F(ScanContextTest, TestSyscollectorDeltasHotfixesDeleted)
 {
     expectOsData();
@@ -964,6 +1052,56 @@ TEST_F(ScanContextTest, TestSynchronizationStateHotfixes)
     flatbuffers::Parser parser;
     ASSERT_TRUE(parser.Parse(rsync_SCHEMA));
     ASSERT_TRUE(parser.Parse(SYNCHRONIZATION_STATE_HOTFIXES_MSG.c_str()));
+    uint8_t* buffer = parser.builder_.GetBufferPointer();
+    std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> msg =
+        Synchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));
+
+    std::shared_ptr<scanContext_t> scanContext;
+    EXPECT_NO_THROW(scanContext = std::make_shared<scanContext_t>(msg));
+
+    EXPECT_EQ(scanContext->getType(), ScannerType::HotfixInsert);
+
+    EXPECT_STREQ(scanContext->agentId().data(),
+                 fbStringGetHelper(
+                     Synchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer))->agent_info()->agent_id()));
+    EXPECT_STREQ(scanContext->agentIp().data(),
+                 fbStringGetHelper(
+                     Synchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer))->agent_info()->agent_ip()));
+    EXPECT_STREQ(scanContext->agentName().data(),
+                 fbStringGetHelper(
+                     Synchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer))->agent_info()->agent_name()));
+    EXPECT_STREQ(
+        scanContext->agentVersion().data(),
+        fbStringGetHelper(
+            Synchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer))->agent_info()->agent_version()));
+    EXPECT_STREQ(scanContext->osHostName().data(), osData.hostName.c_str());
+    EXPECT_STREQ(scanContext->osArchitecture().data(), osData.architecture.c_str());
+    EXPECT_STREQ(scanContext->osName().data(), osData.name.c_str());
+    EXPECT_STREQ(scanContext->osVersion().data(), osData.version.c_str());
+    EXPECT_STREQ(scanContext->osCodeName().data(), osData.codeName.c_str());
+    EXPECT_STREQ(scanContext->osMajorVersion().data(), osData.majorVersion.c_str());
+    EXPECT_STREQ(scanContext->osMinorVersion().data(), osData.minorVersion.c_str());
+    EXPECT_STREQ(scanContext->osPatch().data(), osData.patch.c_str());
+    EXPECT_STREQ(scanContext->osBuild().data(), osData.build.c_str());
+    EXPECT_STREQ(scanContext->osPlatform().data(), osData.platform.c_str());
+    EXPECT_STREQ(scanContext->osKernelSysName().data(), osData.sysName.c_str());
+    EXPECT_STREQ(scanContext->osKernelRelease().data(), osData.kernelRelease.c_str());
+    EXPECT_STREQ(scanContext->osKernelVersion().data(), osData.kernelVersion.c_str());
+    EXPECT_STREQ(scanContext->osRelease().data(), osData.release.c_str());
+    EXPECT_STREQ(scanContext->osDisplayVersion().data(), osData.displayVersion.c_str());
+}
+
+TEST_F(ScanContextTest, TestSynchronizationStateHotfixesNoHotfix)
+{
+    expectOsData();
+
+    spRemediationDataCacheMock = std::make_shared<MockRemediationDataCache>();
+    EXPECT_CALL(*spRemediationDataCacheMock, getRemediationData(_)).WillRepeatedly(testing::Return(Remediation {}));
+    EXPECT_CALL(*spRemediationDataCacheMock, addRemediationData(_, _)).Times(0);
+
+    flatbuffers::Parser parser;
+    ASSERT_TRUE(parser.Parse(rsync_SCHEMA));
+    ASSERT_TRUE(parser.Parse(SYNCHRONIZATION_STATE_HOTFIXES_MSG_NO_HOTFIX.c_str()));
     uint8_t* buffer = parser.builder_.GetBufferPointer();
     std::variant<const SyscollectorDeltas::Delta*, const Synchronization::SyncMsg*, const nlohmann::json*> msg =
         Synchronization::GetSyncMsg(reinterpret_cast<const char*>(buffer));


### PR DESCRIPTION
|Related issue|
|---|
|Closes #41|

## Description

This pull request implements sanity checks for hotfix values in the vulnerability scanner's scan context. The changes include validation logic to ensure hotfix values are properly validated before processing.

### Changes
- Added sanity check validation for hotfix values in `scanContext.hpp`
- Implemented comprehensive unit tests to verify the validation behavior

### Testing
- Tests ensure proper handling of edge cases and invalid inputs
