### PR TITLE
Avoid the loss of precision of the FIM inode field at values higher than 2ˆ53

### DIFF
--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -76,6 +76,7 @@
 #define FIM_REALTIME_FILE_NOT_SUPPORTED         "(6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: '%s'"
 #define FIM_FULL_EBPF_KERNEL_QUEUE              "(6958): Internal ebpf queue for kernel events is full. Too many eBPF events from system files. Next scheduled scan will recover lost data."
 #define FIM_ERROR_EBPF_HEALTHCHECK              "(6959): The eBPF healthcheck has failed. Switching all whodata eBPF configuration to audit."
+#define FIM_WARN_VALUEDOUBLE_CAST               "(6960): Inode value received as floating point (valuedouble) and cast to unsigned long long. Precision may be lost if the value exceeds 2^53."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -76,7 +76,7 @@
 #define FIM_REALTIME_FILE_NOT_SUPPORTED         "(6957): Realtime mode only supports directories, not files. Switching to scheduled mode. File: '%s'"
 #define FIM_FULL_EBPF_KERNEL_QUEUE              "(6958): Internal ebpf queue for kernel events is full. Too many eBPF events from system files. Next scheduled scan will recover lost data."
 #define FIM_ERROR_EBPF_HEALTHCHECK              "(6959): The eBPF healthcheck has failed. Switching all whodata eBPF configuration to audit."
-#define FIM_WARN_VALUEDOUBLE_CAST               "(6960): Inode value received as floating point (valuedouble) and cast to unsigned long long. Precision may be lost if the value exceeds 2^53."
+#define FIM_WARN_INODE_WRONG_TYPE               "(6960): Inode field received with a wrong type, it must be a string."
 
 /* Monitord warning messages */
 #define ROTATE_LOG_LONG_PATH                    "(7500): The path of the rotated log is too long."

