### PR TITLE
Fix false positive when comparing field names. 

### DIFF
--- a/src/wazuh_db/wdb_delta_event.c
+++ b/src/wazuh_db/wdb_delta_event.c
@@ -15,78 +15,106 @@
 #define GE(X, Y) (X >= Y ? true : false)
 #define LE(X, Y) (X <= Y ? true : false)
 
+typedef enum hw_fields {
+    CPU_CORES,
+    CPU_MHZ,
+    RAM_TOTAL,
+    RAM_FREE,
+    RAM_USAGE
+} hw_fields;
+
 const char * HWINFO_FIELDS[] = {
-    "cpu_cores",
-    "cpu_mhz",
-    "ram_total",
-    "ram_free",
-    "ram_usage"
+    [CPU_CORES] = "cpu_cores",
+    [CPU_MHZ] = "cpu_mhz",
+    [RAM_TOTAL] = "ram_total",
+    [RAM_FREE] = "ram_free",
+    [RAM_USAGE] = "ram_usage"
 };
+
+typedef enum group_fields {
+    GROUP_ID
+} group_fields;
 
 const char * GROUPINFO_FIELDS[] = {
-    "group_id"
+    [GROUP_ID] = "group_id"
 };
 
+typedef enum user_fields {
+    USER_ID,
+    USER_GROUP_ID,
+    USER_CREATED,
+    USER_LAST_LOGIN,
+    USER_AUTH_FAILED_COUNT,
+    USER_AUTH_FAILED_TIMESTAMP,
+    USER_PASSWORD_LAST_CHANGE,
+    USER_PASSWORD_EXPIRATION_DATE,
+    USER_PASSWORD_INACTIVE_DAYS,
+    USER_PASSWORD_MAX_DAYS_BETWEEN_CHANGES,
+    USER_PASSWORD_MIN_DAYS_BETWEEN_CHANGES,
+    USER_PASSWORD_WARNING_DAYS_BEFORE_EXPIRATION,
+    PROCESS_PID
+} user_fields;
+
 const char * USERINFO_FIELDS[] = {
-    "user_id",
-    "user_group_id",
-    "user_created",
-    "user_last_login",
-    "user_auth_failed_count",
-    "user_auth_failed_timestamp",
-    "user_password_last_change",
-    "user_password_expiration_date",
-    "user_password_inactive_days",
-    "user_password_max_days_between_changes",
-    "user_password_min_days_between_changes",
-    "user_password_warning_days_before_expiration",
-    "process_pid"
+    [USER_ID] = "user_id",
+    [USER_GROUP_ID] = "user_group_id",
+    [USER_CREATED] = "user_created",
+    [USER_LAST_LOGIN] = "user_last_login",
+    [USER_AUTH_FAILED_COUNT] = "user_auth_failed_count",
+    [USER_AUTH_FAILED_TIMESTAMP] = "user_auth_failed_timestamp",
+    [USER_PASSWORD_LAST_CHANGE] = "user_password_last_change",
+    [USER_PASSWORD_EXPIRATION_DATE] = "user_password_expiration_date",
+    [USER_PASSWORD_INACTIVE_DAYS] = "user_password_inactive_days",
+    [USER_PASSWORD_MAX_DAYS_BETWEEN_CHANGES] = "user_password_max_days_between_changes",
+    [USER_PASSWORD_MIN_DAYS_BETWEEN_CHANGES] = "user_password_min_days_between_changes",
+    [USER_PASSWORD_WARNING_DAYS_BEFORE_EXPIRATION] = "user_password_warning_days_before_expiration",
+    [PROCESS_PID] = "process_pid"
 };
 
 #define IS_VALID_GROUPS_VALUE(field_name, field_value) ( \
-    !strncmp(field_name, GROUPINFO_FIELDS[0], strlen(GROUPINFO_FIELDS[0])) ? \
+    !strcmp(field_name, GROUPINFO_FIELDS[GROUP_ID]) ? \
         GE(field_value, 0) : true \
 )
 
 #define IS_VALID_HWINFO_VALUE(field_name, field_value) ( \
-    !strncmp(field_name, HWINFO_FIELDS[0], strlen(HWINFO_FIELDS[0])) ? \
+    !strcmp(field_name, HWINFO_FIELDS[CPU_CORES]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, HWINFO_FIELDS[1], strlen(HWINFO_FIELDS[1])) ? \
+    !strcmp(field_name, HWINFO_FIELDS[CPU_MHZ]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, HWINFO_FIELDS[2], strlen(HWINFO_FIELDS[2])) ? \
+    !strcmp(field_name, HWINFO_FIELDS[RAM_TOTAL]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, HWINFO_FIELDS[3], strlen(HWINFO_FIELDS[3])) ? \
+    !strcmp(field_name, HWINFO_FIELDS[RAM_FREE]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, HWINFO_FIELDS[4], strlen(HWINFO_FIELDS[4])) ? \
+    !strcmp(field_name, HWINFO_FIELDS[RAM_USAGE]) ? \
         (GT(field_value, 0) && (LE(field_value, 100))): true \
 )
 
 #define IS_VALID_USERS_VALUE(field_name, field_value) ( \
