### PR TITLE
Fix bug in rule 92657 - Extra spaces on alerts

### DIFF
--- a/ruleset/rules/0840-win_event_channel.xml
+++ b/ruleset/rules/0840-win_event_channel.xml
@@ -92,9 +92,7 @@
       <id>T1078.002</id>
       <id>T1021.001</id>
     </mitre>
-    <group>
-      authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,
-    </group>
+    <group>authentication_success,pci_dss_10.2.5,gpg13_7.1,gpg13_7.2,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
 </group>


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/30225 |

# Description

The rule 92657 that is related to RDP connections has some values in the group tag. I see that the line of this tag is broken. This tag causes problem when an alert is generated, so we can't filter as we should. See the screenshot below showing some extra spaces in the rules.group:

![Image](https://github.com/user-attachments/assets/8f4925d5-4a05-44a6-b30e-032f71caaef7)