### PR TITLE
Active response endpoint performance enhancement

### DIFF
--- a/framework/wazuh/active_response.py
+++ b/framework/wazuh/active_response.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from wazuh.core import active_response, common
-from wazuh.core.agent import get_agents_info
+from wazuh.core.agent import get_agents_info, get_rbac_filters, WazuhDBQueryAgents
 from wazuh.core.exception import WazuhException, WazuhError, WazuhResourceNotFound
 from wazuh.core.wazuh_queue import WazuhQueue
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -11,7 +11,7 @@ from wazuh.rbac.decorators import expose_resources
 
 
 @expose_resources(actions=['active-response:command'], resources=['agent:id:{agent_list}'],
-                  post_proc_kwargs={'exclude_codes': [1701, 1703]})
+                  post_proc_kwargs={'exclude_codes': [1701]})
 def run_command(agent_list: list = None, command: str = '', arguments: list = None,
                 alert: dict = None) -> AffectedItemsWazuhResult:
     """Run AR command in a specific agent.
@@ -40,19 +40,30 @@ def run_command(agent_list: list = None, command: str = '', arguments: list = No
                                       none_msg='AR command was not sent to any agent'
                                       )
     if agent_list:
+        system_agents = get_agents_info()
+
+        for agent_id in set(agent_list) - system_agents:
+            result.add_failed_item(id_=agent_id, error=WazuhResourceNotFound(1701))
+
+        rbac_filters = get_rbac_filters(system_resources=system_agents, permitted_resources=agent_list)
+
+        with WazuhDBQueryAgents(select=['id', 'status', 'version'], query="id!=000", **rbac_filters) as db_query:
+            agents = db_query.run()['items']
+
         with WazuhQueue(common.AR_SOCKET) as wq:
-            system_agents = get_agents_info()
-            for agent_id in agent_list:
+            for agent in agents:
                 try:
-                    if agent_id not in system_agents:
-                        raise WazuhResourceNotFound(1701)
-                    if agent_id == "000":
-                        raise WazuhError(1703)
-                    active_response.send_ar_message(agent_id, wq, command, arguments, alert)
+                    if agent['status'] != 'active':
+                        raise WazuhError(1707)
+                    
+                    agent_id = agent['id']
+                    agent_version = agent['version']
+
+                    active_response.send_ar_message(agent_id, agent_version, wq, command, arguments, alert)
                     result.affected_items.append(agent_id)
                     result.total_affected_items += 1
                 except WazuhException as e:
-                    result.add_failed_item(id_=agent_id, error=e)
+                    result.add_failed_item(id_=agent['id'], error=e)
             result.affected_items.sort(key=int)
 
     return result

--- a/framework/wazuh/core/active_response.py
+++ b/framework/wazuh/core/active_response.py
@@ -247,14 +247,16 @@ class ARJsonMessage(ARMessageBuilder):
         return msg_queue
 
 
-def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = '', arguments: list = None,
-                    alert: dict = None) -> None:
+def send_ar_message(agent_id: str = '', agent_version = '', wq: WazuhQueue = None, command: str = '',
+                    arguments: list = None, alert: dict = None) -> None:
     """Send the active response message to the agent.
 
     Parameters
     ----------
     agent_id : str
         ID specifying the agent where the msg_queue will be sent to.
+    agent_version : str
+        Agent version.
     wq : WazuhQueue
         Used for the active response messages.
     command : str
@@ -267,21 +269,9 @@ def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = ''
 
     Raises
     ------
