### PR TITLE
Fix Auditd EXECVE sibling Decoders

### DIFF
--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -16,8 +16,8 @@
 <!-- ID -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <prematch offset="after_parent">^SYSCALL </prematch>
-  <regex offset="after_parent">^(SYSCALL) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <prematch offset="after_parent">^SYSCALL|^EXECVE </prematch>
+  <regex offset="after_parent">^(\S+) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 
@@ -52,49 +52,55 @@
 <!-- EXECVE -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">type=EXECVE msg=audit\(\S+\): argc=\d+ a0="(\.+)" </regex>
+  <regex offset="after_regex">argc=(\d+)</regex>
+  <order>audit.execve.argc</order>
+</decoder>
+
+<decoder name="auditd-syscall">
+  <parent>auditd</parent>
+  <regex offset="after_regex">a0="(\.+)"</regex>
   <order>audit.execve.a0</order>
 </decoder>
 
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">a1="(\.+)" </regex>
+  <regex offset="after_regex">a1="(\.+)"</regex>
   <order>audit.execve.a1</order>
 </decoder>
 
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">a2="(\.+)" </regex>
+  <regex offset="after_regex">a2="(\.+)"</regex>
   <order>audit.execve.a2</order>
 </decoder>
 
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">a3="(\.+)" </regex>
+  <regex offset="after_regex">a3="(\.+)"</regex>
   <order>audit.execve.a3</order>
 </decoder>
 
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">a4="(\.+)" </regex>
+  <regex offset="after_regex">a4="(\.+)"</regex>
   <order>audit.execve.a4</order>
 </decoder>
 
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">a5="(\.+)" </regex>
+  <regex offset="after_regex">a5="(\.+)"</regex>
   <order>audit.execve.a5</order>
 </decoder>
 
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">a6="(\.+)" </regex>
+  <regex offset="after_regex">a6="(\.+)"</regex>
   <order>audit.execve.a6</order>
 </decoder>
 
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">a7="(\.+)" </regex>
+  <regex offset="after_regex">a7="(\.+)"</regex>
   <order>audit.execve.a7</order>
 </decoder>
 

--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -16,7 +16,7 @@
 <!-- ID -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <prematch offset="after_parent">^SYSCALL</prematch>
+  <prematch offset="after_parent">^SYSCALL|^EXECVE </prematch>
   <regex offset="after_parent">^(\S+) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
@@ -50,83 +50,76 @@
 </decoder>
 
 <!-- EXECVE -->
-<decoder name="auditd-execve">
-  <parent>auditd</parent>
-  <prematch offset="after_parent">^EXECVE </prematch>
-  <regex offset="after_parent">^(\S+) msg=audit\(\d+.\d+:(\d+)\): </regex>
-  <order>audit.type,audit.id</order>
-</decoder>
-
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">argc=(\d+)</regex>
   <order>audit.execve.argc</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a0="(\S+)"</regex>
   <order>audit.execve.a0</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a1="(\S+)"</regex>
   <order>audit.execve.a1</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a2="(\S+)"</regex>
   <order>audit.execve.a2</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a3="(\S+)"</regex>
   <order>audit.execve.a3</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a4="(\S+)"</regex>
   <order>audit.execve.a4</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a5="(\S+)"</regex>
   <order>audit.execve.a5</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a6="(\S+)"</regex>
   <order>audit.execve.a6</order>
 </decoder>
 
-<decoder name="auditd-execve">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">a7="(\S+)"</regex>
   <order>audit.execve.a7</order>
 </decoder>
 
 <!-- CWD -->
-<decoder name="auditd-cwd">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">type=CWD msg=audit\(\S+\):\s+cwd="(\S+)" </regex>
   <order>audit.cwd</order>
 </decoder>
 
 <!-- PATH - DIRECTORY: mode=04* -->
-<decoder name="auditd-path">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">type=PATH msg=audit\(\S+\): item=\S+ name="(\S+)" inode=(\S+) dev=\S+ mode=(04\S+) ouid=\S+ ogid=\S+ </regex>
   <order>audit.directory.name, audit.directory.inode, audit.directory.mode</order>
 </decoder>
 
 <!-- PATH - FILE -->
