### PR TITLE
Add agent name to the `global sync-agent-groups-get` query

### DIFF
--- a/src/wazuh_db/wdb.c
+++ b/src/wazuh_db/wdb.c
@@ -192,7 +192,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_SYNC_GET] = "SELECT sync_status FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_SYNC_SET] = "UPDATE agent SET sync_status = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_REQ_GET] = "SELECT id, name FROM agent WHERE id > ? AND group_sync_status = 'syncreq' AND date_add < ? LIMIT 1;",
-    [WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET] = "SELECT id FROM agent WHERE id > ? AND date_add < ? LIMIT 1;",
+    [WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET] = "SELECT id, name FROM agent WHERE id > ? AND date_add < ? LIMIT 1;",
     [WDB_STMT_GLOBAL_GROUP_SYNCREQ_FIND] = "SELECT 1 FROM agent WHERE group_sync_status = 'syncreq';",
     [WDB_STMT_GLOBAL_AGENT_GROUPS_NUMBER_GET] = "SELECT count(id_group) groups_number from belongs WHERE id_agent = ?;",
     [WDB_STMT_GLOBAL_GROUP_SYNC_SET] = "UPDATE agent SET group_sync_status = ? WHERE id = ?;",

--- a/tests/integration/test_wazuh_db/test_groups/data/test_cases/cases_sync_agent_groups_get.yaml
+++ b/tests/integration/test_wazuh_db/test_groups/data/test_cases/cases_sync_agent_groups_get.yaml
@@ -22,7 +22,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"condition":"all"}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test 'all' condition when agent groups are in 'synced'
   description:
@@ -32,7 +32,7 @@
     pre_input:
       - global sql UPDATE agent SET group_sync_status="synced"
     input: global sync-agent-groups-get {"condition":"all"}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test 'sync_status' condition when one agent groups are in 'synced'
   description:
@@ -52,7 +52,7 @@
     pre_input:
       - global sql UPDATE agent SET group_sync_status="synced" WHERE id = 2
     input: global sync-agent-groups-get {"condition":"all"}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test with and invalid filter in condition
   description:
@@ -147,7 +147,7 @@
   metadata:
     pre_required_group: Test_group1,Test_group2
     input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":0}
-    output: "[{'data': [{'id': 1, 'groups': ['Test_group1']}, {'id': 2, 'groups': ['Test_group2']}]}]"
+    output: "[{'data': [{'id': 1, 'name': 'Agent-test1', 'groups': ['Test_group1']}, {'id': 2, 'name': 'Agent-test2', 'groups': ['Test_group2']}]}]"
 
 - name: Test 'agent_registration_delta' with delta in 10000 and sync_status
   description:
@@ -169,7 +169,7 @@
       - global insert-agent {"id":6,"name":"Agent-test6","date_add":1545753642}
       - global set-agent-groups {"mode":"append","sync_status":"syncreq","data":[{"id":6,"groups":["Test_group6"]}]}
     input: global sync-agent-groups-get {"condition":"all", "agent_registration_delta":10000}
-    output: "[{'data': [{'id': 6, 'groups': ['Test_group6']}]}]"
+    output: "[{'data': [{'id': 6, 'name': 'Agent-test6', 'groups': ['Test_group6']}]}]"
 
 - name: Test last_id - by default
   description:


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Fixes a bug when the cluster carries out a full `Agent-groups` synchronization.

## Proposed Changes

Following the changes added at https://github.com/wazuh/wazuh/pull/31109, the `WDB_STMT_GLOBAL_GROUP_SYNC_ALL_GET` was outdated, missing the `name` field as part of the query to be carried out in the master to get all the data required to update the worker (which executes the `global set-agent-groups` command via `wdb_global_set_agent_groups`).

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

#### Master

`cluster.log`:
```
2025/08/06 16:19:22 INFO: [Worker wazuh-worker1] [Agent-groups send] Starting.
2025/08/06 16:19:22 DEBUG: [Worker wazuh-worker1] [Agent-groups send] Sending chunks.
2025/08/06 16:19:22 INFO: [Worker wazuh-worker1] [Agent-groups send] Finished in 0.002s. Updated 1 chunks.
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups send] Starting.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups send] Sending chunks.
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups send] Finished in 0.002s. Updated 1 chunks.
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups send full] Starting.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups send full] Recalculating agent-group hash.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups send full] Obtained 1 chunks of data in 0.000s.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups send full] Sending chunks.
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups send full] Finished in 0.003s. Updated 1 chunks.
```

`global.db` status after folder deletion in worker:
```
sqlite> SELECT * FROM `group`;
id|name
1|default
2|group_test
```

#### Worker

`cluster.log`:
```
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups recv] Starting.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups recv] 1/1 chunks updated in wazuh-db in 0.000s.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups recv] Obtained 1 chunks of data in 0.000s.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups recv] The checksum of master (d0818889a682ab1f56ec88e117d5b3e87b6becbc) and worker (4839dba4cbbb040c70be6cdcd0a61e28279ec796) are different.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups recv] Checksum comparison failed (5/5).
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups recv] Sent request to obtain all agent-groups information from the master node.
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups recv] Finished in 0.002s. Updated 1 chunks.
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups recv full] Starting.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups recv full] 1/1 chunks updated in wazuh-db in 0.000s.
2025/08/06 16:19:32 INFO: [Worker wazuh-worker1] [Agent-groups recv full] Finished in 0.001s. Updated 1 chunks.
2025/08/06 16:19:32 DEBUG: [Worker wazuh-worker1] [Agent-groups recv full] Recalculating agent-group hash.
```

`global.db` status after folder deletion (this behavior was like this before `4.13.0`, checked in `v4.12.0`):
```
sqlite> select * from `group`;
id|name
1|default
3|group_test
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [X] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [X] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->
- Updated `tests/integration/test_wazuh_db/test_groups/data/test_cases/cases_sync_agent_groups_get.yaml`.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
