### PR TITLE
Add whodata section to syscheckd JSON configuration output and update unit tests

### DIFF
--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -294,6 +294,8 @@ cJSON *getSyscheckConfig(void) {
     }
     cJSON_AddNumberToObject(whodata, "queue_size", syscheck.queue_size);
 
+    cJSON_AddStringToObject(whodata, "provider", syscheck.whodata_provider == EBPF_PROVIDER ? "ebpf" : "audit");
+
     cJSON_AddItemToObject(syscfg,"whodata",whodata);
 #endif
 

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -141,6 +141,7 @@ void test_Read_Syscheck_Config_success(void **state)
     assert_int_equal(syscheck.enable_synchronization, 1);
     assert_int_equal(syscheck.restart_audit, 1);
     assert_int_equal(syscheck.enable_whodata, 1);
+    assert_int_equal(syscheck.whodata_provider, AUDIT_PROVIDER);
     assert_null(syscheck.realtime);
     assert_int_equal(syscheck.audit_healthcheck, 1);
     assert_int_equal(syscheck.process_priority, 10);
@@ -394,6 +395,8 @@ void test_getSyscheckConfig(void **state)
     assert_int_equal(cJSON_GetArraySize(whodata_audit_key), 2);
     cJSON *whodata_startup_healthcheck = cJSON_GetObjectItem(sys_whodata, "startup_healthcheck");
     assert_string_equal(cJSON_GetStringValue(whodata_startup_healthcheck), "yes");
+    cJSON *whodata_provider = cJSON_GetObjectItem(sys_whodata, "provider");
+    assert_string_equal(cJSON_GetStringValue(whodata_provider), "audit");
 #endif
 
     cJSON *allow_remote_prefilter_cmd = cJSON_GetObjectItem(sys_items, "allow_remote_prefilter_cmd");
@@ -505,6 +508,8 @@ void test_getSyscheckConfig_no_audit(void **state)
     assert_null(whodata_audit_key);
     cJSON *whodata_startup_healthcheck = cJSON_GetObjectItem(sys_whodata, "startup_healthcheck");
     assert_string_equal(cJSON_GetStringValue(whodata_startup_healthcheck), "no");
+    cJSON *whodata_provider = cJSON_GetObjectItem(sys_whodata, "provider");
+    assert_string_equal(cJSON_GetStringValue(whodata_provider), "audit");
 #else
     cJSON *windows_audit_interval = cJSON_GetObjectItem(sys_items, "windows_audit_interval");
     assert_int_equal(windows_audit_interval->valueint, 0);


### PR DESCRIPTION
## Description

This pull request adds the `whodata` section to the JSON configuration output generated by `getSyscheckConfig()` for UNIX agents in wazuh-syscheckd. The change also includes updates to the corresponding unit tests to ensure the new fields are properly serialized and validated. No changes are required for Windows agents, and documentation updates are not necessary.

## Proposed Changes

- Add the `whodata` section to the syscheckd JSON configuration output on UNIX agents, including the fields: `restart_audit`, `audit_key`, `startup_healthcheck`, `queue_size`, and `provider`.
- Update unit tests to verify the presence and correctness of the new `whodata` fields in the JSON output.
- No changes to Windows agent behavior.
- No documentation changes required.

### Results and Evidence

#### Default (audit) configuration

<details><summary>API response</summary>

