### PR TITLE
Remove server-side osquery configurations and references

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1888,10 +1888,6 @@ components:
                                     type: integer
                                     format: int32
                                     description: "Events coming from the OSCAP module (this agent)"
-                                  osquery:
-                                    type: integer
-                                    format: int32
-                                    description: "Events coming from the OSQuery module (this agent)"
                                   rootcheck:
                                     type: integer
                                     format: int32
@@ -2757,10 +2753,6 @@ components:
                               type: integer
                               format: int32
                               description: "Events coming from OSCAP module"
-                            osquery:
-                              type: integer
-                              format: int32
-                              description: "Events coming from OSQuery module"
                             rootcheck:
                               type: integer
                               format: int32
@@ -2877,10 +2869,6 @@ components:
                               type: integer
                               format: int32
                               description: "Events discarded from OSCAP module because the queue was full"
-                            osquery:
-                              type: integer
-                              format: int32
-                              description: "Events discarded from OSQuery module because the queue was full"
                             rootcheck:
                               type: integer
                               format: int32
@@ -3918,8 +3906,6 @@ components:
           type: object
         open-scap:
           type: object
-        osquery:
-          type: object
         syscollector:
           type: object
 
@@ -4317,8 +4303,6 @@ components:
           wazuh-modulesd:download:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:oscap:
-            $ref: '#/components/schemas/LogSummary'
-          wazuh-modulesd:osquery:
             $ref: '#/components/schemas/LogSummary'
           wazuh-modulesd:syscollector:
             $ref: '#/components/schemas/LogSummary'
@@ -6528,7 +6512,6 @@ components:
         - cis-cat
         - docker-listener
         - open-scap
-        - osquery
         - syscollector
     field:
       in: query
@@ -8017,7 +8000,6 @@ paths:
                                     office365: 0
                                     ms-graph: 0
                                     oscap: 0
-                                    osquery: 0
                                     rootcheck: 1
                                     sca: 194
                                     syscheck: 0
@@ -10491,12 +10473,6 @@ paths:
                         scan-on-start: yes
                         java_path: wodles/java
                         ciscat_path: wodles/ciscat
-                      osquery:
-                        disabled: yes
-                        run_daemon: yes
-                        log_path: /var/log/osquery/osqueryd.results.log
-                        config_path: /etc/osquery/osquery.conf
-                        add_labels: yes
                       syscollector:
                         disabled: no
                         interval: "1h"

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -597,7 +597,6 @@ stages:
               command: !anything
               global: !anything
               localfile: !anything
-              osquery: !anything
               remote: !anything
               rootcheck: !anything
               ruleset: !anything
@@ -630,7 +629,6 @@ stages:
               command: !anything
               global: !anything
               localfile: !anything
-              osquery: !anything
               remote: !anything
               rootcheck: !anything
               ruleset: !anything

--- a/api/test/integration/test_manager_endpoints.tavern.yaml
+++ b/api/test/integration/test_manager_endpoints.tavern.yaml
@@ -83,7 +83,6 @@ marks:
        - command
        - global
        - localfile
-       - osquery
        - remote
        - rootcheck
        - ruleset
@@ -154,7 +153,6 @@ stages:
               command: !anything
               global: !anything
               localfile: !anything
-              osquery: !anything
               remote: !anything
               rootcheck: !anything
               ruleset: !anything

--- a/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
@@ -336,7 +336,6 @@ stages:
               command: !anything
               global: !anything
               localfile: !anything
-              osquery: !anything
               remote: !anything
               rootcheck: !anything
               ruleset: !anything

--- a/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
@@ -340,7 +340,6 @@ stages:
               command: !anything
               global: !anything
               localfile: !anything
-              osquery: !anything
               remote: !anything
               rootcheck: !anything
               ruleset: !anything

--- a/architecture/metrics/004-analysisd-received-localfile.puml
+++ b/architecture/metrics/004-analysisd-received-localfile.puml
@@ -52,8 +52,6 @@
                 analysisd -> state: dropped->modules->ms_graph++
             else Is open-scap OR wodle_open-scap module
                 analysisd -> state: dropped->modules->oscap++
-            else Is osquery module
-                analysisd -> state: dropped->modules->osquery++
             else Is rootcheck module
                 analysisd -> state: dropped->modules->rootcheck++
             else Is SCA module
@@ -105,8 +103,6 @@
                     analysisd -> state: decoded->modules->ms_graph++
                 else Is open-scap OR wodle_open-scap module
                     analysisd -> state: decoded->modules->oscap++
-                else Is osquery module
-                    analysisd -> state: decoded->modules->osquery++
                 else Is rootcheck module
                     analysisd -> state: decoded->modules->rootcheck++
                 else Is sca module

--- a/etc/templates/config/generic/osquery.template
+++ b/etc/templates/config/generic/osquery.template
@@ -1,8 +1,0 @@
-  <!-- Osquery integration -->
-  <wodle name="osquery">
-    <disabled>yes</disabled>
-    <run_daemon>yes</run_daemon>
-    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
-    <config_path>/etc/osquery/osquery.conf</config_path>
-    <add_labels>yes</add_labels>
-  </wodle>

