### PR TITLE
Fix errors with Azure Graph event fields

### DIFF
--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -1180,9 +1180,6 @@
               }
             }
           },
-          "status": {
-            "type": "keyword"
-          },
           "data": {
             "type": "keyword"
           },

--- a/wodles/azure/azure_services/graph.py
+++ b/wodles/azure/azure_services/graph.py
@@ -177,7 +177,7 @@ def get_graph_events(url: str, headers: dict, md5_hash: str, query: str, tag: st
 
     logging.debug(f"Graph request - URL: {url} - Headers: {headers}")
     logging.info("Graph: Requesting data")
-    response = get(url=url, headers=headers, timeout=10)
+    response = get(url=url, headers=headers, timeout=15)
 
     if response.status_code == 200:
         response_json = response.json()
@@ -194,6 +194,17 @@ def get_graph_events(url: str, headers: dict, md5_hash: str, query: str, tag: st
                 new_max=date,
                 query=query,
             )
+            if 'initiatedBy' in value and value['initiatedBy'] is not None:
+                app_value = value['initiatedBy'].get('app')
+                if app_value is None or isinstance(app_value, str):
+                    value['initiatedBy'].pop('app', None)
+                user_value = value['initiatedBy'].get('user')
+                if user_value is None or isinstance(user_value, str):
+                    value['initiatedBy'].pop('user', None)
+
+            if 'status' in value:
+                if value['status'] is None or isinstance(value['status'], str):
+                    value.pop('status', None)
             value['azure_tag'] = 'azure-ad-graph'
             if tag:
                 value['azure_aad_tag'] = tag
@@ -219,3 +230,4 @@ def get_graph_events(url: str, headers: dict, md5_hash: str, query: str, tag: st
     else:
         logging.error(f"Error with Graph request: {response.json()}")
         response.raise_for_status()
+        

--- a/wodles/azure/azure_services/graph.py
+++ b/wodles/azure/azure_services/graph.py
@@ -177,7 +177,7 @@ def get_graph_events(url: str, headers: dict, md5_hash: str, query: str, tag: st
 
     logging.debug(f"Graph request - URL: {url} - Headers: {headers}")
     logging.info("Graph: Requesting data")
-    response = get(url=url, headers=headers, timeout=15)
+    response = get(url=url, headers=headers, timeout=10)
 
     if response.status_code == 200:
         response_json = response.json()

--- a/wodles/azure/tests/azure_services/test_graph.py
+++ b/wodles/azure/tests/azure_services/test_graph.py
@@ -211,6 +211,18 @@ def test_get_graph_events(mock_get, mock_update, mock_send):
     assert mock_update.call_count == num_events
     assert mock_send.call_count == num_events
 
+    for call in mock_send.call_args_list:
+        sent_json = json.loads(call[0][0])
+        if 'initiatedBy' in sent_json and sent_json['initiatedBy'] is not None:
+            app_value = sent_json['initiatedBy'].get('app')
+            user_value = sent_json['initiatedBy'].get('user')
+            if app_value is not None:
+                assert not isinstance(app_value, str)
+            if user_value is not None:
+                assert not isinstance(user_value, str)
+        if 'status' in sent_json:
+            status_value = sent_json['status']
+            assert isinstance(status_value, dict)
 
 @pytest.mark.parametrize('status_code', [400, 500])
 @patch('azure_utils.logging.error')


### PR DESCRIPTION
## Description

This PR closes https://github.com/wazuh/wazuh/issues/29522, where certain fields have been fixed to prevent WARN messages in Filebeat

### Results and Evidence

<details>

<summary>auditLogs/directoryAudits</summary>


```console
root@ubuntu-bionic:/home/vagrant# /var/ossec/wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain xxx.onmicrosoft.com --graph_query 'auditLogs/directoryAudits' --graph_time_offset 10d --debug 3
2025/07/10 13:15:59 azure: INFO: Checking database integrity
2025/07/10 13:15:59 azure: INFO: Database integrity check finished
2025/07/10 13:15:59 azure: INFO: Azure Graph starting.
2025/07/10 13:15:59 azure: INFO: Graph: Getting authentication token.
2025/07/10 13:16:00 azure: INFO: Graph: Building the url.
2025/07/10 13:16:00 azure: INFO: xxxxxxxx was not found in the database for graph. Adding it.
2025/07/10 13:16:00 azure: INFO: Graph: The URL is "https://graph.microsoft.com/xxxxxx/xxxxx2025-06-30T13:16:00.276491Z"
2025/07/10 13:16:00 azure: INFO: Graph: Pagination starts
2025/07/10 13:16:00 azure: INFO: Graph: Requesting data
2025/07/10 13:16:01 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:16:01 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:16:01 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:16:01 azure: INFO: Graph: Sending event by socket.
...
2025/07/10 13:16:01 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:16:01 azure: INFO: Graph: End
```

<details>

<summary>jq '{initiatedBy: .data.initiatedBy}' /var/ossec/logs/alerts/alerts.json</summary>


```console
root@wazuh-master:/# jq '{initiatedBy: .data.initiatedBy}' /var/ossec/logs/alerts/alerts.json
...
{
  "initiatedBy": null
}
{
  "initiatedBy": null
}
{
  "initiatedBy": null
}
{
  "initiatedBy": {
    "app": {
      "appId": "xxxxxx",
      "displayName": "5xxxxxx",
      "servicePrincipalId": "null",
      "servicePrincipalName": "5xxxxxxx"
    }
  }
}
{
  "initiatedBy": {
    "app": {
      "appId": "0xxxxxxxx",
      "displayName": "5xxxxxxxx",
      "servicePrincipalId": "null",
      "servicePrincipalName": "5xxxxxxx"
    }
  }
}
...
{
  "initiatedBy": {
    "user": {
      "id": "0xxxxxxx",
      "displayName": "null",
      "userPrincipalName": "xxxxxxx@wazuh.com",
      "ipAddress": "xxxxxxx",
      "userType": "null",
      "homeTenantId": "null",
      "homeTenantName": "null"
    }
  }
}
{
  "initiatedBy": {
    "user": {
      "id": "xxxxxxxxe",
      "displayName": "null",
      "userPrincipalName": "xxxxxx@wazuh.com",
      "ipAddress": "xxxxxxxx",
      "userType": "null",
      "homeTenantId": "null",
      "homeTenantName": "null"
    }
  }
}
{
  "initiatedBy": null
}
```

As shown in the extraction from `alerts.json`, these fields are always of type object when they contain data, or simply null otherwise.

</details>

```console
root@wazuh-master:/# grep '"initiatedBy"' /var/ossec/logs/alerts/alerts.json
{"timestamp":"2025-07-10T13:16:01.482+0000","rule":{"level":3,"description":"Azure: AD User started security info registration","id":"xxxx","firedtimes":55,"mail":false,"groups":["azure"]},"agent":{"id":"000","name":"ubuntu-bionic"},"manager":{"name":"ubuntu-bionic"},"id":"xxxxxxx","decoder":{"name":"json"},"data":{"id":"Authentication Methods_4xxxxxx","category":"UserManagement","correlationId":"xxxxxxxx","result":"success","resultReason":"User started the registration for Authenticator App with Notification","activityDisplayName":"User started security info registration","activityDateTime":"2025-06-30T13:19:12Z","loggedByService":"Authentication Methods","operationType":"Add","initiatedBy":{"user":{"id":"xxxxxxxxx","displayName":"xxxx xxxxx","userPrincipalName":"xxxxxx@wazuh.com","ipAddress":"xxxxxx","userType":"null","homeTenantId":"null","homeTenantName":"null"}},"targetResources":[{"id":"xxxxxxx","displayName":"Javier xxxxx","type":"User","userPrincipalName":"xxxxxxx@wazuh.com","groupType":null,"modifiedProperties":[]}],"additionalDetails":[{"key":"TransactionId","value":"xxxxxxx"},{"key":"AuthenticationMethodType","value":"AppNotificationOnly"},{"key":"AuthenticationMethod","value":"Authenticator App with Notification"}],"azure_tag":"azure-ad-graph"},"location":"Azure"}
...
{"timestamp":"2025-07-10T13:16:01.485+0000","rule":{"level":3,"description":"Azure: AD Update user","id":"xxxxx","firedtimes":57,"mail":false,"groups":["azure"]},"agent":{"id":"000","name":"ubuntu-bionic"},"manager":{"name":"ubuntu-bionic"},"id":"xxxxxx","decoder":{"name":"json"},"data":{"id":"Directory_2cxxxxxx","category":"UserManagement","correlationId":"xxxxxx","result":"success","activityDisplayName":"Update user","activityDateTime":"2025-06-30T13:19:00.3100549Z","loggedByService":"Core Directory","operationType":"Update","initiatedBy":{"app":{"appId":"null","displayName":"Azure MFA StrongAuthenticationService","servicePrincipalId":"xxxxxxxxx","servicePrincipalName":"null"}},"targetResources":[{"id":"xxxxxxxx","displayName":null,"type":"User","userPrincipalName":"xxxxxx@wazuh.com","groupType":null,"modifiedProperties":[{"displayName":"xxxxxxx","oldValue":"[]","newValue":"[{\"MethodType\":6,\"Default\":true},{\"MethodType\":7,\"Default\":false}]"},{"displayName":"Included Updated Properties","oldValue":null,"newValue":"\"StrongAuthenticationMethod\""},{"displayName":"TargetId.UserType","oldValue":null,"newValue":"\"Member\""},{"displayName":"ActorId.ServicePrincipalNames","oldValue":null,"newValue":"\"xxxxxxxx\""},{"displayName":"SPN","oldValue":null,"newValue":"\"xxxxxxxx\""}]}],"additionalDetails":[{"key":"UserType","value":"Member"}],"azure_tag":"azure-ad-graph"},"location":"Azure"}
...
```

```console
root@ubuntu-bionic:/home/vagrant# cat /var/log/filebeat/filebeat | grep -i -E "initiatedBy.user"
root@ubuntu-bionic:/home/vagrant# cat /var/log/filebeat/filebeat | grep -i -E "initiatedBy.app"
root@ubuntu-bionic:/home/vagrant# cat /var/log/filebeat/filebeat | grep -i -E "initiatedBy"
root@ubuntu-bionic:/home/vagrant# cat /var/log/filebeat/filebeat | grep -i -E "error|warn"
```

</details>

<details>

<summary>auditLogs/signIns</summary>

```console
root@ubuntu-bionic:/home/vagrant# /var/ossec/wodles/azure/azure-logs --graph --graph_auth_path /var/ossec/wodles/azure/credentials --graph_tenant_domain xxxx.onmicrosoft.com --graph_query 'auditLogs/signIns' --graph_time_offset 20d --debug 3
2025/07/10 13:21:55 azure: INFO: Checking database integrity
2025/07/10 13:21:55 azure: INFO: Database integrity check finished
2025/07/10 13:21:55 azure: INFO: Azure Graph starting.
2025/07/10 13:21:55 azure: INFO: Graph: Getting authentication token.
2025/07/10 13:21:56 azure: INFO: Graph: Building the url.
2025/07/10 13:21:56 azure: INFO: Graph: The URL is "https://gxxxx/signIns?&$filter=createdDateTime+ge+2025-06-30T13:21:56.031469Z"
2025/07/10 13:21:56 azure: INFO: Graph: Pagination starts
2025/07/10 13:21:56 azure: INFO: Graph: Requesting data
2025/07/10 13:22:07 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:07 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:07 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:07 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:07 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:07 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:07 azure: INFO: Graph: Sending event by socket.
...
2025/07/10 13:22:08 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:08 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:08 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:08 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:08 azure: INFO: Graph: Sending event by socket.
2025/07/10 13:22:08 azure: INFO: Graph: End
```

<details>

<summary>jq '{status: .data.status}' /var/ossec/logs/alerts/alerts.json</summary>

```console
{
  "status": null
}
{
  "status": null
}
{
  "status": null
}
{
  "status": {
    "errorCode": "0",
    "failureReason": "Other.",
    "additionalDetails": "MFA requirement satisfied by claim in the token"
  }
}
{
  "status": {
    "errorCode": "50126",
    "failureReason": "Error validating credentials due to invalid username or password.",
    "additionalDetails": "The user didn't enter the right credentials.  It's expected to see some number of these errors in your logs due to users making mistakes."
  }
}
{
  "status": {
    "errorCode": "0",
    "failureReason": "Other.",
    "additionalDetails": "MFA requirement satisfied by claim in the token"
  }
}
{
  "status": {
    "errorCode": "50126",
    "failureReason": "Error validating credentials due to invalid username or password.",
    "additionalDetails": "The user didn't enter the right credentials.  It's expected to see some number of these errors in your logs due to users making mistakes."
  }
}
```

As shown, the data.status field should come in one of two ways: either as `null` or as a `JSON object` containing the fields `errorCode`, `failureReason`, and `additionalDetails`. These subfields are of type `keyword`, as defined in the `wazuh-template.json`.
For this reason, the `status` field itself was removed from the template, since whenever it contains data, it will always be a `JSON object`.
</details>


```console
{"timestamp":"2025-07-10T13:22:08.126+0000","rule":{"level":3,"description":"Azure: AD ","id":"xxxxx","firedtimes":76,"mail":false,"groups":["azure"]},"agent":{"id":"000","name":"ubuntu-bionic"},"manager":{"name":"ubuntu-bionic"},"id":"1xxxxxx","decoder":{"name":"json"},"data":{"id":"xxxxxx","createdDateTime":"2025-07-01T10:30:18Z","userDisplayName":"xxxxxx","userPrincipalName":"xxxxxx@wazuh.com","userId":"xxxxxxxxx","appId":"cxxxxxx","appDisplayName":"Azure Portal","ipAddress":"xxxxxxxxx","clientAppUsed":"Browser","correlationId":"xxxxxxxxxx","conditionalAccessStatus":"notApplied","isInteractive":"true","riskDetail":"none","riskLevelAggregated":"none","riskLevelDuringSignIn":"none","riskState":"none","riskEventTypes":[],"riskEventTypes_v2":[],"resourceDisplayName":"Azure Resource Manager","resourceId":"xxxxxxxxx","status":{"errorCode":"0","failureReason":"Other.","additionalDetails":"MFA requirement satisfied by claim in the token"},"deviceDetail":{"operatingSystem":"xxxxxx","browser":"Chrome 138.0.0","isCompliant":"false","isManaged":"false"},"location":{"city":"xxxxxx","state":"xxxxxx","countryOrRegion":"xxxxxx","geoCoordinates":{"altitude":"null","latitude":"xxxxxx","longitude":"xxxxxx"}},"appliedConditionalAccessPolicies":[{"id":"SecurityDefaults","displayName":"Security Defaults","enforcedGrantControls":["xxxxxx"],"enforcedSessionControls":[],"result":"success"},{"id":"xxxxxxxxx","displayName":"Securing security info registration","enforcedGrantControls":["xxxxxx"],"enforcedSessionControls":[],"result":"reportOnlyNotApplied"}],"azure_tag":"azure-ad-graph"},"location":"Azure"}
...
{"timestamp":"2025-07-10T13:22:08.128+0000","rule":{"level":3,"description":"Azure: AD ","id":"xxxxx","firedtimes":xxxxxx,"mail":false,"groups":["azure"]},"agent":{"id":"000","name":"ubuntu-bionic"},"manager":{"name":"ubuntu-bionic"},"id":"xxxxxxxx","decoder":{"name":"json"},"data":{"id":"xxxxxxxx","createdDateTime":"2025-06-30T21:56:33Z","userDisplayName":"xxxxx","userPrincipalName":"xxxxxx@wazuh.com","userId":"xxxxxxxx","appId":"xxxxxxxxx","appDisplayName":"Microsoft Azure CLI","ipAddress":"xxxxxxx","clientAppUsed":"xxxxxxxx","correlationId":"xxxxxxxxx","conditionalAccessStatus":"notApplied","isInteractive":"true","riskDetail":"none","riskLevelAggregated":"none","riskLevelDuringSignIn":"none","riskState":"none","riskEventTypes":[],"riskEventTypes_v2":[],"resourceDisplayName":"Azure Resource Manager","resourceId":"xxxxxxx","status":{"errorCode":"50126","failureReason":"Error validating credentials due to invalid username or password.","additionalDetails":"The user didn't enter the right credentials.  It's expected to see some number of these errors in your logs due to users making mistakes."},"deviceDetail":{"isCompliant":"false","isManaged":"false"},"location":{"city":"xxxxxx","state":"xxxxxx","countryOrRegion":"xxxxx","geoCoordinates":{"altitude":"null","latitude":"xxxxx","longitude":"-xxxxxxx"}},"appliedConditionalAccessPolicies":[],"azure_tag":"azure-ad-graph"},"location":"Azure"}
...
```


```console
root@ubuntu-bionic:/home/vagrant# cat /var/log/filebeat/filebeat | grep -i -E "data.status"
root@ubuntu-bionic:/home/vagrant# cat /var/log/filebeat/filebeat | grep -i -E "status"
root@ubuntu-bionic:/home/vagrant# cat /var/log/filebeat/filebeat | grep -i -E "error|warn"
```

</details>


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

N/A

### Configuration Changes


N/A


### Tests Introduced


N/A


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
