### PR TITLE
Remove `internal_key` from queries filters

### DIFF
--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -287,6 +287,17 @@ stages:
       status_code: 400
       json:
         error: 1403
+  
+  - name: Try to sort agents by internal key
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        sort: internal_key
+    response:
+      status_code: 400
+      json:
+        error: 1403
 
   - name: Search
     request:
@@ -1186,6 +1197,17 @@ stages:
       <<: *get_agents
       params:
         q: group=default;lastKeepAe<1d
+    response:
+      status_code: 400
+      json:
+        error: 1408
+  
+  - name: Try to filter agents by internal key
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: internal_key=test
     response:
       status_code: 400
       json:

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -208,7 +208,7 @@ class WazuhException(Exception):
                'remediation': 'Please select a limit between 1 and 1000'
                },
         1407: 'Query does not match expected format',
-        1408: 'Field does not exist.',
+        1408: 'Field does not exist',
         1409: 'Invalid query operator',
         1410: 'Selecting more than one field in distinct mode',
         1411: 'TimeFrame is not valid',

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -940,7 +940,8 @@ def test_WazuhDBQuery_protected_sort_query(mock_socket_conn, mock_conn_db, mock_
     ({'order': 'asc', 'fields': None}, None),
     ({'order': 'asc', 'fields': ['1']}, None),
     ({'order': 'asc', 'fields': ['bad_field']}, 1403),
-    ({'order': 'asc', 'fields': ['1', '2', '3', '4']}, None)
+    ({'order': 'asc', 'fields': ['1', '2', '3', '4']}, None),
+    ({'order': 'asc', 'fields': ['internal_key']}, 1403)
 ])
 @patch('wazuh.core.utils.path.exists', return_value=True)
 @patch('wazuh.core.utils.glob.glob', return_value=True)
@@ -953,6 +954,7 @@ def test_WazuhDBQuery_protected_add_sort_to_query(mock_socket_conn, mock_conn_db
     query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=sort,
                                search=None, select=None, filters=None,
                                fields=fields,
+                               extra_fields={'internal_key'},
                                default_sort_field=None, query=None,
                                backend=utils.WazuhDBBackend(agent_id=1),
                                count=5, get_data=None)
@@ -1145,7 +1147,8 @@ def test_WazuhDBQuery_protected_parse_query_regex(mock_backend_connect, mock_exi
     ('os.name=debian;os.version>12e),(os.name=ubuntu;os.version>12e)', False, None),
     ('bad_query', True, 1407),
     ('os.bad_field=ubuntu', True, 1408),
-    ('os.name=!ubuntu', True, 1409)
+    ('os.name=!ubuntu', True, 1409),
+    ('internal_key=test', True, 1408)
 ])
 @patch('wazuh.core.utils.path.exists', return_value=True)
 @patch('wazuh.core.utils.glob.glob', return_value=True)
