### PR TITLE
Adds Data/End sending and EndAck/ReqRet receiving handling

### DIFF
--- a/src/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/sync_protocol/include/agent_sync_protocol.hpp
@@ -93,8 +93,9 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @param mode Sync mode
         /// @param realtime Realtime sync
         /// @param dataSize Size of data to send
-        /// @return True on success, false on failure
-        bool sendStartAndWaitAck(const std::string& module, Wazuh::SyncSchema::Mode mode, bool realtime, size_t dataSize);
+        /// @param deadLine The time point by which the operation must complete.
+        /// @return True on success, false on failure or timeout
+        bool sendStartAndWaitAck(const std::string& module, Wazuh::SyncSchema::Mode mode, bool realtime, size_t dataSize, const std::chrono::steady_clock::time_point& deadLine);
 
         /// @brief Receives a startack message from the server
         /// @param timeout Timeout to wait for Ack
@@ -113,16 +114,14 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @brief Sends an end message to the server
         /// @param module Module name
         /// @param session Session id
-        /// @return True on success, false on failure
-        bool sendEndAndWaitAck(const std::string& module, uint64_t session);
+        /// @param deadLine The time point by which the operation must complete.
+        /// @return True on success, false on failure or timeout
+        bool sendEndAndWaitAck(const std::string& module, uint64_t session, const std::chrono::steady_clock::time_point& deadLine);
 
         /// @brief Receives an endack message from the server
+        /// @param timeout Timeout to wait for Ack
         /// @return True on success, false on failure
-        bool receiveEndAck();
-
-        /// @brief Receives a reqret message from the server
-        /// @return Ranges received
-        std::vector<std::pair<uint64_t, uint64_t>> receiveReqRet();
+        bool receiveEndAck(std::chrono::seconds timeout);
 
         /// @brief Clears persisted differences for a module
         /// @param module Module name
@@ -145,6 +144,12 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             WaitingEndAck
         };
 
+        /// @brief Validate phase and session
+        /// @param receivedPhase Received synchronization phase
+        /// @param incomingSession Session received in message
+        /// @return True if current phase and session match the expected ones
+        bool validatePhaseAndSession(const SyncPhase receivedPhase, const uint64_t incomingSession);
+
         /// @brief Synchronization state shared between threads during module sync.
         ///
         /// This structure holds synchronization primitives and state flags used to
@@ -165,6 +170,9 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// @brief Indicates whether an EndAck response has been received.
             bool endAckReceived = false;
 
+            /// @brief Indicates that a ReqRet message has been received.
+            bool reqRetReceived = false;
+
             /// @brief Ranges requested by the manager via ReqRet message.
             std::vector<std::pair<uint64_t, uint64_t>> reqRetRanges;
 