-    !strncmp(field_name, USERINFO_FIELDS[0], strlen(USERINFO_FIELDS[0])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_ID]) ? \
         GE(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[1], strlen(USERINFO_FIELDS[1])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_GROUP_ID]) ? \
         GE(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[2], strlen(USERINFO_FIELDS[1])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_CREATED]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[3], strlen(USERINFO_FIELDS[3])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_LAST_LOGIN]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[4], strlen(USERINFO_FIELDS[4])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_AUTH_FAILED_COUNT]) ? \
         GE(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[5], strlen(USERINFO_FIELDS[5])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_AUTH_FAILED_TIMESTAMP]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[6], strlen(USERINFO_FIELDS[6])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_PASSWORD_LAST_CHANGE]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[7], strlen(USERINFO_FIELDS[7])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_PASSWORD_EXPIRATION_DATE]) ? \
         GT(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[8], strlen(USERINFO_FIELDS[8])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_PASSWORD_INACTIVE_DAYS]) ? \
         GE(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[9], strlen(USERINFO_FIELDS[9])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_PASSWORD_MAX_DAYS_BETWEEN_CHANGES]) ? \
         GE(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[10], strlen(USERINFO_FIELDS[10])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_PASSWORD_MIN_DAYS_BETWEEN_CHANGES]) ? \
         GE(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[11], strlen(USERINFO_FIELDS[11])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[USER_PASSWORD_WARNING_DAYS_BEFORE_EXPIRATION]) ? \
         GE(field_value, 0) : \
-    !strncmp(field_name, USERINFO_FIELDS[12], strlen(USERINFO_FIELDS[12])) ? \
+    !strcmp(field_name, USERINFO_FIELDS[PROCESS_PID]) ? \
         GE(field_value, 0) : true \
 )
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes #30796

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

## Test 

Considering the group event shared by the QA team 

```json
{
  "group_id": 4294967294,
  "group_name": "nobody",
  "group_description": "",
  "group_id_signed": -2,
  "group_uuid": " ",
  "group_is_hidden": 0,
  "group_users": "_avbdeviced:_ftp:_installer:_kadmin_admin:_kadmin_changepw:_krb_anonymous:_krb_changepw:_krb_kadmin:_krb_kerberos:_krb_krbtgt:_krbfast:_krbtgt:_update_sharing:nobody",
  "checksum": "cf5fd3f6bd3c3837ec5737fdee2ec6b763c02c7c",
  "db_status_field_dm": 1
}
```

