### PR TITLE
Fix agents reconnect and restart API integration tests

### DIFF
--- a/framework/wazuh/core/cluster/dapi/dapi.py
+++ b/framework/wazuh/core/cluster/dapi/dapi.py
@@ -611,6 +611,8 @@ class DistributedAPI:
                                                             filters=filters)['items']
             node_name = defaultdict(list)
             for element in system_agents:
+                if element.get('node_name') == 'unknown':
+                    continue
                 node_name[element.get('node_name', '')].append(element['id'])
 
             # Update node_name in case it is empty or a node has no agents


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/30726

## Proposed Changes

Discards agents whose node is unknown to avoid including them in the list of known agents and therefore perform actions on them.

### Results and Evidence

<details><summary>test_rbac_black_agent_endpoints</summary>

```console
(venv) wazuh@wazuh:~/wazuh/api/test/integration$ pytest --nobuild --disable-warnings test_rbac_black_agent_endpoints.tavern.yaml
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.0, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/wazuh/wazuh/api/test/integration
configfile: pytest.ini
plugins: html-2.1.1, cov-4.1.0, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 42 items                                                                                                                                                                          

test_rbac_black_agent_endpoints.tavern.yaml ..........................................

=================================================================== 42 passed, 43 warnings in 876.15s (0:14:36) ===================================================================
```

</details>

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
