### PR TITLE
Hot Reload for Linux Agents

### DIFF
--- a/src/active-response/restart-wazuh.c
+++ b/src/active-response/restart-wazuh.c
@@ -26,7 +26,7 @@ int main (int argc, char **argv) {
 
 #ifndef WIN32
     char log_msg[OS_MAXSTR];
-    char *exec_cmd[3] = { "bin/wazuh-control", "restart", NULL };
+    char *exec_cmd[3] = { "bin/wazuh-control", "reload", NULL };
 
     wfd_t *wfd = wpopenv(*exec_cmd, exec_cmd, W_BIND_STDERR);
     if (!wfd) {

--- a/src/active-response/restart-wazuh.c
+++ b/src/active-response/restart-wazuh.c
@@ -26,7 +26,7 @@ int main (int argc, char **argv) {
 
 #ifndef WIN32
     char log_msg[OS_MAXSTR];
-    char *exec_cmd[3] = { "bin/wazuh-control", "reload", NULL };
+    char *exec_cmd[3] = { "bin/wazuh-control", "restart", NULL };
 
     wfd_t *wfd = wpopenv(*exec_cmd, exec_cmd, W_BIND_STDERR);
     if (!wfd) {

--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -4,10 +4,11 @@
 
 
 PARAM_TYPE=$1
+PARAM_ACTION="${2:-restart}"
 
 help()
 {
-    echo "Usage: $0 [manager|agent]"
+    echo "Usage: $0 [manager|agent] [restart|reload]"
 }
 
 # Usage
@@ -41,6 +42,6 @@ if [ "$TYPE" = "manager" ]; then
     fi
 fi
 
-${PWD}/bin/wazuh-control reload
+${PWD}/bin/wazuh-control $PARAM_ACTION
 
 exit $?;

--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -41,6 +41,6 @@ if [ "$TYPE" = "manager" ]; then
     fi
 fi
 
-${PWD}/bin/wazuh-control restart
+${PWD}/bin/wazuh-control reload
 
 exit $?;

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -64,6 +64,37 @@ void buffer_init();
 /* Send message to a buffer with the aim to avoid flooding issues */
 int buffer_append(const char *msg);
 
+/**
+ * @brief Resizes the internal circular buffer to a desired capacity.
+ *
+ * @param current_capacity The current allocated capacity of the buffer before resizing.
+ * @param desired_capacity The new capacity to which the buffer should be resized.
+ *
+ * @retval 0 on success.
+ * @retval -1 on failure (e.g., invalid capacity, memory allocation error).
+ *
+ * @note If the desired capacity is smaller than the current number of messages,
+ * the buffer will truncate the newest messages to preserve the oldest ones.
+ */
+int w_agentd_buffer_resize(unsigned int current_capacity, unsigned int desired_capacity);
+
+/**
+ * @brief Frees all dynamically allocated memory associated with the agent's message buffer.
+ *
+ * This function performs a complete cleanup of the circular message buffer.
+ * It iterates through all allocated slots up to the provided `current_capacity`,
+ * freeing individual messages first to prevent memory leaks. After clearing
+ * the contents, it deallocates the buffer array itself. Finally, it resets
+ * global buffer-related state variables (like `agt->buflength`, `i`, and `j`)
+ * to indicate an unallocated and empty state.
+ *
+ * This function is thread-safe, utilizing a mutex to protect access to shared buffer state.
+ *
+ * @param current_capacity The current allocated capacity of the buffer to be freed.
+ * This parameter is crucial for iterating over the correct number of slots.
+ */
+void w_agentd_buffer_free(unsigned int current_capacity);
+
 /* Thread to dispatch messages from the buffer */
 #ifdef WIN32
 DWORD WINAPI dispatch_buffer(LPVOID arg);

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -194,8 +194,8 @@ DWORD WINAPI req_receiver(LPVOID arg);
 void * req_receiver(void * arg);
 #endif
 
-// Restart agent
-void * restartAgent();
+// Reload agent
+void * reloadAgent();
 
 // Verify remote configuration. Return 0 on success or -1 on error.
 int verifyRemoteConf();

--- a/src/client-agent/buffer.c
+++ b/src/client-agent/buffer.c
@@ -117,15 +117,13 @@ int buffer_append(const char *msg){
     w_agentd_state_update(INCREMENT_MSG_COUNT, NULL);
 
     /* When buffer is full, event is dropped */
-
-    if (full(i, j, agt->buflength + 1)){
+    if (full(i, j, agt->buflength + 1)) {
 
         w_mutex_unlock(&mutex_lock);
         mdebug2("Unable to store new packet: Buffer is full.");
         return(-1);
 
-    }else{
-
+    } else {
         buffer[i] = strdup(msg);
         forward(i, agt->buflength + 1);
         w_cond_signal(&cond_no_empty);
@@ -139,25 +137,31 @@ int buffer_append(const char *msg){
 #ifdef WIN32
 DWORD WINAPI dispatch_buffer(__attribute__((unused)) LPVOID arg) {
 #else
-void *dispatch_buffer(__attribute__((unused)) void * arg){
+void *dispatch_buffer(__attribute__((unused)) void * arg) {
 #endif
     char flood_msg[OS_MAXSTR];
     char full_msg[OS_MAXSTR];
     char warn_msg[OS_MAXSTR];
     char normal_msg[OS_MAXSTR];
-
     char warn_str[OS_SIZE_2048];
     struct timespec ts0;
     struct timespec ts1;
 
-    while(1){
+
+    while(1) {
         gettime(&ts0);
 
         w_mutex_lock(&mutex_lock);
-
-        while(empty(i, j)){
+        while(empty(i, j) && agt->buffer) {
             w_cond_wait(&cond_no_empty, &mutex_lock);
         }
+
+        if (!agt->buffer) {
+            minfo("Dispatch buffer thread received stop signal. Exiting.");
+            w_mutex_unlock(&mutex_lock);
+            break;
+        }
+
         /* Check if buffer usage reaches any lower level */
         switch (state) {
 
@@ -165,7 +169,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
                 break;
 
             case WARNING:
-                if (normal(i, j)){
+                if (normal(i, j)) {
                     state = NORMAL;
                     buff.normal = 1;
                 }
@@ -175,7 +179,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
                 if (nowarn(i, j))
                     state = WARNING;
 
-                if (normal(i, j)){
+                if (normal(i, j)) {
                     state = NORMAL;
                     buff.normal = 1;
                 }
@@ -185,7 +189,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
                 if (nowarn(i, j))
                     state = WARNING;
 
-                if (normal(i, j)){
+                if (normal(i, j)) {
                     state = NORMAL;
                     buff.normal = 1;
                 }
@@ -193,10 +197,11 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
         }
 
         char * msg_output = buffer[j];
+        unsigned int original_j_for_nulling = j;
         forward(j, agt->buflength + 1);
         w_mutex_unlock(&mutex_lock);
 
-        if (buff.warn){
+        if (buff.warn) {
 
             buff.warn = 0;
             mwarn(WARN_BUFFER, warn_level);
@@ -205,7 +210,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
             send_msg(warn_msg, -1);
         }
 
-        if (buff.full){
+        if (buff.full) {
 
             buff.full = 0;
             mwarn(FULL_BUFFER);
@@ -213,7 +218,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
             send_msg(full_msg, -1);
         }
 
-        if (buff.flood){
+        if (buff.flood) {
 
             buff.flood = 0;
             mwarn(FLOODED_BUFFER);
@@ -221,7 +226,7 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
             send_msg(flood_msg, -1);
         }
 
-        if (buff.normal){
+        if (buff.normal) {
 
             buff.normal = 0;
             minfo(NORMAL_BUFFER, normal_level);
@@ -230,8 +235,12 @@ void *dispatch_buffer(__attribute__((unused)) void * arg){
         }
 
         os_wait();
-        send_msg(msg_output, -1);
-        free(msg_output);
+
+        if (msg_output != NULL) {
+            send_msg(msg_output, -1);
+            os_free(msg_output);
+            buffer[original_j_for_nulling] = NULL;
+        }
 
         gettime(&ts1);
         time_sub(&ts1, &ts0);
@@ -265,4 +274,115 @@ int w_agentd_get_buffer_lenght() {
     }
 
     return retval;
+}
+
+void w_agentd_buffer_free(unsigned int current_capacity) {
+    w_mutex_lock(&mutex_lock);
+
+    // Ensure the buffer is actually allocated before trying to free.
+    if ( buffer == NULL || current_capacity == 0) {
+        mwarn("Buffer is already unallocated or invalid. Skipping free operation.");
+        w_mutex_unlock(&mutex_lock);
+        return;
+    }
+
+    mdebug2("Freeing the client-buffer.");
+    for ( int i=0; i <= current_capacity; i++) {
+        os_free(buffer[i]);
+    }
+
+    os_free(buffer);
+
+    agt->buflength = 0;
+    i = 0;
+    j = 0;
+
+    // Signal to end the dispatch_buffer thread.
+    w_cond_signal(&cond_no_empty);
+    w_mutex_unlock(&mutex_lock);
+
+    minfo("Client buffer freed successfully.");
+}
+
+int w_agentd_buffer_resize(unsigned int current_capacity, unsigned int desired_capacity) {
+
+    if (desired_capacity <= 0) {
+        merror("Invalid new buffer capacity requested: %u.", desired_capacity);
+        return -1;
+    }
+
+    if (desired_capacity == current_capacity) {
+        return 0;
+    }
+
+    // Attempt to reallocate the buffer
+    unsigned int agent_msg_count = w_agentd_get_buffer_lenght();
+    w_mutex_lock(&mutex_lock);
+
+    char **temp_buffer = NULL;
+    if (desired_capacity > current_capacity) {
+        // We add +1 to the desired capacity for internal management of the circular buffer,
+        // allowing it to distinguish between full and empty states.
+        os_calloc(desired_capacity + 1, sizeof(char *), temp_buffer);
+
+        // Copy data in logical ordecoder to the new buffer
+        if (j < i) {
+            mdebug2("Copying contiguous data to new buffer. Count: %u events, "
+                    "tail: %d, head: %d\n", agent_msg_count, j, i);
+            memcpy(temp_buffer, &buffer[j], agent_msg_count * sizeof(char *));
+        } else {
+            int first_part = (current_capacity - j) + 1;
+            mdebug2("Wrapped buffer detected. Copying in two parts:\n");
+            mdebug2("  Part 1: %d bytes from old[tail=%d] → new[0]\n", first_part, j);
+            mdebug2("  Part 2: %d bytes from old[0] → new[%d]\n", i, first_part);
+            memcpy(temp_buffer, &buffer[j], first_part * sizeof(char *));
+            memcpy(temp_buffer + first_part, buffer, i * sizeof(char *));
+        }
+
+    } else {
+
+        mwarn("Shrinking client buffer from %u to %u (messages: %u).",
+              current_capacity, desired_capacity, agent_msg_count);
+
+        unsigned int retained_message_count = (agent_msg_count < desired_capacity) ? agent_msg_count : desired_capacity;
+
+        // Allocate a new temporary buffer of the desired smaller size
+        os_calloc(desired_capacity + 1, sizeof(char *), temp_buffer);
+
+        // Copy the N oldest messages that will be preserved
+        for (unsigned int k = 0; k < retained_message_count; k++) {
+            unsigned int old_idx = (j + k) % (current_capacity + 1);
+            if (buffer[old_idx]) {
+                temp_buffer[k] = buffer[old_idx];
+                buffer[old_idx] = NULL;
+                mdebug2("Moving message from old[%u] to new[%u] (ptr: %p)",
+                        old_idx, k, (void*)temp_buffer[k]);
+            }
+        }
+
+        minfo("Successfully copied %u messages to the new buffer.", retained_message_count);
+
+        // Now free everything in the old buffer
+        // Loop up to and including 'current_capacity' as the buffer was sized for 'current_capacity + 1' elements.
+        for (unsigned int idx = 0; idx <= current_capacity; idx++) {
+            if (buffer[idx]) {
+                mdebug2("Freeing buffer[%u] (ptr: %p)\n", idx, (void *)buffer[idx]);
+                os_free(buffer[idx]);
+            }
+        }
+
+        // Update global buffer state variables for the new smaller buffer
+        agent_msg_count = retained_message_count;
+        w_agentd_state_update(RESET_MSG_COUNT_ON_SHRINK, &agent_msg_count);
+    }
+
+    // Reset tail and head indices for the new buffer
+    j = 0;
+    i = agent_msg_count;
+    os_free(buffer);
+    buffer = temp_buffer;
+    w_mutex_unlock(&mutex_lock);
+    minfo("Client buffer resized from %u to %u elements.",
+          current_capacity, desired_capacity);
+    return 0;
 }

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -295,8 +295,8 @@ int receive_msg()
                                     clear_merged_hash_cache();
                                     if (agt->flags.remote_conf && !verifyRemoteConf()) {
                                         if (agt->flags.auto_restart) {
-                                            minfo("Agent is restarting due to shared configuration changes.");
-                                            restartAgent();
+                                            minfo("Agent is reloading due to shared configuration changes.");
+                                            reloadAgent();
                                         } else {
                                             minfo("Shared agent configuration has been updated.");
                                         }

--- a/src/client-agent/reload_agent.c
+++ b/src/client-agent/reload_agent.c
@@ -21,9 +21,9 @@
 
 static const char AG_IN_RCON[] = "wazuh: Invalid remote configuration";
 
-void * restartAgent() {
+void * reloadAgent() {
 
-	char req[] = "restart";
+	char req[] = "reload";
 
 	#ifndef WIN32
 
@@ -38,11 +38,11 @@ void * restartAgent() {
 	if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
 		switch (errno) {
 		case ECONNREFUSED:
-			merror("Could not auto-restart agent. Is Active Response enabled?");
+			merror("Could not auto-reload agent. Is Active Response enabled?");
 			break;
 
 		default:
-			merror("At restartAgent(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
+			merror("At reloadAgent(): Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
 		}
 	} else {
 		if (OS_SendSecureTCP(sock, length, req)) {

--- a/src/client-agent/state.c
+++ b/src/client-agent/state.c
@@ -209,6 +209,11 @@ void w_agentd_state_update(w_agentd_state_update_t type, void * data) {
     case INCREMENT_MSG_SEND:
         agent_state.msg_sent++;
         break;
+    case RESET_MSG_COUNT_ON_SHRINK:
+        if (data != NULL) {
+            agent_state.msg_count = *((unsigned int *) data);
+        }
+        break;
     default:
         break;
     }

--- a/src/client-agent/state.h
+++ b/src/client-agent/state.h
@@ -37,7 +37,8 @@ typedef enum {
     UPDATE_KEEPALIVE,    ///< Update keepalive represented by time_t
     UPDATE_ACK,          ///< Update last ack represented by time_t
     INCREMENT_MSG_COUNT, ///< Increment number of messages sent to the buffer
-    INCREMENT_MSG_SEND   ///< Increment number of messages sent to the manager
+    INCREMENT_MSG_SEND,   ///< Increment number of messages sent to the manager
+    RESET_MSG_COUNT_ON_SHRINK ///< Reset message counter due to buffer shrinking, taking into account new buffer capacity.
 } w_agentd_state_update_t;
 
 /**

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -41,7 +41,7 @@ typedef struct _agent {
     long force_reconnect_interval;
     int main_ip_update_interval;
     char *profile;
-    int buffer;
+    volatile int buffer;
     int buflength;
     int events_persec;
     int crypto_method;

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -313,8 +313,11 @@ restart)
     restart_service
     ;;
 reload)
-    DAEMONS=$(echo $DAEMONS | sed 's/wazuh-execd//')
+    DAEMONS=$(echo $DAEMONS | sed 's/wazuh-agentd//')
     restart_service
+    # Signal agentd (SIGUSR1) to reload (reconnects execd)
+    pid=`cat ${DIR}/var/run/wazuh-agentd-*.pid`
+    kill -USR1 $pid
     ;;
 status)
     lock

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -95,7 +95,7 @@ unlock()
 help()
 {
     # Help message
-    echo "Usage: $0 {start|stop|restart|status|info [-v -r -t]}";
+    echo "Usage: $0 {start|stop|restart|reload|status|info [-v -r -t]}";
     exit 1;
 }
 

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -66,6 +66,7 @@ void ExecdShutdown(int sig) __attribute__((noreturn));
 size_t wcom_unmerge(const char *file_path, char **output);
 size_t wcom_uncompress(const char * source, const char * target, char ** output);
 size_t wcom_restart(char **output);
+size_t wcom_reload(char ** output);
 size_t wcom_dispatch(char *command, char **output);
 size_t lock_restart(int timeout);
 size_t wcom_getconfig(const char * section, char ** output);

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -64,6 +64,10 @@ size_t wcom_dispatch(char *command, char ** output) {
 
     } else if (strcmp(rcv_comm, "restart") == 0 || strcmp(rcv_comm, "restart-wazuh") == 0) {
         return wcom_restart(output);
+
+    } else if (strcmp(rcv_comm, "reload")  == 0) {
+        return wcom_reload(output);
+
     } else if (strcmp(rcv_comm, "lock_restart") == 0) {
         max_restart_lock = 0;
         int timeout = -2;
@@ -242,6 +246,64 @@ size_t wcom_restart(char ** output) {
     return strlen(*output);
 }
 
+size_t wcom_reload(char ** output) {
+    time_t lock = pending_upg - time(NULL);
+    if (lock <= 0) {
+#ifndef WIN32
+        char *exec_cmd[4] = {NULL};
+
+        if (waccess("active-response/bin/restart.sh", F_OK) == 0) {
+            exec_cmd[0] = "active-response/bin/restart.sh";
+#ifdef CLIENT
+            exec_cmd[1] = "agent";
+#else
+            exec_cmd[1] = "manager";
+#endif
+            exec_cmd[2] = "reload";
+        } else {
+            exec_cmd[0] = "bin/wazuh-control";
+            exec_cmd[1] = "reload";
+        }
+
+        switch (fork()) {
+            case -1:
+                merror("At WCOM reload: Cannot fork");
+                os_strdup("err Cannot fork", *output);
+            break;
+            case 0:
+                if (execv(exec_cmd[0], exec_cmd) < 0) {
+                    merror(EXEC_CMDERROR, *exec_cmd, strerror(errno));
+                    _exit(1);
+                }
+            break;
+            default:
+                os_strdup("ok ", *output);
+            break;
+        }
+
+#else
+        static char command[OS_FLSIZE];
+        snprintf(command, sizeof(command), "%s/%s", AR_BINDIR, "restart-wazuh.exe");
+        char *cmd[2] = { command, NULL };
+        char *cmd_parameters = "{\"version\":1,\"origin\":{\"name\":\"\",\"module\":\"wazuh-execd\"},\"command\":\"add\",\"parameters\":{\"extra_args\":[],\"alert\":{},\"program\":\"restart-wazuh.exe\"}}";
+        wfd_t *wfd = wpopenv(cmd[0], cmd, W_BIND_STDIN);
+        if (wfd) {
+            // Send alert to AR script
+            fprintf(wfd->file_in, "%s\n", cmd_parameters);
+            fflush(wfd->file_in);
+            wpclose(wfd);
+        } else {
+            merror("At WCOM restart: Cannot execute restart process");
+            os_strdup("err Cannot execute restart process", *output);
+        }
+#endif
+    } else {
+        minfo(LOCK_RES, (int)lock);
+    }
+
+    if (!*output) os_strdup("ok ", *output);
+    return strlen(*output);
+}
 
 size_t wcom_getconfig(const char * section, char ** output) {
 

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -86,7 +86,8 @@ list(APPEND client-agent_flags "-Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread
                                 -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap=is_fim_shutdown -Wl,--wrap=fim_db_teardown \
                                 -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize")
 else()
-list(APPEND client-agent_flags "-Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock")
+list(APPEND client-agent_flags "-Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
+                                -Wl,--wrap,getDefine_Int -Wl,--wrap,_minfo -Wl,--wrap,_mwarn")
 endif()
 
 if(${TARGET} STREQUAL "agent")

--- a/src/unit_tests/client-agent/test_buffer.c
+++ b/src/unit_tests/client-agent/test_buffer.c
@@ -18,10 +18,15 @@
 #include "../wrappers/posix/pthread_wrappers.h"
 
 int w_agentd_get_buffer_lenght();
+int buffer_append(const char *msg);
+int w_agentd_buffer_resize(unsigned int current_capacity, unsigned int desired_capacity);
+void w_agentd_buffer_free(unsigned int current_capacity);
+void buffer_init();
 
 extern agent *agt;
 extern int i;
 extern int j;
+extern char **buffer;
 
 /* setup/teardown */
 
@@ -34,6 +39,22 @@ static int teardown_group(void **state) {
     test_mode = 0;
     return 0;
 }
+
+// The mock function for getDefine_Int
+int __wrap_getDefine_Int(const char *category, const char *name, int min, int max) {
+    function_called();
+
+    return mock_type(int);
+}
+
+void __wrap__minfo(const char *file, int line, const char *func, const char *format, ...) {
+        function_called();
+}
+
+void __wrap__mwarn(const char *file, int line, const char *func, const char *format, ...) {
+        function_called();
+}
+
 
 /* tests */
 
@@ -92,12 +113,280 @@ void test_w_agentd_get_buffer_lenght_buffer(void ** state)
 
 }
 
+void test_buffer_append(void **state)
+{
+    os_calloc(1, sizeof(agent), agt);
+    agt->buffer = 1;
+    agt->buflength = 5;
+    i = 0;
+    j = 0;
+    char var[] = "Testing";
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 90);
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 80);
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 15);
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    buffer_init();
+    buffer_append("Testing");
+
+    assert_int_equal(1, w_agentd_get_buffer_lenght());
+
+    // Required for w_agentd_buffer_free
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    // expect_function_call(__wrap__mwarn);
+    expect_function_call(__wrap__minfo);
+
+    w_agentd_buffer_free(agt->buflength);
+
+    os_free(agt);
+}
+
+void test_w_agentd_buffer_resize_shrink(void **state)
+{
+    os_calloc(1, sizeof(agent), agt);
+    agt->buffer = 1;
+    agt->buflength = 5;
+    i = 0;
+    j = 0;
+    char var[] = "Testing";
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 90);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 80);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 15);
+
+    buffer_init();
+
+    for (int k = 0; k < agt->buflength; k++) {
+        // Loock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_lock);
+        // Look and unlock w_agentd_get_buffer_lenght
+        expect_function_call(__wrap_pthread_mutex_lock);
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        // Unloock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        buffer_append("Testing");
+    }
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_function_call(__wrap__mwarn);
+    expect_function_call(__wrap__minfo);
+
+    // Loock, unloock the mutex for the w_agentd_state_update
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap__minfo);
+
+    int new_capacity = 2;
+    int retval = w_agentd_buffer_resize(agt->buflength, new_capacity);
+
+    assert_int_equal(retval, 0);
+
+    // Required for w_agentd_get_buffer_lenght
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    assert_int_equal(2, w_agentd_get_buffer_lenght());
+
+    // Required for w_agentd_buffer_free
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_function_call(__wrap__minfo);
+
+    w_agentd_buffer_free(new_capacity);
+    os_free(agt);
+}
+
+void test_w_agentd_buffer_resize_grow_continue(void **state)
+{
+    os_calloc(1, sizeof(agent), agt);
+    agt->buffer = 1;
+    agt->buflength = 2;
+    i = 0;
+    j = 0;
+    char var[] = "Testing";
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 90);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 80);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 15);
+
+    buffer_init();
+
+    for (int k = 0; k < agt->buflength; k++) {
+        // Loock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_lock);
+        // Look and unlock w_agentd_get_buffer_lenght
+        expect_function_call(__wrap_pthread_mutex_lock);
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        // Unloock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        buffer_append("Testing");
+    }
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap__minfo);
+
+    int new_capacity = 5;
+    int retval = w_agentd_buffer_resize(agt->buflength, new_capacity);
+
+    assert_int_equal(retval, 0);
+
+    // Required for w_agentd_get_buffer_lenght
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    assert_int_equal(2, w_agentd_get_buffer_lenght());
+
+    // Required for w_agentd_buffer_free
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    // expect_function_call(__wrap__mwarn);
+    expect_function_call(__wrap__minfo);
+
+    w_agentd_buffer_free(new_capacity);
+    os_free(agt);
+}
+
+void test_w_agentd_buffer_resize_grow_two_parts(void **state)
+{
+    os_calloc(1, sizeof(agent), agt);
+    agt->buffer = 1;
+    agt->buflength = 2;
+    i = 1;
+    j = 1;
+    char var[] = "Testing";
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 90);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 80);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 15);
+
+    buffer_init();
+
+    for (int k = 0; k < agt->buflength; k++) {
+        // Loock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_lock);
+        // Look and unlock w_agentd_get_buffer_lenght
+        expect_function_call(__wrap_pthread_mutex_lock);
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        // Unloock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        buffer_append("Testing");
+    }
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap_pthread_mutex_lock);
+
+    // Loock, unloock the mutex for the w_agentd_state_update
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap__minfo);
+
+    int new_capacity = 5;
+    int retval = w_agentd_buffer_resize(agt->buflength, new_capacity);
+    agt->buflength = new_capacity;
+    assert_int_equal(retval, 0);
+
+    // Required for w_agentd_get_buffer_lenght
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    assert_int_equal(2, w_agentd_get_buffer_lenght());
+
+    // Required for w_agentd_buffer_free
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    expect_function_call(__wrap__minfo);
+
+    w_agentd_buffer_free(new_capacity);
+    os_free(agt);
+}
+
+void test_w_agentd_buffer_free(void **state)
+{
+    os_calloc(1, sizeof(agent), agt);
+    agt->buffer = 1;
+    agt->buflength = 5;
+    i = 0;
+    j = 0;
+    char var[] = "Testing";
+
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 90);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 80);
+    expect_function_call(__wrap_getDefine_Int);
+    will_return(__wrap_getDefine_Int, 15);
+
+    buffer_init();
+
+    for (int k = 0; k < agt->buflength; k++) {
+        // Loock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_lock);
+        // Look and unlock w_agentd_get_buffer_lenght
+        expect_function_call(__wrap_pthread_mutex_lock);
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        // Unloock w_agentd_buffer_resize
+        expect_function_call(__wrap_pthread_mutex_unlock);
+        buffer_append("Testing");
+    }
+
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_function_call(__wrap__minfo);
+
+    w_agentd_buffer_free(agt->buflength);
+
+    assert_int_equal(agt->buflength, 0);
+    assert_int_equal(i, 0);
+    assert_int_equal(j, 0);
+
+    os_free(agt);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         // Tests w_agentd_get_buffer_lenght
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer_disabled),
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer_empty),
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer),
+        cmocka_unit_test(test_buffer_append),
+        cmocka_unit_test(test_w_agentd_buffer_free),
+        cmocka_unit_test(test_w_agentd_buffer_resize_shrink),
+        cmocka_unit_test(test_w_agentd_buffer_resize_grow_continue),
+        cmocka_unit_test(test_w_agentd_buffer_resize_grow_two_parts),
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/client-agent/test_buffer.c
+++ b/src/unit_tests/client-agent/test_buffer.c
@@ -18,10 +18,13 @@
 #include "../wrappers/posix/pthread_wrappers.h"
 
 int w_agentd_get_buffer_lenght();
+
+#ifndef TEST_WINAGENT
 int buffer_append(const char *msg);
 int w_agentd_buffer_resize(unsigned int current_capacity, unsigned int desired_capacity);
 void w_agentd_buffer_free(unsigned int current_capacity);
 void buffer_init();
+#endif
 
 extern agent *agt;
 extern int i;
@@ -113,6 +116,7 @@ void test_w_agentd_get_buffer_lenght_buffer(void ** state)
 
 }
 
+#ifndef TEST_WINAGENT
 void test_buffer_append(void **state)
 {
     os_calloc(1, sizeof(agent), agt);
@@ -375,6 +379,7 @@ void test_w_agentd_buffer_free(void **state)
 
     os_free(agt);
 }
+#endif
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -382,11 +387,13 @@ int main(void) {
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer_disabled),
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer_empty),
         cmocka_unit_test(test_w_agentd_get_buffer_lenght_buffer),
+        #ifndef TEST_WINAGENT
         cmocka_unit_test(test_buffer_append),
         cmocka_unit_test(test_w_agentd_buffer_free),
         cmocka_unit_test(test_w_agentd_buffer_resize_shrink),
         cmocka_unit_test(test_w_agentd_buffer_resize_grow_continue),
         cmocka_unit_test(test_w_agentd_buffer_resize_grow_two_parts),
+        #endif
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);


### PR DESCRIPTION
| Parent issue | https://github.com/wazuh/wazuh/issues/29641 |
| --- | --- |
|Relative issues |  https://github.com/wazuh/wazuh/issues/29994  https://github.com/wazuh/wazuh/issues/30186 https://github.com/wazuh/wazuh/issues/30714 |

## Description
This PR introduces hot reload capabilities for Unix agents:

- Unix Agent Hot Reload & Execd Reconnection (#29994):
  - Enables hot reload for Wazuh agents on Unix, allowing specific configuration changes to apply without a full service restart.
  - Fixes execd daemon reconnection issues after restarts.

- Dynamic Client Buffer Resizing (#30186):
  - Implements dynamic buffer resizing, with the option to enable or disable it via the Wazuh agent's centralized configuration.

- Independent Agent reload Command (#30714):
  - Introduces a dedicated reload command for agents.
  - This command allows applying configuration changes (e.g., via centralized configuration) without performing a full agent service restart. The active response system and API will still retain the capability to execute a full agent service restart when needed.

- https://github.com/wazuh/wazuh/issues/30897
  - Fixes service consistency after a reload.

### Testing

- https://github.com/wazuh/wazuh/issues/30799
