### PR TITLE
Fix databaseFeedManagerTesttool

### DIFF
--- a/docs/ref/modules/vulnerability-scanner/test-tools.md
+++ b/docs/ref/modules/vulnerability-scanner/test-tools.md
@@ -683,7 +683,7 @@ src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/datab
 Command
 
 ```console
-src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/database_feed_manager_testtool -c config.json -F <CVE5.fbs_PATH> -r <LIST_CVE>
+src/build/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/database_feed_manager_testtool -c config.json -F <CVE5.fbs_PATH> -r <LIST_CVE> -o <OFFSET>
 ```
 
 Configuration file
@@ -704,6 +704,7 @@ Configuration file
 - **`-F` flag**: Path to the `CVE5.fbs` file, the FlatBuffers schema used to parse CVE data.
 - **`-c` flag**: Path to the configuration file, which should match the configuration used by the actual vulnerability scanner.
 - **`-r` flag**: Injects new CVE entries into the database. The input must be a JSON array of CVE objects.
+- **`-o` flag**: Specifies the offset number to use when processing the CVE entries. If not specified or it's a negative number, the default offset of `99999` will be used.
 
 
 #### Output example

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/argsParser.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/argsParser.hpp
@@ -36,6 +36,7 @@ public:
         , m_formatInputFiles {paramValueOf(argc, argv, "-f", std::make_pair(false, "offsets"))}
         , m_replaceCVE {splitActions(paramValueOf(argc, argv, "-r", std::make_pair(false, "")))}
         , m_flatbufferPath {paramValueOf(argc, argv, "-F", std::make_pair(false, "flatbuffer"))}
+        , m_offsetNumber {paramValueOf(argc, argv, "-o", std::make_pair(false, "0"))}
     {
     }
 
@@ -55,6 +56,15 @@ public:
     size_t getWaitTime() const
     {
         return std::stoull(m_waitTime);
+    }
+
+    /**
+     * @brief Gets the offset number.
+     * @return Offset number.
+     */
+    int getOffsetNumber() const
+    {
+        return std::stoi(m_offsetNumber);
     }
 
     /**
@@ -159,6 +169,7 @@ private:
     const std::string m_formatInputFiles;
     const std::vector<std::string> m_replaceCVE;
     const std::string m_flatbufferPath;
+    const std::string m_offsetNumber;
 };
 
 #endif // _CMD_ARGS_PARSER_HPP_

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -18,7 +18,7 @@
 #include <filesystem>
 #include <iostream>
 
-auto constexpr DEFAULT_OFFSET{99999};
+auto constexpr DEFAULT_OFFSET {99999};
 
 std::string g_message {};
 auto g_shouldStop {std::make_shared<ConditionSync>(false)};

--- a/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/testtool/databaseFeedManager/main.cpp
@@ -18,6 +18,8 @@
 #include <filesystem>
 #include <iostream>
 
+auto constexpr DEFAULT_OFFSET{99999};
+
 std::string g_message {};
 auto g_shouldStop {std::make_shared<ConditionSync>(false)};
 
@@ -177,6 +179,7 @@ void cveReplaceLogic(
 
         nlohmann::json resource;
         resource["type"] = "update";
+        resource["offset"] = cmdLineArgs.getOffsetNumber() > 0 ? cmdLineArgs.getOffsetNumber() : DEFAULT_OFFSET;
 
         auto eventContext = std::make_shared<EventContext>(EventContext {.message = "",
                                                                          .resource = resource,


### PR DESCRIPTION
# Objective

This PR introduces a fix for the `cveReplaceLogic()` function used for testing proporse, which provides a structured and validated way to replace CVE entries in the RocksDB database. It uses FlatBuffer parsing and the `StoreModel` interface to ensure consistent updates through the `EventContext` execution path and considered the changes of https://github.com/wazuh/wazuh/pull/29916 

Also makes an update in the corresponding documentation.
