### PR TITLE
Add artifacts on failed integration builds

### DIFF
--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -87,8 +87,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_api/
-      - name: Force fail for logs test
-        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -87,3 +87,19 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_api/
+      # Collect logs if tests fail
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          mkdir -p wazuh-logs
+          sudo cp /var/ossec/logs/ossec.log wazuh-logs/ || true
+          sudo cp /var/ossec/logs/api.log wazuh-logs/ || true
+          sudo journalctl -u wazuh-manager > wazuh-logs/wazuh-manager.service.log || true
+          sudo tar -czf wazuh-logs.tar.gz wazuh-logs
+      # Upload logs artifact if test fails
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wazuh-logs-${{ github.job }}
+          path: wazuh-logs.tar.gz

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -90,8 +90,6 @@ jobs:
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_api/
-      - name: Force fail for logs test
-        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -97,6 +97,7 @@ jobs:
           sudo cp /var/ossec/logs/ossec.log /tmp/wazuh-logs/ || true
           sudo cp /var/ossec/logs/api.log /tmp/wazuh-logs/ || true
           sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
+          sudo chown -R $(whoami):$(whoami) /tmp/wazuh-logs || true
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -85,15 +85,17 @@ jobs:
       # Run integration tests.
       - name: Run API tests
         run: |
+          mkdir -p /tmp/wazuh-logs
+          sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
+          sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_api/
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
         run: |
-          mkdir -p /tmp/wazuh-logs
-          sudo cp /var/ossec/logs/ossec.log /tmp/wazuh-logs/ || true
-          sudo cp /var/ossec/logs/api.log /tmp/wazuh-logs/ || true
           sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
           sudo chown -R $(whoami):$(whoami) /tmp/wazuh-logs || true
       # Upload logs artifact if test fails

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -87,19 +87,20 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_api/
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
         run: |
-          mkdir -p wazuh-logs
-          sudo cp /var/ossec/logs/ossec.log wazuh-logs/ || true
-          sudo cp /var/ossec/logs/api.log wazuh-logs/ || true
-          sudo journalctl -u wazuh-manager > wazuh-logs/wazuh-manager.service.log || true
-          sudo tar -czf wazuh-logs.tar.gz wazuh-logs
+          mkdir -p /tmp/wazuh-logs
+          sudo cp /var/ossec/logs/ossec.log /tmp/wazuh-logs/ || true
+          sudo cp /var/ossec/logs/api.log /tmp/wazuh-logs/ || true
+          sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: wazuh-logs-${{ github.job }}
-          path: wazuh-logs.tar.gz
+          path: /tmp/wazuh-logs

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -87,6 +87,8 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_api/
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -80,17 +80,18 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_api/
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
         run: |
-          mkdir -p wazuh-logs
-          sudo journalctl -u wazuh-manager > wazuh-logs/wazuh-manager.service.log || true
-          sudo tar -czf wazuh-logs.tar.gz wazuh-logs
+          mkdir -p /tmp/wazuh-logs
+          sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: wazuh-logs-${{ github.job }}
-          path: wazuh-logs.tar.gz
+          path: /tmp/wazuh-logs

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -83,8 +83,6 @@ jobs:
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
           sudo python3 -m pytest --tier 2 test_api/
-      - name: Force fail for logs test
-        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -78,14 +78,19 @@ jobs:
       # Run integration tests.
       - name: Run API tests
         run: |
+          mkdir -p /tmp/wazuh-logs
+          sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
+          sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
-          sudo python -m pytest --tier 2 test_api/
+          sudo python3 -m pytest --tier 2 test_api/
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
         run: |
-          mkdir -p /tmp/wazuh-logs
           sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
+          sudo chown -R $(whoami):$(whoami) /tmp/wazuh-logs || true
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -80,3 +80,17 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_api/
+      # Collect logs if tests fail
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          mkdir -p wazuh-logs
+          sudo journalctl -u wazuh-manager > wazuh-logs/wazuh-manager.service.log || true
+          sudo tar -czf wazuh-logs.tar.gz wazuh-logs
+      # Upload logs artifact if test fails
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wazuh-logs-${{ github.job }}
+          path: wazuh-logs.tar.gz

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -80,6 +80,8 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_api/
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -80,8 +80,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_api/
-      - name: Force fail for logs test
-        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -85,6 +85,8 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -85,3 +85,17 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
+      # Collect logs if tests fail
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          mkdir -p wazuh-logs
+          sudo journalctl -u wazuh-manager > wazuh-logs/wazuh-manager.service.log || true
+          sudo tar -czf wazuh-logs.tar.gz wazuh-logs
+      # Upload logs artifact if test fails
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wazuh-logs-${{ github.job }}
+          path: wazuh-logs.tar.gz

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -81,16 +81,21 @@ jobs:
           sudo pip install qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run integration tests.
-      - name: Run RBAC tests
+      - name: Run API tests
         run: |
+          mkdir -p /tmp/wazuh-logs
+          sudo tail -F /var/ossec/logs/api.log >> /tmp/wazuh-logs/api.log 2>/dev/null &
+          sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
           sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
         run: |
-          mkdir -p /tmp/wazuh-logs
           sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
+          sudo chown -R $(whoami):$(whoami) /tmp/wazuh-logs || true
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -85,8 +85,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
-      - name: Force fail for logs test
-        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -88,8 +88,6 @@ jobs:
           sudo tail -F /var/ossec/logs/ossec.log >> /tmp/wazuh-logs/ossec.log 2>/dev/null &
           cd tests/integration
           sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
-      - name: Force fail for logs test
-        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -85,17 +85,18 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest test_api/test_rbac/ --tier 0 --tier 1
+      - name: Force fail for logs test
+        run: exit 1
       # Collect logs if tests fail
       - name: Collect logs on failure
         if: failure()
         run: |
-          mkdir -p wazuh-logs
-          sudo journalctl -u wazuh-manager > wazuh-logs/wazuh-manager.service.log || true
-          sudo tar -czf wazuh-logs.tar.gz wazuh-logs
+          mkdir -p /tmp/wazuh-logs
+          sudo journalctl -u wazuh-manager > /tmp/wazuh-logs/wazuh-manager.service.log || true
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: wazuh-logs-${{ github.job }}
-          path: wazuh-logs.tar.gz
+          path: /tmp/wazuh-logs


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/30532 |

## Description

The` Integration tests for API - Tier 0 and 1`, `Integration tests for API - Tier 2`, and `Integration tests for RBAC (Framework) - Tier 0 and 1` workflows were updated to generate artifacts in the event of a failure.

### Successful runs

Integration tests for API - Tier 0 and 1 --> https://github.com/wazuh/wazuh/actions/runs/16026323938

Integration tests for API - Tier 2 --> https://github.com/wazuh/wazuh/actions/runs/16026331926

Integration tests for RBAC (Framework) - Tier 0 and 1 --> https://github.com/wazuh/wazuh/actions/runs/16026323953

### Failed runs

Integration tests for API - Tier 0 and 1 --> https://github.com/wazuh/wazuh/actions/runs/16025695797

Integration tests for API - Tier 2 --> https://github.com/wazuh/wazuh/actions/runs/16025717128

Integration tests for RBAC (Framework) - Tier 0 and 1 --> https://github.com/wazuh/wazuh/actions/runs/16025695819







