### PR TITLE
Improve template for planned specific support new oss

### DIFF
--- a/.github/ISSUE_TEMPLATE/planned--specific-support-new-oss.md
+++ b/.github/ISSUE_TEMPLATE/planned--specific-support-new-oss.md
@@ -42,7 +42,7 @@ assignees: ''
   - [ ] Add the OS and each architecture to the JobFlow testing tool.
   - [ ] Add the OS and each architecture to the GitHub Deployability and Upgrade release templates.
 - [ ] Add the OS and its supported architectures to the E2E UX Tests spreadsheet (OS sheet).
-- [ ] Create an [issue](https://github.com/wazuh/internal-documentation-requests/issues/new?template=new-OSs-support-request.md) (using the new OSs template), for the documentation team to add support for the new OS version in the full support release version.
+- [ ] Create an [issue](https://github.com/wazuh/internal-documentation-requests/issues/new?template=new-OSs-support-request.md) using the "New OSs Support Request" template, requesting the content team to add support for the new OS version in the full support release version, once this issue has been approved and closed.
 -->
 
 <!-- Uncomment for CPPSERVER issue


### PR DESCRIPTION
|Related issue|
| :--- |
| https://github.com/wazuh/wazuh/issues/30123 |

## Description

Changes to the `planned--specific-support-new-oss.md` template to include more information about the task requesting an issue be opened to the content team.

The content issue should be locked until the issue changes are merged to support a new OS.