### PR TITLE
Send sync messages using wazuh-agentd

### DIFF
--- a/src/sync_protocol/CMakeLists.txt
+++ b/src/sync_protocol/CMakeLists.txt
@@ -27,7 +27,9 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Compiler flags
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2")
+set(CMAKE_CXX_FLAGS
+    "-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2"
+)
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3")
@@ -52,17 +54,14 @@ include(ExternalProject)
 
 set(FLATBUFFERS_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../external/flatbuffers")
 
-ExternalProject_Add(flatc_host_tool
+ExternalProject_Add(
+  flatc_host_tool
   SOURCE_DIR ${FLATBUFFERS_ROOT_DIR}
-  CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE=Release
-    -DFLATBUFFERS_BUILD_TESTS=OFF
-    -DFLATBUFFERS_BUILD_FLATLIB=OFF
-    -DFLATBUFFERS_BUILD_FLATC=ON
-    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+  CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF
+             -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATC=ON
+             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
   BUILD_ALWAYS 1
-  BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatc
-)
+  BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatc)
 
 ExternalProject_Get_Property(flatc_host_tool install_dir)
 set(FLATC_EXECUTABLE ${install_dir}/bin/flatc)
@@ -81,8 +80,7 @@ add_custom_command(
           ${CMAKE_CURRENT_BINARY_DIR} ${SCHEMA_FILE}
   DEPENDS ${SCHEMA_FILE} flatc_host_tool
   COMMENT "Generating FlatBuffers schema"
-  VERBATIM
-)
+  VERBATIM)
 
 add_custom_target(generate_flatbuffers ALL DEPENDS ${GENERATED_HEADER})
 
