### PR TITLE
Adapt wazuh-maild to RFC5322 standard (fixed mutiple email)

### DIFF
--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -26,7 +26,7 @@
 #define DATAMSG             "DATA\r\n"
 #define FROM                "From: " __ossec_name " <%s>\r\n"
 #define REPLYTO             "Reply-To: " __ossec_name " <%s>\r\n"
-#define TO                  "To: <%s>\r\n"
+#define TO                  "To: %s\r\n"
 #define CC                  "Cc: <%s>\r\n"
 #define SUBJECT             "Subject: %s\r\n"
 #define ENDHEADER           "\r\n"
@@ -171,16 +171,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
         free(msg);
     }
 
-    /* Build "From" and "To" in the e-mail header */
-    memset(snd_msg, '\0', 128);
-    snprintf(snd_msg, 127, TO, to[0]);
-
-    if (sendmail) {
-        fprintf(sendmail->file_in, "%s", snd_msg);
-    } else {
-        OS_SendTCP(socket, snd_msg);
-    }
-
+    /* Build "From" in the e-mail header */
     memset(snd_msg, '\0', 128);
     snprintf(snd_msg, 127, FROM, from);
 
@@ -201,24 +192,29 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
         }
     }
 
-    /* Add CCs */
-    if (to[1]) {
-        i = 1;
-        while (1) {
-            if (to[i] == NULL) {
-                break;
-            }
-
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, TO, to[i]);
-
-            if (sendmail) {
-                fprintf(sendmail->file_in, "%s", snd_msg);
+    /* Build a single "To" header with all recipients */
+    {
+        char to_list[1024] = "";
+        size_t to_rem = sizeof(to_list);
+        int first_to = 1;
+        for (i = 0; to[i]; i++) {
+            if (!first_to) {
+                int n = snprintf(to_list + strlen(to_list), to_rem, ", <%s>", to[i]);
+                if (n < 0 || (size_t)n >= to_rem) break;
+                to_rem -= n;
             } else {
-                OS_SendTCP(socket, snd_msg);
+                int n = snprintf(to_list, to_rem, "<%s>", to[i]);
+                if (n < 0 || (size_t)n >= to_rem) break;
+                to_rem -= n;
+                first_to = 0;
             }
-
-            i++;
+        }
+        memset(snd_msg, 0, sizeof(snd_msg));
+        snprintf(snd_msg, sizeof(snd_msg)-1, TO, to_list);
+        if (sendmail) {
+            fprintf(sendmail->file_in, "%s", snd_msg);
+        } else {
+            OS_SendTCP(socket, snd_msg);
         }
     }
 

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -210,7 +210,11 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
             }
         }
         memset(snd_msg, 0, sizeof(snd_msg));
