### PR TITLE
Update RBAC black manager test case response

### DIFF
--- a/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_manager_endpoints.tavern.yaml
@@ -247,4 +247,9 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      <<: *permission_allowed
+      status_code: 202
+      json:
+        error: !anyint
+        data:
+          affected_items: !anything
+          total_failed_items: 0


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/30615 |

## Description

Updates the expected test response status code to 202 instead of sharing it with the other endpoints and expecting 200. 

## Tests

