### PR TITLE
Add collector for the services table

### DIFF
--- a/src/data_provider/src/extended_sources/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(wrappers)
 
 add_subdirectory(groups)
-add_subdirectory(services)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    add_subdirectory(services)
+endif()
 add_subdirectory(users)

--- a/src/data_provider/src/extended_sources/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(wrappers)
 
 add_subdirectory(groups)
+add_subdirectory(services)
 add_subdirectory(users)

--- a/src/data_provider/src/extended_sources/groups/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/groups/CMakeLists.txt
@@ -24,26 +24,26 @@ endif()
 set(SRC_FILES "")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    list(APPEND SRC_FILES 
+    list(APPEND SRC_FILES
       src/groups_windows.cpp
       src/user_groups_windows.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/windows/users_utils_wrapper.cpp 
+      ${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/windows/users_utils_wrapper.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/windows/groups_utils_wrapper.cpp)
-    set(PLATFORM_LIBS_USERS netapi32 advapi32)
+    set(PLATFORM_LIBS_GROUPS netapi32 advapi32)
 else()
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        list(APPEND SRC_FILES 
+        list(APPEND SRC_FILES
           src/groups_linux.cpp
           src/user_groups_linux.cpp)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         find_library(OPEN_DIRECTORY OpenDirectory)
         find_library(FOUNDATION Foundation)
 
-        list(APPEND SRC_FILES 
+        list(APPEND SRC_FILES
           src/groups_darwin.cpp
-          src/user_groups_darwin.cpp 
+          src/user_groups_darwin.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/unix/darwin/od_wrapper.mm)
-        set(PLATFORM_LIBS_USERS ${OPEN_DIRECTORY} ${FOUNDATION})
+        set(PLATFORM_LIBS_GROUPS ${OPEN_DIRECTORY} ${FOUNDATION})
     endif()
 endif()
 
@@ -52,10 +52,10 @@ add_library(groups STATIC ${SRC_FILES})
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   target_link_libraries(groups
     wtsapi32
-    ${PLATFORM_LIBS_USERS}
+    ${PLATFORM_LIBS_GROUPS}
   )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  target_link_libraries(groups ${PLATFORM_LIBS_USERS})
+  target_link_libraries(groups ${PLATFORM_LIBS_GROUPS})
 endif()
 
 if(UNIT_TEST)

--- a/src/data_provider/src/extended_sources/groups/src/user_groups_windows.cpp
+++ b/src/data_provider/src/extended_sources/groups/src/user_groups_windows.cpp
@@ -183,7 +183,7 @@ std::vector<Group> UserGroupsProvider::getLocalGroups()
 
 std::vector<std::string> UserGroupsProvider::getLocalGroupNamesForUser(const std::string& username)
 {
-    std::wstring wUsername = m_usersHelper->stringToWstring(username);
+    std::wstring wUsername = Utils::EncodingWindowsHelper::stringUTF8ToWstring(username);
     DWORD groupInfoLevel = 0;
     DWORD numGroups = 0;
     DWORD totalGroups = 0;

--- a/src/data_provider/src/extended_sources/services/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/services/CMakeLists.txt
@@ -23,7 +23,6 @@ set(SRC_FILES "")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   list(APPEND SRC_FILES src/services_windows.cpp)
-  #set(PLATFORM_LIBS_SERVICES netapi32 advapi32)
 else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND SRC_FILES src/systemd_units_linux.cpp)
@@ -31,13 +30,6 @@ else()
 endif()
 
 add_library(services STATIC ${SRC_FILES})
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  # target_link_libraries(services
-  #     wtsapi32
-  #     ${PLATFORM_LIBS_SERVICES}
-  # )
-endif()
 
 if(UNIT_TEST)
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/src/data_provider/src/extended_sources/services/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/services/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SRC_FILES "")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   list(APPEND SRC_FILES src/services_windows.cpp)
+  set(PLATFORM_LIBS_SERVICES netapi32)
 else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND SRC_FILES src/systemd_units_linux.cpp)
@@ -31,12 +32,6 @@ endif()
 
 add_library(services STATIC ${SRC_FILES})
 
-if(UNIT_TEST)
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_link_libraries(services -fprofile-arcs)
-  else()
-    target_link_libraries(services gcov)
-  endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-
-  add_subdirectory(tests)
-endif(UNIT_TEST)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_link_libraries(services ${PLATFORM_LIBS_SERVICES})
+endif()

--- a/src/data_provider/src/extended_sources/services/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/services/CMakeLists.txt
@@ -22,7 +22,9 @@ endif()
 set(SRC_FILES "")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  list(APPEND SRC_FILES src/services_windows.cpp)
+  list(APPEND SRC_FILES
+    src/services_windows.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/windows/services_utils_wrapper.cpp)
   set(PLATFORM_LIBS_SERVICES netapi32)
 else()
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -35,3 +37,13 @@ add_library(services STATIC ${SRC_FILES})
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   target_link_libraries(services ${PLATFORM_LIBS_SERVICES})
 endif()
+
+if(UNIT_TEST)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      target_link_libraries(services -fprofile-arcs)
+  else()
+      target_link_libraries(services gcov)
+  endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+  add_subdirectory(tests)
+endif(UNIT_TEST)

--- a/src/data_provider/src/extended_sources/services/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/services/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(services)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(include)
+include_directories(${CMAKE_SOURCE_DIR}/../external/nlohmann/)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  include_directories(${CMAKE_SOURCE_DIR}/../shared_modules/utils)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/windows)
+else()
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/unix)
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../wrappers/unix/linux)
+  endif()
+endif()
+
+set(SRC_FILES "")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  list(APPEND SRC_FILES src/services_windows.cpp)
+  #set(PLATFORM_LIBS_SERVICES netapi32 advapi32)
+else()
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND SRC_FILES src/systemd_units_linux.cpp)
+  endif()
+endif()
+
+add_library(services STATIC ${SRC_FILES})
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  # target_link_libraries(services
+  #     wtsapi32
+  #     ${PLATFORM_LIBS_SERVICES}
+  # )
+endif()
+
+if(UNIT_TEST)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_link_libraries(services -fprofile-arcs)
+  else()
+    target_link_libraries(services gcov)
+  endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+  add_subdirectory(tests)
+endif(UNIT_TEST)

--- a/src/data_provider/src/extended_sources/services/include/services_windows.hpp
+++ b/src/data_provider/src/extended_sources/services/include/services_windows.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <windows.h>
+#include <winsvc.h>
 #include "json.hpp"
 
 class ServicesProvider
@@ -27,6 +29,6 @@ class ServicesProvider
         /// @param svc The service status to retrieve details for.
         /// @param results The JSON array to append the service details to.
         /// @return True if successful, false otherwise.
-        bool getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS_PROCESS& svc, nlohmann::json& results);
+        bool getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS_PROCESSW& svc, nlohmann::json& results);
 
 };

--- a/src/data_provider/src/extended_sources/services/include/services_windows.hpp
+++ b/src/data_provider/src/extended_sources/services/include/services_windows.hpp
@@ -1,0 +1,32 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "json.hpp"
+
+class ServicesProvider
+{
+    public:
+        /// @brief Default constructor.
+        ServicesProvider();
+
+        /// @brief Collects services information.
+        /// @return A JSON object containing the collected services information.
+        nlohmann::json collect();
+
+    private:
+        /// @brief Retrieves details of a specific service.
+        /// @param scmHandle Handle to the Service Control Manager.
+        /// @param svc The service status to retrieve details for.
+        /// @param results The JSON array to append the service details to.
+        /// @return True if successful, false otherwise.
+        bool getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS_PROCESS& svc, nlohmann::json& results);
+
+};

--- a/src/data_provider/src/extended_sources/services/include/services_windows.hpp
+++ b/src/data_provider/src/extended_sources/services/include/services_windows.hpp
@@ -9,20 +9,22 @@
 
 #pragma once
 
-#include <windows.h>
-#include <winsvc.h>
-#include "json.hpp"
+#include "iservices_utils_wrapper.hpp"
 #include "iwinsvc_wrapper.hpp"
 #include "iwindows_api_wrapper.hpp"
+#include "json.hpp"
 
+/// @brief ServicesProvider class for managing Windows services.
 class ServicesProvider
 {
     public:
         /// @brief Constructs a ServicesProvider with a specific wrapper.
+        /// @param servicesHelper A shared pointer to an IServicesHelper instance for service operations.
         /// @param winSvcWrapper A shared pointer to an IWinSvcWrapper instance for Windows
         /// service control manager operations.
         /// @param winApiWrapper A shared pointer to an IWindowsApiWrapper instance for Windows API operations.
-        explicit ServicesProvider(std::shared_ptr<IWinSvcWrapper> winSvcWrapper,
+        explicit ServicesProvider(std::shared_ptr<IServicesHelper> servicesHelper,
+                                  std::shared_ptr<IWinSvcWrapper> winSvcWrapper,
                                   std::shared_ptr<IWindowsApiWrapper> winApiWrapper);
 
         /// @brief Default constructor.
@@ -33,6 +35,7 @@ class ServicesProvider
         nlohmann::json collect();
 
     private:
+        std::shared_ptr<IServicesHelper> m_servicesHelper;
         std::shared_ptr<IWinSvcWrapper> m_winSvcWrapper;
         std::shared_ptr<IWindowsApiWrapper> m_winApiWrapper;
 
@@ -42,5 +45,4 @@ class ServicesProvider
         /// @param results The JSON array to append the service details to.
         /// @return True if successful, false otherwise.
         bool getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS_PROCESSW& svc, nlohmann::json& results);
-
 };

--- a/src/data_provider/src/extended_sources/services/include/services_windows.hpp
+++ b/src/data_provider/src/extended_sources/services/include/services_windows.hpp
@@ -12,10 +12,19 @@
 #include <windows.h>
 #include <winsvc.h>
 #include "json.hpp"
