### PR TITLE
Add mutex for hourly events

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -212,6 +212,9 @@ w_queue_t * upgrade_module_input;
 /* Hourly firewall mutex */
 static pthread_mutex_t hourly_firewall_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+/* Hourly event mutex */
+static pthread_mutex_t hourly_event_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 /* Accumulate mutex */
 static pthread_mutex_t accumulate_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -1237,7 +1240,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex)
                         hourly_syscheck++;
                     }
                 }
@@ -1259,7 +1264,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 
@@ -1280,7 +1287,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 
@@ -1301,7 +1310,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 
@@ -1322,7 +1333,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 
@@ -1343,7 +1356,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 
@@ -1364,7 +1379,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 
@@ -1385,7 +1402,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 
@@ -1406,7 +1425,9 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
+                        w_mutex_lock(&hourly_event_mutex);
                         hourly_events++;
+                        w_mutex_unlock(&hourly_event_mutex);
                     }
                 }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -98,7 +98,7 @@ static int execdq = 0;
 /* Active response queue */
 static int arq = 0;
 
-static unsigned int hourly_events;
+static atomic_int_t hourly_events;
 static unsigned int hourly_syscheck;
 static unsigned int hourly_firewall;
 
@@ -212,9 +212,6 @@ w_queue_t * upgrade_module_input;
 /* Hourly firewall mutex */
 static pthread_mutex_t hourly_firewall_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-/* Hourly event mutex */
-static pthread_mutex_t hourly_event_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 /* Accumulate mutex */
 static pthread_mutex_t accumulate_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -307,7 +304,7 @@ int main_analysisd(int argc, char **argv)
     prev_year = 0;
     memset(prev_month, '\0', 4);
     hourly_alerts = 0;
-    hourly_events = 0;
+    hourly_events = (atomic_int_t) ATOMIC_INT_INITIALIZER(0);
     hourly_syscheck = 0;
     hourly_firewall = 0;
 
@@ -1190,9 +1187,9 @@ static void DumpLogstats()
     /* Print total for the hour */
     fprintf(flog, "%d--%d--%d--%d--%d\n\n",
             thishour,
-            hourly_alerts, hourly_events, hourly_syscheck, hourly_firewall);
+            hourly_alerts, atomic_int_get(&hourly_events), hourly_syscheck, hourly_firewall);
     w_guard_mutex_variable(hourly_alert_mutex, (hourly_alerts = 0));
-    hourly_events = 0;
+    atomic_int_set(&hourly_events, 0);
     hourly_syscheck = 0;
     hourly_firewall = 0;
 
@@ -1240,9 +1237,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex)
+                        atomic_int_inc(&hourly_events);
                         hourly_syscheck++;
                     }
                 }
@@ -1264,9 +1259,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 
@@ -1287,9 +1280,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 
@@ -1310,9 +1301,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 
@@ -1333,9 +1322,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 
@@ -1356,9 +1343,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 
@@ -1379,9 +1364,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 
@@ -1402,9 +1385,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 
@@ -1425,9 +1406,7 @@ void * ad_input_main(void * args) {
                     if (result == -1) {
                         free(copy);
                     } else {
-                        w_mutex_lock(&hourly_event_mutex);
-                        hourly_events++;
-                        w_mutex_unlock(&hourly_event_mutex);
+                        atomic_int_inc(&hourly_events);
                     }
                 }
 


### PR DESCRIPTION
## Description

This PR aims to eliminate the race condition found in the static analysis performed by Coverity. It is caused by double-binding in the log rotation thread and in the message-handling thread. To get TSAN to detect it, the code had to be temporarily modified to avoid waiting for a time change in the log rotation thread.
Closes #30358 


## Proposed Changes

The solution was to add a mutex to create a critical section and prevent concurrent access to the resource.

### Results and Evidence
Before the placement of the mutexes

