### PR TITLE
Mistaken alert due to expected regex

### DIFF
--- a/ruleset/rules/0850-audit_rules.xml
+++ b/ruleset/rules/0850-audit_rules.xml
@@ -38,7 +38,7 @@
 
   <rule id="92603" level="6">
     <if_group>audit</if_group>
-    <field name="audit.command" type="pcre2">scp</field>
+    <field name="audit.command" type="pcre2">^scp$</field>
     <field name="audit.file.name" type="pcre2">.+</field>
     <description>A file was copied to this system over SSH using SCP.</description>
     <mitre>
@@ -63,6 +63,16 @@
     <description>Executed recursive query of all files using ls command.</description>
     <mitre>
       <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="92606" level="6">
+    <if_group>audit</if_group>
+    <field name="audit.command" type="pcre2">lscpu</field>
+    <field name="audit.file.name" type="pcre2">.+</field>
+    <description>A file was copied to this system over SSH using LSCPU.</description>
+    <mitre>
+      <id>T1021.004</id>
     </mitre>
   </rule>
 


### PR DESCRIPTION
|Wazuh version| Component | Action type |
|---| --- | --- |
| 4.3.10-40323 | Rules | Error|

<!--
This template reflects sections that must be included in new issues
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the issue.
-->

## Description
When checking why an `audit` alert was triggering, we were able to see that it was triggering incorrectly due to the expected regex in the command.




## Errors/Improvements
### Current results
<!--  Include current results -->
For the following log:
```
type=SYSCALL msg=audit(1678775736.981:686912): arch=c000003e syscall=59 success=yes exit=0 a0=23470f0 a1=2338720 a2=2322be0 a3=7ffd0f0ba460 items=2 ppid=65979 pid=65989 auid=1005 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=20 comm="lscpu" exe="/usr/bin/lscpu" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="audit-wazuh-c" type=EXECVE msg=audit(1678775736.981:686912): argc=1 a0="/usr/bin/lscpu" type=CWD msg=audit(1678775736.981:686912): cwd="/home/user1" type=PATH msg=audit(1678775736.981:686912): item=0 name="/usr/bin/lscpu" inode=175826 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PATH msg=audit(1678775736.981:686912): item=1 name="/lib64/ld-linux-x86-64.so.2" inode=9232264 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PROCTITLE msg=audit(1678775736.981:686912): proctitle="/usr/bin/lscpu"
 ```

The following result is obtained:

<details>
<summary>wazuh-logtest result</summary>
<br>

