### PR TITLE
Match Windows and linux logcollector glob expansion logs

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -452,12 +452,12 @@ void LogCollectorStart()
             w_mutex_init(&current->mutex, &win_el_mutex_attr);
 #endif
         } else {
-            /* On Windows we need to forward the seek for wildcard files */
-#ifdef WIN32
             if (current->file) {
                 minfo(READING_FILE, current->file);
             }
 
+        /* On Windows we need to forward the seek for wildcard files */
+#ifdef WIN32
             if (current->fp) {
                 if (current->future == 0) {
                     w_set_to_last_line_read(current);
@@ -1361,7 +1361,7 @@ int check_pattern_expand(int do_seek) {
                     int added = 0;
 
                     if(!ex_file) {
-                        mdebug1(NEW_GLOB_FILE, globs[j].gpath, g.gl_pathv[glob_offset]);
+                        minfo(NEW_GLOB_FILE, globs[j].gpath, g.gl_pathv[glob_offset]);
 
                         os_realloc(globs[j].gfiles, (i +2)*sizeof(logreader), globs[j].gfiles);
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Before the changes in this PR the Windows logs showed glob expansion correctly:
```
2025/08/01 15:05:41 wazuh-agent: INFO: (1957): New file that matches the 'c:\wildcard_tests\sub*\file*' pattern: 'c:\wildcard_tests\sub1\file1.txt'.
2025/08/01 15:05:41 wazuh-agent: INFO: (1950): Analyzing file: 'c:\wildcard_tests\sub1\file1.txt'.
```
But the Linux ones didn't show anything unless the logcollector's debug level was increased to 2.

After the changes in this PR both environments show the same logs:
```
Windows:
2025/08/01 15:05:41 wazuh-agent: INFO: (1957): New file that matches the 'c:\wildcard_tests\sub*\file*' pattern: 'c:\wildcard_tests\sub1\file1.txt'.
2025/08/01 15:05:41 wazuh-agent: INFO: (1950): Analyzing file: 'c:\wildcard_tests\sub1\file1.txt'.
Linux:
2025/08/04 19:23:22 wazuh-logcollector: INFO: (1957): New file that matches the '/home/vagrant/wildcard_tests/sub1/*.txt' pattern: '/home/vagrant/wildcard_tests/sub1/file1.txt'.
2025/08/04 19:23:22 wazuh-logcollector: INFO: (1950): Analyzing file: '/home/vagrant/wildcard_tests/sub1/file1.txt'.
```

## Additional Tests
<details>
<summary>Folder Structure</summary>

```
        |-----\wildcard_tests
                |
                |-----\sub1
                |       |
                |       |---- file1.txt
                |       |---- file2.txt
                |       |---- file3.txt
                |       |---- file4.txt
                |-----\sub2
                |       |
                |       |---- file5.txt
                |       |---- file6.txt
                |       |---- file7.txt

```
This folder structure is located inside `c:` on Windows and inside `/home/vagrant/` on Linux.
</details>
<details>
<summary>Configuration</summary>

```
Windows:
  <localfile>
    <location>c:\wildcard_tests\sub*\file*</location>
    <log_format>syslog</log_format>
  </localfile>
Linux:
<localfile>
    <log_format>syslog</log_format>
    <location>/home/vagrant/wildcard_tests/sub*/file*</location>
</localfile>
```
</details>
<details>
<summary>Adding a file</summary>

```
Windows:
2025/08/01 15:30:14 wazuh-agent: INFO: (1957): New file that matches the 'c:\wildcard_tests\sub*\file*' pattern: 'c:\wildcard_tests\sub2\file8.txt'.
Linux:
2025/08/04 19:28:45 wazuh-logcollector: INFO: (1957): New file that matches the '/home/vagrant/wildcard_tests/sub1/*.txt' pattern: '/home/vagrant/wildcard_tests/sub1/file6.txt'.
```
</details>
<details>
<summary>Deleting a file</summary>

```
Windows:
2025/08/01 15:32:22 wazuh-agent: INFO: (9200): File 'c:\wildcard_tests\sub2\file8.txt' can not be handled.
2025/08/01 15:32:22 wazuh-agent: INFO: (1959): File 'c:\wildcard_tests\sub2\file8.txt' no longer exists.
Linux:
2025/08/01 14:38:09 wazuh-logcollector: INFO: (1959): File '/home/vagrant/wildcard_tests/sub2/file8.txt' no longer exists.

```
</details>
<details>
<summary>Deleting a directory</summary>

```
Windows:
2025/08/01 15:33:26 wazuh-agent: INFO: (9200): File 'c:\wildcard_tests\sub2\file5.txt' can not be handled.
2025/08/01 15:33:26 wazuh-agent: INFO: (1959): File 'c:\wildcard_tests\sub2\file5.txt' no longer exists.
2025/08/01 15:33:26 wazuh-agent: INFO: (9200): File 'c:\wildcard_tests\sub2\file6.txt' can not be handled.
2025/08/01 15:33:26 wazuh-agent: INFO: (1959): File 'c:\wildcard_tests\sub2\file6.txt' no longer exists.
2025/08/01 15:33:26 wazuh-agent: INFO: (9200): File 'c:\wildcard_tests\sub2\file7.txt' can not be handled.
2025/08/01 15:33:26 wazuh-agent: INFO: (1959): File 'c:\wildcard_tests\sub2\file7.txt' no longer exists.
Linux:
2025/08/01 14:41:21 wazuh-logcollector: INFO: (1959): File '/home/vagrant/wildcard_tests/sub2/file5.txt' no longer exists.
2025/08/01 14:41:21 wazuh-logcollector: INFO: (1959): File '/home/vagrant/wildcard_tests/sub2/file6.txt' no longer exists.
2025/08/01 14:41:21 wazuh-logcollector: INFO: (1959): File '/home/vagrant/wildcard_tests/sub2/file7.txt' no longer exists.
```
</details>
<details>
<summary>Excluding a file</summary>

```
Windows:
2025/08/05 13:04:25 wazuh-agent: INFO: (1957): New file that matches the 'c:\wildcard_tests\sub*\file*' pattern: 'c:\wildcard_tests\sub1\file1.txt'.                                    
2025/08/05 13:04:25 wazuh-agent: INFO: (1965): File excluded: 'c:\wildcard_tests\sub1\file1.txt'.                                                                                       

Linux:
2025/08/04 19:23:22 wazuh-logcollector: INFO: (1957): New file that matches the '/home/vagrant/wildcard_tests/sub1/*.txt' pattern: '/home/vagrant/wildcard_tests/sub1/file1.txt'.
2025/08/04 19:23:22 wazuh-logcollector: INFO: (1965): File excluded: '/home/vagrant/wildcard_tests/sub1/file1.txt'.t
```
</details>

As we can see, the only difference between the shows up when deleting files on Windows, which, besides the `wazuh-agent: INFO: (1959): File 'c:\wildcard_tests\sub2\file8.txt' no longer exists`. also shows `wazuh-agent: INFO: (9200): File 'c:\wildcard_tests\sub2\file8.txt' can not be handled`. 

This debug message is exclusive to Windows since it provides information on Window's HANDLE structures, which are not present on Linux.

The issue being fixed by this PR was discovered while doing testing for https://github.com/wazuh/wazuh/issues/30460 