### PR TITLE
Hot Reload: adds reload cmd

### DIFF
--- a/src/active-response/restart-wazuh.c
+++ b/src/active-response/restart-wazuh.c
@@ -26,7 +26,7 @@ int main (int argc, char **argv) {
 
 #ifndef WIN32
     char log_msg[OS_MAXSTR];
-    char *exec_cmd[3] = { "bin/wazuh-control", "reload", NULL };
+    char *exec_cmd[3] = { "bin/wazuh-control", "restart", NULL };
 
     wfd_t *wfd = wpopenv(*exec_cmd, exec_cmd, W_BIND_STDERR);
     if (!wfd) {

--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -4,10 +4,11 @@
 
 
 PARAM_TYPE=$1
+PARAM_ACTION="${2:-restart}"
 
 help()
 {
-    echo "Usage: $0 [manager|agent]"
+    echo "Usage: $0 [manager|agent] [restart|reload]"
 }
 
 # Usage
@@ -41,6 +42,6 @@ if [ "$TYPE" = "manager" ]; then
     fi
 fi
 
-${PWD}/bin/wazuh-control reload
+${PWD}/bin/wazuh-control $PARAM_ACTION
 
 exit $?;

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -194,8 +194,8 @@ DWORD WINAPI req_receiver(LPVOID arg);
 void * req_receiver(void * arg);
 #endif
 
-// Restart agent
-void * restartAgent();
+// Reload agent
+void * reloadAgent();
 
 // Verify remote configuration. Return 0 on success or -1 on error.
 int verifyRemoteConf();

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -295,8 +295,8 @@ int receive_msg()
                                     clear_merged_hash_cache();
                                     if (agt->flags.remote_conf && !verifyRemoteConf()) {
                                         if (agt->flags.auto_restart) {
-                                            minfo("Agent is restarting due to shared configuration changes.");
-                                            restartAgent();
+                                            minfo("Agent is reloading due to shared configuration changes.");
+                                            reloadAgent();
                                         } else {
                                             minfo("Shared agent configuration has been updated.");
                                         }

--- a/src/client-agent/reload_agent.c
+++ b/src/client-agent/reload_agent.c
@@ -21,9 +21,9 @@
 
 static const char AG_IN_RCON[] = "wazuh: Invalid remote configuration";
 
-void * restartAgent() {
+void * reloadAgent() {
 
-	char req[] = "restart";
+	char req[] = "reload";
 
 	#ifndef WIN32
 
@@ -38,11 +38,11 @@ void * restartAgent() {
 	if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
 		switch (errno) {
 		case ECONNREFUSED:
-			merror("Could not auto-restart agent. Is Active Response enabled?");
+			merror("Could not auto-reload agent. Is Active Response enabled?");
 			break;
 
 		default:
-			merror("At restartAgent(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
+			merror("At reloadAgent(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
 		}
 	} else {
 		if (OS_SendSecureTCP(sock, length, req)) {

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -66,6 +66,7 @@ void ExecdShutdown(int sig) __attribute__((noreturn));
 size_t wcom_unmerge(const char *file_path, char **output);
 size_t wcom_uncompress(const char * source, const char * target, char ** output);
 size_t wcom_restart(char **output);
+size_t wcom_reload(char ** output);
 size_t wcom_dispatch(char *command, char **output);
 size_t lock_restart(int timeout);
 size_t wcom_getconfig(const char * section, char ** output);

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -64,6 +64,10 @@ size_t wcom_dispatch(char *command, char ** output) {
 
     } else if (strcmp(rcv_comm, "restart") == 0 || strcmp(rcv_comm, "restart-wazuh") == 0) {
         return wcom_restart(output);
+
+    } else if (strcmp(rcv_comm, "reload")  == 0) {
+        return wcom_reload(output);
+
     } else if (strcmp(rcv_comm, "lock_restart") == 0) {
         max_restart_lock = 0;
         int timeout = -2;
@@ -242,6 +246,64 @@ size_t wcom_restart(char ** output) {
     return strlen(*output);
 }
 
+size_t wcom_reload(char ** output) {
+    time_t lock = pending_upg - time(NULL);
+    if (lock <= 0) {
+#ifndef WIN32
+        char *exec_cmd[4] = {NULL};
+
+        if (waccess("active-response/bin/restart.sh", F_OK) == 0) {
+            exec_cmd[0] = "active-response/bin/restart.sh";
+#ifdef CLIENT
+            exec_cmd[1] = "agent";
+#else
+            exec_cmd[1] = "manager";
+#endif
+            exec_cmd[2] = "reload";
+        } else {
+            exec_cmd[0] = "bin/wazuh-control";
+            exec_cmd[1] = "reload";
+        }
+
+        switch (fork()) {
+            case -1:
+                merror("At WCOM reload: Cannot fork");
+                os_strdup("err Cannot fork", *output);
+            break;
+            case 0:
+                if (execv(exec_cmd[0], exec_cmd) < 0) {
+                    merror(EXEC_CMDERROR, *exec_cmd, strerror(errno));
+                    _exit(1);
+                }
+            break;
+            default:
+                os_strdup("ok ", *output);
+            break;
+        }
+
+#else
+        static char command[OS_FLSIZE];
+        snprintf(command, sizeof(command), "%s/%s", AR_BINDIR, "restart-wazuh.exe");
+        char *cmd[2] = { command, NULL };
+        char *cmd_parameters = "{\"version\":1,\"origin\":{\"name\":\"\",\"module\":\"wazuh-execd\"},\"command\":\"add\",\"parameters\":{\"extra_args\":[],\"alert\":{},\"program\":\"restart-wazuh.exe\"}}";
+        wfd_t *wfd = wpopenv(cmd[0], cmd, W_BIND_STDIN);
+        if (wfd) {
+            // Send alert to AR script
+            fprintf(wfd->file_in, "%s\n", cmd_parameters);
+            fflush(wfd->file_in);
+            wpclose(wfd);
+        } else {
+            merror("At WCOM restart: Cannot execute restart process");
+            os_strdup("err Cannot execute restart process", *output);
+        }
+#endif
+    } else {
+        minfo(LOCK_RES, (int)lock);
+    }
+
+    if (!*output) os_strdup("ok ", *output);
+    return strlen(*output);
+}
 
 size_t wcom_getconfig(const char * section, char ** output) {
 


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/30714|

## Description

This PR introduces a new, independent reload command, separating its functionality from the existing restart command. This change addresses the need for distinct behaviors between reloading and restarting, providing more precise control over application processes.

The new reload command operates independently of restart and is designed to provide consistent behavior across all supported operating systems (Linux,  and macOS). 

# Testing

On the following video, we're going to examine the behavior of the reload command when updating a centralized configuration, and compare that to what happens when we use an active response that utilizes the restart command.

This change has been tested on Ubuntu and macOS. On the left side of the video, you will see the **ossec.log** and **active-responses.log** files from the Ubuntu OS, while the right side displays the corresponding logs for macOS.

We can clearly observe the difference between the reload command and the restart command. Notably, when an active response command such as `./agent_control -R -a` is sent, the wazuh-agentd daemon is terminated during a restart, whereas it is not with a reload.

I have also attached the log files for more detailed analysis, should it be required.


[Screencast from 07-07-2025 11:07:33 AM.webm](https://github.com/user-attachments/assets/d82b8479-055b-4700-b9a4-0f82e0a10f0c)


<details>
<summary>Macos ossec.log</summary>

```bash
2025/07/07 07:07:57 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2025/07/07 07:07:58 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2025/07/07 07:07:58 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/07/07 07:07:58 wazuh-modulesd:syscollector: INFO: Module finished.
2025/07/07 07:07:58 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2025/07/07 07:07:59 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2025/07/07 07:07:59 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2025/07/07 07:07:59 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2025/07/07 07:07:59 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2025/07/07 07:08:00 wazuh-execd: INFO: Started (pid: 6425).
2025/07/07 07:08:01 wazuh-syscheckd: INFO: Started (pid: 6441).
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2025/07/07 07:08:01 rootcheck: INFO: Starting rootcheck scan.
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6000): Starting daemon...
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/07/07 07:08:01 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2025/07/07 07:08:02 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -an | awk '{if ((/^(tcp|udp)/) && ($4 != "*.*") && ($5 == "*.*")) {print $1" "$4" "$5}}' | sort -u
2025/07/07 07:08:02 wazuh-logcollector: ERROR: (1103): Could not open file '/Users/vagrant/test_buffer.json' due to [(2)-(No such file or directory)].
2025/07/07 07:08:02 wazuh-logcollector: INFO: (1950): Analyzing file: '/Users/vagrant/test_buffer.json'.
2025/07/07 07:08:03 wazuh-logcollector: INFO: (1604): Monitoring macOS logs with: /usr/bin/script -q /dev/null /usr/bin/log stream --style syslog --type activity --type log --type trace --level info --predicate (process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd").
2025/07/07 07:08:03 wazuh-logcollector: INFO: Started (pid: 6452).
2025/07/07 07:08:03 wazuh-modulesd: INFO: Started (pid: 6471).
2025/07/07 07:08:03 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/07/07 07:08:03 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/07/07 07:08:03 sca: INFO: Module started.
2025/07/07 07:08:03 wazuh-modulesd:control: INFO: Starting control thread.
2025/07/07 07:08:03 sca: INFO: Loaded policy '/Library/Ossec/ruleset/sca/cis_apple_macOS_10.12.yml'
2025/07/07 07:08:03 wazuh-modulesd:syscollector: INFO: Module started.
2025/07/07 07:08:03 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/07/07 07:08:03 sca: INFO: Starting Security Configuration Assessment scan.
2025/07/07 07:08:03 sca: INFO: Starting evaluation of policy: '/Library/Ossec/ruleset/sca/cis_apple_macOS_10.12.yml'
2025/07/07 07:08:04 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2025/07/07 07:08:04 wazuh-syscheckd: INFO: FIM sync module started.
2025/07/07 07:08:05 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/07/07 07:08:07 wazuh-agentd: INFO: SIGNAL [(30)-(User defined signal 1: 30)] Received. Reload agentd.
2025/07/07 07:08:07 wazuh-agentd: INFO: Buffer agent.conf updated, enable: 1 size: 600 
2025/07/07 07:08:07 wazuh-agentd: INFO: Client buffer resized from 300 to 600 elements.
2025/07/07 07:08:10 sca: INFO: Evaluation finished for policy '/Library/Ossec/ruleset/sca/cis_apple_macOS_10.12.yml'
2025/07/07 07:08:10 sca: INFO: Security Configuration Assessment scan finished. Duration: 7 seconds.
2025/07/07 07:08:10 wazuh-agentd: WARNING: Error communicating with Security configuration assessment
2025/07/07 07:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.sh'. Not using it on this system.
2025/07/07 07:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.cmd'. Not using it on this system.
2025/07/07 07:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.sh'. Not using it on this system.
2025/07/07 07:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.cmd'. Not using it on this system.
2025/07/07 07:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-wazuh.exe'. Not using it on this system.
2025/07/07 07:08:21 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2025/07/07 07:08:22 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/07/07 07:08:22 wazuh-modulesd:syscollector: INFO: Module finished.
2025/07/07 07:08:22 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2025/07/07 07:08:23 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2025/07/07 07:08:23 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2025/07/07 07:08:23 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2025/07/07 07:08:23 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2025/07/07 07:08:23 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2025/07/07 07:08:24 wazuh-execd: INFO: Started (pid: 7282).
2025/07/07 07:08:25 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2025/07/07 07:08:25 wazuh-agentd: INFO: Using notify time: 10 and max time to reconnect: 60
2025/07/07 07:08:26 wazuh-agentd: INFO: Version detected -> Darwin |This-MacBook-Pro.local |16.7.0 |Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64 |x86_64 [macOS|darwin: 10.12.6 (Sierra)] - Wazuh v5.0.0
2025/07/07 07:08:26 wazuh-agentd: INFO: Started (pid: 7295).
2025/07/07 07:08:26 wazuh-agentd: INFO: Using AES as encryption method.
2025/07/07 07:08:26 wazuh-agentd: INFO: Trying to connect to server ([192.168.100.250]:1514/tcp).
2025/07/07 07:08:26 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.100.250]:1514/tcp).
2025/07/07 07:08:26 wazuh-syscheckd: INFO: Started (pid: 7312).
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2025/07/07 07:08:26 rootcheck: INFO: Starting rootcheck scan.
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6000): Starting daemon...
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/07/07 07:08:26 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2025/07/07 07:08:28 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2025/07/07 07:08:28 wazuh-syscheckd: INFO: FIM sync module started.
2025/07/07 07:08:28 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -an | awk '{if ((/^(tcp|udp)/) && ($4 != "*.*") && ($5 == "*.*")) {print $1" "$4" "$5}}' | sort -u
2025/07/07 07:08:28 wazuh-logcollector: ERROR: (1103): Could not open file '/Users/vagrant/test_buffer.json' due to [(2)-(No such file or directory)].
2025/07/07 07:08:28 wazuh-logcollector: INFO: (1950): Analyzing file: '/Users/vagrant/test_buffer.json'.
2025/07/07 07:08:29 wazuh-logcollector: INFO: (1604): Monitoring macOS logs with: /usr/bin/script -q /dev/null /usr/bin/log stream --style syslog --type activity --type log --type trace --level info --predicate (process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd").
2025/07/07 07:08:29 wazuh-logcollector: INFO: Started (pid: 7324).
2025/07/07 07:08:29 wazuh-modulesd: INFO: Started (pid: 7358).
2025/07/07 07:08:29 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/07/07 07:08:29 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/07/07 07:08:29 sca: INFO: Module started.
2025/07/07 07:08:29 sca: INFO: Loaded policy '/Library/Ossec/ruleset/sca/cis_apple_macOS_10.12.yml'
2025/07/07 07:08:29 wazuh-modulesd:control: INFO: Starting control thread.
2025/07/07 07:08:29 sca: INFO: Starting Security Configuration Assessment scan.
2025/07/07 07:08:29 wazuh-modulesd:syscollector: INFO: Module started.
2025/07/07 07:08:29 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/07/07 07:08:29 sca: INFO: Starting evaluation of policy: '/Library/Ossec/ruleset/sca/cis_apple_macOS_10.12.yml'
2025/07/07 07:08:30 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/07/07 07:08:35 sca: INFO: Evaluation finished for policy '/Library/Ossec/ruleset/sca/cis_apple_macOS_10.12.yml'
2025/07/07 07:08:35 sca: INFO: Security Configuration Assessment scan finished. Duration: 6 seconds.
2025/07/07 07:09:01 rootcheck: INFO: Ending rootcheck scan.

````
</details>

<details>
<summary>MacOS active-responses.log</summary>

```bash
Mon Jul  7 07:07:57 PDT 2025 active-response/bin/restart.sh agent reload   
2025/07/07 07:08:20 active-response/bin/restart-wazuh: Starting
2025/07/07 07:08:20 active-response/bin/restart-wazuh: {"version":1,"origin":{"name":"","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"data":{"srcip":"null"}},"program":"active-response/bin/restart-wazuh"}}

2025/07/07 07:08:32 active-response/bin/restart-wazuh: Ended
```
</details>

<details>
<summary>Ubuntu ossec.log</summary>

```log

2025/07/07 14:07:57 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2025/07/07 14:07:57 wazuh-execd: INFO: Adding offenders timeout: 1 (for #1)
2025/07/07 14:07:57 wazuh-execd: INFO: Adding offenders timeout: 5 (for #2)
2025/07/07 14:07:57 wazuh-execd: INFO: Adding offenders timeout: 10 (for #3)
2025/07/07 14:07:58 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2025/07/07 14:07:58 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/07/07 14:07:58 wazuh-modulesd:syscollector: INFO: Module finished.
2025/07/07 14:07:58 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:07:58 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2025/07/07 14:07:58 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:07:58 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2025/07/07 14:07:58 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:08:00 wazuh-execd: INFO: Adding offenders timeout: 1 (for #1)
2025/07/07 14:08:00 wazuh-execd: INFO: Adding offenders timeout: 5 (for #2)
2025/07/07 14:08:00 wazuh-execd: INFO: Adding offenders timeout: 10 (for #3)
2025/07/07 14:08:00 wazuh-execd: INFO: Started (pid: 2002).
2025/07/07 14:08:01 wazuh-syscheckd: INFO: Started (pid: 2018).
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6000): Starting daemon...
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2025/07/07 14:08:01 rootcheck: INFO: Starting rootcheck scan.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: FIM sync module started.
2025/07/07 14:08:02 wazuh-logcollector: INFO: Monitoring output of command(360): df -P
2025/07/07 14:08:02 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2025/07/07 14:08:02 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20
2025/07/07 14:08:02 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2025/07/07 14:08:02 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2025/07/07 14:08:02 wazuh-logcollector: INFO: (1950): Analyzing file: '/root/test_buffer.json'.
2025/07/07 14:08:02 wazuh-logcollector: INFO: Started (pid: 2048).
2025/07/07 14:08:03 wazuh-modulesd: INFO: Started (pid: 2103).
2025/07/07 14:08:03 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/07/07 14:08:03 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2025/07/07 14:08:03 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/07/07 14:08:03 sca: INFO: Module started.
2025/07/07 14:08:03 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/07/07 14:08:03 wazuh-modulesd:control: INFO: Starting control thread.
2025/07/07 14:08:03 sca: INFO: Starting Security Configuration Assessment scan.
2025/07/07 14:08:03 wazuh-modulesd:syscollector: INFO: Module started.
2025/07/07 14:08:03 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/07/07 14:08:03 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/07/07 14:08:03 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/07/07 14:08:06 wazuh-agentd: INFO: SIGNAL [(10)-(User defined signal 1)] Received. Reload agentd.
2025/07/07 14:08:06 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/07/07 14:08:06 wazuh-agentd: INFO: Buffer agent.conf updated, enable: 1 size: 600 
2025/07/07 14:08:06 wazuh-agentd: INFO: Client buffer resized from 300 to 600 elements.
2025/07/07 14:08:06 sca: INFO: Security Configuration Assessment scan finished. Duration: 3 seconds.
2025/07/07 14:08:10 rootcheck: INFO: Ending rootcheck scan.
2025/07/07 14:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.sh'. Not using it on this system.
2025/07/07 14:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.cmd'. Not using it on this system.
2025/07/07 14:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.sh'. Not using it on this system.
2025/07/07 14:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-ossec.cmd'. Not using it on this system.
2025/07/07 14:08:20 wazuh-execd: INFO: Active response command not present: 'active-response/bin/restart-wazuh.exe'. Not using it on this system.
2025/07/07 14:08:20 wazuh-execd: INFO: Adding offenders timeout: 1 (for #1)
2025/07/07 14:08:20 wazuh-execd: INFO: Adding offenders timeout: 5 (for #2)
2025/07/07 14:08:20 wazuh-execd: INFO: Adding offenders timeout: 10 (for #3)
2025/07/07 14:08:21 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2025/07/07 14:08:21 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/07/07 14:08:21 wazuh-modulesd:syscollector: INFO: Module finished.
2025/07/07 14:08:21 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:08:21 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2025/07/07 14:08:21 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:08:21 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:08:21 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2025/07/07 14:08:21 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:08:22 wazuh-execd: INFO: Adding offenders timeout: 1 (for #1)
2025/07/07 14:08:22 wazuh-execd: INFO: Adding offenders timeout: 5 (for #2)
2025/07/07 14:08:22 wazuh-execd: INFO: Adding offenders timeout: 10 (for #3)
2025/07/07 14:08:22 wazuh-execd: INFO: Started (pid: 2644).
2025/07/07 14:08:24 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2025/07/07 14:08:24 wazuh-agentd: INFO: Using notify time: 10 and max time to reconnect: 60
2025/07/07 14:08:24 wazuh-agentd: INFO: Version detected -> Linux |3f938c2658c2 |6.8.0-60-generic |#63~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Apr 22 19:00:15 UTC 2 |x86_64 [Ubuntu|ubuntu: 22.04.5 LTS (Jammy Jellyfish)] - Wazuh v5.0.0
2025/07/07 14:08:24 wazuh-agentd: INFO: Started (pid: 2655).
2025/07/07 14:08:24 wazuh-agentd: INFO: Using AES as encryption method.
2025/07/07 14:08:24 wazuh-agentd: INFO: Trying to connect to server ([192.168.100.250]:1514/tcp).
2025/07/07 14:08:24 wazuh-agentd: INFO: (4102): Connected to the server ([192.168.100.250]:1514/tcp).
2025/07/07 14:08:25 wazuh-syscheckd: INFO: Started (pid: 2669).
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6000): Starting daemon...
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2025/07/07 14:08:25 rootcheck: INFO: Starting rootcheck scan.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2025/07/07 14:08:25 wazuh-syscheckd: INFO: FIM sync module started.
2025/07/07 14:08:26 wazuh-logcollector: INFO: Monitoring output of command(360): df -P
2025/07/07 14:08:26 wazuh-logcollector: INFO: Monitoring full output of command(360): netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d
2025/07/07 14:08:26 wazuh-logcollector: INFO: Monitoring full output of command(360): last -n 20
2025/07/07 14:08:26 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/ossec/logs/active-responses.log'.
2025/07/07 14:08:26 wazuh-logcollector: INFO: (1950): Analyzing file: '/var/log/dpkg.log'.
2025/07/07 14:08:26 wazuh-logcollector: INFO: (1950): Analyzing file: '/root/test_buffer.json'.
2025/07/07 14:08:26 wazuh-logcollector: INFO: Started (pid: 2701).
2025/07/07 14:08:27 wazuh-modulesd: INFO: Started (pid: 2756).
2025/07/07 14:08:27 wazuh-modulesd:agent-upgrade: INFO: (8153): Module Agent Upgrade started.
2025/07/07 14:08:27 wazuh-modulesd:ciscat: INFO: Module disabled. Exiting...
2025/07/07 14:08:27 wazuh-modulesd:osquery: INFO: Module disabled. Exiting...
2025/07/07 14:08:27 sca: INFO: Module started.
2025/07/07 14:08:27 wazuh-modulesd:control: INFO: Starting control thread.
2025/07/07 14:08:27 sca: INFO: Loaded policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/07/07 14:08:27 sca: INFO: Starting Security Configuration Assessment scan.
2025/07/07 14:08:27 wazuh-modulesd:syscollector: INFO: Module started.
2025/07/07 14:08:27 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2025/07/07 14:08:27 sca: INFO: Starting evaluation of policy: '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/07/07 14:08:27 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2025/07/07 14:08:30 sca: INFO: Evaluation finished for policy '/var/ossec/ruleset/sca/cis_ubuntu22-04.yml'
2025/07/07 14:08:30 sca: INFO: Security Configuration Assessment scan finished. Duration: 3 seconds.
2025/07/07 14:08:34 rootcheck: INFO: Ending rootcheck scan.
2025/07/07 14:07:57 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2025/07/07 14:07:57 wazuh-execd: INFO: Adding offenders timeout: 1 (for #1)
2025/07/07 14:07:57 wazuh-execd: INFO: Adding offenders timeout: 5 (for #2)
2025/07/07 14:07:57 wazuh-execd: INFO: Adding offenders timeout: 10 (for #3)
2025/07/07 14:07:58 wazuh-modulesd: INFO: Shutting down Wazuh modules.
2025/07/07 14:07:58 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2025/07/07 14:07:58 wazuh-modulesd:syscollector: INFO: Module finished.
2025/07/07 14:07:58 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:07:58 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2025/07/07 14:07:58 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:07:58 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2025/07/07 14:07:58 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2025/07/07 14:08:00 wazuh-execd: INFO: Adding offenders timeout: 1 (for #1)
2025/07/07 14:08:00 wazuh-execd: INFO: Adding offenders timeout: 5 (for #2)
2025/07/07 14:08:00 wazuh-execd: INFO: Adding offenders timeout: 10 (for #3)
2025/07/07 14:08:00 wazuh-execd: INFO: Started (pid: 2002).
2025/07/07 14:08:01 wazuh-syscheckd: INFO: Started (pid: 2018).
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/boot', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/etc', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/bin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6003): Monitoring path: '/usr/sbin', with options 'size | permissions | owner | group | mtime | inode | hash_md5 | hash_sha1 | hash_sha256 | scheduled'.
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mtab'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/hosts.deny'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/mail/statistics'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random-seed'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/random.seed'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/adjtime'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/httpd/logs'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/utmpx'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/wtmpx'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/cups/certs'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/dumpdates'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6206): Ignore 'file' entry '/etc/svc/volatile'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6207): Ignore 'file' sregex '.log$|.swp$'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6004): No diff for file: '/etc/ssl/private.key'
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6000): Starting daemon...
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2025/07/07 14:08:01 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
```

</details>



<details>
<summary>Ubuntu active-responses.log</summary>

```bash
Mon Jul  7 14:07:57 UTC 2025 active-response/bin/restart.sh agent reload   
2025/07/07 14:08:20 active-response/bin/restart-wazuh: Starting
2025/07/07 14:08:20 active-response/bin/restart-wazuh: {"version":1,"origin":{"name":"","module":"wazuh-execd"},"command":"add","parameters":{"extra_args":[],"alert":{"data":{"srcip":"null"}},"program":"active-response/bin/restart-wazuh"}}

2025/07/07 14:08:30 active-response/bin/restart-wazuh: Ended
```
</details>