@@ -181,6 +189,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             {
                 startAckReceived = false;
                 endAckReceived = false;
+                reqRetReceived = false;
                 reqRetRanges.clear();
                 phase = SyncPhase::Idle;
                 session = 0;

--- a/src/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/sync_protocol/src/agent_sync_protocol.cpp
@@ -18,6 +18,8 @@
 #include <thread>
 
 constexpr char SYNC_MQ = 's';
+constexpr auto SYNC_GLOBAL_TIMEOUT = std::chrono::minutes(5);
+constexpr auto SYNC_RETRY_TIMEOUT = std::chrono::seconds(20);
 
 using namespace Wazuh::SyncSchema;
 
@@ -44,28 +46,48 @@ void AgentSyncProtocol::synchronizeModule(const std::string& module, Mode mode, 
         return;
     }
 
-    std::vector<PersistedData> data = m_persistentQueue->fetchAll(module);
-
-    if (!sendStartAndWaitAck(module, mode, realtime, data.size()))
+    for (;;)
     {
-        std::cerr << "Failed to send start message" << std::endl;
-        return;
-    }
+        const auto deadLine = std::chrono::steady_clock::now() + SYNC_GLOBAL_TIMEOUT;
 
-    if (!sendDataMessages(module, m_syncState.session, data))
-    {
-        std::cerr << "Failed to send data messages" << std::endl;
-        return;
-    }
+        {
+            std::lock_guard<std::mutex> lock(m_syncState.mtx);
+            m_syncState.reset();
+        }
 
-    if (!sendEndAndWaitAck(module, m_syncState.session))
-    {
-        std::cerr << "Failed to send end message" << std::endl;
-        return;
-    }
+        std::vector<PersistedData> data = m_persistentQueue->fetchAll(module);
 
-    m_syncState.reset();
-    clearPersistedDifferences(module);
+        if (!sendStartAndWaitAck(module, mode, realtime, data.size(), deadLine))
+        {
+            std::cerr << "Failed to send start message or timed out. Retrying sync process...\n";
+            std::this_thread::sleep_for(SYNC_RETRY_TIMEOUT);
+            continue;
+        }
+
+
+        if (!sendDataMessages(module, m_syncState.session, data))
+        {
+            std::cerr << "Failed to send data messages. Retrying sync process...\n";
+            std::this_thread::sleep_for(SYNC_RETRY_TIMEOUT);
+            continue;
+        }
+
+        if (!sendEndAndWaitAck(module, m_syncState.session, deadLine))
+        {
+            std::cerr << "Failed to send end message or timed out. Retrying sync process...\n";
+            std::this_thread::sleep_for(SYNC_RETRY_TIMEOUT);
+            continue;
+        }
+
+        std::cout << "[Sync] Module '" << module << "' synchronized successfully.\n";
+        clearPersistedDifferences(module);
+
+        {
+            std::lock_guard<std::mutex> lock(m_syncState.mtx);
+            m_syncState.reset();
+        }
+        break;
+    }
 }
 
 bool AgentSyncProtocol::ensureQueueAvailable()
@@ -83,7 +105,7 @@ bool AgentSyncProtocol::ensureQueueAvailable()
     return true;
 }
 
