### PR TITLE
Bring new RegistryHelper utility functions from 6.x to 5.x

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check.hpp
@@ -180,8 +180,8 @@ class RegistryRuleEvaluator : public RuleEvaluator
         RuleResult CheckKeyExistence();
 
         IsValidKeyFunc m_isValidKey = nullptr;
-        EnumValuesFunc m_enumValues = nullptr;
         EnumKeysFunc m_enumKeys = nullptr;
+        EnumValuesFunc m_enumValues = nullptr;
         GetValueFunc m_getValue = nullptr;
 };
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
@@ -102,11 +102,10 @@ namespace
         return a.size() == b.size() && std::equal(a.begin(),
                                                   a.end(),
                                                   b.begin(),
-                                                  [](char a, char b)
-        {
-            return std::tolower(static_cast<unsigned char>(a)) ==
-                   std::tolower(static_cast<unsigned char>(b));
-        });
+                                                  [](char str_a, char str_b) {
+                                                      return std::tolower(static_cast<unsigned char>(str_a)) ==
+                                                             std::tolower(static_cast<unsigned char>(str_b));
+                                                  });
     }
 
     RuleResult CheckMatch(const std::string& candidate, const std::string& pattern, bool isRegex)

--- a/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_policy_check_win.cpp
@@ -102,10 +102,11 @@ namespace
         return a.size() == b.size() && std::equal(a.begin(),
                                                   a.end(),
                                                   b.begin(),
-                                                  [](char str_a, char str_b) {
-                                                      return std::tolower(static_cast<unsigned char>(str_a)) ==
-                                                             std::tolower(static_cast<unsigned char>(str_b));
-                                                  });
+                                                  [](char str_a, char str_b)
+        {
+            return std::tolower(static_cast<unsigned char>(str_a)) ==
+                   std::tolower(static_cast<unsigned char>(str_b));
+        });
     }
 
     RuleResult CheckMatch(const std::string& candidate, const std::string& pattern, bool isRegex)


### PR DESCRIPTION
## Description

This PR merges new RegistryHelper functions used in 6.x by SCA to an integration branch in 5.x. This enables us to bring the SCA module from 6.x with less logic to re-implement.

## Evidence

[output_log.zip](https://github.com/user-attachments/files/22243082/output_log.zip)
[sca_db.zip](https://github.com/user-attachments/files/22243084/sca_db.zip)