--- a/extensions/elasticsearch/7.x/wazuh-template.json
+++ b/extensions/elasticsearch/7.x/wazuh-template.json
@@ -364,21 +364,6 @@
       "data.oscap.scan.id",
       "data.oscap.scan.profile.id",
       "data.oscap.scan.profile.title",
-      "data.osquery.columns.address",
-      "data.osquery.columns.command",
-      "data.osquery.columns.description",
-      "data.osquery.columns.dst_ip",
-      "data.osquery.columns.gid",
-      "data.osquery.columns.hostname",
-      "data.osquery.columns.md5",
-      "data.osquery.columns.path",
-      "data.osquery.columns.sha1",
-      "data.osquery.columns.sha256",
-      "data.osquery.columns.src_ip",
-      "data.osquery.columns.user",
-      "data.osquery.columns.username",
-      "data.osquery.name",
-      "data.osquery.pack",
       "data.port.process",
       "data.port.protocol",
       "data.port.state",
@@ -2701,22 +2686,6 @@
                 }
               },
               "severity": {
-                "type": "keyword"
-              }
-            }
-          },
-          "osquery": {
-            "properties": {
-              "name": {
-                "type": "keyword"
-              },
-              "pack": {
-                "type": "keyword"
-              },
-              "action": {
-                "type": "keyword"
-              },
-              "calendarTime": {
                 "type": "keyword"
               }
             }

--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -91,10 +91,6 @@ CONF_SECTIONS = MappingProxyType({
         'type': 'last',
         'list_options': ['nodes']
     },
-    'osquery': {
-        'type': 'merge',
-        'list_options': ['pack']
-    },
     'labels': {
         'type': 'duplicate',
         'list_options': ['label']

--- a/src/engine/tools/agent_simulator.py
+++ b/src/engine/tools/agent_simulator.py
@@ -96,7 +96,6 @@ def get_queue_from_module(module):
         'github': 00,           # TODO check queue
         'office_365': 00,       # TODO check queue
         'open-scap': 00,        # TODO check queue
-        'osquery': 00,          # TODO check queue
         'virustotal': 00,       # TODO check queue
         'dbsync': 53,
         'fim': 56,


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This pull request addresses issue #31052 by removing all remaining server-related references to the deprecated osquery module. As part of the broader agent cleanup effort, these changes ensure consistency across Wazuh components and avoid referencing removed functionality in version 5.0.

Closes #31052

## Proposed Changes

- Removed osquery from the Wodle sections in `api/api/spec/spec.yaml`
- Deleted the obsolete osquery template: `etc/templates/config/generic/osquery.template`
- Removed osquery field mapping from `extensions/elasticsearch/7.x/wazuh-template.json`
- Cleaned up related configuration merging logic in `framework/wazuh/core/configuration.py`
- Removed osquery-related logic from `src/engine/tools/agent_simulator.py`
- Removed or updated osquery-related assertions from integration tests:
  - `test_cluster_endpoints.tavern.yaml`
  - `test_manager_endpoints.tavern.yaml`
  - `test_rbac_black_cluster_endpoints.tavern.yaml`
  - `test_rbac_white_cluster_endpoints.tavern.yaml`
- Removed osquery reference in `architecture/metrics/004-analysisd-received-localfile.puml`

### Results and Evidence

- Confirmed all osquery-related content was removed from the affected files listed in the issue.
- Obsolete configurations and mappings were fully removed, ensuring the server no longer references osquery artifacts.
- Output of `git diff` confirms complete deletion or modification in expected files.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

- Manual visual inspection of modified files confirmed correctness of removals

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [X] MAC OS X
- [X] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity - N/A
  - [ ] Valgrind (memcheck and descriptor leaks check) - N/A
  - [ ] AddressSanitizer - N/A
- Memory tests for Windows
  - [ ] Coverity - N/A
  - [ ] UMDH - N/A
- Memory tests for macOS
  - [ ] Leaks - N/A
  - [ ] AddressSanitizer - N/A

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" - N/A
  - [ ] `runtests.py` executed without errors - N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel - N/A
  - [ ] ASAN for test (utest/ctest) - N/A
  - [ ] TSAN for test and wazuh-engine. - N/A

### Artifacts Affected

- api/api/spec/spec.yaml
- api/test/integration/test_cluster_endpoints.tavern.yaml
- api/test/integration/test_manager_endpoints.tavern.yaml
- api/test/integration/test_rbac_black_cluster_endpoints.tavern.yaml
- api/test/integration/test_rbac_white_cluster_endpoints.tavern.yaml
- architecture/metrics/004-analysisd-received-localfile.puml
- etc/templates/config/generic/osquery.template
- extensions/elasticsearch/7.x/wazuh-template.json
- framework/wazuh/core/configuration.py
- src/engine/tools/agent_simulator.py

### Configuration Changes

- Removed deprecated `osquery` section from configuration templates
- Removed osquery-related config merging logic

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [X] Code changes reviewed
- [X] Relevant evidence provided
- [ ] Tests cover the new functionality - N/A
- [X] Configuration changes documented
- [X] Developer documentation reflects the changes
- [X] Meets requirements and/or definition of done
- [X] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