--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -39,6 +39,7 @@ extern void mock_assert(const int result, const char* const expression,
 
 // Global variables
 static int _base_line = 0;
+#define JS_SAFE_INTEGER_LIMIT ((double)(1ULL << 53))
 
 static const char *FIM_EVENT_TYPE_ARRAY[] = {
     "added",
@@ -138,7 +139,7 @@ cJSON * fim_calculate_dbsync_difference(const fim_file_data *data,
             if (cJSON_IsString(aux)) {
                 strncpy(inode_str, cJSON_GetStringValue(aux), sizeof(inode_str) - 1);
                 inode_str[sizeof(inode_str) - 1] = '\0';
-            } else if (cJSON_IsNumber(aux)) {
+            } else if (cJSON_IsNumber(aux) && aux->valuedouble > JS_SAFE_INTEGER_LIMIT) {
                 snprintf(inode_str, sizeof(inode_str), "%llu", (uint64_t)aux->valuedouble);
                 mwarn(FIM_WARN_VALUEDOUBLE_CAST);
             }
@@ -283,7 +284,7 @@ static void dbsync_attributes_json(const cJSON *dbsync_event, const directory_t 
 
             if (cJSON_IsString(aux)) {
                 cJSON_AddStringToObject(attributes, "inode", cJSON_GetStringValue(aux));
-            } else if (cJSON_IsNumber(aux)) {
+            } else if (cJSON_IsNumber(aux) && aux->valuedouble > JS_SAFE_INTEGER_LIMIT) {
                 snprintf(inode_str, sizeof(inode_str), "%llu", (uint64_t)aux->valuedouble);
                 cJSON_AddStringToObject(attributes, "inode", inode_str);
                 mwarn(FIM_WARN_VALUEDOUBLE_CAST);

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -162,7 +162,7 @@ FIMDBErrorCode fim_db_init(int storage,
                         json["data"]["attributes"].erase("options");
                         json["data"]["attributes"].erase("path");
                         json["data"]["attributes"].erase("scanned");
-                        auto& obj = json.at("data").at("attributes").at("attributes");
+                        auto& obj = json.at("data").at("attributes");
 
                         if (obj.contains("inode") && !obj["inode"].is_string())
                         {

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -162,6 +162,12 @@ FIMDBErrorCode fim_db_init(int storage,
                         json["data"]["attributes"].erase("options");
                         json["data"]["attributes"].erase("path");
                         json["data"]["attributes"].erase("scanned");
+                        auto& obj = json.at("data").at("attributes").at("attributes");
+
+                        if (obj.contains("inode") && !obj["inode"].is_string())
+                        {
+                            obj["inode"] = obj["inode"].dump();
+                        }
 
                         FIMDB::instance().setTimeLastSyncMsg();
                     }
@@ -363,16 +369,9 @@ FIMDBErrorCode fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_ent
 
         try
         {
-
-            const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput
-            {
-                cJSON_Parse((*syncItem->toJSON()).dump().c_str())
-            };
-
-            if (dbsync_sync_txn_row(txn_handler, jsInput.get()) == 0)
-            {
-                retval = FIMDB_OK;
-            }
+            DBSyncTxn txn(txn_handler);
+            txn.syncTxnRow(*syncItem->toJSON());
+            retval = FIMDB_OK;
         }
         catch (std::exception& err)
         {

--- a/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
+++ b/src/syscheckd/src/db/tests/db/ComponentTest/fileInterface/fileTest.cpp
@@ -46,7 +46,7 @@ const auto insertStatement4 = R"({
         "table": "file_entry",
         "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":8432, "gid":"0", "group_name":"root",
         "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-        "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
+        "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810881, "last_event":1596489275,
         "mode":0, "mtime":1578075431, "options":131583, "path":"/tmp/test3.txt", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
         "uid":"0", "user_name":"fakeUser"}]
     }
@@ -418,7 +418,7 @@ TEST_F(DBTestFixture, TestFimDBFileInodeSearchWithBigInode)
         ASSERT_EQ(result, FIMDB_OK);
         callback_data.callback = callbackTestSearch;
         callback_data.context = NULL;
-        result = fim_db_file_inode_search(1152921500312810880, 8432, callback_data);
+        result = fim_db_file_inode_search(1152921500312810881, 8432, callback_data);
         ASSERT_EQ(result, FIMDB_OK);
     });
 }

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTest.cpp
@@ -28,7 +28,7 @@ void FileItemTest::SetUp()
     std::snprintf(data->hash_md5, sizeof(data->hash_md5), "4b531524aa13c8a54614100b570b3dc7");
     std::snprintf(data->hash_sha1, sizeof(data->hash_sha1), "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b");
     std::snprintf(data->hash_sha256, sizeof(data->hash_sha256), "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a");
-    data->inode = 1152921500312810880;
+    data->inode = 1152921500312810881;
     data->last_event = 1596489275;
     data->mode = FIM_SCHEDULED;
     data->mtime = 1578075431;
@@ -101,7 +101,7 @@ TEST_F(FileItemTest, fileItemConstructorFromJSON)
         {
             "attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":"0", "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810881, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":"0", "user_name":"fakeUser"
         }
@@ -148,7 +148,7 @@ TEST_F(FileItemTest, getFIMEntryWithJSONCtr)
         {
             "attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":"0", "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810881, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":"0", "user_name":"fakeUser"
         }
@@ -186,7 +186,7 @@ TEST_F(FileItemTest, getJSONWithFimCtr)
             "table": "file_entry",
             "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":"0", "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810881, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":"0", "user_name":"fakeUser"}]
         }
@@ -203,7 +203,7 @@ TEST_F(FileItemTest, getJSONWithJSONCtr)
             "table": "file_entry",
             "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":"0", "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810881, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":"0", "user_name":"fakeUser"}]
         }
@@ -220,7 +220,7 @@ TEST_F(FileItemTest, fileItemReportOldData)
             "table": "file_entry",
             "data":[{"attributes":"10", "checksum":"a2fbef8f81af27155dcee5e3927ff6243593b91a", "dev":2051, "gid":"0", "group_name":"root",
             "hash_md5":"4b531524aa13c8a54614100b570b3dc7", "hash_sha1":"7902feb66d0bcbe4eb88e1bfacf28befc38bd58b",
-            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810880, "last_event":1596489275,
+            "hash_sha256":"e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a", "inode":1152921500312810881, "last_event":1596489275,
             "mode":0, "mtime":1578075431, "options":131583, "path":"/etc/wgetrc", "perm":"-rw-rw-r--", "scanned":1, "size":4925,
             "uid":"0", "user_name":"fakeUser"}],"options":{"return_old_data": true, "ignore":["last_event"]}
         }