-<decoder name="auditd-path">
+<decoder name="auditd-syscall">
   <parent>auditd</parent>
   <regex offset="after_regex">type=PATH msg=audit\(\S+\): item=\S+ name="(\S+)" inode=(\S+) dev=\S+ mode=(\S+) ouid=\S+ ogid=\S+ |type=PATH msg=audit\(\S+\): item=\S+ name=\((null)\) inode=(\S+) dev=\S+ mode=(\S+) ouid=\S+ ogid=\S+ </regex>
   <order>audit.file.name, audit.file.inode, audit.file.mode</order>
@@ -360,3 +353,28 @@
   <regex>res=(\w+)</regex>
   <order>audit.res</order>
 </decoder>
+
+<decoder name="auditd-generic">
+  <parent>auditd</parent>
+  <regex>name="(\S+)"</regex>
+  <order>audit.directory.name</order>
+</decoder>
+
+<decoder name="auditd-generic">
+  <parent>auditd</parent>
+  <regex>inode=(\S+)</regex>
+  <order>audit.inode</order>
+</decoder>
+
+<decoder name="auditd-generic">
+  <parent>auditd</parent>
+  <regex>mode=(\S+)</regex>
+  <order>audit.mode</order>
+</decoder>
+
+<decoder name="auditd-generic">
+  <parent>auditd</parent>
+  <regex>cwd="(\S+)"</regex>
+  <order>audit.cwd</order>
+</decoder>
+

--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -16,8 +16,8 @@
 <!-- ID -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <prematch offset="after_parent">^SYSCALL|^EXECVE </prematch>
-  <regex offset="after_parent">^(\S+) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <prematch offset="after_parent">^SYSCALL</prematch>
+  <regex offset="after_parent">^(\S+) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 
@@ -50,78 +50,85 @@
 </decoder>
 
 <!-- EXECVE -->
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
+  <parent>auditd</parent>
+  <prematch offset="after_parent">^EXECVE </prematch>
+  <regex offset="after_parent">^(\S+) msg=audit\(\d+.\d+:(\d+)\): </regex>
+  <order>audit.type,audit.id</order>
+</decoder>
+
+<decoder name="auditd-execve">
   <parent>auditd</parent>
   <regex offset="after_regex">argc=(\d+)</regex>
   <order>audit.execve.argc</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a0="(\.+)"</regex>
+  <regex offset="after_regex">a0="(\S+)"</regex>
   <order>audit.execve.a0</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a1="(\.+)"</regex>
+  <regex offset="after_regex">a1="(\S+)"</regex>
   <order>audit.execve.a1</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a2="(\.+)"</regex>
+  <regex offset="after_regex">a2="(\S+)"</regex>
   <order>audit.execve.a2</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a3="(\.+)"</regex>
+  <regex offset="after_regex">a3="(\S+)"</regex>
   <order>audit.execve.a3</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a4="(\.+)"</regex>
+  <regex offset="after_regex">a4="(\S+)"</regex>
   <order>audit.execve.a4</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a5="(\.+)"</regex>
+  <regex offset="after_regex">a5="(\S+)"</regex>
   <order>audit.execve.a5</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a6="(\.+)"</regex>
+  <regex offset="after_regex">a6="(\S+)"</regex>
   <order>audit.execve.a6</order>
 </decoder>
 
-<decoder name="auditd-syscall">
+<decoder name="auditd-execve">
   <parent>auditd</parent>
-  <regex offset="after_regex">a7="(\.+)"</regex>
+  <regex offset="after_regex">a7="(\S+)"</regex>
   <order>audit.execve.a7</order>
 </decoder>
 
 <!-- CWD -->
-<decoder name="auditd-syscall">
+<decoder name="auditd-cwd">
   <parent>auditd</parent>
-  <regex offset="after_regex">type=CWD msg=audit\(\S+\):\s+cwd="(\.+)" </regex>
+  <regex offset="after_regex">type=CWD msg=audit\(\S+\):\s+cwd="(\S+)" </regex>
   <order>audit.cwd</order>
 </decoder>
 
 <!-- PATH - DIRECTORY: mode=04* -->
-<decoder name="auditd-syscall">
+<decoder name="auditd-path">
   <parent>auditd</parent>