```
WARNING: ThreadSanitizer: data race (pid=66876)
  Read of size 4 at 0x5555557e5830 by thread T4 (mutexes: read M301272050075326752):
    #0 ad_input_main analysisd/analysisd.c:1409 (wazuh-analysisd+0x68719)
    #1 <null> <null> (libtsan.so.0+0x2e5ff)

  Previous write of size 4 at 0x5555557e5830 by thread T10 (mutexes: write M647767746406144352):
    #0 DumpLogstats analysisd/analysisd.c:1192 (wazuh-analysisd+0x6757c)
    #1 w_log_rotate_thread analysisd/analysisd.c:2265 (wazuh-analysisd+0x6c827)
    #2 <null> <null> (libtsan.so.0+0x2e5ff)

  Location is global 'hourly_events' of size 4 at 0x5555557e5830 (wazuh-analysisd+0x000000291830)

  Mutex M301272050075326752 is already destroyed.

  Mutex M647767746406144352 is already destroyed.

  Thread T4 (tid=66949, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x189fd7)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18a0a0)
    #3 OS_ReadMSG analysisd/analysisd.c:1030 (wazuh-analysisd+0x668b6)
    #4 main analysisd/analysisd.c:861 (wazuh-analysisd+0x65e37)

  Thread T10 (tid=66955, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x189fd7)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18a0a0)
    #3 OS_ReadMSG analysisd/analysisd.c:1048 (wazuh-analysisd+0x66a54)
    #4 main analysisd/analysisd.c:861 (wazuh-analysisd+0x65e37)

SUMMARY: ThreadSanitizer: data race analysisd/analysisd.c:1409 in ad_input_main
==================
==================
```
After the placement of the mutexes

<details>
  <summary>Report</summary>