--- a/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTestWindows.cpp
+++ b/src/syscheckd/src/db/tests/db/dbItem/FileItem/dbFileItemTestWindows.cpp
@@ -28,7 +28,7 @@ void FileItemTest::SetUp()
     std::snprintf(data->hash_md5, sizeof(data->hash_md5), "4b531524aa13c8a54614100b570b3dc7");
     std::snprintf(data->hash_sha1, sizeof(data->hash_sha1), "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b");
     std::snprintf(data->hash_sha256, sizeof(data->hash_sha256), "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a");
-    data->inode = 1152921500312810880;
+    data->inode = 1152921500312810881;
     data->last_event = 1596489275;
     data->mode = FIM_SCHEDULED;
     data->mtime = 1578075431;
@@ -50,7 +50,7 @@ void FileItemTest::SetUp()
         {"hash_md5", "4b531524aa13c8a54614100b570b3dc7"},
         {"hash_sha1", "7902feb66d0bcbe4eb88e1bfacf28befc38bd58b"},
         {"hash_sha256", "e403b83dd73a41b286f8db2ee36d6b0ea6e80b49f02c476e0a20b4181a3a062a"},
-        {"inode", 1152921500312810880},
+        {"inode", 1152921500312810881},
         {"last_event", 1596489275},
         {"mode", 0},
         {"mtime", 1578075431},

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -833,7 +833,7 @@ static void test_fim_attributes_json(void **state) {
     assert_string_equal(cJSON_GetStringValue(group_name), "testing");
     cJSON *inode = cJSON_GetObjectItem(fim_data->json, "inode");
     assert_non_null(inode);
-    assert_int_equal(inode->valueint, 606060);
+    assert_string_equal(inode->valuestring, "606060");
     cJSON *mtime = cJSON_GetObjectItem(fim_data->json, "mtime");
     assert_non_null(mtime);
     assert_int_equal(mtime->valueint, 1570184223);
@@ -3877,9 +3877,9 @@ static void test_transaction_callback_modify_report_changes(void **state) {
 static void test_transaction_callback_delete(void **state) {
     txn_data_t *data = (txn_data_t *) *state;
 #ifndef TEST_WINAGENT
-    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #else
-    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #endif
 
     fim_txn_context_t *txn_context = data->txn_context;
@@ -3912,10 +3912,10 @@ static void test_transaction_callback_delete_report_changes(void **state) {
     fim_txn_context_t *txn_context = data->txn_context;
 #ifndef TEST_WINAGENT
     const char* path = "/etc/a_test_file.txt";
-    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #else
     const char *path = "c:\\windows\\a_test_file.txt";
-    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #endif
     data->dbsync_event = result;
 
@@ -3942,9 +3942,9 @@ static void test_transaction_callback_delete_report_changes(void **state) {
 static void test_transaction_callback_delete_full_db(void **state) {
     txn_data_t *data = (txn_data_t *) *state;
 #ifndef TEST_WINAGENT
-    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #else
-    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"last_event\":123456789,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #endif
 
     fim_txn_context_t *txn_context = data->txn_context;
@@ -3975,10 +3975,10 @@ static void test_transaction_callback_full_db(void **state) {
     txn_data_t *data = (txn_data_t *) *state;
 #ifndef TEST_WINAGENT
     char* path = "/etc/a_test_file.txt";
-    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #else
     char *path = "c:\\windows\\a_test_file.txt";
-    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":801978,\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
+    cJSON *result = cJSON_Parse("{\"path\":\"c:\\\\windows\\\\a_test_file.txt\",\"size\":11,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"801978\",\"mtime\":1645001693,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\"}");
 #endif
     char debug_msg[OS_SIZE_128] = {0};
 
@@ -4077,13 +4077,13 @@ void test_fim_calculate_dbsync_difference(void **state){
 
     #ifndef TEST_WINAGENT
         char* changed_data = "{\"size\":0, \"perm\":\"rw-rw-r--\", \"attributes\":\"NULL\", \"uid\":\"1000\", \"gid\":\"1000\", \
-        \"user_name\":\"root\", \"group_name\":\"root\", \"mtime\":123456789, \"inode\":1, \"hash_md5\":\"0123456789abcdef0123456789abcdef\", \
+        \"user_name\":\"root\", \"group_name\":\"root\", \"mtime\":123456789, \"inode\":\"1\", \"hash_md5\":\"0123456789abcdef0123456789abcdef\", \
         \"hash_sha1\":\"0123456789abcdef0123456789abcdef01234567\", \"hash_sha256\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \
         \"checksum\":\"0123456789abcdef0123456789abcdef01234567\" }";
     #else
         DEFAULT_FILE_DATA.options |= CHECK_ATTRS;
         char* changed_data = "{\"size\":0, \"perm\":\"{\\\"S-1-5-32-544\\\":{\\\"name\\\":\\\"Administrators\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"write_dac\\\",\\\"write_owner\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]},\\\"S-1-5-18\\\":{\\\"name\\\":\\\"SYSTEM\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"write_dac\\\",\\\"write_owner\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]},\\\"S-1-5-32-545\\\":{\\\"name\\\":\\\"Users\\\",\\\"allowed\\\":[\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"read_ea\\\",\\\"execute\\\",\\\"read_attributes\\\"]},\\\"S-1-5-11\\\":{\\\"name\\\":\\\"Authenticated Users\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]}}\", \"attributes\":\"NULL\", \"uid\":\"1000\", \"gid\":\"1000\", \
-        \"user_name\":\"root\", \"group_name\":\"root\", \"mtime\":123456789, \"inode\":1, \"hash_md5\":\"0123456789abcdef0123456789abcdef\", \
+        \"user_name\":\"root\", \"group_name\":\"root\", \"mtime\":123456789, \"inode\":\"1\", \"hash_md5\":\"0123456789abcdef0123456789abcdef\", \
         \"hash_sha1\":\"0123456789abcdef0123456789abcdef01234567\", \"hash_sha256\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \
         \"checksum\":\"0123456789abcdef0123456789abcdef01234567\" }";
     #endif
@@ -4114,7 +4114,7 @@ void test_fim_calculate_dbsync_difference(void **state){
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "user_name")->valuestring, "root");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "group_name")->valuestring, "root");
     assert_int_equal(cJSON_GetObjectItem(old_attributes, "mtime")->valueint, 123456789);
-    assert_int_equal(cJSON_GetObjectItem(old_attributes, "inode")->valueint, 1);
+    assert_string_equal(cJSON_GetObjectItem(old_attributes, "inode")->valuestring, "1");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "hash_md5")->valuestring, "0123456789abcdef0123456789abcdef");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "hash_sha1")->valuestring, "0123456789abcdef0123456789abcdef01234567");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "hash_sha256")->valuestring, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
@@ -4156,7 +4156,7 @@ void test_fim_calculate_dbsync_difference_no_changed_data(void **state){
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "user_name")->valuestring, "root");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "group_name")->valuestring, "root");
     assert_int_equal(cJSON_GetObjectItem(old_attributes, "mtime")->valueint, 123456789);
