### PR TITLE
Fix authd.pass ACL permissions to match client.keys security level

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -423,12 +423,15 @@ Public Function SetWazuhPermissions()
         grantAuthenticatedUsersPermFolder = "icacls """ & install_dir & """ /grant *S-1-5-11:RX"
         WshShell.run grantAuthenticatedUsersPermFolder, 0, True
 
-        ' Remove Authenticated Users group for ossec.conf, last-ossec.conf  and client.key
+        ' Remove Authenticated Users group for ossec.conf, last-ossec.conf, client.keys and authd.pass
         remAuthenticatedUsersPermsConf = "icacls """ & home_dir & "*ossec.conf" & """ /remove *S-1-5-11 /q"
         WshShell.run remAuthenticatedUsersPermsConf, 0, True
 
         remAuthenticatedUsersPermsKeys = "icacls """ & home_dir & "client.keys" & """ /remove *S-1-5-11 /q"
         WshShell.run remAuthenticatedUsersPermsKeys, 0, True
+
+        remAuthenticatedUsersPermsAuthd = "icacls """ & home_dir & "authd.pass" & """ /remove *S-1-5-11 /q"
+        WshShell.run remAuthenticatedUsersPermsAuthd, 0, True
 
         ' Remove the Authenticated Users group from the tmp directory to avoid
         ' inherited permissions on client.keys and ossec.conf when using win32ui.


### PR DESCRIPTION
## Description

This pull request implements proper Access Control List (ACL) restrictions for the `authd.pass` file in the Windows agent installer. The fix ensures that `authd.pass` has the same restrictive permissions as `client.keys`, limiting access to administrators only.

The issue was identified where `authd.pass` file permissions were not properly secured during both fresh installations and upgrades, potentially exposing sensitive authentication credentials to unauthorized users.

## Proposed Changes

- Modified the Windows agent installer to check and set proper ACL permissions for `authd.pass`
  - Implemented ACL validation during fresh installation when `WAZUH_REGISTRATION_PASSWORD` property is defined
  - Added ACL correction during upgrade process for existing `authd.pass` files with incorrect permissions
  - Ensured `authd.pass` permissions match the security level of `client.keys` (administrator access only)

### Results and Evidence

#### 1. Fresh installation with authd.pass generation
- Clean installation of patched version 4.13.1
- `WAZUH_REGISTRATION_PASSWORD` property defined to trigger `authd.pass` creation
- ✅ Result: `authd.pass` created with proper ACL restrictions

<img width="767" height="520" alt="Screenshot 2025-08-01 180856" src="https://github.com/user-attachments/assets/0fea27f4-86fb-47a7-adc9-3e6854e2e57f" />

#### 2. Fresh installation without authd.pass
- Clean installation of patched version 4.13.1
- No `authd.pass` file created
- ✅ Result: No issues, installer behaves correctly when file is not needed

<img width="495" height="387" alt="Screenshot 2025-08-01 181626" src="https://github.com/user-attachments/assets/67b77582-bbe8-481c-b276-0670b3b3509c" />


#### 3. Upgrade scenario
- Upgrade from version 4.12.0 (with incorrectly permissioned `authd.pass`) to patched version
- ✅ Result: Existing `authd.pass` file permissions corrected to match `client.keys` ACL

**Before fix:** `authd.pass` had overly permissive access rights
**After fix:** `authd.pass` restricted to administrators only, matching `client.keys` security posture

<img width="575" height="316" alt="Screenshot 2025-08-01 181231" src="https://github.com/user-attachments/assets/de560cc9-866e-4e54-b19f-982246e4166d" />

### Artifacts Affected

- Windows Agent Installer

### Configuration Changes

No configuration changes required. The fix is transparent to end users and automatically applies appropriate file permissions.

### Documentation Updates

Not applicable - this is an internal security fix that doesn't change user-facing functionality or configuration options.

### Tests Introduced

No automated tests introduced. Manual testing was performed covering the three key scenarios:
- Fresh installation with password-protected registration
- Fresh installation without registration password
- Upgrade from version with incorrect permissions

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues