### PR TITLE
Add rule to detect root-owned files with world-writable permissions

### DIFF
--- a/ruleset/rules/0015-ossec_rules.xml
+++ b/ruleset/rules/0015-ossec_rules.xml
@@ -169,6 +169,12 @@
     <group>rootcheck,</group>
   </rule>
 
+  <rule id="522" level="2">
+    <if_sid>510</if_sid>
+    <regex>File '(\S+)' is owned by root and has written permissions to anyone</regex>
+    <description>File with world writable permissions found.</description>
+  </rule>
+
   <!-- Process monitoring rules -->
   <rule id="530" level="0">
     <if_sid>500</if_sid>


### PR DESCRIPTION
## Description

This pull request introduces a new rule to specifically detect files owned by `root` that have world-writable permissions. These files are currently reported under a generic Rootcheck rule (`510`), which may lead to noise or lack of specificity.

The goal is to isolate this condition into its own rule with a lower alert level to reduce false positives while maintaining visibility.

## Proposed Changes

* Add rule `522` under the Rootcheck rule hierarchy.
* Match alerts with the message pattern:
  `File '/path' is owned by root and has written permissions to anyone`
* Assign a reduced alert level (`2`) to better reflect its severity.
* Rule hierarchy updated as follows:

```yaml
500: Grouping of Wazuh rules
└── 509: Rootcheck event
    └── 510: Host-based anomaly detection event
        └── 522: File owned by root with global write permissions
```

### Rule added

```xml
<rule id="522" level="2">
  <if_sid>510</if_sid>
  <regex>File '(\S+)' is owned by root and has written permissions to anyone</regex>
  <description>File with world writable permissions found.</description>
</rule>
```

## Results and Evidence

### Configuration

```xml
<rootcheck>
  <check_sys>yes</check_sys>
</rootcheck>
```

### Reproduction steps

```bash
touch /etc/dummy.conf
chown root:root /etc/dummy.conf
chmod o+w /etc/dummy.conf
```

### Alert before the change

```
** Alert 1750952717.0: - ossec,rootcheck,pci_dss_10.6.1,gdpr_IV_35.7.d,
2025 Jun 26 17:45:17 Rocket->rootcheck
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
File '/etc/dummy.conf' is owned by root and has written permissions to anyone.
title: File is owned by root and has written permissions to anyone.
file: /etc/dummy.conf
```

### Alert after the change

No alert is triggered by rule `510`. If uncommented, rule `522` properly matches and reports with level `2`.

## Artifacts Affected

* Rule file `0015-wazuh_rules.xml`

## Configuration Changes

No configuration changes affected.

## Documentation Updates

No related documentation affected.

## Tests Introduced

No tests introduced as the related input is not a _localfile_ log.

## Review Checklist

* [ ] Code changes reviewed
* [ ] Relevant evidence provided
* [ ] Tests cover the new functionality
* [ ] Configuration changes documented
* [ ] Developer documentation reflects the changes
* [ ] Meets requirements and/or definition of done
* [ ] No unresolved dependencies with other issues