-bool AgentSyncProtocol::sendStartAndWaitAck(const std::string& module, Mode mode, bool realtime, size_t dataSize)
+bool AgentSyncProtocol::sendStartAndWaitAck(const std::string& module, Mode mode, bool realtime, size_t dataSize, const std::chrono::steady_clock::time_point& deadLine)
 {
     flatbuffers::FlatBufferBuilder builder;
     auto moduleStr = builder.CreateString(module);
@@ -102,40 +124,44 @@ bool AgentSyncProtocol::sendStartAndWaitAck(const std::string& module, Mode mode
     const size_t buffer_size = builder.GetSize();
     std::vector<uint8_t> messageVector(buffer_ptr, buffer_ptr + buffer_size);
 
-    const auto retryInterval = std::chrono::seconds(30);
-
-    for (int attempt = 1; ; ++attempt)
+    for (;;)
     {
+        if (std::chrono::steady_clock::now() >= deadLine)
+        {
+            std::cerr << "[Sync] Global timeout reached while waiting for StartAck.\n";
+            return false;
+        }
+
         {
             std::lock_guard<std::mutex> lock(m_syncState.mtx);
-            m_syncState.reset();
             m_syncState.phase = SyncPhase::WaitingStartAck;
         }
 
         if (!sendFlatBufferMessageAsString(messageVector, module))
         {
-            std::cerr << "[Sync] Failed to send Start message. Retrying in " << retryInterval.count() << "s...\n";
-            {
-                std::lock_guard<std::mutex> lock(m_syncState.mtx);
-                m_syncState.reset();
-            }
-            std::this_thread::sleep_for(retryInterval);
+            std::cerr << "[Sync] Failed to send Start message. Retrying in " << SYNC_RETRY_TIMEOUT.count() << "s...\n";
+            std::this_thread::sleep_for(SYNC_RETRY_TIMEOUT);
             continue;
         }
 
-        if (receiveStartAck(retryInterval))
+        auto remainingTime = std::chrono::duration_cast<std::chrono::seconds>(deadLine - std::chrono::steady_clock::now());
+        auto waitTime = std::min(SYNC_RETRY_TIMEOUT, remainingTime);
+
+        if (waitTime.count() <= 0)
+        {
+            std::cout << "[Sync] Timed out waiting for StartAck.\n";
+            return false;
+        }
+
+        if (receiveStartAck(waitTime))
         {
             std::lock_guard<std::mutex> lock(m_syncState.mtx);
-
             std::cout << "[Sync] StartAck received. Session " << m_syncState.session << " established.\n";
-
             return true;
         }
 
         std::cout << "[Sync] Timed out waiting for StartAck. Retrying...\n";
     }
-
-    return false;
 }
 
 bool AgentSyncProtocol::receiveStartAck(std::chrono::seconds timeout)
@@ -183,7 +209,7 @@ bool AgentSyncProtocol::sendDataMessages(const std::string& module,
     return true;
 }
 
-bool AgentSyncProtocol::sendEndAndWaitAck(const std::string& module, uint64_t session)
+bool AgentSyncProtocol::sendEndAndWaitAck(const std::string& module, uint64_t session, const std::chrono::steady_clock::time_point& deadLine)
 {
     flatbuffers::FlatBufferBuilder builder;
     EndBuilder endBuilder(builder);
@@ -197,53 +223,96 @@ bool AgentSyncProtocol::sendEndAndWaitAck(const std::string& module, uint64_t se
     const size_t buffer_size = builder.GetSize();
     std::vector<uint8_t> messageVector(buffer_ptr, buffer_ptr + buffer_size);
 
-    if (!sendFlatBufferMessageAsString(messageVector, module))
     {
-        return false;
+        std::lock_guard<std::mutex> lock(m_syncState.mtx);
+        m_syncState.phase = SyncPhase::WaitingEndAck;
     }
 
-    while (true)
-    {
-        const auto ranges = receiveReqRet();
+    bool sendEnd = true;
 
-        if (!ranges.empty())
+    for (;;)
+    {
+        if (std::chrono::steady_clock::now() >= deadLine)
         {
+            std::cerr << "[Sync] Global timeout reached while waiting for EndAck/ReqRet.\n";
+            return false;
+        }
+
+        if (sendEnd && !sendFlatBufferMessageAsString(messageVector, module))
+        {
+            std::cerr << "[Sync] Failed to send End message. Retrying in " << SYNC_RETRY_TIMEOUT.count() << "s...\n";
+            std::this_thread::sleep_for(SYNC_RETRY_TIMEOUT);
+            continue;
+        }
+
+        auto remainingTime = std::chrono::duration_cast<std::chrono::seconds>(deadLine - std::chrono::steady_clock::now());
+        auto waitTime = std::min(SYNC_RETRY_TIMEOUT, remainingTime);
+
+        if (waitTime.count() <= 0)
+        {
+            std::cout << "[Sync] Timeout waiting for EndAck or ReqRet.\n";
+            return false;
+        }
+
+        if (!receiveEndAck(waitTime))
+        {
+            std::cout << "[Sync] Timeout waiting for EndAck or ReqRet. Retrying...\n";
+            continue;
+        }
+
+        bool wasReqRet = false;
+        std::vector<std::pair<uint64_t, uint64_t>> ranges;
+        {
+            std::lock_guard<std::mutex> lock(m_syncState.mtx);
+            wasReqRet = m_syncState.reqRetReceived;
+
+            if (wasReqRet)
+            {
+                ranges = std::move(m_syncState.reqRetRanges);
+                m_syncState.reqRetRanges.clear();
+                m_syncState.reqRetReceived = false;
+            }
+        }
+
+        if (wasReqRet)
+        {
+            if (ranges.empty())
+            {
+                std::cerr << "[Sync] Received ReqRet with empty ranges. Aborting current sync attempt.\n";
+                return false;
+            }
+
             std::vector<PersistedData> rangeData = m_persistentQueue->fetchRange(module, ranges);
 
             if (!sendDataMessages(module, session, rangeData))
             {
+                std::cerr << "[Sync] Failed to resend data for ReqRet.\n";
                 return false;
             }
 
+            sendEnd = false;
             continue;
         }
 
-        return receiveEndAck();
+        {
+            std::lock_guard<std::mutex> lock(m_syncState.mtx);
+
+            if (m_syncState.endAckReceived)
+            {
+                std::cout << "[Sync] EndAck received.\n";
+                return true;
+            }
+        }
     }
 }
 
-bool AgentSyncProtocol::receiveEndAck()
+bool AgentSyncProtocol::receiveEndAck(std::chrono::seconds timeout)
 {
-    // Simulated EndAck
-    return true;
-}
-
-std::vector<std::pair<uint64_t, uint64_t>> AgentSyncProtocol::receiveReqRet()
-{
-    // Simulated ReqRet
-    static int callCount = 0;
-    callCount++;
-
-    if (callCount == 1)
+    std::unique_lock<std::mutex> lock(m_syncState.mtx);
+    return m_syncState.cv.wait_for(lock, timeout, [&]
     {
-        return {{1, 1}, {3, 3}};
-    }
-    else if (callCount == 2)
-    {
-        return {{2, 2}};
-    }
-
-    return {};
+        return m_syncState.endAckReceived || m_syncState.reqRetReceived;
+    });
 }
 
 void AgentSyncProtocol::clearPersistedDifferences(const std::string& module)
@@ -285,13 +354,11 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data)
     {
         case Wazuh::SyncSchema::MessageType::StartAck:
             {
-                const auto* startAck = message->content_as_StartAck();
-                const uint64_t incomingSession = startAck->session();
-
-                std::cout << "[StartAck] session: " << incomingSession << "\n";
-
                 if (m_syncState.phase == SyncPhase::WaitingStartAck)
                 {
+                    const auto* startAck = message->content_as_StartAck();
+                    const uint64_t incomingSession = startAck->session();
+
                     m_syncState.session = incomingSession;
                     m_syncState.startAckReceived = true;
                     m_syncState.cv.notify_all();
@@ -309,21 +376,47 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data)
 
         case Wazuh::SyncSchema::MessageType::EndAck:
             {
-                std::cout << "[EndAck] received\n";
+                const auto* endAck = message->content_as_EndAck();
+                const uint64_t incomingSession = endAck->session();
+
+                if (!validatePhaseAndSession(SyncPhase::WaitingEndAck, incomingSession))
+                {
+                    std::cout << "[EndAck] invalid phase or session. \n";
+                    break;
+                }
+
+                m_syncState.endAckReceived = true;
+                m_syncState.cv.notify_all();
+
+                std::cout << "[EndAck] session ended: " << incomingSession << "\n";
                 break;
             }
 
         case Wazuh::SyncSchema::MessageType::ReqRet:
             {
                 const auto* reqRet = message->content_as_ReqRet();
-                std::vector<std::pair<uint64_t, uint64_t>> reqRetRanges;
+                const uint64_t incomingSession = reqRet->session();
 
-                for (const auto* pair : *reqRet->seq())
+                if (!validatePhaseAndSession(SyncPhase::WaitingEndAck, incomingSession))
                 {
-                    m_syncState.reqRetRanges.emplace_back(pair->begin(), pair->end());
+                    std::cout << "[ReqRet] invalid phase or session. \n";
+                    break;
                 }
 
+                m_syncState.reqRetRanges.clear();
+
+                if (reqRet->seq())
+                {
+                    for (const auto* pair : *reqRet->seq())
+                    {
+                        m_syncState.reqRetRanges.emplace_back(pair->begin(), pair->end());
+                    }
+                }
+
+                m_syncState.reqRetReceived = true;
+
                 std::cout << "[ReqRet] received " << m_syncState.reqRetRanges.size() << " ranges\n";
+                m_syncState.cv.notify_all();
                 break;
             }
 
@@ -332,6 +425,25 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data)
                 std::cerr << "Unknown message type: " << static_cast<int>(messageType) << "\n";
                 return false;
             }
+    }
+
+    return true;
+}
+
+bool AgentSyncProtocol::validatePhaseAndSession(const SyncPhase receivedPhase, const uint64_t incomingSession)
+{
+    if (m_syncState.phase != receivedPhase)
+    {
+        std::cerr << "[Sync] Discarded. Received phase " << static_cast<int>(receivedPhase)
+                  << " but current phase is " << static_cast<int>(m_syncState.phase) << "\n";
+        return false;
+    }
+
+    if (m_syncState.session != incomingSession)
+    {
+        std::cerr << "[Sync] Discarded. Session mismatch. Expected session: "
+                  << m_syncState.session << " received: " << incomingSession << "\n";
+        return false;
     }
 
     return true;


### PR DESCRIPTION

## Description

Closes: 

- #30248 
- #30249 
- #30250 

This PR adds to AgentSyncProtocol the logic for sending the “Data” and "End" message and handling the “EndAck” and "ReqRet" response.

## Proposed Changes

- Added the sending of the "Data" messages.
- Added the sending of the "End" message with a reception timeout and subsequent attempts until receiving "EndAck"
- Added the reception of the "EndAck" message and its logic to notify the threads or discard it if it is not in the WaitingEndAck state
- Added the reception of the "ReqRet" message and its logic to notify the threads or discard it if it is not in the WaitingEndAck state

### Results and Evidence

In order to test these changes, a small integration of AgentSyncProtocol with wazuh-syscheckd was made, and a log was added to the manager to see the messages arriving.

<details><summary>Manager logs:</summary>

```
2025/07/22 17:36:51 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 70 bytes. Hex: 733a46494d3a100000000000000008000c00070008000800000000000002100000000c00100000000800000004000c0000000c00000002000000000000000300000046494d00
2025/07/22 17:37:01 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 70 bytes. Hex: 733a46494d3a100000000000000008000c00070008000800000000000002100000000c00100000000800000004000c0000000c00000002000000000000000300000046494d00
2025/07/22 17:37:11 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 70 bytes. Hex: 733a46494d3a100000000000000008000c00070008000800000000000002100000000c00100000000800000004000c0000000c00000002000000000000000300000046494d00
2025/07/22 17:37:21 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 70 bytes. Hex: 733a46494d3a100000000000000008000c00070008000800000000000002100000000c00100000000800000004000c0000000c00000002000000000000000300000046494d00
2025/07/22 17:37:31 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 70 bytes. Hex: 733a46494d3a100000000000000008000c00070008000800000000000002100000000c00100000000800000004000c0000000c00000002000000000000000300000046494d00
2025/07/22 17:37:41 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 70 bytes. Hex: 733a46494d3a100000000000000008000c00070008000800000000000002100000000c00100000000800000004000c0000000c00000002000000000000000300000046494d00
2025/07/22 17:37:49 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 142 bytes. Hex: 733a46494d3a0c00000008000c0007000800080000000000000114000000100020001800100000000c0008000400100000001c0000003c0000004400000015cd5b070000000001000000000000001d0000007b2264617461223a227b646174617d222c22636f756e746572223a307d00000006000000696e6465784100000b00000066696c656861736831323300
2025/07/22 17:37:49 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 142 bytes. Hex: 733a46494d3a0c00000008000c0007000800080000000000000114000000100020001800100000000c0008000400100000001c0000003c0000004400000015cd5b070000000002000000000000001d0000007b2264617461223a227b646174617d222c22636f756e746572223a307d00000006000000696e6465784100000b00000066696c656861736831323300
2025/07/22 17:37:49 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 54 bytes. Hex: 733a46494d3a100000000000000008000e000700080008000000000000040c000000000006000c0004000600000015cd5b0700000000
2025/07/22 17:37:59 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 54 bytes. Hex: 733a46494d3a100000000000000008000e000700080008000000000000040c000000000006000c0004000600000015cd5b0700000000
2025/07/22 17:38:09 wazuh-remoted: INFO: Successfully processed message from agent id: '007' (any). Final payload size: 54 bytes. Hex: 733a46494d3a100000000000000008000e000700080008000000000000040c000000000006000c0004000600000015cd5b0700000000
```

</details>

As the part of receiving these messages in the manager is not yet developed, a script was created to load the binary data in Flatbuffer and display its content:

<details><summary>Script output:</summary>

```
python3 binary_to_flatbuffer.py tests_log.log 

Raw content type: 2
Message type: Start
  mode: 0
  size: 2
  realtime: False
  module: FIM

Raw content type: 2
Message type: Start
  mode: 0
  size: 2
  realtime: False
  module: FIM

Raw content type: 2
Message type: Start
  mode: 0
  size: 2
  realtime: False
  module: FIM

Raw content type: 2
Message type: Start
  mode: 0
  size: 2
  realtime: False
  module: FIM

Raw content type: 2
Message type: Start
  mode: 0
  size: 2
  realtime: False
  module: FIM

Raw content type: 2
Message type: Start
  mode: 0
  size: 2
  realtime: False
  module: FIM

Raw content type: 1
Message type: Data
  session: 123456789
  seq: 1
  operation: 0
  id: filehash123
  index: indexA
  data (length): 29
  data (text): {"data":"{data}","counter":0}

Raw content type: 1
Message type: Data
  session: 123456789
  seq: 2
  operation: 0
  id: filehash123
  index: indexA
  data (length): 29
  data (text): {"data":"{data}","counter":0}

Raw content type: 4
Message type: End
  Ending session: 123456789

Raw content type: 4
Message type: End
  Ending session: 123456789

Raw content type: 4
Message type: End
  Ending session: 123456789
```

</details>

Temporary records collected on the agent's side

<details><summary>Agent logs:</summary>

```
[2025-07-23 13:17:55] Starting sync process...
[2025-07-23 13:17:55] [sendFlatBufferMessageAsString] sending message
[2025-07-23 13:18:15] [Sync] Timed out waiting for StartAck. Retrying...
[2025-07-23 13:18:15] [sendFlatBufferMessageAsString] sending message
[2025-07-23 13:18:35] [Sync] Timed out waiting for StartAck. Retrying...
[2025-07-23 13:18:35] [sendFlatBufferMessageAsString] sending message
[2025-07-23 13:18:36] [StartAck] Received and accepted for new session: 1234567891
[2025-07-23 13:18:36] [Sync] StartAck received. Session 1234567891 established.
[2025-07-23 13:18:36] Send data...
[2025-07-23 13:18:36] [sendFlatBufferMessageAsString] sending message
[2025-07-23 13:18:36] Send end...
[2025-07-23 13:18:36] [sendFlatBufferMessageAsString] sending message
[2025-07-23 13:18:46] [ReqRet] invalid phase or session
[2025-07-23 13:18:52] [ReqRet] received 1 ranges
[2025-07-23 13:18:52] [sendFlatBufferMessageAsString] sending message
[2025-07-23 13:19:12] [Sync] Timeout waiting for EndAck or ReqRet. Retrying...
[2025-07-23 13:19:32] [Sync] Timeout waiting for EndAck or ReqRet. Retrying...
[2025-07-23 13:19:36] [StartAck] Discarded. Not in WaitingStartAck phase. Current phase: 2
[2025-07-23 13:19:52] [Sync] Timeout waiting for EndAck or ReqRet. Retrying...
[2025-07-23 13:20:02] [EndAck] invalid phase or session
[2025-07-23 13:20:05] [EndAck] session ended: 1234567891
[2025-07-23 13:20:05] [Sync] EndAck received.
[2025-07-23 13:20:05] [Sync] Module 'FIM' synchronized successfully
```

</details>

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
