### PR TITLE
Discard invalid float values in integer fields during JSON parsing

### DIFF
--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -273,6 +273,8 @@ extern "C"
             {
                 flatbuffers::Parser parser;
                 parser.opts.skip_unexpected_fields_in_json = true;
+                parser.opts.zero_on_float_to_int =
+                    true; // Avoids issues with float to int conversion, custom option made for Wazuh.
 
                 if (!parser.Parse(schema))
                 {


### PR DESCRIPTION
|Related issue|
|---|
|Closes #30501 |

> [!IMPORTANT]
> This changes is related to a custom changes made on `flatbuffers` library.

# Objective

This PR aims to solve the parsing of JSON messages to flatbuffers, adding a new option that when is enabled, the FlatBuffers parser replaces float constants assigned to integer fields with zero instead of failing.

## Testing

To test this compile a agent using branch `testingcjsondouble` and connect to manager, the `size` fields for all fim entries should be `0` and inode not be present of the index

![image](https://github.com/user-attachments/assets/0ab3cd06-5246-4b54-90c1-3d969053f766)


Also not errors should be in the `ossec.log`