### PR TITLE
Update cJSON version in README from 1.7.12 to 1.7.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Here you can find all the automation tools maintained by the Wazuh team.
 |Software|Version|Author|License|
 |---|---|---|---|
 |[bzip2](https://github.com/libarchive/bzip2)|1.0.8|Julian Seward|BSD License|
-|[cJSON](https://github.com/DaveGamble/cJSON)|1.7.12|Dave Gamble|MIT License|
+|[cJSON](https://github.com/DaveGamble/cJSON)|1.7.18|Dave Gamble|MIT License|
 |[cPython](https://github.com/python/cpython)|3.10.16|Guido van Rossum|Python Software Foundation License version 2|
 |[cURL](https://github.com/curl/curl)|8.10.0|Daniel Stenberg|MIT License|
 |[Flatbuffers](https://github.com/google/flatbuffers/)|23.5.26|Google Inc.|Apache 2.0 License|


### PR DESCRIPTION
The README file still references an outdated version of the cJSON library (1.7.12).

This pull request updates the reference to the current version used in the project, 1.7.18, to ensure consistency between the documentation and actual dependencies.

Closes #29399.