### PR TITLE
Replace analysisd for wazuh-engine

### DIFF
--- a/src/engine/source/base/CMakeLists.txt
+++ b/src/engine/source/base/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(base_utest
     ${UNIT_SRC_DIR}/error_test.cpp
     ${UNIT_SRC_DIR}/timer_test.cpp
     ${UNIT_SRC_DIR}/expression_test.cpp
+    ${UNIT_SRC_DIR}/process_test.cpp
     ${UNIT_SRC_DIR}/utils/singletonLocator_test.cpp
     ${UNIT_SRC_DIR}/utils/keyValue_test.cpp
     ${UNIT_SRC_DIR}/utils/evpHelper_test.cpp

--- a/src/engine/source/base/include/base/process.hpp
+++ b/src/engine/source/base/include/base/process.hpp
@@ -1,0 +1,99 @@
+#ifndef _BASE_PROCESS_HPP
+#define _BASE_PROCESS_HPP
+
+#include <filesystem>
+#include <fstream>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <fmt/format.h>
+
+#include <base/error.hpp>
+
+namespace base
+{
+/**
+ * @brief Transforms the current process into a daemon (double fork + detach).
+ *
+ * @return std::nullopt if successful, otherwise base::Error
+ */
+OptError goDaemon()
+{
+    pid_t pid = fork();
+    if (pid < 0)
+    {
+        return Error{fmt::format("FORK_ERROR (1st): {} ({})", std::strerror(errno), errno)};
+    }
+    if (pid > 0)
+    {
+        exit(EXIT_SUCCESS);  // Parent exits
+    }
+
+    if (setsid() < 0)
+    {
+        return Error{fmt::format("SETSID_ERROR: {} ({})", std::strerror(errno), errno)};
+    }
+
+    pid = fork();
+    if (pid < 0)
+    {
+        return Error{fmt::format("FORK_ERROR (2nd): {} ({})", std::strerror(errno), errno)};
+    }
+    if (pid > 0)
+    {
+        exit(EXIT_SUCCESS);  // First child exits
+    }
+
+    // Optional: set file mode creation mask
+    umask(027);
+
+    // Redirect stdin, stdout, stderr to /dev/null
+    int fd = open("/dev/null", O_RDWR);
+    if (fd >= 0)
+    {
+        dup2(fd, STDIN_FILENO);
+        dup2(fd, STDOUT_FILENO);
+        dup2(fd, STDERR_FILENO);
+        close(fd);
+    }
+    else
+    {
+        return Error{fmt::format("REDIRECT_ERROR: Could not open /dev/null - {} ({})", std::strerror(errno), errno)};
+    }
+
+    return std::nullopt;
+}
+
+/**
+ * @brief Creates a PID file for the specified service name.
+ *
+ * @param path Directory where the PID file will be written.
+ * @param name Service name (used in filename).
+ * @param pid Process ID to write.
+ * @return std::nullopt if successful, otherwise a base::Error describing the issue.
+ */
+OptError createPID(const std::string& path, const std::string& name, int pid)
+{
+    const auto file = std::filesystem::path(path) / fmt::format("{}-{}.pid", name, pid);
+
+    std::ofstream ofs(file, std::ios::trunc);
+    if (!ofs)
+    {
+        return Error{fmt::format("FILE_ERROR: {} - {} ({})", file.string(), std::strerror(errno), errno)};
+    }
+
+    ofs << pid << '\n';
+    ofs.close();
+
+    if (chmod(file.c_str(), 0640) != 0)
+    {
+        return Error{fmt::format("CHMOD_ERROR: {} - {} ({})", file.string(), std::strerror(errno), errno)};
+    }
+
+    return std::nullopt;
+}
+
+} // namespace base
+
+#endif // _BASE_PROCESS_HPP

--- a/src/engine/source/base/test/src/unit/process_test.cpp
+++ b/src/engine/source/base/test/src/unit/process_test.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+
+#include <base/process.hpp>
+
+using namespace base;
+namespace fs = std::filesystem;
+
+// Exit codes for goDaemon functional test
+static constexpr int EXIT_DAEMON_FAILURE = 2;
+static constexpr int EXIT_WRITE_FAILURE = 3;
+
+// Test createPID success scenario
+TEST(CreatePIDTest, Success)
+{
+    // Arrange
+    fs::path tmpDir = fs::temp_directory_path() / "base_process_test_success";
+    fs::create_directory(tmpDir);
+    std::string svcName = "svc";
+    int pidValue = 12345;
+
+    // Act
+    auto result = createPID(tmpDir.string(), svcName, pidValue);
+
+    // Assert
+    ASSERT_FALSE(isError(result));
+    fs::path pidFile = tmpDir / (svcName + "-" + std::to_string(pidValue) + ".pid");
+    ASSERT_TRUE(fs::exists(pidFile));
+
+    std::ifstream ifs(pidFile);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content;
+    std::getline(ifs, content);
+    EXPECT_EQ(content, std::to_string(pidValue));
+    ifs.close();
+
+    struct stat st;
+    ASSERT_EQ(stat(pidFile.c_str(), &st), 0);
+    mode_t mode = st.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+    EXPECT_EQ(mode, (S_IRUSR | S_IWUSR | S_IRGRP));
+
+    // Cleanup
+    fs::remove_all(tmpDir);
+}
+
+// Test createPID failure scenario
+TEST(CreatePIDTest, Failure)
+{
+    std::string invalidPath = "/tmp/nonexistent_dir_abc";
+    auto result = createPID(invalidPath, "svc", 1);
+    ASSERT_TRUE(isError(result));
+}
+
+// Functional test for goDaemon: grandchild should continue execution
+TEST(GoDaemonFunctionalTest, ContinuesInGrandchild)
+{
+    int fds[2];
+    ASSERT_EQ(pipe(fds), 0);
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+
+    if (pid == 0)
+    {
+        // Child context for goDaemon
+        close(fds[0]);
+        auto err = goDaemon();
+        if (isError(err))
+        {
+            exit(EXIT_DAEMON_FAILURE);
+        }
+        // In grandchild: signal success
+        const char msg = 'X';
+        ssize_t w = write(fds[1], &msg, 1);
+        if (w != 1)
+        {
+            exit(EXIT_WRITE_FAILURE);
+        }
+        exit(EXIT_SUCCESS);
+    }
+
+    // Parent context: read from pipe
+    close(fds[1]);
+    char buf = 0;
+    ssize_t n = read(fds[0], &buf, 1);
+    EXPECT_EQ(n, 1);
+    EXPECT_EQ(buf, 'X');
+
+    int status;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), EXIT_SUCCESS);
+}