-    WazuhError(1707)
-        If the agent with ID agent_id is not active.
     WazuhError(1750)
         If active response is disabled in the specified agent.
     """
-    # Agent basic information
-    agent_info = Agent(agent_id).get_basic_information()
-
-    # Check if agent is active
-    if agent_info['status'].lower() != 'active':
-        raise WazuhError(1707)
-
-    # Once we know the agent is active, store version
-    agent_version = agent_info['version']
-
     # Check if AR is enabled
     agent_conf = Agent(agent_id).get_config('com', 'active-response', agent_version)
     if agent_conf['active-response']['disabled'] == 'yes':
@@ -292,6 +282,3 @@ def send_ar_message(agent_id: str = '', wq: WazuhQueue = None, command: str = ''
     msg_queue = message_builder.create_message(command=command, arguments=arguments, alert=alert)
 
     wq.send_msg_to_agent(msg=msg_queue, agent_id=agent_id, msg_type=WazuhQueue.AR_TYPE)
-
-
-

--- a/framework/wazuh/tests/test_active_response.py
+++ b/framework/wazuh/tests/test_active_response.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+from json import dumps
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -18,36 +19,44 @@ with patch('wazuh.core.common.wazuh_uid'):
         del sys.modules['wazuh.rbac.orm']
         wazuh.rbac.decorators.expose_resources = RBAC_bypasser
 
+        from api.util import remove_nones_to_dict
         from wazuh.active_response import run_command
-        from wazuh.core.tests.test_active_response import agent_config, agent_info_exception_and_version
+        from wazuh.core.tests.test_active_response import agent_config
+        from wazuh.core.tests.test_agent import InitAgent
 
+test_data = InitAgent()
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'etc', 'shared', 'ar.conf')
-full_agent_list = ['000', '001', '002', '003', '004', '005', '006', '007', '008']
+full_agent_list = {'000', '001', '002', '003', '004', '005', '006', '007', '008'}
 
+
+def send_msg_to_wdb(msg, raw=False):
+    query = ' '.join(msg.split(' ')[2:])
+    result = list(map(remove_nones_to_dict, map(dict, test_data.cur.execute(query).fetchall())))
+    return ['ok', dumps(result)] if raw else result
 
 # Tests
 
-@pytest.mark.parametrize('message_exception, send_exception, agent_id, command, arguments, alert, version', [
-    (1701, None, ['999'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
-    (1703, None, ['000'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
-    (1650, None, ['001'], None, [], None, 'Wazuh v4.0.0'),
-    (1652, None, ['002'], 'random', [], None, 'Wazuh v4.0.0'),
-    (None, 1707, ['003'], 'restart-wazuh0', [], None, None),
-    (None, 1750, ['004'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
-    (None, None, ['005'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
-    (None, None, ['006'], '!custom-ar', [], None, 'Wazuh v4.0.0'),
-    (None, None, ['007'], 'restart-wazuh0', ["arg1", "arg2"], None, 'Wazuh v4.0.0'),
-    (None, None, ['001', '002', '003', '004', '005', '006'], 'restart-wazuh0', [], None, 'Wazuh v4.0.0'),
-    (None, None, ['001'], 'restart-wazuh0', ["arg1", "arg2"], None, 'Wazuh v4.2.0'),
-    (None, None, ['002'], 'restart-wazuh0', [], None, 'Wazuh v4.2.1'),
+@pytest.mark.parametrize('message_exception, send_exception, agent_list, command, arguments, alert', [
+    (1650, None, ['001'], None, [], None),
+    (1652, None, ['002'], 'random', [], None),
+    (1701, None, ['999'], 'random', [], None),
+    (None, 1707, ['004'], 'restart-wazuh0', [], None),
+    (None, None, ['006'], 'restart-wazuh0', [], None),
+    (None, None, ['006'], '!custom-ar', [], None),
+    (None, None, ['007'], 'restart-wazuh0', ["arg1", "arg2"], None),
+    (None, None, ['001', '002', '003', '004', '005', '006'], 'restart-wazuh0', [], None),
+    (None, None, ['001'], 'restart-wazuh0', ["arg1", "arg2"], None),
+    (None, None, ['002'], 'restart-wazuh0', [], None),
 ])
 @patch("wazuh.core.wazuh_queue.WazuhQueue._connect")
 @patch("wazuh.syscheck.WazuhQueue._send", return_value='1')
 @patch("wazuh.core.wazuh_queue.WazuhQueue.close")
 @patch('wazuh.core.common.AR_CONF', new=test_data_path)
 @patch('wazuh.active_response.get_agents_info', return_value=full_agent_list)
-def test_run_command(mock_get_agents_info, mock_close, mock_send, mock_conn, message_exception,
-                     send_exception, agent_id, command, arguments, alert, version):
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_run_command(socket_mock, send_mock, mock_get_agents_info, mock_close, mock_send, mock_conn, message_exception,
+                     send_exception, agent_list, command, arguments, alert):
     """Verify the proper operation of active_response module.
 
     Parameters