@@ -109,6 +107,7 @@ target_include_directories(agent_sync_protocol
     ${FLATBUFFERS_ROOT_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../
     ${CMAKE_CURRENT_SOURCE_DIR}/../shared_modules/utils/
+    ${CMAKE_SOURCE_DIR}/../headers
 )
 
 target_link_libraries(agent_sync_protocol

--- a/src/sync_protocol/CMakeLists.txt
+++ b/src/sync_protocol/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(agent_sync_protocol STATIC
   src/persistent_queue.cpp
   src/persistent_queue_storage.cpp
   ${GENERATED_HEADER}
+  src/agent_sync_protocol_c_interface.cpp
 )
 add_dependencies(agent_sync_protocol generate_flatbuffers)
 

--- a/src/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/sync_protocol/include/agent_sync_protocol.hpp
@@ -10,6 +10,7 @@
 #ifndef AGENT_SYNC_PROTOCOL_HPP
 #define AGENT_SYNC_PROTOCOL_HPP
 
+#include "agent_sync_protocol_c_interface.h"
 #include "inventorySync_generated.h"
 #include "ipersistent_queue.hpp"
 
@@ -47,8 +48,9 @@ class AgentSyncProtocol : public IAgentSyncProtocol
 {
     public:
         /// @brief Constructs the synchronization protocol handler.
+        /// @param mqFuncs Functions used to interact with MQueue.
         /// @param queue Optional persistent queue to use for message storage and retrieval.
-        explicit AgentSyncProtocol(std::shared_ptr<IPersistentQueue> queue = nullptr);
+        explicit AgentSyncProtocol(MQ_Functions mqFuncs, std::shared_ptr<IPersistentQueue> queue = nullptr);
 
         /// @copydoc IAgentSyncProtocol::persistDifference
         void persistDifference(const std::string& module,
@@ -61,6 +63,10 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         void synchronizeModule(const std::string& module, Wazuh::SyncSchema::Mode mode, bool realtime) override;
 
     private:
+
+        /// @brief Functions used to interact with MQueue.
+        MQ_Functions m_mqFuncs;
+
         /// @brief Persistent message queue used to store and replay differences for synchronization.
         std::shared_ptr<IPersistentQueue> m_persistentQueue;
 

--- a/src/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/sync_protocol/include/agent_sync_protocol.hpp
@@ -42,6 +42,12 @@ class IAgentSyncProtocol
 
         /// @brief Destructor
         virtual ~IAgentSyncProtocol() = default;
+
+        /// @brief Parses a FlatBuffer response message received from the manager.
+        /// @param data Pointer to the FlatBuffer-encoded message buffer.
+        /// @param size Size in bytes of the buffer.
+        /// @return true if the message was successfully parsed and processed; false otherwise.
+        virtual bool parseResponseBuffer(const uint8_t* data, size_t size) = 0;
 };
 
 class AgentSyncProtocol : public IAgentSyncProtocol
@@ -61,6 +67,12 @@ class AgentSyncProtocol : public IAgentSyncProtocol
 
         /// @copydoc IAgentSyncProtocol::synchronizeModule
         void synchronizeModule(const std::string& module, Wazuh::SyncSchema::Mode mode, bool realtime) override;
+
+        /// @brief Parses a FlatBuffer response message received from the manager.
+        /// @param data Pointer to the FlatBuffer-encoded message buffer.
+        /// @param size Size in bytes of the buffer.
+        /// @return true if the message was successfully parsed and processed; false otherwise.
+        bool parseResponseBuffer(const uint8_t* data, size_t size) override;
 
     private:
 

--- a/src/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/sync_protocol/include/agent_sync_protocol.hpp
@@ -21,46 +21,102 @@
 class IAgentSyncProtocol
 {
     public:
+        /// @brief Persist a difference in the buffer
+        /// @param module Module name
+        /// @param id Difference id (hash ok PKs)
+        /// @param operation Operation type
+        /// @param index Index where to send the difference
+        /// @param data Difference data
         virtual void persistDifference(const std::string& module,
                                        const std::string& id,
                                        Wazuh::SyncSchema::Operation operation,
                                        const std::string& index,
                                        const std::string& data) = 0;
 
+        /// @brief Synchronize a module with the server
+        /// @param module Module name
+        /// @param mode Sync mode
+        /// @param realtime Realtime sync
         virtual void synchronizeModule(const std::string& module, Wazuh::SyncSchema::Mode mode, bool realtime) = 0;
 
+        /// @brief Destructor
         virtual ~IAgentSyncProtocol() = default;
 };
 
 class AgentSyncProtocol : public IAgentSyncProtocol
 {
     public:
+        /// @brief Constructs the synchronization protocol handler.
+        /// @param queue Optional persistent queue to use for message storage and retrieval.
         explicit AgentSyncProtocol(std::shared_ptr<IPersistentQueue> queue = nullptr);
 
+        /// @copydoc IAgentSyncProtocol::persistDifference
         void persistDifference(const std::string& module,
                                const std::string& id,
                                Wazuh::SyncSchema::Operation operation,
                                const std::string& index,
                                const std::string& data) override;
 
+        /// @copydoc IAgentSyncProtocol::synchronizeModule
         void synchronizeModule(const std::string& module, Wazuh::SyncSchema::Mode mode, bool realtime) override;
 
     private:
-
+        /// @brief Persistent message queue used to store and replay differences for synchronization.
         std::shared_ptr<IPersistentQueue> m_persistentQueue;
 
+        /// @brief Queue
+        int m_queue = -1;
+
+        /// @brief Ensures that the queue is available
+        /// @return True on success, false on failure
+        bool ensureQueueAvailable();
+
+        /// @brief Sends a start message to the server
+        /// @param module Module name
+        /// @param mode Sync mode
+        /// @param realtime Realtime sync
+        /// @param session Session id reference
+        /// @param dataSize Size of data to send
+        /// @return True on success, false on failure
         bool sendStartAndWaitAck(const std::string& module, Wazuh::SyncSchema::Mode mode, bool realtime, uint64_t& session, size_t dataSize);
 
-        void sendDataMessages(uint64_t session,
+        /// @brief Receives a startack message from the server
+        /// @param session Session id reference
+        /// @return True on success, false on failure
+        bool receiveStartAck(uint64_t& session);
+
+        /// @brief Sends data messages to the server
+        /// @param module Module name
+        /// @param session Session id
+        /// @param data Data to send
+        /// @return True on success, false on failure
+        bool sendDataMessages(const std::string& module,
+                              uint64_t session,
                               const std::vector<PersistedData>& data);
 
-        void sendEnd(uint64_t session);
-        void sendFlatBufferMessageAsString(flatbuffers::span<uint8_t> fbData);
+        /// @brief Sends an end message to the server
+        /// @param module Module name
+        /// @param session Session id
+        /// @return True on success, false on failure
+        bool sendEndAndWaitAck(const std::string& module, uint64_t session);
+
+        /// @brief Receives an endack message from the server
+        /// @return True on success, false on failure
+        bool receiveEndAck();
+
+        /// @brief Receives a reqret message from the server
+        /// @return Ranges received
+        std::vector<std::pair<uint64_t, uint64_t>> receiveReqRet();
+
+        /// @brief Clears persisted differences for a module
+        /// @param module Module name
         void clearPersistedDifferences(const std::string& module);
 
-        // Simulated server communication
-        std::vector<std::pair<uint64_t, uint64_t>> receiveReqRet();
-        bool receiveEndAck(bool& success);
+        /// @brief Sends a flatbuffer message as a string to the server
+        /// @param fbData Flatbuffer data
+        /// @param module Module name
+        /// @return True on success, false on failure
+        bool sendFlatBufferMessageAsString(flatbuffers::span<uint8_t> fbData, const std::string& module);
 };
 
 #endif // AGENT_SYNC_PROTOCOL_HPP

--- a/src/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @brief Opaque handle to the AgentSyncProtocol C++ object.
+///
+/// Used to interact with the AgentSyncProtocol instance from C code.
+typedef struct AgentSyncProtocol AgentSyncProtocolHandle;
+
+/// @brief Function pointer type for starting a message queue.
+///
+/// @param key The identifier key for the message queue.
+/// @param type The type of queue or message.
+/// @param attempts The number of connection attempts.
+/// @return Integer status code (0 on success, non-zero on failure).
+typedef int (*mq_start_fn)(const char* key, short type, short attempts);
+
+/// @brief Function pointer type for sending a message to the queue.
+///
+/// @param queue The queue identifier.
+/// @param message The message payload to send.
+/// @param locmsg Additional location/context message (optional).
+/// @param loc A character representing the message location or type.
+/// @return Integer status code (0 on success, non-zero on failure).
+typedef int (*mq_send_fn)(int queue, const char* message, const char* locmsg, char loc);
+
+/// @brief Struct containing function pointers for MQ operations.
+///
+/// This structure provides the implementation of MQ start and send operations.
+typedef struct MQ_Functions
+{
+    /// Callback to start a message queue.
+    mq_start_fn start;
+
+    /// Callback to send a message.
+    mq_send_fn send;
+} MQ_Functions;
+
+/// @brief Creates an instance of AgentSyncProtocol.
+///
+/// @param mq_funcs Pointer to a MQ_Functions struct containing the MQ callbacks.
+/// @return A pointer to an opaque AgentSyncProtocol handle, or NULL on failure.
+AgentSyncProtocolHandle* asp_create(const MQ_Functions* mq_funcs);
+
+/// @brief Destroys an AgentSyncProtocol instance.
+///
+/// @param handle Pointer to the AgentSyncProtocol handle to destroy.
+void asp_destroy(AgentSyncProtocolHandle* handle);
+
+/// @brief Persists a difference (diff) for synchronization.
+///
+/// @param handle Pointer to the AgentSyncProtocol handle.
+/// @param module Module name associated with the diff.
+/// @param id Unique identifier for the diff (usually a hash).
+/// @param operation Type of operation (create, modify, delete).
+/// @param index Target index or destination for the diff.
+/// @param data JSON string representing the data to persist.
+void asp_persist_diff(AgentSyncProtocolHandle* handle,
+                      const char* module,
+                      const char* id,
+                      int operation,
+                      const char* index,
+                      const char* data);
+
+// @brief Triggers synchronization of a module.
+///
+/// @param handle Pointer to the AgentSyncProtocol handle.
+/// @param module The name of the module to synchronize.
+/// @param mode Synchronization mode (e.g., full, delta).
+/// @param realtime Boolean flag (non-zero = realtime mode, zero = batch mode).
+void asp_sync_module(AgentSyncProtocolHandle* handle,
+                     const char* module,
+                     int mode,
+                     int realtime);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -78,6 +78,13 @@ void asp_sync_module(AgentSyncProtocolHandle* handle,
                      int mode,
                      int realtime);
 
+/// @brief Parses a response buffer encoded in FlatBuffer format.
+/// @param handle Protocol handle.
+/// @param data Pointer to the FlatBuffer-encoded message.
+/// @param size Size of the message in bytes.
+/// @return 0 if parsed successfully, -1 on error.
+int asp_parse_response_buffer(AgentSyncProtocolHandle* handle, const uint8_t* data, size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/sync_protocol/src/agent_sync_protocol.cpp
@@ -10,19 +10,12 @@
 #include "agent_sync_protocol.hpp"
 #include "ipersistent_queue.hpp"
 #include "persistent_queue.hpp"
+#include "defs.h"
 
 #include <flatbuffers/flatbuffers.h>
 #include <iostream>
 
-extern "C"
-{
-#include "defs.h"
-
-#define SYNC_MQ 's'
-
-    int StartMQ(const char* key, short int type, short int n_attempts);
-    int SendMSG(int queue, const char* message, const char* locmsg, char loc);
-}
+constexpr char SYNC_MQ = 's';
 
 using namespace Wazuh::SyncSchema;
 

--- a/src/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -1,0 +1,77 @@
+#include "agent_sync_protocol_c_interface.h"
+#include "agent_sync_protocol.hpp"
+#include "persistent_queue.hpp"
+#include <memory>
+#include <string>
+
+/// @brief Provides a shared persistent queue instance for all AgentSyncProtocol instances.
+///
+/// This function returns a singleton `std::shared_ptr` to a `PersistentQueue`, ensuring
+/// that all AgentSyncProtocol objects created through the C interface share the same queue.
+///
+/// @return A shared pointer to the persistent queue instance.
+std::shared_ptr<IPersistentQueue> sharedQueue()
+{
+    static std::shared_ptr<IPersistentQueue> queue = std::make_shared<PersistentQueue>();
+    return queue;
+}
+
+/// @brief Wrapper struct that encapsulates the C++ AgentSyncProtocol implementation.
+///
+/// This wrapper is used to bridge the C interface and the internal C++ logic.
+/// It holds a unique_ptr to the actual `AgentSyncProtocol` instance, and is
+/// referenced via a C-compatible opaque pointer (`AgentSyncProtocolHandle*`).
+struct AgentSyncProtocolWrapper
+{
+    /// @brief The actual C++ implementation instance.
+    std::unique_ptr<AgentSyncProtocol> impl;
+
+    /// @brief Constructs the wrapper and initializes the AgentSyncProtocol instance.
+    ///
+    /// @param mq_funcs Structure containing the MQ callback functions provided from C.
+    AgentSyncProtocolWrapper(const MQ_Functions& mq_funcs)
+        : impl(std::make_unique<AgentSyncProtocol>(mq_funcs, sharedQueue())) {}
+};
+
+extern "C" {
+
+    AgentSyncProtocolHandle* asp_create(const MQ_Functions* mq_funcs)
+    {
+        if (!mq_funcs) return nullptr;
+
+        return reinterpret_cast<AgentSyncProtocolHandle*>(new AgentSyncProtocolWrapper(*mq_funcs));
+    }
+
+    void asp_destroy(AgentSyncProtocolHandle* handle)
+    {
+        delete reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
+    }
+
+    void asp_persist_diff(AgentSyncProtocolHandle* handle,
+                          const char* module,
+                          const char* id,
+                          int operation,
+                          const char* index,
+                          const char* data)
+    {
+        if (!handle || !module || !id || !index || !data) return;
+
+        auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
+        wrapper->impl->persistDifference(module, id,
+                                         static_cast<Wazuh::SyncSchema::Operation>(operation),
+                                         index, data);
+    }
+
+    void asp_sync_module(AgentSyncProtocolHandle* handle,
+                         const char* module,
+                         int mode,
+                         int realtime)
+    {
+        if (!handle || !module) return;
+
+        auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
+        wrapper->impl->synchronizeModule(module,
+                                         static_cast<Wazuh::SyncSchema::Mode>(mode), realtime != 0);
+    }
+
+} // extern "C"

--- a/src/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -74,4 +74,12 @@ extern "C" {
                                          static_cast<Wazuh::SyncSchema::Mode>(mode), realtime != 0);
     }
 
+    int asp_parse_response_buffer(AgentSyncProtocolHandle* handle, const uint8_t* data, size_t size)
+    {
+        if (!handle || !data || size == 0) return -1;
+
+        auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
+        return wrapper->impl->parseResponseBuffer(data, size) ? 0 : -1;
+    }
+
 } // extern "C"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/30246|

## Description

This pull request introduces the initial support for receiving and processing manager responses within the agent synchronization protocol. It includes the integration between the message queue system and the `AgentSyncProtocol `component, allowing the agent to correctly parse and handle response messages such as `StartAck`.

## Proposed Changes

- Created a C-compatible interface to expose selected `AgentSyncProtocol `methods for use in C code.
- Connected StartMQ and SendMSG function pointers to the `AgentSyncProtocol `logic via the MQ_Functions structure.
- Implemented a method to parse FlatBuffer responses from the manager (parseResponseBuffer()).
- Exposed the response parser method via a new C interface function: asp_parse_response_buffer().

### Results and Evidence

To validate the concept, an initial integration was performed with the FIM module.

> Note: This integration is not included in the scope of this pull request and will be properly addressed in future issues.

As part of this test, events generated by FIM were successfully sent through the new `AgentSyncProtocol `pipeline and received by the manager. The following output confirms that the synchronization mechanism is working as expected at this early stage:

```
{"timestamp":"2025-07-04T11:02:39.915-0300","agent":{"id":"007","name":"nico-VirtualBox","ip":"192.168.0.59"},"manager":{"name":"vagrant"},"id":"1751637759.8955","full_log":"{Start}","decoder":{},"location":"FIM"}
{"timestamp":"2025-07-04T11:02:39.962-0300","agent":{"id":"007","name":"nico-VirtualBox","ip":"192.168.0.59"},"manager":{"name":"vagrant"},"id":"1751637759.8955","full_log":"{\"data\":\"{data}\",\"counter\":14}","decoder":{"name":"json"},"data":{"data":"{data}","counter":"14"},"location":"FIM"}
{"timestamp":"2025-07-04T11:02:39.962-0300","agent":{"id":"007","name":"nico-VirtualBox","ip":"192.168.0.59"},"manager":{"name":"vagrant"},"id":"1751637759.8955","full_log":"{End}","decoder":{},"location":"FIM"}
{"timestamp":"2025-07-04T11:04:47.870-0300","agent":{"id":"007","name":"nico-VirtualBox","ip":"192.168.0.59"},"manager":{"name":"vagrant"},"id":"1751637887.8955","full_log":"{Start}","decoder":{},"location":"FIM"}
{"timestamp":"2025-07-04T11:04:47.930-0300","agent":{"id":"007","name":"nico-VirtualBox","ip":"192.168.0.59"},"manager":{"name":"vagrant"},"id":"1751637887.8955","full_log":"{\"data\":\"{data}\",\"counter\":15}","decoder":{"name":"json"},"data":{"data":"{data}","counter":"15"},"location":"FIM"}
{"timestamp":"2025-07-04T11:04:47.930-0300","agent":{"id":"007","name":"nico-VirtualBox","ip":"192.168.0.59"},"manager":{"name":"vagrant"},"id":"1751637887.8955","full_log":"{End}","decoder":{},"location":"FIM"}
```

### Artifacts Affected

### Configuration Changes

### Documentation Updates

### Tests Introduced

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->