```console
root@jammy:/home/vagrant/wazuh# bash groups_missing_field.sh
+ /var/ossec/bin/wazuh-control stop
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.14.0 Stopped
+ sleep 1


+ sqlite3 /var/ossec/queue/db/001.db 'select * from sys_groups' --line


+ /var/ossec/bin/wazuh-control start
2025/07/15 18:59:19 wazuh-db[259572] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:19 wazuh-db[259572] main.c:128 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:21 wazuh-modulesd[259580] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:21 wazuh-modulesd[259580] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:21 wazuh-modulesd[259580] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2025/07/15 18:59:21 wazuh-modulesd[259580] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2025/07/15 18:59:21 wazuh-modulesd:router[259580] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2025/07/15 18:59:21 wazuh-modulesd:content_manager[259580] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2025/07/15 18:59:21 wazuh-modulesd:inventory-harvester[259580] wm_harvester.c:151 at wm_inventory_harvester_read(): INFO: Loaded Inventory harvester module.
2025/07/15 18:59:24 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
2025/07/15 18:59:24 wazuh-db[259669] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:24 wazuh-db[259669] main.c:128 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:25 wazuh-syscheckd: INFO: (6001): File integrity monitoring disabled.
2025/07/15 18:59:26 wazuh-modulesd[259885] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:26 wazuh-modulesd[259885] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:26 wazuh-modulesd[259885] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2025/07/15 18:59:26 wazuh-modulesd[259885] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2025/07/15 18:59:26 wazuh-modulesd:router[259885] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2025/07/15 18:59:26 wazuh-modulesd:content_manager[259885] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2025/07/15 18:59:26 wazuh-modulesd:inventory-harvester[259885] wm_harvester.c:151 at wm_inventory_harvester_read(): INFO: Loaded Inventory harvester module.
+ sleep 1


++ cat rsync.json
+ python3 wdb-query.py agent '1 syscollector_groups save2 {"attributes": {"group_id": 4294967294,"group_name": "nobody","group_description": "","group_id_signed": -2,"group_uuid": " ","group_is_hidden": 0,"group_users": "_avbdeviced:_ftp:_installer:_kadmin_admin:_kadmin_changepw:_krb_anonymous:_krb_changepw:_krb_kadmin:_krb_kerberos:_krb_krbtgt:_krbfast:_krbtgt:_update_sharing:nobody","checksum": "cf5fd3f6bd3c3837ec5737fdee2ec6b763c02c7c","scan_time": "2025/07/14 20:23:01"},"index": "nobody","timestamp": ""}'
+ sleep 3


+ /var/ossec/bin/wazuh-control stop
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.14.0 Stopped
+ sleep 1


+ sqlite3 /var/ossec/queue/db/001.db 'select * from sys_groups' --line
          scan_id = 0
        scan_time = 2025/07/14 20:23:01
         group_id = 4294967294
       group_name = nobody
group_description =
  group_id_signed = -2
       group_uuid =
  group_is_hidden = 0
      group_users = _avbdeviced:_ftp:_installer:_kadmin_admin:_kadmin_changepw:_krb_anonymous:_krb_changepw:_krb_kadmin:_krb_kerberos:_krb_krbtgt:_krbfast:_krbtgt:_update_sharing:nobody
         checksum = cf5fd3f6bd3c3837ec5737fdee2ec6b763c02c7c


+ sqlite3 /var/ossec/queue/db/001.db 'delete from sys_groups' --line
+ sqlite3 /var/ossec/queue/db/001.db 'select * from sys_groups' --line


+ /var/ossec/bin/wazuh-control start
2025/07/15 18:59:39 wazuh-db[260908] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:39 wazuh-db[260908] main.c:128 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:40 wazuh-modulesd[260916] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:40 wazuh-modulesd[260916] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:40 wazuh-modulesd[260916] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2025/07/15 18:59:40 wazuh-modulesd[260916] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2025/07/15 18:59:40 wazuh-modulesd:router[260916] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2025/07/15 18:59:40 wazuh-modulesd:content_manager[260916] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2025/07/15 18:59:40 wazuh-modulesd:inventory-harvester[260916] wm_harvester.c:151 at wm_inventory_harvester_read(): INFO: Loaded Inventory harvester module.
2025/07/15 18:59:42 wazuh-integratord: INFO: Remote integrations not configured. Clean exit.
2025/07/15 18:59:43 wazuh-db[261005] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:43 wazuh-db[261005] main.c:128 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:44 wazuh-syscheckd: INFO: (6001): File integrity monitoring disabled.
2025/07/15 18:59:45 wazuh-modulesd[261221] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2025/07/15 18:59:45 wazuh-modulesd[261221] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2025/07/15 18:59:45 wazuh-modulesd[261221] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2025/07/15 18:59:45 wazuh-modulesd[261221] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2025/07/15 18:59:45 wazuh-modulesd:router[261221] wm_router.c:98 at wm_router_read(): INFO: Loaded router module.
2025/07/15 18:59:45 wazuh-modulesd:content_manager[261221] wm_content_manager.c:87 at wm_content_manager_read(): INFO: Loaded content_manager module.
2025/07/15 18:59:45 wazuh-modulesd:inventory-harvester[261221] wm_harvester.c:151 at wm_inventory_harvester_read(): INFO: Loaded Inventory harvester module.
+ sleep1


++ cat dbsync.json
+ python3 wdb-query.py agent '1 dbsync groups INSERTED {"group_id": 4294967294,"group_name": "nobody","group_description": "","group_id_signed": -2,"group_uuid": " ","group_is_hidden": 0,"group_users": "_avbdeviced:_ftp:_installer:_kadmin_admin:_kadmin_changepw:_krb_anonymous:_krb_changepw:_krb_kadmin:_krb_kerberos:_krb_krbtgt:_krbfast:_krbtgt:_update_sharing:nobody","checksum": "cf5fd3f6bd3c3837ec5737fdee2ec6b763c02c7c","scan_time": "2025/07/14 20:23:01"}'
+ sleep 3


+ /var/ossec/bin/wazuh-control stop
wazuh-clusterd not running...
Killing wazuh-modulesd...
Killing wazuh-monitord...
Killing wazuh-logcollector...
Killing wazuh-remoted...
Killing wazuh-syscheckd...
Killing wazuh-analysisd...
wazuh-maild not running...
Killing wazuh-execd...
Killing wazuh-db...
Killing wazuh-authd...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
Killing wazuh-apid...
Wazuh v4.14.0 Stopped
+ sleep 1


+ sqlite3 /var/ossec/queue/db/001.db 'select * from sys_groups' --line
          scan_id = 0
        scan_time = 2025/07/14 20:23:01
         group_id = 4294967294
       group_name = nobody
group_description =
  group_id_signed = -2
       group_uuid =
  group_is_hidden = 0
      group_users = _avbdeviced:_ftp:_installer:_kadmin_admin:_kadmin_changepw:_krb_anonymous:_krb_changepw:_krb_kadmin:_krb_kerberos:_krb_krbtgt:_krbfast:_krbtgt:_update_sharing:nobody
         checksum = cf5fd3f6bd3c3837ec5737fdee2ec6b763c02c7c
```