-  <regex offset="after_regex">type=PATH msg=audit\(\S+\): item=\S+ name="(\.+)" inode=(\S+) dev=\S+ mode=(04\S+) ouid=\S+ ogid=\S+ </regex>
+  <regex offset="after_regex">type=PATH msg=audit\(\S+\): item=\S+ name="(\S+)" inode=(\S+) dev=\S+ mode=(04\S+) ouid=\S+ ogid=\S+ </regex>
   <order>audit.directory.name, audit.directory.inode, audit.directory.mode</order>
 </decoder>
 
 <!-- PATH - FILE -->
-<decoder name="auditd-syscall">
+<decoder name="auditd-path">
   <parent>auditd</parent>
-  <regex offset="after_regex">type=PATH msg=audit\(\S+\): item=\S+ name="(\.+)" inode=(\S+) dev=\S+ mode=(\S+) ouid=\S+ ogid=\S+ |type=PATH msg=audit\(\S+\): item=\S+ name=\((null)\) inode=(\S+) dev=\S+ mode=(\S+) ouid=\S+ ogid=\S+ </regex>
+  <regex offset="after_regex">type=PATH msg=audit\(\S+\): item=\S+ name="(\S+)" inode=(\S+) dev=\S+ mode=(\S+) ouid=\S+ ogid=\S+ |type=PATH msg=audit\(\S+\): item=\S+ name=\((null)\) inode=(\S+) dev=\S+ mode=(\S+) ouid=\S+ ogid=\S+ </regex>
   <order>audit.file.name, audit.file.inode, audit.file.mode</order>
 </decoder>
 
@@ -131,13 +138,13 @@
 <decoder name="auditd-config_change">
   <parent>auditd</parent>
   <prematch offset="after_parent">^CONFIG_CHANGE </prematch>
-  <regex offset="after_parent">^(CONFIG_CHANGE) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <regex offset="after_parent">^(CONFIG_CHANGE) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 
 <decoder name="auditd-config_change">
   <parent>auditd</parent>
-  <regex offset="after_regex">^auid=(\S+) ses=(\S+) op="(\.+)"</regex>
+  <regex offset="after_regex">^auid=(\S+) ses=(\S+) op="(\S+)"</regex>
   <order>audit.auid,audit.session,audit.op</order>
 </decoder>
 
@@ -165,7 +172,7 @@
 <decoder name="auditd-promiscuous">
   <parent>auditd</parent>
   <prematch offset="after_parent">^ANOM_PROMISCUOUS </prematch>
-  <regex offset="after_parent">^(ANOM_PROMISCUOUS) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <regex offset="after_parent">^(ANOM_PROMISCUOUS) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 
@@ -182,7 +189,7 @@
 <decoder name="auditd-selinux_macstatus">
   <parent>auditd</parent>
   <prematch offset="after_parent">^MAC_STATUS </prematch>
-  <regex offset="after_parent">^(MAC_STATUS) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <regex offset="after_parent">^(MAC_STATUS) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 
@@ -221,7 +228,7 @@
 <decoder name="auditd-user_and_cred">
   <parent>auditd</parent>
   <prematch offset="after_parent">^USER_ACCT |^CRED_ACQ |^USER_START |^CRED_REFR|^CRYPTO_KEY_USER|^CRYPTO_SESSION |^USER_AUTH |^USER_ROLE_CHANGE </prematch>
-  <regex offset="after_parent">^(\S+) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <regex offset="after_parent">^(\S+) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 
@@ -262,7 +269,7 @@
 <decoder name="auditd-login">
   <parent>auditd</parent>
   <prematch offset="after_parent">^LOGIN </prematch>
-  <regex offset="after_parent">^(\S+) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <regex offset="after_parent">^(\S+) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 
@@ -290,7 +297,7 @@
 -->
 <decoder name="auditd-generic">
   <parent>auditd</parent>
-  <regex offset="after_parent">^(\S+) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
+  <regex offset="after_parent">^(\S+) msg=audit\(\d+.\d+:(\d+)\): </regex>
   <order>audit.type,audit.id</order>
 </decoder>
 

--- a/ruleset/decoders/0040-auditd_decoders.xml
+++ b/ruleset/decoders/0040-auditd_decoders.xml
@@ -24,21 +24,21 @@
 <!-- SYSCALL -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm=\p(\S+)\p exe=\p(\S+)\p</regex>
+  <regex offset="after_regex">^arch=(\S+) syscall=(\d+) success=(\S+) exit=(\S+) a0=\S+ a1=\S+ a2=\S+ a3=\S+ items=\S+ ppid=(\S+) pid=(\S+) auid=(\S+) uid=(\S+) gid=(\S+) euid=(\S+) suid=(\S+) fsuid=(\S+) egid=(\S+) sgid=(\S+) fsgid=(\S+) tty=(\S+) ses=(\S+) comm="(\S+)" exe="(\S+)"</regex>
   <order>audit.arch,audit.syscall,audit.success,audit.exit,audit.ppid,audit.pid,audit.auid,audit.uid,audit.gid,audit.euid,audit.suid,audit.fsuid,audit.egid,audit.sgid,audit.fsgid,audit.tty,audit.session,audit.command,audit.exe</order>
 </decoder>
 
 <!-- SYSCALL - command -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">comm=\p*(\w+)\p*</regex>
+  <regex offset="after_regex">comm="(\S+)"</regex>
   <order>audit.command</order>
 </decoder>
 
 <!-- SYSCALL - exe -->
 <decoder name="auditd-syscall">
   <parent>auditd</parent>
-  <regex offset="after_regex">exe=\p(\S+)\p</regex>
+  <regex offset="after_regex">exe="(\S+)"</regex>
   <order>audit.exe</order>
 </decoder>
 
@@ -332,13 +332,13 @@
 
 <decoder name="auditd-generic">
   <parent>auditd</parent>
-  <regex>comm=\p(\S+)\p</regex>
+  <regex>comm=(\S+)</regex>
   <order>audit.command</order>
 </decoder>
 
 <decoder name="auditd-generic">
   <parent>auditd</parent>
-  <regex>exe=\p(\S+)\p</regex>
+  <regex>exe=(\S+)</regex>
   <order>audit.exe</order>
 </decoder>
 
@@ -356,7 +356,7 @@
 
 <decoder name="auditd-generic">
   <parent>auditd</parent>
-  <regex>name="(\S+)"</regex>
+  <regex>name=(\S+)</regex>
   <order>audit.directory.name</order>
 </decoder>
 


### PR DESCRIPTION
## Description

A user reported that an `auditd` log was not being correctly decoded, after doing some research, some errors on the decoders were found and it was also noticed that such decoders can be greatly improved.

## Observations

- Some errors were identified in the prematch of the current auditd decoders which prevents EXECVE logs from being properly decoded.
- The following major changes will address the known issue.

```
<decoder name="auditd-syscall">
  <parent>auditd</parent>
  <prematch offset="after_parent">^SYSCALL|^EXECVE </prematch>
  <regex offset="after_parent">^(\S+) msg=audit\(\d\d\d\d\d\d\d\d\d\d.\d\d\d:(\d+)\): </regex>
  <order>audit.type,audit.id</order>
</decoder>
.
.
.
<!-- EXECVE -->
<decoder name="auditd-syscall">
  <parent>auditd</parent>
  <regex offset="after_regex">argc=(\d+) </regex>
  <order>audit.execve.argc</order>
</decoder>

<decoder name="auditd-syscall">
  <parent>auditd</parent>
  <regex offset="after_regex">a0="(\.+)" </regex>
  <order>audit.execve.a0</order>
</decoder>


```

## Test Output

```console
type=EXECVE msg=audit(1481077308.378:538): argc=7 a0="auditctl" a1="-a" a2="exit,always" a3="-F" a4="arch=b32" a5="-S" a6="execve"

**Phase 1: Completed pre-decoding.
        full event: 'type=EXECVE msg=audit(1481077308.378:538): argc=7 a0="auditctl" a1="-a" a2="exit,always" a3="-F" a4="arch=b32" a5="-S" a6="execve"'

**Phase 2: Completed decoding.
        name: 'auditd'
        parent: 'auditd'
        audit.execve.a0: 'auditctl'
        audit.execve.a1: '-a'
        audit.execve.a2: 'exit,always'
        audit.execve.a3: '-F'
        audit.execve.a4: 'arch=b32'
        audit.execve.a5: '-S'
        audit.execve.a6: 'execve'
        audit.execve.argc: '7'
        audit.id: '538'
        audit.type: 'EXECVE'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '3'
        mail: 'False'

```

- Another issue was observed where the last argument is not decoded because of the space after the " of each argument. This will be corrected by removing the space in the regex.

## Test with various type

<details>
<summary>Output</summary>