```json
{
  "data": {
    "affected_items": [
      {
        "syscheck": {
          "disabled": "no",
          "frequency": 43200,
          "skip_nfs": "yes",
          "skip_dev": "yes",
          "skip_sys": "yes",
          "skip_proc": "yes",
          "scan_on_start": "yes",
          "max_files_per_second": 0,
          "file_limit": {
            "enabled": "yes",
            "entries": 100000
          },
          "diff": {
            "disk_quota": {
              "enabled": "yes",
              "limit": 1048576
            },
            "file_size": {
              "enabled": "yes",
              "limit": 51200
            }
          },
          "directories": [
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/bin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/boot",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/etc",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/sbin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/usr/bin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/usr/sbin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            }
          ],
          "nodiff": [
            "/etc/ssl/private.key"
          ],
          "ignore": [
            "/etc/mtab",
            "/etc/hosts.deny",
            "/etc/mail/statistics",
            "/etc/random-seed",
            "/etc/random.seed",
            "/etc/adjtime",
            "/etc/httpd/logs",
            "/etc/utmpx",
            "/etc/wtmpx",
            "/etc/cups/certs",
            "/etc/dumpdates",
            "/etc/svc/volatile"
          ],
          "ignore_sregex": [
            ".log$|.swp$"
          ],
          "whodata": {
            "restart_audit": "yes",
            "startup_healthcheck": "yes",
            "queue_size": 16384,
            "provider": "audit"
          },
          "allow_remote_prefilter_cmd": "no",
          "synchronization": {
            "enabled": "yes",
            "queue_size": 16384,
            "interval": 300,
            "max_eps": 10,
            "response_timeout": 30,
            "max_interval": 3600,
            "thread_pool": 1
          },
          "max_eps": 50,
          "process_priority": 10,
          "database": "disk"
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read",
  "error": 0
}
```

</details>

#### eBPF configuration

```xml
<whodata>
  <provider>ebpf</provider>
</whodata>
```

<details><summary>API response</summary>

```json
{
  "data": {
    "affected_items": [
      {
        "syscheck": {
          "disabled": "no",
          "frequency": 43200,
          "skip_nfs": "yes",
          "skip_dev": "yes",
          "skip_sys": "yes",
          "skip_proc": "yes",
          "scan_on_start": "yes",
          "max_files_per_second": 0,
          "file_limit": {
            "enabled": "yes",
            "entries": 100000
          },
          "diff": {
            "disk_quota": {
              "enabled": "yes",
              "limit": 1048576
            },
            "file_size": {
              "enabled": "yes",
              "limit": 51200
            }
          },
          "directories": [
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/bin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/boot",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/etc",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/sbin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/usr/bin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            },
            {
              "opts": [
                "check_md5sum",
                "check_sha1sum",
                "check_perm",
                "check_size",
                "check_owner",
                "check_group",
                "check_mtime",
                "check_inode",
                "check_sha256sum"
              ],
              "dir": "/usr/sbin",
              "recursion_level": 256,
              "diff_size_limit": 51200
            }
          ],
          "nodiff": [
            "/etc/ssl/private.key"
          ],
          "ignore": [
            "/etc/mtab",
            "/etc/hosts.deny",
            "/etc/mail/statistics",
            "/etc/random-seed",
            "/etc/random.seed",
            "/etc/adjtime",
            "/etc/httpd/logs",
            "/etc/utmpx",
            "/etc/wtmpx",
            "/etc/cups/certs",
            "/etc/dumpdates",
            "/etc/svc/volatile"
          ],
          "ignore_sregex": [
            ".log$|.swp$"
          ],
          "whodata": {
            "restart_audit": "yes",
            "startup_healthcheck": "yes",
            "queue_size": 16384,
            "provider": "ebpf"
          },
          "allow_remote_prefilter_cmd": "no",
          "synchronization": {
            "enabled": "yes",
            "queue_size": 16384,
            "interval": 300,
            "max_eps": 10,
            "response_timeout": 30,
            "max_interval": 3600,
            "thread_pool": 1
          },
          "max_eps": 50,
          "process_priority": 10,
          "database": "disk"
        }
      }
    ],
    "total_affected_items": 1,
    "total_failed_items": 0,
    "failed_items": []
  },
  "message": "Active configuration was successfully read",
  "error": 0
}
```

</details>

### Artifacts Affected

- wazuh-syscheckd (UNIX agent only)

### Configuration Changes

- None required

### Documentation Updates

- Not required

### Tests Introduced

- Unit tests updated to cover the related field in the JSON configuration output.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues