### PR TITLE
wazuh-analysisd writes malformed alerts in alerts.log when <group> contains newline characters

### DIFF
--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -571,7 +571,13 @@ int Rules_OP_ReadRules(const char *rulefile, RuleNode **r_node, ListNode **l_nod
 
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_group) == 0) {
                         config_ruleinfo->group = loadmemory(config_ruleinfo->group, rule_tmp_params.rule_arr_opt[k]->content, log_msg);
-
+                        char * aux_config_rule_group = config_ruleinfo->group;
+                        /* Avoid new lines in group name */
+                        aux_config_rule_group = wstr_replace(aux_config_rule_group, "\n", "");
+                        if (aux_config_rule_group && strlen(aux_config_rule_group) < strlen(config_ruleinfo->group)) {
+                            memcpy(config_ruleinfo->group, aux_config_rule_group, strlen(aux_config_rule_group)+1);
+                        }
+                        os_free(aux_config_rule_group);
                     } else if (strcasecmp(rule_tmp_params.rule_arr_opt[k]->element, xml_comment) == 0) {
 
                         char * newline = strchr(rule_tmp_params.rule_arr_opt[k]->content, '\n');


### PR DESCRIPTION
|Related issue|
|---|
|Closes #30538 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

`wazuh-analysisd` does **not sanitize the content of a `<group>` tag** when rules are loaded.  
If the tag contains embedded new-lines, those characters are copied verbatim into the alert header written to `alerts.log`.  
Any daemon that expects a single-line header then fails to parse the alert file.

## Proposed changes:

* Apply a cleaning process of the groups string replacing all the new lines ( "/n" ) with an empty string.

### Results and Evidence

* Alert generation:

```
╰─# go run write_log.go -m  "Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2"
Sended: 1:[123] (hostname123) any->/var/cosas:Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
```

* alert.log:

```
** Alert 1751383890.3973: - local,syslog,sshd,    Multiline,    text,    group,    
2025 Jul 01 15:31:30 (hostname123) any->/var/cosas
Rule: 100001 (level 5) -> 'sshd: authentication failed from IP 1.1.1.1.'
Src IP: 1.1.1.1
Src Port: 1066
User: root
Dec 10 01:02:02 host sshd[1234]: Failed none for root from 1.1.1.1 port 1066 ssh2
```

* Reportd checking:

```
# /var/ossec/bin/wazuh-reportd -d < /tmp/randomAlert.log 
2025/07/01 15:40:28 wazuh-reportd[478939] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/01 15:40:28 wazuh-reportd[478939] report.c:162 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/01 15:40:28 wazuh-reportd[478939] report.c:192 at main(): DEBUG: Chrooted to directory: /var/ossec, using user: wazuh
2025/07/01 15:40:28 wazuh-reportd[478939] report.c:205 at main(): INFO: Started (pid: 478939).
2025/07/01 15:40:33 wazuh-reportd[478939] report_op.c:574 at os_ReportdStart(): INFO: Report completed. Creating output...
 
Report completed. ==
------------------------------------------------
->Processed alerts: 1
->Post-filtering alerts: 1
->First alert: 2025 Jul 01 15:31:30
->Last alert: 2025 Jul 01 15:31:30
 
 
Top entries for 'Source ip':
------------------------------------------------
1.1.1.1                                                                       |1       |
 
 
Top entries for 'Username':
------------------------------------------------
root                                                                          |1       |
 
 
Top entries for 'Level':
------------------------------------------------
Severity 5                                                                    |1       |
 
 
Top entries for 'Group':
------------------------------------------------
Multiline                                                                     |1       |
group                                                                         |1       |
local                                                                         |1       |
sshd                                                                          |1       |
syslog                                                                        |1       |
text                                                                          |1       |
 
 
Top entries for 'Location':
------------------------------------------------
(hostname123) any->/var/cosas                                                 |1       |
 
 
Top entries for 'Rule':
------------------------------------------------
100001 - sshd: authentication failed from IP 1.1.1.1.                         |1       |

```

### Manual tests with their corresponding evidence


<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer


- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors


### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] ~Configuration changes documented~
- [ ] ~Developer documentation reflects the changes~
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->