### PR TITLE
False positives in Benchmark Ubuntu 24.04

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu24-04.yml
@@ -5273,12 +5273,12 @@ checks:
        - pci_dss_v3.2.1: ["1.1.6", "1.2.1", "2.2.2", "2.2.5"]
        - pci_dss_v4.0: ["1.2.5", "2.2.4", "6.4.1"]
        - soc_2: ["CC6.3", "CC6.6"]
-     condition: all
+     condition: any
      rules:
-      - 'f:/etc/rsyslog.conf -> r:^\s*\t*module\(load="imtcp"\)'
-      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\s*\t*module\(load="imtcp"\)'
-      - 'f:/etc/rsyslog.conf -> r:^\s*\t*input\(type="imtcp" port="514"\)'
-      - 'd:/etc/rsyslog.d -> r:\.*.conf -> r:^\s*\t*input\(type="imtcp" port="514"\)'
+      - 'f:/etc/rsyslog.conf -> !r:^# && r:^\s*\t*module\(load="imtcp"\)'
+      - 'd:/etc/rsyslog.d -> !r:^# && r:\.*.conf -> r:^\s*\t*module\(load="imtcp"\)'
+      - 'f:/etc/rsyslog.conf -> !r:^# && r:^\s*\t*input\(type="imtcp" port="514"\)'
+      - 'd:/etc/rsyslog.d -> !r:^# && r:\.*.conf -> r:^\s*\t*input\(type="imtcp" port="514"\)'
 
   # 6.1.3.8 Ensure logrotate is configured. (Manual) - Not Implemented
 


### PR DESCRIPTION
# Description 
Team, the customer is validating the full rules of this SCA. And mentioned some are exposing a false positive. Even running the remediation.

I reviewed it as well, and here is some evidence.

Attached you will find the full list of tests in RED. For you to double-check the template:

Here some of them:

Rule: 35765
**Checks (Condition: all)**
```
c:stat /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)
c:stat /etc/shadow -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)
```
(Should be chmod 640/600 and ownership root:shadow)
```
root@ubuntu-24-04-test:/home/vboxuser# stat /etc/shadow
  File: /etc/shadow
  Size: 990             Blocks: 8          IO Block: 4096   regular file
Device: 8,2     Inode: 657090      Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (   42/  shadow)
Access: 2025-07-03 15:56:53.402000000 +0000
Modify: 2025-06-10 01:10:23.875914092 +0000
Change: 2025-06-10 01:10:23.884914106 +0000
 Birth: 2025-06-10 01:10:23.875914092 +0000
root@ubuntu-24-04-test:/home/vboxuser# ll /etc/shadow
-rw-r----- 1 root shadow 990 Jun 10 01:10 /etc/shadow
root@ubuntu-24-04-test:/home/vboxuser# chmod u-x,g-wx,o-rwx /etc/shadow
root@ubuntu-24-04-test:/home/vboxuser# systemctl restart wazuh-agent
```
Rule: 35766
**Checks (Condition: all)**
```
c:stat /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)
c:stat /etc/shadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)
```
(Should be chmod 640/600 and ownership root:shadow)
```
root@ubuntu-24-04-test:/home/vboxuser# stat /etc/shadow-
  File: /etc/shadow-
  Size: 970             Blocks: 8          IO Block: 4096   regular file
Device: 8,2     Inode: 655988      Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (   42/  shadow)
Access: 2025-07-03 15:56:55.485000000 +0000
Modify: 2025-06-09 23:14:48.000000000 +0000
Change: 2025-06-10 01:10:23.875914092 +0000
 Birth: 2025-06-09 23:03:22.913000000 +0000
root@ubuntu-24-04-test:/home/vboxuser# ll /etc/shadow-
-rw-r----- 1 root shadow 970 Jun  9 23:14 /etc/shadow-
```


Rule: 35766
**Checks (Condition: all)**

```
c:stat /etc/gshadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*0/\s*\t*root\)
c:stat /etc/gshadow- -> r:^Access:\s*\(0640/-rw-r-----\)|Access:\s*\(0600/-rw-------\) && r:\s*Uid:\s*\(\s*\t*0/\s*\t*root\)\s*\t*Gid:\s*\(\s*\t*\d+/\s*\t*shadow\)
```
(Should be chmod 640/600 and ownership root:shadow)
```
root@ubuntu-24-04-test:/home/vboxuser# stat /etc/gshadow
  File: /etc/gshadow
  Size: 709             Blocks: 8          IO Block: 4096   regular file
Device: 8,2     Inode: 657069      Links: 1
Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (   42/  shadow)
Access: 2025-07-03 15:56:55.129000000 +0000
Modify: 2025-06-10 01:10:23.581913638 +0000
Change: 2025-06-10 01:10:23.589913650 +0000
 Birth: 2025-06-10 01:10:23.581913638 +0000
root@ubuntu-24-04-test:/home/vboxuser# ll /etc/gshadow
-rw-r----- 1 root shadow 709 Jun 10 01:10 /etc/gshadow

```
Can you please validate those for future releases?

Regards!

# Information 

For Ops team, please add information about the customer environment:



# Approved by

DRI name:
- [ ] Marcos Buslaiman

[CIS Benchmark Compliance for Ubuntu 24.04 LTS reviwed.xlsx](https://github.com/user-attachments/files/21046208/CIS.Benchmark.Compliance.for.Ubuntu.24.04.LTS.reviwed.xlsx)

[cis_ubuntu24-04.yml.txt](https://github.com/user-attachments/files/21046229/cis_ubuntu24-04.yml.txt)