@@ -56,8 +65,8 @@ def test_run_command(mock_get_agents_info, mock_close, mock_send, mock_conn, mes
         Exception code expected when calling create_message.
     send_exception : int
         Exception code expected when calling send_command.
-    agent_id : list
-        Agents on which to execute the Active response command.
+    agent_list : list
+        Agents on which to execute the active response command.
     command : string
         Command to be executed on the agent.
     arguments : list
@@ -67,16 +76,19 @@ def test_run_command(mock_get_agents_info, mock_close, mock_send, mock_conn, mes
     version : list
         List with the agent version to test whether the message sent was the correct one or not.
     """
-    with patch('wazuh.core.agent.Agent.get_basic_information',
-               return_value=agent_info_exception_and_version(send_exception, version)):
-        with patch('wazuh.core.agent.Agent.get_config', return_value=agent_config(send_exception)):
-            if message_exception:
-                ret = run_command(agent_list=agent_id, command=command, arguments=arguments, alert=alert)
-                assert ret.render()['data']['failed_items'][0]['error']['code'] == message_exception
+    with patch('wazuh.core.agent.Agent.get_config', return_value=agent_config(send_exception)):
+        ret = run_command(agent_list=agent_list, command=command, arguments=arguments, alert=alert)
+        render = ret.render()
+        message = 'AR command was not sent to any agent'
+
+        if message_exception:
+            assert render['data']['failed_items'][0]['error']['code'] == message_exception
+        elif send_exception:
+            assert render['data']['failed_items'][0]['error']['code'] == send_exception
+        else:
+            if len(render['data']['failed_items']) != 0:
+                message = 'AR command was not sent to some agents'
             else:
-                ret = run_command(agent_list=agent_id, command=command, arguments=arguments, alert=alert)
-                if send_exception:
-                    assert ret.render()['message'] == 'AR command was not sent to any agent'
-                    assert ret.render()['data']['failed_items'][0]['error']['code'] == send_exception
-                else:
-                    assert ret.render()['message'] == 'AR command was sent to all agents'
+                message = 'AR command was sent to all agents'
+        
+        assert render['message'] == message


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/31018.

Improves the performance of the active response endpoint by changing the way in which the affected agents' information is accessed. 

## Proposed Changes

- Fetch the agents information in a single database request instead of doing one per agent.

### Results and Evidence

<details><summary>test_active_response_endpoints.tavern.yaml</summary>

```console
(venv) wazuh@wazuh:~/wazuh/api/test/integration$ pytest --nobuild -vv --disable-warnings test_active_response_endpoints.tavern.yaml
================================================================================================== test session starts ==================================================================================================
platform linux -- Python 3.10.0, pytest-7.3.1, pluggy-1.6.0 -- /home/wazuh/wazuh/venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.0', 'Platform': 'Linux-6.1.0-37-amd64-x86_64-with-glibc2.36', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'html': '2.1.1', 'cov': '4.1.0', 'metadata': '3.1.1', 'anyio': '4.1.0', 'trio': '0.8.0', 'asyncio': '0.18.1', 'tavern': '1.23.5'}}
rootdir: /home/wazuh/wazuh/api/test/integration
configfile: pytest.ini
plugins: html-2.1.1, cov-4.1.0, metadata-3.1.1, anyio-4.1.0, trio-0.8.0, asyncio-0.18.1, tavern-1.23.5
asyncio: mode=auto
collected 2 items                                                                                                                                                                                                       

test_active_response_endpoints.tavern.yaml::PUT /active-response/{:agent_id} PASSED                                                                                                                               [ 50%]
test_active_response_endpoints.tavern.yaml::PUT /active-response PASSED                                                                                                                                           [100%]

======================================================================================= 2 passed, 3 warnings in 420.20s (0:07:00) =======================================================================================
```


</details>

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
