### PR TITLE
Avoid expanded file list in logcollector getconfig output

### DIFF
--- a/src/logcollector/config.c
+++ b/src/logcollector/config.c
@@ -101,36 +101,50 @@ int LogCollectorConfig(const char *cfgfile)
     return (1);
 }
 
+void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath)
+{
+    cJSON* file = cJSON_CreateObject();
 
-void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath) {
-    unsigned int i;
-    cJSON *file = cJSON_CreateObject();
-
-    if (gpath) cJSON_AddStringToObject(file, "file", gpath);
-    else if (reader->ffile) cJSON_AddStringToObject(file, "file", reader->ffile);
-    else if (reader->file) cJSON_AddStringToObject(file,"file",reader->file);
-    if (reader->channel_str != NULL) cJSON_AddStringToObject(file, "channel", reader->channel_str);
-    if (reader->logformat) cJSON_AddStringToObject(file,"logformat",reader->logformat);
-    if (reader->command) cJSON_AddStringToObject(file,"command",reader->command);
-    if (reader->djb_program_name) cJSON_AddStringToObject(file,"djb_program_name",reader->djb_program_name);
-    if (reader->alias) cJSON_AddStringToObject(file,"alias",reader->alias);
-    if (reader->query != NULL) {
-        cJSON * query = cJSON_CreateObject();
-        if (*reader->query != '\0') {
+    if (gpath)
+        cJSON_AddStringToObject(file, "file", gpath);
+    else if (reader->ffile)
+       cJSON_AddStringToObject(file, "file", reader->ffile);
+    else if (reader->file)
+        cJSON_AddStringToObject(file, "file", reader->file);
+    if (reader->channel_str != NULL)
+        cJSON_AddStringToObject(file, "channel", reader->channel_str);
+    if (reader->logformat)
+        cJSON_AddStringToObject(file, "logformat", reader->logformat);
+    if (reader->command)
+        cJSON_AddStringToObject(file, "command", reader->command);
+    if (reader->djb_program_name)
+        cJSON_AddStringToObject(file, "djb_program_name", reader->djb_program_name);
+    if (reader->alias)
+        cJSON_AddStringToObject(file, "alias", reader->alias);
+    if (reader->query != NULL)
+    {
+        cJSON* query = cJSON_CreateObject();
+        if (*reader->query != '\0')
+        {
             cJSON_AddStringToObject(query, "value", reader->query);
         }
-        if (reader->query_level != NULL) {
+        if (reader->query_level != NULL)
+        {
             cJSON_AddStringToObject(query, "level", reader->query_level);
         }
-        if (reader->query_type > 0) {
-            cJSON *type = cJSON_CreateArray();
-            if (reader->query_type & MACOS_LOG_TYPE_LOG) {
+        if (reader->query_type > 0)
+        {
+            cJSON* type = cJSON_CreateArray();
+            if (reader->query_type & MACOS_LOG_TYPE_LOG)
+            {
                 cJSON_AddItemToArray(type, cJSON_CreateString(MACOS_LOG_TYPE_LOG_STR));
             }
-            if (reader->query_type & MACOS_LOG_TYPE_ACTIVITY) {
+            if (reader->query_type & MACOS_LOG_TYPE_ACTIVITY)
+            {
                 cJSON_AddItemToArray(type, cJSON_CreateString(MACOS_LOG_TYPE_ACTIVITY_STR));
             }
-            if (reader->query_type & MACOS_LOG_TYPE_TRACE) {
+            if (reader->query_type & MACOS_LOG_TYPE_TRACE)
+            {
                 cJSON_AddItemToArray(type, cJSON_CreateString(MACOS_LOG_TYPE_TRACE_STR));
             }
             cJSON_AddItemToObject(query, "type", type);
@@ -138,21 +152,26 @@ void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath) 
         cJSON_AddItemToObject(file, "query", query);
     }
     // Invalid configuration for journal logs
-    if (reader->journal_log == NULL) {
+    if (reader->journal_log == NULL)
+    {
         cJSON_AddStringToObject(file, "ignore_binaries", reader->filter_binary ? "yes" : "no");
     }
 
-    if (reader->age_str) cJSON_AddStringToObject(file,"age",reader->age_str);
-    if (reader->exclude) cJSON_AddStringToObject(file,"exclude",reader->exclude);
+    if (reader->age_str)
+        cJSON_AddStringToObject(file, "age", reader->age_str);
+    if (reader->exclude)
+        cJSON_AddStringToObject(file, "exclude", reader->exclude);
 
-    if (reader->logformat != NULL &&
-        strcmp(reader->logformat, EVENTLOG) != 0 &&
-        strcmp(reader->logformat, "command") != 0 &&
-        strcmp(reader->logformat, "full_command") != 0) {
+    if (reader->logformat != NULL && strcmp(reader->logformat, EVENTLOG) != 0 && strcmp(reader->logformat, "command") != 0 &&
+        strcmp(reader->logformat, "full_command") != 0)
+    {
 
-        if (reader->future == 1){
+        if (reader->future == 1)
+        {
             cJSON_AddStringToObject(file, "only-future-events", "yes");
-        } else {
+        }
+        else
+        {
             char offset[OFFSET_SIZE] = {0};
             sprintf(offset, "%ld", reader->diff_max_size);
             cJSON_AddStringToObject(file, "only-future-events", "no");
@@ -160,61 +179,76 @@ void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath) 
         }
     }
 
-    if (reader->target && *reader->target) {
-        cJSON *target = cJSON_CreateArray();
-        for (i=0;reader->target[i];i++) {
+    if (reader->target && *reader->target)
+    {
+        cJSON* target = cJSON_CreateArray();
+        for (int i = 0; reader->target[i]; i++)
+        {
             cJSON_AddItemToArray(target, cJSON_CreateString(reader->target[i]));
         }
-        cJSON_AddItemToObject(file,"target",target);
+        cJSON_AddItemToObject(file, "target", target);
     }
-    if (reader->out_format && *reader->out_format) {
-        cJSON *outformat = cJSON_CreateArray();
-        for (i=0;reader->out_format[i] && reader->out_format[i]->format;i++) {
-            cJSON *item = cJSON_CreateObject();
+    if (reader->out_format && *reader->out_format)
+    {
+        cJSON* outformat = cJSON_CreateArray();
+        for (int i = 0; reader->out_format[i] && reader->out_format[i]->format; i++)
+        {
+            cJSON* item = cJSON_CreateObject();
             if (reader->out_format[i]->target)
-                cJSON_AddStringToObject(item,"target",reader->out_format[i]->target);
+                cJSON_AddStringToObject(item, "target", reader->out_format[i]->target);
             else
-                cJSON_AddStringToObject(item,"target","all");
-            cJSON_AddStringToObject(item,"format",reader->out_format[i]->format);
+                cJSON_AddStringToObject(item, "target", "all");
+            cJSON_AddStringToObject(item, "format", reader->out_format[i]->format);
             cJSON_AddItemToArray(outformat, item);
         }
-        cJSON_AddItemToObject(file,"out_format",outformat);
+        cJSON_AddItemToObject(file, "out_format", outformat);
     }
-    if (reader->duplicated) cJSON_AddNumberToObject(file,"duplicate",reader->duplicated);
-    if (reader->labels && reader->labels[0].key) {
-        cJSON *label = cJSON_CreateObject();
-        for (i=0;reader->labels[i].key;i++) {
-            cJSON_AddStringToObject(label,reader->labels[i].key,reader->labels[i].value);
+    if (reader->duplicated)
+        cJSON_AddNumberToObject(file, "duplicate", reader->duplicated);
+    if (reader->labels && reader->labels[0].key)
+    {
+        cJSON* label = cJSON_CreateObject();
+        for (int i = 0; reader->labels[i].key; i++)
+        {
+            cJSON_AddStringToObject(label, reader->labels[i].key, reader->labels[i].value);
         }
-        cJSON_AddItemToObject(file,"labels",label);
+        cJSON_AddItemToObject(file, "labels", label);
     }
-    if (reader->ign && reader->logformat != NULL && (strcmp(reader->logformat,"command")==0 || strcmp(reader->logformat,"full_command")==0)) cJSON_AddNumberToObject(file,"frequency",reader->ign);
-    if (reader->reconnect_time && reader->logformat != NULL && strcmp(reader->logformat,"eventchannel")==0) cJSON_AddNumberToObject(file,"reconnect_time",reader->reconnect_time);
-    if (reader->multiline) {
-        cJSON * multiline = cJSON_CreateObject();
+    if (reader->ign && reader->logformat != NULL &&
+        (strcmp(reader->logformat, "command") == 0 || strcmp(reader->logformat, "full_command") == 0))
+        cJSON_AddNumberToObject(file, "frequency", reader->ign);
+    if (reader->reconnect_time && reader->logformat != NULL && strcmp(reader->logformat, "eventchannel") == 0)
+        cJSON_AddNumberToObject(file, "reconnect_time", reader->reconnect_time);
+    if (reader->multiline)
+    {
+        cJSON* multiline = cJSON_CreateObject();
         cJSON_AddStringToObject(multiline, "match", multiline_attr_match_str(reader->multiline->match_type));
         cJSON_AddStringToObject(multiline, "replace", multiline_attr_replace_str(reader->multiline->replace_type));
         cJSON_AddStringToObject(multiline, "regex", w_expression_get_regex_pattern(reader->multiline->regex));
         cJSON_AddNumberToObject(multiline, "timeout", reader->multiline->timeout);
         cJSON_AddItemToObject(file, "multiline_regex", multiline);
     }
-    if (reader->journal_log != NULL && reader->journal_log->filters != NULL) {
+    if (reader->journal_log != NULL && reader->journal_log->filters != NULL)
+    {
 
-        cJSON * filters = w_journal_filter_list_as_json(reader->journal_log->filters);
-        if (filters != NULL) {
+        cJSON* filters = w_journal_filter_list_as_json(reader->journal_log->filters);
+        if (filters != NULL)
+        {
             cJSON_AddItemToObject(file, "filters", filters);
         }
 
         cJSON_AddBoolToObject(file, "filters_disabled", reader->journal_log->disable_filters);
     }
-    if (reader->regex_ignore != NULL) {
-        OSListNode *node_it;
-        w_expression_t *exp_it;
-        cJSON * ignore_array = cJSON_CreateArray();
+    if (reader->regex_ignore != NULL)
+    {
+        OSListNode* node_it;
+        w_expression_t* exp_it;
+        cJSON* ignore_array = cJSON_CreateArray();
 
-        OSList_foreach(node_it, reader->regex_ignore) {
+        OSList_foreach(node_it, reader->regex_ignore)
+        {
             exp_it = node_it->data;
-            cJSON * ignore_object = cJSON_CreateObject();
+            cJSON* ignore_object = cJSON_CreateObject();
 
             cJSON_AddStringToObject(ignore_object, "value", w_expression_get_regex_pattern(exp_it));
             cJSON_AddStringToObject(ignore_object, "type", w_expression_get_regex_type(exp_it));
@@ -222,20 +256,25 @@ void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath) 
             cJSON_AddItemToArray(ignore_array, ignore_object);
         }
 
-        if (cJSON_GetArraySize(ignore_array) > 0) {
+        if (cJSON_GetArraySize(ignore_array) > 0)
+        {
             cJSON_AddItemToObject(file, "ignore", ignore_array);
-        } else {
+        }
+        else
+        {
             cJSON_free(ignore_array);
         }
     }
-    if (reader->regex_restrict != NULL) {
-        OSListNode *node_it;
-        w_expression_t *exp_it;
-        cJSON * restrict_array = cJSON_CreateArray();
+    if (reader->regex_restrict != NULL)
+    {
+        OSListNode* node_it;
+        w_expression_t* exp_it;
+        cJSON* restrict_array = cJSON_CreateArray();
 
-        OSList_foreach(node_it, reader->regex_restrict) {
+        OSList_foreach(node_it, reader->regex_restrict)
+        {
             exp_it = node_it->data;
-            cJSON * restrict_object = cJSON_CreateObject();
+            cJSON* restrict_object = cJSON_CreateObject();
 
             cJSON_AddStringToObject(restrict_object, "value", w_expression_get_regex_pattern(exp_it));
             cJSON_AddStringToObject(restrict_object, "type", w_expression_get_regex_type(exp_it));
@@ -243,16 +282,18 @@ void _getLocalfilesListJSON(logreader* reader, cJSON* array, const char *gpath) 
             cJSON_AddItemToArray(restrict_array, restrict_object);
         }
 
-        if (cJSON_GetArraySize(restrict_array) > 0) {
+        if (cJSON_GetArraySize(restrict_array) > 0)
+        {
             cJSON_AddItemToObject(file, "restrict", restrict_array);
-        } else {
+        }
+        else
+        {
             cJSON_free(restrict_array);
         }
     }
 
     cJSON_AddItemToArray(array, file);
 }
-
 
 cJSON *getLocalfileConfig(void) {
 


### PR DESCRIPTION
## Description

This pull request addresses an issue where the Wazuh agent fails to return large configuration responses due to a 64 KB message size limit. When querying the active configuration of Logcollector, wildcard paths were previously expanded into full lists of resolved files. This could cause the response to exceed the allowed size, especially when monitoring hundreds of files.

## Proposed Changes

- Limit the `getconfig` response from Logcollector to the configured values only.
- For wildcard paths, the original path as written in the configuration (e.g. `/tmp/test*/*.log`) is returned in the `file` field.
- For `<date_format>` entries, the literal pattern (e.g. `myapp-%Y-%m-%d.log`) is shown instead of resolved filenames.
- The runtime-resolved list of monitored files remains accessible through the existing `stats` query, which supports pagination.

### Results and Evidence

#### Configuration

```xml
<localfile>
  <log_format>syslog</log_format>
  <location>/var/ossec/logs/active-responses.log</location>
</localfile>

<localfile>
  <log_format>syslog</log_format>
  <location>/var/log/dpkg.log</location>
</localfile>

<localfile>
  <log_format>syslog</log_format>
  <location>/tmp/test*/*.log</location>
</localfile>

<localfile>
  <log_format>syslog</log_format>
  <location>/tmp/year-%Y.log</location>
</localfile>
````

#### Files

```
/tmp
├── test-of-paths-wazuh-logcollector
│   ├── myapp-1.log
│   ├── myapp-10.log
│   ├── myapp-2.log
│   ├── myapp-3.log
│   ├── myapp-4.log
│   ├── myapp-5.log
│   ├── myapp-6.log
│   ├── myapp-7.log
│   ├── myapp-8.log
│   └── myapp-9.log
└── year-2025.log
```

<details><summary><h4>Logs</h4></summary>

```
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1236 at set_read(): DEBUG: Socket target for '/tmp/test-of-paths-wazuh-logcollector/myapp-1.log' -> agent
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-1.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-10.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-2.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-3.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-4.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-5.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-6.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-7.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-8.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1364 at check_pattern_expand(): DEBUG: (1957): New file that matches the '/tmp/test*/*.log' pattern: '/tmp/test-of-paths-wazuh-logcollector/myapp-9.log'.
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:1236 at set_read(): DEBUG: Socket target for '/tmp/year-2025.log' -> agent
2025/07/02 13:43:45 wazuh-logcollector[73157] logcollector.c:435 at LogCollectorStart(): INFO: (1950): Analyzing file: '/tmp/year-2025.log'.
```

</details>

#### API request to manager:

```bash
wazuh-api https://localhost:55000/manager/configuration/logcollector/localfile | jq
```

Returns:

```json
{
  "data": {
    "affected_items": [
      {
        "localfile": [
          {
            "file": "/var/ossec/logs/active-responses.log",
            "logformat": "syslog",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
              "agent"
            ]
          },
          {
            "file": "/var/log/dpkg.log",
            "logformat": "syslog",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
              "agent"
            ]
          },
          {
            "file": "/tmp/year-%Y.log",
            "logformat": "syslog",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
              "agent"
            ]
          },
          {
            "file": "/tmp/test*/*.log",
            "logformat": "syslog",
            "ignore_binaries": "no",
            "only-future-events": "yes",
            "target": [
              "agent"
            ]
          }
        ]
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read",
  "error": 0
}
```

#### API request to stats:

```bash
wazuh-api https://localhost:55000/agents/000/stats/logcollector | jq
```

Returns the resolved list of monitored files as expected.

<details><summary>Result</summary>

```json
{
  "data": {
    "affected_items": [
      {
        "global": {
          "start": "2025-07-02T13:44:46Z",
          "end": "2025-07-02T13:45:43Z",
          "files": [
            {
              "location": "/var/log/dpkg.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-1.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-2.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/var/ossec/logs/active-responses.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-3.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-4.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-5.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-6.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-10.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/year-%Y.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-7.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-8.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-9.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/year-2025.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            }
          ]
        },
        "interval": {
          "start": "2025-07-02T13:44:46Z",
          "end": "2025-07-02T13:45:43Z",
          "files": [
            {
              "location": "/var/log/dpkg.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-1.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-2.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/var/ossec/logs/active-responses.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-3.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-4.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-5.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-6.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-10.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/year-%Y.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-7.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-8.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/test-of-paths-wazuh-logcollector/myapp-9.log",
              "events": 0,
              "bytes": 0,
              "targets": []
            },
            {
              "location": "/tmp/year-2025.log",
              "events": 0,
              "bytes": 0,
              "targets": [
                {
                  "name": "agent",
                  "drops": 0
                }
              ]
            }
          ]
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Statistical information for each agent was successfully read",
  "error": 0
}
```

</details>

### Artifacts Affected

* `wazuh-logcollector` (UNIX)
* `wazuh-agent.exe` (Windows)

### Configuration Changes

None.

### Documentation Updates

Not required. The JSON structure remains unchanged.

### Tests Introduced

* Manual testing using custom configuration with wildcards and date format patterns.
* Logcollector executed under Valgrind to ensure memory safety.

<details><summary><h4>Valgrind report</h4></summary>

```
==73381== HEAP SUMMARY:
==73381==     in use at exit: 47,051 bytes in 629 blocks
==73381==   total heap usage: 27,016 allocs, 26,387 frees, 29,259,352 bytes allocated
==73381==
==73381== LEAK SUMMARY:
==73381==    definitely lost: 0 bytes in 0 blocks
==73381==    indirectly lost: 0 bytes in 0 blocks
==73381==      possibly lost: 2,016 bytes in 7 blocks
==73381==    still reachable: 45,035 bytes in 622 blocks
==73381==         suppressed: 0 bytes in 0 blocks
```

</details>

## Review Checklist

* [ ] Code changes reviewed
* [ ] Relevant evidence provided
* [ ] Tests cover the new functionality
* [ ] Configuration changes documented
* [ ] Developer documentation reflects the changes
* [ ] Meets requirements and/or definition of done
* [ ] No unresolved dependencies with other issues