### PR TITLE
Wazuh Server API fails for `/agents/:agentid/restart` requests - Implementation

### DIFF
--- a/api/api/controllers/agent_controller.py
+++ b/api/api/controllers/agent_controller.py
@@ -582,7 +582,7 @@ async def restart_agent(agent_id: str, pretty: bool = False, wait_for_complete: 
     dapi = DistributedAPI(f=agent.restart_agents,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master',
-                          is_async=False,
+                          is_async=True,
                           wait_for_complete=wait_for_complete,
                           logger=logger,
                           rbac_permissions=request.context['token_info']['rbac_policies']

--- a/api/api/controllers/test/test_agent_controller.py
+++ b/api/api/controllers/test/test_agent_controller.py
@@ -414,7 +414,7 @@ async def test_restart_agent(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_
     mock_dapi.assert_called_once_with(f=agent.restart_agents,
                                       f_kwargs=mock_remove.return_value,
                                       request_type='distributed_master',
-                                      is_async=False,
+                                      is_async=True,
                                       wait_for_complete=False,
                                       logger=ANY,
                                       rbac_permissions=mock_request.context['token_info']['rbac_policies']


### PR DESCRIPTION
|Related issue|
|---|
|#30650|

## Description

This PR aims to solve #30650 by marking `/agents/:agentid/restart` endpoint DAPI internal call as async

## Tests

https://jenkins-staging.qa.wazuh.info/job/Test_integration_endpoints/106/
https://jenkins-staging.qa.wazuh.info/job/Test_integration_endpoints/107