### PR TITLE
Improve agent healthcheck robustness

### DIFF
--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/healthcheck.py
@@ -6,6 +6,9 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
+    if code := get_agent_health_base():
+        exit(code)
+
     # Check that the syscollector differences are sent. This is part of the DBs synchronization process, and it happens
     # after the scan (modules with debug = 2 is needed).
     sync_sent_logs = ('DEBUG: Sync sent: {"component":'f'"{component}"' for component in
@@ -13,5 +16,4 @@ if __name__ == "__main__":
                        'syscollector_packages', 'syscollector_network_iface', 'syscollector_network_protocol',
                        'syscollector_network_address'))
 
-    exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs)
-         or get_agent_health_base())
+    exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs))

--- a/api/test/integration/env/configurations/experimental/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/experimental/agent/healthcheck/legacy_healthcheck.py
@@ -6,5 +6,7 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
-    exit(check(os.system("grep -q 'wazuh-modulesd:syscollector.*INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
-         or get_agent_health_base())
+    exit(check(any([
+        get_agent_health_base(),
+        os.system("grep -q 'wazuh-modulesd:syscollector.*INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+    ])))

--- a/api/test/integration/env/configurations/sca/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/sca/agent/healthcheck/healthcheck.py
@@ -6,6 +6,7 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
-    exit(check(
-        os.system("grep -q 'sca.*: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log"))
-         or get_agent_health_base())
+    exit(check(any([
+        get_agent_health_base(),
+        os.system("grep -q 'sca.*: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log")
+    ])))

--- a/api/test/integration/env/configurations/sca/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/sca/agent/healthcheck/legacy_healthcheck.py
@@ -6,6 +6,7 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
-    exit(check(
-        os.system("grep -q 'sca.*: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log"))
-         or get_agent_health_base())
+    exit(check(any([
+        get_agent_health_base(),
+        os.system("grep -q 'sca.*: INFO: Security Configuration Assessment scan finished.' /var/ossec/logs/ossec.log")
+    ])))

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/healthcheck.py
@@ -6,6 +6,7 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
-    exit(check(os.system(
-        "grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log"))
-         or get_agent_health_base())
+    exit(check(any([
+        get_agent_health_base(),
+        os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    ])))

--- a/api/test/integration/env/configurations/syscheck/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/syscheck/agent/healthcheck/legacy_healthcheck.py
@@ -6,6 +6,7 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
-    exit(check(os.system(
-        "grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log"))
-         or get_agent_health_base())
+    exit(check(any([
+        get_agent_health_base,
+        os.system("grep -q 'syscheckd: INFO: (6009): File integrity monitoring scan ended.' /var/ossec/logs/ossec.log")
+    ])))

--- a/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/agent/healthcheck/healthcheck.py
@@ -6,6 +6,9 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
+    if code := get_agent_health_base():
+        exit(code)
+
     # Check that the syscollector differences are sent. This is part of the DBs synchronization process, and it happens
     # after the scan (modules with debug = 2 is needed).
     sync_sent_logs = ('DEBUG: Sync sent: {"component":'f'"{component}"' for component in
@@ -13,5 +16,4 @@ if __name__ == "__main__":
                        'syscollector_packages', 'syscollector_network_iface', 'syscollector_network_protocol',
                        'syscollector_network_address'))
 
-    exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs)
-         or get_agent_health_base())
+    exit(any(check(os.system(f"grep -q '{log}' /var/ossec/logs/ossec.log")) for log in sync_sent_logs))

--- a/api/test/integration/env/configurations/syscollector/agent/healthcheck/legacy_healthcheck.py
+++ b/api/test/integration/env/configurations/syscollector/agent/healthcheck/legacy_healthcheck.py
@@ -6,5 +6,7 @@ sys.path.append('/tools')
 from healthcheck_utils import get_agent_health_base, check
 
 if __name__ == "__main__":
-    exit(check(os.system("grep -q 'wazuh-modulesd:syscollector.*INFO: Evaluation finished.' /var/ossec/logs/ossec.log"))
-         or get_agent_health_base())
+    exit(check(any([
+        get_agent_health_base(),
+        os.system("grep -q 'wazuh-modulesd:syscollector.*INFO: Evaluation finished.' /var/ossec/logs/ossec.log")
+    ])))


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/29861 |

## Description

Inverts the agents healthcheck logic to ensure no restart is in progress before looking at the logs for the specific module.

### Tests

<details><summary>API integration tests</summary>

[Build](https://jenkins-staging.qa.wazuh.info/job/Test_integration_endpoints/98)

| **Test name** | **Pass** | **XPass** | **Skip** | **XFail** | **Fail** | **Issues Ref.** | **Status** |
|--|--|--|--|--|--|--|--|
| test_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_DELETE_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_GET_endpoints.tavern.yaml | 93 | 0 | 0 | 0 | 2 | https://github.com/wazuh/wazuh/issues/30452 | :yellow_circle: |
| test_agent_POST_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_agent_PUT_endpoints.tavern.yaml | 10 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_cluster_endpoints.tavern.yaml | 49 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_decoder_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_default_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_event_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_manager_endpoints.tavern.yaml | 35 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_agent_endpoints.tavern.yaml | 42 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_cluster_endpoints.tavern.yaml | 19 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_manager_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 1 | https://github.com/wazuh/wazuh/issues/30467#issuecomment-3008001155 | :red_circle: |
| test_rbac_black_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_syscollector_endpoints.tavern.yaml | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_black_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_active_response_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_agent_endpoints.tavern.yaml | 42 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_all_endpoints.tavern.yaml | 162 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cdb_list_endpoints.tavern.yaml | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_cluster_endpoints.tavern.yaml | 19 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_decoder_endpoints.tavern.yaml | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_event_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_experimental_endpoints.tavern.yaml | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_logtest_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_manager_endpoints.tavern.yaml | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_mitre_endpoints.tavern.yaml | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_overview_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_rule_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_sca_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_security_endpoints.tavern.yaml | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_syscollector_endpoints.tavern.yaml | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rbac_white_task_endpoints.tavern.yaml | 1 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rootcheck_endpoints.tavern.yaml | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_rule_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_sca_endpoints.tavern.yaml | 45 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_DELETE_endpoints.tavern.yaml | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_GET_endpoints.tavern.yaml | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_POST_endpoints.tavern.yaml | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_security_PUT_endpoints.tavern.yaml | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscheck_endpoints.tavern.yaml | 34 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_syscollector_endpoints.tavern.yaml | 159 | 0 | 0 | 0 | 0 |  | :green_circle: |
| test_task_endpoints.tavern.yaml | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |

</details>