--- a/src/engine/source/base/test/src/unit/process_test.cpp
+++ b/src/engine/source/base/test/src/unit/process_test.cpp
@@ -2,7 +2,7 @@
 
 #include <base/process.hpp>
 
-using namespace base;
+using namespace base::process;
 namespace fs = std::filesystem;
 
 // Exit codes for goDaemon functional test
@@ -62,8 +62,12 @@ TEST(GoDaemonFunctionalTest, ContinuesInGrandchild)
     {
         // Child context for goDaemon
         close(fds[0]);
-        auto err = goDaemon();
-        if (isError(err))
+
+        try
+        {
+            goDaemon();
+        }
+        catch (...)
         {
             exit(EXIT_DAEMON_FAILURE);
         }

--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -52,7 +52,8 @@ constexpr std::string_view ARCHIVER_ENABLED = "/engine/archiver/enabled";
 constexpr std::string_view ARCHIVER_PATH = "/engine/archiver/path";
 
 constexpr std::string_view PID_FILE_PATH = "/engine/pid/path";
-
+constexpr std::string_view USER = "/engine/user";
+constexpr std::string_view GROUP = "/engine/group";
 }; // namespace conf::key
 
 #endif // _CONF_KEYS_HPP

--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -51,6 +51,8 @@ constexpr std::string_view METRICS_EXPORT_TIMEOUT = "/engine/metrics/export_time
 constexpr std::string_view ARCHIVER_ENABLED = "/engine/archiver/enabled";
 constexpr std::string_view ARCHIVER_PATH = "/engine/archiver/path";
 
+constexpr std::string_view PID_FILE_PATH = "/engine/pid/path";
+
 }; // namespace conf::key
 
 #endif // _CONF_KEYS_HPP

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -102,8 +102,10 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
     addUnit<bool>(key::ARCHIVER_ENABLED, "WAZUH_ARCHIVER_ENABLED", false);
     addUnit<std::string>(key::ARCHIVER_PATH, "WAZUH_ARCHIVER_PATH", (wazuhRoot / "logs/archives/archives.json").c_str());
 
-    // PID file path
+    // Process module
     addUnit<std::string>(key::PID_FILE_PATH, "WAZUH_ENGINE_PID_FILE_PATH", (wazuhRoot / "var/run/").c_str());
+    addUnit<std::string>(key::USER, "WAZUH_ENGINE_USER", "wazuh");
+    addUnit<std::string>(key::GROUP, "WAZUH_ENGINE_GROUP", "wazuh");
 };
 
 void Conf::validate(const json::Json& config) const

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -46,10 +46,10 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
     addUnit<std::string>(key::LOGGING_LEVEL, "WAZUH_LOG_LEVEL", "info");
 
     // Store module
-    addUnit<std::string>(key::STORE_PATH, "WAZUH_STORE_PATH", "/var/ossec/engine/store");
+    addUnit<std::string>(key::STORE_PATH, "WAZUH_STORE_PATH", (wazuhRoot / "engine/store").c_str());
 
     // KVDB module