```bash
╭─root@ca37659e68c4 /workspaces/devContainer/wazuh/src ‹enhancement/30358-RC-hourly-events› 
╰─# /var/ossec/bin/wazuh-analysisd -f -u root    
2025/07/10 16:28:58 wazuh-analysisd: INFO: Total rules enabled: '7067'
2025/07/10 16:28:58 wazuh-analysisd: INFO: Started (pid: 9341).
2025/07/10 16:28:59 wazuh-analysisd: INFO: EPS limit disabled
2025/07/10 16:28:59 wazuh-analysisd: INFO: (7200): Logtest started
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 1 at 0x5555557e24ad by thread T36:
    #0 <null> <null> (libtsan.so.0+0x4a951)
    #1 Start_Time analysisd/stats.c:446 (wazuh-analysisd+0x62844)
    #2 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #3 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous read of size 1 at 0x5555557e24ad by thread T10 (mutexes: write M647767746406132128):
    #0 <null> <null> (libtsan.so.0+0x557f7)
    #1 <null> <null> (libtsan.so.0+0x55aed)
    #2 DumpLogstats analysisd/analysisd.c:1166 (wazuh-analysisd+0x656ea)

  Location is global 'prev_month' of size 4 at 0x5555557e24ac (wazuh-analysisd+0x00000028e4ad)

  Mutex M647767746406132128 is already destroyed.

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T10 (tid=9413, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1051 (wazuh-analysisd+0x64ff1)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x4a951) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 1 at 0x5555557e24ae by thread T36:
    #0 <null> <null> (libtsan.so.0+0x4a951)
    #1 Start_Time analysisd/stats.c:446 (wazuh-analysisd+0x62844)
    #2 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #3 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous read of size 1 at 0x5555557e24ae by thread T10 (mutexes: write M647767746406132128):
    #0 <null> <null> (libtsan.so.0+0x557f7)
    #1 <null> <null> (libtsan.so.0+0x55aed)
    #2 DumpLogstats analysisd/analysisd.c:1157 (wazuh-analysisd+0x65614)

  Location is global 'prev_month' of size 4 at 0x5555557e24ac (wazuh-analysisd+0x00000028e4ae)

  Mutex M647767746406132128 is already destroyed.

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T10 (tid=9413, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1051 (wazuh-analysisd+0x64ff1)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x4a951) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 4 at 0x5555557e2428 by thread T37:
    #0 Start_Time analysisd/stats.c:440 (wazuh-analysisd+0x62746)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 4 at 0x5555557e2428 by thread T36:
    #0 Start_Time analysisd/stats.c:440 (wazuh-analysisd+0x62746)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global '_fired' of size 4 at 0x5555557e2428 (wazuh-analysisd+0x00000028e428)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:440 in Start_Time
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 4 at 0x5555557e2424 by thread T37:
    #0 Start_Time analysisd/stats.c:441 (wazuh-analysisd+0x6275f)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 4 at 0x5555557e2424 by thread T36:
    #0 Start_Time analysisd/stats.c:441 (wazuh-analysisd+0x6275f)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global '_cignorehour' of size 4 at 0x5555557e2424 (wazuh-analysisd+0x00000028e424)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:441 in Start_Time
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 4 at 0x5555557e24a0 by thread T37:
    #0 Start_Time analysisd/stats.c:443 (wazuh-analysisd+0x6278b)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 4 at 0x5555557e24a0 by thread T36:
    #0 Start_Time analysisd/stats.c:443 (wazuh-analysisd+0x6278b)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global 'today' of size 4 at 0x5555557e24a0 (wazuh-analysisd+0x00000028e4a0)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:443 in Start_Time
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 4 at 0x5555557e24a4 by thread T37:
    #0 Start_Time analysisd/stats.c:444 (wazuh-analysisd+0x627b3)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 4 at 0x5555557e24a4 by thread T36:
    #0 Start_Time analysisd/stats.c:444 (wazuh-analysisd+0x627b3)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global 'thishour' of size 4 at 0x5555557e24a4 (wazuh-analysisd+0x00000028e4a4)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:444 in Start_Time
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 1 at 0x5555557e24af by thread T37:
    #0 Start_Time analysisd/stats.c:447 (wazuh-analysisd+0x62853)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 1 at 0x5555557e24af by thread T36:
    #0 Start_Time analysisd/stats.c:447 (wazuh-analysisd+0x62853)
    #1 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global 'prev_month' of size 4 at 0x5555557e24ac (wazuh-analysisd+0x00000028e4af)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:447 in Start_Time
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 8 at 0x5555557e1ce0 by thread T37:
    #0 <null> <null> (libtsan.so.0+0x614cb)
    #1 Start_Hour analysisd/stats.c:402 (wazuh-analysisd+0x62344)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 8 at 0x5555557e1ce0 by thread T36:
    #0 <null> <null> (libtsan.so.0+0x614cb)
    #1 Start_Hour analysisd/stats.c:402 (wazuh-analysisd+0x62344)
    #2 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global '__stats_comment' of size 192 at 0x5555557e1ce0 (wazuh-analysisd+0x00000028dce0)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x614cb) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 4 at 0x5555557e1da0 by thread T37:
    #0 Start_Hour analysisd/stats.c:405 (wazuh-analysisd+0x62378)
    #1 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 4 at 0x5555557e1da0 by thread T36:
    #0 Start_Hour analysisd/stats.c:405 (wazuh-analysisd+0x62378)
    #1 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global 'maxdiff' of size 4 at 0x5555557e1da0 (wazuh-analysisd+0x00000028dda0)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:405 in Start_Hour
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 4 at 0x5555557e1da4 by thread T37:
    #0 Start_Hour analysisd/stats.c:409 (wazuh-analysisd+0x623b2)
    #1 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 4 at 0x5555557e1da4 by thread T36:
    #0 Start_Hour analysisd/stats.c:409 (wazuh-analysisd+0x623b2)
    #1 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global 'mindiff' of size 4 at 0x5555557e1da4 (wazuh-analysisd+0x00000028dda4)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:409 in Start_Hour
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 4 at 0x5555557e01f0 by thread T37:
    #0 Start_Hour analysisd/stats.c:413 (wazuh-analysisd+0x623ec)
    #1 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Previous write of size 4 at 0x5555557e01f0 by thread T36:
    #0 Start_Hour analysisd/stats.c:413 (wazuh-analysisd+0x623ec)
    #1 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global 'percent_diff' of size 4 at 0x5555557e01f0 (wazuh-analysisd+0x00000028c1f0)

  Thread T37 (tid=9440, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

  Thread T36 (tid=9439, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race analysisd/stats.c:413 in Start_Hour
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 8 at 0x5555557e24c0 by thread T4:
    #0 <null> <null> (libtsan.so.0+0x3a05b)
    #1 gettime shared/time_op.c:37 (wazuh-analysisd+0x1a1e38)
    #2 ad_input_main analysisd/analysisd.c:1219 (wazuh-analysisd+0x65a49)

  Previous read of size 8 at 0x5555557e24c0 by thread T39:
    #0 <null> <null> (libtsan.so.0+0x4836b)
    #1 Start_Time analysisd/stats.c:437 (wazuh-analysisd+0x62737)
    #2 Start_Hour analysisd/stats.c:399 (wazuh-analysisd+0x6232b)
    #3 w_process_event_thread analysisd/analysisd.c:1995 (wazuh-analysisd+0x68835)

  Location is global 'c_timespec' of size 16 at 0x5555557e24c0 (wazuh-analysisd+0x00000028e4c0)

  Thread T4 (tid=9407, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1033 (wazuh-analysisd+0x64e53)

  Thread T39 (tid=9442, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1085 (wazuh-analysisd+0x6525e)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x3a05b) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Read of size 8 at 0x7ba40000a458 by thread T49:
    #0 OSHash_Begin shared/hash_op.c:594 (wazuh-analysisd+0x17d2f4)
    #1 w_analysisd_clean_agents_state analysisd/state.c:561 (wazuh-analysisd+0x540d8)
    #2 w_analysisd_state_main analysisd/state.c:263 (wazuh-analysisd+0x5284b)
    #3 <null> <null> (libtsan.so.0+0x2e5ff)

  Previous write of size 8 at 0x7ba40000a458 by thread T32 (mutexes: write M650019546219814048, write M646964839490587120):
    #0 _OSHash_Add shared/hash_op.c:291 (wazuh-analysisd+0x17bf42)
    #1 OSHash_Add shared/hash_op.c:234 (wazuh-analysisd+0x17bc5b)
    #2 OSHash_Add_ex shared/hash_op.c:332 (wazuh-analysisd+0x17c168)
    #3 get_node analysisd/state.c:551 (wazuh-analysisd+0x54055)
    #4 w_inc_agents_modules_logcollector_others_decoded_events analysisd/state.c:774 (wazuh-analysisd+0x55e43)
    #5 w_inc_modules_logcollector_others_decoded_events analysisd/state.c:1143 (wazuh-analysisd+0x58a60)
    #6 w_inc_decoded_by_component_events analysisd/state.c:870 (wazuh-analysisd+0x56a2e)
    #7 w_decode_event_thread analysisd/analysisd.c:1828 (wazuh-analysisd+0x67fa9)

  As if synchronized via sleep:
    #0 <null> <null> (libtsan.so.0+0x66757)
    #1 w_analysisd_state_main analysisd/state.c:262 (wazuh-analysisd+0x5283f)
    #2 <null> <null> (libtsan.so.0+0x2e5ff)

  Location is heap block of size 16432 at 0x7ba40000a000 allocated by main thread:
    #0 <null> <null> (libtsan.so.0+0x34179)
    #1 OSHash_setSize shared/hash_op.c:135 (wazuh-analysisd+0x17b662)
    #2 OS_ReadMSG analysisd/analysisd.c:1024 (wazuh-analysisd+0x64dd0)

  Mutex M650019546219814048 is already destroyed.

  Mutex M646964839490587120 is already destroyed.

  Thread T49 (tid=9452, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1102 (wazuh-analysisd+0x653ab)

  Thread T32 (tid=9435, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1080 (wazuh-analysisd+0x65201)

SUMMARY: ThreadSanitizer: data race shared/hash_op.c:594 in OSHash_Begin
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Read of size 8 at 0x7b0800152050 by thread T49:
    #0 OSHash_Begin shared/hash_op.c:595 (wazuh-analysisd+0x17d312)
    #1 w_analysisd_clean_agents_state analysisd/state.c:561 (wazuh-analysisd+0x540d8)
    #2 w_analysisd_state_main analysisd/state.c:263 (wazuh-analysisd+0x5284b)
    #3 <null> <null> (libtsan.so.0+0x2e5ff)

  Previous write of size 8 at 0x7b0800152050 by thread T32 (mutexes: write M650019546219814048, write M646964839490587120):
    #0 <null> <null> (libtsan.so.0+0x31edc)
    #1 _OSHash_Add shared/hash_op.c:274 (wazuh-analysisd+0x17bdcc)
    #2 OSHash_Add shared/hash_op.c:234 (wazuh-analysisd+0x17bc5b)
    #3 OSHash_Add_ex shared/hash_op.c:332 (wazuh-analysisd+0x17c168)
    #4 get_node analysisd/state.c:551 (wazuh-analysisd+0x54055)
    #5 w_inc_agents_modules_logcollector_others_decoded_events analysisd/state.c:774 (wazuh-analysisd+0x55e43)
    #6 w_inc_modules_logcollector_others_decoded_events analysisd/state.c:1143 (wazuh-analysisd+0x58a60)
    #7 w_inc_decoded_by_component_events analysisd/state.c:870 (wazuh-analysisd+0x56a2e)
    #8 w_decode_event_thread analysisd/analysisd.c:1828 (wazuh-analysisd+0x67fa9)

  As if synchronized via sleep:
    #0 <null> <null> (libtsan.so.0+0x66757)
    #1 w_analysisd_state_main analysisd/state.c:262 (wazuh-analysisd+0x5283f)
    #2 <null> <null> (libtsan.so.0+0x2e5ff)

  Location is heap block of size 32 at 0x7b0800152040 allocated by thread T32:
    #0 <null> <null> (libtsan.so.0+0x31edc)
    #1 _OSHash_Add shared/hash_op.c:274 (wazuh-analysisd+0x17bdcc)
    #2 OSHash_Add shared/hash_op.c:234 (wazuh-analysisd+0x17bc5b)
    #3 OSHash_Add_ex shared/hash_op.c:332 (wazuh-analysisd+0x17c168)
    #4 get_node analysisd/state.c:551 (wazuh-analysisd+0x54055)
    #5 w_inc_agents_modules_logcollector_others_decoded_events analysisd/state.c:774 (wazuh-analysisd+0x55e43)
    #6 w_inc_modules_logcollector_others_decoded_events analysisd/state.c:1143 (wazuh-analysisd+0x58a60)
    #7 w_inc_decoded_by_component_events analysisd/state.c:870 (wazuh-analysisd+0x56a2e)
    #8 w_decode_event_thread analysisd/analysisd.c:1828 (wazuh-analysisd+0x67fa9)

  Mutex M650019546219814048 is already destroyed.

  Mutex M646964839490587120 is already destroyed.

  Thread T49 (tid=9452, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1102 (wazuh-analysisd+0x653ab)

  Thread T32 (tid=9435, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1080 (wazuh-analysisd+0x65201)

SUMMARY: ThreadSanitizer: data race shared/hash_op.c:595 in OSHash_Begin
==================
==================
WARNING: ThreadSanitizer: data race (pid=9341)
  Write of size 8 at 0x7b440002ff90 by thread T49:
    #0 <null> <null> (libtsan.so.0+0x37ab8)
    #1 w_analysisd_clean_agents_state analysisd/state.c:589 (wazuh-analysisd+0x5422a)
    #2 w_analysisd_state_main analysisd/state.c:263 (wazuh-analysisd+0x5284b)
    #3 <null> <null> (libtsan.so.0+0x2e5ff)

  Previous write of size 8 at 0x7b440002ff90 by thread T6 (mutexes: write M647767746406132128, write M650019546219814048):
    #0 w_inc_agents_alerts_written analysisd/state.c:789 (wazuh-analysisd+0x5609f)
    #1 w_inc_alerts_written analysisd/state.c:1387 (wazuh-analysisd+0x5acca)
    #2 w_writer_log_thread analysisd/analysisd.c:1518 (wazuh-analysisd+0x6706b)

  As if synchronized via sleep:
    #0 <null> <null> (libtsan.so.0+0x66757)
    #1 w_analysisd_state_main analysisd/state.c:262 (wazuh-analysisd+0x5283f)
    #2 <null> <null> (libtsan.so.0+0x2e5ff)

  Mutex M647767746406132128 is already destroyed.

  Mutex M650019546219814048 is already destroyed.

  Thread T49 (tid=9452, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1102 (wazuh-analysisd+0x653ab)

  Thread T6 (tid=9409, running) created by main thread at:
    #0 <null> <null> (libtsan.so.0+0x605b8)
    #1 CreateThreadJoinable shared/pthreads_op.c:47 (wazuh-analysisd+0x186492)
    #2 CreateThread shared/pthreads_op.c:62 (wazuh-analysisd+0x18655b)
    #3 OS_ReadMSG analysisd/analysisd.c:1039 (wazuh-analysisd+0x64edd)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.0+0x37ab8) 
==================

```
</details>

## Review Checklist


- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