@@ -1156,7 +1159,8 @@ def test_WazuhDBQuery_protected_parse_query(mock_socket_conn, mock_conn_db, mock
     """Test WazuhDBQuery._parse_query function."""
     query = utils.WazuhDBQuery(offset=0, limit=1, table='agent', sort=None,
                                search=None, select=None, filters=None,
-                               fields={'os.name': None, 'os.version': None},
+                               fields={'os.name': None, 'os.version': None, 'internal_key': None},
+                               extra_fields={'internal_key'},
                                default_sort_field=None, query=q,
                                backend=utils.WazuhDBBackend(agent_id=1),
                                count=5, get_data=None)

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -1643,7 +1643,7 @@ class WazuhDBQuery(object):
     def _add_sort_to_query(self):
         if self.sort:
             if self.sort['fields']:
-                sort_fields, allowed_sort_fields = self.sort['fields'], set(self.fields.keys())
+                sort_fields, allowed_sort_fields = self.sort['fields'], set(self.fields.keys()) - self.extra_fields
                 # Check every element in sort['fields'] is in allowed_sort_fields
                 if not set(sort_fields).issubset(allowed_sort_fields):
                     raise WazuhError(1403, "Allowed sort fields: {}. Fields: {}".format(
@@ -1698,7 +1698,7 @@ class WazuhDBQuery(object):
 
         level = 0
         for open_level, field, operator, value, close_level, separator in self.query_regex.findall(self.q):
-            if field not in self.fields.keys():
+            if field not in set(self.fields.keys()) - self.extra_fields:
                 raise WazuhError(1408, "Available fields: {}. Field: {}".format(', '.join(self.fields), field))
             if operator not in self.query_operators:
                 raise WazuhError(1409,


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/30620 |


## Description

Removes fields inside `extra_fields` from queries filters and sorts to avoid exposing internal fields that users cannot retrieve. 

## Tests


<details><summary>Try to filter by internal_key</summary>

```console
wazuh@wazuh:~/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55050/agents?q=internal_key=test | jq
{
  "title": "Bad Request",
  "detail": "Field does not exist: Available fields: id, name, ip, status, os.name, os.version, os.platform, version, manager, dateAdd, group, mergedSum, configSum, os.codename, os.major, os.minor, os.uname, os.arch, os.build, node_name, lastKeepAlive, internal_key, registerIP, disconnection_time, group_config_status, status_code. Field: internal_key",
  "dapi_errors": {
    "master-node": {
      "error": "Field does not exist: Available fields: id, name, ip, status, os.name, os.version, os.platform, version, manager, dateAdd, group, mergedSum, configSum, os.codename, os.major, os.minor, os.uname, os.arch, os.build, node_name, lastKeepAlive, internal_key, registerIP, disconnection_time, group_config_status, status_code. Field: internal_key"
    }
  },
  "error": 1408
}
```

</details>

<details><summary>Try to sort by internal_key</summary>

```console
wazuh@wazuh:~/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55050/agents?sort=internal_key | jq
{
  "title": "Bad Request",
  "detail": "Not a valid sort field : Allowed sort fields: ['configSum', 'dateAdd', 'disconnection_time', 'group', 'group_config_status', 'id', 'ip', 'lastKeepAlive', 'manager', 'mergedSum', 'name', 'node_name', 'os.arch', 'os.build', 'os.codename', 'os.major', 'os.minor', 'os.name', 'os.platform', 'os.uname', 'os.version', 'registerIP', 'status', 'status_code', 'version']. Fields: internal_key",
  "remediation": "Please, use only allowed sort fields",
  "dapi_errors": {
    "master-node": {
      "error": "Not a valid sort field : Allowed sort fields: ['configSum', 'dateAdd', 'disconnection_time', 'group', 'group_config_status', 'id', 'ip', 'lastKeepAlive', 'manager', 'mergedSum', 'name', 'node_name', 'os.arch', 'os.build', 'os.codename', 'os.major', 'os.minor', 'os.name', 'os.platform', 'os.uname', 'os.version', 'registerIP', 'status', 'status_code', 'version']. Fields: internal_key"
    }
  },
  "error": 1403
}
```

</details>

<details><summary>Try to select the internal key field</summary>

```console
wazuh@wazuh:~/wazuh-tools/framework/environments/dev$ curl -H "Authorization: Bearer $TOKEN" -ks https://0.0.0.0:55050/agents?select=internal_key | jq
{
  "title": "Bad Request",
  "detail": "Not a valid select field: Allowed select fields: id, name, ip, status, os.name, os.version, os.platform, version, manager, dateAdd, group, mergedSum, configSum, os.codename, os.major, os.minor, os.uname, os.arch, os.build, node_name, lastKeepAlive, internal_key, registerIP, disconnection_time, group_config_status, status_code. Fields internal_key",
  "remediation": "Please, use only allowed select fields",
  "dapi_errors": {
    "master-node": {
      "error": "Not a valid select field: Allowed select fields: id, name, ip, status, os.name, os.version, os.platform, version, manager, dateAdd, group, mergedSum, configSum, os.codename, os.major, os.minor, os.uname, os.arch, os.build, node_name, lastKeepAlive, internal_key, registerIP, disconnection_time, group_config_status, status_code. Fields internal_key"
    }
  },
  "error": 1724
}
```

</details>

<details><summary>test_agent_GET_endpoints.tavern.yaml</summary>

```console
(venv) wazuh@wazuh:~/wazuh/api/test/integration$ pytest --nobuild --disable-warnings test_agent_GET_endpoints.tavern.yaml
============================================ test session starts =============================================
platform linux -- Python 3.10.0, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/wazuh/api/test/integration
configfile: pytest.ini
plugins: html-2.1.1, cov-4.1.0, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 96 items

test_agent_GET_endpoints.tavern.yaml ................................................................. [ 67%]
...............................                                                                        [100%]

================================ 96 passed, 97 warnings in 293.31s (0:04:53) =================================
```

</details>