```console
type=CWD msg=audit(1481077231.371:479):  cwd="/home/some_user"

**Phase 1: Completed pre-decoding.
        full event: 'type=CWD msg=audit(1481077231.371:479):  cwd="/home/some_user"'

**Phase 2: Completed decoding.
        name: 'auditd'
        audit.cwd: '/home/some_user'
        audit.id: '479'
        audit.type: 'CWD'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '1'
        mail: 'False'

type=PATH msg=audit(1481077231.371:479): item=0 name="/sbin/auditctl" inode=17367907 dev=08:01 mode=0100750 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:auditctl_exec_t:s0 objtype=NORMAL

**Phase 1: Completed pre-decoding.
        full event: 'type=PATH msg=audit(1481077231.371:479): item=0 name="/sbin/auditctl" inode=17367907 dev=08:01 mode=0100750 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:auditctl_exec_t:s0 objtype=NORMAL'

**Phase 2: Completed decoding.
        name: 'auditd'
        audit.directory.name: '/sbin/auditctl'
        audit.gid: '0'
        audit.id: '479'
        audit.inode: '17367907'
        audit.mode: '0100750'
        audit.type: 'PATH'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '2'
        mail: 'False'

type=EXECVE msg=audit(1481077231.371:479): argc=7 a0="auditctl" a1="-a" a2="exit,always" a3="-F" a4="arch=b32" a5="-S" a6="execve"

**Phase 1: Completed pre-decoding.
        full event: 'type=EXECVE msg=audit(1481077231.371:479): argc=7 a0="auditctl" a1="-a" a2="exit,always" a3="-F" a4="arch=b32" a5="-S" a6="execve"'

**Phase 2: Completed decoding.
        name: 'auditd'
        parent: 'auditd'
        audit.execve.a0: 'auditctl'
        audit.execve.a1: '-a'
        audit.execve.a2: 'exit,always'
        audit.execve.a3: '-F'
        audit.execve.a4: 'arch=b32'
        audit.execve.a5: '-S'
        audit.execve.a6: 'execve'
        audit.execve.argc: '7'
        audit.id: '479'
        audit.type: 'EXECVE'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '3'
        mail: 'False'

type=USER_LOGIN msg=audit(1481077083.414:473): pid=1339 uid=0 auid=1000 ses=3 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe="/usr/sbin/sshd" hostname=pool-216.160.83.61.washdc.fios.verizon.net addr=216.160.83.61 terminal=/dev/pts/0 res=success'

**Phase 1: Completed pre-decoding.
        full event: 'type=USER_LOGIN msg=audit(1481077083.414:473): pid=1339 uid=0 auid=1000 ses=3 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=login id=1000 exe="/usr/sbin/sshd" hostname=pool-216.160.83.61.washdc.fios.verizon.net addr=216.160.83.61 terminal=/dev/pts/0 res=success''

**Phase 2: Completed decoding.
        name: 'auditd'
        audit.auid: '1000'
        audit.exe: '/usr/sbin/sshd'
        audit.id: '473'
        audit.pid: '1339'
        audit.res: 'success'
        audit.session: '3'
        audit.type: 'USER_LOGIN'
        audit.uid: '0'
        srcip: '216.160.83.61'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '4'
        mail: 'False'

type=USER_ROLE_CHANGE msg=audit(1481077083.358:467): pid=1339 uid=0 auid=1000 ses=3 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='pam: default-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 selected-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 exe="/usr/sbin/sshd" hostname=pool-216.160.83.61.washdc.fios.verizon.net addr=216.160.83.61 terminal=ssh res=success'

**Phase 1: Completed pre-decoding.
        full event: 'type=USER_ROLE_CHANGE msg=audit(1481077083.358:467): pid=1339 uid=0 auid=1000 ses=3 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='pam: default-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 selected-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 exe="/usr/sbin/sshd" hostname=pool-216.160.83.61.washdc.fios.verizon.net addr=216.160.83.61 terminal=ssh res=success''

**Phase 2: Completed decoding.
        name: 'auditd'
        parent: 'auditd'
        audit.auid: '1000'
        audit.exe: '/usr/sbin/sshd'
        audit.id: '467'
        audit.pid: '1339'
        audit.session: '3'
        audit.subj: 'system_u:system_r:sshd_t:s0-s0:c0.c1023'
        audit.type: 'USER_ROLE_CHANGE'
        audit.uid: '0'
        srcip: '216.160.83.61'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '5'
        mail: 'False'

type=SYSCALL msg=audit(1481076991.202:356): arch=c000003e syscall=54 success=yes exit=0 a0=4 a1=0 a2=40 a3=d53640 items=0 ppid=296 pid=1036 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="iptables" exe="/usr/sbin/xtables-multi" subj=system_u:system_r:iptables_t:s0 key=(null)

**Phase 1: Completed pre-decoding.
        full event: 'type=SYSCALL msg=audit(1481076991.202:356): arch=c000003e syscall=54 success=yes exit=0 a0=4 a1=0 a2=40 a3=d53640 items=0 ppid=296 pid=1036 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="iptables" exe="/usr/sbin/xtables-multi" subj=system_u:system_r:iptables_t:s0 key=(null)'

**Phase 2: Completed decoding.
        name: 'auditd'
        parent: 'auditd'
        audit.arch: 'c000003e'
        audit.auid: '4294967295'
        audit.command: 'iptables'
        audit.egid: '0'
        audit.euid: '0'
        audit.exe: '/usr/sbin/xtables'
        audit.exit: '0'
        audit.fsgid: '0'
        audit.fsuid: '0'
        audit.gid: '0'
        audit.id: '356'
        audit.key: 'null'
        audit.pid: '1036'
        audit.ppid: '296'
        audit.session: '4294967295'
        audit.sgid: '0'
        audit.success: 'yes'
        audit.suid: '0'
        audit.syscall: '54'
        audit.tty: '(none)'
        audit.type: 'SYSCALL'
        audit.uid: '0'

**Phase 3: Completed filtering (rules).
        id: '80700'
        level: '0'
        description: 'Audit: Messages grouped.'
        groups: '['audit']'
        firedtimes: '6'
        mail: 'False'

type=CONFIG_CHANGE msg=audit(1480085540.632:5846): auid=0 ses=1 op="remove rule" key="audit-wazuh-w" list=4 res=1

**Phase 1: Completed pre-decoding.
        full event: 'type=CONFIG_CHANGE msg=audit(1480085540.632:5846): auid=0 ses=1 op="remove rule" key="audit-wazuh-w" list=4 res=1'

**Phase 2: Completed decoding.
        name: 'auditd'
        parent: 'auditd'
        audit.id: '5846'
        audit.key: 'audit-wazuh-w'
        audit.list: '4'
        audit.res: '1'
        audit.type: 'CONFIG_CHANGE'

**Phase 3: Completed filtering (rules).
        id: '80705'
        level: '3'
        description: 'Auditd: Configuration changed.'
        groups: '['audit', 'audit_configuration']'
        firedtimes: '1'
        gdpr: '['IV_30.1.g']'
        gpg13: '['10.1']'
        mail: 'False'
**Alert to be generated.

type=ANOM_PROMISCUOUS msg=audit(1390181243.575:738): dev=vethDvSeyL prom=0 old_prom=256 auid=4294967295 uid=0 gid=0 ses=4294967295

**Phase 1: Completed pre-decoding.
        full event: 'type=ANOM_PROMISCUOUS msg=audit(1390181243.575:738): dev=vethDvSeyL prom=0 old_prom=256 auid=4294967295 uid=0 gid=0 ses=4294967295'

**Phase 2: Completed decoding.
        name: 'auditd'
        parent: 'auditd'
        audit.auid: '4294967295'
        audit.dev: 'vethDvSeyL'
        audit.gid: '0'
        audit.id: '738'
        audit.old_prom: '256'
        audit.prom: '0'
        audit.session: '4294967295'
        audit.type: 'ANOM_PROMISCUOUS'
        audit.uid: '0'

**Phase 3: Completed filtering (rules).
        id: '80710'
        level: '10'
        description: 'Auditd: Device enables promiscuous mode.'
        groups: '['audit', 'audit_anom']'
        firedtimes: '1'
        gdpr: '['IV_30.1.g', 'IV_35.7.d']'
        gpg13: '['4.14']'
        hipaa: '['164.312.b']'
        mail: 'False'
        nist_800_53: '['AU.6', 'SI.4']'
        pci_dss: '['10.6.1', '11.4']'
        tsc: '['CC6.1', 'CC6.8', 'CC7.2', 'CC7.3']'
**Alert to be generated.
```

</details>