### PR TITLE
Improve inventory key generation for accurate OS VD tracking

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factoryOrchestrator.hpp
@@ -119,7 +119,8 @@ public:
 
             case ScannerType::Os:
                 orchestration = std::make_shared<TOsScanner>(databaseFeedManager);
-                orchestration->setLast(std::make_shared<TScanInventorySync>(inventoryDatabase));
+                orchestration->setLast(std::make_shared<TScanInventorySync>(
+                    inventoryDatabase, std::make_shared<TResultIndexer>(indexerConnector)));
                 orchestration->setLast(std::make_shared<TEventDetailsBuilder>(databaseFeedManager));
                 orchestration->setLast(std::make_shared<TScanOsAlertDetailsBuilder>(databaseFeedManager));
                 orchestration->setLast(std::make_shared<TEventSendReport>(reportDispatcher));

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -149,6 +149,6 @@ public:
     // LCOV_EXCL_STOP
 };
 
-using InventorySync = TInventorySync<>;
+using InventorySync = TInventorySync<TScanContext<>>;
 
 #endif // _INVENTORY_SYNC_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -58,6 +58,12 @@ protected:
      */
     void appendAffectedComponentKey(const std::shared_ptr<TScanContext>& data, std::string& out) const
     {
+
+        if (!data)
+        {
+            throw std::runtime_error("Invalid scan context data for inventory key.");
+        }
+
         using Type = AffectedComponentType;
 
         // Append the "_" separator

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/inventorySync.hpp
@@ -51,6 +51,36 @@ protected:
     } // LCOV_EXCL_LINE
 
     /**
+     * @brief Builds the affected component key for the inventory database.
+     *
+     * @param data Scan context.
+     * @param out Output string to append the affected component key.
+     */
+    void appendAffectedComponentKey(const std::shared_ptr<TScanContext>& data, std::string& out) const
+    {
+        using Type = AffectedComponentType;
+
+        // Append the "_" separator
+        out += "_";
+
+        switch (data->affectedComponentType())
+        {
+            case Type::Os:
+                out.reserve(out.size() + data->osName().size() + 1 + data->osVersion().size());
+                out += data->osName();
+                out += '_';
+                out += data->osVersion();
+                break;
+
+            case Type::Package: out += data->packageItemId(); break;
+
+            case Type::Hotfix: out += data->hotfixId(); break;
+
+            default: throw std::runtime_error("Invalid affected component type for inventory key.");
+        }
+    }
+
+    /**
      * @brief Get the affected component key.
      *
      * @param data Scan context.

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
@@ -30,8 +30,10 @@ template<typename TScanContext = ScanContext,
          typename TAbstractHandler = AbstractHandler<std::shared_ptr<TScanContext>>>
 class TScanInventorySync final
     : public AbstractHandler<std::shared_ptr<TScanContext>>
-    , public InventorySync
+    , public TInventorySync<TScanContext>
 {
+    using TInventorySync<TScanContext>::m_inventoryDatabase;
+
 private:
     std::shared_ptr<TAbstractHandler> m_subOrchestration;
 
@@ -45,7 +47,7 @@ public:
      */
     explicit TScanInventorySync(Utils::RocksDBWrapper& inventoryDatabase,
                                 std::shared_ptr<TAbstractHandler> subOrchestration)
-        : InventorySync(inventoryDatabase)
+        : TInventorySync<TScanContext>(inventoryDatabase)
         , m_subOrchestration(subOrchestration)
     {
     }
@@ -63,7 +65,7 @@ public:
         std::string key =
             agentId.compare("000") == 0 && data->clusterStatus() ? std::string(data->clusterNodeName()) + "_" : "";
         key.append(agentId);
-        appendAffectedComponentKey(data, key);
+        TInventorySync<TScanContext>::appendAffectedComponentKey(data, key);
 
         const auto& column = AFFECTED_COMPONENT_COLUMNS.at(
             data->affectedComponentType()); // Get the column name based on the affected component type.

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
@@ -20,6 +20,9 @@
  * @brief TScanInventorySync class.
  * This class is in charge of synchronizing the inventory database.
  * It receives the scan context and the inventory database and returns the scan context with the inventory updated.