-    assert_int_equal(cJSON_GetObjectItem(old_attributes, "inode")->valueint, 1);
+    assert_string_equal(cJSON_GetObjectItem(old_attributes, "inode")->valuestring, "1");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "hash_md5")->valuestring, "0123456789abcdef0123456789abcdef");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "hash_sha1")->valuestring, "0123456789abcdef0123456789abcdef01234567");
     assert_string_equal(cJSON_GetObjectItem(old_attributes, "hash_sha256")->valuestring, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
@@ -4259,15 +4259,15 @@ static void test_dbsync_attributes_json(void **state) {
     directory_t configuration = { .options = -1, .tag = "tag_name" };
     json_struct_t *data = *state;
 #ifndef TEST_WINAGENT
-    const char *result_str = "{\"type\":\"file\",\"size\":11,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":271017,\"mtime\":1646124392,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"c0edc82c463da5f4ab8dd420a778a9688a923a72\"}";
-    cJSON *dbsync_event = cJSON_Parse("{\"attributes\":\"\",\"checksum\":\"c0edc82c463da5f4ab8dd420a778a9688a923a72\",\"dev\":64768,\"gid\":\"0\",\"group_name\":\"root\",\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"inode\":271017,\"last_event\":1646124394,\"mode\":0,\"mtime\":1646124392,\"options\":131583,\"path\":\"/etc/testfile\",\"perm\":\"rw-r--r--\",\"scanned\":1,\"size\":11,\"uid\":\"0\",\"user_name\":\"root\"}");
+    const char *result_str = "{\"type\":\"file\",\"size\":11,\"perm\":\"rw-r--r--\",\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"root\",\"group_name\":\"root\",\"inode\":\"271017\",\"mtime\":1646124392,\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"checksum\":\"c0edc82c463da5f4ab8dd420a778a9688a923a72\"}";
+    cJSON *dbsync_event = cJSON_Parse("{\"attributes\":\"\",\"checksum\":\"c0edc82c463da5f4ab8dd420a778a9688a923a72\",\"dev\":64768,\"gid\":\"0\",\"group_name\":\"root\",\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"inode\":\"271017\",\"last_event\":1646124394,\"mode\":0,\"mtime\":1646124392,\"options\":131583,\"path\":\"/etc/testfile\",\"perm\":\"rw-r--r--\",\"scanned\":1,\"size\":11,\"uid\":\"0\",\"user_name\":\"root\"}");
 #else
     cJSON *dbsync_event = cJSON_Parse("{\"size\":0, \"perm\":\"{\\\"S-1-5-32-544\\\":{\\\"name\\\":\\\"Administrators\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"write_dac\\\",\\\"write_owner\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]},\\\"S-1-5-18\\\":{\\\"name\\\":\\\"SYSTEM\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"write_dac\\\",\\\"write_owner\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]},\\\"S-1-5-32-545\\\":{\\\"name\\\":\\\"Users\\\",\\\"allowed\\\":[\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"read_ea\\\",\\\"execute\\\",\\\"read_attributes\\\"]},\\\"S-1-5-11\\\":{\\\"name\\\":\\\"Authenticated Users\\\",\\\"allowed\\\":[\\\"delete\\\",\\\"read_control\\\",\\\"synchronize\\\",\\\"read_data\\\",\\\"write_data\\\",\\\"append_data\\\",\\\"read_ea\\\",\\\"write_ea\\\",\\\"execute\\\",\\\"read_attributes\\\",\\\"write_attributes\\\"]}}\", \"attributes\":\"ARCHIVE\", \"uid\":\"0\", \"gid\":\"0\", \
-        \"user_name\":\"Administrators\", \"group_name\":\"\", \"mtime\":1646145212, \"inode\":0, \"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\", \
+        \"user_name\":\"Administrators\", \"group_name\":\"\", \"mtime\":1646145212, \"inode\":\"0\", \"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\", \
         \"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\", \"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\", \
         \"checksum\":\"ac962fef86e12e656b882fc88170fff24bf10a77\" }");
 
-    char *result_str = "{\"type\":\"file\",\"size\":0,\"perm\":{\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]},\"S-1-5-11\":{\"name\":\"Authenticated Users\",\"allowed\":[\"delete\",\"read_control\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]}},\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"Administrators\",\"inode\":0,\"mtime\":1646145212,\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"attributes\":\"ARCHIVE\",\"checksum\":\"ac962fef86e12e656b882fc88170fff24bf10a77\"}";
+    char *result_str = "{\"type\":\"file\",\"size\":0,\"perm\":{\"S-1-5-32-544\":{\"name\":\"Administrators\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-18\":{\"name\":\"SYSTEM\",\"allowed\":[\"delete\",\"read_control\",\"write_dac\",\"write_owner\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]},\"S-1-5-32-545\":{\"name\":\"Users\",\"allowed\":[\"read_control\",\"synchronize\",\"read_data\",\"read_ea\",\"execute\",\"read_attributes\"]},\"S-1-5-11\":{\"name\":\"Authenticated Users\",\"allowed\":[\"delete\",\"read_control\",\"synchronize\",\"read_data\",\"write_data\",\"append_data\",\"read_ea\",\"write_ea\",\"execute\",\"read_attributes\",\"write_attributes\"]}},\"uid\":\"0\",\"gid\":\"0\",\"user_name\":\"Administrators\",\"inode\":\"0\",\"mtime\":1646145212,\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"attributes\":\"ARCHIVE\",\"checksum\":\"ac962fef86e12e656b882fc88170fff24bf10a77\"}";
 #endif
     cJSON *attributes = cJSON_CreateObject();
 

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -200,7 +200,7 @@ static int setup_fim_data(void **state) {
     fim_data->new_data->user_name = strdup("test1");
     fim_data->new_data->group_name = strdup("testing1");
     fim_data->new_data->mtime = 1570184224;
-    fim_data->new_data->inode = 1152921500312810880;
+    fim_data->new_data->inode = 1152921500312810881;
     strcpy(fim_data->new_data->hash_md5, "3691689a513ace7e508297b583d7550d");
     strcpy(fim_data->new_data->hash_sha1, "07f05add1049244e7e75ad0f54f24d8094cd8f8b");
     strcpy(fim_data->new_data->hash_sha256, "672a8ceaea40a441f0268ca9bbb33e9959643c6262667b61fbe57694df224d40");


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/30437|

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

This PR includes an option to avoid the problem found in FIM related to the inodes of macOS 14+ versions, which are numbers higher than the floating data type limit (2^53). This prevents our implementation with cJSON, which takes int64 as valuedouble.
The solutions must be carefully go controlling all the use cases of this type of variable, by the agent, we are going to modify the variable type of the inode to text, string, whenever cJSON is going to be used, to avoid the loss of precision.
This must be done in multiple places and FIM paths, since each mode, schedule, realtime and whodata, and each alert type uses them differently.

## Configuration options

```
    <directories>/test</directories>
    <directories realtime="yes">/testrealtime</directories>
    <directories whodata="yes">/testwhodata</directories>
```


## Testing
- Sync message related to FIM event in the baseline scan:
```
2025/07/02 13:07:21 wazuh-syscheckd[69544] run_check.c:114 at fim_send_sync_state(): DEBUG: (6317): Sending integrity control message: {"component":"fim_file","data":{"attributes":{"attributes":"","checksum":"d089e4c6a9b49c4a3e60b242c4ee6285b3c2940b","gid":"0","group_name":"root","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":"917507","mtime":1751461329,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"index":"/test/file","timestamp":1751461341},"type":"state"}
```
- Added, modified and deleted events for schedule and realtime modes (whodata flow is identical to realtime for this case):
```
2025/07/02 12:57:01 wazuh-syscheckd[68192] run_check.c:125 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/test/file","version":2,"mode":"scheduled","type":"added","timestamp":1751461021,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":"917508","mtime":1751461013,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"0c96911b62894a17eb16b8ccce10a26115f5577c"}}}
2025/07/02 12:57:12 wazuh-syscheckd[68192] run_check.c:125 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/test/file","version":2,"mode":"scheduled","type":"modified","timestamp":1751461032,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":"917508","mtime":1751461022,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"e95ee9121743fef1553b6e4fecbdb0609d28bdf4"},"old_attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":"917508","mtime":1751461013,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"0c96911b62894a17eb16b8ccce10a26115f5577c"},"changed_attributes":["mtime"]}}
2025/07/02 12:57:23 wazuh-syscheckd[68192] run_check.c:125 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/test/file","version":2,"mode":"scheduled","type":"deleted","timestamp":1751461032,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":"917508","mtime":1751461022,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"e95ee9121743fef1553b6e4fecbdb0609d28bdf4"}}}
2025/07/02 12:57:25 wazuh-syscheckd[68192] run_check.c:125 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"data":{"attributes":{"checksum":"3b1a788b5b8778e3fbc6ba90bf7cb211d7a2bf29","gid":"0","group_name":"root","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":"1441796","mtime":1751461045,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"mode":"realtime","path":"/testrealtime/file","timestamp":1751461045,"type":"added","version":"2.0"},"type":"event"}
2025/07/02 12:57:26 wazuh-syscheckd[68192] run_check.c:125 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"data":{"attributes":{"checksum":"6f05c9d09c0d655efb16cd4290ef9b2a1bd8cffd","gid":"0","group_name":"root","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":"1441796","mtime":1751461046,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"changed_attributes":["mtime"],"mode":"realtime","old_attributes":{"checksum":"3b1a788b5b8778e3fbc6ba90bf7cb211d7a2bf29","gid":"0","group_name":"root","hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","inode":"1441796","mtime":1751461045,"perm":"rw-r--r--","size":0,"type":"file","uid":"0","user_name":"root"},"path":"/testrealtime/file","timestamp":1751461046,"type":"modified","version":"2.0"},"type":"event"}
2025/07/02 12:57:29 wazuh-syscheckd[68192] run_check.c:125 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"type":"event","data":{"path":"/testrealtime/file","version":2,"mode":"realtime","type":"deleted","timestamp":1751461046,"attributes":{"type":"file","size":0,"perm":"rw-r--r--","uid":"0","gid":"0","user_name":"root","group_name":"root","inode":"1441796","mtime":1751461046,"hash_md5":"d41d8cd98f00b204e9800998ecf8427e","hash_sha1":"da39a3ee5e6b4b0d3255bfef95601890afd80709","hash_sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","checksum":"6f05c9d09c0d655efb16cd4290ef9b2a1bd8cffd"}}}
```

