### PR TITLE
Add agent name to set-get group sync on wazuh-db

### DIFF
--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -9109,6 +9109,7 @@ void test_wdb_global_validate_groups_success(void **state) {
 void test_wdb_global_set_agent_groups_override_success(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
+    const char * agent_name = "agent001";
     int group_id = 1;
     char group_name[] = "GROUP";
     char hash[] = "19dcd0dd"; //"GROUP" hash
@@ -9123,6 +9124,7 @@ void test_wdb_global_set_agent_groups_override_success(void **state) {
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
         cJSON_AddItemToObject(j_agent_group, "id", cJSON_CreateNumber(agent_id));
+        cJSON_AddItemToObject(j_agent_group, "name", cJSON_CreateString(agent_name));
         cJSON_AddItemToObject(j_agent_group, "groups", cJSON_Duplicate(j_group_array, TRUE));
         cJSON_AddItemToArray(j_agents_group_info, j_agent_group);
 
@@ -9159,6 +9161,7 @@ void test_wdb_global_set_agent_groups_override_success(void **state) {
 void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
+    const char * agent_name = "agent001";
     int group_id = 1;
     char group_name[] = "GROUP";
     char hash[] = "19dcd0dd"; //"GROUP" hash
@@ -9173,6 +9176,7 @@ void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
         cJSON_AddItemToObject(j_agent_group, "id", cJSON_CreateNumber(agent_id));
+        cJSON_AddItemToObject(j_agent_group, "name", cJSON_CreateString(agent_name));
         cJSON_AddItemToObject(j_agent_group, "groups", cJSON_Duplicate(j_group_array, TRUE));
         cJSON_AddItemToArray(j_agents_group_info, j_agent_group);
 
@@ -9212,6 +9216,7 @@ void test_wdb_global_set_agent_groups_override_delete_error(void **state) {
 void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
+    const char * agent_name = "agent001";
     char group_name[] = "GROUP";
     char hash[] = "19dcd0dd"; //"GROUP" hash
     char sync_status[] = "synced";
@@ -9227,6 +9232,7 @@ void test_wdb_global_set_agent_groups_add_modes_assign_error(void **state) {
     for (int i=0; i<AGENTS_SIZE; i++) {
         cJSON* j_agent_group = cJSON_CreateObject();
         cJSON_AddItemToObject(j_agent_group, "id", cJSON_CreateNumber(agent_id));
+        cJSON_AddItemToObject(j_agent_group, "name", cJSON_CreateString(agent_name));
         cJSON_AddItemToObject(j_agent_group, "groups", cJSON_Duplicate(j_group_array_invalid, TRUE));
         cJSON_AddItemToArray(j_agents_group_info, j_agent_group);
 
@@ -9872,6 +9878,7 @@ void test_wdb_global_recalculate_all_agent_groups_hash_recalculate_error(void **
 void test_wdb_global_assign_agent_group_agent_not_exists_success(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
+    const char* agent_name = "agent-01";
     int group_id = 1;
     int priority = 0;
     char group_name[] = "test_group";
@@ -9922,7 +9929,7 @@ void test_wdb_global_assign_agent_group_agent_not_exists_success(void **state) {
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2); // name
-    expect_string(__wrap_sqlite3_bind_text, buffer, "unknown");
+    expect_string(__wrap_sqlite3_bind_text, buffer, agent_name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 3); // ip
     expect_string(__wrap_sqlite3_bind_text, buffer, "0.0.0.0");
@@ -9953,7 +9960,7 @@ void test_wdb_global_assign_agent_group_agent_not_exists_success(void **state) {
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
-    wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, priority, true);
+    wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, priority, agent_name);
 
     assert_int_equal(result, WDBC_OK);
     __real_cJSON_Delete(j_groups);
@@ -9962,6 +9969,7 @@ void test_wdb_global_assign_agent_group_agent_not_exists_success(void **state) {
 void test_wdb_global_assign_agent_group_agent_not_exists_insert_fail(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     int agent_id = 1;
+    const char* agent_name = "agent-01";
     int group_id = 1;
     int priority = 0;
     char group_name[] = "test_group";
@@ -10012,7 +10020,7 @@ void test_wdb_global_assign_agent_group_agent_not_exists_insert_fail(void **stat
     expect_value(__wrap_sqlite3_bind_int, value, agent_id);
     will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 2); // name
-    expect_string(__wrap_sqlite3_bind_text, buffer, "unknown");
+    expect_string(__wrap_sqlite3_bind_text, buffer, agent_name);
     will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
     expect_value(__wrap_sqlite3_bind_text, pos, 3); // ip
     expect_string(__wrap_sqlite3_bind_text, buffer, "0.0.0.0");
@@ -10045,7 +10053,7 @@ void test_wdb_global_assign_agent_group_agent_not_exists_insert_fail(void **stat
 
     expect_string(__wrap__mdebug1, formatted_msg, "Unable to insert group 'test_group' for agent '1', retry failed after creating agent in never_connected state.");
 
-    wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, priority, true);
+    wdbc_result result = wdb_global_assign_agent_group(data->wdb, agent_id, j_groups, priority, agent_name);
 
     assert_int_equal(result, WDBC_ERROR);
     __real_cJSON_Delete(j_groups);

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -105,6 +105,8 @@ int main(int argc, char ** argv)
     wconfig.max_fragmentation = getDefine_Int("wazuh_db", "max_fragmentation", 0, 100);
     wconfig.check_fragmentation_interval = getDefine_Int("wazuh_db", "check_fragmentation_interval", 1, 30758400);
 
+    wconfig.is_worker_node = w_is_worker() == 1;
+
     // Allocating memory for configuration structures and setting default values
     wdb_init_conf();
 

--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -191,7 +191,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_REQ_KEEPALIVE_GET] = "SELECT id, last_keepalive FROM agent WHERE id > ? AND sync_status = 'syncreq_keepalive' LIMIT 1;",
     [WDB_STMT_GLOBAL_SYNC_GET] = "SELECT sync_status FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
-    [WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET] = "SELECT id FROM agent WHERE id > ? AND group_sync_status = 'syncreq' AND date_add < ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET] = "SELECT id, name FROM agent WHERE id > ? AND group_sync_status = 'syncreq' AND date_add < ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET] = "SELECT id FROM agent WHERE id > ? AND date_add < ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND] = "SELECT 1 FROM agent WHERE group_sync_status = 'syncreq';",
     [WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET] = "SELECT count(id_group) groups_number from belongs WHERE id_agent = ?;",

--- a/src/wazuh_db/wdb.h
+++ b/src/wazuh_db/wdb.h
@@ -387,6 +387,7 @@ typedef struct wdb_config {
     int max_fragmentation;
     int check_fragmentation_interval;
     wdb_backup_settings_node** wdb_backup_settings;
+    bool is_worker_node; ///< Indicates if the node is a cluster worker node
 } wdb_config;
 
 /// Enumeration of components supported by the integrity library.
@@ -2190,10 +2191,11 @@ int wdb_global_get_agent_max_group_priority(wdb_t *wdb, int id);
  * @param [in] id ID of the agent to add new groups.
  * @param [in] j_groups JSON array with all the groups of the agent.
  * @param [in] priority Initial priority to insert the groups.
- * @param [in] add_agent If true and the agent doesn't exist, it will be created.
+ * @param [in] create_agent_name If not null and the agent doesn't exist, it will be created with the given name.
  * @return wdbc_result representing the status of the command.
  */
-wdbc_result wdb_global_assign_agent_group(wdb_t *wdb, int id, cJSON* j_groups, int priority, bool add_agent);
+wdbc_result
+wdb_global_assign_agent_group(wdb_t* wdb, int id, cJSON* j_groups, int priority, const char* create_agent_name);
 
 /**
  * @brief Deletes groups of an agent.

--- a/tests/integration/test_wazuh_db/test_groups/data/test_cases/cases_sync_agent_groups_get.yaml
+++ b/tests/integration/test_wazuh_db/test_groups/data/test_cases/cases_sync_agent_groups_get.yaml
@@ -4,7 +4,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"condition":"sync_status"}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test sync_status without response
   description:
@@ -42,7 +42,7 @@
     pre_input:
       - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
     input: global sync-agent-groups-get {"condition":"sync_status"}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}]}]"
 
 - name: Test 'all' condition when one agent groups are in 'synced'
   description:
@@ -76,7 +76,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":true}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
     new_status: synced
     agent_id: "[1,2]"
 
@@ -86,7 +86,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"condition":"sync_status", "set_synced":false}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
     new_status: syncreq
     agent_id: "[1,2]"
 
@@ -106,8 +106,8 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":true}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']},
-             {'id': 2, 'groups': ['Test_group2']}], 'hash': '[GLOBAL_HASH]'}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']},
+             {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}], 'hash': '[GLOBAL_HASH]'}]"
 
 - name: Test only get_global_hash
   description:
@@ -123,7 +123,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status", "get_global_hash":false}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test get_global_hash with invalid value
   description:
@@ -139,7 +139,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":0}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test 'agent_registration_delta' in 0 and all condition
   description:
@@ -158,7 +158,7 @@
       - global insert-agent {"id":5,"name":"Agent-test5","date_add":1545753642}
       - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":5,"groups":["Test_group5"]}]}
     input: global sync-agent-groups-get {"condition":"sync_status", "agent_registration_delta":10000}
-    output: "[{'data': [{'id': 5, 'groups': ['Test_group5']}]}]"
+    output: "[{'data': [{'id': 5, 'name': 'Agent-test5', 'groups': ['Test_group5']}]}]"
 
 - name: Test 'agent_registration_delta' with delta in 10000 and all
   description:
@@ -177,7 +177,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"last_id":0, "condition":"sync_status"}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test last_id - obtain from second group
   description:
@@ -185,7 +185,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"last_id":1, "condition":"sync_status"}
-    output: "[{'data': [{'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test last_id - with not exist id
   description:


### PR DESCRIPTION
## Description

Closes #30820 

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:

-->

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->


#### Global-DB Before connecting agent

***Master***

```
root@120-ubuntu22:/home/vagrant/wazuh# sqlite3 /var/ossec/queue/db/global.db 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite> select * from agent;
0|120-ubuntu22|127.0.0.1|127.0.0.1||Ubuntu|22.04.5 LTS|22|04|Jammy Jellyfish||ubuntu|Linux |120-ubuntu22 |5.15.0-133-generic |#144-Ubuntu SMP Fri Feb 7 20:47:38 UTC 2025 |x86_64|x86_64|Wazuh v4.13.0|||120-ubuntu22|master|1753465852|253402300799|||synced|synced|active|0|synced|0
1|126-t101||any|d69c0901a0dfdf02c9c7f400b45640302b2c45f0ac5c29d521b8a5fe946b551e||||||||||||||unknown|1753466316||group02|bb57c4ec|synced|synced|never_connected|0|not synced|0
```

***Worker***

```
root@121-ubuntu22:/home/vagrant/wazuh# sqlite3 /var/ossec/queue/db/global.db 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite> select * from agent;
0|121-ubuntu22|127.0.0.1|127.0.0.1||Ubuntu|22.04.5 LTS|22|04|Jammy Jellyfish||ubuntu|Linux |121-ubuntu22 |5.15.0-133-generic |#144-Ubuntu SMP Fri Feb 7 20:47:38 UTC 2025 |x86_64|x86_64|Wazuh v4.13.0|||121-ubuntu22|worker01|1753465854|253402300799|||synced|synced|active|0|synced|0
1|126-t101|0.0.0.0|0.0.0.0|||||||||||||||unknown|1753466321||group02|bb57c4ec|synced|synced|never_connected|0|not synced|0

```

#### Global-DB After connecting agent (To worker)


***Master***
```
root@120-ubuntu22:/home/vagrant/wazuh# sqlite3 /var/ossec/queue/db/global.db 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite> select * from agent;
0|120-ubuntu22|127.0.0.1|127.0.0.1||Ubuntu|22.04.5 LTS|22|04|Jammy Jellyfish||ubuntu|Linux |120-ubuntu22 |5.15.0-133-generic |#144-Ubuntu SMP Fri Feb 7 20:47:38 UTC 2025 |x86_64|x86_64|Wazuh v4.13.0|||120-ubuntu22|master|1753465852|253402300799|||synced|synced|active|0|synced|0
1|126-t101|10.0.2.15|any|d69c0901a0dfdf02c9c7f400b45640302b2c45f0ac5c29d521b8a5fe946b551e|CentOS Linux|7.8|7|8|||centos|Linux |126-centos-7 |3.10.0-1127.el7.x86_64 |#1 SMP Tue Mar 31 23:36:51 UTC 2020 |x86_64|x86_64|Wazuh v4.13.0|ab73af41699f13fdd81903b5f23d8d00|3edcba6cafd9808f908eb57a0158d663|121-ubuntu22|worker01|1753466316|1753467291|group02|bb57c4ec|synced|synced|active|0|synced|0
```

***Worker***
```
root@121-ubuntu22:/home/vagrant/wazuh# sqlite3 /var/ossec/queue/db/global.db 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.
sqlite> select * from agent;
0|121-ubuntu22|127.0.0.1|127.0.0.1||Ubuntu|22.04.5 LTS|22|04|Jammy Jellyfish||ubuntu|Linux |121-ubuntu22 |5.15.0-133-generic |#144-Ubuntu SMP Fri Feb 7 20:47:38 UTC 2025 |x86_64|x86_64|Wazuh v4.13.0|||121-ubuntu22|worker01|1753465854|253402300799|||synced|synced|active|0|synced|0
1|126-t101|10.0.2.15|0.0.0.0||CentOS Linux|7.8|7|8|||centos|Linux |126-centos-7 |3.10.0-1127.el7.x86_64 |#1 SMP Tue Mar 31 23:36:51 UTC 2020 |x86_64|x86_64|Wazuh v4.13.0|ab73af41699f13fdd81903b5f23d8d00|3edcba6cafd9808f908eb57a0158d663|121-ubuntu22|worker01|1753466321|1753467297|group02|bb57c4ec|synced|syncreq_keepalive|active|0|synced|0

```

***Master***
```bash
root@120-ubuntu22:/home/vagrant# /var/ossec/bin/cluster_control -a
ID   NAME          IP         STATUS  VERSION        NODE NAME  
000  120-ubuntu22  127.0.0.1  active  Wazuh v4.13.0  master     
001  126-t101      10.0.2.15  active  Wazuh v4.13.0  worker01   
```

***Worker***
```bash
root@121-ubuntu22:/home/vagrant# /var/ossec/bin/cluster_control -a
ID   NAME          IP         STATUS  VERSION        NODE NAME  
000  120-ubuntu22  127.0.0.1  active  Wazuh v4.13.0  master     
001  126-t101      10.0.2.15  active  Wazuh v4.13.0  worker01   
```

***Alerts from the agent connected to worker***

```json
{"timestamp":"2025-07-25T20:11:28.170+0000","rule":{"level":3,"description":"PAM: Login session closed.","id":"5502","firedtimes":2,"mail":false,"groups":["pam","syslog"],"pci_dss":["10.2.5"],"gpg13":["7.8","7.9"],"gdpr":["IV_32.2"],"hipaa":["164.312.b"],"nist_800_53":["AU.14","AC.7"],"tsc":["CC6.8","CC7.2","CC7.3"]},"agent":{"id":"001","name":"126-t101","ip":"10.0.2.15"},"manager":{"name":"121-ubuntu22"},"id":"1753474288.685180","cluster":{"name":"wazuh","node":"worker01"},"full_log":"Jul 25 20:11:28 126-centos-7 sudo[8696]: pam_unix(sudo:session): session closed for user root","predecoder":{"program_name":"sudo","timestamp":"Jul 25 20:11:28","hostname":"126-centos-7"},"decoder":{"parent":"pam","name":"pam"},"data":{"dstuser":"root"},"location":"journald"}
```


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

