### PR TITLE
Changes in config.c to avoid false warnings in verify-agent-conf

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1633,9 +1633,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
     const char *xml_file_limit = "file_limit";
     const char *xml_enabled = "enabled";
     const char *xml_entries = "entries";
-#ifdef WIN32
     const char *xml_registry_limit = "registry_limit";
-#endif
     const char *xml_ignore = "ignore";
     const char *xml_registry_ignore = "registry_ignore";
 #ifdef WIN32
@@ -1819,7 +1817,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             OS_ClearNode(children);
         }
 
-#ifdef WIN32
         // Get registry limit
         else if (strcmp(node[i]->element, xml_registry_limit) == 0) {
             if (!(children = OS_GetElementsbyNode(xml, node[i]))) {
@@ -1828,10 +1825,14 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
             for(j = 0; children[j]; j++) {
                 if (strcmp(children[j]->element, xml_enabled) == 0) {
                     if (strcmp(children[j]->content, "yes") == 0) {
+#ifdef WIN32
                         syscheck->registry_limit_enabled = true;
+#endif
                     }
                     else if (strcmp(children[j]->content, "no") == 0) {
+#ifdef WIN32
                         syscheck->registry_limit_enabled = false;
+#endif
                     }
                     else {
                         mwarn(XML_VALUEERR, children[j]->element, children[j]->content);
@@ -1845,23 +1846,29 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         OS_ClearNode(children);
                         return (OS_INVALID);
                     }
-
+#ifdef WIN32
                     syscheck->db_entry_registry_limit = atoi(children[j]->content);
 
                     if (syscheck->db_entry_registry_limit < 0) {
                         mdebug2("Maximum value allowed for registry_limit is '%d'", MAX_FILE_LIMIT);
+
                         syscheck->db_entry_registry_limit = MAX_FILE_LIMIT;
                     }
+#else
+                    if(atoi(children[j]->content) < 0){
+                        mdebug2("Maximum value allowed for registry_limit is '%d'", MAX_FILE_LIMIT);
+                    }
+#endif
                 }
             }
-
+#ifdef WIN32
             if (!syscheck->registry_limit_enabled) {
                 syscheck->db_entry_registry_limit = 0;
             }
-
+#endif
             OS_ClearNode(children);
         }
-#endif
+
 
         /* Get if xml_scan_on_start */
         else if (strcmp(node[i]->element, xml_scan_on_start) == 0) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1853,10 +1853,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                         mdebug2("Maximum value allowed for registry_limit is '%d'", MAX_FILE_LIMIT);
                         syscheck->db_entry_registry_limit = MAX_FILE_LIMIT;
                     }
-#else
-                    if (atoi(children[j]->content) < 0) {
-                        mdebug2("Maximum value allowed for registry_limit is '%d'", MAX_FILE_LIMIT);
-                    }
 #endif
                 }
             }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -1851,11 +1851,10 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 
                     if (syscheck->db_entry_registry_limit < 0) {
                         mdebug2("Maximum value allowed for registry_limit is '%d'", MAX_FILE_LIMIT);
-
                         syscheck->db_entry_registry_limit = MAX_FILE_LIMIT;
                     }
 #else
-                    if(atoi(children[j]->content) < 0){
+                    if (atoi(children[j]->content) < 0) {
                         mdebug2("Maximum value allowed for registry_limit is '%d'", MAX_FILE_LIMIT);
                     }
 #endif
@@ -1868,7 +1867,6 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
 #endif
             OS_ClearNode(children);
         }
-
 
         /* Get if xml_scan_on_start */
         else if (strcmp(node[i]->element, xml_scan_on_start) == 0) {


### PR DESCRIPTION
## Description

This PR closes #28873: [[BUG] Cannot override registry_limit or file_limit with agent.conf](https://github.com/wazuh/wazuh/issues/28873#top)
 by adding some changes to the config.c code.

Previously, if a user executed verify-agent-conf in a linux environment, he would get a missleading warning if the <registry_limit> element was present.

## Proposed Changes

Now the <registry_limit> section in agent.conf is properly verified, so it won't generate a warning without a reason. For this, i 

### Results and Evidence

After configuring the agent.conf file on the manager, the verification process did not produce any warnings.

<img width="720" height="312" alt="image" src="https://github.com/user-attachments/assets/ec59fbdd-173e-43f5-b464-4f94384ab447" />

And it was properly sent to the Windows agent:

<img width="727" height="340" alt="image" src="https://github.com/user-attachments/assets/d3320c86-bf63-4213-86eb-8cb8e8fe48fc" />

