### PR TITLE
Improve compatibility with modern Linux distributions by using ss instead of netstat

### DIFF
--- a/etc/templates/config/generic/localfile-commands.template
+++ b/etc/templates/config/generic/localfile-commands.template
@@ -6,7 +6,7 @@
 
   <localfile>
     <log_format>full_command</log_format>
-    <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
+    <command>(ss -tulpn | awk '/^(tcp|udp)/ { proto=$1; split($5, local, ":"); ip=local[1]; gsub(/%[a-zA-Z0-9_]+/, "", ip); port=local[2]; foreign=$6; match($0, /users:\(\("([^"]+)",pid=([0-9]+)/, proc); program=proc[2] "/" proc[1]; if (port != "") print proto, ip ":" port, foreign, program }' | sort -t: -k2,2n) 2>/dev/null || (netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d)</command>
     <alias>netstat listening ports</alias>
     <frequency>360</frequency>
   </localfile>


### PR DESCRIPTION
## Description
The netstat command is part of the deprecated net-tools package and is no longer installed by default on most modern Linux distributions. The recommended replacement is the ss command, which is included in the iproute2 package and provides more detailed and efficient socket statistics.

However, since Wazuh runs on a wide range of Linux systems—some of which may not have ss installed or available this change implements a fallback. It attempts to use ss first, and if that fails, falls back to netstat if available. This ensures broader compatibility across diverse environments without assuming the presence of either tool.

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
- [x] Source installation
- [x] Review logs syntax and correct language


<!-- Checks for huge PRs that affect the product more generally -->
- [x] Retrocompatibility with older Wazuh versions
