### PR TITLE
Change PUT /cluster/restart RBAC white AIT expected response

### DIFF
--- a/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_all_endpoints.tavern.yaml
@@ -906,7 +906,7 @@ stages:
       headers:
         Authorization: "Bearer {test_login_token}"
     response:
-      <<: *empty_response
+      <<: *permission_denied
 
   - name: Try to restart master-node node (specific)
     request:


### PR DESCRIPTION
## Description

Fixes the `test_rbac_white_all_endpoints.tavern.yaml::PUT /cluster/restart` test, currently failing after the changes introduced at https://github.com/wazuh/wazuh/pull/30494. The endpoint does not deliver a blank response when the user making the `PUT /cluster/restart` request does not have the required permissions.


## Proposed Changes

- Change the expected API response in the test.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

```console
$ TOKEN=$(curl -u testing:wazuh -s -k -X POST https://0.0.0.0:55000/security/user/authenticate | jq -r '.data.token') && echo $TOKEN
eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzUzMTEzMDExLCJleHAiOjE3NTMxMTM5MTEsInN1YiI6InRlc3RpbmciLCJydW5fYXMiOmZhbHNlLCJyYmFjX3JvbGVzIjpbXSwicmJhY19tb2RlIjoid2hpdGUifQ.AVxORJAgtZbpqX4uFuStkepjZrUMrWTLty8QGi6l8KdNbxDamryqAegPvzO_t1GVYwfOuozLt0nTEhEL5_MiGP6pAZB1FlhNS1ELVR4Ms0nosckLIJCzgClS_PH3Yxc0UGm6z9NVZzIwb3Gnz2gFbeiT9CLlXS4her_bSR0IPAGVsWBL

$ curl -H "Authorization: Bearer $TOKEN" -ki -X PUT "https://0.0.0.0:55000/cluster/restart" 
HTTP/1.1 403 Forbidden
date: Mon, 21 Jul 2025 15:50:31 GMT
content-type: application/problem+json; charset=utf-8
content-length: 419

{
    "title": "Permission Denied",
    "detail": "Permission denied: Resource type: node:id",
    "remediation": "Please, make sure you have permissions to execute the current request. For more information on how to set up permissions, please visit https://documentation.wazuh.com/4.14/user-manual/api/rbac/configuration.html",
    "dapi_errors": {
        "unknown-node": {
            "error": "Permission denied: Resource type: node:id"
        }
    },
    "error": 4000
}

```

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