-        snprintf(snd_msg, sizeof(snd_msg)-1, TO, to_list);
+        int n = snprintf(snd_msg, sizeof(snd_msg) - 1, TO, to_list);
+        if (n < 0 || n >= (int)(sizeof(snd_msg)-1)) {
+            merror("Error formatting 'To' header: snprintf failed or output truncated.");
+            return OS_INVALID;
+        }
         if (sendmail) {
             fprintf(sendmail->file_in, "%s", snd_msg);
         } else {

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -540,15 +540,15 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
         /* Send single TO: if there is at least one */
         if (p != to_list) {
-        if (sendmail) {
-            fprintf(sendmail->file_in, TO, to_list);
-        } else {
-            char hdr[1080];
-            int hl = snprintf(hdr, sizeof(hdr), TO, to_list);
-            if (hl > 0 && (size_t)hl < sizeof(hdr)) {
-            OS_SendTCP(socket, hdr);
+            if (sendmail) {
+                fprintf(sendmail->file_in, TO, to_list);
+            } else {
+                char hdr[1080];
+                int hl = snprintf(hdr, sizeof(hdr), TO, to_list);
+                if (hl > 0 && (size_t)hl < sizeof(hdr)) {
+                OS_SendTCP(socket, hdr);
+                }
             }
-        }
         }
     }
 


### PR DESCRIPTION
## Description

This PR introduces an improvement to the maild daemon by complying with the RFC5322 standard, which prevents duplicate headers. This prevented emails from being sent to more than one recipient, as they bounced back to the sender, reporting the standard error https://support.google.com/a/answer/13567860?hl=en.
Closes #30676

## Proposed Changes

- Features added: An enhancement was added to comply with RFC 5322
- Bugs fixed: Repeated headers were being sent, which Google interprets as spam.
- Any relevant technical details: The change was introduced for emails with FULL, DEFAULT and SMS formats.

### Results and Evidence

<details>
  <summary>Ossec.conf for full event</summary>

  ```xml
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>yes</email_notification>
    <smtp_server>localhost</smtp_server>
    <email_from>sender@gmail.com</email_from>
    <email_to>secret@hotmail.com</email_to>
    <email_maxperhour>120</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
  </global>

  <alerts>
    <log_alert_level>3</log_alert_level>
    <email_alert_level>7</email_alert_level>
  </alerts>

  <email_alerts>
    <email_to>coxole7585@bulmp3.com</email_to>
    <email_to>filtikelti@gufum.com</email_to>
    <level>7</level>
    <do_not_delay/>
  </email_alerts>
 ```

</details> 

![2025-07-08_11-37](https://github.com/user-attachments/assets/bf9e8509-d930-4d99-98cc-eed1c129b16c)

![2025-07-08_11-39](https://github.com/user-attachments/assets/119277bf-31bb-4ef8-ab35-e3f730d3aa91)

![2025-07-08_11-43](https://github.com/user-attachments/assets/deabf538-1cd7-42ed-aa84-f57d5d6d88c8)


<details>
  <summary>Ossec.conf for SMS</summary>

  ```xml
  <global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>yes</email_notification>
    <smtp_server>localhost</smtp_server>
    <email_from>sender@gmail.com</email_from>
    <email_to>secret@hotmail.com</email_to>
    <email_maxperhour>120</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
  </global>

  <alerts>
    <log_alert_level>3</log_alert_level>
    <email_alert_level>7</email_alert_level>
  </alerts>

  <email_alerts>
    <email_to>coxole7585@bulmp3.com</email_to>
    <email_to>filtikelti@gufum.com</email_to>
    <format>sms</format>
    <level>7</level>
    <do_not_delay/>
  </email_alerts>
 ```

</details> 

![2025-07-08_11-50](https://github.com/user-attachments/assets/5dbb5d41-f8f0-449c-8291-c6428ad7ba80)
![2025-07-08_11-49](https://github.com/user-attachments/assets/55b48666-04de-4c10-bb94-37542ab9d8ea)


### Manual tests with their corresponding evidence

After installation, the proc was set up to perform the analysis with ASAN. Tests were performed using the wazuh-maild daemon, manually running alerts in the alerts.log file, and then running all the dameons and receiving alerts compiled by the manager.

<details>
  <summary>ASAN in maild for 4.14.0</summary>

  ```
=================================================================
==50468==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 148 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff76279a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x5555555febad in Read_Global config/global-config.c:210
    #2 0x5555555f1a1b in read_main_elements config/config.c:85
    #3 0x5555555f415f in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680c38  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4c38)
    #1 0x555555602b67 in Read_Global config/global-config.c:498
    #2 0x5555555f1a1b in read_main_elements config/config.c:85
    #3 0x5555555f415f in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680c38  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4c38)
    #1 0x555555603000 in Read_Global config/global-config.c:518
    #2 0x5555555f1a1b in read_main_elements config/config.c:85
    #3 0x5555555f415f in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 94 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x5555557356e5 in OS_IsValidIP shared/validate_op.c:412
    #2 0x555555602ef5 in Read_Global config/global-config.c:507
    #3 0x5555555f1a1b in read_main_elements config/config.c:85
    #4 0x5555555f415f in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 48 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x555555602cdb in Read_Global config/global-config.c:504
    #2 0x5555555f1a1b in read_main_elements config/config.c:85
    #3 0x5555555f415f in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x555555603174 in Read_Global config/global-config.c:525
    #2 0x5555555f1a1b in read_main_elements config/config.c:85
    #3 0x5555555f415f in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff76279a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x55555574bfb2 in OSMatch_Compile os_regex/os_match_compile.c:55
    #2 0x555555603393 in Read_Global config/global-config.c:530
    #3 0x5555555f1a1b in read_main_elements config/config.c:85
    #4 0x5555555f415f in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 23 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff76279a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x55555574c634 in OSMatch_Compile os_regex/os_match_compile.c:131
    #2 0x555555603393 in Read_Global config/global-config.c:530
    #3 0x5555555f1a1b in read_main_elements config/config.c:85
    #4 0x5555555f415f in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x55555574c26c in OSMatch_Compile os_regex/os_match_compile.c:99
    #2 0x555555603393 in Read_Global config/global-config.c:530
    #3 0x5555555f1a1b in read_main_elements config/config.c:85
    #4 0x5555555f415f in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x55555574c2f6 in OSMatch_Compile os_regex/os_match_compile.c:101
    #2 0x555555603393 in Read_Global config/global-config.c:530
    #3 0x5555555f1a1b in read_main_elements config/config.c:85
    #4 0x5555555f415f in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x55555574c2b1 in OSMatch_Compile os_regex/os_match_compile.c:100
    #2 0x555555603393 in Read_Global config/global-config.c:530
    #3 0x5555555f1a1b in read_main_elements config/config.c:85
    #4 0x5555555f415f in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x555555736109 in OS_IsValidIP shared/validate_op.c:490
    #2 0x555555602ef5 in Read_Global config/global-config.c:507
    #3 0x5555555f1a1b in read_main_elements config/config.c:85
    #4 0x5555555f415f in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

SUMMARY: AddressSanitizer: 489 byte(s) leaked in 16 allocation(s).
 ```

</details> 


<details>
  <summary>ASAN in maild for enhancemnet branch</summary>

  ```
=================================================================
==48199==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 148 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff76279a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x5555555fefb2 in Read_Global config/global-config.c:210
    #2 0x5555555f1e20 in read_main_elements config/config.c:85
    #3 0x5555555f4564 in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680c38  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4c38)
    #1 0x555555602f6c in Read_Global config/global-config.c:498
    #2 0x5555555f1e20 in read_main_elements config/config.c:85
    #3 0x5555555f4564 in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680c38  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4c38)
    #1 0x555555603405 in Read_Global config/global-config.c:518
    #2 0x5555555f1e20 in read_main_elements config/config.c:85
    #3 0x5555555f4564 in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 94 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x555555735aea in OS_IsValidIP shared/validate_op.c:412
    #2 0x5555556032fa in Read_Global config/global-config.c:507
    #3 0x5555555f1e20 in read_main_elements config/config.c:85
    #4 0x5555555f4564 in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 48 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x5555556030e0 in Read_Global config/global-config.c:504
    #2 0x5555555f1e20 in read_main_elements config/config.c:85
    #3 0x5555555f4564 in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x555555603579 in Read_Global config/global-config.c:525
    #2 0x5555555f1e20 in read_main_elements config/config.c:85
    #3 0x5555555f4564 in ReadConfig config/config.c:372
    #4 0x5555555e1781 in MailConf os_maild/config.c:54
    #5 0x5555555e48c7 in main os_maild/maild.c:129
    #6 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff76279a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x55555574c3b7 in OSMatch_Compile os_regex/os_match_compile.c:55
    #2 0x555555603798 in Read_Global config/global-config.c:530
    #3 0x5555555f1e20 in read_main_elements config/config.c:85
    #4 0x5555555f4564 in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 23 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff76279a7  (/lib/x86_64-linux-gnu/libasan.so.6+0x5b9a7)
    #1 0x55555574ca39 in OSMatch_Compile os_regex/os_match_compile.c:131
    #2 0x555555603798 in Read_Global config/global-config.c:530
    #3 0x5555555f1e20 in read_main_elements config/config.c:85
    #4 0x5555555f4564 in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x55555574c671 in OSMatch_Compile os_regex/os_match_compile.c:99
    #2 0x555555603798 in Read_Global config/global-config.c:530
    #3 0x5555555f1e20 in read_main_elements config/config.c:85
    #4 0x5555555f4564 in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x55555574c6fb in OSMatch_Compile os_regex/os_match_compile.c:101
    #2 0x555555603798 in Read_Global config/global-config.c:530
    #3 0x5555555f1e20 in read_main_elements config/config.c:85
    #4 0x5555555f4564 in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x55555574c6b6 in OSMatch_Compile os_regex/os_match_compile.c:100
    #2 0x555555603798 in Read_Global config/global-config.c:530
    #3 0x5555555f1e20 in read_main_elements config/config.c:85
    #4 0x5555555f4564 in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff7680a57  (/lib/x86_64-linux-gnu/libasan.so.6+0xb4a57)
    #1 0x55555573650e in OS_IsValidIP shared/validate_op.c:490
    #2 0x5555556032fa in Read_Global config/global-config.c:507
    #3 0x5555555f1e20 in read_main_elements config/config.c:85
    #4 0x5555555f4564 in ReadConfig config/config.c:372
    #5 0x5555555e1781 in MailConf os_maild/config.c:54
    #6 0x5555555e48c7 in main os_maild/maild.c:129
    #7 0x7ffff6865d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)

SUMMARY: AddressSanitizer: 489 byte(s) leaked in 16 allocation(s).
 ```

</details> 

## Review Checklist


- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
