### PR TITLE
Increase timeout in Windows Tier 0 FIM test to reduce flakiness

### DIFF
--- a/tests/integration/test_fim/test_files/test_file_limit/test_fill_capacity.py
+++ b/tests/integration/test_fim/test_files/test_file_limit/test_fill_capacity.py
@@ -165,7 +165,7 @@ def test_fill_capacity(test_configuration, test_metadata, set_wazuh_configuratio
 
     files_amount = files_amount if files_amount <= max_entries else max_entries
     if sys.platform == WINDOWS:
-        log_monitor.start(generate_callback(FILE_ENTRIES_PATH_COUNT), timeout=300)
+        log_monitor.start(generate_callback(FILE_ENTRIES_PATH_COUNT), timeout=600)
     else:
         log_monitor.start(generate_callback(INODE_ENTRIES_PATH_COUNT), timeout=60)
 


### PR DESCRIPTION
## Description

This PR addresses a flaky behavior in the Windows Tier 0 FIM test, where a timeout sometimes prevents the log monitor from capturing the expected file count log entry. The issue is not due to a code regression but rather intermittent delays in event processing.

## Proposed Changes

Increased the log monitor timeout from 5 minutes (300 seconds) to 10 minutes (600 seconds) in the affected test case.

This change allows more time for the agent to emit the expected log:
```
(6335): Fim file entries count: '100000'
```

### Results and Evidence

<!--
The test has been executed successfully with the updated timeout. The log entry was captured as expected, confirming that the increased timeout resolves the flakiness without requiring retries.
-->

|Status|Test|Job|
|:-:|--|--|
|🟢| 4_testintegration_fim-tier-0-1-win|[#291](https://github.com/wazuh/wazuh/actions/runs/16465949075)|
|🟢| 4_testintegration_fim-tier-0-1-win|[#294](https://github.com/wazuh/wazuh/actions/runs/16469109942)|

### Artifacts Affected

* Tier 0 FIM test for Windows agents

### Configuration Changes

* None

### Documentation Updates

* None

### Tests Introduced

* No new tests introduced. This change modifies the timeout of an existing test.

## Review Checklist

* [ ] Code changes reviewed
* [ ] Relevant evidence provided
* [ ] Tests cover the new functionality
* [ ] Configuration changes documented
* [ ] Developer documentation reflects the changes
* [ ] Meets requirements and/or definition of done
* [ ] No unresolved dependencies with other issues