```
Starting wazuh-logtest v4.3.10
Type one log per line

type=SYSCALL msg=audit(1678775736.981:686912): arch=c000003e syscall=59 success=yes exit=0 a0=23470f0 a1=2338720 a2=2322be0 a3=7ffd0f0ba460 items=2 ppid=65979 pid=65989 auid=1005 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=20 comm="lscpu" exe="/usr/bin/lscpu" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="audit-wazuh-c" type=EXECVE msg=audit(1678775736.981:686912): argc=1 a0="/usr/bin/lscpu" type=CWD msg=audit(1678775736.981:686912): cwd="/home/user1" type=PATH msg=audit(1678775736.981:686912): item=0 name="/usr/bin/lscpu" inode=175826 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PATH msg=audit(1678775736.981:686912): item=1 name="/lib64/ld-linux-x86-64.so.2" inode=9232264 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PROCTITLE msg=audit(1678775736.981:686912): proctitle="/usr/bin/lscpu"

**Phase 1: Completed pre-decoding.
	full event: 'type=SYSCALL msg=audit(1678775736.981:686912): arch=c000003e syscall=59 success=yes exit=0 a0=23470f0 a1=2338720 a2=2322be0 a3=7ffd0f0ba460 items=2 ppid=65979 pid=65989 auid=1005 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=20 comm="lscpu" exe="/usr/bin/lscpu" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="audit-wazuh-c" type=EXECVE msg=audit(1678775736.981:686912): argc=1 a0="/usr/bin/lscpu" type=CWD msg=audit(1678775736.981:686912): cwd="/home/user1" type=PATH msg=audit(1678775736.981:686912): item=0 name="/usr/bin/lscpu" inode=175826 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PATH msg=audit(1678775736.981:686912): item=1 name="/lib64/ld-linux-x86-64.so.2" inode=9232264 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PROCTITLE msg=audit(1678775736.981:686912): proctitle="/usr/bin/lscpu"'

**Phase 2: Completed decoding.
	name: 'auditd'
	parent: 'auditd'
	audit.arch: 'c000003e'
	audit.auid: '1005'
	audit.command: 'lscpu'
	audit.cwd: '/home/user1'
	audit.egid: '0'
	audit.euid: '0'
	audit.exe: '/usr/bin/lscpu'
	audit.execve.a0: '/usr/bin/lscpu'
	audit.exit: '0'
	audit.file.inode: '175826'
	audit.file.mode: '0100755'
	audit.file.name: '/usr/bin/lscpu'
	audit.fsgid: '0'
	audit.fsuid: '0'
	audit.gid: '0'
	audit.id: '686912'
	audit.key: 'audit-wazuh-c'
	audit.pid: '65989'
	audit.ppid: '65979'
	audit.session: '20'
	audit.sgid: '0'
	audit.success: 'yes'
	audit.suid: '0'
	audit.syscall: '59'
	audit.tty: 'pts1'
	audit.type: 'SYSCALL'
	audit.uid: '0'

**Phase 3: Completed filtering (rules).
	id: '92603'
	level: '6'
	description: 'A file was copied to this system over SSH using SCP.'
	groups: '['audit_detections']'
	firedtimes: '1'
	mail: 'True'
	mitre.id: '['T1021.004']'
	mitre.tactic: '['Lateral Movement']'
	mitre.technique: '['SSH']'
**Alert to be generated.
```
</details>

In which we can see that it matches with the `92603` rule, which indicates that a file has been copied with SCP. However, this is not what the event says, since the command is `lscpu`.

This is because the rule looks for the command to contain `scp`:

```xml
  <rule id="92603" level="6">
    <if_group>audit</if_group>
    <field name="audit.command" type="pcre2">scp</field>
    <field name="audit.file.name" type="pcre2">.+</field>
    <description>A file was copied to this system over SSH using SCP.</description>
    <mitre>
      <id>T1021.004</id>
    </mitre>
  </rule>
```

### Expected results
<!--  Include expected results -->

The event should be matched with a rule for `lscpu` or with a generic `audit` rule and let the users decide if they want to create a custom rule for this event.

## Resources
### Log source / integration
<!-- Especify where the logs come from and/or if integration is required-->

This rule belongs to the `audit` rules.


### Log examples

```
type=SYSCALL msg=audit(1678775736.981:686912): arch=c000003e syscall=59 success=yes exit=0 a0=23470f0 a1=2338720 a2=2322be0 a3=7ffd0f0ba460 items=2 ppid=65979 pid=65989 auid=1005 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=20 comm="lscpu" exe="/usr/bin/lscpu" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="audit-wazuh-c" type=EXECVE msg=audit(1678775736.981:686912): argc=1 a0="/usr/bin/lscpu" type=CWD msg=audit(1678775736.981:686912): cwd="/home/user1" type=PATH msg=audit(1678775736.981:686912): item=0 name="/usr/bin/lscpu" inode=175826 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:bin_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PATH msg=audit(1678775736.981:686912): item=1 name="/lib64/ld-linux-x86-64.so.2" inode=9232264 dev=fd:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:ld_so_t:s0 objtype=NORMAL cap_fp=0000000000000000 cap_fi=0000000000000000 cap_fe=0 cap_fver=0 type=PROCTITLE msg=audit(1678775736.981:686912): proctitle="/usr/bin/lscpu"
```

