### PR TITLE
Add write permissions to Wazuh Server 6.0.0 image workflow

### DIFF
--- a/.github/workflows/6_builderprecompiled_server-images.yml
+++ b/.github/workflows/6_builderprecompiled_server-images.yml
@@ -37,6 +37,8 @@ on:
 
 jobs:
   Upload-package-building-images:
+    permissions:
+      packages: write
     runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'wz-linux-arm64' || 'ubuntu-24.04' }}
     timeout-minutes: 140
     name: Package - Upload pkg_${{ inputs.system }}_server_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/30617|

## Description

Modifies the workflow permissions to allow push packages to GHCR.

Successful run: https://github.com/wazuh/wazuh/actions/runs/16002311822/job/45140940738