### PR TITLE
Use systemctl reload if available in hot-reload mechanism

### DIFF
--- a/src/active-response/restart.sh
+++ b/src/active-response/restart.sh
@@ -42,6 +42,10 @@ if [ "$TYPE" = "manager" ]; then
     fi
 fi
 
-${PWD}/bin/wazuh-control $PARAM_ACTION
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl $PARAM_ACTION wazuh-$TYPE
+else
+    ${PWD}/bin/wazuh-control $PARAM_ACTION
+fi
 
 exit $?;


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/30897|

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Hi team,

This PR makes use of the already implemented `systemctl reload wazuh-agent` command to reload the agent if the systemctl command is available; otherwise, it will be done using the wazuh-control script.

## Tests

### Ubuntu 22.04 environment

The agent is running and connected to the server:

```console
root@agent1-ubu22:/home/vagrant# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: ena>
     Active: active (running) since Wed 2025-07-16 11:08:42 UTC; 16s ago
    Process: 138210 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exite>
      Tasks: 33 (limit: 3447)
     Memory: 19.2M
        CPU: 4.741s
     CGroup: /system.slice/wazuh-agent.service
             ├─138233 /var/ossec/bin/wazuh-execd
             ├─138243 /var/ossec/bin/wazuh-agentd
             ├─138257 /var/ossec/bin/wazuh-syscheckd
             ├─138268 /var/ossec/bin/wazuh-logcollector
             └─138284 /var/ossec/bin/wazuh-modulesd

Jul 16 11:08:36 agent1-ubu22 systemd[1]: Starting Wazuh agent...
Jul 16 11:08:36 agent1-ubu22 env[138210]: Starting Wazuh v4.14.0...
Jul 16 11:08:37 agent1-ubu22 env[138210]: Started wazuh-execd...
Jul 16 11:08:38 agent1-ubu22 env[138210]: Started wazuh-agentd...
Jul 16 11:08:38 agent1-ubu22 env[138210]: Started wazuh-syscheckd...
Jul 16 11:08:39 agent1-ubu22 env[138210]: Started wazuh-logcollector...
```

The `/var/ossec/etc/shared/default/agent.conf` file is modified in the server as follows:
```xml
<agent_config name="agent1-ubu22">

        <client_buffer>
                <disabled>no</disabled>
                <queue_size>20000</queue_size>
                <events_per_second>50</events_per_second>
        </client_buffer>

        <syscheck>
                <directories realtime="yes">/test</directories>
        </syscheck>

</agent_config>
```

The reload is triggered, and the logs appear in the agent:

```console
2025/07/16 11:10:27 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2025/07/16 11:10:33 wazuh-agentd: INFO: SIGNAL [(10)-(User defined signal 1)] Received. Reload agentd.
2025/07/16 11:10:33 wazuh-agentd: INFO: Buffer agent.conf updated, enable: 1 size: 20000 
2025/07/16 11:10:33 wazuh-agentd: INFO: Client buffer resized from 5000 to 20000 elements.
```

The agent systemctl reported status is checked, and the listed processes are consistent with the reload, agentd PID remains the same, but the rest has changed:

```console
root@agent1-ubu22:/home/vagrant# systemctl status wazuh-agent
● wazuh-agent.service - Wazuh agent
     Loaded: loaded (/etc/systemd/system/wazuh-agent.service; enabled; vendor preset: ena>
     Active: active (running) since Wed 2025-07-16 11:08:42 UTC; 45min ago
    Process: 138210 ExecStart=/usr/bin/env /var/ossec/bin/wazuh-control start (code=exite>
    Process: 139851 ExecReload=/usr/bin/env /var/ossec/bin/wazuh-control reload (code=exi>
      Tasks: 32 (limit: 3447)
     Memory: 21.9M
        CPU: 16.951s
     CGroup: /system.slice/wazuh-agent.service
             ├─138243 /var/ossec/bin/wazuh-agentd
             ├─139929 /var/ossec/bin/wazuh-execd
             ├─139942 /var/ossec/bin/wazuh-syscheckd
             ├─139953 /var/ossec/bin/wazuh-logcollector
             └─139969 /var/ossec/bin/wazuh-modulesd

Jul 16 11:31:38 agent1-ubu22 env[139851]: Killing wazuh-execd...
Jul 16 11:31:38 agent1-ubu22 env[139851]: Wazuh v4.14.0 Stopped
Jul 16 11:31:39 agent1-ubu22 env[139851]: Starting Wazuh v4.14.0...
Jul 16 11:31:40 agent1-ubu22 env[139851]: Started wazuh-execd...
Jul 16 11:31:40 agent1-ubu22 env[139851]: wazuh-agentd already running...
Jul 16 11:31:40 agent1-ubu22 env[139851]: Started wazuh-syscheckd...
Jul 16 11:31:41 agent1-ubu22 env[139851]: Started wazuh-logcollector...
Jul 16 11:31:42 agent1-ubu22 env[139851]: Started wazuh-modulesd...
Jul 16 11:31:44 agent1-ubu22 env[139851]: Completed.
Jul 16 11:31:44 agent1-ubu22 systemd[1]: Reloaded Wazuh agent.
```

### Solaris 11 environment

The agent is running and connected to the server.

The `/var/ossec/etc/shared/default/agent.conf` file is modified in the server as follows:
```xml
<agent_config name="vbox">

        <client_buffer>
                <disabled>no</disabled>
                <queue_size>20000</queue_size>
                <events_per_second>50</events_per_second>
        </client_buffer>

        <syscheck>
                <directories realtime="yes">/test</directories>
        </syscheck>

</agent_config>
```

The reload is triggered in the agent:

```console
2025/07/16 14:31:36 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2025/07/16 14:31:44 wazuh-agentd: INFO: SIGNAL [(16)-(User Signal 1)] Received. Reload agentd.
2025/07/16 14:31:45 wazuh-agentd: INFO: Buffer agent.conf updated, enable: 1 size: 20000 
2025/07/16 14:31:45 wazuh-agentd: INFO: Client buffer resized from 5000 to 20000 elements.
```

And the agent connection is maintained as expected.