+ * Note: The sub-orchestration can be never be a nullptr, adding a check inside of the handleRequest method downgrad
+ e the performance
+ * of the orchestration.
  *
  * @tparam TScanContext scan context type.
  */
@@ -94,10 +97,15 @@ public:
                 rawInventory = value.ToString();
             }
         }
-
-        std::vector<std::string> inventory = Utils::split(rawInventory, ',');
-        std::vector<std::string> inventoryBase = inventory;
         bool isInventoryEmpty = rawInventory.empty();
+        std::vector<std::string> inventory;
+        std::vector<std::string> inventoryBase;
+
+        if (!isInventoryEmpty)
+        {
+            inventory = Utils::split(rawInventory, ',');
+            inventoryBase = inventory;
+        }
 
         // Elements are the cves of the scan result.
         for (auto& [cve, value] : data->m_elements)

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanInventorySync.hpp
@@ -23,20 +23,27 @@
  *
  * @tparam TScanContext scan context type.
  */
-template<typename TScanContext = ScanContext>
+template<typename TScanContext = ScanContext,
+         typename TAbstractHandler = AbstractHandler<std::shared_ptr<TScanContext>>>
 class TScanInventorySync final
     : public AbstractHandler<std::shared_ptr<TScanContext>>
     , public InventorySync
 {
+private:
+    std::shared_ptr<TAbstractHandler> m_subOrchestration;
+
 public:
     // LCOV_EXCL_START
     /**
      * @brief ScanInventorySync constructor.
      *
      * @param inventoryDatabase Inventory database.
+     * @param subOrchestration Sub orchestration to handle indexer operations.
      */
-    explicit TScanInventorySync(Utils::RocksDBWrapper& inventoryDatabase)
+    explicit TScanInventorySync(Utils::RocksDBWrapper& inventoryDatabase,
+                                std::shared_ptr<TAbstractHandler> subOrchestration)
         : InventorySync(inventoryDatabase)
+        , m_subOrchestration(subOrchestration)
     {
     }
     // LCOV_EXCL_STOP
@@ -53,23 +60,44 @@ public:
         std::string key =
             agentId.compare("000") == 0 && data->clusterStatus() ? std::string(data->clusterNodeName()) + "_" : "";
         key.append(agentId);
-        key.append("_");
+        appendAffectedComponentKey(data, key);
 
-        // Create the key for the inventory.
-        key.append(affectedComponentKey(data));
+        const auto& column = AFFECTED_COMPONENT_COLUMNS.at(
+            data->affectedComponentType()); // Get the column name based on the affected component type.
 
-        const auto& column = AFFECTED_COMPONENT_COLUMNS.at(data->affectedComponentType());
-        std::vector<std::string> inventory;
-        std::vector<std::string> inventoryBase;
-        bool isInventoryEmpty = true;
-
+        // For OS scan, the key is "agentID_OSNAME_OSVERSION". Using this approach, we can handle
+        // the case where the OS is upgraded and the scan result is different from the previous one.
         std::string rawInventory;
-        if (m_inventoryDatabase.get(key, rawInventory, column))
+        for (const auto& [databaseKey, value] : m_inventoryDatabase.seek(agentId, column))
         {
-            inventory = Utils::split(rawInventory, ',');
-            inventoryBase = inventory;
-            isInventoryEmpty = false;
+            if (databaseKey.compare(key) != 0)
+            {
+                logDebug2(WM_VULNSCAN_LOGTAG, "Deleting agent element key: %s", databaseKey.c_str());
+                const auto inventory = Utils::splitView(value.ToStringView(), ',');
+                for (const auto& cve : inventory)
+                {
+                    // Call sub orchestrator to delete the element from the indexer instance.
+                    auto context = std::make_shared<TScanContext>();
+                    context->m_noIndex = data->m_noIndex;
+                    std::string keyContext;
+                    keyContext.append(databaseKey);
+                    keyContext.append("_");
+                    keyContext.append(cve);
+                    context->m_elements.emplace(cve, TInventorySync<TScanContext>::buildElement("DELETED", keyContext));
+                    m_subOrchestration->handleRequest(std::move(context));
+                }
+                // Delete the key from the inventory database.
+                m_inventoryDatabase.delete_(databaseKey, AFFECTED_COMPONENT_COLUMNS.at(data->affectedComponentType()));
+            }
+            else
+            {
+                rawInventory = value.ToString();
+            }
         }
+
+        std::vector<std::string> inventory = Utils::split(rawInventory, ',');
+        std::vector<std::string> inventoryBase = inventory;
+        bool isInventoryEmpty = rawInventory.empty();
 
         // Elements are the cves of the scan result.
         for (auto& [cve, value] : data->m_elements)

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockScanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockScanContext.hpp
@@ -18,47 +18,100 @@
 /**
  * @class MockScanContext
  *
- * @brief Mock class for simulating a scan context object.
+ * @brief Mock implementation of the ScanContext interface for unit testing.
  *
+ * This class uses Google Mock to simulate the behavior of a ScanContext.
+ * It provides mock methods for all required virtual functions used in
+ * TScanInventorySync and related logic. Public members are exposed directly
+ * for manipulation in test cases.
  */
 class MockScanContext
 {
 public:
     /**
-     * @brief Mock Constructor
+     * @brief Default constructor.
      *
-     * @note This method is intended for testing purposes and does not perform any real action.
+     * Initializes the mock scan context. No real initialization is performed.
      */
     MockScanContext() = default;
 
     /**
-     * @brief Mock Destructor
+     * @brief Virtual destructor.
      *
+     * Allows proper cleanup of derived mock types, if any.
      */
     virtual ~MockScanContext() = default;
 
     /**
-     * @brief Mock method for agentId.
-     *
-     * @note This method is intended for testing purposes and does not perform any real action.
+     * @brief Gets the agent ID.
+     * @return The mocked agent ID.
      */
-    MOCK_METHOD(std::string, agentId, (), ());
+    MOCK_METHOD(std::string, agentId, (), (const));
 
     /**
-     * @brief Mock method for clusterStatus.
-     *
-     * @note This method is intended for testing purposes and does not perform any real action.
+     * @brief Indicates whether the agent is part of a cluster.
+     * @return True if cluster agent, false otherwise.
      */
-    MOCK_METHOD(bool, clusterStatus, (), ());
+    MOCK_METHOD(bool, clusterStatus, (), (const));
 
     /**
-     * @brief Mock method for clusterNodeName.
-     *
-     * @note This method is intended for testing purposes and does not perform any real action.
+     * @brief Gets the cluster node name.
+     * @return The mocked cluster node name.
      */
-    MOCK_METHOD(std::string, clusterNodeName, (), ());
+    MOCK_METHOD(std::string, clusterNodeName, (), (const));
 
-    std::vector<AgentData> m_agents; ///< Agent data list.
+    /**
+     * @brief Gets the affected component type (OS, Package, etc.).
+     * @return A mocked AffectedComponentType enum.
+     */
+    MOCK_METHOD(AffectedComponentType, affectedComponentType, (), (const));
+
+    /**
+     * @brief Gets the OS name (e.g., "Ubuntu").
+     * @return The mocked OS name.
+     */
+    MOCK_METHOD(std::string, osName, (), (const));
+
+    /**
+     * @brief Gets the OS version (e.g., "22.04").
+     * @return The mocked OS version.
+     */
+    MOCK_METHOD(std::string, osVersion, (), (const));
+
+    /**
+     * @brief Gets the package item ID (used for Package scans).
+     * @return The mocked package item ID.
+     */
+    MOCK_METHOD(std::string, packageItemId, (), (const));
+
+    /**
+     * @brief Gets the hotfix ID (used for Hotfix scans).
+     * @return The mocked hotfix ID.
+     */
+    MOCK_METHOD(std::string, hotfixId, (), (const));
+
+    /**
+     * @brief Elements to process in the scan.
+     *
+     * Represents CVEs and their corresponding metadata.
+     * Used directly by TScanInventorySync to determine insertions and deletions.
+     */
+    std::unordered_map<std::string, nlohmann::json> m_elements;
+
+    /**
+     * @brief Flag indicating if this context should avoid indexing.
+     */
+    bool m_noIndex = false;
+
+    /**
+     * @brief Flag indicating if this is the first scan for the agent.
+     */
+    bool m_isFirstScan = true;
+
+    /**
+     * @brief Optional agent metadata associated with the scan.
+     */
+    std::vector<AgentData> m_agents;
 };
 
 #endif // _MOCK_SCAN_CONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanInventory_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanInventory_test.cpp
@@ -1,0 +1,173 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 16, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "scanInventory_test.hpp"
+#include "MockScanContext.hpp"
+#include "mocks/chainOfResponsabilityMock.h"
+#include "scanContext.hpp"
+#include "scanOrchestrator.hpp"
+
+using ::testing::_;
+using ::testing::NiceMock; // NiceMock is used to create a mock object that does not require expectations to be set.
+using ::testing::Return;
+
+void ScanInventorySyncTest::SetUp()
+{
+    m_inventoryDatabase = std::make_unique<Utils::RocksDBWrapper>(INVENTORY_DB_PATH);
+    for (const auto& element : AFFECTED_COMPONENT_COLUMNS)
+    {
+        if (!m_inventoryDatabase->columnExists(element.second))
+        {
+            m_inventoryDatabase->createColumn(element.second);
+        }
+    }
+}
+
+void ScanInventorySyncTest::TearDown()
+{
+    m_inventoryDatabase->deleteAll();
+    m_inventoryDatabase.reset();
+    std::filesystem::remove_all(INVENTORY_DB_PATH);
+}
+
+TEST_F(ScanInventorySyncTest, UpgradeOSWithOldContent)
+{
+    // Simulate legacy scan result already in DB (pre-upgrade).
+    m_inventoryDatabase->put("001_Redhat", "CVE-2021-33560,CVE-2019-13627,CVE-2021-40528", OS);
+
+    // Create sub-orchestration mock.
+    using SpecializedHandler = MockAbstractHandler<std::shared_ptr<MockScanContext>>;
+    auto spSubOrchestration = std::make_shared<SpecializedHandler>();
+
+    // Expect one call for deletion (each old CVE triggers one context to delete).
+    EXPECT_CALL(*spSubOrchestration, handleRequest(testing::_)).Times(3);
+
+    // Class under test.
+    auto scanInventory = std::make_shared<TScanInventorySync<MockScanContext, SpecializedHandler>>(*m_inventoryDatabase,
+                                                                                                   spSubOrchestration);
+
+    // Create the mock scan context.
+    auto scanContext = std::make_shared<NiceMock<MockScanContext>>();
+
+    // Expectations for mocked methods.
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(Return("001"));
+    EXPECT_CALL(*scanContext, clusterStatus()).WillRepeatedly(Return(false));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillRepeatedly(Return(""));
+    EXPECT_CALL(*scanContext, affectedComponentType()).WillRepeatedly(Return(AffectedComponentType::Os));
+    EXPECT_CALL(*scanContext, osName()).WillRepeatedly(Return("RedHat"));
+    EXPECT_CALL(*scanContext, osVersion()).WillRepeatedly(Return("8.8.8"));
+
+    // Simulate the scan now returns a different CVE (new OS).
+    scanContext->m_elements.emplace("CVE-2026-2026", nlohmann::json::object());
+
+    // Act
+    EXPECT_NO_THROW(scanInventory->handleRequest(scanContext));
+
+    // Assert legacy key was deleted.
+    std::string legacyInventory;
+    EXPECT_FALSE(m_inventoryDatabase->get("001_Redhat", legacyInventory, OS));
+
+    // Assert new inventory was stored correctly.
+    std::string newInventory;
+    std::string newKey = "001_RedHat_8.8.8";
+    EXPECT_TRUE(m_inventoryDatabase->get(newKey, newInventory, OS));
+    EXPECT_THAT(newInventory, ::testing::HasSubstr("CVE-2026-2026"));
+}
+
+TEST_F(ScanInventorySyncTest, FirstScanWithoutPreviousInventory)
+{
+    // Sub-orchestration should not be called (no deletions).
+    using SpecializedHandler = MockAbstractHandler<std::shared_ptr<MockScanContext>>;
+    auto spSubOrchestration = std::make_shared<SpecializedHandler>();
+    EXPECT_CALL(*spSubOrchestration, handleRequest(testing::_)).Times(0);
+
+    auto scanInventory = std::make_shared<TScanInventorySync<MockScanContext, SpecializedHandler>>(*m_inventoryDatabase,
+                                                                                                   spSubOrchestration);
+
+    auto scanContext = std::make_shared<NiceMock<MockScanContext>>();
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(Return("001"));
+    EXPECT_CALL(*scanContext, clusterStatus()).WillRepeatedly(Return(false));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillRepeatedly(Return(""));
+    EXPECT_CALL(*scanContext, affectedComponentType()).WillRepeatedly(Return(AffectedComponentType::Os));
+    EXPECT_CALL(*scanContext, osName()).WillRepeatedly(Return("Debian"));
+    EXPECT_CALL(*scanContext, osVersion()).WillRepeatedly(Return("12.1"));
+
+    // First scan CVEs
+    scanContext->m_elements.emplace("CVE-1000-0001", nlohmann::json::object());
+    scanContext->m_elements.emplace("CVE-1000-0002", nlohmann::json::object());
+
+    // Act
+    auto result = scanInventory->handleRequest(scanContext);
+
+    // Assert inventory was created
+    std::string key = "001_Debian_12.1";
+    std::string stored;
+    EXPECT_TRUE(m_inventoryDatabase->get(key, stored, OS));
+    EXPECT_THAT(stored, ::testing::HasSubstr("CVE-1000-0001"));
+    EXPECT_THAT(stored, ::testing::HasSubstr("CVE-1000-0002"));
+
+    // Assert initial scan timestamp recorded
+    std::string ts;
+    EXPECT_TRUE(m_inventoryDatabase->get("001", ts, OS_INITIAL_SCAN));
+
+    // Assert both CVEs marked as INSERTED
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->m_elements.size(), 2);
+    for (auto& [cve, el] : result->m_elements)
+    {
+        EXPECT_EQ(el["operation"], "INSERTED");
+        EXPECT_THAT(el["id"], ::testing::HasSubstr(key + "_" + cve));
+    }
+}
+
+TEST_F(ScanInventorySyncTest, ClusterAgentUsesPrefixedKey)
+{
+    // Setup cluster agent context
+    using SpecializedHandler = MockAbstractHandler<std::shared_ptr<MockScanContext>>;
+    auto spSubOrchestration = std::make_shared<SpecializedHandler>();
+
+    // No deletions expected since it's a first scan
+    EXPECT_CALL(*spSubOrchestration, handleRequest(testing::_)).Times(0);
+
+    auto scanInventory = std::make_shared<TScanInventorySync<MockScanContext, SpecializedHandler>>(*m_inventoryDatabase,
+                                                                                                   spSubOrchestration);
+
+    auto scanContext = std::make_shared<NiceMock<MockScanContext>>();
+    EXPECT_CALL(*scanContext, agentId()).WillRepeatedly(Return("000")); // Cluster agent
+    EXPECT_CALL(*scanContext, clusterStatus()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*scanContext, clusterNodeName()).WillRepeatedly(Return("node-alpha"));
+
+    EXPECT_CALL(*scanContext, affectedComponentType()).WillRepeatedly(Return(AffectedComponentType::Os));
+    EXPECT_CALL(*scanContext, osName()).WillRepeatedly(Return("ClusterOS"));
+    EXPECT_CALL(*scanContext, osVersion()).WillRepeatedly(Return("1.0"));
+
+    // New CVE found
+    scanContext->m_elements.emplace("CVE-CLUSTER-0001", nlohmann::json::object());
+
+    // Act
+    auto result = scanInventory->handleRequest(scanContext);
+
+    // Assert correct key is used (prefix with cluster node name)
+    std::string expectedKey = "node-alpha_000_ClusterOS_1.0";
+    std::string stored;
+    EXPECT_TRUE(m_inventoryDatabase->get(expectedKey, stored, OS));
+    EXPECT_THAT(stored, ::testing::HasSubstr("CVE-CLUSTER-0001"));
+
+    // Validate initial scan timestamp also recorded
+    std::string ts;
+    EXPECT_TRUE(m_inventoryDatabase->get("000", ts, OS_INITIAL_SCAN));
+
+    // Validate result contains inserted element with correct ID
+    ASSERT_NE(result, nullptr);
+    ASSERT_TRUE(result->m_elements.find("CVE-CLUSTER-0001") != result->m_elements.end());
+    EXPECT_EQ(result->m_elements["CVE-CLUSTER-0001"]["operation"], "INSERTED");
+    EXPECT_EQ(result->m_elements["CVE-CLUSTER-0001"]["id"], expectedKey + "_CVE-CLUSTER-0001");
+}

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanInventory_test.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanInventory_test.hpp
@@ -1,0 +1,48 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 16, 2025.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SCAN_INVENTORY_TEST_HPP
+#define _SCAN_INVENTORY_TEST_HPP
+
+#include "rocksDBWrapper.hpp"
+#include "gtest/gtest.h"
+
+/**
+ * @brief Runs tests for ScanInventory class.
+ */
+class ScanInventorySyncTest : public ::testing::Test
+{
+protected:
+    // LCOV_EXCL_START
+    ScanInventorySyncTest() = default;
+    ~ScanInventorySyncTest() override = default;
+
+    /**
+     * @brief Set up for every test.
+     *
+     */
+    void SetUp() override;
+
+    /**
+     * @brief Tear down for every test.
+     *
+     */
+    void TearDown() override;
+
+    /**
+     * @brief RocksDB inventory database.
+     *
+     */
+    std::unique_ptr<Utils::RocksDBWrapper> m_inventoryDatabase;
+    // LCOV_EXCL_STOP
+};
+
+#endif // _SCAN_INVENTORY_TEST_HPP


