### PR TITLE
Fix ThreadEventDispatcher shutdown delay

### DIFF
--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -214,8 +214,15 @@ private:
             catch (const std::exception& ex)
             {
                 // Sleep for a second to avoid busy loop
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-                std::cerr << "Dispatch handler error, " << ex.what() << "\n";
+                if (m_running)
+                {
+                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                    std::cerr << "Dispatch handler error, " << ex.what() << "\n";
+                }
+                else
+                {
+                    std::cout << "ThreadEventDispatcher dispatch end.\n";
+                }
             }
         }
     }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #30651|

# Fix ThreadEventDispatcher shutdown delay

## Description

This PR fixes a performance issue in the `ThreadEventDispatcher` class where a 1-second sleep was being executed during graceful shutdown, causing unnecessary delays in the shutdown process.

## Changes

- **Modified**: `src/shared_modules/utils/threadEventDispatcher.hpp`
  - Removed the 1-second sleep during graceful shutdown in the exception handling block
  - Added proper shutdown message when the dispatcher is stopping
  - Improved shutdown responsiveness by avoiding unnecessary delays

## Technical Details

The change modifies the exception handling block in the `dispatch()` method to avoid the sleep during shutdown:

```cpp
catch (const std::exception& ex)
{
    // Sleep for a second to avoid busy loop
    if (m_running)
    {
        std::this_thread::sleep_for(std::chrono::seconds(1));
        std::cerr << "Dispatch handler error, " << ex.what() << "\n";
    }
    else
    {
        std::cout << "ThreadEventDispatcher dispatch end.\n";
    }
}
```

This ensures that:
- The 1-second sleep only occurs when the dispatcher is actively running
- Shutdown operations complete immediately without unnecessary delays
- The dispatcher responds quickly to shutdown requests

## Testing

- [x] Verified that error handling still works correctly during normal operation
- [x] Confirmed that shutdown completes immediately without delays