+#include "iwinsvc_wrapper.hpp"
+#include "iwindows_api_wrapper.hpp"
 
 class ServicesProvider
 {
     public:
+        /// @brief Constructs a ServicesProvider with a specific wrapper.
+        /// @param winSvcWrapper A shared pointer to an IWinSvcWrapper instance for Windows
+        /// service control manager operations.
+        /// @param winApiWrapper A shared pointer to an IWindowsApiWrapper instance for Windows API operations.
+        explicit ServicesProvider(std::shared_ptr<IWinSvcWrapper> winSvcWrapper,
+                                  std::shared_ptr<IWindowsApiWrapper> winApiWrapper);
+
         /// @brief Default constructor.
         ServicesProvider();
 
@@ -24,6 +33,9 @@ class ServicesProvider
         nlohmann::json collect();
 
     private:
+        std::shared_ptr<IWinSvcWrapper> m_winSvcWrapper;
+        std::shared_ptr<IWindowsApiWrapper> m_winApiWrapper;
+
         /// @brief Retrieves details of a specific service.
         /// @param scmHandle Handle to the Service Control Manager.
         /// @param svc The service status to retrieve details for.

--- a/src/data_provider/src/extended_sources/services/src/services_windows.cpp
+++ b/src/data_provider/src/extended_sources/services/src/services_windows.cpp
@@ -8,8 +8,10 @@
 #include <string>
 #include <vector>
 
-#include "encodingWindowsHelper.h"
 #include "services_windows.hpp"
+#include "winsvc_wrapper.hpp"
+#include "windows_api_wrapper.hpp"
+#include "encodingWindowsHelper.h"
 
 using json = nlohmann::json;
 
@@ -33,9 +35,9 @@ std::optional<std::wstring> expandEnvStringW(const std::wstring& input)
     return result;
 }
 
-const std::string kSvcStartType[] = {"BOOT_START", "SYSTEM_START", "AUTO_START", "DEMAND_START", "DISABLED"};
+const std::string K_SERVICE_START_TYPE[] = {"BOOT_START", "SYSTEM_START", "AUTO_START", "DEMAND_START", "DISABLED"};
 
-const std::string kSvcStatus[] =
+const std::string K_SERVICE_STATUS[] =
 {
     "UNKNOWN", "STOPPED", "START_PENDING", "STOP_PENDING", "RUNNING", "CONTINUE_PENDING", "PAUSE_PENDING", "PAUSED"
 };
@@ -44,7 +46,7 @@ const std::string kSvcStatus[] =
  * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
  * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
  */