-    addUnit<std::string>(key::KVDB_PATH, "WAZUH_KVDB_PATH", "/var/ossec/engine/kvdb/");
+    addUnit<std::string>(key::KVDB_PATH, "WAZUH_KVDB_PATH", (wazuhRoot / "engine/kvdb/").c_str());
 
     // Indexer connector
     addUnit<std::string>(key::INDEXER_INDEX, "WAZUH_INDEXER_INDEX", "wazuh-alerts-5.x-0001");
@@ -89,7 +89,7 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
     addUnit<int>(key::SERVER_EVENT_THREADS, "WAZUH_SERVER_EVENT_THREADS", 1);
 
     // TZDB module
-    addUnit<std::string>(key::TZDB_PATH, "WAZUH_TZDB_PATH", "/var/ossec/queue/tzdb");
+    addUnit<std::string>(key::TZDB_PATH, "WAZUH_TZDB_PATH", (wazuhRoot / "queue/tzdb").c_str());
     addUnit<bool>(key::TZDB_AUTO_UPDATE, "WAZUH_TZDB_AUTO_UPDATE", false);
     addUnit<std::string>(key::TZDB_FORCE_VERSION_UPDATE, "WAZUH_TZDB_FORCE_VERSION_UPDATE", "");
 
@@ -100,10 +100,10 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
 
     // Archiver module
     addUnit<bool>(key::ARCHIVER_ENABLED, "WAZUH_ARCHIVER_ENABLED", false);
-    addUnit<std::string>(key::ARCHIVER_PATH, "WAZUH_ARCHIVER_PATH", "/var/ossec/logs/archives/archives.json");
+    addUnit<std::string>(key::ARCHIVER_PATH, "WAZUH_ARCHIVER_PATH", (wazuhRoot / "logs/archives/archives.json").c_str());
 
     // PID file path
-    addUnit<std::string>(key::PID_FILE_PATH, "WAZUH_ENGINE_PID_FILE_PATH", "/var/ossec/var/run/");
+    addUnit<std::string>(key::PID_FILE_PATH, "WAZUH_ENGINE_PID_FILE_PATH", (wazuhRoot / "var/run/").c_str());
 };
 
 void Conf::validate(const json::Json& config) const

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -101,6 +101,9 @@ Conf::Conf(std::shared_ptr<IApiLoader> apiLoader)
     // Archiver module
     addUnit<bool>(key::ARCHIVER_ENABLED, "WAZUH_ARCHIVER_ENABLED", false);
     addUnit<std::string>(key::ARCHIVER_PATH, "WAZUH_ARCHIVER_PATH", "/var/ossec/logs/archives/archives.json");
+
+    // PID file path
+    addUnit<std::string>(key::PID_FILE_PATH, "WAZUH_ENGINE_PID_FILE_PATH", "/var/ossec/var/run/");
 };
 
 void Conf::validate(const json::Json& config) const

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -1128,7 +1128,7 @@ InstallLocal()
     ${INSTALL} -m 0750 -o root -g 0 build/engine/wazuh-engine ${INSTALLDIR}/bin
 
     installEngineStore
-
+    ${INSTALL} -d -m 0770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/queue/tzdb
     # TODO Deletes old ruleset and stats, rootcheck and SCA?
     ${INSTALL} -m 0660 -o root -g ${WAZUH_GROUP} ../ruleset/rootcheck/db/*.txt ${INSTALLDIR}/etc/rootcheck
 


### PR DESCRIPTION
|Related issue|
|---|
|#30239|

## Description

This PR updates the service management and runtime layout for Wazuh-Engine by:

1. **`wazuh-control` Script Updates**  
   - Removed all references and handlers for the deprecated daemons:  
     - `wazuh-analysisd`  
     - `wazuh-maild`  
     - `wazuh-dbd` (not to be confused with `wazuh-db`)  
     - `wazuh-reportd`  
   - Added support for `wazuh-engine` in the `start`, `stop`, `restart` and `status` commands.  
   - Implemented a helper that checks if the engine is running by:  
     1. Inspecting its PID file.  
     2. Sending a test query over the engine’s UNIX socket.

2. **Daemonization & PID File Helpers**  
   - Introduced `base::goDaemon()` to perform the standard double-fork + session‐detach and redirect stdio to `/dev/null`.  
   - Introduced `base::createPID(path, name, pid)` to write a `<name>-<pid>.pid` file with secure permissions.  
   - Added the engine’s PID file path configuration (`pid_file_path`) to the `engine.conf` loader.

3. **Configuration**  
   - Extended the engine’s configuration schema to include `pid_file_path`, so the control script and engine binary agree on where to read/write the PID file.

4. **Tests**  
   - Added unit tests for `base::goDaemon()` verifying:  
     - Parent exits correctly.  
     - Grandchild continues execution.  
   - Added unit tests for `base::createPID()` covering:  
     - Successful file creation, content and permissions.  
     - Error handling on invalid paths.  
   - Integrated these tests into the CI pipeline to prevent regressions.