### PR TITLE
Replace `get_system_nodes` duplicated logic blocks

### DIFF
--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -20,7 +20,7 @@ from api.models.security_model import (CreateUserModel, PolicyModel, RoleModel,
 from api.util import (deprecate_endpoint, parse_api_param, raise_if_exc,
                       remove_nones_to_dict)
 from wazuh import security, __version__
-from wazuh.core.cluster.control import get_system_nodes
+from wazuh.core.cluster.control import get_system_nodes_or_none
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.exception import WazuhException, WazuhPermissionError
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
@@ -1198,10 +1198,7 @@ async def revoke_all_tokens(pretty: bool = False) -> ConnexionResponse:
     """
     f_kwargs = {}
 
-    nodes = await get_system_nodes()
-    if isinstance(nodes, Exception):
-        nodes = None
-
+    nodes = await get_system_nodes_or_none()
     dapi = DistributedAPI(f=security.wrapper_revoke_tokens,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
                           request_type='distributed_master' if nodes is not None else 'local_any',
@@ -1252,10 +1249,7 @@ async def get_security_config(pretty: bool = False, wait_for_complete: bool = Fa
 
 async def security_revoke_tokens():
     """Revokes all tokens on all nodes after a change in security configuration."""
-    nodes = await get_system_nodes()
-    if isinstance(nodes, Exception):
-        nodes = None
-
+    nodes = await get_system_nodes_or_none()
     dapi = DistributedAPI(f=revoke_tokens,
                           request_type='distributed_master' if nodes is not None else 'local_any',
                           is_async=False,

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -885,16 +885,12 @@ async def test_get_rbac_actions(mock_exc, mock_dapi, mock_remove, mock_dfunc):
 @patch('api.controllers.security_controller.remove_nones_to_dict')
 @patch('api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
-@patch('api.controllers.security_controller.isinstance')
 @pytest.mark.parametrize('mock_snodes', [None, AsyncMock()])
-async def test_revoke_all_tokens(mock_isins, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_snodes,
+async def test_revoke_all_tokens(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_snodes,
                                  mock_request):
     """Verify 'revoke_all_tokens' endpoint is working as expected."""
-    mock_isins.return_value = True if not mock_snodes else False
     with patch('api.controllers.security_controller.get_system_nodes_or_none', return_value=mock_snodes):
         result = await revoke_all_tokens()
-        if not mock_snodes:
-            mock_isins.assert_called_once()
         mock_dapi.assert_called_once_with(f=security.wrapper_revoke_tokens,
                                           f_kwargs=mock_remove.return_value,
                                           request_type='distributed_master' if mock_snodes is not None else 'local_any',
@@ -964,12 +960,10 @@ async def test_get_security_config(mock_exc, mock_dapi, mock_remove, mock_dfunc,
 @patch('api.controllers.security_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
 @patch('api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
-@patch('api.controllers.security_controller.isinstance')
 @pytest.mark.parametrize('mock_snodes', [None, AsyncMock()])
-async def test_security_revoke_tokens(mock_isins, mock_exc, mock_dapi, mock_dfunc, mock_snodes):
+async def test_security_revoke_tokens(mock_exc, mock_dapi, mock_dfunc, mock_snodes):
     """Verify 'security_revoke_tokens' endpoint is working as expected."""
-    mock_isins.return_value = True if not mock_snodes else False
-    with patch('api.controllers.security_controller.get_system_nodes', return_value=mock_snodes):
+    with patch('api.controllers.security_controller.get_system_nodes_or_none', return_value=mock_snodes):
         await security_revoke_tokens()
         mock_dapi.assert_called_once_with(f=security.revoke_tokens,
                                           request_type='distributed_master' if mock_snodes is not None else 'local_any',

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -891,7 +891,7 @@ async def test_revoke_all_tokens(mock_isins, mock_exc, mock_dapi, mock_remove, m
                                  mock_request):
     """Verify 'revoke_all_tokens' endpoint is working as expected."""
     mock_isins.return_value = True if not mock_snodes else False
-    with patch('api.controllers.security_controller.get_system_nodes', return_value=mock_snodes):
+    with patch('api.controllers.security_controller.get_system_nodes_or_none', return_value=mock_snodes):
         result = await revoke_all_tokens()
         if not mock_snodes:
             mock_isins.assert_called_once()
@@ -920,7 +920,7 @@ async def test_revoke_all_tokens(mock_isins, mock_exc, mock_dapi, mock_remove, m
 async def test_revoke_all_tokens_ko(mock_type, mock_len, mock_exc, mock_dapi, mock_remove, mock_dfunc,
                                     mock_request):
     """Verify 'revoke_all_tokens' endpoint is handling WazuhPermissionError as expected."""
-    with patch('api.controllers.security_controller.get_system_nodes', return_value=AsyncMock()) as mock_snodes:
+    with patch('api.controllers.security_controller.get_system_nodes_or_none', return_value=AsyncMock()) as mock_snodes:
         result = await revoke_all_tokens()
         mock_dapi.assert_called_once_with(f=security.wrapper_revoke_tokens,
                                           f_kwargs=mock_remove.return_value,

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -3,7 +3,6 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
-from typing import Optional
 
 from wazuh import WazuhInternalError
 from wazuh.core import common
@@ -187,7 +186,7 @@ async def get_system_nodes():
         raise e
 
 
-async def get_system_nodes_or_none() -> Optional[dict]:
+async def get_system_nodes_or_none() -> list | None:
     """Get the list of system nodes or None if an exception occurs.
 
     Returns

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
+from typing import Optional
 
 from wazuh import WazuhInternalError
 from wazuh.core import common
@@ -184,6 +185,21 @@ async def get_system_nodes():
         if e.code == 3012:
             return WazuhError(3013)
         raise e
+
+
+async def get_system_nodes_or_none() -> Optional[dict]:
+    """Get the list of system nodes or None if an exception occurs.
+
+    Returns
+    -------
+    nodes : list or None
+        List of node names or None if an exception is raised.
+    """
+    nodes = await get_system_nodes()
+    if isinstance(nodes, Exception):
+        nodes = None
+
+    return nodes
 
 
 async def get_node_ruleset_integrity(lc: local_client.LocalClient) -> dict:

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -145,6 +145,21 @@ async def test_get_system_nodes():
 
 
 @pytest.mark.asyncio
+async def test_get_system_nodes_or_none():
+    """Verify that get_system_nodes_or_none function returns the name of all cluster nodes."""
+    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client):
+        expected_result = [{'items': [{'name': 'master'}]}]
+        for expected in expected_result:
+            with patch('wazuh.core.cluster.control.get_nodes', return_value=expected):
+                result = await control.get_system_nodes_or_none()
+                assert result == [expected['items'][0]['name']]
+
+        with patch('wazuh.core.cluster.control.get_nodes', side_effect=WazuhInternalError(3012)):
+            result = await control.get_system_nodes_or_none()
+            assert result is None
+
+
+@pytest.mark.asyncio
 async def test_get_node_ruleset_integrity():
     """Verify that get_node_ruleset_integrity function uses the expected command."""
     local_client = LocalClient()


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/30970

Replaces duplicated logic blocks with a new function.

### Results and Evidence

<details><summary>PUT /security/config</summary>

```console
(venv) wazuh@wazuh:~/wazuh$ curl -H "Authorization: Bearer $TOKEN" -X PUT -k https://0.0.0.0:55050/security/config -d '{"auth_token_exp_timeout": 100}' | jq
{
  "message": "Configuration was successfully updated",
  "error": 0
}
```

</details>

<details><summary>DELETE /security/config</summary>

```console
(venv) wazuh@wazuh:~/wazuh$ curl -H "Authorization: Bearer $TOKEN" -X DELETE -k https://0.0.0.0:55050/security/config | jq
{
  "message": "Configuration was successfully updated",
  "error": 0
}
```

</details>

<details><summary>PUT /security/user/revoke</summary>

```console
(venv) wazuh@wazuh:~/wazuh$ curl -H "Authorization: Bearer $TOKEN" -X PUT -k https://0.0.0.0:55050/security/user/revoke | jq
{
  "message": "Tokens were successfully revoked",
  "error": 0
}
```

</details>

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