-const std::map<int, std::string> kServiceType = {{0x00000001, "KERNEL_DRIVER"},
+const std::map<int, std::string> K_SERVICE_TYPE = {{0x00000001, "KERNEL_DRIVER"},
     {0x00000002, "FILE_SYSTEM_DRIVER"},
     {0x00000010, "OWN_PROCESS"},
     {0x00000020, "SHARE_PROCESS"},
@@ -97,53 +99,62 @@ std::optional<std::wstring> readServiceDllFromParameters(const std::wstring& ser
     return buffer;
 }
 
-ServicesProvider::ServicesProvider() {}
+ServicesProvider::ServicesProvider(std::shared_ptr<IWinSvcWrapper> winSvcWrapper,
+                                   std::shared_ptr<IWindowsApiWrapper> winApiWrapper)
+    : m_winSvcWrapper(std::move(winSvcWrapper))
+    , m_winApiWrapper(std::move(winApiWrapper))
+{}
+
+ServicesProvider::ServicesProvider()
+    : m_winSvcWrapper(std::make_shared<WinSvcWrapper>())
+    , m_winApiWrapper(std::make_shared<WindowsApiWrapper>())
+{}
 
 bool ServicesProvider::getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS_PROCESSW& svc, json& results)
 {
 
-    auto svcHandle = OpenServiceW(scmHandle, svc.lpServiceName, SERVICE_QUERY_CONFIG);
+    auto svcHandle = m_winSvcWrapper->OpenServiceWWrapper(scmHandle, svc.lpServiceName, SERVICE_QUERY_CONFIG);
 
     if (!svcHandle)
     {
-        std::cerr << "Error opening service handle: " << GetLastError() << "\n";
+        std::cerr << "Error opening service handle: " << m_winApiWrapper->GetLastErrorWrapper() << "\n";
         return false;
     }
 
     DWORD cbBufSize = 0;
-    QueryServiceConfigW(svcHandle, nullptr, 0, &cbBufSize);
+    m_winSvcWrapper->QueryServiceConfigWWrapper(svcHandle, nullptr, 0, &cbBufSize);
 
-    if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    if (m_winApiWrapper->GetLastErrorWrapper() != ERROR_INSUFFICIENT_BUFFER)
     {
-        std::cerr << "Error getting config size: " << GetLastError() << "\n";
-        CloseServiceHandle(svcHandle);
+        std::cerr << "Error getting config size: " << m_winApiWrapper->GetLastErrorWrapper() << "\n";
+        m_winSvcWrapper->CloseServiceHandleWrapper(svcHandle);
         return false;
     }
 
     auto configBuf = std::make_unique<wchar_t[]>(cbBufSize);
     auto config = reinterpret_cast<LPQUERY_SERVICE_CONFIGW>(configBuf.get());
 
-    if (!QueryServiceConfigW(svcHandle, config, cbBufSize, &cbBufSize))
+    if (!m_winSvcWrapper->QueryServiceConfigWWrapper(svcHandle, config, cbBufSize, &cbBufSize))
     {
-        std::cerr << "Error reading service config: " << GetLastError() << "\n";
-        CloseServiceHandle(svcHandle);
+        std::cerr << "Error reading service config: " << m_winApiWrapper->GetLastErrorWrapper() << "\n";
+        m_winSvcWrapper->CloseServiceHandleWrapper(svcHandle);
         return false;
     }
 
     json item;
     item["name"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(svc.lpServiceName);
     item["display_name"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(svc.lpDisplayName);
-    item["status"] = kSvcStatus[svc.ServiceStatusProcess.dwCurrentState];
+    item["status"] = K_SERVICE_STATUS[svc.ServiceStatusProcess.dwCurrentState];
     item["pid"] = svc.ServiceStatusProcess.dwProcessId;
     item["win32_exit_code"] = svc.ServiceStatusProcess.dwWin32ExitCode;
     item["service_exit_code"] = svc.ServiceStatusProcess.dwServiceSpecificExitCode;
-    item["start_type"] = kSvcStartType[config->dwStartType];
+    item["start_type"] = K_SERVICE_START_TYPE[config->dwStartType];
     item["path"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(config->lpBinaryPathName);
     item["user_account"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(config->lpServiceStartName);
 
-    if (kServiceType.count(config->dwServiceType) > 0)
+    if (K_SERVICE_TYPE.count(config->dwServiceType) > 0)
     {
-        item["service_type"] = kServiceType.at(config->dwServiceType);
+        item["service_type"] = K_SERVICE_TYPE.at(config->dwServiceType);
     }
     else
     {
@@ -153,14 +164,14 @@ bool ServicesProvider::getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS
     item["description"] = "";
 
     DWORD descBufSize = 0;
-    QueryServiceConfig2W(svcHandle, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &descBufSize);
+    m_winSvcWrapper->QueryServiceConfig2WWrapper(svcHandle, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &descBufSize);
 
-    if (GetLastError() == ERROR_INSUFFICIENT_BUFFER && descBufSize > 0)
+    if (m_winApiWrapper->GetLastErrorWrapper() == ERROR_INSUFFICIENT_BUFFER && descBufSize > 0)
     {
         auto descBuf = std::make_unique<BYTE[]>(descBufSize);
         auto desc = reinterpret_cast<LPSERVICE_DESCRIPTIONW>(descBuf.get());
 
-        if (QueryServiceConfig2W(svcHandle, SERVICE_CONFIG_DESCRIPTION, descBuf.get(), descBufSize, &descBufSize))
+        if (m_winSvcWrapper->QueryServiceConfig2WWrapper(svcHandle, SERVICE_CONFIG_DESCRIPTION, descBuf.get(), descBufSize, &descBufSize))
         {
             if (desc->lpDescription != nullptr)
             {
@@ -187,59 +198,58 @@ bool ServicesProvider::getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS
     }
 
     results.push_back(item);
-    CloseServiceHandle(svcHandle);
+    m_winSvcWrapper->CloseServiceHandleWrapper(svcHandle);
     return true;
 }
 
 nlohmann::json ServicesProvider::collect()
 {
-
     json results = json::array();
 
-    auto scmHandle = OpenSCManager(nullptr, nullptr, GENERIC_READ);
+    auto scmHandle = m_winSvcWrapper->OpenSCManagerWrapper(nullptr, nullptr, GENERIC_READ);
 
     if (!scmHandle)
     {
-        std::cerr << "Failed to connect to Service Connection Manager: " << GetLastError() << "\n";
+        std::cerr << "Failed to connect to Service Connection Manager: " << m_winApiWrapper->GetLastErrorWrapper() << "\n";
         return results;
     }
 
     DWORD bytesNeeded = 0;
     DWORD serviceCount = 0;
-    EnumServicesStatusExW(scmHandle,
-                          SC_ENUM_PROCESS_INFO,
-                          SERVICE_WIN32 | SERVICE_DRIVER,
-                          SERVICE_STATE_ALL,
-                          nullptr,
-                          0,
-                          &bytesNeeded,
-                          &serviceCount,
-                          nullptr,
-                          nullptr);
+    m_winSvcWrapper->EnumServicesStatusExWWrapper(scmHandle,
+                                                  SC_ENUM_PROCESS_INFO,
+                                                  SERVICE_WIN32 | SERVICE_DRIVER,
+                                                  SERVICE_STATE_ALL,
+                                                  nullptr,
+                                                  0,
+                                                  &bytesNeeded,
+                                                  &serviceCount,
+                                                  nullptr,
+                                                  nullptr);
 
-    if (GetLastError() != ERROR_MORE_DATA)
+    if (m_winApiWrapper->GetLastErrorWrapper() != ERROR_MORE_DATA)
     {
-        std::cerr << "Error querying buffer size: " << GetLastError() << "\n";
-        CloseServiceHandle(scmHandle);
+        std::cerr << "Error querying buffer size: " << m_winApiWrapper->GetLastErrorWrapper() << "\n";
+        m_winSvcWrapper->CloseServiceHandleWrapper(scmHandle);
         return results;
     }
 
     auto buffer = std::make_unique<BYTE[]>(bytesNeeded);
     auto services = reinterpret_cast<ENUM_SERVICE_STATUS_PROCESSW*>(buffer.get());
 
-    if (!EnumServicesStatusExW(scmHandle,
-                               SC_ENUM_PROCESS_INFO,
-                               SERVICE_WIN32 | SERVICE_DRIVER,
-                               SERVICE_STATE_ALL,
-                               buffer.get(),
-                               bytesNeeded,
-                               &bytesNeeded,
-                               &serviceCount,
-                               nullptr,
-                               nullptr))
+    if (!m_winSvcWrapper->EnumServicesStatusExWWrapper(scmHandle,
+                                                       SC_ENUM_PROCESS_INFO,
+                                                       SERVICE_WIN32 | SERVICE_DRIVER,
+                                                       SERVICE_STATE_ALL,
+                                                       buffer.get(),
+                                                       bytesNeeded,
+                                                       &bytesNeeded,
+                                                       &serviceCount,
+                                                       nullptr,
+                                                       nullptr))
     {
-        std::cerr << "Error enumerating services: " << GetLastError() << "\n";
-        CloseServiceHandle(scmHandle);
+        std::cerr << "Error enumerating services: " << m_winApiWrapper->GetLastErrorWrapper() << "\n";
+        m_winSvcWrapper->CloseServiceHandleWrapper(scmHandle);
         return results;
     }
 
@@ -251,6 +261,6 @@ nlohmann::json ServicesProvider::collect()
         }
     }
 
-    CloseServiceHandle(scmHandle);
+    m_winSvcWrapper->CloseServiceHandleWrapper(scmHandle);
     return results;
 }

--- a/src/data_provider/src/extended_sources/services/src/services_windows.cpp
+++ b/src/data_provider/src/extended_sources/services/src/services_windows.cpp
@@ -1,0 +1,194 @@
+#include <windows.h>
+#include <winsvc.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "services_windows.hpp"
+// #include <nlohmann/json.hpp>
+// #include "windows_api_wrapper.hpp"
+#include "encodingWindowsHelper.h"
+
+using json = nlohmann::json;
+
+std::optional<std::string> expandEnvString(const std::string& str) {
+    DWORD size = ExpandEnvironmentStringsA(str.c_str(), nullptr, 0);
+    if (size == 0) {
+        return std::nullopt;
+    }
+    std::string result(size, '\0');
+    ExpandEnvironmentStringsA(str.c_str(), &result[0], size);
+    result.pop_back(); // remove null terminator
+    return result;
+}
+
+const std::string kSvcStartType[] = {"BOOT_START", "SYSTEM_START", "AUTO_START", "DEMAND_START", "DISABLED"};
+
+const std::string kSvcStatus[] = {
+    "UNKNOWN", "STOPPED", "START_PENDING", "STOP_PENDING", "RUNNING", "CONTINUE_PENDING", "PAUSE_PENDING", "PAUSED"};
+
+/* Possible values defined here (dwServiceType):
+ * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status
+ * https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configw
+ */
+const std::map<int, std::string> kServiceType = {
+    {0x00000001, "KERNEL_DRIVER"},
+    {0x00000002, "FILE_SYSTEM_DRIVER"},
+    {0x00000010, "OWN_PROCESS"},
+    {0x00000020, "SHARE_PROCESS"},
+    {0x00000050, "USER_OWN_PROCESS"},
+    {0x00000060, "USER_SHARE_PROCESS"},
+    {0x000000d0, "USER_OWN_PROCESS(Instance)"},
+    {0x000000e0, "USER_SHARE_PROCESS(Instance)"},
+    {0x00000100, "INTERACTIVE_PROCESS"},
+    {0x00000110, "OWN_PROCESS(Interactive)"},
+    {0x00000120, "SHARE_PROCESS(Interactive)"}
+};
+
+std::optional<std::string> readRegistryValue(HKEY root,
+                                             const std::string& subkey,
+                                             const std::string& valueName) {
+    HKEY hKey;
+    if (RegOpenKeyExA(root, subkey.c_str(), 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
+        return std::nullopt;
+    }
+
+    DWORD type = 0;
+    DWORD dataSize = 0;
+    if (RegQueryValueExA(hKey, valueName.c_str(), nullptr, &type, nullptr, &dataSize) != ERROR_SUCCESS ||
+        type != REG_SZ) {
+        RegCloseKey(hKey);
+        return std::nullopt;
+    }
+
+    std::vector<char> data(dataSize);
+    if (RegQueryValueExA(hKey, valueName.c_str(), nullptr, nullptr,
+                         reinterpret_cast<LPBYTE>(data.data()), &dataSize) != ERROR_SUCCESS) {
+        RegCloseKey(hKey);
+        return std::nullopt;
+    }
+
+    RegCloseKey(hKey);
+    return std::string(data.data());
+}
+
+bool ServicesProvider::getService(SC_HANDLE scmHandle, const ENUM_SERVICE_STATUS_PROCESS& svc, json& results) {
+
+    auto svcHandle = OpenServiceW(scmHandle, svc.lpServiceName, SERVICE_QUERY_CONFIG);
+
+    if (!svcHandle) {
+        std::cerr << "Error opening service handle: " << GetLastError() << "\n";
+        return false;
+    }
+
+    DWORD cbBufSize = 0;
+    QueryServiceConfigW(svcHandle, nullptr, 0, &cbBufSize);
+    if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+        std::cerr << "Error getting config size: " << GetLastError() << "\n";
+        CloseServiceHandle(svcHandle);
+        return false;
+    }
+
+    auto configBuf = std::make_unique<wchar_t[]>(cbBufSize);
+    auto config = reinterpret_cast<LPQUERY_SERVICE_CONFIGW>(configBuf.get());
+
+    if (!QueryServiceConfigW(svcHandle, config, cbBufSize, &cbBufSize)) {
+        std::cerr << "Error reading service config: " << GetLastError() << "\n";
+        CloseServiceHandle(svcHandle);
+        return false;
+    }
+
+    json item;
+    item["name"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(svc.lpServiceName);
+    item["display_name"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(svc.lpDisplayName);
+    item["status"] = kSvcStatus[svc.ServiceStatusProcess.dwCurrentState];
+    item["pid"] = svc.ServiceStatusProcess.dwProcessId;
+    item["win32_exit_code"] = svc.ServiceStatusProcess.dwWin32ExitCode;
+    item["service_exit_code"] = svc.ServiceStatusProcess.dwServiceSpecificExitCode;
+    item["start_type"] = kSvcStartType[config->dwStartType];
+    item["path"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(config->lpBinaryPathName);
+    item["user_account"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(config->lpServiceStartName);
+
+    if (kServiceType.count(config->dwServiceType) > 0) {
+        item["service_type"] = kServiceType.at(config->dwServiceType);
+    } else {
+        item["service_type"] = "UNKNOWN";
+    }
+
+    DWORD descBufSize = 0;
+    QueryServiceConfig2W(svcHandle, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &descBufSize);
+    if (GetLastError() == ERROR_INSUFFICIENT_BUFFER && descBufSize > 0) {
+        auto descBuf = std::make_unique<BYTE[]>(descBufSize);
+        auto desc = reinterpret_cast<LPSERVICE_DESCRIPTION>(descBuf.get());
+
+        if (QueryServiceConfig2W(svcHandle, SERVICE_CONFIG_DESCRIPTION,
+                                descBuf.get(), descBufSize, &descBufSize)) {
+            if (desc->lpDescription != nullptr) {
+                item["description"] = Utils::EncodingWindowsHelper::wstringToStringUTF8(desc->lpDescription);
+            }
+        } else {
+            std::cerr << "Warning: Failed to get service description. Error: " << GetLastError() << "\n";
+        }
+    }
+
+    std::string regPath = "SYSTEM\\CurrentControlSet\\Services\\" + item["name"].get<std::string>() + "\\Parameters";
+    auto serviceDll = readRegistryValue(HKEY_LOCAL_MACHINE, regPath, "ServiceDll");
+    if (serviceDll.has_value()) {
+        auto expanded = expandEnvString(serviceDll.value());
+        item["module_path"] = expanded.value_or(serviceDll.value());
+    }
+
+    results.push_back(item);
+    CloseServiceHandle(svcHandle);
+    return true;
+}
+
+nlohmann::json ServicesProvider::collect() {
+
+    json results = json::array();
+
+    auto scmHandle = OpenSCManager(nullptr, nullptr, GENERIC_READ);
+
+    if (!scmHandle) {
+        std::cerr << "Failed to connect to Service Connection Manager: " << GetLastError() << "\n";
+        return results;
+    }
+
+    DWORD bytesNeeded = 0;
+    DWORD serviceCount = 0;
+    EnumServicesStatusEx(scmHandle, SC_ENUM_PROCESS_INFO,
+                         SERVICE_WIN32 | SERVICE_DRIVER, SERVICE_STATE_ALL,
+                         nullptr, 0, &bytesNeeded, &serviceCount,
+                         nullptr, nullptr);
+
+    if (GetLastError() != ERROR_MORE_DATA) {
+        std::cerr << "Error querying buffer size: " << GetLastError() << "\n";
+        CloseServiceHandle(scmHandle);
+        return results;
+    }
+
+    auto buffer = std::make_unique<BYTE[]>(bytesNeeded);
+    auto services = reinterpret_cast<ENUM_SERVICE_STATUS_PROCESS*>(buffer.get());
+
+    if (!EnumServicesStatusEx(scmHandle, SC_ENUM_PROCESS_INFO,
+                              SERVICE_WIN32 | SERVICE_DRIVER, SERVICE_STATE_ALL,
+                              buffer.get(), bytesNeeded, &bytesNeeded,
+                              &serviceCount, nullptr, nullptr)) {
+        std::cerr << "Error enumerating services: " << GetLastError() << "\n";
+        CloseServiceHandle(scmHandle);
+        return results;
+    }
+
+    for (DWORD i = 0; i < serviceCount; ++i) {
+        if (!getService(scmHandle, services[i], results)) {
+            std::cerr << "Warning: Failed to get details for service\n";
+        }
+    }
+
+    CloseServiceHandle(scmHandle);
+    return results;
+}

--- a/src/data_provider/src/extended_sources/services/tests/CMakeLists.txt
+++ b/src/data_provider/src/extended_sources/services/tests/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(extended_sources_services_unit_test)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(${CMAKE_SOURCE_DIR}/../external/googletest/googletest/include/)
+include_directories(${CMAKE_SOURCE_DIR}/../external/googletest/googlemock/include/)
+link_directories(${CMAKE_SOURCE_DIR}/../external/googletest/lib/)
+
+set(TEST_SRC "main.cpp")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    list(APPEND TEST_SRC test_services_windows.cpp)
+endif()
+
+add_executable(extended_sources_services_unit_test ${TEST_SRC})
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    target_link_libraries(extended_sources_services_unit_test
+        services
+        debug gtestd
+        debug gmockd
+        debug gtest_maind
+        debug gmock_maind
+        optimized gtest
+        optimized gmock
+        optimized gtest_main
+        optimized gmock_main
+    )
+endif()
+
+add_test(NAME ServicesTests COMMAND extended_sources_services_unit_test)

--- a/src/data_provider/src/extended_sources/services/tests/main.cpp
+++ b/src/data_provider/src/extended_sources/services/tests/main.cpp
@@ -1,0 +1,17 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/data_provider/src/extended_sources/services/tests/test_services_windows.cpp
+++ b/src/data_provider/src/extended_sources/services/tests/test_services_windows.cpp
@@ -1,0 +1,328 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "services_windows.hpp"
+#include "encodingWindowsHelper.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Eq;
+using ::testing::Truly;
+using ::testing::NotNull;
+using ::testing::StrEq;
+
+class MockServicesHelper : public IServicesHelper
+{
+    public:
+        MOCK_METHOD(std::optional<std::wstring>, readServiceDllFromParameters, (const std::wstring& serviceName), (override));
+        MOCK_METHOD(std::optional<std::wstring>, expandEnvStringW, (const std::wstring& str), (override));
+};
+
+class MockWinSvcWrapper : public IWinSvcWrapper
+{
+    public:
+        MOCK_METHOD(SC_HANDLE, OpenSCManagerWrapper, (LPCWSTR lpMachineName, LPCWSTR lpDatabaseName, DWORD dwDesiredAccess), (override));
+        MOCK_METHOD(SC_HANDLE, OpenServiceWWrapper, (SC_HANDLE hSCManager, LPCWSTR lpServiceName, DWORD dwDesiredAccess), (override));
+        MOCK_METHOD(BOOL, CloseServiceHandleWrapper, (SC_HANDLE hSCObject), (override));
+        MOCK_METHOD(BOOL, QueryServiceConfigWWrapper, (SC_HANDLE hService, LPQUERY_SERVICE_CONFIGW lpServiceConfig, DWORD cbBufSize, LPDWORD pcbBytesNeeded), (override));
+        MOCK_METHOD(BOOL, QueryServiceConfig2WWrapper, (SC_HANDLE hService, DWORD dwInfoLevel, LPBYTE lpBuffer, DWORD cbBufSize, LPDWORD pcbBytesNeeded), (override));
+        MOCK_METHOD(BOOL, EnumServicesStatusExWWrapper, (SC_HANDLE hSCManager, SC_ENUM_TYPE InfoLevel, DWORD dwServiceType, DWORD dwServiceState, LPBYTE lpServices, DWORD cbBufSize, LPDWORD pcbBytesNeeded,
+                                                         LPDWORD lpServicesReturned, LPDWORD lpResumeHandle, LPCWSTR pszGroupName), (override));
+};
+
+class MockWindowsApiWrapper : public IWindowsApiWrapper
+{
+    public:
+        MOCK_METHOD(DWORD, NetUserEnumWrapper,
+                    (LPCWSTR, DWORD, DWORD, LPBYTE*, DWORD, LPDWORD, LPDWORD, LPDWORD), (override));
+        MOCK_METHOD(DWORD, NetLocalGroupEnumWrapper,
+                    (LPCWSTR, DWORD, LPBYTE*, DWORD, LPDWORD, LPDWORD, LPDWORD), (override));
+        MOCK_METHOD(DWORD, NetUserGetInfoWrapper,
+                    (LPCWSTR, LPCWSTR, DWORD, LPBYTE*), (override));
+        MOCK_METHOD(DWORD, RegOpenKeyExWWrapper,
+                    (HKEY, LPCWSTR, DWORD, REGSAM, PHKEY), (override));
+        MOCK_METHOD(DWORD, RegQueryValueExWWrapper,
+                    (HKEY, LPCWSTR, LPDWORD, LPDWORD, LPBYTE, LPDWORD), (override));
+        MOCK_METHOD(LSTATUS, RegQueryInfoKeyWWrapper,
+                    (HKEY, LPWSTR, LPDWORD, LPDWORD, LPDWORD, LPDWORD,
+                     LPDWORD, LPDWORD, LPDWORD, LPDWORD, LPDWORD, PFILETIME), (override));
+        MOCK_METHOD(bool, IsValidSidWrapper, (PSID), (override));
+        MOCK_METHOD(BOOL, ConvertSidToStringSidAWrapper, (PSID, LPSTR*), (override));
+        MOCK_METHOD(bool, ConvertSidToStringSidWWrapper, (PSID, LPWSTR*), (override));
+        MOCK_METHOD(BOOL, ConvertStringSidToSidAWrapper, (LPCSTR, PSID*), (override));
+        MOCK_METHOD(BOOL, LookupAccountSidWWrapper,
+                    (LPCWSTR, PSID, LPWSTR, LPDWORD, LPWSTR, LPDWORD, PSID_NAME_USE), (override));
+        MOCK_METHOD(bool, LookupAccountNameWWrapper,
+                    (LPCWSTR, LPCWSTR, PSID, LPDWORD, LPWSTR, LPDWORD, PSID_NAME_USE), (override));
+        MOCK_METHOD(void, FreeSidWrapper, (LPVOID), (override));
+        MOCK_METHOD(DWORD, NetUserGetLocalGroupsWrapper,
+                    (LPCWSTR, LPCWSTR, DWORD, DWORD, LPBYTE*, DWORD, LPDWORD, LPDWORD), (override));
+        MOCK_METHOD(PUCHAR, GetSidSubAuthorityCountWrapper, (PSID), (override));
+        MOCK_METHOD(PDWORD, GetSidSubAuthorityWrapper, (PSID, DWORD), (override));
+        MOCK_METHOD(LSTATUS, RegEnumKeyWWrapper, (HKEY, DWORD, LPWSTR, DWORD), (override));
+        MOCK_METHOD(DWORD, GetLastErrorWrapper, (), (override));
+        MOCK_METHOD(LSTATUS, RegCloseKeyWrapper, (HKEY hKey), (override));
+};
+
+class ServicesProviderTest : public ::testing::Test
+{
+    protected:
+        std::shared_ptr<MockServicesHelper> mockServicesHelper;
+        std::shared_ptr<MockWinSvcWrapper> mockWinSvcWrapper;
+        std::shared_ptr<MockWindowsApiWrapper> mockWinApiWrapper;
+        std::unique_ptr<ServicesProvider> servicesProvider;
+
+        void SetUp() override
+        {
+            mockServicesHelper = std::make_shared<MockServicesHelper>();
+            mockWinSvcWrapper = std::make_shared<MockWinSvcWrapper>();
+            mockWinApiWrapper = std::make_shared<MockWindowsApiWrapper>();
+            servicesProvider = std::make_unique<ServicesProvider>(mockServicesHelper, mockWinSvcWrapper, mockWinApiWrapper);
+        }
+
+        // Helper to simulate LPQUERY_SERVICE_CONFIGW buffer
+        void SetQueryServiceConfigWBuffer(LPQUERY_SERVICE_CONFIGW config, const std::string& binaryPath, const std::string& startName, DWORD startType, DWORD serviceType)
+        {
+            static WCHAR binaryPathBuffer[MAX_PATH];
+            static WCHAR startNameBuffer[MAX_PATH];
+
+            std::wcsncpy(binaryPathBuffer, Utils::EncodingWindowsHelper::stringUTF8ToWstring(binaryPath).c_str(), MAX_PATH - 1);
+            binaryPathBuffer[MAX_PATH - 1] = L'\0';
+            std::wcsncpy(startNameBuffer, Utils::EncodingWindowsHelper::stringUTF8ToWstring(startName).c_str(), MAX_PATH - 1);
+            startNameBuffer[MAX_PATH - 1] = L'\0';
+
+            config->dwServiceType = serviceType;
+            config->dwStartType = startType;
+            config->lpBinaryPathName = binaryPathBuffer;
+            config->lpServiceStartName = startNameBuffer;
+        }
+
+        void SetServiceDescriptionWBuffer(LPSERVICE_DESCRIPTIONW desc, const std::string& descriptionText)
+        {
+            static WCHAR descriptionBuffer[1024];
+
+            if (!descriptionText.empty())
+            {
+                std::wcsncpy(descriptionBuffer, Utils::EncodingWindowsHelper::stringUTF8ToWstring(descriptionText).c_str(), 1023);
+                descriptionBuffer[1023] = L'\0';
+                desc->lpDescription = descriptionBuffer;
+            }
+            else
+            {
+                desc->lpDescription = nullptr;
+            }
+        }
+};
+
+TEST_F(ServicesProviderTest, Collect_Success)
+{
+    SC_HANDLE fakeScmHandle = reinterpret_cast<SC_HANDLE>(100);
+
+    // Mock OpenSCManagerWrapper
+    EXPECT_CALL(*mockWinSvcWrapper, OpenSCManagerWrapper(nullptr, nullptr, GENERIC_READ))
+    .WillOnce(Return(fakeScmHandle));
+
+    DWORD initialBytesNeeded = 2 * sizeof(ENUM_SERVICE_STATUS_PROCESSW); // Two services
+    DWORD initialServiceCount = 0;
+    EXPECT_CALL(*mockWinSvcWrapper, EnumServicesStatusExWWrapper(fakeScmHandle, SC_ENUM_PROCESS_INFO, SERVICE_WIN32 | SERVICE_DRIVER, SERVICE_STATE_ALL, nullptr, 0, _, _, nullptr, nullptr))
+    .WillOnce(DoAll(SetArgPointee<6>(initialBytesNeeded), SetArgPointee<7>(initialServiceCount), Return(FALSE)));
+    EXPECT_CALL(*mockWinApiWrapper, GetLastErrorWrapper())
+    .WillOnce(Return(ERROR_MORE_DATA))
+    .WillOnce(Return(ERROR_INSUFFICIENT_BUFFER))
+    .WillOnce(Return(ERROR_INSUFFICIENT_BUFFER))
+    .WillOnce(Return(ERROR_INSUFFICIENT_BUFFER))
+    .WillOnce(Return(ERROR_INVALID_PARAMETER));
+
+    // Simulate EnumServicesStatusExWWrapper for actual data
+    DWORD finalServiceCount = 2;
+    EXPECT_CALL(*mockWinSvcWrapper, EnumServicesStatusExWWrapper(fakeScmHandle, SC_ENUM_PROCESS_INFO, SERVICE_WIN32 | SERVICE_DRIVER, SERVICE_STATE_ALL, _, initialBytesNeeded, _, _, nullptr, nullptr))
+    .WillOnce(DoAll(Invoke([&](SC_HANDLE, SC_ENUM_TYPE, DWORD, DWORD, LPBYTE lpServices, DWORD, LPDWORD pcbBytesNeeded, LPDWORD lpServicesReturned, LPDWORD, LPCWSTR)
+    {
+        ENUM_SERVICE_STATUS_PROCESSW* services = reinterpret_cast<ENUM_SERVICE_STATUS_PROCESSW*>(lpServices);
+
+        // Service 1
+        static WCHAR svc1Name[] = L"ServiceA";
+        static WCHAR svc1DisplayName[] = L"Display Service A";
+        services[0].lpServiceName = svc1Name;
+        services[0].lpDisplayName = svc1DisplayName;
+        services[0].ServiceStatusProcess.dwCurrentState = SERVICE_RUNNING;
+        services[0].ServiceStatusProcess.dwProcessId = 111;
+        services[0].ServiceStatusProcess.dwWin32ExitCode = 0;
+        services[0].ServiceStatusProcess.dwServiceSpecificExitCode = 0;
+
+        // Service 2
+        static WCHAR svc2Name[] = L"ServiceB";
+        static WCHAR svc2DisplayName[] = L"Display Service B";
+        services[1].lpServiceName = svc2Name;
+        services[1].lpDisplayName = svc2DisplayName;
+        services[1].ServiceStatusProcess.dwCurrentState = SERVICE_STOPPED;
+        services[1].ServiceStatusProcess.dwProcessId = 222;
+        services[1].ServiceStatusProcess.dwWin32ExitCode = 0;
+        services[1].ServiceStatusProcess.dwServiceSpecificExitCode = 0;
+
+        *pcbBytesNeeded = initialBytesNeeded;
+        *lpServicesReturned = finalServiceCount;
+        return TRUE;
+    }), Return(TRUE)));
+
+    // Mock for ServiceA
+    SC_HANDLE fakeSvcHandleA = reinterpret_cast<SC_HANDLE>(201);
+    EXPECT_CALL(*mockWinSvcWrapper, OpenServiceWWrapper(fakeScmHandle, StrEq(L"ServiceA"), SERVICE_QUERY_CONFIG))
+    .WillOnce(Return(fakeSvcHandleA));
+
+    DWORD requiredSize = sizeof(QUERY_SERVICE_CONFIGW) + 100;
+
+    EXPECT_CALL(*mockWinSvcWrapper, QueryServiceConfigWWrapper(fakeSvcHandleA, nullptr, 0, _))
+    .WillOnce(DoAll(SetArgPointee<3>(requiredSize), Return(FALSE)));
+
+    EXPECT_CALL(*mockWinSvcWrapper, QueryServiceConfigWWrapper(fakeSvcHandleA, NotNull(), requiredSize, _))
+    .WillOnce(DoAll(Invoke([&](SC_HANDLE, LPQUERY_SERVICE_CONFIGW config, DWORD, LPDWORD pcbBytesNeeded)
+    {
+        SetQueryServiceConfigWBuffer(config, "C:\\Path\\A.exe", "LocalSystemA", SERVICE_AUTO_START, SERVICE_WIN32_OWN_PROCESS);
+        *pcbBytesNeeded = requiredSize;
+        return TRUE;
+    }), Return(TRUE)));
+
+    requiredSize = sizeof(SERVICE_DESCRIPTIONW) + 50;
+
+    EXPECT_CALL(*mockWinSvcWrapper, QueryServiceConfig2WWrapper(fakeSvcHandleA, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, _))
+    .WillOnce(DoAll(SetArgPointee<4>(requiredSize), Return(FALSE)));
+    EXPECT_CALL(*mockWinSvcWrapper, QueryServiceConfig2WWrapper(fakeSvcHandleA, SERVICE_CONFIG_DESCRIPTION, NotNull(), requiredSize, _))
+    .WillOnce(DoAll(Invoke([&](SC_HANDLE, DWORD, LPBYTE lpBuffer, DWORD, LPDWORD pcbBytesNeeded)
+    {
+        LPSERVICE_DESCRIPTIONW desc = reinterpret_cast<LPSERVICE_DESCRIPTIONW>(lpBuffer);
+        SetServiceDescriptionWBuffer(desc, "Desc A.");
+        *pcbBytesNeeded = requiredSize;
+        return TRUE;
+    }), Return(TRUE)));
+    EXPECT_CALL(*mockServicesHelper, readServiceDllFromParameters(Eq(L"ServiceA")))
+    .WillOnce(Return(std::make_optional(L"C:\\Path\\ModuleA.dll")));
+    EXPECT_CALL(*mockServicesHelper, expandEnvStringW(Eq(L"C:\\Path\\ModuleA.dll")))
+    .WillOnce(Return(std::make_optional(L"C:\\Path\\ModuleA.dll")));
+    EXPECT_CALL(*mockWinSvcWrapper, CloseServiceHandleWrapper(fakeSvcHandleA))
+    .WillOnce(Return(TRUE));
+
+    // Mock for ServiceB
+    SC_HANDLE fakeSvcHandleB = reinterpret_cast<SC_HANDLE>(202);
+
+    EXPECT_CALL(*mockWinSvcWrapper, OpenServiceWWrapper(fakeScmHandle, StrEq(L"ServiceB"), SERVICE_QUERY_CONFIG))
+    .WillOnce(Return(fakeSvcHandleB));
+
+    requiredSize = sizeof(QUERY_SERVICE_CONFIGW) + 100;
+
+    EXPECT_CALL(*mockWinSvcWrapper, QueryServiceConfigWWrapper(fakeSvcHandleB, nullptr, 0, _))
+    .WillOnce(DoAll(SetArgPointee<3>(requiredSize), Return(FALSE)));
+    EXPECT_CALL(*mockWinSvcWrapper, QueryServiceConfigWWrapper(fakeSvcHandleB, NotNull(), requiredSize, _))
+    .WillOnce(DoAll(Invoke([&](SC_HANDLE, LPQUERY_SERVICE_CONFIGW config, DWORD, LPDWORD pcbBytesNeeded)
+    {
+        SetQueryServiceConfigWBuffer(config, "C:\\Path\\B.exe", "NetworkServiceB", SERVICE_DEMAND_START, SERVICE_FILE_SYSTEM_DRIVER);
+        *pcbBytesNeeded = requiredSize;
+        return TRUE;
+    }), Return(TRUE)));
+    EXPECT_CALL(*mockWinSvcWrapper, QueryServiceConfig2WWrapper(fakeSvcHandleB, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, _))
+    .WillOnce(DoAll(SetArgPointee<4>(0), Return(FALSE))); // No description for B
+    EXPECT_CALL(*mockServicesHelper, readServiceDllFromParameters(Eq(L"ServiceB")))
+    .WillOnce(Return(std::nullopt)); // No module path for B
+    EXPECT_CALL(*mockWinSvcWrapper, CloseServiceHandleWrapper(fakeSvcHandleB))
+    .WillOnce(Return(TRUE));
+
+    // Mock CloseSCManagerWrapper
+    EXPECT_CALL(*mockWinSvcWrapper, CloseServiceHandleWrapper(fakeScmHandle))
+    .WillOnce(Return(TRUE));
+
+    nlohmann::json results = servicesProvider->collect();
+
+    ASSERT_EQ(results.size(), 2u);
+
+    // Verify Service A
+    const auto& svc1 = results[0];
+    EXPECT_EQ(svc1["name"], "ServiceA");
+    EXPECT_EQ(svc1["display_name"], "Display Service A");
+    EXPECT_EQ(svc1["status"], "RUNNING");
+    EXPECT_EQ(svc1["pid"], 111);
+    EXPECT_EQ(svc1["path"], "C:\\Path\\A.exe");
+    EXPECT_EQ(svc1["description"], "Desc A.");
+    EXPECT_EQ(svc1["module_path"], "C:\\Path\\ModuleA.dll");
+
+    // Verify Service B
+    const auto& svc2 = results[1];
+    EXPECT_EQ(svc2["name"], "ServiceB");
+    EXPECT_EQ(svc2["display_name"], "Display Service B");
+    EXPECT_EQ(svc2["status"], "STOPPED");
+    EXPECT_EQ(svc2["pid"], 222);
+    EXPECT_EQ(svc2["path"], "C:\\Path\\B.exe");
+    EXPECT_EQ(svc2["description"], ""); // No description for B
+    EXPECT_EQ(svc2["module_path"], ""); // No module path for B
+}
+
+TEST_F(ServicesProviderTest, Collect_OpenSCManagerFails)
+{
+    // Mock OpenSCManagerWrapper to fail
+    EXPECT_CALL(*mockWinSvcWrapper, OpenSCManagerWrapper(nullptr, nullptr, GENERIC_READ))
+    .WillOnce(Return(nullptr));
+    EXPECT_CALL(*mockWinApiWrapper, GetLastErrorWrapper())
+    .WillOnce(Return(ERROR_DATABASE_DOES_NOT_EXIST));
+
+    nlohmann::json results = servicesProvider->collect();
+
+    ASSERT_TRUE(results.empty());
+}
+
+TEST_F(ServicesProviderTest, Collect_EnumServicesStatusExWFailsToGetBufferSize)
+{
+    SC_HANDLE fakeScmHandle = reinterpret_cast<SC_HANDLE>(100);
+
+    EXPECT_CALL(*mockWinSvcWrapper, OpenSCManagerWrapper(nullptr, nullptr, GENERIC_READ))
+    .WillOnce(Return(fakeScmHandle));
+
+    EXPECT_CALL(*mockWinSvcWrapper, EnumServicesStatusExWWrapper(fakeScmHandle, SC_ENUM_PROCESS_INFO, SERVICE_WIN32 | SERVICE_DRIVER, SERVICE_STATE_ALL, nullptr, 0, _, _, nullptr, nullptr))
+    .WillOnce(DoAll(SetArgPointee<6>(0), SetArgPointee<7>(0), Return(FALSE)));
+    EXPECT_CALL(*mockWinApiWrapper, GetLastErrorWrapper())
+    .WillRepeatedly(Return(ERROR_INVALID_PARAMETER));
+
+    EXPECT_CALL(*mockWinSvcWrapper, CloseServiceHandleWrapper(fakeScmHandle))
+    .WillOnce(Return(TRUE));
+
+    nlohmann::json results = servicesProvider->collect();
+
+    ASSERT_TRUE(results.empty());
+}
+
+TEST_F(ServicesProviderTest, Collect_EnumServicesStatusExWFailsToGetData)
+{
+    SC_HANDLE fakeScmHandle = reinterpret_cast<SC_HANDLE>(100);
+
+    EXPECT_CALL(*mockWinSvcWrapper, OpenSCManagerWrapper(nullptr, nullptr, GENERIC_READ))
+    .WillOnce(Return(fakeScmHandle));
+
+    // Simulate EnumServicesStatusExWWrapper for buffer size (success)
+    DWORD initialBytesNeeded = 2 * sizeof(ENUM_SERVICE_STATUS_PROCESSW);
+    DWORD initialServiceCount = 0;
+    EXPECT_CALL(*mockWinSvcWrapper, EnumServicesStatusExWWrapper(fakeScmHandle, SC_ENUM_PROCESS_INFO, SERVICE_WIN32 | SERVICE_DRIVER, SERVICE_STATE_ALL, nullptr, 0, _, _, nullptr, nullptr))
+    .WillOnce(DoAll(SetArgPointee<6>(initialBytesNeeded), SetArgPointee<7>(initialServiceCount), Return(FALSE)));
+    EXPECT_CALL(*mockWinApiWrapper, GetLastErrorWrapper())
+    .WillOnce(Return(ERROR_MORE_DATA))
+    .WillOnce(Return(ERROR_NOT_ENOUGH_MEMORY));
+
+    // Mock EnumServicesStatusExWWrapper to fail getting actual data
+    EXPECT_CALL(*mockWinSvcWrapper, EnumServicesStatusExWWrapper(fakeScmHandle, SC_ENUM_PROCESS_INFO, SERVICE_WIN32 | SERVICE_DRIVER, SERVICE_STATE_ALL, _, initialBytesNeeded, _, _, nullptr, nullptr))
+    .WillOnce(Return(FALSE));
+
+    EXPECT_CALL(*mockWinSvcWrapper, CloseServiceHandleWrapper(fakeScmHandle))
+    .WillOnce(Return(TRUE));
+
+    nlohmann::json results = servicesProvider->collect();
+
+    ASSERT_TRUE(results.empty());
+}

--- a/src/data_provider/src/extended_sources/users/tests/test_logged_in_users_win.cpp
+++ b/src/data_provider/src/extended_sources/users/tests/test_logged_in_users_win.cpp
@@ -57,7 +57,6 @@ class MockWinSecurityBaseApiWrapper : public IWinSecurityBaseApiWrapper
 class MockUsersHelper : public IUsersHelper
 {
     public:
-        MOCK_METHOD(std::wstring, stringToWstring, (const std::string& src), (override));
         MOCK_METHOD(std::string, getUserShell, (const std::string& sid), (override));
         MOCK_METHOD(std::vector<User>, processLocalAccounts, (std::set<std::string>& processed_sids), (override));
         MOCK_METHOD(std::vector<User>, processRoamingProfiles, (std::set<std::string>& processed_sids), (override));

--- a/src/data_provider/src/extended_sources/wrappers/windows/iservices_utils_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/iservices_utils_wrapper.hpp
@@ -1,0 +1,32 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <windows.h>
+#include <optional>
+#include <string>
+
+// Interface for the windows services helper wrapper
+class IServicesHelper
+{
+    public:
+        /// Destructor
+        virtual ~IServicesHelper() = default;
+
+        /// @brief Expands environment variables in a given string.
+        /// @param input The input string potentially containing environment variables.
+        /// @return A string with environment variables expanded, or std::nullopt if expansion fails
+        virtual std::optional<std::wstring> expandEnvStringW(const std::wstring& input) = 0;
+
+        /// @brief Reads the ServiceDll value from the service parameters registry key.
+        /// @param serviceName The name of the service to read the ServiceDll from.
+        /// @return The ServiceDll path as a std::wstring if found, or std::nullopt if not found or an error occurs.
+        virtual std::optional<std::wstring> readServiceDllFromParameters(const std::wstring& serviceName) = 0;
+};

--- a/src/data_provider/src/extended_sources/wrappers/windows/iusers_utils_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/iusers_utils_wrapper.hpp
@@ -43,11 +43,6 @@ class IUsersHelper
         /// Destructor
         virtual ~IUsersHelper() = default;
 
-        /// @brief Converts a UTF-8 std::string to a wide string (wstring).
-        /// @param src Input UTF-8 string.
-        /// @return Converted wide string.
-        virtual std::wstring stringToWstring(const std::string& src) = 0;
-
         /// @brief Retrieves the shell path for the user identified by the SID.
         /// @param sid String representation of the user's SID.
         /// @return The shell executable path.

--- a/src/data_provider/src/extended_sources/wrappers/windows/iwindows_api_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/iwindows_api_wrapper.hpp
@@ -11,6 +11,7 @@
 
 #include <windows.h>
 #include <lm.h>
+#include <sddl.h>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/data_provider/src/extended_sources/wrappers/windows/iwinsvc_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/iwinsvc_wrapper.hpp
@@ -1,0 +1,84 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <winsvc.h>
+
+/// @brief Interface for Windows Service Control Manager (SCM) operations.
+////// Provides methods to interact with the SCM, such as opening the service control manager,
+/// opening services, querying service configurations, and enumerating services.
+class IWinSvcWrapper
+{
+    public:
+        /// @brief Default destructor.
+        virtual ~IWinSvcWrapper() = default;
+
+        /// @brief Opens a service control manager database.
+        /// @param lpMachineName Name of the machine to connect to.
+        /// @param dwDesiredAccess Access rights for the service control manager.
+        /// @return Handle to the opened service control manager database.
+        virtual SC_HANDLE OpenSCManagerWrapper(LPCWSTR lpMachineName, LPCWSTR lpDatabaseName, DWORD dwDesiredAccess) = 0;
+
+        /// @brief Enumerates services in the service control manager database.
+        /// @details This function retrieves information about services in the specified service control manager database.
+        /// @note The function is a wrapper for the Windows API EnumServicesStatusExW.
+        /// @param hSCManager Handle to the service control manager database.
+        /// @param dwInfoLevel Information level to retrieve.
+        /// @param dwServiceType Type of services to be enumerated
+        /// @param dwServiceState State of services to be enumerated
+        /// @param lpServices Pointer to a buffer that receives the service information.
+        /// @param cbBufSize Size of the buffer pointed to by lpServices.
+        /// @param pcbBytesNeeded Pointer to a variable that receives the size of the data returned in lpServices.
+        /// @param lpServicesReturned Pointer to a variable that receives the number of services returned in lpServices.
+        /// @param lpResumeHandle Pointer to a variable that receives a resume handle for the enumeration.
+        /// @param pszGroupName Name of the group to which the services belong.
+        /// @return TRUE if successful, FALSE otherwise.
+        virtual BOOL EnumServicesStatusExWWrapper(
+            SC_HANDLE hSCManager,
+            SC_ENUM_TYPE dwInfoLevel,
+            DWORD dwServiceType,
+            DWORD dwServiceState,
+            LPBYTE lpServices,
+            DWORD cbBufSize,
+            LPDWORD pcbBytesNeeded,
+            LPDWORD lpServicesReturned,
+            LPDWORD lpResumeHandle,
+            LPCWSTR pszGroupName) = 0;
+
+        /// @brief Opens a service in the service control manager database.
+        /// @param hSCManager Handle to the service control manager database.
+        /// @param lpServiceName Name of the service to open.
+        /// @param dwDesiredAccess Access rights for the service.
+        /// @return Handle to the opened service.
+        virtual SC_HANDLE OpenServiceWWrapper(SC_HANDLE hSCManager, LPCWSTR lpServiceName, DWORD dwDesiredAccess) = 0;
+
+        /// @brief Queries the configuration of a service.
+        /// @param hService Handle to the service.
+        /// @param lpServiceConfig Pointer to a buffer that receives the service configuration.
+        /// @param cbBufSize Size of the buffer pointed to by lpServiceConfig.
+        /// @param pcbBytesNeeded Pointer to a variable that receives the size of the data returned
+        /// @return TRUE if successful, FALSE otherwise.
+        virtual BOOL QueryServiceConfigWWrapper(SC_HANDLE hService, LPQUERY_SERVICE_CONFIGW lpServiceConfig,
+                                                DWORD cbBufSize, LPDWORD pcbBytesNeeded) = 0;
+
+        /// @brief Queries the configuration of a service with additional information.
+        /// @param hService Handle to the service.
+        /// @param dwInfoLevel Information level to retrieve.
+        /// @param lpBuffer Pointer to a buffer that receives the service configuration.
+        /// @param cbBufSize Size of the buffer pointed to by lpBuffer.
+        /// @param pcbBytesNeeded Pointer to a variable that receives the size of the data returned
+        /// @return TRUE if successful, FALSE otherwise.
+        virtual BOOL QueryServiceConfig2WWrapper(SC_HANDLE hService, DWORD dwInfoLevel,
+                                                 LPBYTE lpBuffer, DWORD cbBufSize, LPDWORD pcbBytesNeeded) = 0;
+
+        /// @brief Closes a handle to a service control manager database.
+        /// @param hSCManager Handle to the service control manager database.
+        virtual void CloseServiceHandleWrapper(SC_HANDLE hSCManager) = 0;
+};

--- a/src/data_provider/src/extended_sources/wrappers/windows/iwinsvc_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/iwinsvc_wrapper.hpp
@@ -80,5 +80,6 @@ class IWinSvcWrapper
 
         /// @brief Closes a handle to a service control manager database.
         /// @param hSCManager Handle to the service control manager database.
-        virtual void CloseServiceHandleWrapper(SC_HANDLE hSCManager) = 0;
+        /// @return TRUE if successful, FALSE otherwise.
+        virtual BOOL CloseServiceHandleWrapper(SC_HANDLE hSCManager) = 0;
 };

--- a/src/data_provider/src/extended_sources/wrappers/windows/services_utils_wrapper.cpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/services_utils_wrapper.cpp
@@ -1,0 +1,81 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "services_utils_wrapper.hpp"
+#include "windows_api_wrapper.hpp"
+
+ServicesHelper::ServicesHelper(std::shared_ptr<IWindowsApiWrapper> winapiWrapper)
+    : m_winapiWrapper(std::move(winapiWrapper))
+{
+}
+
+ServicesHelper::ServicesHelper()
+    : m_winapiWrapper(std::make_shared<WindowsApiWrapper>())
+{
+}
+
+std::optional<std::wstring> ServicesHelper::expandEnvStringW(const std::wstring& input)
+{
+    DWORD size = ExpandEnvironmentStringsW(input.c_str(), nullptr, 0);
+
+    if (size == 0)
+    {
+        return std::nullopt;
+    }
+
+    std::wstring result(size, L'\0');
+
+    if (ExpandEnvironmentStringsW(input.c_str(), &result[0], size) == 0)
+    {
+        return std::nullopt;
+    }
+
+    result.pop_back(); // Remove null terminator
+    return result;
+}
+
+std::optional<std::wstring> ServicesHelper::readServiceDllFromParameters(const std::wstring& serviceName)
+{
+    const std::wstring subkey = L"SYSTEM\\CurrentControlSet\\Services\\" + serviceName + L"\\Parameters";
+    HKEY hKey = nullptr;
+
+    LSTATUS status = m_winapiWrapper->RegOpenKeyExWWrapper(HKEY_LOCAL_MACHINE, subkey.c_str(), 0, KEY_READ, &hKey);
+
+    if (status != ERROR_SUCCESS)
+    {
+        return std::nullopt;
+    }
+
+    DWORD type = 0;
+    DWORD dataSize = 0;
+    status = m_winapiWrapper->RegQueryValueExWWrapper(hKey, L"ServiceDll", nullptr, &type, nullptr, &dataSize);
+
+    if (status != ERROR_SUCCESS || (type != REG_SZ && type != REG_EXPAND_SZ))
+    {
+        m_winapiWrapper->RegCloseKeyWrapper(hKey);
+        return std::nullopt;
+    }
+
+    std::wstring buffer(dataSize / sizeof(wchar_t), L'\0');
+    status = m_winapiWrapper->RegQueryValueExWWrapper(hKey, L"ServiceDll", nullptr, nullptr, reinterpret_cast<LPBYTE>(&buffer[0]), &dataSize);
+
+    m_winapiWrapper->RegCloseKeyWrapper(hKey);
+
+    if (status != ERROR_SUCCESS)
+    {
+        return std::nullopt;
+    }
+
+    if (!buffer.empty() && buffer.back() == L'\0')
+    {
+        buffer.pop_back();
+    }
+
+    return buffer;
+}

--- a/src/data_provider/src/extended_sources/wrappers/windows/services_utils_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/services_utils_wrapper.hpp
@@ -1,0 +1,39 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "iservices_utils_wrapper.hpp"
+#include "iwindows_api_wrapper.hpp"
+
+/// @brief Helper class for Windows services operations.
+class ServicesHelper : public IServicesHelper
+{
+    private:
+        /// @brief Windows API wrapper instance used for system calls.
+        std::shared_ptr<IWindowsApiWrapper> m_winapiWrapper;
+
+    public:
+        /// @brief Constructs a ServicesHelper.
+        /// @param winapiWrapper Shared pointer to an `IWindowsApiWrapper`.
+        explicit ServicesHelper(std::shared_ptr<IWindowsApiWrapper> winapiWrapper);
+
+        /// @brief Default constructor.
+        ServicesHelper();
+
+        /// @brief Expands environment variables in a given string.
+        /// @param input The input string potentially containing environment variables.
+        /// @return A string with environment variables expanded, or std::nullopt if expansion fails
+        std::optional<std::wstring> expandEnvStringW(const std::wstring& input) override;
+
+        /// @brief Reads the ServiceDll value from the service parameters registry key.
+        /// @param serviceName The name of the service to read the ServiceDll from.
+        /// @return The ServiceDll path as a std::wstring if found, or std::nullopt if not found or an error occurs.
+        std::optional<std::wstring> readServiceDllFromParameters(const std::wstring& serviceName) override;
+};

--- a/src/data_provider/src/extended_sources/wrappers/windows/users_utils_wrapper.cpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/users_utils_wrapper.cpp
@@ -24,7 +24,7 @@ std::string UsersHelper::getUserHomeDir(const std::string& sid)
 {
     std::wstring profile_key_path = kRegProfileKey;
     profile_key_path += kRegSep;
-    profile_key_path += stringToWstring(sid);
+    profile_key_path += Utils::EncodingWindowsHelper::stringUTF8ToWstring(sid);
 
     HKEY hkey;
     auto ret = m_winapiWrapper->RegOpenKeyExWWrapper(
@@ -231,23 +231,6 @@ std::optional<std::vector<std::string>> UsersHelper::getRoamingProfileSids()
     }
 
     return subkeys_names;
-}
-
-std::wstring UsersHelper::stringToWstring(const std::string& src)
-{
-    std::wstring utf16le_str;
-
-    try
-    {
-        std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-        utf16le_str = converter.from_bytes(src);
-    }
-    catch (const std::exception& /* e */)
-    {
-        // std::cout << "Failed to convert string to wstring " << src;
-    }
-
-    return utf16le_str;
 }
 
 std::string UsersHelper::getUserShell(const std::string& sid)

--- a/src/data_provider/src/extended_sources/wrappers/windows/users_utils_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/users_utils_wrapper.hpp
@@ -222,11 +222,6 @@ class UsersHelper : public IUsersHelper
         /// @brief Default constructor.
         UsersHelper();
 
-        /// @brief Converts a UTF-8 std::string to a wide string (wstring).
-        /// @param src Input UTF-8 string.
-        /// @return Converted wide string.
-        std::wstring stringToWstring(const std::string& src);
-
         /// @brief Retrieves the shell path for the user identified by the SID.
         /// @param sid String representation of the user's SID.
         /// @return The shell executable path.

--- a/src/data_provider/src/extended_sources/wrappers/windows/winsvc_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/winsvc_wrapper.hpp
@@ -96,8 +96,9 @@ class WinSvcWrapper : public IWinSvcWrapper
 
         /// @brief Closes a handle to a service control manager database.
         /// @param hSCManager Handle to the service control manager database.
-        void CloseServiceHandleWrapper(SC_HANDLE hSCManager) override
+        /// @return TRUE if successful, FALSE otherwise.
+        BOOL CloseServiceHandleWrapper(SC_HANDLE hSCManager) override
         {
-            CloseServiceHandle(hSCManager);
+            return CloseServiceHandle(hSCManager);
         }
 };

--- a/src/data_provider/src/extended_sources/wrappers/windows/winsvc_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/windows/winsvc_wrapper.hpp
@@ -1,0 +1,103 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "iwinsvc_wrapper.hpp"
+
+/// @brief Wrapper for Windows Service Control Manager (SCM) operations.
+////// Provides concrete implementations of the `IWinSvcWrapper` interface by delegating
+/// to native Windows API functions. This allows for easier mocking and testing.
+class WinSvcWrapper : public IWinSvcWrapper
+{
+    public:
+        /// @brief Opens a service control manager database.
+        /// @param lpMachineName Name of the machine to connect to.
+        /// @param lpDatabaseName Name of the database to open.
+        /// @param dwDesiredAccess Access rights for the service control manager.
+        /// @return Handle to the opened service control manager database.
+        SC_HANDLE OpenSCManagerWrapper(LPCWSTR lpMachineName, LPCWSTR lpDatabaseName, DWORD dwDesiredAccess) override
+        {
+            return OpenSCManagerW(lpMachineName, lpDatabaseName, dwDesiredAccess);
+        }
+
+        /// @brief Enumerates services in the service control manager database.
+        /// @details This function retrieves information about services in the specified service control manager database.
+        /// @note The function is a wrapper for the Windows API EnumServicesStatusExW.
+        /// @param hSCManager Handle to the service control manager database.
+        /// @param dwInfoLevel Information level to retrieve.
+        /// @param dwServiceType Type of services to be enumerated
+        /// @param dwServiceState State of services to be enumerated
+        /// @param lpServices Pointer to a buffer that receives the service information.
+        /// @param cbBufSize Size of the buffer pointed to by lpServices.
+        /// @param pcbBytesNeeded Pointer to a variable that receives the size of the data returned in lpServices.
+        /// @param lpServicesReturned Pointer to a variable that receives the number of services returned in lpServices.
+        /// @param lpResumeHandle Pointer to a variable that receives a resume handle for the enumeration.
+        /// @param pszGroupName Name of the group to which the services belong.
+        /// @return TRUE if successful, FALSE otherwise.
+        BOOL EnumServicesStatusExWWrapper(
+            SC_HANDLE hSCManager,
+            SC_ENUM_TYPE dwInfoLevel,
+            DWORD dwServiceType,
+            DWORD dwServiceState,
+            LPBYTE lpServices,
+            DWORD cbBufSize,
+            LPDWORD pcbBytesNeeded,
+            LPDWORD lpServicesReturned,
+            LPDWORD lpResumeHandle,
+            LPCWSTR pszGroupName) override
+        {
+            return EnumServicesStatusExW(hSCManager, dwInfoLevel, dwServiceType,
+                                         dwServiceState, lpServices, cbBufSize,
+                                         pcbBytesNeeded, lpServicesReturned,
+                                         lpResumeHandle, pszGroupName);
+        }
+
+        /// @brief Opens a service in the service control manager database.
+        /// @param hSCManager Handle to the service control manager database.
+        /// @param lpServiceName Name of the service to open.
+        /// @param dwDesiredAccess Access rights for the service.
+        /// @return Handle to the opened service.
+        SC_HANDLE OpenServiceWWrapper(SC_HANDLE hSCManager, LPCWSTR lpServiceName, DWORD dwDesiredAccess) override
+        {
+            return OpenServiceW(hSCManager, lpServiceName, dwDesiredAccess);
+        }
+
+        /// @brief Queries the configuration of a service.
+        /// @param hService Handle to the service.
+        /// @param lpServiceConfig Pointer to a buffer that receives the service configuration.
+        /// @param cbBufSize Size of the buffer pointed to by lpServiceConfig.
+        /// @param pcbBytesNeeded Pointer to a variable that receives the size of the data returned
+        /// @return TRUE if successful, FALSE otherwise.
+        BOOL QueryServiceConfigWWrapper(SC_HANDLE hService, LPQUERY_SERVICE_CONFIGW lpServiceConfig,
+                                        DWORD cbBufSize, LPDWORD pcbBytesNeeded) override
+        {
+            return QueryServiceConfigW(hService, lpServiceConfig, cbBufSize, pcbBytesNeeded);
+        }
+
+        /// @brief Queries the configuration of a service with additional information.
+        /// @param hService Handle to the service.
+        /// @param dwInfoLevel Information level to retrieve.
+        /// @param lpBuffer Pointer to a buffer that receives the service configuration.
+        /// @param cbBufSize Size of the buffer pointed to by lpBuffer.
+        /// @param pcbBytesNeeded Pointer to a variable that receives the size of the data returned
+        /// @return TRUE if successful, FALSE otherwise.
+        BOOL QueryServiceConfig2WWrapper(SC_HANDLE hService, DWORD dwInfoLevel,
+                                         LPBYTE lpBuffer, DWORD cbBufSize, LPDWORD pcbBytesNeeded) override
+        {
+            return QueryServiceConfig2W(hService, dwInfoLevel, lpBuffer, cbBufSize, pcbBytesNeeded);
+        }
+
+        /// @brief Closes a handle to a service control manager database.
+        /// @param hSCManager Handle to the service control manager database.
+        void CloseServiceHandleWrapper(SC_HANDLE hSCManager) override
+        {
+            CloseServiceHandle(hSCManager);
+        }
+};

--- a/src/shared_modules/utils/encodingWindowsHelper.h
+++ b/src/shared_modules/utils/encodingWindowsHelper.h
@@ -68,6 +68,25 @@ namespace Utils
                 return retVal;
             }
 
+            static std::wstring stringUTF8ToWstring(const std::string& inputArgument)
+            {
+                std::wstring retVal;
+
+                if (!inputArgument.empty())
+                {
+                    const auto inputArgumentSize{static_cast<int>(inputArgument.size())};
+                    const auto sizeNeeded {MultiByteToWideChar(CP_UTF8, 0, inputArgument.data(), inputArgumentSize, nullptr, 0)};
+                    auto buffer{std::make_unique<wchar_t[]>(sizeNeeded)};
+
+                    if (MultiByteToWideChar(CP_UTF8, 0, inputArgument.data(), inputArgumentSize, buffer.get(), sizeNeeded) > 0)
+                    {
+                        retVal.assign(buffer.get(), sizeNeeded);
+                    }
+                }
+
+                return retVal;
+            }
+
             static std::string stringAnsiToStringUTF8(const std::string& inputArgument)
             {
                 return wstringToStringUTF8(stringToWStringAnsi(inputArgument));


### PR DESCRIPTION
## Description

Closes #30789 

Implements a new Windows-only collector for the `services` inventory table within the `syscollector` module. This collector will use the `extended_sources` submodule to retrieve detailed metadata about installed Windows services, providing visibility into service configuration, execution status, and ownership.

The information collected will be mapped to the inventory model and formatted in accordance with ECS-compatible schemas where applicable. This will improve system observability, troubleshooting, and compliance auditing capabilities.

**Relevant fields:**

| Column              | Type     | Description                                                                 |
|---------------------|----------|-----------------------------------------------------------------------------|
| `name`              | text     | Service name                                                                |
| `service_type`      | text     | Service type (e.g., OWN_PROCESS, SHARE_PROCESS, Interactive)               |
| `display_name`      | text     | Service display name                                                        |
| `status`            | text     | Current status (e.g., RUNNING, STOPPED, PAUSED)                             |
| `pid`               | integer  | PID of the service process                                                  |
| `start_type`        | text     | Startup type (e.g., BOOT_START, AUTO_START, DEMAND_START, DISABLED)        |
| `win32_exit_code`   | integer  | Exit code used by the service to report errors                             |
| `service_exit_code` | integer  | Service-specific error code                                                 |
| `path`              | text     | Path to service executable                                                  |
| `module_path`       | text     | Path to ServiceDll module                                                   |
| `description`       | text     | Service description                                                         |
| `user_account`      | text     | Account under which the service runs (e.g., `.\LocalSystem`, `Domain\User`)|

## Proposed Changes

- Implement a new `WindowsServiceProvider` class in `extended_sources` module.
- Add unit tests to validate the new class.
- Add the required wrappers to allow unit testing.

### Results and Evidence

<details><summary>Source item example</summary>

```json
{
    "description": "Enables the detection, download, and installation of updates for Windows and other programs. If this service is disabled, users of this computer will not be able to use Windows Update or its automatic updating feature, and programs will not be able to use the Windows Update Agent (WUA) API.",
    "display_name": "Windows Update",
    "module_path": "C:\\Windows\\system32\\wuaueng.dll",
    "name": "wuauserv",
    "path": "C:\\Windows\\system32\\svchost.exe -k netsvcs -p",
    "pid": "3328",
    "service_exit_code": "0",
    "service_type": "SHARE_PROCESS",
    "start_type": "DEMAND_START",
    "status": "RUNNING",
    "user_account": "LocalSystem",
    "win32_exit_code": "0"
}
```
</details> 

<details><summary>Services collector item example</summary>

```json
{
    "description": "Enables the detection, download, and installation of updates for Windows and other programs. If this service is disabled, users of this computer will not be able to use Windows Update or its automatic updating feature, and programs will not be able to use the Windows Update Agent (WUA) API.",
    "display_name": "Windows Update",
    "module_path": "C:\\Windows\\system32\\wuaueng.dll",
    "name": "wuauserv",
    "path": "C:\\Windows\\system32\\svchost.exe -k netsvcs -p",
    "pid": 0,
    "service_exit_code": 0,
    "service_type": "SHARE_PROCESS",
    "start_type": "DEMAND_START",
    "status": "STOPPED",
    "user_account": "LocalSystem",
    "win32_exit_code": 1077
}
```
</details>

- [source_services.log](https://github.com/user-attachments/files/21318775/osquery_services.log)
- [wazuh_services_collector.log](https://github.com/user-attachments/files/21318776/wazuh_services.log)

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->