### PR TITLE
Add support for GCP Application Default Credentials

### DIFF
--- a/wodles/gcloud/buckets/bucket.py
+++ b/wodles/gcloud/buckets/bucket.py
@@ -60,12 +60,20 @@ class WazuhGCloudBucket(WazuhGCloudIntegration):
         super().__init__(logger)
         self.bucket_name = bucket_name
         self.bucket = None
-        try:
-            self.client = storage.client.Client.from_service_account_json(credentials_file)
-        except JSONDecodeError as error:
-            raise exceptions.GCloudError(1000, credentials_file=credentials_file) from error
-        except FileNotFoundError as error:
-            raise exceptions.GCloudError(1001, credentials_file=credentials_file) from error
+
+        if credentials_file:
+            # If a credentials file path is provided, use it to create the client.
+            try:
+                self.client = storage.client.Client.from_service_account_json(credentials_file)
+            except JSONDecodeError as error:
+                raise exceptions.GCloudError(1000, credentials_file=credentials_file) from error
+            except FileNotFoundError as error:
+                raise exceptions.GCloudError(1001, credentials_file=credentials_file) from error
+        else:
+            # If no credentials file is provided, instantiate the client directly.
+            # This will attempt to use Application Default Credentials (ADC).
+            self.client = storage.client.Client()
+
         self.project_id = self.client.project
         self.prefix = prefix if not prefix or prefix[-1] == '/' else f'{prefix}/'
         self.delete_file = delete_file

--- a/wodles/gcloud/pubsub/subscriber.py
+++ b/wodles/gcloud/pubsub/subscriber.py
@@ -61,15 +61,23 @@ class WazuhGCloudSubscriber(WazuhGCloudIntegration):
 
         Parameters
         ----------
-        credentials_file : str
-            Path to credentials file.
+        credentials_file : str, optional
+            Path to credentials file. If not provided, the client will attempt
+            to use Application Default Credentials or other environment
+            configurations.
 
         Returns
         -------
         pubsub.subscriber.Client
-            Instance of subscriber client object created with the provided key.
+            Instance of subscriber client object.
         """
-        return pubsub.subscriber.Client.from_service_account_file(credentials_file)  # noqa: E501
+        if credentials_file:
+            # If a credentials file path is provided, use it to create the client.
+            return pubsub.subscriber.Client.from_service_account_file(credentials_file)
+        else:
+            # If no credentials file is provided, instantiate the client directly.
+            # This will attempt to use Application Default Credentials (ADC).
+            return pubsub.subscriber.Client()
 
     def get_subscription_path(self, project: str, subscription_id: str) -> str:
         """Get the subscription path.

--- a/wodles/gcloud/tools.py
+++ b/wodles/gcloud/tools.py
@@ -49,7 +49,7 @@ def get_script_arguments():
                         help='Subscription name')
 
     parser.add_argument('-c', '--credentials_file', dest='credentials_file',
-                        help='Path to credentials file', required=True)
+                        help='Path to credentials file')
 
     parser.add_argument('-m', '--max_messages', dest='max_messages', type=int,
                         help='Number of maximum messages pulled in each iteration', default=100)
@@ -71,8 +71,8 @@ def get_script_arguments():
 
     parser.add_argument('-t', '--num_threads', dest='n_threads', type=int,
                         help='Number of threads', required=False, default=min_num_threads)
-    
-    parser.add_argument('--reparse', action='store_true', dest='reparse', 
+
+    parser.add_argument('--reparse', action='store_true', dest='reparse',
                         help='Parse the log, even if its been parsed before', default=False)
 
     return parser.parse_args()


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Previously, using the GCP integration required passing a credentials file.

https://documentation.wazuh.com/current/cloud-security/gcp/prerequisites/gcloud-python-script.html  
https://documentation.wazuh.com/current/cloud-security/gcp/supported-services/pubsub.html#configuring-the-wazuh-module-for-google-cloud-pub-sub  
https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#credentials-file

However, GCP supports Application Default Credentials (ADC), which allows the GCP auth library to figure out which credentials to use based on the environment.

https://cloud.google.com/docs/authentication/application-default-credentials  
https://googleapis.dev/python/google-api-core/latest/auth.html

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

* Change the `-c` / `--credentials_file` CLI argument to be optional.  
* Update the Python code for PubSub and Cloud Storage to fall back to ADC if no credentials file is passed.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

I tested calling the `gcloud` script in a Compute Engine VM with both PubSub and Cloud Storage. Both succeeded without any authentication errors.

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

Python scripts in `wodles/gcloud/`.

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

N/A

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

None.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