### PR DESCRIPTION
| Related issue |
|---------------------|
| Closes #30704 |

## Objective

This pull request introduces the `appendAffectedComponentKey` method to standardize and centralize the construction of inventory keys in the `inventorySync` process. This change enhances the maintainability and correctness of how affected component keys are built, especially for OS scans where version mismatches due to system upgrades can lead to outdated or conflicting records in the inventory database.

The change summary is

* Added a new method:

  ```cpp
  void appendAffectedComponentKey(const std::shared_ptr<TScanContext>& data, std::string& out) const
  ```

  This function appends the affected component’s identity (e.g., OS name/version, package ID, or hotfix ID) to a given string, handling formatting and type-specific behavior internally.

* Replaced inline key-building logic with:

  ```cpp
  appendAffectedComponentKey(data, key);
  ```

  This improves clarity, reduces duplication, and allows consistent key formatting across affected component types.

* Ensured keys for OS scans follow the format:
  `agentID_OSNAME_OSVERSION`
  This format allows proper differentiation between outdated and current OS scan results, enabling the system to detect and delete stale entries when the OS is upgraded.

* Enhanced inventory cleanup logic:
  The inventory sync step now identifies mismatched keys and triggers appropriate suborchestration deletion flows to clean up associated CVEs from the indexer.

## Testing

#### Before change

<img width="621" height="157" alt="image" src="https://github.com/user-attachments/assets/21bf8a62-de75-4441-a939-5de3d2c0206e" />


#### After change

> [!NOTE]
> To simulate the change, modify the `CurrentBuild`, `CurrentBuildNumber` and `DisplayVersion` on `HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsfoft\Windows NT\CurrentVersion`

##### Before upgrade

<img width="1921" height="965" alt="image" src="https://github.com/user-attachments/assets/f0d74970-bb11-413b-b84e-f3d0b0aae11f" />

##### After upgrade

<img width="1921" height="968" alt="image" src="https://github.com/user-attachments/assets/80396271-b48f-49c9-97f5-21b7f69fbb8a" />
