### PR TITLE
Fix macOS SCA CIS 5.10 XProtect evaluation.

### DIFF
--- a/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
+++ b/ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml
@@ -1414,7 +1414,7 @@ checks:
       - soc_2: ["CC6.8"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan" -> r:^1$'
+      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan$" -> r:^1$'
       - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan.startup" -> r:^1$'
 
   # 6.1.1 Ensure Show All Filename Extensions Setting is Enabled. (Automated) - Not Implemented

--- a/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
+++ b/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
@@ -1437,7 +1437,7 @@ checks:
       - soc_2: ["CC6.8"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan" -> r:^1$'
+      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan$" -> r:^1$'
       - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan.startup" -> r:^1$'
 
   # 6.1.1 Ensure Show All Filename Extensions Setting is Enabled. (Automated) - Not Implemented


### PR DESCRIPTION
Evalulating the rule for XProtect always fails due to multiple outputs matching the same regex.

<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

macOS CIS Benchmark Rule 5.10 evaluating XProtect is up and running failed since the grep call to "com.apple.XProtect.daemon.scan" also matches "com.apple.XProtect.daemon.scan.startup" which is the check in the next line.

## Proposed Changes

Added checking for the line end to the regex. Alternative approach would have been to expect "2" as result of grep.

### Results and Evidence

Terminal command outputs for comparison:

Before:
```shell
CI-MacMini-M1-Augsburg:~ root# launchctl list | grep -c com.apple.XProtect.daemon.scan
2
```

<img width="1019" height="479" alt="image" src="https://github.com/user-attachments/assets/6f41331a-bbc7-4aef-be7f-3efb289b7db9" />

After:

```shell
CI-MacMini-M1-Augsburg:~ root# launchctl list | grep -c com.apple.XProtect.daemon.scan$
1
```

<img width="1027" height="529" alt="image" src="https://github.com/user-attachments/assets/88ad6d23-bcec-4712-b61a-7ef4191493eb" />

### Manual tests with their corresponding evidence

N/A

### Artifacts Affected

Default configuration files:
- ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
- ruleset/sca/darwin/23/cis_apple_macOS_14.x.yml

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
